### PR TITLE
cs2gs: LINQ follow-ups (tuple arity-8 cap, __qN collision guard, query combo tests) (#1998)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1998LinqFollowUpTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1998LinqFollowUpTests.cs
@@ -1,0 +1,255 @@
+// <copyright file="Issue1998LinqFollowUpTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1998 (follow-ups from the #1902/#1997 Opus review):
+/// <list type="number">
+/// <item>a query scope that grows past G#'s 7-element tuple arity cap now
+/// reports a precise, actionable <see cref="TranslationDiagnostic"/> instead
+/// of silently emitting a tuple shape that would only surface as an opaque
+/// GS0159 much later at G# bind time;</item>
+/// <item>the synthesized transparent-identifier tuple parameter name
+/// (<c>__qN</c>) now guards against colliding with a user-declared range
+/// variable literally named <c>__q0</c>/etc.;</item>
+/// <item>previously-untested query-clause combinations (join after a
+/// preceding <c>let</c>, a join continuing a <c>group ... into</c>, and a
+/// scope with more than 3 range variables) are locked in with regression
+/// tests.</item>
+/// </list>
+/// </summary>
+public class Issue1998LinqFollowUpTests
+{
+    [Fact]
+    public void QueryScope_GrowingPastSevenRangeVariables_ReportsPreciseDiagnostic()
+    {
+        // Eight range variables in scope by the final `let` (n plus 7 lets):
+        // exceeds G#'s 7-element tuple arity cap.
+        string source = @"
+using System.Linq;
+
+namespace Corpus.Issue1998
+{
+    public class Holder
+    {
+        public int[] Sums(int[] nums)
+        {
+            var q = from n in nums
+                    let a = n + 1
+                    let b = n + 2
+                    let c = n + 3
+                    let d = n + 4
+                    let e = n + 5
+                    let f = n + 6
+                    let g = n + 7
+                    select n + a + b + c + d + e + f + g;
+            return q.ToArray();
+        }
+    }
+}
+";
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Source.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        _ = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        TranslationDiagnostic diagnostic = Assert.Single(context.Diagnostics);
+        Assert.Equal(TranslationSeverity.Unsupported, diagnostic.Severity);
+        Assert.Contains("8 range variables", diagnostic.Message, StringComparison.Ordinal);
+        Assert.Contains("7 elements", diagnostic.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void QueryScope_WithUserLocalNamed__q0_DoesNotCollideWithSynthesizedTupleParam()
+    {
+        // A user local literally named `__q0` sits alongside the query so the
+        // synthesized tuple parameter (which would otherwise also start at
+        // `__q0`) must be bumped past it.
+        string rendered = Render(@"
+using System.Linq;
+
+namespace Corpus.Issue1998
+{
+    public class Holder
+    {
+        public int[] Sums(int[] nums)
+        {
+            int __q0 = 41;
+            var q = from n in nums
+                    let sq = n * n
+                    where sq > __q0
+                    select n + sq;
+            return q.ToArray();
+        }
+    }
+}
+");
+
+        Assert.DoesNotContain("let (n, sq) = __q0", rendered, StringComparison.Ordinal);
+        Assert.Contains("let (n, sq) = __q1", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void JoinAfterLetClause_WidensThreeElementScope_LowersToJoinWithTupleResultSelector()
+    {
+        string rendered = Render(@"
+using System.Linq;
+
+namespace Corpus.Issue1998
+{
+    public class Order
+    {
+        public int CustomerId;
+        public int Amount;
+    }
+
+    public class Customer
+    {
+        public int Id;
+        public string Name;
+    }
+
+    public class Holder
+    {
+        public string[] Receipts(Order[] orders, Customer[] customers)
+        {
+            var receipts = from o in orders
+                           let taxed = o.Amount + o.Amount / 10
+                           join c in customers on o.CustomerId equals c.Id
+                           select c.Name + "":"" + taxed;
+            return receipts.ToArray();
+        }
+    }
+}
+");
+
+        Assert.Contains(
+            "orders.Select((o Order) -> {",
+            rendered,
+            StringComparison.Ordinal);
+        Assert.Contains("return (o, o.Amount + o.Amount / 10)", rendered, StringComparison.Ordinal);
+        Assert.Contains(
+            "}).Join(customers, (__q0 (Order, int32)) -> {",
+            rendered,
+            StringComparison.Ordinal);
+        Assert.Contains("let (o, taxed) = __q0", rendered, StringComparison.Ordinal);
+        Assert.Contains("return o.CustomerId", rendered, StringComparison.Ordinal);
+        Assert.Contains("(c Customer) -> c.Id", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void GroupClauseContinuation_FollowedByJoin_LowersToGroupByThenJoin()
+    {
+        string rendered = Render(@"
+using System.Linq;
+
+namespace Corpus.Issue1998
+{
+    public class Sale
+    {
+        public int RegionId;
+        public int Amount;
+    }
+
+    public class Region
+    {
+        public int Id;
+        public string Name;
+    }
+
+    public class Holder
+    {
+        public string[] Totals(Sale[] sales, Region[] regions)
+        {
+            var totals = from s in sales
+                         group s.Amount by s.RegionId into g
+                         join r in regions on g.Key equals r.Id
+                         select r.Name + ""="" + g.Sum();
+            return totals.ToArray();
+        }
+    }
+}
+");
+
+        Assert.Contains("sales.GroupBy((s Sale) -> s.RegionId, (s Sale) -> s.Amount)", rendered, StringComparison.Ordinal);
+        Assert.Contains(".Join(regions,", rendered, StringComparison.Ordinal);
+        Assert.Contains("g.Sum()", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void QueryScope_WithMoreThanThreeRangeVariables_WidensTupleAcrossMultipleLets()
+    {
+        string rendered = Render(@"
+using System.Linq;
+
+namespace Corpus.Issue1998
+{
+    public class Holder
+    {
+        public int[] Combined(int[] nums)
+        {
+            var q = from a in nums
+                    let b = a + 1
+                    let c = a + 2
+                    let d = a + 3
+                    select a + b + c + d;
+            return q.ToArray();
+        }
+    }
+}
+");
+
+        Assert.Contains("}).Select((__q0 (int32, int32)) -> {", rendered, StringComparison.Ordinal);
+        Assert.Contains("let (a, b) = __q0", rendered, StringComparison.Ordinal);
+        Assert.Contains("}).Select((__q1 (int32, int32, int32)) -> {", rendered, StringComparison.Ordinal);
+        Assert.Contains("let (a, b, c) = __q1", rendered, StringComparison.Ordinal);
+        Assert.Contains("}).Select((__q2 (int32, int32, int32, int32)) -> {", rendered, StringComparison.Ordinal);
+        Assert.Contains("let (a, b, c, d) = __q2", rendered, StringComparison.Ordinal);
+        Assert.Contains("return a + b + c + d", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -696,6 +696,11 @@ public sealed class CSharpToGSharpTranslator
         // stands in (see <see cref="BuildScopeParameter"/>).
         private int queryScopeCounter;
 
+        // Issue #1998: the query currently being lowered, set for the duration of
+        // `TranslateQuery` — anchors the arity-cap diagnostic in
+        // `BuildScopeParameter`.
+        private QueryExpressionSyntax currentQueryNode;
+
         // Issue #1897: numbers the `__spreadN` temporary built to lower a
         // collection-expression spread element (see
         // <see cref="TranslateSpreadCollectionExpression"/>).
@@ -14785,7 +14790,23 @@ public sealed class CSharpToGSharpTranslator
             // tuple (see <see cref="BuildScopeParameter"/>).
             var scope = new List<(string Name, GTypeReference Type)> { (from.Identifier.Text, rangeType) };
 
-            current = this.LowerQueryBody(query.Body, scope, current);
+            // Issue #1998: track the enclosing query node so a scope that grows
+            // past G#'s tuple arity cap (see <see cref="BuildScopeParameter"/>)
+            // can anchor a precise diagnostic rather than silently emitting a
+            // tuple shape that would only surface as an opaque GS0159 much
+            // later, at G# bind time. Save/restore to stay correct for a
+            // (rare) query nested inside this one's lambda bodies.
+            QueryExpressionSyntax previousQueryNode = this.currentQueryNode;
+            this.currentQueryNode = query;
+            try
+            {
+                current = this.LowerQueryBody(query.Body, scope, current);
+            }
+            finally
+            {
+                this.currentQueryNode = previousQueryNode;
+            }
+
             return current;
         }
 
@@ -15127,12 +15148,63 @@ public sealed class CSharpToGSharpTranslator
                 return new Parameter(SanitizeIdentifier(scope[0].Name), scope[0].Type);
             }
 
-            string tupleParamName = $"__q{this.queryScopeCounter++}";
+            // Issue #1998: G#'s tuple family (mirroring the BCL's `ValueTuple`)
+            // tops out at arity 7 — a query scope this wide (`from` plus 6+
+            // `let`/second-`from`/`join` clauses) has no canonical tuple to
+            // widen into. Report a precise, actionable diagnostic HERE (rather
+            // than silently emitting the oversized tuple shape, which would
+            // only surface as an opaque GS0159 much later at G# bind time) and
+            // still emit the best-effort shape so a single query with one
+            // over-wide scope doesn't block translating the rest of the file.
+            if (scope.Count > 7 && this.currentQueryNode != null)
+            {
+                string scopeMessage =
+                    $"Query scope has grown to {scope.Count} range variables ({string.Join(", ", scope.Select(v => v.Name))}); " +
+                    "G# tuples support at most 7 elements (ADR-0115 §B), so this scope has no canonical G# lowering. " +
+                    "Split the query (e.g. an intermediate `select new { ... }`-style projection via a `let`, or a nested query) " +
+                    "to keep each transparent-identifier scope at 7 or fewer range variables.";
+                this.context.Report(new TranslationDiagnostic(
+                    nameof(QueryExpressionSyntax),
+                    scopeMessage,
+                    this.currentQueryNode.GetLocation(),
+                    TranslationSeverity.Unsupported));
+            }
+
+            // Issue #1998: guard against a `__qN` collision with EITHER a
+            // range variable already in this scope OR any other user local
+            // visible at the query (a user local literally named `__q0`
+            // outside the query scope would otherwise still shadow/be
+            // shadowed by the synthesized tuple parameter) — bump the counter
+            // past any hit.
+            string tupleParamName;
+            do
+            {
+                tupleParamName = $"__q{this.queryScopeCounter++}";
+            }
+            while (scope.Any(v => v.Name == tupleParamName) || this.IsNameVisibleAtCurrentQuery(tupleParamName));
+
             prologue.Add(new TupleDeconstructionStatement(
                 BindingKind.Let,
                 scope.Select(v => SanitizeIdentifier(v.Name)).ToList(),
                 new IdentifierExpression(tupleParamName)));
             return new Parameter(tupleParamName, new TupleTypeReference(scope.Select(v => v.Type).ToList()));
+        }
+
+        // Issue #1998: whether `name` resolves to any symbol (local, parameter,
+        // field, …) visible at the currently-lowering query's position, via the
+        // active semantic model. Backs the `__qN` collision guard above —
+        // `LookupSymbols` sees every C# local in scope at that source position,
+        // not just the query's own range variables (`scope`).
+        private bool IsNameVisibleAtCurrentQuery(string name)
+        {
+            if (this.currentQueryNode == null)
+            {
+                return false;
+            }
+
+            return this.context.SemanticModel
+                .LookupSymbols(this.currentQueryNode.SpanStart, name: name)
+                .Length > 0;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1998

Follow-ups from the #1902/#1997 Opus review.

## 1. Arity-8 tuple-scope cap → precise diagnostic
A query's transparent-identifier scope (`from` + several `let`/second-`from`/`join` clauses) that grows past 7 range variables has no canonical G# tuple to widen into (G#'s `TupleTypeSymbol`/`MemberLookup` erasure both cap at arity 7, mirroring the BCL's non-chained `ValueTuple` family here). Previously this failed silently downstream as an opaque GS0159 at G# bind time.

I evaluated a full `TRest`-chaining fix (mirroring `System.ValueTuple<T1..T7,TRest>`), but it touches independent arity-capped switches in **5 separate places** (`TupleTypeSymbol.BuildClrType`, `MemberLookup`'s two erasure paths, the `Evaluator`'s tuple-literal construction, and **4** separate `ReflectionMetadataEmitter` TypeSpec/ctor/field-ref switches) plus nested `.Rest.ItemN` field-access rewiring for IL emission — a correctness-sensitive, multi-file change disproportionate to a follow-up ticket. Per the issue's own guidance, I implemented the precise-diagnostic fallback instead: `BuildScopeParameter` now reports a `TranslationDiagnostic` naming the exact range-variable count and clause, anchored at the query, so the gap surfaces immediately with actionable guidance instead of a confusing downstream error.

## 2. `__qN` collision guard
The synthesized transparent-identifier tuple parameter name (`__qN`) now checks both the current query scope **and** every other symbol visible at the query's position (via `SemanticModel.LookupSymbols`), bumping the counter past any collision with a user local/parameter/field literally named `__q0` etc.

## 3. Test coverage
Added `Issue1998LinqFollowUpTests` covering:
- the new arity-cap diagnostic (8-range-variable scope)
- the `__qN` collision guard (user local named `__q0`)
- join after a preceding `let` (3-element scope widening into a `Join`)
- `group ... into` continued by a `join` (group-then-join continuation)
- a scope widened past 3 range variables via multiple `let`s

## Test results
- `dotnet build src/Compiler/Compiler.csproj -c Release`: clean
- `dotnet build GSharp.sln -c Release`: clean
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: **5526 passed, 1 skipped, 0 failed**
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release`: **1040 passed, 0 failed**
- `docs/cs2gs-coverage-matrix.md` regenerated via `cs2gs coverage --write` after a full solution build: no diff (translator change doesn't affect tracked construct coverage)

Nothing deferred: all three sub-items are fixed and covered by regression tests; item 1's diagnostic fallback is documented above with the reasoning for not attempting the full runtime-wide `TRest` chain in this change.