### PR TITLE
gsc: fix nullable-local delegate snapshot invoke crash (#2066)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -3906,11 +3906,28 @@ internal sealed class OverloadResolver
     /// </description></item>
     /// </list>
     /// </summary>
+    /// <param name="syntax">The call-expression syntax.</param>
+    /// <param name="variable">The callee variable.</param>
+    /// <param name="fnType">The delegate's equivalent function-type shape.</param>
+    /// <param name="args">The already-bound, already-converted call arguments.</param>
+    /// <param name="targetNarrowedType">
+    /// Issue #2066: when the callee variable's declared type is nullable and
+    /// an active smart-cast frame has narrowed it (the direct-call binders
+    /// only reach this helper once a narrowed non-nullable delegate/function
+    /// shape has been matched), the concrete narrowed type to report from the
+    /// synthesized target read's <see cref="BoundExpression.Type"/> — for
+    /// example the actual <see cref="DelegateTypeSymbol"/> for a named
+    /// delegate, so downstream emit's delegate-shape dispatch (<see
+    /// cref="Emit.MethodBodyEmitter.EmitIndirectCall"/>) sees the narrowed
+    /// shape rather than the raw nullable declared type. <c>null</c> when the
+    /// variable's declared type is already non-nullable.
+    /// </param>
     private BoundExpression BuildIndirectDelegateCall(
         CallExpressionSyntax syntax,
         VariableSymbol variable,
         FunctionTypeSymbol fnType,
-        ImmutableArray<BoundExpression> args)
+        ImmutableArray<BoundExpression> args,
+        TypeSymbol targetNarrowedType = null)
     {
         if (variable is ImplicitFieldVariableSymbol implicitField)
         {
@@ -3938,7 +3955,7 @@ internal sealed class OverloadResolver
             return new BoundIndirectCallExpression(null, memberLoad, fnType, args);
         }
 
-        return new BoundIndirectCallExpression(null, new BoundVariableExpression(null, variable), fnType, args);
+        return new BoundIndirectCallExpression(null, new BoundVariableExpression(null, variable, targetNarrowedType), fnType, args);
     }
 
     /// <summary>
@@ -3954,6 +3971,41 @@ internal sealed class OverloadResolver
             new BoundVariableExpression(null, implicitField.Receiver),
             implicitField.StructType,
             implicitField.Field);
+
+    /// <summary>
+    /// Issue #2066: resolves the effective (smart-cast-narrowed) type to use
+    /// when binding direct call syntax <c>f(args)</c> on a variable. A
+    /// nil-guarded nullable-local delegate (<c>let f T? = ...; if f != nil {
+    /// f(args) }</c>) narrows to its non-nullable underlying delegate/function
+    /// type inside the guarded scope (Phase 3.C.4 smart-cast), but the
+    /// direct-call binders below dispatch by matching <see
+    /// cref="VariableSymbol.Type"/> against the concrete (non-nullable)
+    /// delegate shape (<see cref="FunctionTypeSymbol"/>, <see
+    /// cref="DelegateTypeSymbol"/>, or an imported CLR delegate <c>Type</c>).
+    /// Without consulting the active narrowing frame, the raw nullable
+    /// declared type never matches any of those shapes and the call falls
+    /// through to <see cref="DiagnosticBag.ReportNotAFunction"/> — this walks
+    /// the same <see cref="BinderContext.NarrowedVariables"/> stack <see
+    /// cref="ExpressionBinder"/> uses for ordinary reads, so a guarded
+    /// snapshot invokes exactly like the unwrapped field/variable would.
+    /// </summary>
+    private TypeSymbol GetNarrowedCallableType(VariableSymbol variable)
+    {
+        if (variable.Type is not NullableTypeSymbol)
+        {
+            return variable.Type;
+        }
+
+        for (var i = binderCtx.NarrowedVariables.Count - 1; i >= 0; i--)
+        {
+            if (binderCtx.NarrowedVariables[i].TryGetValue(variable, out var narrowed))
+            {
+                return narrowed;
+            }
+        }
+
+        return variable.Type;
+    }
 
     private bool TryBindNullableDelegateInvocation(
         VariableSymbol variable,
@@ -4628,7 +4680,7 @@ internal sealed class OverloadResolver
         // Phase 4.7: invoking a function-typed variable goes through the
         // indirect-call path. Sites like `add(1, 2)` where `add` is `let
         // add func(int, int) int = ...` reduce to BoundIndirectCallExpression.
-        if (symbol is VariableSymbol variable && variable.Type is FunctionTypeSymbol fnType)
+        if (symbol is VariableSymbol variable && GetNarrowedCallableType(variable) is FunctionTypeSymbol fnType)
         {
             // Issue #343: indirect calls through a function-typed variable have
             // no preserved parameter names; named arguments are not allowed.
@@ -4691,13 +4743,14 @@ internal sealed class OverloadResolver
                 convertedArgs.Add(conversions.BindConversion(argLoc, fnPermutedArgs[i], fnType.ParameterTypes[i]));
             }
 
-            return BuildIndirectDelegateCall(syntax, variable, fnType, convertedArgs.MoveToImmutable());
+            var fnTargetNarrowedType = variable.Type is NullableTypeSymbol ? (TypeSymbol)fnType : null;
+            return BuildIndirectDelegateCall(syntax, variable, fnType, convertedArgs.MoveToImmutable(), fnTargetNarrowedType);
         }
 
         // ADR-0059 / issue #255: direct call syntax `h(args)` on a variable
         // of a user-declared named delegate type. Mirrors the CLR-delegate
         // branch below — both end up dispatching through Invoke.
-        if (symbol is VariableSymbol namedDelegateVar && namedDelegateVar.Type is DelegateTypeSymbol namedDelegateSym)
+        if (symbol is VariableSymbol namedDelegateVar && GetNarrowedCallableType(namedDelegateVar) is DelegateTypeSymbol namedDelegateSym)
         {
             // Issue #343: named-delegate Invoke parameter names live on the
             // delegate-type symbol; they are not surfaced to the call site.
@@ -4764,7 +4817,8 @@ internal sealed class OverloadResolver
                 convertedNamedArgs.Add(conversions.BindConversion(argLoc, ndPermutedArgs[i], namedDelegateSym.Parameters[i].Type));
             }
 
-            return BuildIndirectDelegateCall(syntax, namedDelegateVar, namedDelegateSym.EquivalentFunctionType, convertedNamedArgs.MoveToImmutable());
+            var ndTargetNarrowedType = namedDelegateVar.Type is NullableTypeSymbol ? (TypeSymbol)namedDelegateSym : null;
+            return BuildIndirectDelegateCall(syntax, namedDelegateVar, namedDelegateSym.EquivalentFunctionType, convertedNamedArgs.MoveToImmutable(), ndTargetNarrowedType);
         }
 
         // #325: a variable whose type is a CLR delegate (e.g. `Func[int32,

--- a/test/Compiler.Tests/Emit/Issue2066NullableDelegateSnapshotEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2066NullableDelegateSnapshotEmitTests.cs
@@ -1,0 +1,209 @@
+// <copyright file="Issue2066NullableDelegateSnapshotEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2066 — a nullable local of a delegate type, null-guarded and then
+/// invoked with direct call syntax (<c>snapshot(args)</c>, no <c>?</c> on the
+/// call), crashed at bind time with <c>GS0131 'snapshot' is not a
+/// function</c>. Nil-guard smart-cast narrowing (Phase 3.C.4) records that
+/// <c>snapshot</c> is non-nullable inside the guarded scope, but the
+/// direct-call binders in <c>OverloadResolver</c> matched only the raw
+/// (nullable) declared type against the concrete delegate/function-type
+/// shapes, so the narrowed-non-null case never matched and fell through to
+/// the "not a function" diagnostic.
+/// <para>
+/// The fix threads the active smart-cast narrowing frame into the direct-call
+/// dispatch so it observes the narrowed (non-nullable) delegate shape,
+/// exactly as an ordinary narrowed variable read already does — covering
+/// both a user-declared named delegate type (<c>type T = delegate func(...)
+/// ...</c>) and a native function-typed local (<c>(T) -&gt; R</c>), any
+/// arity, and both <c>void</c> and non-<c>void</c> return types.
+/// </para>
+/// Each test uses a UNIQUE package/type name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed.
+/// <para>
+/// Note: the first test raises the delegate via a plain public field (not a
+/// field-like <c>event</c>) — a field-like event of a user-declared named
+/// delegate type has a separate, unrelated accessor-emission bug (filed as
+/// issue #2085) that fails ilverify regardless of how (or whether) it is
+/// ever assigned, independent of the narrowing/invoke fix under test here.
+/// </para>
+/// </summary>
+public class Issue2066NullableDelegateSnapshotEmitTests
+{
+    [Fact]
+    public void NamedDelegate_NullableLocalSnapshot_VoidReturn_Runs()
+    {
+        const string source = """
+            package i2066namedvoid
+            import System
+
+            type TickHandler = delegate func(count int32) void
+
+            class Clock
+            {
+                public var Ticked TickHandler
+
+                func Fire(count int32)
+                {
+                    let snapshot TickHandler? = this.Ticked
+                    if snapshot != nil
+                    {
+                        snapshot(count)
+                    }
+                }
+            }
+
+            func OnTick(count int32) void
+            {
+                System.Console.WriteLine(count)
+            }
+
+            func Main()
+            {
+                let c = Clock()
+                c.Ticked = OnTick
+                c.Fire(5)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n", output);
+    }
+
+    [Fact]
+    public void NamedDelegate_NullableLocalSnapshot_NonVoidReturn_Runs()
+    {
+        const string source = """
+            package i2066namedret
+            import System
+
+            type Adder = delegate func(a int32, b int32) int32
+
+            func Main()
+            {
+                let concrete Adder = (a int32, b int32) -> a + b
+                let snapshot Adder? = concrete
+                if snapshot != nil
+                {
+                    System.Console.WriteLine(snapshot(3, 4))
+                }
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void FunctionTypedLocal_NullableSnapshot_Runs()
+    {
+        const string source = """
+            package i2066functype
+            import System
+
+            func Main()
+            {
+                let f ((int32) -> int32)? = (x int32) -> x * 2
+                if f != nil
+                {
+                    System.Console.WriteLine(f(21))
+                }
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2066_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2066

A nil-guarded nullable local of a delegate type (a named delegate type declared with `type T = delegate func(...) ...`, or a native function-typed local `(T) -> R`) failed to bind when invoked with direct call syntax after the guard (`if snapshot != nil { snapshot(x) }`), reporting `GS0131 'snapshot is not a function'` at compile time.

**Root cause:** the direct-call binders in `OverloadResolver` dispatch by pattern-matching the callee `VariableSymbol`'s declared `Type` against the concrete (non-nullable) `FunctionTypeSymbol`/`DelegateTypeSymbol`/CLR-delegate shapes. Nil-guard smart-cast narrowing (Phase 3.C.4) records that the variable is non-nullable inside the guarded scope, but that narrowing frame was consulted only by ordinary variable-read binding (`ExpressionBinder`), not by these call-site dispatch checks, so a narrowed nullable-delegate local's declared (nullable) type never matched any of the concrete shapes and fell through to the 'not a function' diagnostic.

**Fix:** add `OverloadResolver.GetNarrowedCallableType`, mirroring `ExpressionBinder`'s narrowed-type lookup over the active `BinderContext.NarrowedVariables` frames, and consult it in the `FunctionTypeSymbol` and `DelegateTypeSymbol` direct-call dispatch checks. Thread the narrowed (non-nullable) type through to the synthesized callee read (`BoundVariableExpression`'s `narrowedType` parameter) so downstream emit's delegate-shape dispatch (`MethodBodyEmitter.EmitIndirectCall`) also observes the narrowed shape instead of the raw nullable declared type. Generalizes to any nullable-local delegate type, arity, and return type (void or non-void).

**Tests:** added `Issue2066NullableDelegateSnapshotEmitTests` covering a user-declared named delegate type (void and non-void return) and a native function-typed local — all compile, ilverify, and run correctly end to end.

**Out of scope (filed separately):** while investigating, found two separate, unrelated, pre-existing gsc bugs and filed them rather than fixing here:
- #2082: assigning an inline lambda/func-literal to a named-delegate-typed event via `+=` erases to a CLR Action/Func closure instead of the named delegate type.
- #2085: a field-like event of a named delegate type emits invalid add_/remove_ accessor IL regardless of assignment.

Note: there is a concurrent PR #2079 from another agent also targeting #2066; this PR was produced per an independent task assignment on branch `fix/2066-nullable-delegate-snapshot`.