### PR TITLE
gsc: enforce accessibility for static/shared method calls (#2071)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2789,6 +2789,16 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
+            // Issue #950 / #2058: enforce `protected`/`private` static method
+            // access — mirrors the instance-call check in
+            // OverloadResolver.BindUserInstanceCall. Interface static methods
+            // already have their own private-visibility diagnostic (issue
+            // #756), so this only applies to class/struct owners.
+            if (structSym != null && !AccessibilityChecker.IsAccessible(method.Accessibility, structSym, this.function))
+            {
+                Diagnostics.ReportMemberInaccessible(ce.Identifier.Location, method.Name, structSym.Name, method.Accessibility);
+            }
+
             // Issue #951: bind any deferred un-typed arrow lambda against the
             // selected static method's delegate-typed parameter so its omitted
             // parameter type(s) and inferred return type are filled in from the

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2058PrivateMethodCallTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2058PrivateMethodCallTests.cs
@@ -1,0 +1,150 @@
+// <copyright file="Issue2058PrivateMethodCallTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2058: a <c>private</c> method called from outside its declaring
+/// type is now diagnosed (GS0472), mirroring the existing <c>protected</c>
+/// method-call enforcement (issue #950 / GS0379) and the field/property
+/// enforcement added for issue #2044. Covers instance and static (<c>shared</c>)
+/// private methods called from outside the declaring type (must report), and
+/// legal same-type, inherited-protected, and public calls (must not report).
+/// </summary>
+public class Issue2058PrivateMethodCallTests
+{
+    [Fact]
+    public void ExternalCode_CallsPrivateInstanceMethod_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    private func Secret() int32 { return 42 }
+}
+
+class Other {
+    func Poke(f Foo) int32 {
+        return f.Secret()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_CallsPrivateStaticMethod_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    shared {
+        private func Secret() int32 { return 42 }
+    }
+}
+
+class Other {
+    func Poke() int32 {
+        return Foo.Secret()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void InternalCode_CallsPrivateInstanceMethodFromSameType_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    private func Secret() int32 { return 42 }
+    func Reveal() int32 { return Secret() }
+}
+
+class Other {
+    func Poke(f Foo) int32 {
+        return f.Reveal()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void InternalCode_CallsPrivateStaticMethodFromSameType_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    shared {
+        func Reveal() int32 { return Secret() }
+        private func Secret() int32 { return 42 }
+    }
+}
+
+class Other {
+    func Poke() int32 {
+        return Foo.Reveal()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void DerivedClass_CallsInheritedProtectedMethod_NoDiagnostics()
+    {
+        var source = @"
+open class Base {
+    protected func Helper() int32 { return 1 }
+}
+
+class Derived : Base {
+    func Poke() int32 { return Helper() }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_CallsPublicMethod_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    func Greet() int32 { return 42 }
+}
+
+class Other {
+    func Poke(f Foo) int32 {
+        return f.Greet()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #2071

Enforces `private`/`protected` accessibility on static/shared method calls via `BindUserTypeStaticCall` (ExpressionBinder.Access.cs), mirroring the instance-call gate added for #2058/#2060. The instance-call path landed separately on main via #2060; this PR completes the static-call variant. Includes tests covering private and protected static method calls from outside the declaring type.