### PR TITLE
Fix #2069: named delegate type fails emit as local/field/param type

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -2959,6 +2959,27 @@ internal sealed class OverloadResolver
                 continue;
             }
 
+            // Issue #2069: a func/arrow literal argument flowing into a NAMED
+            // delegate parameter classifies as an implicit conversion (see
+            // Conversion.Classify's FunctionTypeSymbol -> DelegateTypeSymbol
+            // structural-assignability branch) but is otherwise never routed
+            // through BindConversion by the general implicit-conversion
+            // fast path below, which leaves matching-shape arguments
+            // unwrapped. Without an explicit BoundConversionExpression node,
+            // the emitter materialises the literal against its natural
+            // structural shape (System.Action/Func) instead of the named
+            // delegate's own emitted TypeDef, producing unverifiable IL
+            // ("Delegate has no emitted TypeDef" upstream, or a stack-type
+            // mismatch downstream). Force the wrap here, mirroring the tuple/
+            // nullable special cases below.
+            if (parameter.Type is DelegateTypeSymbol namedDelegateCtorTarget
+                && argument.Type is FunctionTypeSymbol
+                && !ReferenceEquals(argument.Type, namedDelegateCtorTarget))
+            {
+                boundArguments[i] = conversions.BindConversion(parameterSyntax[i].Location, argument, parameter.Type);
+                continue;
+            }
+
             if (argument.Type != parameter.Type
                 && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit)
             {
@@ -3342,6 +3363,22 @@ internal sealed class OverloadResolver
             var argLocation = i < parameterSyntax.Length && parameterSyntax[i] != null
                 ? parameterSyntax[i].Location
                 : syntax.Identifier.Location;
+
+            // Issue #2069: force the wrap for a func/arrow literal argument
+            // flowing into a NAMED delegate parameter — see the matching
+            // comment above (constructor-argument path) for the full
+            // rationale. Without it, the general implicit-conversion fast
+            // path below leaves the literal unwrapped and it materialises
+            // against its natural Action/Func shape instead of the named
+            // delegate's own TypeDef.
+            if (paramType is DelegateTypeSymbol namedDelegateParamTarget
+                && argument.Type is FunctionTypeSymbol
+                && !ReferenceEquals(argument.Type, namedDelegateParamTarget))
+            {
+                convertedArguments.Add(conversions.BindConversion(argLocation, argument, paramType));
+                continue;
+            }
+
             if (argument.Type != paramType
                 && !Conversion.Classify(argument.Type, paramType).IsImplicit)
             {
@@ -3739,6 +3776,18 @@ internal sealed class OverloadResolver
                     convertedArgs.Add(argument);
                     continue;
                 }
+            }
+
+            // Issue #2069: force the wrap for a func/arrow literal argument
+            // flowing into a NAMED delegate parameter — see the matching
+            // comment at the constructor-argument path (above in this file)
+            // for the full rationale.
+            if (parameter.Type is DelegateTypeSymbol namedDelegateInitTarget
+                && argument.Type is FunctionTypeSymbol
+                && !ReferenceEquals(argument.Type, namedDelegateInitTarget))
+            {
+                convertedArgs.Add(conversions.BindConversion(argLocation, argument, parameter.Type));
+                continue;
             }
 
             if (argument.Type != parameter.Type
@@ -5286,6 +5335,23 @@ internal sealed class OverloadResolver
             {
                 var tupleLoc = i < parameterSyntax.Length ? parameterSyntax[i].Location : syntax.Identifier.Location;
                 boundArguments[i] = conversions.BindConversion(tupleLoc, argument, expectedType);
+                continue;
+            }
+
+            // Issue #2069: force the wrap for a func/arrow literal argument
+            // flowing into a NAMED delegate parameter — see the matching
+            // comment at the constructor-argument path (above in this file)
+            // for the full rationale. This is the general free-function /
+            // method call-argument path, the one that reproduces the issue's
+            // exact repro (`Apply((n int32) -> ...)` against a `func
+            // Apply(h TickHandler)` parameter).
+            if (expectedType is DelegateTypeSymbol namedDelegateCallTarget
+                && argument.Type is FunctionTypeSymbol
+                && !(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type))
+                && !ReferenceEquals(argument.Type, namedDelegateCallTarget))
+            {
+                var namedDelegateLoc = i < parameterSyntax.Length ? parameterSyntax[i].Location : syntax.Identifier.Location;
+                boundArguments[i] = conversions.BindConversion(namedDelegateLoc, argument, expectedType);
                 continue;
             }
 

--- a/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
@@ -108,7 +108,8 @@ internal sealed class InterpolatedStringHandlerLowerer : NestedFunctionBodyRewri
             program.Structs,
             program.Interfaces,
             program.Enums,
-            program.Globals)
+            program.Globals,
+            program.Delegates)
         {
             Imports = program.Imports,
             FriendAssemblies = program.FriendAssemblies,

--- a/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
@@ -117,7 +117,8 @@ internal sealed class SideEffectSpiller : NestedFunctionBodyRewriter
             program.Structs,
             program.Interfaces,
             program.Enums,
-            program.Globals)
+            program.Globals,
+            program.Delegates)
         {
             Imports = program.Imports,
             FriendAssemblies = program.FriendAssemblies,

--- a/test/Compiler.Tests/Emit/Issue2069NamedDelegateUsageEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2069NamedDelegateUsageEmitTests.cs
@@ -1,0 +1,217 @@
+// <copyright file="Issue2069NamedDelegateUsageEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2069 — a NAMED delegate type (<c>type Name = delegate func(...) ...</c>)
+/// used as the type of a local variable, a class field/auto-property, or a
+/// function parameter crashed emit with <c>InvalidOperationException: Delegate
+/// '...' has no emitted TypeDef</c>.
+/// <para>
+/// Root cause: several lowering passes (<c>InterpolatedStringHandlerLowerer</c>,
+/// <c>SideEffectSpiller</c>) reconstruct a new <see cref="GSharp.Core.CodeAnalysis.Binding.BoundProgram"/>
+/// from a prior one but omitted the <c>Delegates</c> constructor argument,
+/// silently truncating <c>BoundProgram.Delegates</c> to empty (the
+/// convenience overload defaults it when not supplied). The emitter's
+/// named-delegate TypeDef pass iterates exactly that (now-empty) collection,
+/// so any named delegate never got an emitted TypeDef whenever one of those
+/// rewriters ran on the compilation — which happens whenever a statement
+/// needs side-effect spilling (e.g. a property/field assignment used again as
+/// an argument in the same statement), not merely by referencing the type.
+/// The fix threads <c>program.Delegates</c> through both reconstructions,
+/// matching the other two BoundProgram-rebuilding rewriters
+/// (<c>BaseCallForwarderRewriter</c>, <c>CaptureBoxingRewriter</c>) that
+/// already did this correctly.
+/// </para>
+/// Each fact below uses a UNIQUE package name because the in-process type
+/// caches are name-keyed.
+/// </summary>
+public class Issue2069NamedDelegateUsageEmitTests
+{
+    [Fact]
+    public void EndToEnd_NamedDelegate_AsLocalVariableType_Runs()
+    {
+        const string source = """
+            package i2069local
+            import System
+
+            type TickHandler = delegate func(n int32) void
+
+            func Main() {
+                var h TickHandler = (n int32) -> System.Console.WriteLine(n * 2)
+                h(21)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NamedDelegate_AsFieldAndParamType_Runs()
+    {
+        // Reproduces the exact issue #2069 shape: a named-delegate-typed
+        // auto-property assigned via a member-access setter and then reread
+        // as an argument in the SAME statement, which forces the
+        // SideEffectSpiller rewriter to reconstruct BoundProgram.
+        const string source = """
+            package i2069fieldparam
+            import System
+
+            type TickHandler = delegate func(n int32) void
+
+            class C {
+                prop H TickHandler { get; set; }
+            }
+
+            func Apply(h TickHandler) {
+                h(1)
+            }
+
+            func Main() {
+                var c = C()
+                c.H = (n int32) -> System.Console.WriteLine(n + 99)
+                Apply(c.H)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("100\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NamedDelegate_AsPlainFieldType_Runs()
+    {
+        const string source = """
+            package i2069plainfield
+            import System
+
+            type TickHandler = delegate func(n int32) void
+
+            class C {
+                var H TickHandler
+            }
+
+            func Main() {
+                var c = C()
+                c.H = (n int32) -> System.Console.WriteLine(n)
+                c.H(7)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NamedDelegate_AsParameterType_Runs()
+    {
+        const string source = """
+            package i2069param
+            import System
+
+            type TickHandler = delegate func(n int32) void
+
+            func Apply(h TickHandler) {
+                h(5)
+            }
+
+            func Main() {
+                Apply((n int32) -> System.Console.WriteLine(n * 10))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("50\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2069_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2069

## Root cause (two bugs)

**Bug 1 — `BoundProgram.Delegates` silently dropped during lowering.**
`InterpolatedStringHandlerLowerer` and `SideEffectSpiller` each reconstruct a fresh `BoundProgram` from the prior one but omitted the `Delegates` constructor argument. `BoundProgram`'s constructor treats a missing/default `ImmutableArray<T>` as empty, so whenever `SideEffectSpiller` ran (e.g. a property-setter call whose result is reused, `c.H = lambda; Apply(c.H)`) `Program.Delegates` was silently truncated to empty, and the emitter threw `Delegate '...' has no emitted TypeDef` even though the delegate was correctly declared during binding.

**Bug 2 — func/arrow literal call arguments never wrapped in a conversion node for named-delegate parameters.**
`OverloadResolver` has 4 near-duplicate call-argument-binding paths (constructor calls, base-call/chaining-initializer calls, two free-function-call variants). Each skips conversion-wrapping whenever `Conversion.Classify` already reports the argument's implicit conversion — a valid shortcut for real CLR delegates (`Action<T>`/`Func<T>`), whose natural literal materialization already matches the parameter type, but wrong for named (user-declared) delegates, whose natural materialization defaults to `System.Action`/`Func`, not the named delegate's own emitted TypeDef. Without an explicit `BoundConversionExpression`, the existing (and correct) `EmitFunctionToNamedDelegateConversion` dispatch never fired, producing unverifiable IL.

## Fix

1. Thread `program.Delegates` through the two lowering rewriters that omitted it.
2. Force conversion-wrapping in all 4 `OverloadResolver` call-argument paths whenever a `FunctionTypeSymbol` argument targets a `DelegateTypeSymbol` parameter.

## Tests

Added `test/Compiler.Tests/Emit/Issue2069NamedDelegateUsageEmitTests.cs`: 4 end-to-end compile+run tests — named delegate as local variable type, plain field type, field+param combo (exact original repro shape), and parameter type receiving a lambda argument directly.

- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter "FullyQualifiedName~Issue2069"` → 4/4 passed
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` → 5512 passed, 1 skipped, 0 failed
- Broader Compiler.Tests delegate/lambda/Issue1502/Issue889 slice → 205/205 passed

No regressions. All 4 affected `OverloadResolver` call sites fixed (not just the one needed by the failing test) — nothing deferred.
