### PR TITLE
gsc: bind range-slice via IsSameAs instead of runtime Type[] GetMethod (GS9998) (#2114)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -5448,7 +5448,31 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var slice = clrType.GetMethod("Slice", BindingFlags.Public | BindingFlags.Instance, binder: null, new[] { typeof(int), typeof(int) }, modifiers: null);
+        // Issue #2114: probe for `Slice(int, int)` by enumerating candidates and
+        // comparing parameter types with IsSameAs, rather than the reflection
+        // overload that takes a runtime Type[]. When `clrType` is a
+        // MetadataLoadContext RoType (the `/reference:` resolver path), passing
+        // runtime `typeof(int)` to GetMethod makes DefaultBinder.SelectMethod
+        // throw "Type must be a type provided by the MetadataLoadContext" and
+        // crash the compiler (GS9998). IsSameAs works across both contexts.
+        MethodInfo slice = null;
+        foreach (var candidate in clrType.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (candidate.Name != "Slice")
+            {
+                continue;
+            }
+
+            var sliceParams = candidate.GetParameters();
+            if (sliceParams.Length == 2
+                && sliceParams[0].ParameterType.IsSameAs(typeof(int))
+                && sliceParams[1].ParameterType.IsSameAs(typeof(int)))
+            {
+                slice = candidate;
+                break;
+            }
+        }
+
         if (slice == null)
         {
             return false;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2114RangeSliceMlcTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2114RangeSliceMlcTests.cs
@@ -1,0 +1,108 @@
+// <copyright file="Issue2114RangeSliceMlcTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #2114: binding a range-slice expression
+/// <c>expr[a..b]</c> against a sliceable BCL type (e.g. <c>Span</c> /
+/// <c>ReadOnlySpan</c>) must not crash when the receiver type is resolved
+/// through a <see cref="System.Reflection.MetadataLoadContext"/> (the
+/// <c>/reference:</c> resolver path used by the BuildTask and cs2gs migrate).
+/// <para>
+/// The slice-shape probe in <c>ExpressionBinder.TryFindSliceShape</c> previously
+/// called <c>clrType.GetMethod("Slice", …, new[] { typeof(int), typeof(int) }, …)</c>.
+/// When <c>clrType</c> is an MLC <c>RoType</c>, comparing its candidate parameter
+/// types against the host's runtime <c>typeof(int)</c> made
+/// <c>DefaultBinder.SelectMethod</c> throw
+/// <c>ArgumentException: Type must be a type provided by the MetadataLoadContext</c>,
+/// surfaced as a <c>GS9998</c> ICE. The probe now enumerates candidates and
+/// compares parameter types with <c>IsSameAs</c>, which works across reflection
+/// contexts.
+/// </para>
+/// </summary>
+public class Issue2114RangeSliceMlcTests
+{
+    /// <summary>
+    /// Build a <see cref="ReferenceResolver"/> rooted at BCL reference
+    /// assemblies. Supplying explicit paths forces gsc into the
+    /// <see cref="System.Reflection.MetadataLoadContext"/> resolution path,
+    /// reproducing the BuildTask / migrate scenario inside the test process.
+    /// </summary>
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+            typeof(System.ReadOnlySpan<>).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.Linq.Enumerable).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    private static ImmutableArray<Diagnostic> BindWithMlc(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            MetadataLoadContextResolver());
+        return globalScope.Diagnostics;
+    }
+
+    [Fact]
+    public void RangeSlice_OnReadOnlySpan_UnderMlc_DoesNotCrash()
+    {
+        var source = """
+            package Repro
+            import System
+
+            func TakeTail(s ReadOnlySpan[int64]) ReadOnlySpan[int64] {
+                return s[2..]
+            }
+            """;
+
+        // Pre-fix this threw ArgumentException from the binder (GS9998 ICE).
+        var diagnostics = BindWithMlc(source);
+
+        Assert.DoesNotContain(
+            diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void RangeSlice_OnSpan_WithBounds_UnderMlc_DoesNotCrash()
+    {
+        var source = """
+            package Repro
+            import System
+
+            func Middle(s Span[uint8]) Span[uint8] {
+                return s[1..3]
+            }
+            """;
+
+        var diagnostics = BindWithMlc(source);
+
+        Assert.DoesNotContain(
+            diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error);
+    }
+}


### PR DESCRIPTION
Binding a range-slice `expr[a..b]` against a sliceable BCL type (`Span`/`ReadOnlySpan`/array-like) crashed gsc with a `GS9998` ICE whenever the receiver type was resolved through a `MetadataLoadContext` — the `/reference:` resolver path used by the BuildTask and by cs2gs `migrate`:

```
error GS9998: ArgumentException: Type must be a type provided by the MetadataLoadContext. (Parameter 'types')
```

**Root cause.** `ExpressionBinder.TryFindSliceShape` probed for a `Slice(int, int)` method with the reflection overload that takes a runtime `Type[]`:

```csharp
clrType.GetMethod("Slice", ..., new[] { typeof(int), typeof(int) }, ...);
```

When `clrType` is an MLC `RoType`, `DefaultBinder.SelectMethod` compares its candidate parameter types against the host's runtime `typeof(int)` and throws.

**Fix.** Enumerate `Slice` candidates and compare each parameter type with `IsSameAs(typeof(int))` — the cross-context-safe comparison already used by the sibling `TryFindCountedIntIndexer` probe (and mandated by the #835 guard test). Audited the other `GetMethod`/`GetConstructor` sites in `Binding/` that pass a runtime `Type[]`; all use `typeof(...)` runtime receivers (string/Array/Monitor/Convert/FormattableStringFactory), so they are already context-safe — only `TryFindSliceShape` operated on a possibly-MLC receiver.

Unblocks the cs2gs migration of Oahu.Decrypt (e.g. `ChunkOffsetList.Read64`'s `longsSpan[count32Bit..]`).

**Tests.** New `Issue2114RangeSliceMlcTests` binds range-slices on `ReadOnlySpan`/`Span` under a `MetadataLoadContext` resolver (throws pre-fix). Full `Core.Tests` (5536) and `Interpreter.Tests` (412) pass.

Fixes #2114

Refs #914
