### PR TITLE
gsc: add regression tests confirming #2085 and #2082 named-delegate event bugs already fixed

### DIFF
--- a/test/Compiler.Tests/Emit/Issue2082LambdaLiteralNamedDelegateEventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2082LambdaLiteralNamedDelegateEventEmitTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="Issue2082LambdaLiteralNamedDelegateEventEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2082: assigning an inline lambda/func-literal to a field-like event
+/// of a user-declared named delegate type via <c>+=</c> must adapt the lambda
+/// to the declared named-delegate type, not erase it to the lambda's natural
+/// CLR <c>Action</c>/<c>Func</c> shape. Previously the lambda kept its
+/// closure-delegate CLR type, mismatching the event accessor's declared
+/// parameter type and failing IL verification.
+/// </summary>
+public class Issue2082LambdaLiteralNamedDelegateEventEmitTests
+{
+    [Fact]
+    public void LambdaLiteralAddedToNamedDelegateEvent_AdaptsToDeclaredType_RunsAndVerifies()
+    {
+        var source = """
+            package Issue2082Pkg
+            import System
+
+            type TickHandler = delegate func(count int32) void
+
+            class Clock {
+                public event Ticked TickHandler
+            }
+
+            func Main() {
+                let c = Clock()
+                c.Ticked += func(count int32) void { System.Console.WriteLine(count) }
+            }
+            """;
+
+        Assert.Equal(string.Empty, CompileAndRun(source, invoke: false));
+    }
+
+    [Fact]
+    public void LambdaLiteralAddedToNamedDelegateEvent_InvokedViaSnapshot_ProducesCorrectOutput()
+    {
+        var source = """
+            package Issue2082Pkg2
+            import System
+
+            type TickHandler = delegate func(count int32) void
+
+            class Clock {
+                event Ticked TickHandler
+
+                func Subscribe() {
+                    Ticked += func(count int32) void { System.Console.WriteLine(count) }
+                }
+
+                func Fire(count int32) {
+                    let snapshot = Ticked
+                    if snapshot != nil {
+                        snapshot(count)
+                    }
+                }
+            }
+
+            let c = Clock()
+            c.Subscribe()
+            c.Fire(42)
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source, invoke: true));
+    }
+
+    private static string CompileAndRun(string source, bool invoke)
+    {
+        var tempDir = Path.Combine(AppContext.BaseDirectory, "Issue2082_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2085FieldLikeEventBareDeclarationEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2085FieldLikeEventBareDeclarationEmitTests.cs
@@ -1,0 +1,91 @@
+// <copyright file="Issue2085FieldLikeEventBareDeclarationEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2085: simply declaring a field-like event of a user-declared named
+/// delegate type (no assignment, no subscription) must emit add_X/remove_X
+/// accessor bodies that verify cleanly. The CAS-loop's Delegate.Combine/Remove
+/// call returns System.Delegate; the castclass back to the named delegate
+/// type and the Interlocked.CompareExchange&lt;T&gt; instantiation must agree
+/// with the locals' declared type, or ilverify reports StackUnexpected.
+/// </summary>
+public class Issue2085FieldLikeEventBareDeclarationEmitTests
+{
+    [Fact]
+    public void BareNamedDelegateEventDeclaration_NoAssignment_Verifies()
+    {
+        var source = """
+            package Issue2085Pkg
+            import System
+
+            type TickHandler = delegate func(count int32) void
+
+            class Clock {
+                public event Ticked TickHandler
+            }
+
+            func Main() {
+            }
+            """;
+
+        CompileAndVerify(source);
+    }
+
+    private static void CompileAndVerify(string source)
+    {
+        var tempDir = Path.Combine(AppContext.BaseDirectory, "Issue2085_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2085
Fixes #2082

## Investigation

Both issues were filed as suspected remaining gaps in named-delegate field-like event codegen, discovered alongside #2066/#2079 (nullable-local delegate snapshot invoke fix). Verified against current `main` (post-#2079):

- **#2085 repro** (bare `public event Ticked TickHandler` declaration, no assignment) compiles cleanly and the emitted `add_Ticked`/`remove_Ticked` accessors pass `ilverify`.
- **#2082 repro** (`c.Ticked += func(count int32) void { ... }`) compiles cleanly, passes `ilverify`, and (extended with a snapshot-invoke to actually exercise the subscribed handler) runs and prints the expected output.

Root cause for both: `MemberDefEmitter.GetEventTypeHandle` previously fell through to a `System.Delegate` fallback for user-declared named delegate types (no runtime CLR `Type`), which mismatched the CAS-loop's `castclass`/`Interlocked.CompareExchange<T>` locals (typed as the named delegate itself) and any `+=` operand adaptation keyed off the same handle. The #2079 fix (already merged) routes `DelegateTypeSymbol` through the same `TypeSpec` machinery used for `FunctionTypeSymbol`, which resolves both the accessor-body CAS loop (#2085) and the lambda-to-event-handler binding (#2082) - they shared the same root cause and got fixed together, even though only #2066 was the fix's original target.

No production code change needed. This PR adds dedicated regression tests to lock in the fix and give #2085/#2082 explicit CI coverage they didn't have before:
- `Issue2085FieldLikeEventBareDeclarationEmitTests`: bare field-like named-delegate event declaration, no assignment, compile + ilverify.
- `Issue2082LambdaLiteralNamedDelegateEventEmitTests`: lambda-literal `+=` to a named-delegate event, compile + ilverify + actual invoke-and-run assertion.

## Test results
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter "FullyQualifiedName~Issue2085|FullyQualifiedName~Issue2082"` -> 3 passed.
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter "FullyQualifiedName~Delegate|FullyQualifiedName~Event"` -> 157 passed, 0 failed (no regression).
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` -> 5534 passed, 1 skipped, 0 failed.

Nothing deferred: both repros from the issue bodies were reproduced against current `main`, found already fixed, and locked in with regression tests.
