### PR TITLE
cs2gs: null-guard nullable intermediates in is-form + merge shared-prefix property subpatterns

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1971ExtPropPatternFollowUpTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1971ExtPropPatternFollowUpTranslationTests.cs
@@ -1,0 +1,293 @@
+// <copyright file="Issue1971ExtPropPatternFollowUpTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1971: two Opus-review follow-ups from #1969/#1891's extended
+/// property-subpattern (<c>{ Start.X: 0 }</c>) lowering.
+///
+/// 1. Null-safety divergence: C#'s extended property subpattern implicitly
+/// null-checks every intermediate member of the dotted chain — a null
+/// intermediate means the whole pattern falls through (no match, no throw).
+/// The switch-arm lowering (nested <c>PropertyPattern</c>s) already gets this
+/// for free from <c>MethodBodyEmitter.EmitPropertyPattern</c>'s own
+/// <c>NullableTypeSymbol</c> guard (issue #1923) as long as the intermediate
+/// field's G# type stays nullable (<c>Point?</c>). The is-form lowering had no
+/// such guard — it flattened the whole path into one raw member-access chain
+/// (<c>s.Start.X == 0</c>), so a null NULLABLE intermediate NREs instead of
+/// falling through. These tests assert the is-form now emits an explicit
+/// <c>!= nil</c> guard for a nullable-reference intermediate, and stays
+/// guard-free for a non-nullable one (G#'s own non-null contract already
+/// covers that case).
+///
+/// 2. Shared-prefix chains (<c>{ A.B: 0, A.C: 1 }</c>) previously lowered to
+/// <c>{ A: { B: 0 }, A: { C: 1 } }</c> — a duplicate top-level field. These
+/// tests assert subpatterns sharing a leftmost identifier now merge into ONE
+/// nested field, to any shared-prefix depth.
+/// </summary>
+public class Issue1971ExtPropPatternFollowUpTranslationTests
+{
+    private const string NullableStartSource = @"
+#nullable enable
+namespace Corpus.Issue1971
+{
+    public class Point
+    {
+        public int X;
+        public int Y;
+    }
+
+    public class Segment
+    {
+        public Point? Start;
+        public int Length;
+    }
+";
+
+    private const string NonNullableStartSource = @"
+#nullable enable
+namespace Corpus.Issue1971
+{
+    public class Point
+    {
+        public int X;
+        public int Y;
+    }
+
+    public class Segment
+    {
+        public Point Start = new Point();
+        public int Length;
+    }
+";
+
+    [Fact]
+    public void IsPattern_NullableIntermediate_EmitsNullGuardBeforeMemberChain()
+    {
+        string rendered = Render(NullableStartSource + @"
+    public class Holder
+    {
+        public bool Describe(Segment s)
+        {
+            if (s is { Start.X: 0 })
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}
+");
+
+        Assert.Contains("s.Start != nil && s.Start.X == 0", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void IsPattern_NonNullableIntermediate_StaysGuardFree()
+    {
+        string rendered = Render(NonNullableStartSource + @"
+    public class Holder
+    {
+        public bool Describe(Segment s)
+        {
+            if (s is { Start.X: 0 })
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}
+");
+
+        Assert.Contains("s.Start.X == 0", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("s.Start != nil", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void IsPattern_NullableDeepChain_GuardsEveryNullableIntermediate()
+    {
+        string rendered = Render(@"
+#nullable enable
+namespace Corpus.Issue1971
+{
+    public class C
+    {
+        public int Value;
+    }
+
+    public class B
+    {
+        public C? C;
+    }
+
+    public class A
+    {
+        public B? B;
+    }
+
+    public class Holder
+    {
+        public bool Describe(A a)
+        {
+            if (a is { B.C.Value: 0 })
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}
+");
+
+        Assert.Contains("a.B != nil && a.B.C != nil && a.B.C.Value == 0", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchExpression_SharedPrefixSubpatterns_MergeIntoOneNestedField()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1971
+{
+    public class Point
+    {
+        public int X;
+        public int Y;
+    }
+
+    public class Segment
+    {
+        public Point Start;
+        public int Length;
+    }
+
+    public class Holder
+    {
+        public string Describe(Segment s) => s switch
+        {
+            { Start.X: 0, Start.Y: 0 } => ""origin"",
+            _ => ""other"",
+        };
+    }
+}
+");
+
+        Assert.Contains("{ Start: { X: 0, Y: 0 } }", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("Start: { X: 0 }, Start:", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchExpression_DeepSharedPrefixSubpatterns_MergeAtDeepestCommonAncestor()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1971
+{
+    public class C
+    {
+        public int Value1;
+        public int Value2;
+    }
+
+    public class B
+    {
+        public C C;
+    }
+
+    public class A
+    {
+        public B B;
+    }
+
+    public class Holder
+    {
+        public string Describe(A a) => a switch
+        {
+            { B.C.Value1: 0, B.C.Value2: 1 } => ""zero"",
+            _ => ""other"",
+        };
+    }
+}
+");
+
+        Assert.Contains("{ B: { C: { Value1: 0, Value2: 1 } } }", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchExpression_SharedPrefixCombinedWithSimpleSubpattern_PreservesFieldOrder()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1971
+{
+    public class Point
+    {
+        public int X;
+        public int Y;
+    }
+
+    public class Segment
+    {
+        public Point Start;
+        public int Length;
+    }
+
+    public class Holder
+    {
+        public string Describe(Segment s) => s switch
+        {
+            { Length: 1, Start.X: 0, Start.Y: 0 } => ""match"",
+            _ => ""other"",
+        };
+    }
+}
+");
+
+        // "Start" merges its two subpatterns into one nested field at its
+        // FIRST occurrence — after "Length", which comes first in the source.
+        Assert.Contains("{ Length: 1, Start: { X: 0, Y: 0 } }", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1971ExtPropPatternFollowUpTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1971ExtPropPatternFollowUpTranslationTests.cs
@@ -264,6 +264,151 @@ namespace Corpus.Issue1971
         AssertRoundTripParses(rendered);
     }
 
+    [Fact]
+    public void SwitchExpression_LeafThenNestedCollisionOnSameSegment_ReportsUnsupportedInsteadOfSilentlyDroppingSubpattern()
+    {
+        // Bug (N1, Opus review of #1971): `A.B: not null` (leaf check on `B`)
+        // and `A.B.C: 1` (nested check under `B`) target the same path
+        // segment `B`, ONE LEVEL UNDER the shared root `A`, in two
+        // incompatible ways. The merge optimization must not silently keep
+        // one and drop the other — it must report a loud gap. (`B: not null`
+        // is used as the leaf check — rather than `B: null`, which would make
+        // the arm statically unreachable per CS8510 since it contradicts the
+        // nested `B.C` check — since a reference-typed `B` can be
+        // pattern-compared against `not null` while ALSO exposing a member
+        // for the nested check; an `int` leaf check couldn't do both, since
+        // `int` has no further members to nest into.)
+        (Cs2Gs.CodeModel.Ast.CompilationUnit unit, TranslationContext context) = RenderAllowingDiagnostics(@"
+namespace Corpus.Issue1971
+{
+    public class TypeB
+    {
+        public int C;
+    }
+
+    public class TypeA
+    {
+        public TypeB B;
+    }
+
+    public class RootHolder
+    {
+        public TypeA A;
+    }
+
+    public class Holder
+    {
+        public string Describe(RootHolder root) => root switch
+        {
+            { A.B: not null, A.B.C: 1 } => ""match"",
+            _ => ""other"",
+        };
+    }
+}
+");
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported
+                && d.Message.Contains("'B'", StringComparison.Ordinal)
+                && d.Message.Contains("'A'", StringComparison.Ordinal));
+
+        string rendered = GSharpPrinter.Print(unit);
+
+        // Neither subpattern's condition should be silently emitted as if the
+        // merge had fully succeeded (that would hide the data loss).
+        Assert.DoesNotContain("{ A: { B: { C: 1 } } }", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("B: not nil", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SwitchExpression_NestedThenLeafCollisionOnSameSegment_ReportsUnsupportedInsteadOfSilentlyDroppingSubpattern()
+    {
+        // Mirror case of the above: the nested-member check (`A.B.C: 1`) is
+        // seen BEFORE the leaf check (`A.B: not null`) on the same segment
+        // `B`. Must still report the gap loudly, not silently drop either
+        // side.
+        (Cs2Gs.CodeModel.Ast.CompilationUnit unit, TranslationContext context) = RenderAllowingDiagnostics(@"
+namespace Corpus.Issue1971
+{
+    public class TypeB
+    {
+        public int C;
+    }
+
+    public class TypeA
+    {
+        public TypeB B;
+    }
+
+    public class RootHolder
+    {
+        public TypeA A;
+    }
+
+    public class Holder
+    {
+        public string Describe(RootHolder root) => root switch
+        {
+            { A.B.C: 1, A.B: not null } => ""match"",
+            _ => ""other"",
+        };
+    }
+}
+");
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported
+                && d.Message.Contains("'B'", StringComparison.Ordinal)
+                && d.Message.Contains("'A'", StringComparison.Ordinal));
+
+        string rendered = GSharpPrinter.Print(unit);
+
+        Assert.DoesNotContain("{ A: { B: { C: 1 } } }", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("B: not nil", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SwitchArm_NullableIntermediate_PreservesNestedFieldForEmitterNullGuard()
+    {
+        // Switch-arm counterpart to IsPattern_NullableIntermediate_EmitsNullGuardBeforeMemberChain:
+        // the switch-arm lowering (nested PropertyPattern, not a flattened
+        // member-access chain) should free-ride on gsc's existing #1923
+        // null-guard in MethodBodyEmitter.EmitPropertyPattern, as long as the
+        // intermediate field's G# type stays nullable (`Start` on `Point?`).
+        string rendered = Render(NullableStartSource + @"
+    public class Holder
+    {
+        public string Describe(Segment s) => s switch
+        {
+            { Start.X: 0 } => ""origin-x"",
+            _ => ""other"",
+        };
+    }
+}
+");
+
+        Assert.Contains("{ Start: { X: 0 } }", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static (Cs2Gs.CodeModel.Ast.CompilationUnit Unit, TranslationContext Context) RenderAllowingDiagnostics(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return (unit, context);
+    }
+
     private static void AssertRoundTripParses(string rendered)
     {
         RoundTripResult result = GSharpRoundTrip.Validate(rendered);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -10658,11 +10658,23 @@ public sealed class CSharpToGSharpTranslator
                         continue;
                     }
 
-                    string memberName = sub.NameColon?.Name.Identifier.Text
-                        ?? sub.ExpressionColon?.Expression.ToString();
-                    GExpression memberAccess = new MemberAccessExpression(memberReceiver, SanitizeIdentifier(memberName));
-                    ITypeSymbol memberType = this.TryGetSubpatternMemberType(sub);
-                    GExpression memberTest = this.TranslatePatternTest(memberAccess, sub.Pattern, memberType, isNestedPatternMember: true);
+                    GExpression memberTest;
+                    if (sub.NameColon != null)
+                    {
+                        string memberName = sub.NameColon.Name.Identifier.Text;
+                        GExpression memberAccess = new MemberAccessExpression(memberReceiver, SanitizeIdentifier(memberName));
+                        ITypeSymbol memberType = this.TryGetSubpatternMemberType(sub);
+                        memberTest = this.TranslatePatternTest(memberAccess, sub.Pattern, memberType, isNestedPatternMember: true);
+                    }
+                    else
+                    {
+                        // Issue #1971: an extended subpattern (`Start.X: 0`)
+                        // dotted chain needs a per-intermediate nullable-guard,
+                        // not a single flat member access — see
+                        // <see cref="TranslateExtendedPropertyMemberTest"/>.
+                        memberTest = this.TranslateExtendedPropertyMemberTest(sub.ExpressionColon.Expression, sub.Pattern, memberReceiver);
+                    }
+
                     test = test == null ? memberTest : new BinaryExpression(test, "&&", memberTest);
                 }
             }
@@ -10764,20 +10776,12 @@ public sealed class CSharpToGSharpTranslator
             };
         }
 
-        // Issue #1891: lowers an extended property subpattern's dotted member
-        // path (`Start.X`, `A.B.C`, ...) to nested G# `PropertyPattern` fields —
-        // `Start.X: 0` becomes `Start: { X: 0 }` — since a G# property-pattern
-        // field is a single identifier with no dotted form. Supports any chain
-        // depth; the innermost field carries the actual subpattern translated
-        // against the fully-qualified member-access receiver (so a binding like
-        // `Start.X: var x` still reads `receiver.Start.X`).
-        private PropertyPatternField BuildExtendedPropertyField(
-            ExpressionSyntax memberPath,
-            PatternSyntax leafPattern,
-            GExpression receiver,
-            List<(ISymbol Symbol, GExpression Replacement)> bindings,
-            HashSet<string> usedDesignators,
-            List<GExpression> guards)
+        // Splits an extended property subpattern's dotted member path
+        // (`Start.X`, `A.B.C`, ...) into its leaf-to-root identifier chain
+        // (`["Start", "X"]`, `["A", "B", "C"]`), unsanitized. Shared by the
+        // is-form guard builder (<see cref="TranslateExtendedPropertyMemberTest"/>)
+        // and the switch-arm nested-field builder (<see cref="ExtendedPropertyFieldTree"/>).
+        private static List<string> SplitMemberPath(ExpressionSyntax memberPath)
         {
             var names = new List<string>();
             ExpressionSyntax current = memberPath;
@@ -10788,26 +10792,85 @@ public sealed class CSharpToGSharpTranslator
             }
 
             names.Insert(0, current.ToString());
+            return names;
+        }
+
+        // Issue #1971 (follow-up to #1891/#1969): a C# extended property
+        // subpattern (`Start.X: 0`) implicitly null-checks every intermediate
+        // member of the dotted chain — `null` at any step means the whole
+        // pattern doesn't match (no throw), mirroring how a nested recursive
+        // pattern (`{ Start: { X: 0 } }`) against a nullable-typed field is
+        // bound (see `PatternBinder.BindPropertyPattern`'s issue #1923 comment,
+        // and the corresponding null guard `MethodBodyEmitter.EmitPropertyPattern`
+        // emits for a `NullableTypeSymbol` subject). The is-form lowering
+        // previously flattened the whole path into a single raw member-access
+        // chain (`recv.Start.X == 0`) with no such guard: G#'s non-null-by-default
+        // type contract means a raw `ldfld` on a null intermediate NREs instead of
+        // falling through like C# does. This walks the chain once, building the
+        // nested member access AND an `!= nil` guard for each intermediate step
+        // whose DECLARED type is a nullable reference (a non-nullable
+        // intermediate keeps the guard-free raw access — G#'s own non-null
+        // contract already guarantees it, so no guard is needed there).
+        private GExpression TranslateExtendedPropertyMemberTest(
+            ExpressionSyntax memberPath,
+            PatternSyntax leafPattern,
+            GExpression receiver)
+        {
+            List<string> names = SplitMemberPath(memberPath);
+
+            // `intermediateExprs[i]` is the sub-expression whose runtime value
+            // is used as the receiver for the access producing `names[i + 1]`
+            // (e.g. for `Start.X`, `intermediateExprs[0]` is the `Start`
+            // sub-expression — its declared nullability decides whether a
+            // guard is needed before reading `.X`). Walked positionally from
+            // the outermost `MemberAccessExpressionSyntax` inward, so it lines
+            // up with `names` regardless of repeated identifiers in the chain.
+            var intermediateExprs = new ExpressionSyntax[names.Count - 1];
+            ExpressionSyntax current = memberPath;
+            int pos = names.Count - 1;
+            while (current is MemberAccessExpressionSyntax memberAccess)
+            {
+                pos--;
+                intermediateExprs[pos] = memberAccess.Expression;
+                current = memberAccess.Expression;
+            }
 
             GExpression memberReceiver = receiver;
+            GExpression guard = null;
             for (int i = 0; i < names.Count - 1; i++)
             {
                 memberReceiver = new MemberAccessExpression(memberReceiver, SanitizeIdentifier(names[i]));
+
+                ITypeSymbol declaredType = this.ResolveDeclaredReceiverType(
+                    this.context.GetTypeInfo(intermediateExprs[i]).Type, intermediateExprs[i]);
+                if (declaredType is { IsReferenceType: true } && declaredType.NullableAnnotation == NullableAnnotation.Annotated)
+                {
+                    GExpression stepGuard = new BinaryExpression(memberReceiver, "!=", LiteralExpression.Null());
+                    guard = guard == null ? stepGuard : new BinaryExpression(guard, "&&", stepGuard);
+                }
             }
 
             string leafName = SanitizeIdentifier(names[^1]);
-            PropertyPatternField field = new PropertyPatternField(
-                leafName,
-                this.TranslatePattern(leafPattern, new MemberAccessExpression(memberReceiver, leafName), bindings, usedDesignators, guards));
+            GExpression finalMemberAccess = new MemberAccessExpression(memberReceiver, leafName);
+            ITypeSymbol leafType = this.context.GetTypeInfo(memberPath).Type;
+            GExpression leafTest = this.TranslatePatternTest(finalMemberAccess, leafPattern, leafType, isNestedPatternMember: true);
 
-            for (int i = names.Count - 2; i >= 0; i--)
-            {
-                field = new PropertyPatternField(SanitizeIdentifier(names[i]), new PropertyPattern(new List<PropertyPatternField> { field }));
-            }
-
-            return field;
+            return guard == null ? leafTest : new BinaryExpression(guard, "&&", leafTest);
         }
 
+        // Issue #1891: lowers an extended property subpattern's dotted member
+        // path (`Start.X`, `A.B.C`, ...) to nested G# `PropertyPattern` fields —
+        // `Start.X: 0` becomes `Start: { X: 0 }` — since a G# property-pattern
+        // field is a single identifier with no dotted form. Supports any chain
+        // depth; the innermost field carries the actual subpattern translated
+        // against the fully-qualified member-access receiver (so a binding like
+        // `Start.X: var x` still reads `receiver.Start.X`).
+        //
+        // Issue #1971: multiple subpatterns sharing a leftmost identifier
+        // prefix (`{ A.B: 0, A.C: 1 }`) are grouped through
+        // <see cref="ExtendedPropertyFieldTree"/> before being converted, so
+        // they merge into one nested field (`{ A: { B: 0, C: 1 } }`) instead of
+        // emitting the same top-level field name twice.
         // Resolves the property name each positional subpattern of `recursive`
         // deconstructs to (issue #1887), so a positional pattern can lower to the
         // same nested member-access form a property pattern uses. Returns null
@@ -14768,6 +14831,8 @@ public sealed class CSharpToGSharpTranslator
                 var fields = new List<PropertyPatternField>();
                 if (recursive.PropertyPatternClause != null)
                 {
+                    var extendedFieldTrees = new Dictionary<string, ExtendedPropertyFieldTree>();
+                    var extendedFieldRootOrder = new List<string>();
                     foreach (SubpatternSyntax sub in recursive.PropertyPatternClause.Subpatterns)
                     {
                         if (sub.NameColon != null)
@@ -14794,12 +14859,48 @@ public sealed class CSharpToGSharpTranslator
                             // `Start.X: 0` becomes `Start: { X: 0 }`, agreeing
                             // with the nested-pattern form a user could already
                             // write directly. Works to any chain depth.
-                            fields.Add(this.BuildExtendedPropertyField(
-                                sub.ExpressionColon.Expression, sub.Pattern, receiver, bindings, usedDesignators, guards));
+                            //
+                            // Issue #1971: multiple subpatterns sharing a
+                            // leftmost identifier (`{ A.B: 0, A.C: 1 }`) must
+                            // merge into ONE nested field (`{ A: { B: 0, C: 1 } }`)
+                            // instead of emitting the top-level field `A` twice —
+                            // grouped here via `extendedFieldTrees`, keyed by the
+                            // sanitized root identifier, and converted once all
+                            // subpatterns have been scanned. `fields` reserves the
+                            // root's position at its FIRST occurrence so field
+                            // order still matches the source.
+                            List<string> names = SplitMemberPath(sub.ExpressionColon.Expression);
+                            string rootName = SanitizeIdentifier(names[0]);
+                            if (!extendedFieldTrees.TryGetValue(rootName, out ExtendedPropertyFieldTree tree))
+                            {
+                                tree = new ExtendedPropertyFieldTree();
+                                extendedFieldTrees[rootName] = tree;
+                                extendedFieldRootOrder.Add(rootName);
+                                fields.Add(null); // placeholder, filled in after the loop
+                            }
+
+                            tree.Insert(names, 1, sub.Pattern);
                             continue;
                         }
 
                         this.context.ReportUnsupported(sub, "positional subpattern has no canonical G# form yet (ADR-0115 §B).");
+                    }
+
+                    if (extendedFieldRootOrder.Count > 0)
+                    {
+                        int placeholderIndex = 0;
+                        foreach (string rootName in extendedFieldRootOrder)
+                        {
+                            while (fields[placeholderIndex] != null)
+                            {
+                                placeholderIndex++;
+                            }
+
+                            ExtendedPropertyFieldTree tree = extendedFieldTrees[rootName];
+                            List<PropertyPatternField> childFields = tree.ConvertChildren(
+                                this, new MemberAccessExpression(receiver, rootName), bindings, usedDesignators, guards);
+                            fields[placeholderIndex] = new PropertyPatternField(rootName, new PropertyPattern(childFields));
+                        }
                     }
                 }
 
@@ -15577,6 +15678,77 @@ public sealed class CSharpToGSharpTranslator
             /// expression that could re-run a side effect).
             /// </summary>
             public IReadOnlyList<GExpression> DimensionSizes { get; }
+        }
+
+        // Issue #1971: groups extended property subpatterns (`{ A.B: 0, A.C: 1 }`,
+        // parsed as `ExpressionColon`) sharing a leftmost identifier prefix so
+        // <see cref="TranslateRecursivePattern"/> can merge them into ONE nested
+        // `PropertyPattern` field (`{ A: { B: 0, C: 1 } }`) instead of emitting
+        // the same top-level field name twice — works to any shared-prefix depth
+        // (`{ A.B.C: 0, A.B.D: 1 }` merges at `A.B` too).
+        private sealed class ExtendedPropertyFieldTree
+        {
+            // Preserves first-occurrence order of each child name at this
+            // level, so the emitted field order matches the source's leftmost
+            // occurrence of each shared prefix (mirrors how a hand-written
+            // nested pattern would read).
+            private readonly List<string> order = new List<string>();
+            private readonly Dictionary<string, PatternSyntax> leaves = new Dictionary<string, PatternSyntax>();
+            private readonly Dictionary<string, ExtendedPropertyFieldTree> children = new Dictionary<string, ExtendedPropertyFieldTree>();
+
+            public void Insert(List<string> names, int index, PatternSyntax leafPattern)
+            {
+                string name = names[index];
+                if (index == names.Count - 1)
+                {
+                    if (!this.leaves.ContainsKey(name) && !this.children.ContainsKey(name))
+                    {
+                        this.order.Add(name);
+                    }
+
+                    this.leaves[name] = leafPattern;
+                    return;
+                }
+
+                if (!this.children.TryGetValue(name, out ExtendedPropertyFieldTree child))
+                {
+                    child = new ExtendedPropertyFieldTree();
+                    this.children[name] = child;
+                    if (!this.leaves.ContainsKey(name))
+                    {
+                        this.order.Add(name);
+                    }
+                }
+
+                child.Insert(names, index + 1, leafPattern);
+            }
+
+            public List<PropertyPatternField> ConvertChildren(
+                DeclarationVisitor translator,
+                GExpression parentReceiver,
+                List<(ISymbol Symbol, GExpression Replacement)> bindings,
+                HashSet<string> usedDesignators,
+                List<GExpression> guards)
+            {
+                var fields = new List<PropertyPatternField>();
+                foreach (string name in this.order)
+                {
+                    GExpression memberReceiver = new MemberAccessExpression(parentReceiver, name);
+                    if (this.leaves.TryGetValue(name, out PatternSyntax leafPattern))
+                    {
+                        fields.Add(new PropertyPatternField(
+                            name,
+                            translator.TranslatePattern(leafPattern, memberReceiver, bindings, usedDesignators, guards)));
+                        continue;
+                    }
+
+                    ExtendedPropertyFieldTree child = this.children[name];
+                    List<PropertyPatternField> childFields = child.ConvertChildren(translator, memberReceiver, bindings, usedDesignators, guards);
+                    fields.Add(new PropertyPatternField(name, new PropertyPattern(childFields)));
+                }
+
+                return fields;
+            }
         }
     }
 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -14897,6 +14897,26 @@ public sealed class CSharpToGSharpTranslator
                             }
 
                             ExtendedPropertyFieldTree tree = extendedFieldTrees[rootName];
+                            if (tree.HasCollision)
+                            {
+                                // Bug (N1, Opus review of #1971): a path segment
+                                // that is BOTH a leaf value check (`A.B: 0`) AND
+                                // a nested-member check (`A.B.C: 1`) at the same
+                                // name cannot be merged into a single
+                                // PropertyPattern field — one side would have to
+                                // be silently dropped. Per ADR-0115 ("never
+                                // guess"), report the gap loudly instead of
+                                // guessing which side to keep, and fall back to
+                                // an empty nested field for '{rootName}' so the
+                                // merge optimization doesn't emit a
+                                // semantically-wrong pattern.
+                                this.context.ReportUnsupported(
+                                    recursive.PropertyPatternClause,
+                                    $"extended property pattern mixes a direct value check and a nested member check on the same path segment '{tree.CollisionSegment}' (rooted at '{rootName}'); not supported.");
+                                fields[placeholderIndex] = new PropertyPatternField(rootName, new PropertyPattern(new List<PropertyPatternField>()));
+                                continue;
+                            }
+
                             List<PropertyPatternField> childFields = tree.ConvertChildren(
                                 this, new MemberAccessExpression(receiver, rootName), bindings, usedDesignators, guards);
                             fields[placeholderIndex] = new PropertyPatternField(rootName, new PropertyPattern(childFields));
@@ -15696,12 +15716,35 @@ public sealed class CSharpToGSharpTranslator
             private readonly Dictionary<string, PatternSyntax> leaves = new Dictionary<string, PatternSyntax>();
             private readonly Dictionary<string, ExtendedPropertyFieldTree> children = new Dictionary<string, ExtendedPropertyFieldTree>();
 
+            // Bug (N1, Opus review of #1971): set when a path segment is
+            // targeted by BOTH a leaf value check (`A.B: 0`) and a nested
+            // member check (`A.B.C: 1`) — merging those into one
+            // PropertyPattern field would require silently dropping one side.
+            // Propagated up from whichever depth the collision occurs at, so
+            // the caller can detect it anywhere in the (sub)tree and bail out
+            // of the whole merge for the offending root instead of guessing.
+            public bool HasCollision { get; private set; }
+
+            public string CollisionSegment { get; private set; }
+
             public void Insert(List<string> names, int index, PatternSyntax leafPattern)
             {
                 string name = names[index];
                 if (index == names.Count - 1)
                 {
-                    if (!this.leaves.ContainsKey(name) && !this.children.ContainsKey(name))
+                    if (this.children.ContainsKey(name))
+                    {
+                        // A nested-member check for `name` was already inserted
+                        // (e.g. `A.B.C: ...` seen before `A.B: ...`) — this
+                        // leaf check would collide with it. Don't add it as a
+                        // leaf (that would silently drop the nested subtree);
+                        // record the collision instead.
+                        this.HasCollision = true;
+                        this.CollisionSegment = name;
+                        return;
+                    }
+
+                    if (!this.leaves.ContainsKey(name))
                     {
                         this.order.Add(name);
                     }
@@ -15710,17 +15753,31 @@ public sealed class CSharpToGSharpTranslator
                     return;
                 }
 
+                if (this.leaves.ContainsKey(name))
+                {
+                    // A leaf value check for `name` was already inserted (e.g.
+                    // `A.B: ...` seen before `A.B.C: ...`) — this nested check
+                    // would collide with it. Don't create/descend into a child
+                    // (that would silently drop the leaf check); record the
+                    // collision instead.
+                    this.HasCollision = true;
+                    this.CollisionSegment = name;
+                    return;
+                }
+
                 if (!this.children.TryGetValue(name, out ExtendedPropertyFieldTree child))
                 {
                     child = new ExtendedPropertyFieldTree();
                     this.children[name] = child;
-                    if (!this.leaves.ContainsKey(name))
-                    {
-                        this.order.Add(name);
-                    }
+                    this.order.Add(name);
                 }
 
                 child.Insert(names, index + 1, leafPattern);
+                if (child.HasCollision)
+                {
+                    this.HasCollision = true;
+                    this.CollisionSegment = child.CollisionSegment;
+                }
             }
 
             public List<PropertyPatternField> ConvertChildren(


### PR DESCRIPTION
Fixes #1971

Follow-ups from PR #1969 (#1891) Opus review, all 3 items addressed:

1. **Null-safety divergence**: the is-form extended-property-subpattern lowering (`recv.Start.X == 0`) flattened a dotted member chain into one raw member-access with no null check, so a NULLABLE-reference intermediate would NRE instead of falling through like C# does. A new `TranslateExtendedPropertyMemberTest` walks the chain once, inserting an explicit `!= nil` guard before each nullable-reference intermediate step; a non-nullable intermediate keeps the guard-free raw access (G#'s own non-null contract already covers that case). The switch-arm lowering (nested `PropertyPattern`) already gets this null-safety for free from gsc's own `MethodBodyEmitter.EmitPropertyPattern` nullable guard (issue #1923) as long as the intermediate field's G# type stays nullable — verified this holds.

2. **Shared-prefix chains**: `{ A.B: 0, A.C: 1 }` previously lowered to `{ A: { B: 0 }, A: { C: 1 } }` (duplicate top-level field). A new `ExtendedPropertyFieldTree` groups `ExpressionColon` subpatterns by leftmost identifier — recursively, to any shared-prefix depth — before converting to nested `PropertyPatternField`s, merging into `{ A: { B: 0, C: 1 } }`.

3. **Test coverage**: added `Issue1971ExtPropPatternFollowUpTranslationTests.cs` with 6 tests covering both fixes — nullable/non-nullable is-form intermediates (shallow + deep chains), and shared-prefix merging (shallow, deep, and combined with a simple subpattern, verifying field order is preserved).

## Testing
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~1971"` — 6/6 pass
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~1891|FullyQualifiedName~1969"` — 4/4 pass (no regression)
- Full suite: `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` — 1072/1072 pass
- `dotnet build GSharp.sln -c Release` — clean
- `cs2gs coverage --write` — no diff (not a new construct kind)

## Note
During implementation, discovered and fixed a subtle pre-existing hazard: `SubpatternSyntax.NameColon` is populated even for simple non-dotted subpatterns (Roslyn keeps it as a compatibility view), so branching on `ExpressionColon != null` first (instead of `NameColon != null` first) would have mis-handled every simple field as if it were a dotted path. Fixed by checking `NameColon` first in the is-form loop, matching the switch-arm loop's existing (correct) ordering; caught by the existing #1923 regression test.