### PR TITLE
cs2gs: precise gap diagnostic for ref-returning indexer + return-ref-call test (#1987)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1900RefLocalsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1900RefLocalsTranslationTests.cs
@@ -147,6 +147,81 @@ namespace Corpus.Issue1900
     }
 
     [Fact]
+    public void ReturnRefOverCallResult_StaysLoudGap()
+    {
+        // Issue #1987: `return ref F(x)` where the ref-return operand is
+        // itself a call result hits the same TranslateRefExpression fallback
+        // as RefAliasingCallResult_StaysLoudGap above, just at a `return ref`
+        // site instead of a `ref` local's initializer — this shape was
+        // previously untested.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+namespace Corpus.Issue1987
+{
+    public class Holder
+    {
+        public ref int Outer(int[] data)
+        {
+            return ref Middle(data);
+        }
+
+        private static ref int Middle(int[] values)
+        {
+            return ref values[1];
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors);
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Message.Contains("not a call result", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ElementAccess_OnRefReturningIndexer_StaysLoudGap()
+    {
+        // Issue #1987: `list[i]` where the indexer is a user-defined
+        // ref-returning indexer (`ref T this[int i]`) has no canonical G#
+        // form — G# has no ref-returning indexer, so lowering to a plain
+        // index expression would drop the ref-aliasing semantics entirely.
+        // This must gap precisely here rather than emit a call-under-index
+        // that gsc later rejects with a generic compile error.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+namespace Corpus.Issue1987
+{
+    public class RefIndexable
+    {
+        private int[] data = new int[4];
+
+        public ref int this[int i] => ref this.data[i];
+    }
+
+    public class Holder
+    {
+        public int Read(RefIndexable list, int i)
+        {
+            return list[i];
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors);
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Message.Contains("ref-returning indexer", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void RefAliasingCallResult_StaysLoudGap()
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -9865,6 +9865,28 @@ public sealed class CSharpToGSharpTranslator
                         return this.TranslateMultiDimElementAccess(elementAccess, multiDimArray.Rank);
                     }
 
+                    // Issue #1987: `list[i]` against a ref-returning indexer
+                    // (`ref T this[int i]`) DECLARED IN THE TRANSLATED SOURCE
+                    // (as opposed to a BCL type like `Span<T>`, whose
+                    // ref-returning indexer gsc's binder already auto-
+                    // dereferences via `BoundClrIndexExpression` +
+                    // `AutoDereferenceRefReturn` — that shape is genuinely
+                    // gap-free and must keep translating as-is). A ref-
+                    // returning indexer declared in the C# project being
+                    // translated has no gsc counterpart at all: G#'s own
+                    // `prop this[i T] U` indexer syntax has no ref-return
+                    // modifier, so the element access below would lower to a
+                    // plain call-under-index that gsc rejects with a generic
+                    // compile error instead of a precise gap. Detect it here.
+                    if (this.context.GetSymbolInfo(elementAccess).Symbol is IPropertySymbol { RefKind: not RefKind.None } refIndexer &&
+                        refIndexer.Locations.Any(l => l.IsInSource))
+                    {
+                        this.context.ReportUnsupported(
+                            elementAccess,
+                            $"element access '{elementAccess}' targets ref-returning indexer '{refIndexer.ContainingType?.Name}.this[]' which has no canonical G# form yet: G#'s user-defined indexer syntax has no ref-return modifier, so aliasing its element via a plain index expression would drop the ref semantics (issue #1987).");
+                        return new IdentifierExpression("nil");
+                    }
+
                     GExpression index = elementAccess.ArgumentList.Arguments.Count > 0
                         ? this.CoerceIndexToInt32(
                             elementAccess,


### PR DESCRIPTION
Fixes #1987

Two follow-ups from #1986/#1900 Opus review:

1. **Ref-returning indexer element access**: `ElementAccessExpressionSyntax` targeting a ref-returning indexer (`ref T this[int i]`) declared in the translated C# source now reports a precise CS2GS-GAP diagnostic instead of lowering to a call-under-index that gsc rejects with a generic compile error. BCL ref-returning indexers (e.g. `Span<T>`) are unaffected — gsc already auto-dereferences those natively via `BoundClrIndexExpression`, so only indexers declared in the source being translated are gapped.
2. **`return ref F(x)` test**: added a regression test locking in the existing (correct) loud-gap behavior when a ref-return operand is itself a call result — the `TranslateRefExpression` fallback path already existed but was untested.

Also added a test for the new ref-returning-indexer gap.

Test results:
- `dotnet test tools/cs2gs/Cs2Gs.Tests`: 1059 passed, 0 failed
- `dotnet test test/Core.Tests`: 5534 passed, 1 skipped, 0 failed

Coverage matrix regenerated (no diff).