### PR TITLE
cs2gs: route expression-bodied member returns through null-forgiveness (#1354)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1354PropertyNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1354PropertyNullableTranslationTests.cs
@@ -122,6 +122,34 @@ namespace Demo
     }
 
     [Fact]
+    public void NullCheckedComputedProperty_ExpressionBodiedMember_EmitsNonNullAssertion()
+    {
+        // An EXPRESSION-BODIED member (`=> Work`) that returns a promoted `T?`
+        // property where the member is declared non-null `T` must route its
+        // returned value through the null-forgiveness pass, exactly like the
+        // statement-form `return Work;` does. This mirrors Oahu's
+        // `Mp4Operation.OperationTask => Continuation` (issue #1354): before the
+        // fix, WrapExpressionBody used a plain TranslateExpression and dropped
+        // the `!!`, yielding a `T? -> T` mismatch (GS0155).
+        string printed = TranslateUnit(@"
+#nullable enable
+using System.Threading.Tasks;
+namespace Demo
+{
+    public class C
+    {
+        private Task? backing;
+        protected virtual Task Work => backing ?? Task.CompletedTask;
+        public void Guard() { if (Work is null) { } }
+        public Task OperationTask => Work;
+    }
+}");
+
+        Assert.Contains("prop Work Task?", printed);
+        Assert.Contains("prop OperationTask Task -> Work!!", printed);
+    }
+
+    [Fact]
     public void PropertyNeverNullChecked_StaysNonNullable()
     {
         // Precision guard: a property that is never null-checked nor

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4944,12 +4944,19 @@ public sealed class CSharpToGSharpTranslator
                     () => this.TranslateExpressionStatements(expression).ToList()).ToList());
             }
 
+            // A non-void expression body is a `return expr`. Route the returned
+            // value through the null-forgiveness pass (issue #1354) exactly like
+            // a statement-form `return expr;` does, so a promoted-nullable value
+            // (`T?`) returned where the member is declared non-null `T` gets its
+            // flow-proven `!!` assertion (e.g. `prop OperationTask Task ->
+            // Continuation!!`). Using plain TranslateExpression here left
+            // expression-bodied members without the assertion → GS0155.
             return new BlockStatement(this.WithSpillSeam(() => this.WithHoistedPostfix(
                 expression,
                 () => this.WithHoistedAssignments(
                     expression,
                     includeSelf: true,
-                    () => new List<GStatement> { new ReturnStatement(this.TranslateExpression(expression)) })).ToList()).ToList());
+                    () => new List<GStatement> { new ReturnStatement(this.TranslateValueWithNullForgiveness(expression)) })).ToList()).ToList());
         }
 
         private BlockStatement TranslateBlock(BlockSyntax block)


### PR DESCRIPTION
## Problem

`WrapExpressionBody` translated a non-void expression body (`=> expr`) with a plain `TranslateExpression`, so a promoted-nullable value (`T?`) returned where the member is declared non-null `T` never received its flow-proven `!!` assertion. The statement-form `return expr;` path (issue #1354) and conditional arms already applied it.

This left expression-bodied members (methods, operators, properties, indexers) emitting a `T? -> T` mismatch (GS0155). Concretely, Oahu.Decrypt's `Mp4Operation`:

```csharp
protected virtual Task Continuation => continuation ?? Task.CompletedTask; // null-checked elsewhere -> promoted to Task?
public Task OperationTask => Continuation;                                  // declared non-null Task
```

translated to `prop OperationTask Task -> Continuation` (no `!!`) -> GS0155.

## Fix

Route the non-void expression-body return through `TranslateValueWithNullForgiveness` (the same helper used by statement-form returns and conditional arms), so a flow-proven promoted-nullable value gets its `!!` assertion: `prop OperationTask Task -> Continuation!!`.

## Impact

Drives Oahu.Decrypt from 1 compile error to **compile=PASS**. Foundation unchanged. This is the expression-body sibling of the existing #1354 statement-return null-forgiveness pass.

## Tests

- New `Issue1354PropertyNullableTranslationTests.NullCheckedComputedProperty_ExpressionBodiedMember_EmitsNonNullAssertion` asserts `prop OperationTask Task -> Work!!`.
- Full cs2gs translation suite green (943 + new).

Refs #914
