### PR TITLE
gsc: enforce accessibility on &method-group-to-delegate and constructor calls (#2067)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -193,6 +193,17 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
+            // Issue #2067: `&Foo.Private` (method-group-to-delegate /
+            // function-pointer conversion) must enforce the declaring
+            // struct's `protected`/`private` accessibility the same way
+            // BindUserInstanceCall does for regular calls (issue #2058) —
+            // this is a separate binder path (ldftn), so it needs its own gate.
+            if (target.StaticOwnerType is StructSymbol methodDeclaringType
+                && !AccessibilityChecker.IsAccessible(target.Accessibility, methodDeclaringType, getCurrentFunction()))
+            {
+                Diagnostics.ReportMemberInaccessible(syntax.OperatorToken.Location, target.Name, methodDeclaringType.Name, target.Accessibility);
+            }
+
             var fpParamTypes = ImmutableArray.CreateBuilder<TypeSymbol>(target.Parameters.Length);
             foreach (var p in target.Parameters)
             {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -3384,6 +3384,16 @@ internal sealed class OverloadResolver
             return new BoundErrorExpression(syntax);
         }
 
+        // Issue #2067: enforce `protected`/`private` on an explicit `init(...)`
+        // constructor the same way BindUserInstanceCall enforces it on regular
+        // method calls (issue #2058) — a separate binder path resolves
+        // constructor calls, so it needs its own accessibility gate.
+        if (selectedCtor.DeclaringType is StructSymbol ctorDeclaringType
+            && !AccessibilityChecker.IsAccessible(selectedCtor.Function.Accessibility, ctorDeclaringType, getCurrentFunction()))
+        {
+            Diagnostics.ReportMemberInaccessible(syntax.Identifier.Location, "init", ctorDeclaringType.Name, selectedCtor.Function.Accessibility);
+        }
+
         return new BoundConstructorCallExpression(syntax, classType, convertedArguments.ToImmutable(), selectedCtor);
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2067AddressOfMethodAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2067AddressOfMethodAccessibilityTests.cs
@@ -1,0 +1,115 @@
+// <copyright file="Issue2067AddressOfMethodAccessibilityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2067 (follow-up from #2065 / #2058): <c>&amp;Foo.Method</c> (the
+/// method-group-to-delegate / managed-function-pointer conversion, ADR-0122
+/// §9) resolves through <see cref="GSharp.Core.CodeAnalysis.Binding.ExpressionBinder"/>'s
+/// address-of binder, a separate path from regular calls, so
+/// <see cref="AccessibilityChecker.IsAccessible"/> was never consulted there —
+/// taking the address of a <c>private</c>/<c>protected</c> static method from
+/// outside its declaring type went undiagnosed. Mirrors
+/// <c>Issue2058PrivateMethodCallAccessibilityTests</c> for <c>&amp;Method</c>.
+/// </summary>
+public class Issue2067AddressOfMethodAccessibilityTests
+{
+    [Fact]
+    public void ExternalCode_TakesAddressOfPrivateStaticMethod_ReportsGS0472()
+    {
+        var source = @"
+package P
+
+class Foo {
+    shared {
+        private func Secret() int32 { return 42 }
+    }
+}
+
+unsafe func run() {
+    let fp *func() int32 = &Foo.Secret
+}
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_TakesAddressOfProtectedStaticMethod_ReportsGS0379NotGS0472()
+    {
+        var source = @"
+package P
+
+open class Foo {
+    shared {
+        protected func Guarded() int32 { return 7 }
+    }
+}
+
+unsafe func run() {
+    let fp *func() int32 = &Foo.Guarded
+}
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0379");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void InternalCode_TakesAddressOfPrivateStaticMethodFromSameType_NoDiagnostics()
+    {
+        var source = @"
+package P
+
+class Foo {
+    shared {
+        private func Secret() int32 { return 42 }
+
+        unsafe func run() {
+            let fp *func() int32 = &Foo.Secret
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_TakesAddressOfPublicStaticMethod_NoDiagnostics()
+    {
+        var source = @"
+package P
+
+class Foo {
+    shared {
+        func Reveal() int32 { return 42 }
+    }
+}
+
+unsafe func run() {
+    let fp *func() int32 = &Foo.Reveal
+}
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0472");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0379");
+    }
+
+    private static IEnumerable<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2067PrivateConstructorAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2067PrivateConstructorAccessibilityTests.cs
@@ -1,0 +1,126 @@
+// <copyright file="Issue2067PrivateConstructorAccessibilityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2067 (follow-up from #2065 / #2058): an explicit <c>init(...)</c>
+/// constructor resolves through a separate binder path from regular method
+/// calls, so <see cref="AccessibilityChecker.IsAccessible"/> was never
+/// consulted there — a <c>private</c>/<c>protected</c> constructor called
+/// from outside its declaring type went undiagnosed at compile time (the CLR
+/// would still reject it at runtime). Mirrors
+/// <c>Issue2058PrivateMethodCallAccessibilityTests</c> for constructors.
+/// </summary>
+public class Issue2067PrivateConstructorAccessibilityTests
+{
+    [Fact]
+    public void ExternalCode_CallsPrivateConstructor_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    private init() {}
+}
+
+class Other {
+    func Make() Foo {
+        return Foo()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_CallsProtectedConstructor_ReportsGS0379NotGS0472()
+    {
+        var source = @"
+open class Base {
+    protected init() {}
+}
+
+class Other {
+    func Make() Base {
+        return Base()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void InternalCode_CallsPrivateConstructorFromSameType_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    private init() {}
+
+    func Make() Foo {
+        return Foo()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void DerivedClass_CallsBaseProtectedConstructor_NoDiagnostics()
+    {
+        var source = @"
+open class Base {
+    protected init() {}
+}
+
+class Derived : Base {
+    init() : base() {}
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_CallsPublicConstructor_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    init() {}
+}
+
+class Other {
+    func Make() Foo {
+        return Foo()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #2067

Follow-up from #2065 / #2058 review: two call-like binder paths still bypassed `AccessibilityChecker.IsAccessible`, so gsc never diagnosed private/protected access on them at compile time (the CLR still enforces it at runtime).

## Fix

1. **Constructor calls (`init(...)`)** — `OverloadResolver`'s constructor-call resolution now runs the same accessibility gate `BindUserInstanceCall` uses for method calls: `private`/`protected` constructor invoked from outside its declaring type reports GS0472/GS0379 via `DiagnosticBag.ReportMemberInaccessible`.
2. **`&Method` (method-group-to-delegate / ldftn function pointer)** — `ExpressionBinder.BindAddressOfExpression` now checks the target static method's accessibility against the current context (`AccessibilityChecker.IsAccessible` on `StaticOwnerType`) before synthesizing the function-pointer value, reporting the same GS0472/GS0379 diagnostics.

`BindUserTypeStaticCall` (issue #2071) intentionally untouched — separate branch/issue.

## Tests

Two new test files mirroring `Issue2058PrivateMethodCallAccessibilityTests`:
- `Issue2067PrivateConstructorAccessibilityTests` — private/protected ctor from outside declaring type (GS0472/GS0379), same-type and derived-type (`base()`) calls stay clean, public ctor stays clean.
- `Issue2067AddressOfMethodAccessibilityTests` — `&Foo.Secret` from outside declaring type (GS0472/GS0379), same-type use and public static method stay clean.

## Verification

- `dotnet build src/Compiler/Compiler.csproj -c Release` — 0 warnings, 0 errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 5521 passed, 1 skipped (pre-existing baseline-regen skip), 0 failed. Zero regressions.
