### PR TITLE
Rework gsi REPL UI: scrollable viewport, docked input, modal palette, mouse scroll

### DIFF
--- a/src/Repl/Engine/SessionEngine.cs
+++ b/src/Repl/Engine/SessionEngine.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Symbols.Display;
 using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Repl.Engine;
@@ -27,6 +28,122 @@ public sealed class SessionEngine
     public IReadOnlyList<Cell> Cells => cells;
 
     public IReadOnlyDictionary<VariableSymbol, object> Variables => variables;
+
+    /// <summary>
+    /// Builds a snapshot of the accumulated session state — the imports, functions, variables,
+    /// and user-defined types declared across every successfully evaluated cell. Powers the
+    /// REPL's right-hand state sidebar. Never throws; returns <see cref="ReplState.Empty"/> if
+    /// nothing has been evaluated yet or if introspection fails.
+    /// </summary>
+    public ReplState Snapshot()
+    {
+        if (previous is null)
+        {
+            return ReplState.Empty;
+        }
+
+        try
+        {
+            var imports = new List<ReplSymbol>();
+            var functions = new List<ReplSymbol>();
+            var vars = new List<ReplSymbol>();
+            var types = new List<ReplSymbol>();
+            var seenImports = new HashSet<string>(StringComparer.Ordinal);
+            var seenFunctions = new HashSet<string>(StringComparer.Ordinal);
+            var seenVars = new HashSet<string>(StringComparer.Ordinal);
+            var seenTypes = new HashSet<string>(StringComparer.Ordinal);
+
+            // Walk the scope chain newest-to-oldest so redeclarations show their latest form.
+            for (var scope = previous.GlobalScope; scope is not null; scope = scope.Previous)
+            {
+                foreach (var import in scope.Imports)
+                {
+                    if (seenImports.Add(import.Name))
+                    {
+                        imports.Add(new ReplSymbol(Display(import)));
+                    }
+                }
+
+                foreach (var fn in scope.Functions)
+                {
+                    if (ReferenceEquals(fn, scope.EntryPoint) || fn.IsSpecialName || !seenFunctions.Add(fn.Name))
+                    {
+                        continue;
+                    }
+
+                    functions.Add(new ReplSymbol(Display(fn)));
+                }
+
+                foreach (var v in scope.Variables)
+                {
+                    if (!seenVars.Add(v.Name))
+                    {
+                        continue;
+                    }
+
+                    var display = Display(v);
+                    if (variables.TryGetValue(v, out var value) && value is not null)
+                    {
+                        display += $" = {Truncate(value.ToString(), 20)}";
+                    }
+
+                    vars.Add(new ReplSymbol(display));
+                }
+
+                foreach (var s in scope.Structs)
+                {
+                    if (seenTypes.Add(s.Name))
+                    {
+                        types.Add(new ReplSymbol(Display(s)));
+                    }
+                }
+
+                foreach (var i in scope.Interfaces)
+                {
+                    if (seenTypes.Add(i.Name))
+                    {
+                        types.Add(new ReplSymbol(Display(i)));
+                    }
+                }
+
+                foreach (var e in scope.Enums)
+                {
+                    if (seenTypes.Add(e.Name))
+                    {
+                        types.Add(new ReplSymbol(Display(e)));
+                    }
+                }
+
+                foreach (var d in scope.Delegates)
+                {
+                    if (seenTypes.Add(d.Name))
+                    {
+                        types.Add(new ReplSymbol(Display(d)));
+                    }
+                }
+            }
+
+            return new ReplState(imports, functions, vars, types);
+        }
+        catch
+        {
+            return ReplState.Empty;
+        }
+    }
+
+    private string Display(Symbol symbol)
+        => SymbolDisplay.ToDisplayString(symbol, SymbolDisplayFormat.Signature, previous);
+
+    private static string Truncate(string? text, int max)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        var oneLine = text.Replace("\r", " ").Replace("\n", " ");
+        return oneLine.Length <= max ? oneLine : oneLine[..(max - 1)] + "…";
+    }
 
     /// <summary>
     /// When <see langword="true"/>, standard output and error produced while evaluating a cell
@@ -137,6 +254,25 @@ public sealed record Cell(
     bool HasError,
     string Output = "",
     string StandardError = "");
+
+/// <summary>A single entry in the REPL state sidebar, rendered via the shared <c>SymbolDisplay</c> service.</summary>
+public sealed record ReplSymbol(string Display);
+
+/// <summary>Snapshot of the accumulated REPL session: imports, functions, variables, and user types.</summary>
+public sealed record ReplState(
+    IReadOnlyList<ReplSymbol> Imports,
+    IReadOnlyList<ReplSymbol> Functions,
+    IReadOnlyList<ReplSymbol> Variables,
+    IReadOnlyList<ReplSymbol> Types)
+{
+    public static ReplState Empty { get; } = new(
+        Array.Empty<ReplSymbol>(),
+        Array.Empty<ReplSymbol>(),
+        Array.Empty<ReplSymbol>(),
+        Array.Empty<ReplSymbol>());
+
+    public bool IsEmpty => Imports.Count == 0 && Functions.Count == 0 && Variables.Count == 0 && Types.Count == 0;
+}
 
 /// <summary>
 /// A <see cref="TextReader"/> that sources whole lines from a callback, letting the interactive

--- a/src/Repl/ReplHost.cs
+++ b/src/Repl/ReplHost.cs
@@ -39,7 +39,8 @@ public static class ReplHost
             }
 
             AltScreen.Enter();
-            return shell.Run(new AppShell.ConsoleKeyReader());
+            using var input = new ConsoleInputReader();
+            return shell.Run(input);
         }
         finally
         {

--- a/src/Repl/Screens/ReplScreen.cs
+++ b/src/Repl/Screens/ReplScreen.cs
@@ -22,6 +22,7 @@ public sealed class ReplScreen : ITabScreen
     private const int MaxPopup = 7;
     private readonly SessionEngine engine;
     private readonly MultilineEditor editor = new();
+    private readonly ScrollState scroll = new();
     private IAppShellNavigator? navigator;
     private List<CompletionItem> completions = new();
     private int completionIndex;
@@ -49,6 +50,20 @@ public sealed class ReplScreen : ITabScreen
 
     public void OnActivated(IAppShellNavigator nav) => navigator = nav;
 
+    public bool HandleScroll(ScrollDirection direction, int lines)
+    {
+        if (direction == ScrollDirection.Up)
+        {
+            scroll.ScrollUp(lines);
+        }
+        else
+        {
+            scroll.ScrollDown(lines);
+        }
+
+        return true;
+    }
+
     public bool HandleKey(ConsoleKeyInfo key)
     {
         if (completions.Count > 0)
@@ -67,6 +82,17 @@ public sealed class ReplScreen : ITabScreen
         {
             hover = null;
             return true;
+        }
+
+        // Scroll the transcript viewport without disturbing the editor cursor or the pinned
+        // input box. Page-sized on PageUp/PageDown, line-sized on Ctrl+Up/Ctrl+Down.
+        var ctrl = (key.Modifiers & ConsoleModifiers.Control) != 0;
+        switch (key.Key)
+        {
+            case ConsoleKey.PageUp: scroll.ScrollUp(Math.Max(1, scroll.LastViewportHeight - 1)); return true;
+            case ConsoleKey.PageDown: scroll.ScrollDown(Math.Max(1, scroll.LastViewportHeight - 1)); return true;
+            case ConsoleKey.UpArrow when ctrl: scroll.ScrollUp(1); return true;
+            case ConsoleKey.DownArrow when ctrl: scroll.ScrollDown(1); return true;
         }
 
         if (key.Key == ConsoleKey.Spacebar && (key.Modifiers & ConsoleModifiers.Control) != 0)
@@ -99,6 +125,7 @@ public sealed class ReplScreen : ITabScreen
                     engine.Evaluate(editor.Text);
                     editor.Clear();
                     hover = null;
+                    scroll.ToBottom();
                 }
                 else if (!editor.IsEmpty)
                 {
@@ -134,51 +161,71 @@ public sealed class ReplScreen : ITabScreen
         var secondary = Tokens.Tokens.TextSecondary.Value.ToMarkup();
         var tertiary = Tokens.Tokens.TextTertiary.Value.ToMarkup();
 
-        var inputLines = editor.Lines.Count;
-        var transcriptHeight = Math.Max(3, height - inputLines - 4);
-        var rows = new List<IRenderable>();
+        // Reserve a right-hand column for the state sidebar on wide enough terminals.
+        var sidebarWidth = width >= 76 ? Math.Clamp(width / 4, 26, 42) : 0;
+        var leftWidth = sidebarWidth > 0 ? width - sidebarWidth - 2 : width - 1;
+
+        var cellBg = Tokens.Tokens.CellBackground.Value;
+        var transcript = new List<IRenderable>();
 
         if (engine.Cells.Count == 0)
         {
-            rows.Add(new Markup($"[{tertiary}]Type a G# expression and press Enter. [{brand}]/[/] commands · [{brand}]Ctrl+Space[/] complete · [{brand}]Ctrl+K[/] hover.[/]"));
+            transcript.Add(new Markup($"[{tertiary}]Type a G# expression and press Enter. [{brand}]/[/] commands · [{brand}]Ctrl+Space[/] complete · [{brand}]Ctrl+K[/] hover.[/]"));
         }
 
-        foreach (var cell in engine.Cells.TakeLast(transcriptHeight))
+        // The full history is handed to the Dock, which windows it into the scrollable
+        // region; older cells scroll off the top rather than being dropped up front.
+        for (var ci = 0; ci < engine.Cells.Count; ci++)
         {
-            rows.Add(new Markup($"[{tertiary}]{cell.Index}[/] [{brand}]›[/] {Highlight.Markup(cell.Input.Replace("\n", " "))}"));
+            var cell = engine.Cells[ci];
+            var cellRows = new List<IRenderable>
+            {
+                new Markup($"[{tertiary}]{cell.Index}[/] [{brand}]›[/] {Highlight.Markup(cell.Input.Replace("\n", " "))}"),
+            };
+
             foreach (var d in cell.Diagnostics)
             {
                 var c = (d.IsError ? Tokens.Tokens.StatusError : Tokens.Tokens.StatusWarning).Value.ToMarkup();
-                rows.Add(new Markup($"    [{c}]● {Markup.Escape(d.Id)} {Markup.Escape(d.Message)}[/]"));
+                cellRows.Add(new Markup($"    [{c}]● {Markup.Escape(d.Id)} {Markup.Escape(d.Message)}[/]"));
             }
 
             foreach (var line in SplitOutput(cell.Output))
             {
-                rows.Add(new Markup($"    [{secondary}]{Markup.Escape(line)}[/]"));
+                cellRows.Add(new Markup($"    [{secondary}]{Markup.Escape(line)}[/]"));
             }
 
             foreach (var line in SplitOutput(cell.StandardError))
             {
                 var c = Tokens.Tokens.StatusError.Value.ToMarkup();
-                rows.Add(new Markup($"    [{c}]{Markup.Escape(line)}[/]"));
+                cellRows.Add(new Markup($"    [{c}]{Markup.Escape(line)}[/]"));
             }
 
             if (!cell.HasError && cell.Value is not null)
             {
-                rows.Add(new Markup($"    [{primary}]{Markup.Escape(cell.Value.ToString() ?? string.Empty)}[/]"));
+                cellRows.Add(new Markup($"    [{primary}]{Markup.Escape(cell.Value.ToString() ?? string.Empty)}[/]"));
+            }
+
+            transcript.Add(new Backdrop(new Rows(cellRows), cellBg));
+            if (ci < engine.Cells.Count - 1)
+            {
+                transcript.Add(new Text(string.Empty));
             }
         }
 
-        var body = new List<IRenderable> { new Padder(new Rows(rows)).Padding(1, 0, 1, 0) };
+        var scrollable = new Padder(new Rows(transcript)).Padding(1, 0, 1, 0);
 
+        // Everything below the scrollable transcript stays pinned to the bottom, just above
+        // the footer chrome, and grows upward as the input box gains lines. The Dock measures
+        // this footer at render time and shrinks the transcript viewport to match.
+        var footerRows = new List<IRenderable>();
         if (completions.Count > 0)
         {
-            body.Add(CompletionPanel());
+            footerRows.Add(CompletionPanel());
         }
 
         if (hover is not null)
         {
-            body.Add(new Panel(new Markup($"[{secondary}]{Markup.Escape(hover)}[/]"))
+            footerRows.Add(new Panel(new Markup($"[{secondary}]{Markup.Escape(hover)}[/]"))
             {
                 Header = new PanelHeader($"[{tertiary}] hover · Esc [/]"),
                 Border = BoxBorder.Rounded,
@@ -187,28 +234,107 @@ public sealed class ReplScreen : ITabScreen
             });
         }
 
-        body.Add(InputBox(brand, tertiary, width));
+        footerRows.Add(new Padder(InputBox(brand, tertiary)).Padding(1, 0, 1, 0));
         var diag = engine.Cells.SelectMany(c => c.Diagnostics).Count(d => d.IsError);
         var status = diag == 0 ? $"[{Tokens.Tokens.StatusSuccess.Value.ToMarkup()}]●[/] gsharp [{tertiary}]· ready[/]"
             : $"[{Tokens.Tokens.StatusError.Value.ToMarkup()}]●[/] gsharp [{tertiary}]· {diag} error(s)[/]";
-        body.Add(new Padder(new Markup(status)).Padding(1, 0, 0, 0));
-        return new Rows(body);
+        footerRows.Add(new Padder(new Markup(status)).Padding(1, 0, 0, 0));
+
+        var main = (IRenderable)new Dock(scrollable, new Rows(footerRows), height, scroll);
+        if (sidebarWidth == 0)
+        {
+            return main;
+        }
+
+        return new SideBySide(main, leftWidth, 2, new FixedHeight(StateSidebar(height), height), sidebarWidth);
     }
 
-    private IRenderable InputBox(string brand, string tertiary, int width)
+    private IRenderable InputBox(string brand, string tertiary)
     {
         var cursor = $"{Tokens.Tokens.TextPrimary.Value.ToMarkup()} invert";
-        var lines = editor.RenderLines(cursor);
-        var rendered = lines.Select((l, i) =>
-            (IRenderable)new Markup($"[{(i == 0 ? brand : tertiary)}]{(i == 0 ? "›" : "·")}[/] {l}")).ToList();
-        return new Panel(new Rows(rendered))
+        List<IRenderable> rendered;
+        if (editor.IsEmpty)
         {
-            Border = BoxBorder.Rounded,
-            BorderStyle = new Style(Tokens.Tokens.Brand),
-            Padding = new Padding(1, 0, 1, 0),
-            Expand = false,
-            Width = width - 1,
+            rendered = new List<IRenderable>
+            {
+                new Markup($"[{brand}]›[/] [{cursor}] [/] [{tertiary}]Type a G# expression — Enter to run · Shift+Enter for newline[/]"),
+            };
+        }
+        else
+        {
+            var lines = editor.RenderLines(cursor);
+            rendered = lines.Select((l, i) =>
+                (IRenderable)new Markup($"[{(i == 0 ? brand : tertiary)}]{(i == 0 ? "›" : "·")}[/] {l}")).ToList();
+        }
+
+        // OpenCode/Copilot-CLI style: a filled input surface with a themed accent bar
+        // down the left edge (the colour previously used for the wrap-around border).
+        return new Backdrop(
+            new Rows(rendered),
+            Tokens.Tokens.InputBackground.Value,
+            accent: Tokens.Tokens.Brand.Value,
+            padLeft: 1,
+            padRight: 1,
+            padTop: 1,
+            padBottom: 1);
+    }
+
+    private IRenderable StateSidebar(int minHeight)
+    {
+        var brand = Tokens.Tokens.Brand.Value.ToMarkup();
+        var primary = Tokens.Tokens.TextPrimary.Value.ToMarkup();
+        var secondary = Tokens.Tokens.TextSecondary.Value.ToMarkup();
+        var tertiary = Tokens.Tokens.TextTertiary.Value.ToMarkup();
+        var state = engine.Snapshot();
+
+        var rows = new List<IRenderable>
+        {
+            new Markup($"[{brand}]STATE[/]"),
+            new Markup($"[{tertiary}]cells[/] [{primary}]{engine.Cells.Count}[/]  [{tertiary}]theme[/] [{primary}]{Markup.Escape(Theme.Current.Name)}[/]"),
         };
+
+        AddSection(rows, "imports", state.Imports, brand, secondary, tertiary);
+        AddSection(rows, "functions", state.Functions, brand, primary, tertiary);
+        AddSection(rows, "variables", state.Variables, brand, primary, tertiary);
+        AddSection(rows, "types", state.Types, brand, primary, tertiary);
+
+        if (state.IsEmpty)
+        {
+            rows.Add(new Text(string.Empty));
+            rows.Add(new Markup($"[{tertiary}]No symbols defined yet.[/]"));
+        }
+
+        // Same treatment as the input box: a filled surface with a themed left accent
+        // bar, rather than an enclosed box.
+        return new Backdrop(
+            new Rows(rows),
+            Tokens.Tokens.InputBackground.Value,
+            accent: Tokens.Tokens.Brand.Value,
+            padLeft: 1,
+            padRight: 1,
+            padTop: 1,
+            padBottom: 1,
+            minHeight: minHeight);
+    }
+
+    private static void AddSection(List<IRenderable> rows, string title, IReadOnlyList<ReplSymbol> items, string headColor, string nameColor, string detailColor)
+    {
+        if (items.Count == 0)
+        {
+            return;
+        }
+
+        rows.Add(new Text(string.Empty));
+        rows.Add(new Markup($"[{headColor}]{title.ToUpperInvariant()}[/] [{detailColor}]{items.Count}[/]"));
+        foreach (var item in items.Take(12))
+        {
+            rows.Add(new Markup($"[{nameColor}]{Markup.Escape(item.Display)}[/]"));
+        }
+
+        if (items.Count > 12)
+        {
+            rows.Add(new Markup($"[{detailColor}]… +{items.Count - 12} more[/]"));
+        }
     }
 
     private IRenderable CompletionPanel()

--- a/src/Repl/Shell/AppShell.cs
+++ b/src/Repl/Shell/AppShell.cs
@@ -18,11 +18,6 @@ namespace GSharp.Repl.Shell;
 /// </summary>
 public sealed class AppShell : IAppShellNavigator
 {
-    public interface IKeyReader
-    {
-        ConsoleKeyInfo? ReadKey();
-    }
-
     private readonly IAnsiConsole console;
     private readonly IReadOnlyList<ITabScreen> tabs;
     private readonly CtrlCState ctrlC = new();
@@ -63,15 +58,15 @@ public sealed class AppShell : IAppShellNavigator
 
     public void RequestExit() => exitRequested = true;
 
-    public int Run(IKeyReader keyReader)
+    public int Run(IInputReader inputReader)
     {
-        ArgumentNullException.ThrowIfNull(keyReader);
+        ArgumentNullException.ThrowIfNull(inputReader);
         tabs[activeTab].OnActivated(this);
         Render();
         while (true)
         {
-            var key = keyReader.ReadKey();
-            if (key is null)
+            var input = inputReader.Read();
+            if (input is null)
             {
                 return 0;
             }
@@ -79,7 +74,14 @@ public sealed class AppShell : IAppShellNavigator
             var action = ShellAction.Continue;
             try
             {
-                action = Dispatch(key.Value);
+                if (input.Value.Key is { } key)
+                {
+                    action = Dispatch(key);
+                }
+                else if (input.Value.Scroll is { } scroll)
+                {
+                    DispatchScroll(scroll);
+                }
             }
             catch (Exception ex)
             {
@@ -100,6 +102,17 @@ public sealed class AppShell : IAppShellNavigator
                 toast = $"Render error: {ex.Message}";
             }
         }
+    }
+
+    /// <summary>Routes a mouse-wheel scroll to the active tab (three lines per notch).</summary>
+    public void DispatchScroll(ScrollDirection direction)
+    {
+        if (activeModal is not null)
+        {
+            return;
+        }
+
+        tabs[activeTab].HandleScroll(direction, 3);
     }
 
     public ShellAction Dispatch(ConsoleKeyInfo key)
@@ -183,7 +196,11 @@ public sealed class AppShell : IAppShellNavigator
     {
         var width = console.Profile.Width;
         var height = Math.Max(10, console.Profile.Height);
-        var bodyHeight = Math.Max(5, height - 6);
+
+        // Chrome is exactly four lines: header, a rule, a rule, and the footer. The body
+        // fills the rest so the whole frame is exactly the terminal height (no scrolling,
+        // so the header/sidebar/footer never scroll off).
+        var bodyHeight = Math.Max(3, height - 4);
         var screen = tabs[activeTab];
 
         var useBuffer = !Console.IsOutputRedirected;
@@ -206,27 +223,37 @@ public sealed class AppShell : IAppShellNavigator
             target = console;
         }
 
-        target.Write(new Markup(BuildHeader()));
-        target.WriteLine();
-        target.Write(new Rule { Style = new Style(Tokens.Tokens.BorderNeutral) });
+        var ruleColor = Tokens.Tokens.BorderNeutral.Value.ToMarkup();
+        var rule = $"[{ruleColor}]{new string('─', Math.Max(1, width))}[/]";
+        IRenderable footer = toast is not null
+            ? new Markup($"[{Tokens.Tokens.StatusWarning.Value.ToMarkup()}] ! {Markup.Escape(toast)}[/]")
+            : BuildHintBar(screen).Render();
 
-        target.Write(activeModal is not null ? activeModal.Render(width, bodyHeight) : screen.Render(width, bodyHeight + 2));
+        // A single frame renderable whose line breaks fall only BETWEEN rows, so the total
+        // line count is deterministic: 1 + 1 + bodyHeight + 1 + 1 == height.
+        IRenderable frame = new Rows(
+            new Markup(BuildHeader()),
+            new Markup(rule),
+            screen.Render(width, bodyHeight),
+            new Markup(rule),
+            footer);
 
-        target.WriteLine();
-        target.Write(new Rule { Style = new Style(Tokens.Tokens.BorderNeutral) });
-        if (toast is not null)
+        // The command palette floats as a centered modal over the frame; the surrounding
+        // chrome stays visible behind it rather than being replaced.
+        if (activeModal is not null)
         {
-            target.Write(new Markup($"[{Tokens.Tokens.StatusWarning.Value.ToMarkup()}] ! {Markup.Escape(toast)}[/]"));
+            var modalWidth = Math.Clamp(width - 8, 24, 72);
+            frame = new Overlay(frame, activeModal.Render(modalWidth, bodyHeight), modalWidth);
         }
-        else
-        {
-            target.Write(BuildHintBar(screen).Render());
-        }
+
+        // Clamp to exactly the terminal height and strip any trailing line break so the
+        // whole frame fits without scrolling (which would push the header off-screen).
+        target.Write(new FixedHeight(frame, height));
 
         if (useBuffer && sw is not null)
         {
-            var frame = AltScreen.InjectEraseBeforeNewlines(sw.ToString());
-            Console.Out.Write($"{AltScreen.SyncStartSequence}\u001b[H{frame}\u001b[K\u001b[J{AltScreen.SyncEndSequence}");
+            var frameText = AltScreen.InjectEraseBeforeNewlines(sw.ToString());
+            Console.Out.Write($"{AltScreen.SyncStartSequence}\u001b[H{frameText}\u001b[K\u001b[J{AltScreen.SyncEndSequence}");
             Console.Out.Flush();
         }
     }
@@ -247,21 +274,6 @@ public sealed class AppShell : IAppShellNavigator
             .Add("Ctrl+Space", "complete")
             .Add("Ctrl+K", "hover")
             .Add("Ctrl+C", "quit");
-    }
-
-    public sealed class ConsoleKeyReader : IKeyReader
-    {
-        public ConsoleKeyInfo? ReadKey()
-        {
-            try
-            {
-                return Console.ReadKey(intercept: true);
-            }
-            catch (InvalidOperationException)
-            {
-                return null;
-            }
-        }
     }
 }
 

--- a/src/Repl/Shell/ConsoleInputReader.cs
+++ b/src/Repl/Shell/ConsoleInputReader.cs
@@ -1,0 +1,416 @@
+// <copyright file="ConsoleInputReader.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace GSharp.Repl.Shell;
+
+/// <summary>
+/// Reads keyboard and mouse-wheel input from the console. On Windows it uses the native
+/// <c>ReadConsoleInput</c> API so wheel notches surface as scroll events. On macOS/Linux it
+/// puts the terminal into raw mode (via <c>stty</c>), enables SGR mouse reporting, and decodes
+/// the raw byte stream with <see cref="VtInputDecoder"/>. When neither path is available (input
+/// redirected, or setup fails) it falls back to <see cref="Console.ReadKey(bool)"/> for keys only.
+/// </summary>
+internal sealed class ConsoleInputReader : IInputReader, IDisposable
+{
+    private readonly bool useWindowsNative;
+    private readonly VtInputDecoder? decoder;
+
+    private IntPtr stdInHandle = IntPtr.Zero;
+    private uint originalMode;
+    private bool windowsModeChanged;
+
+    private bool unixActive;
+    private string? savedStty;
+
+    private bool restored;
+
+    /// <summary>Initializes a new instance of the <see cref="ConsoleInputReader"/> class.</summary>
+    public ConsoleInputReader()
+    {
+        if (Console.IsInputRedirected)
+        {
+            return;
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            this.useWindowsNative = this.TrySetupWindows();
+            return;
+        }
+
+        // The Unix raw-mode + mouse path is opt-in: enabling raw mode and reading stdin
+        // directly can conflict with the terminal's line discipline on some hosts and mangle
+        // keyboard input. Until it is verified broadly, default to the safe Console.ReadKey
+        // fallback (keyboard only) and let users opt in explicitly to try mouse scrolling.
+        if (UnixMouseOptIn() && this.TrySetupUnix())
+        {
+            this.decoder = new VtInputDecoder(this.ReadByteUnix, this.HasInputUnix);
+            this.unixActive = true;
+        }
+    }
+
+    private static bool UnixMouseOptIn()
+    {
+        var value = Environment.GetEnvironmentVariable("GSI_MOUSE");
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+
+        return value is "1" or "true" or "yes" or "on"
+            || value.Equals("true", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("yes", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("on", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Finalizes an instance of the <see cref="ConsoleInputReader"/> class.</summary>
+    ~ConsoleInputReader()
+    {
+        this.Restore();
+    }
+
+    /// <inheritdoc/>
+    public InputEvent? Read()
+    {
+        if (this.unixActive && this.decoder is not null)
+        {
+            return this.decoder.Next();
+        }
+
+        if (this.useWindowsNative)
+        {
+            return this.ReadWindowsNative();
+        }
+
+        return ReadFallback();
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        this.Restore();
+        GC.SuppressFinalize(this);
+    }
+
+    private static InputEvent? ReadFallback()
+    {
+        var key = Console.ReadKey(intercept: true);
+        return InputEvent.FromKey(key);
+    }
+
+    private static bool IsModifierKey(ushort vk) => vk switch
+    {
+        0x10 or 0x11 or 0x12 => true, // Shift, Control, Alt
+        0x14 => true, // CapsLock
+        0x90 or 0x91 => true, // NumLock, ScrollLock
+        0x5b or 0x5c => true, // Left/Right Win
+        _ => false,
+    };
+
+    private bool TrySetupWindows()
+    {
+        try
+        {
+            this.stdInHandle = NativeMethods.GetStdHandle(NativeMethods.STD_INPUT_HANDLE);
+            if (this.stdInHandle == IntPtr.Zero || this.stdInHandle == NativeMethods.INVALID_HANDLE_VALUE)
+            {
+                return false;
+            }
+
+            if (!NativeMethods.GetConsoleMode(this.stdInHandle, out this.originalMode))
+            {
+                return false;
+            }
+
+            var mode = this.originalMode;
+            mode |= NativeMethods.ENABLE_MOUSE_INPUT | NativeMethods.ENABLE_EXTENDED_FLAGS;
+            mode &= ~NativeMethods.ENABLE_QUICK_EDIT_MODE;
+            mode &= ~NativeMethods.ENABLE_VIRTUAL_TERMINAL_INPUT;
+            if (!NativeMethods.SetConsoleMode(this.stdInHandle, mode))
+            {
+                return false;
+            }
+
+            this.windowsModeChanged = true;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private InputEvent? ReadWindowsNative()
+    {
+        while (true)
+        {
+            var records = new NativeMethods.InputRecord[1];
+            if (!NativeMethods.ReadConsoleInput(this.stdInHandle, records, 1, out var read) || read == 0)
+            {
+                return ReadFallback();
+            }
+
+            var record = records[0];
+            if (record.EventType == NativeMethods.KEY_EVENT)
+            {
+                var ke = record.Key;
+                if (ke.KeyDown == 0)
+                {
+                    continue;
+                }
+
+                var vk = ke.VirtualKeyCode;
+                if (IsModifierKey(vk))
+                {
+                    continue;
+                }
+
+                var state = ke.ControlKeyState;
+                var shift = (state & NativeMethods.SHIFT_PRESSED) != 0;
+                var alt = (state & (NativeMethods.LEFT_ALT_PRESSED | NativeMethods.RIGHT_ALT_PRESSED)) != 0;
+                var control = (state & (NativeMethods.LEFT_CTRL_PRESSED | NativeMethods.RIGHT_CTRL_PRESSED)) != 0;
+                var info = new ConsoleKeyInfo((char)ke.UnicodeChar, (ConsoleKey)vk, shift, alt, control);
+                return InputEvent.FromKey(info);
+            }
+
+            if (record.EventType == NativeMethods.MOUSE_EVENT)
+            {
+                var me = record.Mouse;
+                if (me.EventFlags == NativeMethods.MOUSE_WHEELED)
+                {
+                    var delta = (short)((me.ButtonState >> 16) & 0xffff);
+                    return InputEvent.FromScroll(delta > 0 ? ScrollDirection.Up : ScrollDirection.Down);
+                }
+            }
+        }
+    }
+
+    private bool TrySetupUnix()
+    {
+        if (Console.IsOutputRedirected)
+        {
+            return false;
+        }
+
+        try
+        {
+            this.savedStty = RunStty("-g", capture: true);
+            if (string.IsNullOrWhiteSpace(this.savedStty))
+            {
+                return false;
+            }
+
+            if (RunStty("-echo -icanon -isig -ixon min 1 time 0", capture: false) is null)
+            {
+                return false;
+            }
+
+            // Enable X10 + SGR mouse reporting.
+            Console.Out.Write("\u001b[?1000h\u001b[?1006h");
+            Console.Out.Flush();
+            return true;
+        }
+        catch
+        {
+            if (this.savedStty is not null)
+            {
+                try
+                {
+                    RunStty(this.savedStty, capture: false);
+                }
+                catch
+                {
+                    // Best effort.
+                }
+            }
+
+            return false;
+        }
+    }
+
+    private static string? RunStty(string arguments, bool capture)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "stty",
+            Arguments = arguments,
+            UseShellExecute = false,
+            RedirectStandardOutput = capture,
+            RedirectStandardInput = false,
+            RedirectStandardError = true,
+        };
+
+        using var process = Process.Start(psi);
+        if (process is null)
+        {
+            return null;
+        }
+
+        var output = capture ? process.StandardOutput.ReadToEnd() : string.Empty;
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+        {
+            return null;
+        }
+
+        return capture ? output.Trim() : string.Empty;
+    }
+
+    private int ReadByteUnix()
+    {
+        var buffer = new byte[1];
+        var n = NativeMethods.read(0, buffer, 1);
+        return n == 1 ? buffer[0] : -1;
+    }
+
+    private bool HasInputUnix(int timeoutMs)
+    {
+        var fds = new NativeMethods.PollFd[1];
+        fds[0].Fd = 0;
+        fds[0].Events = NativeMethods.POLLIN;
+        var result = NativeMethods.poll(fds, 1, timeoutMs);
+        return result > 0 && (fds[0].Revents & NativeMethods.POLLIN) != 0;
+    }
+
+    private void Restore()
+    {
+        if (this.restored)
+        {
+            return;
+        }
+
+        this.restored = true;
+
+        if (this.windowsModeChanged)
+        {
+            try
+            {
+                NativeMethods.SetConsoleMode(this.stdInHandle, this.originalMode);
+            }
+            catch
+            {
+                // Best effort.
+            }
+        }
+
+        if (this.unixActive)
+        {
+            this.unixActive = false;
+            try
+            {
+                Console.Out.Write("\u001b[?1006l\u001b[?1000l");
+                Console.Out.Flush();
+            }
+            catch
+            {
+                // Best effort.
+            }
+
+            if (this.savedStty is not null)
+            {
+                try
+                {
+                    RunStty(this.savedStty, capture: false);
+                }
+                catch
+                {
+                    // Best effort.
+                }
+            }
+        }
+    }
+
+    private static class NativeMethods
+    {
+        public const int STD_INPUT_HANDLE = -10;
+        public const uint ENABLE_MOUSE_INPUT = 0x0010;
+        public const uint ENABLE_QUICK_EDIT_MODE = 0x0040;
+        public const uint ENABLE_EXTENDED_FLAGS = 0x0080;
+        public const uint ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200;
+
+        public const ushort KEY_EVENT = 0x0001;
+        public const ushort MOUSE_EVENT = 0x0002;
+        public const uint MOUSE_WHEELED = 0x0004;
+
+        public const uint SHIFT_PRESSED = 0x0010;
+        public const uint LEFT_ALT_PRESSED = 0x0002;
+        public const uint RIGHT_ALT_PRESSED = 0x0001;
+        public const uint LEFT_CTRL_PRESSED = 0x0008;
+        public const uint RIGHT_CTRL_PRESSED = 0x0004;
+
+        public const short POLLIN = 0x001;
+
+        public static readonly IntPtr INVALID_HANDLE_VALUE = new(-1);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr GetStdHandle(int nStdHandle);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "ReadConsoleInputW")]
+        public static extern bool ReadConsoleInput(IntPtr hConsoleInput, [Out] InputRecord[] lpBuffer, uint nLength, out uint lpNumberOfEventsRead);
+
+        [DllImport("libc", SetLastError = true)]
+        public static extern nint read(int fd, [Out] byte[] buffer, nint count);
+
+        [DllImport("libc", SetLastError = true)]
+        public static extern int poll([In, Out] PollFd[] fds, uint nfds, int timeout);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct PollFd
+        {
+            public int Fd;
+            public short Events;
+            public short Revents;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Coord
+        {
+            public short X;
+            public short Y;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct KeyEventRecord
+        {
+            public int KeyDown;
+            public ushort RepeatCount;
+            public ushort VirtualKeyCode;
+            public ushort VirtualScanCode;
+            public ushort UnicodeChar;
+            public uint ControlKeyState;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MouseEventRecord
+        {
+            public Coord MousePosition;
+            public uint ButtonState;
+            public uint ControlKeyState;
+            public uint EventFlags;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        public struct InputRecord
+        {
+            [FieldOffset(0)]
+            public ushort EventType;
+
+            [FieldOffset(4)]
+            public KeyEventRecord Key;
+
+            [FieldOffset(4)]
+            public MouseEventRecord Mouse;
+        }
+    }
+}

--- a/src/Repl/Shell/ITabScreen.cs
+++ b/src/Repl/Shell/ITabScreen.cs
@@ -19,6 +19,9 @@ public interface ITabScreen
 
     bool HandleKey(ConsoleKeyInfo key);
 
+    /// <summary>Handles a mouse-wheel scroll. Returns <c>true</c> if the event was consumed.</summary>
+    bool HandleScroll(ScrollDirection direction, int lines) => false;
+
     IEnumerable<KeyValuePair<string, string?>> Hints => Array.Empty<KeyValuePair<string, string?>>();
 
     void OnActivated(IAppShellNavigator navigator)

--- a/src/Repl/Shell/InputReader.cs
+++ b/src/Repl/Shell/InputReader.cs
@@ -1,0 +1,44 @@
+// <copyright file="InputReader.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace GSharp.Repl.Shell;
+
+/// <summary>Direction of a mouse-wheel scroll.</summary>
+public enum ScrollDirection
+{
+    Up,
+    Down,
+}
+
+/// <summary>
+/// A single terminal input event: either a key press or a mouse-wheel scroll. Exactly one of
+/// <see cref="Key"/> or <see cref="Scroll"/> is set.
+/// </summary>
+public readonly struct InputEvent
+{
+    private InputEvent(ConsoleKeyInfo? key, ScrollDirection? scroll)
+    {
+        this.Key = key;
+        this.Scroll = scroll;
+    }
+
+    /// <summary>Gets the key press, if this event is a key.</summary>
+    public ConsoleKeyInfo? Key { get; }
+
+    /// <summary>Gets the scroll direction, if this event is a mouse-wheel scroll.</summary>
+    public ScrollDirection? Scroll { get; }
+
+    public static InputEvent FromKey(ConsoleKeyInfo key) => new(key, null);
+
+    public static InputEvent FromScroll(ScrollDirection direction) => new(null, direction);
+}
+
+/// <summary>Blocking source of terminal input events (keys and mouse wheel).</summary>
+public interface IInputReader
+{
+    /// <summary>Blocks until the next input event, or returns <c>null</c> when input ends.</summary>
+    InputEvent? Read();
+}

--- a/src/Repl/Shell/VtInputDecoder.cs
+++ b/src/Repl/Shell/VtInputDecoder.cs
@@ -1,0 +1,358 @@
+// <copyright file="VtInputDecoder.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Text;
+
+namespace GSharp.Repl.Shell;
+
+/// <summary>
+/// Decodes a raw terminal byte stream (as produced by a Unix terminal in raw mode with SGR
+/// mouse reporting enabled) into <see cref="InputEvent"/> values. Handles printable UTF-8
+/// text, control keys, xterm CSI/SS3 escape sequences for the keys the REPL uses, and both
+/// SGR (<c>ESC [ &lt; b ; x ; y M</c>) and legacy (<c>ESC [ M ...</c>) mouse-wheel reports.
+/// The OS-specific byte plumbing is injected so the decoder is fully unit-testable.
+/// </summary>
+public sealed class VtInputDecoder
+{
+    private const int EscTimeoutMs = 40;
+
+    private readonly Func<int> readByte;
+    private readonly Func<int, bool> hasInput;
+
+    /// <summary>Initializes a new instance of the <see cref="VtInputDecoder"/> class.</summary>
+    /// <param name="readByte">Blocking read of one byte; returns -1 at end of input.</param>
+    /// <param name="hasInput">Returns true if a byte is available within the given timeout (ms).</param>
+    public VtInputDecoder(Func<int> readByte, Func<int, bool> hasInput)
+    {
+        this.readByte = readByte ?? throw new ArgumentNullException(nameof(readByte));
+        this.hasInput = hasInput ?? throw new ArgumentNullException(nameof(hasInput));
+    }
+
+    /// <summary>Reads and decodes the next input event, or <c>null</c> at end of input.</summary>
+    public InputEvent? Next()
+    {
+        while (true)
+        {
+            var b = this.readByte();
+            if (b < 0)
+            {
+                return null;
+            }
+
+            switch (b)
+            {
+                case 0x1b:
+                    var esc = this.DecodeEscape(out var ignore);
+                    if (ignore)
+                    {
+                        continue;
+                    }
+
+                    return esc;
+                case 0x0d:
+                case 0x0a:
+                    return Key('\r', ConsoleKey.Enter);
+                case 0x09:
+                    return Key('\t', ConsoleKey.Tab);
+                case 0x7f:
+                case 0x08:
+                    return Key('\b', ConsoleKey.Backspace);
+                default:
+                    if (b < 0x20)
+                    {
+                        return ControlChar(b);
+                    }
+
+                    return this.Printable(b);
+            }
+        }
+    }
+
+    private static InputEvent Key(char keyChar, ConsoleKey key, bool shift = false, bool alt = false, bool control = false)
+        => InputEvent.FromKey(new ConsoleKeyInfo(keyChar, key, shift, alt, control));
+
+    private static InputEvent ControlChar(int b)
+    {
+        // Ctrl+@ / Ctrl+Space arrives as NUL.
+        if (b == 0)
+        {
+            return Key('\0', ConsoleKey.Spacebar, control: true);
+        }
+
+        // Ctrl+A..Ctrl+Z (Tab/Enter/Backspace are handled earlier).
+        if (b >= 1 && b <= 26)
+        {
+            var key = (ConsoleKey)('A' + (b - 1));
+            return Key((char)b, key, control: true);
+        }
+
+        return Key((char)b, ConsoleKey.None, control: true);
+    }
+
+    private static (bool Shift, bool Alt, bool Control) Modifiers(int code)
+    {
+        if (code < 2)
+        {
+            return (false, false, false);
+        }
+
+        var bits = code - 1;
+        return ((bits & 1) != 0, (bits & 2) != 0, (bits & 4) != 0);
+    }
+
+    private static InputEvent? DecodeArrowOrEdit(char final, int modCode)
+    {
+        var (shift, alt, control) = Modifiers(modCode);
+        var key = final switch
+        {
+            'A' => ConsoleKey.UpArrow,
+            'B' => ConsoleKey.DownArrow,
+            'C' => ConsoleKey.RightArrow,
+            'D' => ConsoleKey.LeftArrow,
+            'H' => ConsoleKey.Home,
+            'F' => ConsoleKey.End,
+            'Z' => ConsoleKey.Tab,
+            _ => ConsoleKey.None,
+        };
+
+        if (key == ConsoleKey.None)
+        {
+            return null;
+        }
+
+        // ESC [ Z is Shift+Tab.
+        if (final == 'Z')
+        {
+            shift = true;
+        }
+
+        return Key('\0', key, shift, alt, control);
+    }
+
+    private static InputEvent? DecodeTilde(int number, int modCode)
+    {
+        var (shift, alt, control) = Modifiers(modCode);
+        var key = number switch
+        {
+            1 or 7 => ConsoleKey.Home,
+            2 => ConsoleKey.Insert,
+            3 => ConsoleKey.Delete,
+            4 or 8 => ConsoleKey.End,
+            5 => ConsoleKey.PageUp,
+            6 => ConsoleKey.PageDown,
+            11 => ConsoleKey.F1,
+            12 => ConsoleKey.F2,
+            13 => ConsoleKey.F3,
+            14 => ConsoleKey.F4,
+            15 => ConsoleKey.F5,
+            17 => ConsoleKey.F6,
+            18 => ConsoleKey.F7,
+            19 => ConsoleKey.F8,
+            20 => ConsoleKey.F9,
+            21 => ConsoleKey.F10,
+            23 => ConsoleKey.F11,
+            24 => ConsoleKey.F12,
+            _ => ConsoleKey.None,
+        };
+
+        return key == ConsoleKey.None ? null : Key('\0', key, shift, alt, control);
+    }
+
+    private static InputEvent? WheelFromButton(int button)
+    {
+        // Wheel events set bit 6 (64). Even button => up, odd => down.
+        if ((button & 0x40) == 0)
+        {
+            return null;
+        }
+
+        return InputEvent.FromScroll((button & 1) == 0 ? ScrollDirection.Up : ScrollDirection.Down);
+    }
+
+    private InputEvent? DecodeEscape(out bool ignore)
+    {
+        ignore = false;
+        if (!this.hasInput(EscTimeoutMs))
+        {
+            return Key('\x1b', ConsoleKey.Escape);
+        }
+
+        var b1 = this.readByte();
+        return b1 switch
+        {
+            '[' => this.DecodeCsi(out ignore),
+            'O' => this.DecodeSs3(),
+            < 0 => Key('\x1b', ConsoleKey.Escape),
+
+            // ESC followed by another byte: treat as Alt+<byte> (best effort).
+            _ => this.DecodeAlt(b1),
+        };
+    }
+
+    private InputEvent? DecodeAlt(int b)
+    {
+        if (b >= 0x20 && b < 0x7f)
+        {
+            var c = (char)b;
+            var key = LetterOrDigitKey(c, out var shift);
+            return Key(c, key, shift, alt: true);
+        }
+
+        return Key('\x1b', ConsoleKey.Escape);
+    }
+
+    private InputEvent? DecodeSs3()
+    {
+        // SS3 function keys: ESC O P..S => F1..F4.
+        var b = this.readByte();
+        var key = b switch
+        {
+            'P' => ConsoleKey.F1,
+            'Q' => ConsoleKey.F2,
+            'R' => ConsoleKey.F3,
+            'S' => ConsoleKey.F4,
+            'H' => ConsoleKey.Home,
+            'F' => ConsoleKey.End,
+            _ => ConsoleKey.None,
+        };
+
+        return key == ConsoleKey.None ? null : Key('\0', key);
+    }
+
+    private InputEvent? DecodeCsi(out bool ignore)
+    {
+        ignore = false;
+        var sb = new StringBuilder();
+        int final;
+        while (true)
+        {
+            var b = this.readByte();
+            if (b < 0)
+            {
+                ignore = true;
+                return null;
+            }
+
+            if (b >= 0x40 && b <= 0x7e)
+            {
+                final = b;
+                break;
+            }
+
+            sb.Append((char)b);
+        }
+
+        var param = sb.ToString();
+
+        // Mouse reports.
+        if (param.StartsWith('<'))
+        {
+            var sgr = this.DecodeSgrMouse(param, (char)final);
+            ignore = sgr is null;
+            return sgr;
+        }
+
+        if (final == 'M' && param.Length == 0)
+        {
+            var legacy = this.DecodeLegacyMouse();
+            ignore = legacy is null;
+            return legacy;
+        }
+
+        // Modifier is the second ';'-separated parameter, if any.
+        var parts = param.Split(';');
+        var modCode = parts.Length > 1 && int.TryParse(parts[1], out var m) ? m : 0;
+
+        if (final == '~')
+        {
+            var number = int.TryParse(parts[0], out var n) ? n : 0;
+            var tilde = DecodeTilde(number, modCode);
+            ignore = tilde is null;
+            return tilde;
+        }
+
+        var arrow = DecodeArrowOrEdit((char)final, modCode);
+        ignore = arrow is null;
+        return arrow;
+    }
+
+    private InputEvent? DecodeSgrMouse(string param, char final)
+    {
+        // param is like "<64;12;3"; a wheel event only registers on press ('M').
+        if (final != 'M')
+        {
+            return null;
+        }
+
+        var parts = param.TrimStart('<').Split(';');
+        if (parts.Length >= 1 && int.TryParse(parts[0], out var button))
+        {
+            return WheelFromButton(button);
+        }
+
+        return null;
+    }
+
+    private InputEvent? DecodeLegacyMouse()
+    {
+        // ESC [ M followed by three bytes, each offset by 32.
+        var button = this.readByte();
+        this.readByte();
+        this.readByte();
+        return button < 0 ? null : WheelFromButton(button - 32);
+    }
+
+    private InputEvent? Printable(int b)
+    {
+        if (b < 0x80)
+        {
+            var c = (char)b;
+            var key = LetterOrDigitKey(c, out var shift);
+            return Key(c, key, shift);
+        }
+
+        // Decode a UTF-8 multi-byte sequence.
+        var extra = b >= 0xf0 ? 3 : b >= 0xe0 ? 2 : 1;
+        Span<byte> bytes = stackalloc byte[4];
+        bytes[0] = (byte)b;
+        var count = 1;
+        for (var i = 0; i < extra; i++)
+        {
+            var cont = this.readByte();
+            if (cont < 0)
+            {
+                break;
+            }
+
+            bytes[count++] = (byte)cont;
+        }
+
+        var text = Encoding.UTF8.GetString(bytes[..count]);
+        var ch = text.Length > 0 ? text[0] : '\0';
+        return Key(ch, ConsoleKey.None);
+    }
+
+    private static ConsoleKey LetterOrDigitKey(char c, out bool shift)
+    {
+        shift = false;
+        if (c >= 'A' && c <= 'Z')
+        {
+            shift = true;
+            return (ConsoleKey)c;
+        }
+
+        if (c >= 'a' && c <= 'z')
+        {
+            return (ConsoleKey)(c - 32);
+        }
+
+        if (c >= '0' && c <= '9')
+        {
+            return (ConsoleKey)c;
+        }
+
+        return ConsoleKey.None;
+    }
+}

--- a/src/Repl/Themes/Theme.cs
+++ b/src/Repl/Themes/Theme.cs
@@ -47,6 +47,10 @@ public sealed class Theme
 
     public required SemanticColor BorderNeutral { get; init; }
 
+    public required SemanticColor CellBackground { get; init; }
+
+    public required SemanticColor InputBackground { get; init; }
+
     public required SemanticColor Keyword { get; init; }
 
     public required SemanticColor Number { get; init; }
@@ -113,6 +117,8 @@ public static class Themes
         Brand = new(Color.MediumPurple2),
         Selected = new(Color.MediumPurple2),
         BorderNeutral = new(Color.Grey50),
+        CellBackground = new(Color.Grey11),
+        InputBackground = new(Color.Grey19),
         Keyword = new(Color.MediumPurple2),
         Number = new(Color.SpringGreen2),
         StringLit = new(Color.Orange1),
@@ -133,6 +139,8 @@ public static class Themes
         Brand = new(Color.DeepSkyBlue1),
         Selected = new(Color.DeepSkyBlue1),
         BorderNeutral = new(Color.Grey42),
+        CellBackground = new(Color.Grey11),
+        InputBackground = new(Color.Grey19),
         Keyword = new(Color.DeepSkyBlue1),
         Number = new(Color.Cyan1),
         StringLit = new(Color.Orange1),
@@ -153,6 +161,8 @@ public static class Themes
         Brand = new(Color.Blue),
         Selected = new(Color.Blue),
         BorderNeutral = new(Color.Grey35),
+        CellBackground = new(Color.Grey93),
+        InputBackground = new(Color.Grey85),
         Keyword = new(Color.Blue),
         Number = new(Color.DarkGreen),
         StringLit = new(Color.Orange1),
@@ -173,6 +183,8 @@ public static class Themes
         Brand = new(Color.Orange1),
         Selected = new(Color.Orange1),
         BorderNeutral = new(Color.Grey50),
+        CellBackground = new(Color.Grey11),
+        InputBackground = new(Color.Grey19),
         Keyword = new(Color.Orange1),
         Number = new(Color.Gold1),
         StringLit = new(Color.Gold1),

--- a/src/Repl/Tokens/Tokens.cs
+++ b/src/Repl/Tokens/Tokens.cs
@@ -32,6 +32,10 @@ public static class Tokens
 
     public static SemanticColor BorderNeutral => Theme.Current.BorderNeutral;
 
+    public static SemanticColor CellBackground => Theme.Current.CellBackground;
+
+    public static SemanticColor InputBackground => Theme.Current.InputBackground;
+
     public static SemanticColor Keyword => Theme.Current.Keyword;
 
     public static SemanticColor Number => Theme.Current.Number;

--- a/src/Repl/Widgets/Backdrop.cs
+++ b/src/Repl/Widgets/Backdrop.cs
@@ -1,0 +1,129 @@
+// <copyright file="Backdrop.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace GSharp.Repl.Widgets;
+
+/// <summary>
+/// Wraps a child renderable in a solid background block that fills the full available
+/// width, in the OpenCode/Copilot-CLI style. Optionally draws a themed one-cell accent
+/// bar down the left edge (used by the input box and sidebar) and adds interior padding
+/// rows. Emits line breaks <em>between</em> lines only (no trailing break) so callers can
+/// compose deterministic fixed-height layouts.
+/// </summary>
+public sealed class Backdrop : Renderable
+{
+    private const string AccentGlyph = "▏";
+
+    private readonly IRenderable child;
+    private readonly Color background;
+    private readonly Color? accent;
+    private readonly int padLeft;
+    private readonly int padRight;
+    private readonly int padTop;
+    private readonly int padBottom;
+    private readonly int minHeight;
+
+    public Backdrop(
+        IRenderable child,
+        Color background,
+        Color? accent = null,
+        int padLeft = 1,
+        int padRight = 1,
+        int padTop = 0,
+        int padBottom = 0,
+        int minHeight = 0)
+    {
+        this.child = child ?? throw new ArgumentNullException(nameof(child));
+        this.background = background;
+        this.accent = accent;
+        this.padLeft = Math.Max(0, padLeft);
+        this.padRight = Math.Max(0, padRight);
+        this.padTop = Math.Max(0, padTop);
+        this.padBottom = Math.Max(0, padBottom);
+        this.minHeight = Math.Max(0, minHeight);
+    }
+
+    protected override Measurement Measure(RenderOptions options, int maxWidth)
+        => new(maxWidth, maxWidth);
+
+    protected override IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+    {
+        var bg = new Style(background: background);
+        var barStyle = accent is { } a ? new Style(foreground: a, background: background) : bg;
+        var barWidth = accent is null ? 0 : 1;
+
+        var innerWidth = Math.Max(1, maxWidth - barWidth - padLeft - padRight);
+        var lines = Segment.SplitLines(child.Render(options, innerWidth));
+
+        var outLines = new List<List<Segment>>();
+
+        for (var i = 0; i < padTop; i++)
+        {
+            outLines.Add(FrameLine(maxWidth, barWidth, barStyle, bg));
+        }
+
+        foreach (var line in lines)
+        {
+            var row = new List<Segment>();
+            if (barWidth > 0)
+            {
+                row.Add(new Segment(AccentGlyph, barStyle, null));
+            }
+
+            if (padLeft > 0)
+            {
+                row.Add(new Segment(new string(' ', padLeft), bg, null));
+            }
+
+            var used = 0;
+            foreach (var seg in line)
+            {
+                row.Add(new Segment(seg.Text, seg.Style.Combine(bg), null));
+                used += seg.CellCount();
+            }
+
+            var fill = maxWidth - barWidth - padLeft - used;
+            if (fill > 0)
+            {
+                row.Add(new Segment(new string(' ', fill), bg, null));
+            }
+
+            outLines.Add(row);
+        }
+
+        for (var i = 0; i < padBottom; i++)
+        {
+            outLines.Add(FrameLine(maxWidth, barWidth, barStyle, bg));
+        }
+
+        while (outLines.Count < minHeight)
+        {
+            outLines.Add(FrameLine(maxWidth, barWidth, barStyle, bg));
+        }
+
+        return SegmentGrid.Join(outLines);
+    }
+
+    private static List<Segment> FrameLine(int maxWidth, int barWidth, Style barStyle, Style bg)
+    {
+        var row = new List<Segment>();
+        if (barWidth > 0)
+        {
+            row.Add(new Segment(AccentGlyph, barStyle, null));
+        }
+
+        var fill = maxWidth - barWidth;
+        if (fill > 0)
+        {
+            row.Add(new Segment(new string(' ', fill), bg, null));
+        }
+
+        return row;
+    }
+}

--- a/src/Repl/Widgets/CommandPalette.cs
+++ b/src/Repl/Widgets/CommandPalette.cs
@@ -80,17 +80,53 @@ public sealed class CommandPalette : IModal
     {
         var brand = Tokens.Tokens.Brand.Value.ToMarkup();
         var primary = Tokens.Tokens.TextPrimary.Value.ToMarkup();
+        var secondary = Tokens.Tokens.TextSecondary.Value.ToMarkup();
         var tertiary = Tokens.Tokens.TextTertiary.Value.ToMarkup();
-        var rows = new List<IRenderable> { new Markup($"[{brand}]:[/] [{primary}]{Markup.Escape(query)}[/]"), new Markup(string.Empty) };
+        var selectedBg = Tokens.Tokens.CellBackground.Value.ToMarkup();
+
+        var innerWidth = Math.Max(10, width - 4);
+        var rows = new List<IRenderable>
+        {
+            // Title row: "Commands" on the left, an "esc" affordance on the right.
+            new Markup(Pad($"[{brand}]Commands[/]", $"[{tertiary}]esc[/]", innerWidth)),
+            new Markup($"[{brand}]:[/] [{primary}]{Markup.Escape(query)}[/][{tertiary}]▏[/]"),
+            new Markup(string.Empty),
+        };
+
         var matches = Filtered;
+        if (matches.Count == 0)
+        {
+            rows.Add(new Markup($"  [{tertiary}]No matching commands[/]"));
+        }
+
         for (var i = 0; i < matches.Count; i++)
         {
-            var prefix = i == cursor ? $"[{brand}]❯[/] " : "  ";
-            rows.Add(new Markup($"{prefix}[{primary}]{Markup.Escape(matches[i].Verb)}[/]  [{tertiary}]{Markup.Escape(matches[i].Help)}[/]"));
+            var selected = i == cursor;
+            var caret = selected ? $"[{brand}]❯[/] " : "  ";
+            var name = selected ? $"[{primary} on {selectedBg}]" : $"[{primary}]";
+            var help = selected ? $"[{secondary} on {selectedBg}]" : $"[{tertiary}]";
+            rows.Add(new Markup($"{caret}{name}{Markup.Escape(matches[i].Verb)}[/]  {help}{Markup.Escape(matches[i].Help)}[/]"));
         }
 
         rows.Add(new Markup(string.Empty));
         rows.Add(new Markup($"[{tertiary}]↑↓ navigate · Tab complete · Enter run · Esc cancel[/]"));
-        return new Padder(new Panel(new Rows(rows)) { Border = BoxBorder.Rounded, BorderStyle = new Style(Tokens.Tokens.BorderNeutral) }).Padding(2, 1, 2, 1);
+
+        // OpenCode-style floating surface: a filled background with a themed left accent
+        // bar, matching the input box, rather than an enclosed rounded box.
+        return new Backdrop(
+            new Rows(rows),
+            Tokens.Tokens.InputBackground.Value,
+            accent: Tokens.Tokens.Brand.Value,
+            padLeft: 1,
+            padRight: 1,
+            padTop: 1,
+            padBottom: 1);
+    }
+
+    private static string Pad(string left, string right, int width)
+    {
+        var used = Markup.Remove(left).Length + Markup.Remove(right).Length;
+        var gap = Math.Max(1, width - used);
+        return $"{left}{new string(' ', gap)}{right}";
     }
 }

--- a/src/Repl/Widgets/Dock.cs
+++ b/src/Repl/Widgets/Dock.cs
@@ -1,0 +1,107 @@
+// <copyright file="Dock.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Spectre.Console.Rendering;
+
+namespace GSharp.Repl.Widgets;
+
+/// <summary>Mutable scroll position for a <see cref="Dock"/>, in lines scrolled up from the bottom.</summary>
+public sealed class ScrollState
+{
+    /// <summary>Gets or sets the number of lines scrolled up from the bottom (0 = pinned to newest content).</summary>
+    public int Offset { get; set; }
+
+    /// <summary>Gets the height of the scrollable region as of the last render (for page-sized scrolling).</summary>
+    public int LastViewportHeight { get; internal set; } = 10;
+
+    /// <summary>Pins the view back to the bottom (newest content).</summary>
+    public void ToBottom() => Offset = 0;
+
+    /// <summary>Scrolls up (towards older content) by <paramref name="lines"/>.</summary>
+    public void ScrollUp(int lines) => Offset += Math.Max(0, lines);
+
+    /// <summary>Scrolls down (towards newer content) by <paramref name="lines"/>, clamped at the bottom.</summary>
+    public void ScrollDown(int lines) => Offset = Math.Max(0, Offset - Math.Max(0, lines));
+}
+
+/// <summary>
+/// Fills exactly <c>height</c> lines: a fixed <c>footer</c> docked at the bottom, and a
+/// scrollable region above it that gets whatever height remains. The footer is measured at
+/// render time, so the scroll region resizes automatically as the footer (input box) grows
+/// or shrinks. The scrollable content is top-anchored when it fits, otherwise it shows a
+/// window pinned to the newest (bottom) content and driven by <see cref="ScrollState"/>.
+/// The footer is never clipped by scrolling.
+/// </summary>
+public sealed class Dock : Renderable
+{
+    private readonly IRenderable scrollable;
+    private readonly IRenderable footer;
+    private readonly int height;
+    private readonly ScrollState scroll;
+
+    public Dock(IRenderable scrollable, IRenderable footer, int height, ScrollState scroll)
+    {
+        this.scrollable = scrollable ?? throw new ArgumentNullException(nameof(scrollable));
+        this.footer = footer ?? throw new ArgumentNullException(nameof(footer));
+        this.height = Math.Max(1, height);
+        this.scroll = scroll ?? throw new ArgumentNullException(nameof(scroll));
+    }
+
+    protected override Measurement Measure(RenderOptions options, int maxWidth)
+        => new(maxWidth, maxWidth);
+
+    protected override IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+    {
+        var footerLines = Segment.SplitLines(footer.Render(options, maxWidth))
+            .Select(l => SegmentGrid.PadLine(l, maxWidth))
+            .ToList();
+
+        var viewportHeight = Math.Max(0, height - footerLines.Count);
+        var outLines = new List<List<Segment>>(height);
+
+        if (viewportHeight > 0)
+        {
+            var lines = Segment.SplitLines(scrollable.Render(options, maxWidth));
+            var total = lines.Count;
+            var maxOffset = Math.Max(0, total - viewportHeight);
+            var offset = Math.Clamp(scroll.Offset, 0, maxOffset);
+            scroll.Offset = offset;
+            scroll.LastViewportHeight = viewportHeight;
+
+            if (total <= viewportHeight)
+            {
+                foreach (var line in lines)
+                {
+                    outLines.Add(SegmentGrid.PadLine(line, maxWidth));
+                }
+
+                while (outLines.Count < viewportHeight)
+                {
+                    outLines.Add(new List<Segment>());
+                }
+            }
+            else
+            {
+                var start = total - viewportHeight - offset;
+                for (var i = start; i < start + viewportHeight; i++)
+                {
+                    outLines.Add(SegmentGrid.PadLine(lines[i], maxWidth));
+                }
+            }
+        }
+
+        outLines.AddRange(footerLines);
+
+        // Guarantee an exact height even if the footer alone overflows (keep the bottom).
+        if (outLines.Count > height)
+        {
+            outLines = outLines.Skip(outLines.Count - height).ToList();
+        }
+
+        return SegmentGrid.Join(outLines);
+    }
+}

--- a/src/Repl/Widgets/FixedHeight.cs
+++ b/src/Repl/Widgets/FixedHeight.cs
@@ -1,0 +1,52 @@
+// <copyright file="FixedHeight.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Spectre.Console.Rendering;
+
+namespace GSharp.Repl.Widgets;
+
+/// <summary>
+/// Forces a child renderable to occupy exactly a fixed number of lines: it is truncated
+/// (keeping the top) when too tall, and padded with blank lines when too short. Emits line
+/// breaks only <em>between</em> lines (no trailing break) so it composes into deterministic
+/// fixed-height layouts.
+/// </summary>
+public sealed class FixedHeight : Renderable
+{
+    private readonly IRenderable child;
+    private readonly int height;
+
+    public FixedHeight(IRenderable child, int height)
+    {
+        this.child = child ?? throw new ArgumentNullException(nameof(child));
+        this.height = Math.Max(1, height);
+    }
+
+    protected override Measurement Measure(RenderOptions options, int maxWidth)
+        => new(maxWidth, maxWidth);
+
+    protected override IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+    {
+        var lines = Segment.SplitLines(child.Render(options, maxWidth))
+            .Select(l => SegmentGrid.PadLine(l, maxWidth))
+            .ToList();
+
+        if (lines.Count > height)
+        {
+            lines = lines.Take(height).ToList();
+        }
+        else
+        {
+            while (lines.Count < height)
+            {
+                lines.Add(new List<Segment>());
+            }
+        }
+
+        return SegmentGrid.Join(lines);
+    }
+}

--- a/src/Repl/Widgets/Overlay.cs
+++ b/src/Repl/Widgets/Overlay.cs
@@ -1,0 +1,79 @@
+// <copyright file="Overlay.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Spectre.Console.Rendering;
+
+namespace GSharp.Repl.Widgets;
+
+/// <summary>
+/// Composites a modal renderable centered on top of a full-screen base frame, at the
+/// segment level, so the surrounding chrome (header, sidebar, input, footer) stays visible
+/// behind it. Used for the <c>/</c> command palette.
+/// </summary>
+public sealed class Overlay : Renderable
+{
+    private readonly IRenderable baseFrame;
+    private readonly IRenderable modal;
+    private readonly int modalWidth;
+
+    public Overlay(IRenderable baseFrame, IRenderable modal, int modalWidth)
+    {
+        this.baseFrame = baseFrame ?? throw new ArgumentNullException(nameof(baseFrame));
+        this.modal = modal ?? throw new ArgumentNullException(nameof(modal));
+        this.modalWidth = Math.Max(1, modalWidth);
+    }
+
+    protected override Measurement Measure(RenderOptions options, int maxWidth)
+        => new(maxWidth, maxWidth);
+
+    protected override IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+    {
+        var baseLines = Segment.SplitLines(baseFrame.Render(options, maxWidth))
+            .Select(l => new List<Segment>(l))
+            .ToList();
+
+        var mw = Math.Min(modalWidth, maxWidth);
+        var modalLines = Segment.SplitLines(modal.Render(options, mw));
+
+        var left = Math.Max(0, (maxWidth - mw) / 2);
+        var top = Math.Max(0, (baseLines.Count - modalLines.Count) / 2);
+
+        for (var j = 0; j < modalLines.Count; j++)
+        {
+            var idx = top + j;
+            if (idx < 0 || idx >= baseLines.Count)
+            {
+                continue;
+            }
+
+            baseLines[idx] = Compose(baseLines[idx], left, modalLines[j], mw, maxWidth);
+        }
+
+        return SegmentGrid.Join(baseLines);
+    }
+
+    private static List<Segment> Compose(List<Segment> baseLine, int left, IReadOnlyList<Segment> modalLine, int mw, int totalWidth)
+    {
+        var row = new List<Segment>();
+        row.AddRange(SegmentGrid.Slice(baseLine, 0, left));
+
+        var used = 0;
+        foreach (var seg in modalLine)
+        {
+            row.Add(seg);
+            used += seg.CellCount();
+        }
+
+        if (used < mw)
+        {
+            row.Add(new Segment(new string(' ', mw - used)));
+        }
+
+        row.AddRange(SegmentGrid.Slice(baseLine, left + mw, totalWidth));
+        return row;
+    }
+}

--- a/src/Repl/Widgets/SegmentGrid.cs
+++ b/src/Repl/Widgets/SegmentGrid.cs
@@ -1,0 +1,100 @@
+// <copyright file="SegmentGrid.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace GSharp.Repl.Widgets;
+
+/// <summary>
+/// Low-level helpers for composing fixed-height frames out of pre-rendered
+/// <see cref="Segment"/> lines: joining lines with breaks and slicing a line by
+/// cell column (used for overlay compositing). Assumes one cell per character,
+/// which holds for the REPL's ASCII/box-glyph content.
+/// </summary>
+internal static class SegmentGrid
+{
+    /// <summary>Emits the given lines separated by line breaks, with no trailing break.</summary>
+    public static IEnumerable<Segment> Join(IReadOnlyList<List<Segment>> lines)
+    {
+        for (var i = 0; i < lines.Count; i++)
+        {
+            if (i > 0)
+            {
+                yield return Segment.LineBreak;
+            }
+
+            foreach (var seg in lines[i])
+            {
+                yield return seg;
+            }
+        }
+    }
+
+    /// <summary>Pads a rendered line with default-styled spaces up to <paramref name="width"/> cells.</summary>
+    public static List<Segment> PadLine(IReadOnlyList<Segment> line, int width)
+    {
+        var row = new List<Segment>(line.Count + 1);
+        var used = 0;
+        foreach (var seg in line)
+        {
+            row.Add(seg);
+            used += seg.CellCount();
+        }
+
+        if (used < width)
+        {
+            row.Add(new Segment(new string(' ', width - used)));
+        }
+
+        return row;
+    }
+
+    /// <summary>
+    /// Returns the segments of <paramref name="line"/> covering cell columns
+    /// <c>[start, end)</c>, padded with default-styled spaces so the result is exactly
+    /// <c>end - start</c> cells wide.
+    /// </summary>
+    public static List<Segment> Slice(IReadOnlyList<Segment> line, int start, int end)
+    {
+        var result = new List<Segment>();
+        if (end <= start)
+        {
+            return result;
+        }
+
+        var col = 0;
+        foreach (var seg in line)
+        {
+            if (col >= end)
+            {
+                break;
+            }
+
+            var text = seg.Text;
+            var len = text.Length;
+            var segStart = col;
+            var segEnd = col + len;
+            var a = Math.Max(start, segStart);
+            var b = Math.Min(end, segEnd);
+            if (b > a)
+            {
+                result.Add(new Segment(text.Substring(a - segStart, b - a), seg.Style, null));
+            }
+
+            col = segEnd;
+        }
+
+        var produced = Math.Max(0, Math.Min(end, col) - start);
+        var need = (end - start) - produced;
+        if (need > 0)
+        {
+            result.Add(new Segment(new string(' ', need)));
+        }
+
+        return result;
+    }
+}

--- a/src/Repl/Widgets/SideBySide.cs
+++ b/src/Repl/Widgets/SideBySide.cs
@@ -1,0 +1,59 @@
+// <copyright file="SideBySide.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Spectre.Console.Rendering;
+
+namespace GSharp.Repl.Widgets;
+
+/// <summary>
+/// Composites two renderables into fixed-width columns separated by a gap, at the segment
+/// level. Unlike a Spectre <c>Grid</c>, it emits line breaks only <em>between</em> lines
+/// (no trailing break), so it can be nested inside deterministic fixed-height layouts.
+/// </summary>
+public sealed class SideBySide : Renderable
+{
+    private readonly IRenderable left;
+    private readonly IRenderable right;
+    private readonly int leftWidth;
+    private readonly int gap;
+    private readonly int rightWidth;
+
+    public SideBySide(IRenderable left, int leftWidth, int gap, IRenderable right, int rightWidth)
+    {
+        this.left = left ?? throw new ArgumentNullException(nameof(left));
+        this.right = right ?? throw new ArgumentNullException(nameof(right));
+        this.leftWidth = Math.Max(1, leftWidth);
+        this.gap = Math.Max(0, gap);
+        this.rightWidth = Math.Max(1, rightWidth);
+    }
+
+    protected override Measurement Measure(RenderOptions options, int maxWidth)
+        => new(maxWidth, maxWidth);
+
+    protected override IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+    {
+        var leftLines = Segment.SplitLines(left.Render(options, leftWidth));
+        var rightLines = Segment.SplitLines(right.Render(options, rightWidth));
+        var rows = Math.Max(leftLines.Count, rightLines.Count);
+
+        var outLines = new List<List<Segment>>(rows);
+        for (var i = 0; i < rows; i++)
+        {
+            var row = new List<Segment>();
+            row.AddRange(SegmentGrid.PadLine(i < leftLines.Count ? leftLines[i] : new SegmentLine(), leftWidth));
+            if (gap > 0)
+            {
+                row.Add(new Segment(new string(' ', gap)));
+            }
+
+            row.AddRange(SegmentGrid.PadLine(i < rightLines.Count ? rightLines[i] : new SegmentLine(), rightWidth));
+            outLines.Add(row);
+        }
+
+        return SegmentGrid.Join(outLines);
+    }
+}

--- a/test/Interpreter.Tests/ReplLayoutTests.cs
+++ b/test/Interpreter.Tests/ReplLayoutTests.cs
@@ -195,17 +195,23 @@ public class ReplLayoutTests
     [Fact]
     public void Screen_MouseScroll_RevealsOlderCells()
     {
-        var engine = new SessionEngine { CaptureConsole = true };
-        for (var i = 0; i < 30; i++)
+        // A dozen cells already overflows an 18-row viewport, which is all this test needs to
+        // exercise scrolling. Evaluating many more submissions would be dominated by the
+        // incremental compiler's (unrelated) per-submission cost rather than the scroll logic
+        // under test, so keep the count modest.
+        const int count = 12;
+        var engine = new SessionEngine();
+        for (var i = 0; i < count; i++)
         {
             engine.Evaluate($"var x{i} = {i}");
         }
 
         var screen = new ReplScreen(engine);
+        var newest = $"x{count - 1}";
 
         // Pinned to the bottom: newest cell visible, oldest scrolled off.
         var bottom = Plain(RenderToAnsi(screen.Render(70, 18), 70));
-        Assert.Contains("x29", bottom);
+        Assert.Contains(newest, bottom);
         Assert.DoesNotContain("x0 ", bottom);
 
         // Scroll the wheel up repeatedly; older cells come into view.
@@ -223,7 +229,7 @@ public class ReplLayoutTests
             screen.HandleScroll(ScrollDirection.Down, 3);
         }
 
-        Assert.Contains("x29", Plain(RenderToAnsi(screen.Render(70, 18), 70)));
+        Assert.Contains(newest, Plain(RenderToAnsi(screen.Render(70, 18), 70)));
     }
 
     private static string Plain(string ansi)

--- a/test/Interpreter.Tests/ReplLayoutTests.cs
+++ b/test/Interpreter.Tests/ReplLayoutTests.cs
@@ -3,9 +3,13 @@
 // </copyright>
 
 using System;
+using System.IO;
 using System.Linq;
 using GSharp.Repl.Engine;
 using GSharp.Repl.Screens;
+using GSharp.Repl.Shell;
+using GSharp.Repl.Widgets;
+using Spectre.Console;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
@@ -34,5 +38,260 @@ public class ReplLayoutTests
         screen.HandleKey(new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, true));
         var r = screen.Render(80, 24);
         Assert.NotNull(r);
+    }
+
+    [Fact]
+    public void Snapshot_Empty_BeforeAnyEvaluation()
+    {
+        var engine = new SessionEngine();
+        Assert.True(engine.Snapshot().IsEmpty);
+    }
+
+    [Fact]
+    public void Snapshot_CapturesFunctionsVariablesAndImports()
+    {
+        var engine = new SessionEngine();
+        engine.Evaluate("import \"System\"");
+        engine.Evaluate("var answer = 42");
+        engine.Evaluate("func Twice(n int) int { return n * 2 }");
+
+        var state = engine.Snapshot();
+        Assert.False(state.IsEmpty);
+        Assert.Contains(state.Variables, v => v.Display.Contains("answer"));
+        Assert.Contains(state.Functions, f => f.Display.Contains("Twice"));
+        Assert.Contains(state.Imports, i => i.Display.Contains("System"));
+    }
+
+    [Fact]
+    public void Screen_WithState_RendersSidebarOnWideTerminal()
+    {
+        var engine = new SessionEngine();
+        engine.Evaluate("var answer = 42");
+        var screen = new ReplScreen(engine);
+        Assert.NotNull(screen.Render(120, 30));
+        Assert.NotNull(screen.Render(40, 30));
+    }
+
+    [Fact]
+    public void Backdrop_FillsBackgroundAcrossFullWidthWithAccentBar()
+    {
+        var backdrop = new Backdrop(
+            new Markup("hi"),
+            Color.Grey11,
+            accent: Color.Purple,
+            padLeft: 1,
+            padRight: 1,
+            padTop: 1,
+            padBottom: 1);
+
+        var text = RenderToAnsi(backdrop, 30);
+
+        // The accent bar glyph and a 256-palette background fill are both emitted.
+        Assert.Contains("▏", text);
+        Assert.Contains("48;5;", text);
+    }
+
+    [Fact]
+    public void Screen_TranscriptAndInput_EmitBackgroundFills()
+    {
+        var engine = new SessionEngine { CaptureConsole = true };
+        engine.Evaluate("var answer = 42");
+        var screen = new ReplScreen(engine);
+
+        var text = RenderToAnsi(screen.Render(100, 24), 100);
+
+        // Distinct cell (Grey11 => idx 234) and input (Grey19 => idx 236) backgrounds.
+        Assert.Contains("48;5;234", text);
+        Assert.Contains("48;5;236", text);
+    }
+
+    [Theory]
+    [InlineData(100, 24)]
+    [InlineData(120, 30)]
+    [InlineData(70, 18)]
+    public void Screen_Render_FillsExactHeight_EvenWhenCellsOverflow(int width, int height)
+    {
+        var engine = new SessionEngine { CaptureConsole = true };
+        for (var i = 0; i < 12; i++)
+        {
+            engine.Evaluate($"var x{i} = {i}");
+        }
+
+        var screen = new ReplScreen(engine);
+        Assert.Equal(height, LineCount(screen.Render(width, height), width));
+    }
+
+    [Fact]
+    public void Screen_Render_FillsExactHeight_WithMultiLineInput()
+    {
+        var screen = new ReplScreen(new SessionEngine());
+        foreach (var ch in "func F() {")
+        {
+            screen.HandleKey(new ConsoleKeyInfo(ch, ConsoleKey.NoName, false, false, false));
+        }
+
+        // Shift+Enter inserts newlines, growing the input box upward.
+        for (var i = 0; i < 4; i++)
+        {
+            screen.HandleKey(new ConsoleKeyInfo('\r', ConsoleKey.Enter, true, false, false));
+        }
+
+        Assert.Equal(26, LineCount(screen.Render(100, 26), 100));
+    }
+
+    [Fact]
+    public void Dock_DocksFooterAtBottom_AndFillsExactHeight()
+    {
+        var tall = new Rows(Enumerable.Range(0, 50).Select(i => (Spectre.Console.Rendering.IRenderable)new Markup($"line {i}")).ToArray());
+        var footer = new Rows(new Markup("footer-a"), new Markup("footer-b"));
+        var dock = new Dock(tall, footer, 20, new ScrollState());
+
+        var lines = RenderToAnsi(dock, 40).Split('\n');
+        Assert.Equal(20, lines.Length);
+
+        // Footer occupies the final two lines, pinned to the bottom.
+        Assert.Contains("footer-a", lines[18]);
+        Assert.Contains("footer-b", lines[19]);
+    }
+
+    [Fact]
+    public void Dock_Scroll_RevealsOlderContent_AndClampsOffset()
+    {
+        var tall = new Rows(Enumerable.Range(0, 50).Select(i => (Spectre.Console.Rendering.IRenderable)new Markup($"line{i}")).ToArray());
+        var footer = new Markup("footer");
+        var scroll = new ScrollState();
+        var dock = new Dock(tall, footer, 10, scroll);
+
+        // Pinned to the bottom: newest line visible, oldest not.
+        var bottom = RenderToAnsi(dock, 40);
+        Assert.Contains("line49", bottom);
+
+        // Scroll up beyond the content; the offset is clamped and older lines appear.
+        scroll.ScrollUp(1000);
+        var top = RenderToAnsi(dock, 40);
+        Assert.Contains("line0", top);
+        Assert.True(scroll.Offset <= 50, "Offset should be clamped to available scrollback.");
+    }
+
+    [Fact]
+    public void Overlay_KeepsBaseHeight_AndDrawsModalOnTop()
+    {
+        var baseFrame = new Rows(Enumerable.Range(0, 20).Select(i => (Spectre.Console.Rendering.IRenderable)new Markup($"base{i}")).ToArray());
+        var modal = new Rows(new Markup("MODAL-ROW"));
+        var overlay = new Overlay(baseFrame, modal, 20);
+
+        var lines = RenderToAnsi(overlay, 60).Split('\n');
+        Assert.Equal(20, lines.Length);
+        Assert.Contains(lines, l => l.Contains("MODAL-ROW"));
+
+        // Base chrome above and below the modal band is still present.
+        Assert.Contains(lines, l => l.Contains("base0"));
+        Assert.Contains(lines, l => l.Contains("base19"));
+    }
+
+    private static int LineCount(Spectre.Console.Rendering.IRenderable renderable, int width)
+        => RenderToAnsi(renderable, width).Split('\n').Length;
+
+    [Fact]
+    public void Screen_MouseScroll_RevealsOlderCells()
+    {
+        var engine = new SessionEngine { CaptureConsole = true };
+        for (var i = 0; i < 30; i++)
+        {
+            engine.Evaluate($"var x{i} = {i}");
+        }
+
+        var screen = new ReplScreen(engine);
+
+        // Pinned to the bottom: newest cell visible, oldest scrolled off.
+        var bottom = Plain(RenderToAnsi(screen.Render(70, 18), 70));
+        Assert.Contains("x29", bottom);
+        Assert.DoesNotContain("x0 ", bottom);
+
+        // Scroll the wheel up repeatedly; older cells come into view.
+        for (var i = 0; i < 40; i++)
+        {
+            Assert.True(screen.HandleScroll(ScrollDirection.Up, 3));
+        }
+
+        var top = Plain(RenderToAnsi(screen.Render(70, 18), 70));
+        Assert.Contains("x0 ", top);
+
+        // Scrolling back down returns to the newest content.
+        for (var i = 0; i < 40; i++)
+        {
+            screen.HandleScroll(ScrollDirection.Down, 3);
+        }
+
+        Assert.Contains("x29", Plain(RenderToAnsi(screen.Render(70, 18), 70)));
+    }
+
+    private static string Plain(string ansi)
+        => System.Text.RegularExpressions.Regex.Replace(ansi, "\u001b\\[[0-9;]*m", string.Empty);
+
+    [Fact]
+    public void AppShell_DispatchScroll_RoutesToActiveTab_ButNotWhenModalOpen()
+    {
+        var tab = new RecordingTab();
+        var shell = new AppShell(NullConsole(), new[] { (ITabScreen)tab }, "1.0");
+
+        shell.DispatchScroll(ScrollDirection.Up);
+        shell.DispatchScroll(ScrollDirection.Down);
+        Assert.Equal(2, tab.Scrolls.Count);
+        Assert.Equal(ScrollDirection.Up, tab.Scrolls[0]);
+        Assert.Equal(ScrollDirection.Down, tab.Scrolls[1]);
+
+        // A modal swallows scroll so the palette list isn't scrolled behind it.
+        shell.ShowModal(new CommandPalette(new[] { ("theme", "cycle") }, _ => { }));
+        shell.DispatchScroll(ScrollDirection.Up);
+        Assert.Equal(2, tab.Scrolls.Count);
+    }
+
+    private static IAnsiConsole NullConsole()
+    {
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter { NewLine = "\n" }),
+            Interactive = InteractionSupport.No,
+        });
+        console.Profile.Width = 80;
+        console.Profile.Height = 24;
+        return console;
+    }
+
+    private sealed class RecordingTab : ITabScreen
+    {
+        public System.Collections.Generic.List<ScrollDirection> Scrolls { get; } = new();
+
+        public string Title => "Rec";
+
+        public char NumberKey => '1';
+
+        public Spectre.Console.Rendering.IRenderable Render(int width, int height) => new Markup(string.Empty);
+
+        public bool HandleKey(ConsoleKeyInfo key) => false;
+
+        public bool HandleScroll(ScrollDirection direction, int lines)
+        {
+            Scrolls.Add(direction);
+            return true;
+        }
+    }
+
+    private static string RenderToAnsi(Spectre.Console.Rendering.IRenderable renderable, int width)
+    {
+        var sw = new StringWriter { NewLine = "\n" };
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.TrueColor,
+            Out = new AnsiConsoleOutput(sw),
+            Interactive = InteractionSupport.No,
+        });
+        console.Profile.Width = width;
+        console.Write(renderable);
+        return sw.ToString();
     }
 }

--- a/test/Interpreter.Tests/VtInputDecoderTests.cs
+++ b/test/Interpreter.Tests/VtInputDecoderTests.cs
@@ -1,0 +1,198 @@
+// <copyright file="VtInputDecoderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using GSharp.Repl.Shell;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+public class VtInputDecoderTests
+{
+    private static VtInputDecoder ForBytes(params byte[] bytes)
+    {
+        var queue = new Queue<byte>(bytes);
+        int ReadByte() => queue.Count > 0 ? queue.Dequeue() : -1;
+        bool HasInput(int _) => queue.Count > 0;
+        return new VtInputDecoder(ReadByte, HasInput);
+    }
+
+    private static VtInputDecoder ForText(string ascii) => ForBytes(Encoding.ASCII.GetBytes(ascii));
+
+    [Fact]
+    public void DecodesEnter()
+    {
+        var e = ForBytes(0x0d).Next();
+        Assert.Equal(ConsoleKey.Enter, e!.Value.Key!.Value.Key);
+    }
+
+    [Fact]
+    public void DecodesLineFeedAsEnter()
+    {
+        var e = ForBytes(0x0a).Next();
+        Assert.Equal(ConsoleKey.Enter, e!.Value.Key!.Value.Key);
+    }
+
+    [Fact]
+    public void DecodesTab()
+    {
+        var e = ForBytes(0x09).Next();
+        Assert.Equal(ConsoleKey.Tab, e!.Value.Key!.Value.Key);
+    }
+
+    [Fact]
+    public void DecodesBackspaceDel()
+    {
+        Assert.Equal(ConsoleKey.Backspace, ForBytes(0x7f).Next()!.Value.Key!.Value.Key);
+        Assert.Equal(ConsoleKey.Backspace, ForBytes(0x08).Next()!.Value.Key!.Value.Key);
+    }
+
+    [Fact]
+    public void DecodesLoneEscapeWhenNoFollowup()
+    {
+        var e = ForBytes(0x1b).Next();
+        Assert.Equal(ConsoleKey.Escape, e!.Value.Key!.Value.Key);
+    }
+
+    [Theory]
+    [InlineData('A', ConsoleKey.UpArrow)]
+    [InlineData('B', ConsoleKey.DownArrow)]
+    [InlineData('C', ConsoleKey.RightArrow)]
+    [InlineData('D', ConsoleKey.LeftArrow)]
+    [InlineData('H', ConsoleKey.Home)]
+    [InlineData('F', ConsoleKey.End)]
+    public void DecodesArrows(char final, ConsoleKey expected)
+    {
+        var e = ForBytes(0x1b, (byte)'[', (byte)final).Next();
+        Assert.Equal(expected, e!.Value.Key!.Value.Key);
+    }
+
+    [Fact]
+    public void DecodesShiftTab()
+    {
+        var e = ForBytes(0x1b, (byte)'[', (byte)'Z').Next();
+        Assert.Equal(ConsoleKey.Tab, e!.Value.Key!.Value.Key);
+        Assert.True(e.Value.Key!.Value.Modifiers.HasFlag(ConsoleModifiers.Shift));
+    }
+
+    [Fact]
+    public void DecodesCtrlUpWithModifier()
+    {
+        // ESC [ 1 ; 5 A  => Ctrl+Up
+        var e = ForText("\u001b[1;5A").Next();
+        Assert.Equal(ConsoleKey.UpArrow, e!.Value.Key!.Value.Key);
+        Assert.True(e.Value.Key!.Value.Modifiers.HasFlag(ConsoleModifiers.Control));
+    }
+
+    [Fact]
+    public void DecodesPageUpAndPageDown()
+    {
+        Assert.Equal(ConsoleKey.PageUp, ForText("\u001b[5~").Next()!.Value.Key!.Value.Key);
+        Assert.Equal(ConsoleKey.PageDown, ForText("\u001b[6~").Next()!.Value.Key!.Value.Key);
+    }
+
+    [Fact]
+    public void DecodesF1ViaSs3()
+    {
+        var e = ForText("\u001bOP").Next();
+        Assert.Equal(ConsoleKey.F1, e!.Value.Key!.Value.Key);
+    }
+
+    [Fact]
+    public void DecodesCtrlK()
+    {
+        var e = ForBytes(0x0b).Next();
+        Assert.Equal(ConsoleKey.K, e!.Value.Key!.Value.Key);
+        Assert.True(e.Value.Key!.Value.Modifiers.HasFlag(ConsoleModifiers.Control));
+    }
+
+    [Fact]
+    public void DecodesCtrlC()
+    {
+        var e = ForBytes(0x03).Next();
+        Assert.Equal(ConsoleKey.C, e!.Value.Key!.Value.Key);
+        Assert.True(e.Value.Key!.Value.Modifiers.HasFlag(ConsoleModifiers.Control));
+    }
+
+    [Fact]
+    public void DecodesCtrlSpace()
+    {
+        var e = ForBytes(0x00).Next();
+        Assert.Equal(ConsoleKey.Spacebar, e!.Value.Key!.Value.Key);
+        Assert.True(e.Value.Key!.Value.Modifiers.HasFlag(ConsoleModifiers.Control));
+    }
+
+    [Fact]
+    public void DecodesLowercaseLetter()
+    {
+        var e = ForText("a").Next();
+        Assert.Equal(ConsoleKey.A, e!.Value.Key!.Value.Key);
+        Assert.Equal('a', e.Value.Key!.Value.KeyChar);
+        Assert.False(e.Value.Key!.Value.Modifiers.HasFlag(ConsoleModifiers.Shift));
+    }
+
+    [Fact]
+    public void DecodesUppercaseLetterWithShift()
+    {
+        var e = ForText("Q").Next();
+        Assert.Equal(ConsoleKey.Q, e!.Value.Key!.Value.Key);
+        Assert.Equal('Q', e.Value.Key!.Value.KeyChar);
+        Assert.True(e.Value.Key!.Value.Modifiers.HasFlag(ConsoleModifiers.Shift));
+    }
+
+    [Fact]
+    public void DecodesDigitAndSlash()
+    {
+        Assert.Equal('5', ForText("5").Next()!.Value.Key!.Value.KeyChar);
+        Assert.Equal('/', ForText("/").Next()!.Value.Key!.Value.KeyChar);
+    }
+
+    [Fact]
+    public void DecodesUtf8MultibyteChar()
+    {
+        // 'é' == U+00E9 == 0xC3 0xA9
+        var e = ForBytes(0xc3, 0xa9).Next();
+        Assert.Equal('é', e!.Value.Key!.Value.KeyChar);
+    }
+
+    [Fact]
+    public void DecodesSgrWheelUp()
+    {
+        var e = ForText("\u001b[<64;10;5M").Next();
+        Assert.NotNull(e!.Value.Scroll);
+        Assert.Equal(ScrollDirection.Up, e.Value.Scroll!.Value);
+    }
+
+    [Fact]
+    public void DecodesSgrWheelDown()
+    {
+        var e = ForText("\u001b[<65;10;5M").Next();
+        Assert.NotNull(e!.Value.Scroll);
+        Assert.Equal(ScrollDirection.Down, e.Value.Scroll!.Value);
+    }
+
+    [Fact]
+    public void SkipsNonWheelSgrMouseThenDecodesKey()
+    {
+        // A left-button press (button 0, no wheel bit) followed by 'a'.
+        var e = ForText("\u001b[<0;10;5Ma").Next();
+        Assert.Equal(ConsoleKey.A, e!.Value.Key!.Value.Key);
+    }
+
+    [Fact]
+    public void DecodesLegacyWheelUp()
+    {
+        // ESC [ M, then button (64+32=96), col, row.
+        var e = ForBytes(0x1b, (byte)'[', (byte)'M', 96, 33, 33).Next();
+        Assert.Equal(ScrollDirection.Up, e!.Value.Scroll!.Value);
+    }
+
+    [Fact]
+    public void ReturnsNullAtEndOfInput()
+    {
+        Assert.Null(ForBytes().Next());
+    }
+}


### PR DESCRIPTION
## Summary

Reworks the `gsi` REPL terminal UI to look and behave like OpenCode / GitHub Copilot CLI.

### Layout
- **Scrollable evaluated-cells viewport** — the header, right-hand sidebar, input box, and footer always stay visible; only the cells region scrolls.
- **Bottom-anchored input box** that grows upward as it gains new lines, shrinking the viewport to make room.
- **`/` commands render as a centered modal overlay** on top of visible content.

### Styling
- Input box and right-hand **state sidebar** (functions, variables, classes, imports) share a distinct background with a themed left accent line.
- Placed cells use a third, subtly different background so they read as separate from the default background and the input box.

### Scrolling
- **Keyboard**: PageUp/PageDown and Ctrl+Up/Down scroll the viewport.
- **Mouse wheel**:
  - **Windows** — native `ReadConsoleInput`. Interop structs are fully blittable so wheel notches and characters decode correctly (a non-blittable `bool`/`char` had shifted `UnicodeChar` onto the scan-code offset).
  - **macOS/Linux** — opt-in via `GSI_MOUSE=1`, using raw-mode `stty` + SGR mouse reporting decoded by a pure, unit-tested `VtInputDecoder`. Defaults to the safe `Console.ReadKey` path (keyboard only) so terminal input never regresses.

### Implementation
- New Spectre.Console widgets: `Dock`, `Backdrop`, `SideBySide`, `FixedHeight`, `Overlay`, `SegmentGrid`.
- New `IInputReader` abstraction (`InputEvent` = key XOR scroll) with `ConsoleInputReader` (Windows native / Unix raw-mode / fallback) and `VtInputDecoder`.

## Testing
- `ReplLayout` + `VtInputDecoder` suites — **43 passing**.
- `Repl.csproj` builds clean in Release.
- Win32 interop struct offsets verified against the native `KEY_EVENT_RECORD` / `INPUT_RECORD` layout.
