### PR TITLE
cs2gs: fix stray discard write in expression-position deconstruction assignment (#2099)

### DIFF
--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -200,7 +200,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | RightShiftExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/RightShiftExpression.cs |  |  |
 | ScopedType | ScopedTypeSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/ScopedType.cs |  | scoped Span/scoped ref parameters translate and verify (grid G12). |
 | SetAccessorDeclaration | AccessorDeclarationSyntax | ADR-0115 §B.11 |  |  |  |  |
-| SimpleAssignmentExpression | AssignmentExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/SimpleAssignmentExpression.cs | https://github.com/DavidObando/gsharp/issues/1895 | Deconstruction-assignment into existing locals emits let bindings (issue #1895). |
+| SimpleAssignmentExpression | AssignmentExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/SimpleAssignmentExpression.cs | https://github.com/DavidObando/gsharp/issues/1895, https://github.com/DavidObando/gsharp/issues/1974 | Deconstruction-assignment into existing locals emits let bindings (issue #1895); generalized to expression position and nested targets (issue #1974). |
 | SimpleBaseType | SimpleBaseTypeSyntax | ADR-0115 §B.6 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/SimpleBaseType.cs |  |  |
 | SimpleLambdaExpression | SimpleLambdaExpressionSyntax | ADR-0115 §B.20 |  | tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/SimpleLambdaExpression.cs |  |  |
 | SimpleMemberAccessExpression | MemberAccessExpressionSyntax | ADR-0115 §B |  |  |  |  |

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1895DeconstructAssignTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1895DeconstructAssignTranslationTests.cs
@@ -226,6 +226,33 @@ namespace Corpus.Issue1895
     }
 
     [Fact]
+    public void NestedAllDiscardTarget_SkipsPointlessInnerBinding()
+    {
+        // `(x, (_, _)) = e` (issue #2099, item 3): the nested arm is entirely
+        // discards, so it must not allocate a real temp for itself or emit a
+        // pointless inner `let (_, _) = __deconN` binding.
+        string rendered = Render(@"
+namespace Corpus.Issue1895
+{
+    public class Holder
+    {
+        public void M()
+        {
+            int x = 1;
+            (x, (_, _)) = (2, (3, 4));
+            System.Console.WriteLine(x);
+        }
+    }
+}
+");
+
+        Assert.Contains("let (__decon0, _) = (2, (3, 4))", rendered, StringComparison.Ordinal);
+        Assert.Contains("x = __decon0", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("let (_, _)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
     public void ElementAccessTarget_StaysLoudGap()
     {
         // `(arr[i], y) = rhs`: C# evaluates `arr`/`i` before `rhs`, but the

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1974ExpressionPositionDeconstructAssignTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1974ExpressionPositionDeconstructAssignTranslationTests.cs
@@ -143,6 +143,11 @@ namespace Corpus.Issue1974
         Assert.Contains("x = __decon0", rendered, StringComparison.Ordinal);
         Assert.Contains("let r = (__decon0, __decon1)", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("(__decon0, _)", rendered, StringComparison.Ordinal);
+
+        // Issue #2099: the discard still gets a real temp to feed the
+        // expression's value, but `_` isn't a real assignable location — no
+        // stray `_ = __decon1;` write-back should be emitted for it.
+        Assert.DoesNotContain("_ = __decon", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -7375,6 +7375,27 @@ public sealed class CSharpToGSharpTranslator
                 this.IsTrueDiscard(discardCandidate)) ||
                 targetExpr is DeclarationExpressionSyntax { Designation: DiscardDesignationSyntax };
 
+        // True when EVERY leaf of a (possibly nested) tuple pattern is a
+        // discard, e.g. `(_, _)` or `(_, (_, _))` — the whole arm is then
+        // dead and can be skipped without allocating any temp or recursing
+        // into it (issue #2099, item 3).
+        private bool IsAllDiscardTuple(TupleExpressionSyntax pattern)
+        {
+            foreach (ArgumentSyntax argument in pattern.Arguments)
+            {
+                ExpressionSyntax element = argument.Expression;
+                bool elementIsAllDiscard = element is TupleExpressionSyntax nestedTuple
+                    ? this.IsAllDiscardTuple(nestedTuple)
+                    : this.IsDeconstructionDiscard(element);
+                if (!elementIsAllDiscard)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         // Recursively checks every leaf of a (possibly nested) deconstruction
         // *assignment* target for a non-identifier storage reference (`arr[i]`,
         // `obj.F`, ...). A nested tuple target or a new `var`/nested-`var`
@@ -7440,11 +7461,14 @@ public sealed class CSharpToGSharpTranslator
                 ExpressionSyntax targetExpr = pattern.Arguments[i].Expression;
 
                 // A nested tuple target needs its own real temp to recurse
-                // into, even when `forceRealTemps` is false — its own leaves
-                // decide their own discard-ness independently below.
+                // into — UNLESS every leaf underneath it is itself a true
+                // discard, in which case the whole nested arm is dead and
+                // recursing into it would only emit a pointless inner
+                // `let (_, _) = __deconN` binding (issue #2099, item 3).
                 bool needsRealTemp = forceRealTemps ||
-                    targetExpr is TupleExpressionSyntax ||
-                    !this.IsDeconstructionDiscard(targetExpr);
+                    (targetExpr is TupleExpressionSyntax nestedDiscardCheck
+                        ? !this.IsAllDiscardTuple(nestedDiscardCheck)
+                        : !this.IsDeconstructionDiscard(targetExpr));
                 temps.Add(needsRealTemp ? $"__decon{this.deconCounter++}" : "_");
             }
 
@@ -7524,10 +7548,19 @@ public sealed class CSharpToGSharpTranslator
                 }
 
                 // An existing local (or member/element access) target: write
-                // the spilled value back.
-                statements.Add(new AssignmentStatement(
-                    this.TranslateExpression(targetExpr),
-                    tempRead));
+                // the spilled value back. A discard target still gets a real
+                // temp here (`forceRealTemps=true`, e.g. expression-position
+                // `(x, _) = (1, 2)`) so its value can be reconstructed into
+                // the outer tuple, but `_` isn't a real assignable location —
+                // skip the write itself to avoid emitting a stray, dead
+                // `_ = __decon1;` statement (issue #2099).
+                if (!this.IsDeconstructionDiscard(targetExpr))
+                {
+                    statements.Add(new AssignmentStatement(
+                        this.TranslateExpression(targetExpr),
+                        tempRead));
+                }
+
                 values.Add(tempRead);
             }
 

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -1981,8 +1981,8 @@
     "rule": "ADR-0115 \u00A7B",
     "rationale": "None",
     "fixture": "tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/SimpleAssignmentExpression.cs",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1895",
-    "notes": "Deconstruction-assignment into existing locals emits let bindings (issue #1895)."
+    "issue": "https://github.com/DavidObando/gsharp/issues/1895, https://github.com/DavidObando/gsharp/issues/1974",
+    "notes": "Deconstruction-assignment into existing locals emits let bindings (issue #1895); generalized to expression position and nested targets (issue #1974)."
   },
   {
     "kind": "SimpleBaseType",


### PR DESCRIPTION
Fixes #2099

Non-blocking follow-ups from PR #2090 (#1974) Opus review, both required items fixed plus the optional suggestion:

1. **Stray discard write (required, real bug)**: for `(x, _) = (1, 2)` in expression position, `_` gets a real temp `__decon1` (needed so the outer expression can rebuild the tuple value), but the code then fell through to the final "existing target" branch and emitted a dead `_ = __decon1;` write. Fixed by skipping the `AssignmentStatement` emission in that branch when `IsDeconstructionDiscard(targetExpr)` is true — `tempRead` is still returned to the caller so the reconstructed tuple value is unaffected. Added `Assert.DoesNotContain("_ = __decon", rendered)` to the existing `DiscardTarget_InExpressionPosition_StillCapturesValueInRealTemp` regression test.
2. **Coverage-matrix row 203 (required, doc fix)**: updated `docs/cs2gs-coverage-matrix.md` (and its generating source, `tools/cs2gs/coverage/csharp-construct-inventory.json`) so the `SimpleAssignmentExpression` note/issue links cite both #1895 (statement position, existing-locals-only) and #1974 (expression position, nested targets).
3. **Nested all-discard short-circuit (optional suggestion, done)**: `(_, (_, _)) = e` no longer allocates a temp for the nested arm or recurses into it, avoiding the pointless inner `let (_, _) = __deconN` binding the issue called out as legal-but-harmless. Added a regression test (`NestedAllDiscardTarget_SkipsPointlessInnerBinding`) asserting no `let (_, _)` is emitted.

## Testing
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~1974|FullyQualifiedName~1895"` — 16 passed (was 15; added 2 new assertions/tests)
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` — full suite, 1075 passed, 0 failed

No work deferred — all three items (two required, one optional) are addressed in this PR.