### PR TITLE
cs2gs: harden collection-expression spread (element coercion, Span target, empty/nested, per-fixture ilverify marker) (#1985)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/CorpusApp.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CorpusApp.cs
@@ -34,6 +34,13 @@ public sealed class CorpusApp
     /// but is opt-in per app since unverifiable-by-design unsafe IL, unlike a
     /// verifier false positive, is not universally true of every corpus app.
     /// </param>
+    /// <param name="allowUnsafeIlTypes">
+    /// The fixture type names (from the marker file's non-blank lines) whose
+    /// unverifiable IL is expected (issue #1985). Empty means "whole app" —
+    /// back-compat with the original per-app marker for apps (e.g. G12,
+    /// wholly unsafe by design) where every fixture may legitimately produce
+    /// unverifiable IL.
+    /// </param>
     public CorpusApp(
         string id,
         string projectPath,
@@ -42,7 +49,8 @@ public sealed class CorpusApp
         IReadOnlyList<string> referencedAssemblies = null,
         string testsProjectPath = null,
         string testsBaselinePath = null,
-        bool allowUnsafeIl = false)
+        bool allowUnsafeIl = false,
+        IReadOnlyList<string> allowUnsafeIlTypes = null)
     {
         this.Id = id ?? throw new ArgumentNullException(nameof(id));
         this.ProjectPath = projectPath ?? throw new ArgumentNullException(nameof(projectPath));
@@ -52,6 +60,7 @@ public sealed class CorpusApp
         this.TestsProjectPath = testsProjectPath;
         this.TestsBaselinePath = testsBaselinePath;
         this.AllowUnsafeIl = allowUnsafeIl;
+        this.AllowUnsafeIlTypes = allowUnsafeIlTypes ?? ImmutableArray<string>.Empty;
     }
 
     /// <summary>Gets the stable corpus app id.</summary>
@@ -89,4 +98,11 @@ public sealed class CorpusApp
     /// file (see <see cref="CorpusDiscovery"/>).
     /// </summary>
     public bool AllowUnsafeIl { get; }
+
+    /// <summary>
+    /// Gets the fixture type names the <c>ilverify.allow-unsafe</c> marker
+    /// scopes <see cref="AllowUnsafeIl"/> to (one per non-blank marker-file
+    /// line), or empty for the whole-app allowance (issue #1985).
+    /// </summary>
+    public IReadOnlyList<string> AllowUnsafeIlTypes { get; }
 }

--- a/tools/cs2gs/Cs2Gs.Pipeline/CorpusDiscovery.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CorpusDiscovery.cs
@@ -21,12 +21,15 @@ namespace Cs2Gs.Pipeline;
 public static class CorpusDiscovery
 {
     /// <summary>
-    /// The marker file (empty, sibling to the <c>.csproj</c>) that opts an app
-    /// into <see cref="CorpusApp.AllowUnsafeIl"/> (issue #1933): stage 3
-    /// treats the app's known-unverifiable unsafe IL (pointer writes,
-    /// <c>fixed</c>, <c>stackalloc</c>) as expected rather than gating,
-    /// mirroring the always-on <see cref="IlVerifyRunner.KnownIlVerifyFalsePositives"/>
-    /// ignore bundle but opt-in per app.
+    /// The marker file (sibling to the <c>.csproj</c>) that opts an app into
+    /// <see cref="CorpusApp.AllowUnsafeIl"/> (issue #1933): stage 3 treats the
+    /// app's known-unverifiable unsafe IL (pointer writes, <c>fixed</c>,
+    /// <c>stackalloc</c>) as expected rather than gating, mirroring the
+    /// always-on <see cref="IlVerifyRunner.KnownIlVerifyFalsePositives"/>
+    /// ignore bundle but opt-in per app. When the file lists fixture type
+    /// names (one per line), the allowance is scoped to just those types
+    /// (issue #1985) — a blank/empty marker keeps the original whole-app
+    /// allowance for apps that are unsafe-by-design throughout (e.g. G12).
     /// </summary>
     public const string AllowUnsafeIlMarkerFileName = "ilverify.allow-unsafe";
 
@@ -72,6 +75,9 @@ public static class CorpusDiscovery
             (string testsProject, string testsBaseline) = FindSiblingTestOracle(fullCorpus, folderName);
 
             bool allowUnsafeIl = File.Exists(Path.Combine(projectDir, AllowUnsafeIlMarkerFileName));
+            IReadOnlyList<string> allowUnsafeIlTypes = allowUnsafeIl
+                ? ReadAllowUnsafeIlTypes(Path.Combine(projectDir, AllowUnsafeIlMarkerFileName))
+                : Array.Empty<string>();
 
             apps.Add(new CorpusApp(
                 id,
@@ -81,7 +87,8 @@ public static class CorpusDiscovery
                 referencedAssemblies: null,
                 testsProjectPath: testsProject,
                 testsBaselinePath: testsBaseline,
-                allowUnsafeIl: allowUnsafeIl));
+                allowUnsafeIl: allowUnsafeIl,
+                allowUnsafeIlTypes: allowUnsafeIlTypes));
         }
 
         return apps;
@@ -112,6 +119,19 @@ public static class CorpusDiscovery
         string normalized = path.Replace('\\', '/');
         return normalized.Contains("/bin/", StringComparison.Ordinal) ||
             normalized.Contains("/obj/", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Reads the marker file's non-blank, non-comment (<c>#</c>-prefixed)
+    /// lines as fixture type names (issue #1985 per-fixture scoping). An
+    /// empty/blank-only marker keeps the original whole-app allowance.
+    /// </summary>
+    private static IReadOnlyList<string> ReadAllowUnsafeIlTypes(string markerPath)
+    {
+        return File.ReadAllLines(markerPath)
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0 && !line.StartsWith("#", StringComparison.Ordinal))
+            .ToList();
     }
 
     private static (string TestsProject, string TestsBaseline) FindSiblingTestOracle(

--- a/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyStage.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -79,16 +80,31 @@ public sealed class IlVerifyStage : IMigrationStage
         // Unsafe-IL allowance (#1933): the app opted into
         // CorpusApp.AllowUnsafeIl and ilverify actually parsed error(s) (as
         // opposed to a bare tool crash) — expected-unverifiable, not a gate.
+        // When the marker scopes to specific fixture types (#1985), only
+        // errors whose failing method belongs to one of those types are
+        // swallowed; an error elsewhere in the app still gates, so a genuine
+        // unsafe-IL regression outside the allow-listed fixture(s) is not
+        // masked by the app-wide marker.
+        IReadOnlyList<IlVerifyError> gatingErrors = result.Errors;
         if (context.App.AllowUnsafeIl && result.Errors.Count > 0)
         {
-            return Task.FromResult(StageOutcome.Passed());
+            if (context.App.AllowUnsafeIlTypes.Count == 0)
+            {
+                return Task.FromResult(StageOutcome.Passed());
+            }
+
+            gatingErrors = result.Errors.Where(e => !IsAllowedUnsafeType(e, context.App.AllowUnsafeIlTypes)).ToList();
+            if (gatingErrors.Count == 0)
+            {
+                return Task.FromResult(StageOutcome.Passed());
+            }
         }
 
         string gsFile = context.EmittedFiles.Count > 0 ? context.EmittedFiles[0].RelativeGsPath : null;
 
         var artifacts = new List<TriageArtifact>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
-        foreach (IlVerifyError error in result.Errors)
+        foreach (IlVerifyError error in gatingErrors)
         {
             // One artifact per distinct error-code + failing-method skeleton.
             string key = (error.Code ?? string.Empty) + "|" + (error.Method ?? string.Empty);
@@ -122,5 +138,26 @@ public sealed class IlVerifyStage : IMigrationStage
 
         string oneLine = value.Replace("\r", " ").Replace("\n", " ").Trim();
         return oneLine.Length <= 200 ? oneLine : oneLine.Substring(0, 200);
+    }
+
+    // `error.Method` is the `Type::Method(sig)` skeleton (IlVerifyRunner); the
+    // allow-listed marker lines are bare type names, so match on the
+    // `Type::` prefix.
+    private static bool IsAllowedUnsafeType(IlVerifyError error, IReadOnlyList<string> allowedTypes)
+    {
+        if (string.IsNullOrEmpty(error.Method))
+        {
+            return false;
+        }
+
+        foreach (string allowedType in allowedTypes)
+        {
+            if (error.Method.StartsWith(allowedType + "::", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1897CollectionExpressionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1897CollectionExpressionTranslationTests.cs
@@ -64,6 +64,101 @@ namespace Corpus.Issue1897
     }
 
     [Fact]
+    public void SpreadElement_CoercesMismatchedElementTypeBeforeAddRange()
+    {
+        // Issue #1985: spreading `int[]` into a `long[]` target must project
+        // through the implicit `int -> long` conversion before `AddRange`,
+        // since `List[int64].AddRange(IEnumerable[int32])` does not bind in gsc.
+        string rendered = Render(@"
+namespace Corpus.Issue1985
+{
+    public class Holder
+    {
+        public long[] Combine(int[] rest)
+        {
+            long[] s = [.. rest];
+            return s;
+        }
+    }
+}
+");
+
+        Assert.Contains(".AddRange(rest.Select((__x int32) -> int64(__x)))", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SpreadElement_SpanTarget_LowersViaToArray()
+    {
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue1985
+{
+    public class Holder
+    {
+        public int Combine(int[] rest)
+        {
+            Span<int> s = [0, .. rest, 9];
+            return s[0];
+        }
+    }
+}
+");
+
+        Assert.Contains("List[int32]()", rendered, StringComparison.Ordinal);
+        Assert.Contains(".AddRange(rest)", rendered, StringComparison.Ordinal);
+        Assert.Contains(".ToArray()", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SpreadElement_EmptySpread_LowersToEmptyListThenToArray()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1985
+{
+    public class Holder
+    {
+        public int[] Combine(int[] empty)
+        {
+            int[] s = [.. empty];
+            return s;
+        }
+    }
+}
+");
+
+        Assert.Contains("List[int32]()", rendered, StringComparison.Ordinal);
+        Assert.Contains(".AddRange(empty)", rendered, StringComparison.Ordinal);
+        Assert.Contains(".ToArray()", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SpreadElement_NestedSpreads_LowerToSequentialAddRangeCalls()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1985
+{
+    public class Holder
+    {
+        public int[] Combine(int[] a, int[] b)
+        {
+            int[] s = [.. a, .. b];
+            return s;
+        }
+    }
+}
+");
+
+        Assert.Contains(".AddRange(a)", rendered, StringComparison.Ordinal);
+        Assert.Contains(".AddRange(b)", rendered, StringComparison.Ordinal);
+        Assert.Contains(".ToArray()", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
     public void ListTarget_LowersToCollectionInitializerNotArrayLiteral()
     {
         string rendered = Render(@"

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1933UnsafeIlVerifyPolicyTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1933UnsafeIlVerifyPolicyTests.cs
@@ -92,6 +92,64 @@ public class Issue1933UnsafeIlVerifyPolicyTests
     }
 
     /// <summary>
+    /// Issue #1985: G05's marker scopes the allowance to just the
+    /// stackalloc-emitting fixture — a future genuine unsafe-IL error
+    /// elsewhere in G05 must not be swallowed by the app-wide marker.
+    /// </summary>
+    [Fact]
+    public void CorpusDiscovery_G05CollectionsConsole_ScopesAllowUnsafeIlToStackAllocFixture()
+    {
+        string corpus = ResolveCorpusDir();
+        CorpusApp g05 = CorpusDiscovery.FindById(corpus, "corpus/G05-Collections-Console");
+
+        Assert.NotNull(g05);
+        Assert.True(g05.AllowUnsafeIl);
+        Assert.Equal(
+            new[] { "Corpus.Grid05.StackAllocArrayCreationExpressionFixture" },
+            g05.AllowUnsafeIlTypes);
+    }
+
+    /// <summary>
+    /// Issue #1985: an ilverify error whose failing method is NOT in the
+    /// marker's allow-listed fixture types still gates the stage, even though
+    /// the app carries the marker — the whole app is no longer a blanket
+    /// allowance once the marker is scoped.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_UnsafeIlError_OutsideAllowedFixtureType_StillFailsStage()
+    {
+        var error = new IlVerifyError(
+            "ExpectedNumericType",
+            "Corpus.Grid05.SomeOtherFixture::Run()",
+            "[IL]: Error [ExpectedNumericType]: [/abs/App.dll : Corpus.Grid05.SomeOtherFixture::Run()] boom");
+        IlVerifyResult fakeResult = IlVerifyResult.FromRun(1, error.RawLine, new[] { error });
+
+        StageOutcome outcome = await RunWithFakeResultAsync(
+            allowUnsafeIl: true,
+            fakeResult,
+            allowUnsafeIlTypes: new[] { "Corpus.Grid05.StackAllocArrayCreationExpressionFixture" });
+
+        Assert.Equal(StageStatus.Failed, outcome.Status);
+        Assert.Single(outcome.Artifacts);
+    }
+
+    /// <summary>
+    /// Issue #1985: an ilverify error whose failing method IS in the marker's
+    /// allow-listed fixture types passes, same as the whole-app allowance.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_UnsafeIlError_InsideAllowedFixtureType_PassesStage()
+    {
+        StageOutcome outcome = await RunWithFakeResultAsync(
+            allowUnsafeIl: true,
+            FakeUnverifiablePointerResult(),
+            allowUnsafeIlTypes: new[] { "Corpus.Grid12.Constructs.PointerTypeFixture" });
+
+        Assert.Equal(StageStatus.Passed, outcome.Status);
+        Assert.Empty(outcome.Artifacts);
+    }
+
+    /// <summary>
     /// An app with no <c>ilverify.allow-unsafe</c> marker file (the common
     /// case) discovers <see cref="CorpusApp.AllowUnsafeIl"/> as
     /// <see langword="false"/>.
@@ -155,7 +213,8 @@ public class Issue1933UnsafeIlVerifyPolicyTests
         return IlVerifyResult.FromRun(1, error.RawLine, new[] { error });
     }
 
-    private static async Task<StageOutcome> RunWithFakeResultAsync(bool allowUnsafeIl, IlVerifyResult fakeResult)
+    private static async Task<StageOutcome> RunWithFakeResultAsync(
+        bool allowUnsafeIl, IlVerifyResult fakeResult, IReadOnlyList<string> allowUnsafeIlTypes = null)
     {
         string outRoot = NewOutputRoot("issue-1933-unsafe-il");
         var runner = new FakeResultIlVerifyRunner(fakeResult);
@@ -168,7 +227,8 @@ public class Issue1933UnsafeIlVerifyPolicyTests
             "corpus/Fake",
             "/fake/Fake.csproj",
             TargetKind.Exe,
-            allowUnsafeIl: allowUnsafeIl);
+            allowUnsafeIl: allowUnsafeIl,
+            allowUnsafeIlTypes: allowUnsafeIlTypes);
         var options = new PipelineOptions { GscPath = "/fake/gsc.dll", OutputRoot = outRoot };
         var context = new StageExecutionContext(
             app,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -11356,13 +11356,18 @@ public sealed class CSharpToGSharpTranslator
                     new List<GExpression>(),
                     new List<GTypeReference> { elementType })));
 
+            ITypeSymbol targetElementSymbol = GetEnumerableElementType(
+                this.context.GetTypeInfo(collection).ConvertedType ?? this.context.GetTypeInfo(collection).Type);
+
             foreach (CollectionElementSyntax element in collection.Elements)
             {
                 if (element is SpreadElementSyntax spread)
                 {
+                    GExpression source = this.CoerceSpreadSource(
+                        spread.Expression, this.TranslateExpression(spread.Expression), targetElementSymbol, elementType);
                     this.pendingSpillPrologue.Add(new ExpressionStatement(new InvocationExpression(
                         new MemberAccessExpression(new IdentifierExpression(temp), "AddRange"),
-                        new List<GExpression> { this.TranslateExpression(spread.Expression) })));
+                        new List<GExpression> { source })));
                 }
                 else
                 {
@@ -11383,6 +11388,41 @@ public sealed class CSharpToGSharpTranslator
             // `Enumerable.ToArray[T]()` extension method).
             return new InvocationExpression(
                 new MemberAccessExpression(new IdentifierExpression(temp), "ToArray"));
+        }
+
+        // A spread source (`..src` in `[..src]`) whose element type `U` differs
+        // from the target collection's element type `T` (an implicit conversion
+        // exists, e.g. `int[]` spread into a `long[]` target) needs a projection
+        // before `AddRange`, since `List[T].AddRange(IEnumerable[U])` does not
+        // bind in gsc (issue #1985). Wraps the source in `.Select(x => (T)x)`.
+        private GExpression CoerceSpreadSource(
+            ExpressionSyntax sourceExpression, GExpression translatedSource, ITypeSymbol targetElementSymbol, GTypeReference targetElementType)
+        {
+            if (targetElementSymbol == null)
+            {
+                return translatedSource;
+            }
+
+            ITypeSymbol sourceType = this.context.GetTypeInfo(sourceExpression).Type;
+            ITypeSymbol sourceElementSymbol = GetEnumerableElementType(sourceType);
+            if (sourceElementSymbol == null ||
+                SymbolEqualityComparer.Default.Equals(sourceElementSymbol, targetElementSymbol))
+            {
+                return translatedSource;
+            }
+
+            Conversion conversion = this.context.Compilation.ClassifyConversion(sourceElementSymbol, targetElementSymbol);
+            if (!conversion.Exists || conversion.IsIdentity)
+            {
+                return translatedSource;
+            }
+
+            GTypeReference sourceElementType = this.typeMapper.Map(sourceElementSymbol, this.context, sourceExpression.GetLocation());
+            var lambda = new LambdaExpression(
+                new List<Parameter> { new Parameter("__x", sourceElementType) },
+                expressionBody: new ConversionExpression(targetElementType, new IdentifierExpression("__x")));
+            return new InvocationExpression(
+                new MemberAccessExpression(translatedSource, "Select"), new List<GExpression> { lambda });
         }
 
         private GExpression CoerceCollectionElement(ExpressionSyntax element, GTypeReference elementType)

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/ilverify.allow-unsafe
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/ilverify.allow-unsafe
@@ -1,0 +1,1 @@
+Corpus.Grid05.StackAllocArrayCreationExpressionFixture


### PR DESCRIPTION
Fixes #1985

Follow-ups from PR #1984 (#1897) Opus review, all four addressed:

1. **Element-type coercion**: `TranslateSpreadCollectionExpression` translated a spread source raw with no coercion, so spreading `U[]` into a `T[]`/`List<T>` target (implicit `U -> T` conversion, `U != T`) produced `List[T].AddRange(IEnumerable[U])`, which does not bind in gsc. Now wraps the spread source in `.Select(x => T(x))` whenever the source element type differs from the target's and an implicit conversion exists (`Compilation.ClassifyConversion`).
2. **Span target coverage**: added a spread test targeting `Span<T>`, locking in the `.ToArray()` -> `Span` implicit-conversion path.
3. **Empty/nested spread coverage**: added tests for `[.. empty]` and `[..a, ..b]`.
4. **Per-fixture ilverify marker**: `ilverify.allow-unsafe` was per-app only — a future genuine unsafe-IL bug anywhere else in a mixed app (e.g. G05, whose only unsafe fixture is `stackalloc`) would have been invisible to stage 3. The marker file can now list fixture type names (one per line); `IlVerifyStage` only swallows errors whose failing method belongs to an allow-listed type. A blank/empty marker keeps the original whole-app allowance (used by G12, which is unsafe-by-design throughout). G05's marker now scopes to just `Corpus.Grid05.StackAllocArrayCreationExpressionFixture`.

## Testing
- `dotnet build GSharp.sln -c Release`: succeeded.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release`: 1064 passed, 0 failed.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: 5534 passed, 1 skipped, 0 failed.
- `docs/cs2gs-coverage-matrix.md` regenerated (checked, no diff — no new construct kinds introduced).