### PR TITLE
Fix implicit T -> Nullable<T> lift for tuple-shaped types (#2051)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -1948,6 +1948,25 @@ public sealed class Conversion
             return false;
         }
 
+        // Issue #2051: a `NullableTypeSymbol` relays its UNDERLYING type's
+        // `ClrType` (see `NullableTypeSymbol.ClrType` / ADR-0001 §Phase 3.C.1) —
+        // for a value-type underlying, that is the bare `T`, NOT the actual CLR
+        // runtime representation `System.Nullable<T>`. Without this guard, a
+        // tuple-shaped `T` compared against `Nullable<T>` (e.g. `(int32,int32)`
+        // vs `(int32,int32)?`) would satisfy `ta.ClrType == b.ClrType` below
+        // purely because of that relay, misclassifying the true CLR-widening
+        // `T -> Nullable<T>` lift (#504) as a same-representation `Identity`
+        // conversion. That skips the `newobj Nullable<T>::.ctor(T)` wrap
+        // entirely, leaving a raw `ValueTuple` on the stack where a
+        // `Nullable<ValueTuple>` is expected (ilverify `StackUnexpected`).
+        // Scalar value-type nullables (`int32?`) never reach this helper — it
+        // only fires when one side is a `TupleTypeSymbol` — so this is scoped
+        // to the ValueTuple-shaped case the issue describes.
+        if (a is NullableTypeSymbol || b is NullableTypeSymbol)
+        {
+            return false;
+        }
+
         if (a is TupleTypeSymbol ta && b is not TupleTypeSymbol)
         {
             return ta.ClrType != null && b.ClrType != null && ta.ClrType == b.ClrType;

--- a/test/Compiler.Tests/Emit/Issue2051TupleNullableWrapEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2051TupleNullableWrapEmitTests.cs
@@ -1,0 +1,182 @@
+// <copyright file="Issue2051TupleNullableWrapEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2051: the implicit `T -> Nullable&lt;T&gt;` lift (issue #504) must
+/// also fire when `T` is a ValueTuple-shaped value type. The
+/// <c>EmitConversion</c> lift arm keys off <c>from == toValueNullableLift.UnderlyingType</c>,
+/// which holds for tuple types (they are interned via
+/// <c>TupleTypeSymbol.Get</c>), but the arm was never reached for a bare
+/// tuple-literal initializer/argument because
+/// <see cref="System.Reflection.Emit"/>... (see production code comments) —
+/// the fix ensures a raw <c>ValueTuple`2</c> is never left on the stack where
+/// a <c>Nullable`1&lt;ValueTuple`2&gt;</c> is expected.
+/// </summary>
+public class Issue2051TupleNullableWrapEmitTests
+{
+    [Fact]
+    public void LocalVariableInitializer_TupleLiteralIntoNullableTuple_WrapsAndVerifies()
+    {
+        var source = """
+            package TupleNullableLocalPkg
+
+            import System
+
+            var p (int32, int32)? = (0, 0)
+            let v = p!!
+            Console.WriteLine(v.Item1)
+            Console.WriteLine(v.Item2)
+            """;
+
+        Assert.Equal("0\n0\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ArgumentPassing_TupleLiteralIntoNullableTupleParameter_WrapsAndVerifies()
+    {
+        var source = """
+            package TupleNullableArgPkg
+
+            import System
+
+            func Test(v (int32, int32)?) int32 {
+                let t = v!!
+                return t.Item1 + t.Item2
+            }
+
+            Console.WriteLine(Test((3, 4)))
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ReturnPosition_TupleLiteralIntoNullableTupleReturnType_WrapsAndVerifies()
+    {
+        var source = """
+            package TupleNullableReturnPkg
+
+            import System
+
+            func Make() (int32, int32)? {
+                return (5, 6)
+            }
+
+            let r = Make()!!
+            Console.WriteLine(r.Item1)
+            Console.WriteLine(r.Item2)
+            """;
+
+        Assert.Equal("5\n6\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2051_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}


### PR DESCRIPTION
Fixes #2051

## Root cause

`Conversion.IsTupleClrEquivalent` (added for issue #813, to unify a G# `TupleTypeSymbol` with an equivalent imported CLR `System.ValueTuple<...>`) compared `ta.ClrType == b.ClrType` whenever one side was a tuple. `NullableTypeSymbol.ClrType` relays its *underlying* type's `ClrType` (by design, for the reference-type case), so for a value-type underlying it returns the bare `T`, not the true CLR runtime representation `System.Nullable<T>`.

As a result, `(int32, int32)` and `(int32, int32)?` compared as CLR-equivalent, and `Conversion.Classify` returned `Identity` instead of the normal `T -> Nullable<T>` implicit lift (#504). `ConversionClassifier` short-circuits identity conversions by returning the expression unchanged, so the `newobj Nullable<T>::.ctor(T)` wrap was never emitted — a raw `ValueTuple` was left on the stack wherever ilverify expected `Nullable<ValueTuple>`.

This only affects ValueTuple-shaped `T`, because `IsTupleClrEquivalent` only runs when one side is a `TupleTypeSymbol`. Scalar value-type nullables (`int32?`) never reach this helper and were unaffected, exactly as described in the issue.

## Fix

`src/Core/CodeAnalysis/Binding/Conversion.cs`: `IsTupleClrEquivalent` now returns `false` whenever either side is a `NullableTypeSymbol`, so a tuple compared against `Nullable<tuple>` falls through to the normal implicit-lift classification and the emitter's existing `Nullable<T>` wrap machinery (already used correctly for scalar/enum/struct nullables) takes over.

## Testing

- Added `test/Compiler.Tests/Emit/Issue2051TupleNullableWrapEmitTests.cs` covering:
  - local-variable initializer: `var p (int32, int32)? = (0, 0)`
  - argument passing: `Test((3, 4))` into a `(int32, int32)?` parameter
  - return position: `return (5, 6)` from a `(int32, int32)?`-returning function

  Each test compiles via `gsc`, verifies the emitted assembly with `ilverify` (previously failing with `StackUnexpected`), and executes it to confirm correct runtime unwrapping via `!!`.
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter "FullyQualifiedName~2051"` — 3/3 pass.
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter "FullyQualifiedName~1572|FullyQualifiedName~504|FullyQualifiedName~Issue813|FullyQualifiedName~Issue1256"` — 33/33 pass (no regression on existing nullable-value-type or tuple-conversion coverage).
- `dotnet test test/Core.Tests/Core.Tests.csproj` — 5534 passed, 0 failed, 1 skipped (pre-existing `RegenerateBaseline`).
