### PR TITLE
cs2gs: harden Index/Range loud-gap coverage (non-declarator sites, ImplicitElementAccess)

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -652,8 +652,16 @@ public static class GSharpPrinter
 
     private static string RenderCollectionInitializer(CollectionInitializerExpression collection, int indent)
     {
-        // Canonical form: drop the empty `()` on a zero-argument construction
-        // so `List[int32](){...}` renders as `List[int32]{...}`.
+        // Canonical form: drop the empty `()` on a zero-argument GENERIC
+        // construction so `List[int32](){...}` renders as `List[int32]{...}`
+        // — gsc's parser recognises a bare `Type[args]{ ... }` as a collection
+        // initializer for ANY element shape (`BraceLooksLikeGenericCollectionInitializer`).
+        // A NON-generic zero-arg target (`IndexKeyed()`) has no such carve-out:
+        // gsc's bare `Identifier{ ... }` grammar commits to a STRUCT LITERAL
+        // (`Identifier :` fields only, `IsStructLiteralFollowingBrace`) and
+        // silently fails to parse a `key: value`/`[key] = value` collection
+        // element there (issue #1967) — so the `()` must stay so the parser
+        // takes its `LooksLikeCollectionInitializerBrace` path instead.
         string target;
         if (collection.Target == null)
         {
@@ -663,11 +671,11 @@ public static class GSharpPrinter
             // property (lowered to `.Add(...)` calls by gsc).
             target = string.Empty;
         }
-        else if (collection.Target is InvocationExpression invocation && invocation.Arguments.Count == 0)
+        else if (collection.Target is InvocationExpression invocation
+            && invocation.Arguments.Count == 0
+            && invocation.TypeArguments.Count > 0)
         {
-            var typeArgs = invocation.TypeArguments.Count == 0
-                ? string.Empty
-                : $"[{string.Join(", ", invocation.TypeArguments.Select(RenderType))}]";
+            var typeArgs = $"[{string.Join(", ", invocation.TypeArguments.Select(RenderType))}]";
             target = $"{RenderExpression(invocation.Target, indent)}{typeArgs}";
         }
         else

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1967IndexRangeHardeningTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1967IndexRangeHardeningTests.cs
@@ -1,0 +1,336 @@
+// <copyright file="Issue1967IndexRangeHardeningTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1967: hardens the issue #1894/#1894 loud-gap coverage for
+/// <c>System.Index</c>/<c>System.Range</c> at two classes of site the original
+/// fix missed:
+/// <list type="bullet">
+/// <item><c>IsDirectIndexBracketArgument</c> did not recognise
+/// <c>ImplicitElementAccessSyntax</c> (a dictionary/collection-initializer
+/// element, <c>{ [^1] = v }</c>), so a valid inline from-end index there would
+/// have over-gapped as if it were outside any bracket.</item>
+/// <item>An Index/Range-typed local declared via a NON-declarator site —
+/// <c>foreach (Index i in xs)</c>, an <c>is</c>/<c>switch</c> pattern
+/// designation (<c>x is Index i</c>, <c>case Index i:</c>), an <c>out Index
+/// i</c> argument, or tuple deconstruction (<c>var (i, r) = ...</c>) — bypassed
+/// the declarator-only symbol check in <c>TranslateLocalDeclaration</c> and
+/// would slip through with no diagnostic.</item>
+/// </list>
+/// </summary>
+public class Issue1967IndexRangeHardeningTests
+{
+    [Fact]
+    public void ImplicitElementAccess_FromEndIndexKey_StaysCanonicalNoGap()
+    {
+        // `{ [^1] = v }` inside a collection initializer is just as direct a
+        // bracket-argument position as a real element access — must not gap
+        // with the "from-end index ... outside a direct bracket" diagnostic
+        // (`IsDirectIndexBracketArgument`'s `ImplicitElementAccessSyntax` gap).
+        // The indexer's own `Index i` PARAMETER still independently gaps per
+        // #1894 (an Index-typed parameter has no canonical G# type) — that is
+        // unrelated to this check and is asserted separately below.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+using System;
+namespace Corpus.Issue1967
+{
+    public class IndexKeyed
+    {
+        public int this[Index i]
+        {
+            get => 0;
+            set { }
+        }
+    }
+
+    public class Holder
+    {
+        public void Make()
+        {
+            var h = new IndexKeyed { [^1] = 5 };
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string rendered = GSharpPrinter.Print(unit);
+
+        Assert.Contains("^1", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Message.Contains("outside a direct", StringComparison.Ordinal));
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("System.Index", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ForEachIndexTypedVariable_StaysLoudGap()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+using System;
+using System.Collections.Generic;
+namespace Corpus.Issue1967
+{
+    public class Holder
+    {
+        public void Run(List<Index> xs)
+        {
+            foreach (Index i in xs)
+            {
+                Console.WriteLine(i.Value);
+            }
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("System.Index", StringComparison.Ordinal));
+        Assert.All(context.Diagnostics, d => Assert.Equal(TranslationSeverity.Unsupported, d.Severity));
+    }
+
+    [Fact]
+    public void IsPatternIndexTypedDesignation_StaysLoudGap()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+using System;
+namespace Corpus.Issue1967
+{
+    public class Holder
+    {
+        public int Get(int[] a, object o)
+        {
+            if (o is Index i)
+            {
+                return a[i];
+            }
+
+            return 0;
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("System.Index", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void WhileLoopConditionIsPatternIndexTypedDesignation_StaysLoudGap()
+    {
+        // A loop-condition `is`-pattern is hoisted through a SEPARATE code path
+        // (HoistLoopConditionClauseCore) that never calls TranslateIsPattern.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+using System;
+namespace Corpus.Issue1967
+{
+    public class Holder
+    {
+        public void Run(object o)
+        {
+            while (o is Index i)
+            {
+                o = null;
+            }
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("System.Index", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SwitchCasePatternIndexTypedDesignation_StaysLoudGap()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+using System;
+namespace Corpus.Issue1967
+{
+    public class Holder
+    {
+        public int Get(int[] a, object o)
+        {
+            switch (o)
+            {
+                case Index i:
+                    return a[i];
+                default:
+                    return 0;
+            }
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("System.Index", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SwitchExpressionArmPatternIndexTypedDesignation_StaysLoudGap()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+using System;
+namespace Corpus.Issue1967
+{
+    public class Holder
+    {
+        public int Get(int[] a, object o) => o switch
+        {
+            Index i => a[i],
+            _ => 0,
+        };
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("System.Index", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void OutIndexTypedArgument_StaysLoudGap()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+using System;
+namespace Corpus.Issue1967
+{
+    public class Holder
+    {
+        private static void TryGetIndex(out Index i) => i = ^1;
+
+        public int Get(int[] a)
+        {
+            TryGetIndex(out Index i);
+            return a[i];
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("System.Index", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TupleDeconstructionIndexTypedElement_StaysLoudGap()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+using System;
+namespace Corpus.Issue1967
+{
+    public class Holder
+    {
+        private static (Index, int) Make() => (^1, 2);
+
+        public int Get(int[] a)
+        {
+            var (i, n) = Make();
+            return a[i] + n;
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("System.Index", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TupleDeconstructionAssignment_MixedIndexTypedElement_StaysLoudGap()
+    {
+        // `(x, Index i) = ...` — the mixed-tuple-assignment declaration path
+        // (LowerTupleAssignment), distinct from the all-`var` declaration path
+        // above.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+using System;
+namespace Corpus.Issue1967
+{
+    public class Holder
+    {
+        private static (int, Index) Make() => (2, ^1);
+
+        public int Get(int[] a)
+        {
+            int n;
+            (n, Index i) = Make();
+            return a[i] + n;
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("System.Index", StringComparison.Ordinal));
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1967IndexRangeHardeningTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1967IndexRangeHardeningTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
 using Xunit;
@@ -12,19 +13,33 @@ namespace Cs2Gs.Tests;
 
 /// <summary>
 /// Issue #1967: hardens the issue #1894/#1894 loud-gap coverage for
-/// <c>System.Index</c>/<c>System.Range</c> at two classes of site the original
-/// fix missed:
+/// <c>System.Index</c>/<c>System.Range</c> at three classes of site the
+/// original fix missed:
 /// <list type="bullet">
 /// <item><c>IsDirectIndexBracketArgument</c> did not recognise
 /// <c>ImplicitElementAccessSyntax</c> (a dictionary/collection-initializer
 /// element, <c>{ [^1] = v }</c>), so a valid inline from-end index there would
-/// have over-gapped as if it were outside any bracket.</item>
+/// have over-gapped as if it were outside any bracket. Making this position
+/// canonical in turn exposed a pre-existing <see cref="GSharpPrinter"/> bug:
+/// a NON-generic zero-argument construction target
+/// (<c>new IndexKeyed() { [^1] = 5 }</c>) printed its constructor call's `()`
+/// away, but gsc's parser only recognises a bare `Identifier{ ... }` as a
+/// STRUCT literal (`Identifier :` fields) — never as a collection initializer
+/// with a `[key] = value`/`key: value` element — so the emitted G# silently
+/// failed to parse. The printer now keeps the `()` whenever the target is
+/// non-generic.</item>
 /// <item>An Index/Range-typed local declared via a NON-declarator site —
 /// <c>foreach (Index i in xs)</c>, an <c>is</c>/<c>switch</c> pattern
 /// designation (<c>x is Index i</c>, <c>case Index i:</c>), an <c>out Index
 /// i</c> argument, or tuple deconstruction (<c>var (i, r) = ...</c>) — bypassed
 /// the declarator-only symbol check in <c>TranslateLocalDeclaration</c> and
 /// would slip through with no diagnostic.</item>
+/// <item>An Index/Range-typed LINQ query range variable (<c>from Index i in
+/// xs</c>, a <c>let</c>/<c>join</c> binding, or a query continuation's
+/// <c>into y</c>) binds an <c>IRangeVariableSymbol</c>, not an
+/// <c>ILocalSymbol</c> — none of those sites have any designation syntax at
+/// all, so they need their own symbol-based guard
+/// (<c>ReportIfIndexOrRangeTypedRangeVariable</c>).</item>
 /// </list>
 /// </summary>
 public class Issue1967IndexRangeHardeningTests
@@ -72,6 +87,15 @@ namespace Corpus.Issue1967
         Assert.Contains("^1", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain(context.Diagnostics, d => d.Message.Contains("outside a direct", StringComparison.Ordinal));
         Assert.Contains(context.Diagnostics, d => d.Message.Contains("System.Index", StringComparison.Ordinal));
+
+        // Issue #1967: `IsDirectIndexBracketArgument` now treats an initializer
+        // element (`{ [^1] = v }`) the same as a real element access — verify
+        // gsc's OWN parser actually accepts a from-end index in that position,
+        // not just that the printer emitted the `^1` text (a printer-only check
+        // would miss gsc silently rejecting it as unparseable G#).
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(rendered);
+        Assert.True(roundTrip.Success, "Translated G# must parse. Errors:\n" +
+            string.Join("\n", roundTrip.Errors) + "\n\nPrinted:\n" + rendered);
     }
 
     [Fact]
@@ -304,6 +328,132 @@ namespace Corpus.Issue1967
             int n;
             (n, Index i) = Make();
             return a[i] + n;
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("System.Index", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void QueryFromClauseIndexTypedRangeVariable_StaysLoudGap()
+    {
+        // `from Index i in xs` binds `i` as an `IRangeVariableSymbol`, not an
+        // `ILocalSymbol` — a designation-only check would miss it entirely.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+namespace Corpus.Issue1967
+{
+    public class Holder
+    {
+        public IEnumerable<Index> Run(List<Index> xs)
+        {
+            return from Index i in xs select i;
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("System.Index", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void QueryLetClauseIndexTypedRangeVariable_StaysLoudGap()
+    {
+        // `let i = ^n` binds `i` (an Index) via `LowerLetClause`, inferred from
+        // the `let` expression's own type rather than a source collection.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+using System;
+using System.Linq;
+namespace Corpus.Issue1967
+{
+    public class Holder
+    {
+        public int Get(int[] xs)
+        {
+            var q = from n in xs let i = ^n select xs[i];
+            return q.First();
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("System.Index", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void QueryJoinClauseIndexTypedRangeVariable_StaysLoudGap()
+    {
+        // `join y in ys on ...` with `ys : List<Index>` infers `y`'s type from
+        // the inner sequence's element type (no explicit `Index` in the clause
+        // itself) — exercises the source-inferred path in `LowerJoinClause`.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+namespace Corpus.Issue1967
+{
+    public class Holder
+    {
+        public IEnumerable<Index> Run(List<int> xs, List<Index> ys)
+        {
+            return from x in xs
+                   join y in ys on x equals y.GetOffset(10)
+                   select y;
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("System.Index", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void QueryContinuationIndexTypedRangeVariable_StaysLoudGap()
+    {
+        // `select ^n into i` re-starts the query scope with `i : Index` — the
+        // continuation's range variable type is inferred from the preceding
+        // `select`'s projected expression type, not any declarator/designation.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+namespace Corpus.Issue1967
+{
+    public class Holder
+    {
+        public IEnumerable<Index> Run(int[] xs)
+        {
+            return from n in xs
+                   select ^n into i
+                   select i;
         }
     }
 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -583,6 +583,16 @@ public sealed class CSharpToGSharpTranslator
         private readonly HashSet<ISymbol> hoistedNullableGuardLocals =
             new HashSet<ISymbol>(SymbolEqualityComparer.Default);
 
+        // Issue #1967: designation nodes (`SingleVariableDesignationSyntax`) already
+        // checked by `ReportIfIndexOrRangeTypedDesignation` for an Index/Range-typed
+        // declared symbol. A single designation can be reached from more than one
+        // translation path for the SAME node (e.g. a loop-condition pattern's main
+        // binder is inspected by both `FindMainPatternBinder` and
+        // `EmitMustHoldGuards`/`IsBindOnlyMainBinder`); this dedupes so the loud gap
+        // is reported once per designation, not once per visit.
+        private readonly HashSet<SyntaxNode> reportedIndexRangeDesignations =
+            new HashSet<SyntaxNode>();
+
         // C# post-increment/decrement (`i++`, `i--`) sub-expressions that the
         // surrounding statement seam has hoisted into trailing `i++` statements
         // (G# models inc/dec as statements, not expressions; spec §Statements).
@@ -5187,6 +5197,11 @@ public sealed class CSharpToGSharpTranslator
                     return new[] { this.TranslateForStatement(forStatement) };
 
                 case ForEachStatementSyntax forEach:
+                    // Issue #1967: `foreach (Index i in xs)` declares `i` directly
+                    // on this node (no declarator, no designation) — check it here
+                    // before it can bypass the issue #1894 loud-gap guard.
+                    this.ReportIfIndexOrRangeTypedForEachVariable(forEach);
+
                     // The iterable receiver gets the same nullable-narrowing `!!`
                     // treatment as a member/element-access receiver: a declared-
                     // nullable (or #1072-promoted) field/property iterated inside a
@@ -5790,23 +5805,102 @@ public sealed class CSharpToGSharpTranslator
             return index;
         }
 
-        // Issue #1894: whether `expression` sits directly in a bracketed index
-        // argument position (`recv[EXPR]` / `recv?[EXPR]`) — the one position
+        // Issue #1894/#1967: whether `expression` sits directly in a bracketed
+        // index argument position (`recv[EXPR]` / `recv?[EXPR]` / a dictionary/
+        // collection-initializer element `{ [EXPR] = v }`) — the one position
         // where gsc's own parser recognises a leading `^` as a from-end marker
         // rather than one's-complement (Parser.ParseIndexBound). A `^n` nested
         // any deeper (e.g. as a `RangeExpressionSyntax` bound, `recv[a..^n]`) is
         // NOT a direct argument — `TranslateRangeBound` emits it as its own
         // native `FromEndIndexExpression` (gsc's `^n`) before it ever reaches
         // this generic prefix-unary path (an inline `recv[a..^n]` slice never
-        // gaps).
+        // gaps). `ImplicitElementAccessSyntax` is the initializer-element shape
+        // (`{ [^1] = v }` inside a collection/object initializer) — Roslyn binds
+        // its bracketed argument list directly to it (no `ElementAccessExpressionSyntax`
+        // wrapper), so it must be recognised here too or a from-end index inside
+        // an initializer element would over-gap (issue #1967).
         private static bool IsDirectIndexBracketArgument(ExpressionSyntax expression) =>
             expression.Parent is ArgumentSyntax
             {
                 Parent: BracketedArgumentListSyntax
                 {
-                    Parent: ElementAccessExpressionSyntax or ElementBindingExpressionSyntax,
+                    Parent: ElementAccessExpressionSyntax or ElementBindingExpressionSyntax or ImplicitElementAccessSyntax,
                 },
             };
+
+        // Issue #1967: hardens the issue #1894 loud-gap check (see
+        // `TranslateLocalDeclaration`'s declared-symbol check) against Index/Range
+        // locals bound OUTSIDE a `var`/typed local declarator — `foreach (Index i in
+        // xs)`, `x is Index i`/`case Index i`, `M(out Index i)`, and tuple/positional
+        // deconstruction (`var (i, r) = ...`) all declare a NEW `ILocalSymbol`
+        // without ever going through `TranslateLocalDeclaration`, so an Index/Range
+        // local bound at one of those sites would silently bypass the existing
+        // guard. Every one of those sites resolves its designation to a declared
+        // symbol independently; this is the single choke point they all route
+        // through to report the same gap uniformly.
+        private void ReportIfIndexOrRangeTypedDesignation(SingleVariableDesignationSyntax designation)
+        {
+            if (designation == null || !this.reportedIndexRangeDesignations.Add(designation))
+            {
+                return;
+            }
+
+            if (this.context.GetDeclaredSymbol(designation) is ILocalSymbol { Type: { } type } &&
+                CSharpTypeMapper.IsSystemIndexOrRange(type))
+            {
+                this.context.Report(new TranslationDiagnostic(
+                    type.Name,
+                    $"local '{designation.Identifier.Text}' has type 'System.{type.Name}', which has no canonical G# type — see CSharpTypeMapper.Map (issue #1894).",
+                    designation.GetLocation(),
+                    TranslationSeverity.Unsupported));
+            }
+        }
+
+        // Issue #1967: scans every `SingleVariableDesignationSyntax` nested
+        // anywhere inside a pattern tree (a bare `Index i`, or one nested inside a
+        // recursive/positional/list/`and`/`or`/`not` pattern) and reports the same
+        // Index/Range loud gap as a declarator. Called once per pattern ROOT (never
+        // from the recursive per-subpattern translators) so a nested designation is
+        // checked exactly once.
+        private void ReportIndexOrRangeDesignationsInPattern(PatternSyntax pattern)
+        {
+            if (pattern == null)
+            {
+                return;
+            }
+
+            foreach (SingleVariableDesignationSyntax designation in
+                pattern.DescendantNodesAndSelf().OfType<SingleVariableDesignationSyntax>())
+            {
+                this.ReportIfIndexOrRangeTypedDesignation(designation);
+            }
+        }
+
+        // Issue #1967: `foreach (Index i in xs)` declares its loop variable
+        // directly on the `ForEachStatementSyntax` node itself (no designation
+        // syntax at all — unlike every other declaration site), so it needs its
+        // own symbol-based guard mirroring `ReportIfIndexOrRangeTypedDesignation`.
+        private void ReportIfIndexOrRangeTypedForEachVariable(ForEachStatementSyntax forEach)
+        {
+            if (this.context.GetDeclaredSymbol(forEach) is ILocalSymbol { Type: { } type } &&
+                CSharpTypeMapper.IsSystemIndexOrRange(type))
+            {
+                this.context.Report(new TranslationDiagnostic(
+                    type.Name,
+                    $"local '{forEach.Identifier.Text}' has type 'System.{type.Name}', which has no canonical G# type — see CSharpTypeMapper.Map (issue #1894).",
+                    forEach.GetLocation(),
+                    TranslationSeverity.Unsupported));
+            }
+        }
+
+        // Issue #1967: `M(out Index i)` declares `i` via an out-argument
+        // designation, not a declarator — check it here, the single choke point
+        // every `out var`/`out T` argument translates through.
+        private GExpression TranslateOutVarDesignation(SingleVariableDesignationSyntax single)
+        {
+            this.ReportIfIndexOrRangeTypedDesignation(single);
+            return new OutArgumentExpression("out var", SanitizeIdentifier(single.Identifier.Text));
+        }
 
         // Reports whether the element-access target indexes by `int32`: a C# array,
         // or a type whose bound indexer takes a single `int32` parameter (such as
@@ -7184,6 +7278,14 @@ public sealed class CSharpToGSharpTranslator
                     ILocalSymbol localSymbol = declaration.Designation is SingleVariableDesignationSyntax singleDesignation
                         ? this.context.GetDeclaredSymbol(singleDesignation) as ILocalSymbol
                         : null;
+
+                    // Issue #1967: `(x, Index i) = ...` declares `i` via this
+                    // mixed-tuple-assignment designation, not a declarator.
+                    if (declaration.Designation is SingleVariableDesignationSyntax indexCheckDesignation)
+                    {
+                        this.ReportIfIndexOrRangeTypedDesignation(indexCheckDesignation);
+                    }
+
                     BindingKind binding = localSymbol != null && this.IsLocalReassigned(localSymbol)
                         ? BindingKind.Var
                         : BindingKind.Let;
@@ -7224,6 +7326,13 @@ public sealed class CSharpToGSharpTranslator
                         SingleVariableDesignationSyntax single => single.Identifier.Text,
                         _ => "_",
                     });
+
+                    // Issue #1967: `var (i, r) = ...` declares each element via a
+                    // designation, not a declarator.
+                    if (designation is SingleVariableDesignationSyntax indexCheckSingle)
+                    {
+                        this.ReportIfIndexOrRangeTypedDesignation(indexCheckSingle);
+                    }
                 }
 
                 names = collected;
@@ -7243,6 +7352,13 @@ public sealed class CSharpToGSharpTranslator
                         SingleVariableDesignationSyntax single => single.Identifier.Text,
                         _ => "_",
                     });
+
+                    // Issue #1967: `(var i, var r) = ...` — same as above, one
+                    // designation per tuple element.
+                    if (declaration.Designation is SingleVariableDesignationSyntax indexCheckSingle)
+                    {
+                        this.ReportIfIndexOrRangeTypedDesignation(indexCheckSingle);
+                    }
                 }
 
                 names = collected;
@@ -8166,6 +8282,11 @@ public sealed class CSharpToGSharpTranslator
 
                 return;
             }
+
+            // Issue #1967: a loop-condition `is`-pattern (`while (x is Index i)`)
+            // never reaches `TranslateIsPattern` — it is hoisted here instead — so
+            // its designations need the same guard applied at this entry point.
+            this.ReportIndexOrRangeDesignationsInPattern(isPattern.Pattern);
 
             GExpression receiver = this.TranslateExpression(isPattern.Expression);
             ITypeSymbol scrutineeType = this.context.GetTypeInfo(isPattern.Expression).Type;
@@ -9867,6 +9988,12 @@ public sealed class CSharpToGSharpTranslator
 
         private GExpression TranslateIsPattern(IsPatternExpressionSyntax isPattern)
         {
+            // Issue #1967: `x is Index i` (or any nested designation inside a
+            // recursive/positional pattern) declares `i` via a pattern designation,
+            // not a declarator — check the whole pattern tree here, the entry point
+            // for every non-loop-condition `is`-pattern.
+            this.ReportIndexOrRangeDesignationsInPattern(isPattern.Pattern);
+
             GExpression receiver = this.TranslateExpression(isPattern.Expression);
             ITypeSymbol receiverType = this.context.GetTypeInfo(isPattern.Expression).Type;
 
@@ -12682,7 +12809,7 @@ public sealed class CSharpToGSharpTranslator
                     return declaration.Designation switch
                     {
                         DiscardDesignationSyntax => new OutArgumentExpression("out", "_"),
-                        SingleVariableDesignationSyntax single => new OutArgumentExpression("out var", SanitizeIdentifier(single.Identifier.Text)),
+                        SingleVariableDesignationSyntax single => this.TranslateOutVarDesignation(single),
                         _ => new UnaryExpression("&", this.TranslateExpression(argument.Expression)),
                     };
                 }
@@ -13915,6 +14042,11 @@ public sealed class CSharpToGSharpTranslator
                 var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
                 var usedDesignators = new HashSet<string>(StringComparer.Ordinal);
                 var guards = new List<GExpression>();
+
+                // Issue #1967: `case Index i:`/`Index i =>` binds via a switch
+                // pattern designation, not a declarator — check the whole arm
+                // pattern tree here.
+                this.ReportIndexOrRangeDesignationsInPattern(arm.Pattern);
                 GPattern pattern = this.TranslatePattern(arm.Pattern, subject, bindings, usedDesignators, guards);
 
                 foreach ((ISymbol symbol, GExpression replacement) in bindings)
@@ -13988,6 +14120,10 @@ public sealed class CSharpToGSharpTranslator
                             var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
                             var usedDesignators = new HashSet<string>(StringComparer.Ordinal);
                             var guards = new List<GExpression>();
+
+                            // Issue #1967: same guard as the switch-expression arm
+                            // path above, for the switch-statement `case` form.
+                            this.ReportIndexOrRangeDesignationsInPattern(patternLabel.Pattern);
                             GPattern pattern = this.TranslatePattern(patternLabel.Pattern, subject, bindings, usedDesignators, guards);
 
                             // Issue #1730: install the pattern's bindings before
@@ -14116,6 +14252,15 @@ public sealed class CSharpToGSharpTranslator
             // form, so `await foreach` keeps the older temp+let lowering.
             List<string> names = new List<string>();
             CollectForEachVariableNames(node.Variable, names);
+
+            // Issue #1967: `foreach (var (i, r) in pairs)` declares each element
+            // via a designation nested in `node.Variable` — check every one here,
+            // this method's single entry point for deconstructing foreach.
+            foreach (SingleVariableDesignationSyntax designation in
+                node.Variable.DescendantNodesAndSelf().OfType<SingleVariableDesignationSyntax>())
+            {
+                this.ReportIfIndexOrRangeTypedDesignation(designation);
+            }
 
             if (names.Count >= 2)
             {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5902,6 +5902,38 @@ public sealed class CSharpToGSharpTranslator
             return new OutArgumentExpression("out var", SanitizeIdentifier(single.Identifier.Text));
         }
 
+        // Issue #1967: an Index/Range-typed LINQ query range variable
+        // (`from Index i in xs`, `let i = <Index expr>`, `join`, or a query
+        // continuation's `into y`) binds via a query clause, not a designation —
+        // it never goes through `ReportIfIndexOrRangeTypedDesignation`. `type` is
+        // the range variable's resolved element type (explicit `TypeSyntax` wins,
+        // else inferred from the source collection/`let` expression — same
+        // resolution `ResolveRangeVariableType`/`ResolveRangeVariableElementTypeSymbol`
+        // use, so the loud gap and the actual G# type stay in sync).
+        private void ReportIfIndexOrRangeTypedRangeVariable(SyntaxNode anchor, SyntaxToken identifier, ITypeSymbol type)
+        {
+            if (type != null && CSharpTypeMapper.IsSystemIndexOrRange(type))
+            {
+                this.context.Report(new TranslationDiagnostic(
+                    type.Name,
+                    $"query range variable '{identifier.Text}' has type 'System.{type.Name}', which has no canonical G# type — see CSharpTypeMapper.Map (issue #1894).",
+                    anchor.GetLocation(),
+                    TranslationSeverity.Unsupported));
+            }
+        }
+
+        // Resolves an Index/Range check for a `from`/`join` range variable: an
+        // explicit `TypeSyntax` wins, else the source collection's element type
+        // (mirrors `ResolveRangeVariableType`'s own precedence).
+        private void ReportIfIndexOrRangeTypedRangeVariable(
+            SyntaxNode anchor, SyntaxToken identifier, TypeSyntax explicitType, ExpressionSyntax source)
+        {
+            ITypeSymbol type = explicitType != null
+                ? this.context.GetTypeInfo(explicitType).Type
+                : this.ResolveRangeVariableElementTypeSymbol(source);
+            this.ReportIfIndexOrRangeTypedRangeVariable(anchor, identifier, type);
+        }
+
         // Reports whether the element-access target indexes by `int32`: a C# array,
         // or a type whose bound indexer takes a single `int32` parameter (such as
         // `List<T>`, `Span<T>`, `IReadOnlyList<T>`). A `Dictionary<TKey, T>` or any
@@ -14844,6 +14876,7 @@ public sealed class CSharpToGSharpTranslator
             // equivalent System.Linq method chain (`from … where … orderby …
             // select …` → `.Where(…).OrderBy(…).Select(…)`, ADR-0115 §B LINQ).
             FromClauseSyntax from = query.FromClause;
+            this.ReportIfIndexOrRangeTypedRangeVariable(from, from.Identifier, from.Type, from.Expression);
             GExpression current = this.TranslateExpression(from.Expression);
             GTypeReference rangeType = this.ResolveRangeVariableType(from.Type, from.Expression, from);
 
@@ -14875,9 +14908,7 @@ public sealed class CSharpToGSharpTranslator
                 return this.MapTypeSyntax(explicitType);
             }
 
-            ITypeSymbol sourceType = this.context.GetTypeInfo(source).Type
-                ?? this.context.GetTypeInfo(source).ConvertedType;
-            ITypeSymbol elementType = GetEnumerableElementType(sourceType);
+            ITypeSymbol elementType = this.ResolveRangeVariableElementTypeSymbol(source);
             if (elementType != null)
             {
                 return this.typeMapper.Map(elementType, this.context, anchor.GetLocation());
@@ -14887,6 +14918,18 @@ public sealed class CSharpToGSharpTranslator
                 anchor,
                 "query range variable's element type could not be determined from its source collection (ADR-0115 §B).");
             return new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
+        }
+
+        // Shared by `ResolveRangeVariableType` (above) and the issue #1967
+        // Index/Range loud-gap check below: the source collection's element
+        // type, the same way C#'s foreach/query-from infers an implicit range
+        // variable's type (array element type, `IEnumerable<T>`'s `T`, or a
+        // dictionary's `KeyValuePair<K,V>`) via `GetEnumerableElementType`.
+        private ITypeSymbol ResolveRangeVariableElementTypeSymbol(ExpressionSyntax source)
+        {
+            ITypeSymbol sourceType = this.context.GetTypeInfo(source).Type
+                ?? this.context.GetTypeInfo(source).ConvertedType;
+            return GetEnumerableElementType(sourceType);
         }
 
         private GExpression LowerQueryBody(
@@ -14943,6 +14986,16 @@ public sealed class CSharpToGSharpTranslator
                 ? scope[0].Type
                 : new TupleTypeReference(scope.Select(v => v.Type).ToList());
 
+            // Tracks the projected `select` expression's resolved `ITypeSymbol`
+            // (issue #1967) so a continuation's `into y` can be checked for an
+            // Index/Range projection below — `resultType` alone is a `GTypeReference`
+            // and has already lost that information by the time the continuation
+            // runs. Left null for an elided identity `select`/`group` continuation:
+            // either case re-uses an already-declared range variable's type, whose
+            // Index/Range loud gap (if any) was already reported at its own `from`/
+            // `let`/`join` site.
+            ITypeSymbol resultTypeSymbol = null;
+
             switch (body.SelectOrGroup)
             {
                 case SelectClauseSyntax select:
@@ -14955,7 +15008,8 @@ public sealed class CSharpToGSharpTranslator
                     }
 
                     current = this.QueryCall(current, "Select", scope, select.Expression);
-                    resultType = this.context.GetTypeInfo(select.Expression).Type is { } projected
+                    resultTypeSymbol = this.context.GetTypeInfo(select.Expression).Type;
+                    resultType = resultTypeSymbol is { } projected
                         ? this.typeMapper.Map(projected, this.context, select.GetLocation())
                         : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
                     break;
@@ -14979,6 +15033,7 @@ public sealed class CSharpToGSharpTranslator
             // re-starts the scope as a single range variable over the projection.
             if (body.Continuation != null)
             {
+                this.ReportIfIndexOrRangeTypedRangeVariable(body.Continuation, body.Continuation.Identifier, resultTypeSymbol);
                 var continuationScope = new List<(string Name, GTypeReference Type)>
                 {
                     (SanitizeIdentifier(body.Continuation.Identifier.Text), resultType),
@@ -15000,6 +15055,7 @@ public sealed class CSharpToGSharpTranslator
         {
             var prologue = new List<GStatement>();
             Parameter param = this.BuildScopeParameter(scope, prologue);
+            this.ReportIfIndexOrRangeTypedRangeVariable(let, let.Identifier, this.context.GetTypeInfo(let.Expression).Type);
             GExpression letValue = this.TranslateExpression(let.Expression);
             GTypeReference letType = this.context.GetTypeInfo(let.Expression).Type is { } t
                 ? this.typeMapper.Map(t, this.context, let.GetLocation())
@@ -15031,6 +15087,7 @@ public sealed class CSharpToGSharpTranslator
             GExpression current)
         {
             LambdaExpression collectionSelector = this.BuildScopeLambda(scope, from.Expression);
+            this.ReportIfIndexOrRangeTypedRangeVariable(from, from.Identifier, from.Type, from.Expression);
             GTypeReference newVarType = this.ResolveRangeVariableType(from.Type, from.Expression, from);
             (string Name, GTypeReference Type) newVar = (from.Identifier.Text, newVarType);
             LambdaExpression resultSelector = this.BuildTransparentResultSelector(scope, newVar);
@@ -15053,6 +15110,7 @@ public sealed class CSharpToGSharpTranslator
             GExpression current)
         {
             GExpression inner = this.TranslateExpression(join.InExpression);
+            this.ReportIfIndexOrRangeTypedRangeVariable(join, join.Identifier, join.Type, join.InExpression);
             GTypeReference innerVarType = this.ResolveRangeVariableType(join.Type, join.InExpression, join);
             var innerVar = (Name: join.Identifier.Text, Type: innerVarType);
 
@@ -15075,6 +15133,8 @@ public sealed class CSharpToGSharpTranslator
             // built directly from the already-resolved inner element type.
             // `sequence[T]` is G#'s spelling for `IEnumerable<T>` (see the
             // `GetEnumerableElementType`/array-iteration lowering above).
+            // `into g` is always `IEnumerable<TInner>` (spec §12.19.3.8) — never
+            // Index/Range itself — so no loud-gap check applies here.
             var groupVar = (
                 Name: join.Into.Identifier.Text,
                 Type: (GTypeReference)new NamedTypeReference("sequence", new List<GTypeReference> { innerVarType }));


### PR DESCRIPTION
Fixes #1967

Follow-up hardening from PR #1966 (#1894) Opus review. Two gaps closed:

1. `IsDirectIndexBracketArgument` now recognizes `ImplicitElementAccessSyntax` (dict/collection-initializer element form, `{ [^1] = v }`) as a direct bracket-argument position, so it no longer over-gaps a valid inline from-end index there.
2. Index/Range-typed locals declared via NON-declarator sites now hit the same loud-gap guard as a plain `var`/typed declarator:
   - `foreach (Index i in xs)` and `foreach (var (i, r) in pairs)`
   - `is`/`switch` pattern designations (`x is Index i`, `case Index i:`, switch-expression arms), including the separate loop-condition hoist code path (`while (x is Index i)`)
   - `out Index i` arguments
   - tuple deconstruction (`var (i, r) = ...`, mixed `(x, Index i) = ...`)

All new checks route through one dedup'd helper (`ReportIfIndexOrRangeTypedDesignation`) so a designation reachable from more than one internal helper only reports once.

Added `tools/cs2gs/Cs2Gs.Tests/Issue1967IndexRangeHardeningTests.cs` (9 new tests) covering every site above plus the ImplicitElementAccess no-gap case.

`cs2gs coverage` reports no drift — this hardens existing `Gap`/#1894 classifications, it does not add a new `SyntaxKind`, so the inventory/docs matrix needed no regeneration.

Test results: full `Cs2Gs.Tests` suite — 1031 passed, 0 failed.