### PR TITLE
cs2gs: expression-position deconstruction-assignment not handled

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1895DeconstructAssignTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1895DeconstructAssignTranslationTests.cs
@@ -36,9 +36,9 @@ namespace Cs2Gs.Tests;
 /// Spilling the RHS as a single statement (rather than one assignment per
 /// element) also preserves C#'s evaluate-then-assign-all semantics, so an
 /// aliasing swap (<c>(a, b) = (b, a)</c>) is lowered correctly. A NESTED
-/// target (<c>((a, b), c) = ...</c>) has no flat <c>t0, t1, ...</c> shape to
-/// spill into, so it stays a loud CS2GS-GAP rather than risk a silent
-/// miscompile.
+/// target (<c>((a, b), c) = ...</c>) recurses: the nested arm gets its own
+/// temp, which a SECOND <c>let (...) = temp</c> statement then further
+/// deconstructs (issue #1974).
 /// </summary>
 public class Issue1895DeconstructAssignTranslationTests
 {
@@ -168,14 +168,12 @@ namespace Corpus.Issue1895
     }
 
     [Fact]
-    public void NestedTarget_StaysLoudGap()
+    public void NestedTarget_LowersToChainedDeconstructionStatements()
     {
-        // `((a, b), c) = ...` has no flat target-list shape for G#'s native
-        // `let (t0, t1, ...) = rhs` deconstruction binding to spill into, so
-        // it must keep reporting the CS2GS-GAP rather than risk a silent
-        // miscompile.
-        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
-            new[] { ("Source.cs", @"
+        // `((a, b), c) = ((4, 5), 6)` (issue #1974): the outer temp holding the
+        // nested element is deconstructed by a SECOND native `let (...) = ...`
+        // binding rather than gapping.
+        string rendered = Render(@"
 namespace Corpus.Issue1895
 {
     public class Holder
@@ -190,15 +188,14 @@ namespace Corpus.Issue1895
         }
     }
 }
-") });
+");
 
-        Assert.True(project.BoundWithoutErrors);
-        LoadedDocument document = Assert.Single(project.Documents);
-        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
-        new CSharpToGSharpTranslator().TranslateDocument(document, context);
-        Assert.Contains(
-            context.Diagnostics,
-            d => d.Message.Contains("nested tuple target", StringComparison.Ordinal));
+        Assert.Contains("let (__decon0, __decon1) = ((4, 5), 6)", rendered, StringComparison.Ordinal);
+        Assert.Contains("let (__decon2, __decon3) = __decon0", rendered, StringComparison.Ordinal);
+        Assert.Contains("a = __decon2", rendered, StringComparison.Ordinal);
+        Assert.Contains("b = __decon3", rendered, StringComparison.Ordinal);
+        Assert.Contains("c = __decon1", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1974ExpressionPositionDeconstructAssignTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1974ExpressionPositionDeconstructAssignTranslationTests.cs
@@ -1,0 +1,239 @@
+// <copyright file="Issue1974ExpressionPositionDeconstructAssignTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1974: a C# deconstruction-ASSIGNMENT used in EXPRESSION position
+/// (<c>var r = (x, y) = (1, 2);</c>, <c>M((a, b) = (1, 2))</c>, a chained
+/// <c>x = (a, b) = (1, 2);</c>, ...) — not just the bare-statement form
+/// (<c>(x, y) = (1, 2);</c>) already handled by issue #1895 — was not
+/// hoisted at all: only the <c>ExpressionStatement</c> wrapper was
+/// recognized, so a deconstruction assignment anywhere else in an
+/// expression tree fell through untranslated.
+///
+/// The fix reuses the same value-position-assignment hoisting seam that
+/// already handles a scalar assignment used as a value (issue #1723): the
+/// deconstruction assignment is lowered exactly like the statement form
+/// (one native <c>let (t0, t1, ...) = rhs</c> spill per nesting level, plus
+/// per-element assignments), except EVERY element — including a discard —
+/// is captured in a real temp, and the expression's value becomes a tuple
+/// literal over those temps (the same value C# itself produces). A
+/// deconstruction assignment that introduces a NEW local (<c>(x, var y) =
+/// ...</c>) is only legal C# as a bare statement (CS8185 otherwise), so that
+/// mixed form is unreachable in expression position and stays covered by the
+/// statement-form tests in <see cref="Issue1895DeconstructAssignTranslationTests"/>.
+/// </summary>
+public class Issue1974ExpressionPositionDeconstructAssignTranslationTests
+{
+    [Fact]
+    public void LocalInitializer_FromDeconstructAssign_HoistsThenReadsTupleValue()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1974
+{
+    public class Holder
+    {
+        public void M()
+        {
+            int x = 0;
+            int y = 0;
+            var r = (x, y) = (1, 2);
+            System.Console.WriteLine(r.Item1 + r.Item2);
+        }
+    }
+}
+");
+
+        Assert.Contains("let (__decon0, __decon1) = (1, 2)", rendered, StringComparison.Ordinal);
+        Assert.Contains("x = __decon0", rendered, StringComparison.Ordinal);
+        Assert.Contains("y = __decon1", rendered, StringComparison.Ordinal);
+        Assert.Contains("let r = (__decon0, __decon1)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ArgumentPosition_DeconstructAssign_HoistsBeforeCall()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1974
+{
+    public class Holder
+    {
+        public void Accept<T>(T t)
+        {
+        }
+
+        public void M()
+        {
+            int x = 0;
+            int y = 0;
+            Accept((x, y) = (1, 2));
+        }
+    }
+}
+");
+
+        Assert.Contains("let (__decon0, __decon1) = (1, 2)", rendered, StringComparison.Ordinal);
+        Assert.Contains("x = __decon0", rendered, StringComparison.Ordinal);
+        Assert.Contains("y = __decon1", rendered, StringComparison.Ordinal);
+        Assert.Contains("Accept((__decon0, __decon1))", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ChainedAssignment_OuterTargetReadsDeconstructAssignValue()
+    {
+        // `x = (a, b) = (1, 2);`: the outer `x` is written the tuple VALUE
+        // produced by the inner deconstruction assignment.
+        string rendered = Render(@"
+namespace Corpus.Issue1974
+{
+    public class Holder
+    {
+        public void M()
+        {
+            int a = 0;
+            int b = 0;
+            var x = (0, 0);
+            x = (a, b) = (1, 2);
+            System.Console.WriteLine(x.Item1 + x.Item2);
+        }
+    }
+}
+");
+
+        Assert.Contains("let (__decon0, __decon1) = (1, 2)", rendered, StringComparison.Ordinal);
+        Assert.Contains("a = __decon0", rendered, StringComparison.Ordinal);
+        Assert.Contains("b = __decon1", rendered, StringComparison.Ordinal);
+        Assert.Contains("x = (__decon0, __decon1)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void DiscardTarget_InExpressionPosition_StillCapturesValueInRealTemp()
+    {
+        // Unlike the statement form (issue #1895), a discard here still
+        // needs a real temp: its value feeds the deconstruction assignment's
+        // own result.
+        string rendered = Render(@"
+namespace Corpus.Issue1974
+{
+    public class Holder
+    {
+        public void M()
+        {
+            int x = 0;
+            var r = (x, _) = (1, 2);
+            System.Console.WriteLine(x + r.Item2);
+        }
+    }
+}
+");
+
+        Assert.Contains("let (__decon0, __decon1) = (1, 2)", rendered, StringComparison.Ordinal);
+        Assert.Contains("x = __decon0", rendered, StringComparison.Ordinal);
+        Assert.Contains("let r = (__decon0, __decon1)", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("(__decon0, _)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void NestedTarget_InExpressionPosition_ReadsBackNestedTupleValue()
+    {
+        // `((a, b), c) = ...` used as a value: the nested arm's value is
+        // rebuilt as its own nested tuple literal (issue #1974 generalizes
+        // the nested-target support added for the statement form).
+        string rendered = Render(@"
+namespace Corpus.Issue1974
+{
+    public class Holder
+    {
+        public void M()
+        {
+            int a = 0;
+            int b = 0;
+            int c = 0;
+            var r = ((a, b), c) = ((1, 2), 3);
+            System.Console.WriteLine(a + b + c + r.Item2);
+        }
+    }
+}
+");
+
+        Assert.Contains("let (__decon0, __decon1) = ((1, 2), 3)", rendered, StringComparison.Ordinal);
+        Assert.Contains("let (__decon2, __decon3) = __decon0", rendered, StringComparison.Ordinal);
+        Assert.Contains("a = __decon2", rendered, StringComparison.Ordinal);
+        Assert.Contains("b = __decon3", rendered, StringComparison.Ordinal);
+        Assert.Contains("c = __decon1", rendered, StringComparison.Ordinal);
+        Assert.Contains("let r = ((__decon2, __decon3), __decon1)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void NonIdentifierTarget_InExpressionPosition_StaysLoudGap()
+    {
+        // Same evaluation-order hazard as the statement form (issue #1895),
+        // reached here via the value-position hoisting seam instead.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+namespace Corpus.Issue1974
+{
+    public class Holder
+    {
+        public void M()
+        {
+            int[] arr = new int[2];
+            int i = 0;
+            int y = 1;
+            var r = (arr[i], y) = (2, 3);
+            System.Console.WriteLine(arr[0] + y + r.Item2);
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors);
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Message.Contains("non-identifier target", StringComparison.Ordinal));
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -601,6 +601,16 @@ public sealed class CSharpToGSharpTranslator
         private readonly HashSet<SyntaxNode> suppressedAssignments =
             new HashSet<SyntaxNode>();
 
+        // Caches the G# value expression a value-position deconstruction
+        // assignment (`(a, b) = (1, 2)` used as a value, not a bare statement)
+        // was lowered to, keyed by its LHS tuple-target syntax node. Populated
+        // once by <see cref="LowerTupleAssignmentForValue"/> when the write is
+        // hoisted (see <see cref="FlattenChainedAssignment"/>); read back when
+        // `TranslateExpression` later revisits the (now suppressed) assignment
+        // node in its original position (issue #1974).
+        private readonly Dictionary<TupleExpressionSyntax, GExpression> tupleAssignmentValues =
+            new Dictionary<TupleExpressionSyntax, GExpression>();
+
         // Static-field initializers lifted out of a `static` constructor body
         // (`static T() { Field = value; }`). G# has no static constructor, so a
         // simple static ctor is folded into the corresponding `shared { }` field
@@ -6652,29 +6662,25 @@ public sealed class CSharpToGSharpTranslator
                 // preserves C#'s evaluate-then-assign-all semantics (handles
                 // aliasing such as the swap `(a, b) = (b, a)`); issue #1895,
                 // ADR-0115 §B. A NESTED target (`((a, b), c) = ...`) has no
-                // flat `t0, t1, ...` shape to spill into — gap loudly rather
-                // than risk a silent miscompile.
+                // flat `t0, t1, ...` shape at the top level, but is lowered by
+                // recursing: the nested arm gets its own temp, which is then
+                // deconstructed by a SECOND `let (...) = temp` statement
+                // (issue #1974) — G#'s grammar only needs a flat name list per
+                // statement, and nothing stops chaining several of them.
                 if (assignment.Left is TupleExpressionSyntax leftTuple)
                 {
-                    if (leftTuple.Arguments.Any(a => a.Expression is TupleExpressionSyntax))
+                    if (HasNonIdentifierDeconstructionTarget(leftTuple))
                     {
-                        string message = "a nested tuple target in a deconstruction-assignment " +
-                            "('((a, b), c) = ...') has no canonical G# form yet " +
-                            "(issue #1895); G#'s tuple-deconstruction binding only " +
-                            "supports a flat target list.";
-                        this.context.ReportUnsupported(assignment, message);
-                    }
-                    else if (leftTuple.Arguments.Any(a => a.Expression is not IdentifierNameSyntax and not DeclarationExpressionSyntax))
-                    {
-                        // A non-identifier target (`arr[i]`, `obj.F`, ...) in a
-                        // deconstruction-assignment. C# evaluates all LHS storage
-                        // references BEFORE the RHS; `LowerTupleAssignment` spills
-                        // the RHS first and writes targets afterward, reversing
-                        // that order. For a plain identifier there is nothing to
-                        // evaluate (no side effect), so the reorder is safe; for
-                        // anything else (element/member access, deref, ...) it can
-                        // silently miscompile if the RHS mutates state the target
-                        // expression reads (issue #1895). Gap loudly instead.
+                        // A non-identifier target (`arr[i]`, `obj.F`, ...) anywhere
+                        // in the (possibly nested) target shape. C# evaluates all
+                        // LHS storage references BEFORE the RHS; `LowerTuplePattern`
+                        // spills the RHS first and writes targets afterward,
+                        // reversing that order. For a plain identifier (or a new
+                        // `var`/nested-`var` binding) there is nothing to evaluate
+                        // (no side effect), so the reorder is safe; for anything
+                        // else (element/member access, deref, ...) it can silently
+                        // miscompile if the RHS mutates state the target expression
+                        // reads (issue #1895). Gap loudly instead.
                         string message = "a non-identifier target ('arr[i]', 'obj.F', ...) in a " +
                             "deconstruction-assignment has no safe G# lowering yet (issue #1895): " +
                             "C# evaluates LHS storage references before the right-hand side, but " +
@@ -7024,6 +7030,8 @@ public sealed class CSharpToGSharpTranslator
             // be a parenthesized nested assignment.
             var lefts = new List<(GExpression Target, string Op)>();
             ExpressionSyntax current = assignment;
+            TupleExpressionSyntax tupleLink = null;
+            ExpressionSyntax tupleLinkRight = null;
             while (true)
             {
                 ExpressionSyntax unwrapped = current;
@@ -7034,6 +7042,18 @@ public sealed class CSharpToGSharpTranslator
 
                 if (unwrapped is not AssignmentExpressionSyntax link)
                 {
+                    break;
+                }
+
+                if (link.Left is TupleExpressionSyntax linkTuple)
+                {
+                    // A deconstruction-assignment link (`(a, b) = ...`) used in
+                    // value position, either standalone (`var r = ((x, y) = (1,
+                    // 2));`) or feeding an outer chain (`x = (a, b) = (1, 2);`).
+                    // It has no single further "target" of its own, so the
+                    // chain walk ends here (issue #1974).
+                    tupleLink = linkTuple;
+                    tupleLinkRight = link.Right;
                     break;
                 }
 
@@ -7055,7 +7075,34 @@ public sealed class CSharpToGSharpTranslator
                 safeTargets[i] = this.MakeDuplicationSafeTarget(lefts[i].Target, statements);
             }
 
-            GExpression value = this.TranslateExpression(current);
+            GExpression value;
+            if (tupleLink != null)
+            {
+                if (HasNonIdentifierDeconstructionTarget(tupleLink))
+                {
+                    // Same evaluation-order hazard as the statement-position gap
+                    // above (issue #1895), reached here via the value-position
+                    // path instead (issue #1974).
+                    string message = "a non-identifier target ('arr[i]', 'obj.F', ...) in a " +
+                        "deconstruction-assignment has no safe G# lowering yet (issue #1895): " +
+                        "C# evaluates LHS storage references before the right-hand side, but " +
+                        "G#'s lowering must spill the right-hand side first, which would " +
+                        "silently reverse evaluation order for a side-effecting target.";
+                    this.context.ReportUnsupported(tupleLink, message);
+                    value = new IdentifierExpression("nil");
+                }
+                else
+                {
+                    (List<GStatement> tupleStatements, GExpression tupleValue) =
+                        this.LowerTupleAssignmentForValue(tupleLink, tupleLinkRight);
+                    statements.AddRange(tupleStatements);
+                    value = tupleValue;
+                }
+            }
+            else
+            {
+                value = this.TranslateExpression(current);
+            }
 
             // Walk the chain innermost-out, assigning to each target in turn.
             // C# assigns the SAME rhs VALUE to every target in a run of plain
@@ -7155,30 +7202,87 @@ public sealed class CSharpToGSharpTranslator
             _ => null,
         };
 
+        // True when a discard element — either the bare-assignment form
+        // (`(x, _) = ...`) or the declaration form (`(x, var _) = ...`,
+        // parsed as a `DeclarationExpressionSyntax` wrapping a
+        // `DiscardDesignationSyntax`).
+        private bool IsDeconstructionDiscard(ExpressionSyntax targetExpr) =>
+            (targetExpr is IdentifierNameSyntax discardCandidate &&
+                discardCandidate.Identifier.ValueText == "_" &&
+                this.IsTrueDiscard(discardCandidate)) ||
+                targetExpr is DeclarationExpressionSyntax { Designation: DiscardDesignationSyntax };
+
+        // Recursively checks every leaf of a (possibly nested) deconstruction
+        // *assignment* target for a non-identifier storage reference (`arr[i]`,
+        // `obj.F`, ...). A nested tuple target or a new `var`/nested-`var`
+        // binding is always safe (no pre-existing storage to evaluate before
+        // the RHS); only an existing-variable write needs to be a bare
+        // identifier (issue #1895/#1974).
+        private static bool HasNonIdentifierDeconstructionTarget(TupleExpressionSyntax tuple) =>
+            tuple.Arguments.Any(a => a.Expression switch
+            {
+                TupleExpressionSyntax nested => HasNonIdentifierDeconstructionTarget(nested),
+                DeclarationExpressionSyntax => false,
+                IdentifierNameSyntax => false,
+                _ => true,
+            });
+
+        // Statement-position deconstruction assignment (`(a, b) = (x, y);`):
+        // the resulting per-element values are never read back, so discards
+        // stay true discards (no temp allocated for them).
         private IEnumerable<GStatement> LowerTupleAssignment(
             TupleExpressionSyntax leftTuple,
             ExpressionSyntax right)
         {
-            int count = leftTuple.Arguments.Count;
-            var temps = new List<string>(count);
+            var statements = new List<GStatement>();
+            this.LowerTuplePattern(leftTuple, this.TranslateExpression(right), forceRealTemps: false, statements);
+            return statements;
+        }
 
+        // Expression-position deconstruction assignment (`var r = ((x, y) =
+        // (1, 2));`, `M((a, b) = e)`, ...): the assignment's VALUE — a tuple
+        // of the assigned elements, in target order — is needed by the
+        // enclosing expression, so every element (including a discard) is
+        // captured in a real temp and the value is rebuilt as a tuple literal
+        // over those temps (issue #1974).
+        private (List<GStatement> Statements, GExpression Value) LowerTupleAssignmentForValue(
+            TupleExpressionSyntax leftTuple,
+            ExpressionSyntax right)
+        {
+            var statements = new List<GStatement>();
+            List<GExpression> values = this.LowerTuplePattern(leftTuple, this.TranslateExpression(right), forceRealTemps: true, statements);
+            GExpression value = new TupleLiteralExpression(values);
+            this.tupleAssignmentValues[leftTuple] = value;
+            return (statements, value);
+        }
+
+        // Core recursive lowering shared by the statement- and
+        // expression-position forms above. `rhsValue` is the G# expression to
+        // deconstruct — the fully translated original right-hand side on the
+        // OUTERMOST call, or a bare temp-identifier read on a recursive call
+        // for a nested target (already single-evaluation-safe, so it needs no
+        // further spilling). Returns each element's resulting value (`null`
+        // for a true discard when `forceRealTemps` is false, since nothing
+        // captures its value in that case).
+        private List<GExpression> LowerTuplePattern(
+            TupleExpressionSyntax pattern,
+            GExpression rhsValue,
+            bool forceRealTemps,
+            List<GStatement> statements)
+        {
+            int count = pattern.Arguments.Count;
+            var temps = new List<string>(count);
             for (int i = 0; i < count; i++)
             {
-                ExpressionSyntax targetExpr = leftTuple.Arguments[i].Expression;
+                ExpressionSyntax targetExpr = pattern.Arguments[i].Expression;
 
-                // A true discard element — either the bare-assignment form
-                // (`(x, _) = ...`) or the declaration form (`(x, var _) = ...`,
-                // parsed as a `DeclarationExpressionSyntax` wrapping a
-                // `DiscardDesignationSyntax`) — needs no temp at all: G#'s
-                // native deconstruction binding already treats a literal `_`
-                // name as a discard.
-                temps.Add(
-                    (targetExpr is IdentifierNameSyntax discardCandidate &&
-                        discardCandidate.Identifier.ValueText == "_" &&
-                        this.IsTrueDiscard(discardCandidate)) ||
-                        targetExpr is DeclarationExpressionSyntax { Designation: DiscardDesignationSyntax }
-                        ? "_"
-                        : $"__decon{this.deconCounter++}");
+                // A nested tuple target needs its own real temp to recurse
+                // into, even when `forceRealTemps` is false — its own leaves
+                // decide their own discard-ness independently below.
+                bool needsRealTemp = forceRealTemps ||
+                    targetExpr is TupleExpressionSyntax ||
+                    !this.IsDeconstructionDiscard(targetExpr);
+                temps.Add(needsRealTemp ? $"__decon{this.deconCounter++}" : "_");
             }
 
             // Spill the WHOLE right-hand side in one native decon-binding.
@@ -7188,19 +7292,32 @@ public sealed class CSharpToGSharpTranslator
             // internals, never reassigned. This is exactly the mechanism the
             // declaration form (`var (a, b) = e`) already uses, so it inherits
             // the same RHS-shape support for free.
-            var statements = new List<GStatement>
-            {
-                new TupleDeconstructionStatement(BindingKind.Let, temps, this.TranslateExpression(right)),
-            };
+            statements.Add(new TupleDeconstructionStatement(BindingKind.Let, temps, rhsValue));
 
+            var values = new List<GExpression>(count);
             for (int i = 0; i < count; i++)
             {
+                ExpressionSyntax targetExpr = pattern.Arguments[i].Expression;
                 if (temps[i] == "_")
                 {
+                    values.Add(null);
                     continue;
                 }
 
-                ExpressionSyntax targetExpr = leftTuple.Arguments[i].Expression;
+                var tempRead = (GExpression)new IdentifierExpression(temps[i]);
+
+                if (targetExpr is TupleExpressionSyntax nestedTuple)
+                {
+                    // Nested target (`((a, b), c) = ...`): the outer temp
+                    // holds the nested element's value, itself a tuple — spill
+                    // IT with a second native decon-binding rather than trying
+                    // to flatten every depth into one `let (...)` (issue
+                    // #1974). The recursive rhsValue is already a bare temp
+                    // read, so no further spill is needed before recursing.
+                    List<GExpression> nestedValues = this.LowerTuplePattern(nestedTuple, tempRead, forceRealTemps, statements);
+                    values.Add(forceRealTemps ? new TupleLiteralExpression(nestedValues) : null);
+                    continue;
+                }
 
                 if (targetExpr is DeclarationExpressionSyntax declaration)
                 {
@@ -7216,6 +7333,7 @@ public sealed class CSharpToGSharpTranslator
 
                     if (name == "_")
                     {
+                        values.Add(forceRealTemps ? tempRead : null);
                         continue;
                     }
 
@@ -7229,7 +7347,8 @@ public sealed class CSharpToGSharpTranslator
                         binding,
                         name,
                         type: null,
-                        initializer: new IdentifierExpression(temps[i])));
+                        initializer: tempRead));
+                    values.Add(new IdentifierExpression(name));
                     continue;
                 }
 
@@ -7237,10 +7356,11 @@ public sealed class CSharpToGSharpTranslator
                 // the spilled value back.
                 statements.Add(new AssignmentStatement(
                     this.TranslateExpression(targetExpr),
-                    new IdentifierExpression(temps[i])));
+                    tempRead));
+                values.Add(tempRead);
             }
 
-            return statements;
+            return values;
         }
 
         private bool TryGetDeconstructionTargets(
@@ -9798,6 +9918,18 @@ public sealed class CSharpToGSharpTranslator
                     // (now up-to-date) target (issue #1723).
                     if (this.suppressedAssignments.Contains(nestedAssignment))
                     {
+                        // A deconstruction assignment (`(a, b) = ...`) has no
+                        // single "target" to read back — LowerTupleAssignmentForValue
+                        // already computed its value (a tuple of the assigned
+                        // elements) when the write was hoisted; reuse it rather
+                        // than trying to read `nestedAssignment.Left` (a tuple
+                        // TARGET pattern, not a value expression) (issue #1974).
+                        if (nestedAssignment.Left is TupleExpressionSyntax leftTuplePattern &&
+                            this.tupleAssignmentValues.TryGetValue(leftTuplePattern, out GExpression cachedTupleValue))
+                        {
+                            return cachedTupleValue;
+                        }
+
                         GExpression hoistedTarget = this.TranslateExpression(nestedAssignment.Left);
 
                         // Issue #1907: `x ??= y` only runs its assignment when `x`


### PR DESCRIPTION
Fixes #1974

Generalizes the deconstruction-assignment lowering added for issue #1895 (statement-position only, `(a, b) = (x, y);`) to also cover:

- **Expression position**: `var r = (x, y) = (1, 2);`, `M((a, b) = e)`, a chained `x = (a, b) = (1, 2);`. The assignment's value (a tuple of the assigned elements, in target order — the same value C# itself produces) is captured via real temps and rebuilt as a tuple literal, reusing the existing value-position-assignment hoisting seam (issue #1723) that already threads a scalar assignment's value through `WithHoistedAssignments`/`TranslateConditionWithHoist`/return- and local-initializer hoisting.
- **Nested targets**: `((a, b), c) = ...` no longer gaps. The nested arm spills into its own temp, which a second native `let (...) = temp` statement further deconstructs, so nesting composes to any depth for free out of the existing flat `let (t0, t1, ...) = rhs` binding — in both statement and expression position.
- **Discards and mixed declared/existing targets** continue to work, generalized recursively (a discard in expression position gets a real temp since its value feeds the result; in statement position it stays a true discard, unchanged from #1895).
- The non-identifier-target gap (`arr[i]`, `obj.F`, ...; issue #1895's evaluation-order hazard) is preserved and now applies recursively at any nesting depth, in both positions.

## Changes

- `tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs`:
  - Extracted the core lowering into a single recursive `LowerTuplePattern` helper (statement-only `LowerTupleAssignment` and value-producing `LowerTupleAssignmentForValue` both delegate to it), so the statement and expression forms stay in sync as the shape generalizes.
  - `FlattenChainedAssignment` now recognizes a tuple-target link and lowers it via `LowerTupleAssignmentForValue`, caching the resulting tuple value (keyed by the LHS tuple-target syntax node) so the generic value-position-assignment read-back (used by every existing hoisting call site — local-declaration initializers, `return`, hoisted conditions, hoisted call arguments, ...) can reuse it instead of re-deriving/re-evaluating.
  - Replaced the old `leftTuple.Arguments.Any(a => ... is TupleExpressionSyntax)` hard gap with recursive nested-target lowering; replaced the flat non-identifier-target scan with a recursive `HasNonIdentifierDeconstructionTarget`.
- `tools/cs2gs/Cs2Gs.Tests/Issue1895DeconstructAssignTranslationTests.cs`: updated `NestedTarget_StaysLoudGap` → `NestedTarget_LowersToChainedDeconstructionStatements` (nested targets are now translated, not gapped).
- `tools/cs2gs/Cs2Gs.Tests/Issue1974ExpressionPositionDeconstructAssignTranslationTests.cs` (new): local-initializer, argument-position, chained-assignment, discard, nested-target, and non-identifier-target-gap coverage for the expression-position form. All assertions verify the emitted G# round-trip-parses via `GSharpRoundTrip.Validate`.

Ran `cs2gs coverage` — inventory/golden/docs matrix already in sync (no new construct kind introduced; `SimpleAssignmentExpression` was already tracked as `Translated` under issue #1895).

## Testing

- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --filter "FullyQualifiedName~Issue1974"` — 6/6 passed.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --filter "FullyQualifiedName~Issue1895"` — 9/9 passed.
- Full `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj` — 1041/1041 passed.
