### PR TITLE
gsc: enforce member accessibility in with-expressions and object initializers (#2059)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -419,20 +419,35 @@ internal sealed partial class ExpressionBinder
 
         if (receiverType is StructSymbol structSymbol)
         {
-            if (TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, propertyName, MemberQuery.Instance(MemberKinds.Field), out var field, out _))
+            if (TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, propertyName, MemberQuery.Instance(MemberKinds.Field), out var field, out var fieldDeclaringType))
             {
+                // Issue #2059: an object-initializer-suffix (`T(){ Field = v }`)
+                // member write is subject to the same `protected`/`private`
+                // accessibility rule as a plain assignment (issue #950 / #2044).
+                if (!AccessibilityChecker.IsAccessible(field.Accessibility, fieldDeclaringType, this.function))
+                {
+                    Diagnostics.ReportMemberInaccessible(initSyntax.PropertyIdentifier.Location, field.Name, fieldDeclaringType.Name, field.Accessibility);
+                }
+
                 var value = BindExpression(initSyntax.Value);
                 var converted = conversions.BindConversion(initSyntax.Value.Location, value, field.Type);
                 return new BoundFieldAssignmentExpression(initSyntax, receiverLocal, structSymbol, field, converted);
             }
 
-            if (TypeMemberModel.TryGetProperty(structSymbol, propertyName, out var prop))
+            if (TypeMemberModel.TryGetProperty(structSymbol, propertyName, out var prop, out var propDeclaringType))
             {
                 if (!prop.HasSetter)
                 {
                     Diagnostics.ReportCannotAssign(initSyntax.EqualsToken.Location, propertyName);
                     _ = BindExpression(initSyntax.Value);
                     return null;
+                }
+
+                // Issue #2059: object-initializer-suffix property write —
+                // mirrors the field check above.
+                if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
+                {
+                    Diagnostics.ReportMemberInaccessible(initSyntax.PropertyIdentifier.Location, prop.Name, propDeclaringType.Name, prop.Accessibility);
                 }
 
                 var value = BindExpression(initSyntax.Value);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -64,6 +64,15 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
+            // Issue #2059: a `with` update is a write to the named field —
+            // enforce the same `protected`/`private` accessibility rule as a
+            // plain assignment / composite literal member init (issue #950 /
+            // #2044 / #2059).
+            if (!AccessibilityChecker.IsAccessible(field.Accessibility, declaringType, this.function))
+            {
+                Diagnostics.ReportMemberInaccessible(initSyntax.FieldIdentifier.Location, field.Name, declaringType.Name, field.Accessibility);
+            }
+
             var valueExpr = BindExpression(initSyntax.Value);
             valueExpr = conversions.BindConversion(initSyntax.Value.Location, valueExpr, field.Type);
             explicitValues[fieldName] = (field, declaringType, valueExpr);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2059LiteralAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2059LiteralAccessibilityTests.cs
@@ -1,0 +1,189 @@
+// <copyright file="Issue2059LiteralAccessibilityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2059: a composite/struct literal member initializer
+/// (<c>Foo{ Secret: v }</c>), a <c>with</c>-expression field update
+/// (<c>p with { Secret = v }</c>), and an object-initializer-suffix member
+/// write (<c>Foo(){ Secret = v }</c>) are all writes to the named member —
+/// each now enforces the same <c>protected</c>/<c>private</c> accessibility
+/// rule as a plain assignment (issue #950 / #2044), reusing
+/// <see cref="Symbols.AccessibilityChecker.IsAccessible"/> and
+/// <see cref="DiagnosticBag.ReportMemberInaccessible"/>.
+/// </summary>
+public class Issue2059LiteralAccessibilityTests
+{
+    [Fact]
+    public void ExternalCode_StructLiteralInitsPrivateField_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    private var Secret int32
+}
+
+class Other {
+    func Poke() int32 {
+        let f = Foo{Secret: 42}
+        return 0
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_StructLiteralInitsProtectedField_ReportsGS0379()
+    {
+        var source = @"
+open class Foo {
+    protected var Secret int32
+}
+
+class Other {
+    func Poke() int32 {
+        let f = Foo{Secret: 42}
+        return 0
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    [Fact]
+    public void ExternalCode_StructLiteralInitsPrivateProperty_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    private prop Secret int32 { get; set }
+}
+
+class Other {
+    func Poke() int32 {
+        let f = Foo{Secret: 42}
+        return 0
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void SameType_StructLiteralInitsPrivateField_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    private var Secret int32
+
+    static func Make(v int32) Foo {
+        return Foo{Secret: v}
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_StructLiteralInitsPublicField_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    var Value int32
+}
+
+class Other {
+    func Poke() int32 {
+        let f = Foo{Value: 42}
+        return f.Value
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    [Fact]
+    public void ExternalCode_WithExpressionUpdatesPrivateField_ReportsGS0472()
+    {
+        var source = @"
+data struct Point {
+    private var x int32
+    var y int32
+}
+
+class Other {
+    func Poke(p Point) Point {
+        return p with { x = 10 }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void SameType_WithExpressionUpdatesPrivateField_NoDiagnostics()
+    {
+        var source = @"
+data struct Point {
+    private var x int32
+    var y int32
+
+    func Bump() Point {
+        return this with { x = 10 }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_ObjectInitializerSuffixWritesPrivateField_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    private var Secret int32
+}
+
+class Other {
+    func Poke() int32 {
+        let f = Foo(){Secret = 42}
+        return 0
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #2059

Enforces `private`/`protected` accessibility on member writes in `with`-expressions (LowerCopyOrWith, ExpressionBinder.Calls.cs) and object-initializer suffixes (BindObjectInitializerAssignment, ExpressionBinder.Assignments.cs), reusing AccessibilityChecker.IsAccessible + ReportMemberInaccessible. The composite/struct-literal member-init path landed separately on main via #2060; this PR completes the remaining with-expr + object-initializer sites. Includes tests for both from outside the declaring type.