### PR TITLE
cs2gs: widen private helpers of extension-bearing static classes

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/StaticMemberQualificationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/StaticMemberQualificationTranslationTests.cs
@@ -107,6 +107,33 @@ namespace Corpus.StaticMember
         Assert.DoesNotContain("Box.Tab", rendered, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void PrivateHelper_OfExtensionBearingStaticClass_IsWidenedForLiftedCallers()
+    {
+        // A `private` non-extension member of a `static class` that also declares
+        // extension methods becomes unreachable once those extension methods are
+        // lifted to top-level `func`s: the lifted func qualifies the sibling call
+        // through the owning type (`Helpers.SendOrPost`), and G# accessibility then
+        // rejects the class-private member (GS0472). The private modifier must be
+        // dropped so the qualified reference still binds.
+        const string source = @"
+namespace Corpus.PrivateHelper
+{
+    public static class Helpers
+    {
+        private static void SendOrPost(System.Action work) => work();
+
+        public static void Post(this System.Threading.SynchronizationContext ctx, System.Action work)
+            => SendOrPost(work);
+    }
+}
+";
+        string rendered = TranslateAndPrint(source);
+
+        Assert.Contains("Helpers.SendOrPost", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("private func SendOrPost", rendered, StringComparison.Ordinal);
+    }
+
     private static string TranslateAndPrint(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1039,6 +1039,20 @@ public sealed class CSharpToGSharpTranslator
                     // positions, so it is omitted (ADR-0115 §B.10).
                     return Visibility.Default;
                 case Accessibility.Private:
+                    // A `private` static member of a `static class` that ALSO
+                    // declares extension methods becomes unreachable once those
+                    // methods are lifted to top-level `func`s (ADR-0115 §B.5): the
+                    // lifted func qualifies the sibling reference through the owning
+                    // type (`Owner.Helper`), but G# accessibility then treats the
+                    // former class-private member as inaccessible (GS0472). Widen it
+                    // to the position default so the qualified reference still binds
+                    // (a private helper of a static utility class is an internal
+                    // implementation detail with no external callers to over-expose).
+                    if (IsMemberOfExtensionBearingStaticClass(symbol))
+                    {
+                        return Visibility.Default;
+                    }
+
                     return Visibility.Private;
                 case Accessibility.Internal:
                     return Visibility.Internal;
@@ -1062,6 +1076,32 @@ public sealed class CSharpToGSharpTranslator
                 default:
                     return Visibility.Default;
             }
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> when <paramref name="symbol"/> is a member
+        /// of a <c>static class</c> that also declares at least one extension method.
+        /// Such a class is decomposed at translation time — its extension methods are
+        /// lifted to top-level receiver-clause <c>func</c>s (ADR-0115 §B.5) — so any
+        /// sibling <c>private</c> member the lifted funcs reference must be widened to
+        /// stay reachable across the resulting file scope (would otherwise be GS0472).
+        /// </summary>
+        private static bool IsMemberOfExtensionBearingStaticClass(ISymbol symbol)
+        {
+            if (symbol.ContainingType is not { IsStatic: true, TypeKind: TypeKind.Class } container)
+            {
+                return false;
+            }
+
+            foreach (ISymbol member in container.GetMembers())
+            {
+                if (member is IMethodSymbol { IsExtensionMethod: true })
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
Fixes a cs2gs defect where a `private` non-extension member of a `static class` that also declares extension methods became inaccessible (GS0472) in the translated G#.

Example (from Oahu.Foundation `SyncContextExtensions`, `TypeExtension`, `ExImage`):
```csharp
public static class SyncContextExtensions
{
    private static void SendOrPost(...) { ... }          // private helper
    public static void Post(this SynchronizationContext sync, ...)
        => SendOrPost(sync.Post, delgat);                // calls the helper
}
```

## Root cause
The extension methods (`Post`/`Send`) lift to top-level receiver-clause `func`s (ADR-0115 §B.5), while `SendOrPost` stays in the class's `shared { }` block. The lifted func calls it qualified through the owning type (`SyncContextExtensions.SendOrPost`), but because the member is `private`, G#'s (now-enforced) accessibility rejects the reference — the lifted func is no longer *within* the class:
```
GS0472: 'SyncContextExtensions.SendOrPost' is inaccessible due to its protection level
```

## Fix
In `MapVisibility`, widen a `private` member of an extension-bearing static class to the position default (`Visibility.Default`), so the qualified sibling reference binds. Such a member is an internal implementation detail of a static utility class with no external callers, so widening is harmless and keeps the translation compiling.

## Testing
- New test `PrivateHelper_OfExtensionBearingStaticClass_IsWidenedForLiftedCallers`.
- Full cs2gs suite passes (0 failures).
- Oahu.Foundation GS0472: 25 → 2 (the remaining 2 are a separate gsc shared-field-initializer accessibility gap, filed separately).

Refs #914
