### PR TITLE
gsc: allow private members of enclosing type from its static field/property initializer (GS0472)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -284,6 +284,7 @@ public sealed class Binder
             isPrimitiveTypeName: IsPrimitiveTypeName,
             refKindToString: RefKindToString,
             getCurrentFunction: () => this.function,
+            setCurrentFunction: fn => this.function = fn,
             bindInterpolatedStringAsFormattable: (syntax, targetType) => expressions.BindInterpolatedStringAsFormattable(syntax, targetType));
         expressions = new ExpressionBinder(
             binderCtx,

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -87,6 +87,7 @@ internal sealed class DeclarationBinder
     private readonly Func<string, bool> isPrimitiveTypeName;
     private readonly Func<RefKind, string> refKindToString;
     private readonly Func<FunctionSymbol> getCurrentFunction;
+    private readonly Action<FunctionSymbol> setCurrentFunction;
 
     private readonly List<(StructDeclarationSyntax Syntax, StructSymbol Symbol)> pendingInterfaceImplementationChecks
         = new List<(StructDeclarationSyntax, StructSymbol)>();
@@ -145,6 +146,7 @@ internal sealed class DeclarationBinder
         Func<string, bool> isPrimitiveTypeName,
         Func<RefKind, string> refKindToString,
         Func<FunctionSymbol> getCurrentFunction,
+        Action<FunctionSymbol> setCurrentFunction,
         BindInterpolatedStringAsFormattableDelegate bindInterpolatedStringAsFormattable = null)
     {
         this.binderCtx = binderCtx ?? throw new ArgumentNullException(nameof(binderCtx));
@@ -163,6 +165,7 @@ internal sealed class DeclarationBinder
         this.isPrimitiveTypeName = isPrimitiveTypeName ?? throw new ArgumentNullException(nameof(isPrimitiveTypeName));
         this.refKindToString = refKindToString ?? throw new ArgumentNullException(nameof(refKindToString));
         this.getCurrentFunction = getCurrentFunction ?? throw new ArgumentNullException(nameof(getCurrentFunction));
+        this.setCurrentFunction = setCurrentFunction ?? throw new ArgumentNullException(nameof(setCurrentFunction));
     }
 
     private DiagnosticBag Diagnostics => binderCtx.Diagnostics;
@@ -2921,7 +2924,22 @@ internal sealed class DeclarationBinder
         {
             var savedFieldInitScope = scope;
             var savedFieldInitTypeParameters = binderCtx.CurrentTypeParameters;
+            var savedFieldInitFunction = getCurrentFunction();
             scope = fieldInitScope;
+
+            // Issue #2111: a static field/property initializer is bound outside
+            // any function body, so no "current function" is established. The
+            // accessibility gate (AccessibilityChecker) derives the enclosing
+            // type from the current function, so without one a `private`/
+            // `protected` member of the ENCLOSING type accessed through a
+            // type-qualified receiver (`Type.Member`) or a constructor call
+            // (`Type()`) is wrongly rejected with GS0472 — even though the
+            // initializer belongs to that very type. Establish the enclosing
+            // type as the accessibility context for the duration of initializer
+            // binding by installing a synthetic static function owned by
+            // `structSymbol`, mirroring how a `shared` function body (which
+            // already works) carries its `StaticOwnerType`.
+            setCurrentFunction(CreateFieldInitializerAccessibilityContext(structSymbol));
             if (!structSymbol.TypeParameters.IsDefaultOrEmpty)
             {
                 binderCtx.CurrentTypeParameters = new Dictionary<string, TypeParameterSymbol>();
@@ -2949,6 +2967,7 @@ internal sealed class DeclarationBinder
             {
                 scope = savedFieldInitScope;
                 binderCtx.CurrentTypeParameters = savedFieldInitTypeParameters;
+                setCurrentFunction(savedFieldInitFunction);
             }
         });
 
@@ -3011,6 +3030,32 @@ internal sealed class DeclarationBinder
         {
             pendingAbstractImplementationChecks.Add((syntax, structSymbol));
         }
+    }
+
+    /// <summary>
+    /// Issue #2111: builds the synthetic static function used as the
+    /// accessibility context while binding a type's deferred static/instance
+    /// field and property initializers. The function carries no body and is
+    /// never emitted; its sole purpose is to expose <paramref name="owner"/> as
+    /// the enclosing type (via <see cref="FunctionSymbol.StaticOwnerType"/>) so
+    /// that <see cref="AccessibilityChecker"/> treats a `private`/`protected`
+    /// member of the enclosing type reached through a type-qualified receiver
+    /// (`Type.Member`) or a constructor call (`Type()`) as accessible — matching
+    /// how a `shared` function body already behaves.
+    /// </summary>
+    /// <param name="owner">The type whose initializers are being bound.</param>
+    /// <returns>A synthetic static function owned by <paramref name="owner"/>.</returns>
+    private static FunctionSymbol CreateFieldInitializerAccessibilityContext(StructSymbol owner)
+    {
+        var context = new FunctionSymbol(
+            "<field-initializer>",
+            ImmutableArray<ParameterSymbol>.Empty,
+            TypeSymbol.Void)
+        {
+            IsStatic = true,
+            StaticOwnerType = owner,
+        };
+        return context;
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2111FieldInitializerAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2111FieldInitializerAccessibilityTests.cs
@@ -1,0 +1,111 @@
+// <copyright file="Issue2111FieldInitializerAccessibilityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2111: a static field/property initializer inside a <c>shared { }</c>
+/// block is bound outside any function body, so no "current type" was
+/// established for the accessibility gate
+/// (<see cref="AccessibilityChecker.IsAccessible"/>). As a result a
+/// <c>private</c> member of the ENCLOSING type accessed through a type-qualified
+/// receiver (<c>Type.Member</c>) or a constructor call (<c>Type()</c>) was
+/// wrongly rejected with GS0472 — even though an unqualified call in the same
+/// initializer, and both access forms from a <c>shared</c> function body,
+/// already worked. The fix threads the enclosing type through the accessibility
+/// context while binding field/property initializers.
+/// </summary>
+public class Issue2111FieldInitializerAccessibilityTests
+{
+    [Fact]
+    public void SharedFieldInitializer_QualifiedPrivateStaticCall_NoGS0472()
+    {
+        var source = @"
+class ApplEnv {
+    shared {
+        let OSVersion int32 = ApplEnv.GetOsVersion()
+        private func GetOsVersion() int32 {
+            return 42
+        }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void SharedFieldInitializer_PrivateConstructorCall_NoGS0472()
+    {
+        var source = @"
+class Logging {
+    private init() {
+    }
+    shared {
+        private let Instance Logging = Logging()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void SharedFieldInitializer_UnqualifiedPrivateStaticCall_NoGS0472()
+    {
+        var source = @"
+class ApplEnv2 {
+    shared {
+        let OSVersion int32 = GetOsVersion()
+        private func GetOsVersion() int32 {
+            return 42
+        }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_QualifiedPrivateStaticCallInInitializer_StillReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    shared {
+        private func Secret() int32 {
+            return 42
+        }
+    }
+}
+
+class Bar {
+    shared {
+        let Value int32 = Foo.Secret()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #2111 — a `private` (or `protected`) member of the enclosing type was wrongly rejected with **GS0472** when accessed from that type's own **static field/property initializer** via a type-qualified receiver (`Type.Member`) or a constructor call (`Type()`).

## Root cause
Static field/property initializers in a `shared { }` block are bound by a *deferred* pass (`BindDeferredFieldInitializers`) that runs **outside any function body**, so no "current function" was established. `AccessibilityChecker.IsAccessible` derives the enclosing type solely from the current function (`ReceiverType`/`StaticOwnerType`/`LexicalEnclosingType`); with no current function the enclosing type was `null`, so any private/protected member reached via `Type.Member` or `Type()` failed the gate. Unqualified static calls escaped it (they resolve as functions in the static-member scope), and `shared` function bodies work because they carry their `StaticOwnerType`.

## Fix (general)
While binding a type's deferred field/property initializers, install a synthetic static function owned by the enclosing type (`StaticOwnerType = structSymbol`) as the current function, then restore it — mirroring the working function-body path. Covers all member kinds (methods, properties, fields, constructors) in any static/instance initializer.

## Files
- `src/Core/CodeAnalysis/Binding/DeclarationBinder.cs`
- `src/Core/CodeAnalysis/Binding/Binder.cs`
- `test/Core.Tests/CodeAnalysis/Binding/Issue2111FieldInitializerAccessibilityTests.cs` (new)

## Testing
- Build (Release): 0 warnings, 0 errors.
- Both repros + all four control cases: compile.
- New regression tests: 4 passed (incl. a negative control that external private access is *still* GS0472).
- Core.Tests: 5538 passed, 1 skipped.
- Interpreter.Tests: 412 passed.

Surfaced translating Oahu.Foundation with cs2gs.

Fixes #2111

Refs #914
