### PR TITLE
Deflake Many_Interpolation_Holes_Parse_Near_Linear_Time perf test (#2088)

### DIFF
--- a/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringTests.cs
@@ -487,13 +487,18 @@ public class InterpolatedStringTests
             return System.Math.Max(best, 1);
         }
 
-        var small = TimeParse(BuildSource(500));
-        var large = TimeParse(BuildSource(4000)); // 8x the holes/text
+        // Use a large-enough `small` baseline that fixed per-run overhead and
+        // scheduler/cache noise are a small fraction of the measurement — a
+        // tiny baseline (e.g. 500 holes) is dominated by noise on shared CI
+        // hardware and makes the ratio spuriously large (see issue #2088).
+        var small = TimeParse(BuildSource(2000));
+        var large = TimeParse(BuildSource(16000)); // 8x the holes/text
 
         // Quadratic behavior would show ~64x growth; near-linear should stay
-        // well under that. Generous bound to avoid flakiness on shared CI
-        // hardware while still catching a regression back to O(n^2).
-        Assert.True(large < small * 30, $"expected near-linear scaling, got small={small} large={large} ratio={(double)large / small}");
+        // well under that. Bound is generous (50x for 8x input) to tolerate
+        // wall-clock noise on oversubscribed CI runners while still catching a
+        // regression back to O(n^2).
+        Assert.True(large < small * 50, $"expected near-linear scaling, got small={small} large={large} ratio={(double)large / small}");
     }
 
     private static (ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Diagnostics, System.Collections.Generic.Dictionary<VariableSymbol, object> Variables) Evaluate(string source)


### PR DESCRIPTION
Fixes #2088

Raise the `small` baseline (500->2000 holes) so fixed per-run overhead and scheduler/cache noise are a smaller fraction of the wall-clock measurement, and loosen the ratio bound (30x->50x for 8x input) to tolerate noise on oversubscribed CI runners while still catching an O(n^2) regression (~64x).

The tiny 500-hole baseline was dominated by noise on shared CI hardware and produced spurious ratios (observed 33x on #2076 build, 55x on #2077 build) that failed the required `build` check on unrelated PRs and forced manual re-runs.