### PR TITLE
gsc: promote non-capturing lambda referencing enclosing type parameters to a generic method (constrained-call StackUnexpected)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/LambdaEnclosingTypeParameterCollector.cs
+++ b/src/Core/CodeAnalysis/Emit/LambdaEnclosingTypeParameterCollector.cs
@@ -1,0 +1,124 @@
+// <copyright file="LambdaEnclosingTypeParameterCollector.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #2118: walks a non-capturing lambda body and gathers every
+/// <see cref="TypeParameterSymbol"/> it references (through expression types,
+/// declared-local types, type arguments, <c>is</c>/pattern target types, and
+/// <c>typeof</c>/<c>sizeof</c> operands). The lambda itself declares no type
+/// parameters, so any type parameter reachable from its body is necessarily an
+/// enclosing one that must be promoted onto the synthesized static method as a
+/// generic method type parameter for the emitted IL to verify. Mirrors the node
+/// coverage of <c>LambdaBinder.EnclosingTypeParameterReferenceWalker</c> but
+/// accumulates ALL references instead of stopping at the first.
+/// </summary>
+internal sealed class LambdaEnclosingTypeParameterCollector : BoundTreeWalker
+{
+    private readonly List<TypeParameterSymbol> sink;
+
+    private LambdaEnclosingTypeParameterCollector(List<TypeParameterSymbol> sink)
+    {
+        this.sink = sink;
+    }
+
+    /// <summary>
+    /// Collects every type parameter referenced anywhere in <paramref name="body"/>
+    /// into <paramref name="sink"/> (order/duplicates are the caller's concern;
+    /// <see cref="SynthesizedClosureReifier.CollectOrdered"/> deduplicates and
+    /// canonicalizes).
+    /// </summary>
+    /// <param name="body">The bound lambda body to walk.</param>
+    /// <param name="sink">The accumulator list.</param>
+    public static void Collect(BoundStatement body, List<TypeParameterSymbol> sink)
+    {
+        if (body == null)
+        {
+            return;
+        }
+
+        new LambdaEnclosingTypeParameterCollector(sink).VisitStatement(body);
+    }
+
+    public override void VisitExpression(BoundExpression node)
+    {
+        if (node == null)
+        {
+            return;
+        }
+
+        TypeSymbol.CollectReferencedTypeParameters(node.Type, this.sink);
+        switch (node)
+        {
+            case BoundCallExpression call:
+                this.CheckTypeArguments(call.MethodTypeArguments);
+                break;
+            case BoundUserInstanceCallExpression userInstanceCall:
+                this.CheckTypeArguments(userInstanceCall.MethodTypeArguments);
+                break;
+            case BoundImportedCallExpression importedCall:
+                this.CheckTypeArguments(importedCall.TypeArgumentSymbols);
+                break;
+            case BoundImportedInstanceCallExpression importedInstanceCall:
+                this.CheckTypeArguments(importedInstanceCall.TypeArgumentSymbols);
+                TypeSymbol.CollectReferencedTypeParameters(importedInstanceCall.ConstrainedReceiverTypeParameter, this.sink);
+                TypeSymbol.CollectReferencedTypeParameters(importedInstanceCall.ConstrainedInterfaceType, this.sink);
+                break;
+            case BoundIsExpression isExpression:
+                TypeSymbol.CollectReferencedTypeParameters(isExpression.TargetType, this.sink);
+                break;
+            case BoundTypeOfExpression typeOfExpression:
+                TypeSymbol.CollectReferencedTypeParameters(typeOfExpression.OperandType, this.sink);
+                break;
+            case BoundSizeOfExpression sizeOfExpression:
+                TypeSymbol.CollectReferencedTypeParameters(sizeOfExpression.MeasuredType, this.sink);
+                break;
+            case BoundConstrainedStaticCallExpression constrainedStaticCall:
+                TypeSymbol.CollectReferencedTypeParameters(constrainedStaticCall.TypeParameter, this.sink);
+                break;
+        }
+
+        base.VisitExpression(node);
+    }
+
+    public override void VisitPattern(BoundPattern node)
+    {
+        if (node == null)
+        {
+            return;
+        }
+
+        TypeSymbol.CollectReferencedTypeParameters(node.Type, this.sink);
+        if (node is BoundTypePattern typePattern)
+        {
+            TypeSymbol.CollectReferencedTypeParameters(typePattern.TargetType, this.sink);
+        }
+
+        base.VisitPattern(node);
+    }
+
+    protected override void VisitVariableDeclaration(BoundVariableDeclaration node)
+    {
+        TypeSymbol.CollectReferencedTypeParameters(node.Variable.Type, this.sink);
+        base.VisitVariableDeclaration(node);
+    }
+
+    private void CheckTypeArguments(System.Collections.Immutable.ImmutableArray<TypeSymbol> typeArguments)
+    {
+        if (typeArguments.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        foreach (var typeArgument in typeArguments)
+        {
+            TypeSymbol.CollectReferencedTypeParameters(typeArgument, this.sink);
+        }
+    }
+}

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -345,7 +345,7 @@ internal sealed partial class MethodBodyEmitter
                 $"Function literal '{literal.Function.Name}' captures outer variables; closure emit fell through synthesis.");
         }
 
-        if (!this.outer.cache.FunctionHandles.TryGetValue(literal.Function, out var methodHandle))
+        if (!this.outer.cache.FunctionHandles.TryGetValue(literal.Function, out _))
         {
             throw new InvalidOperationException(
                 $"Function literal '{literal.Function.Name}' has no emitted MethodDef.");
@@ -353,7 +353,7 @@ internal sealed partial class MethodBodyEmitter
 
         this.il.OpCode(ILOpCode.Ldnull);
         this.il.OpCode(ILOpCode.Ldftn);
-        this.il.Token(methodHandle);
+        this.il.Token(this.outer.ResolveLambdaFunctionFtnToken(literal.Function));
         this.il.OpCode(ILOpCode.Newobj);
         this.il.Token(delegateCtorHandle);
     }
@@ -683,7 +683,7 @@ internal sealed partial class MethodBodyEmitter
                 $"Function literal '{literal.Function.Name}' captures outer variables; closure emit fell through synthesis.");
         }
 
-        if (!this.outer.cache.FunctionHandles.TryGetValue(literal.Function, out var methodHandle))
+        if (!this.outer.cache.FunctionHandles.TryGetValue(literal.Function, out _))
         {
             throw new InvalidOperationException(
                 $"Function literal '{literal.Function.Name}' has no emitted MethodDef.");
@@ -691,7 +691,7 @@ internal sealed partial class MethodBodyEmitter
 
         this.il.OpCode(ILOpCode.Ldnull);
         this.il.OpCode(ILOpCode.Ldftn);
-        this.il.Token(methodHandle);
+        this.il.Token(this.outer.ResolveLambdaFunctionFtnToken(literal.Function));
         this.il.OpCode(ILOpCode.Newobj);
 
         // ADR-0087 §3 R6: see capture-bearing branch above — reified

--- a/src/Core/CodeAnalysis/Emit/PendingGenericParameter.cs
+++ b/src/Core/CodeAnalysis/Emit/PendingGenericParameter.cs
@@ -32,10 +32,20 @@ namespace GSharp.Core.CodeAnalysis.Emit;
 /// a required custom modifier of
 /// <c>System.Runtime.InteropServices.UnmanagedType</c>.
 /// </param>
+/// <param name="PreResolvedConstraintHandle">
+/// Issue #2118: a pre-resolved <c>TypeDefOrRefOrSpec</c> handle for the
+/// interface constraint, resolved eagerly while an emit-time context (such as a
+/// generic-promoted lambda's type-parameter remap) was active. When present it
+/// is used verbatim by <see cref="TypeDefEmitter.FlushPendingGenericParameters"/>
+/// instead of re-resolving <see cref="InterfaceConstraintType"/> at flush time
+/// (when the context is gone), so the constraint encodes the method's own
+/// <c>MVar</c> slots rather than the enclosing parameter it textually references.
+/// </param>
 internal readonly record struct PendingGenericParameter(
     EntityHandle Owner,
     GenericParameterAttributes Attributes,
     string Name,
     ushort Index,
     GSharp.Core.CodeAnalysis.Symbols.TypeSymbol InterfaceConstraintType,
-    bool HasUnmanagedConstraint = false);
+    bool HasUnmanagedConstraint = false,
+    EntityHandle? PreResolvedConstraintHandle = null);

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -387,6 +387,81 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
+    // Issue #2118: a non-capturing lambda whose signature/body references an
+    // enclosing method/type parameter (e.g. `func Build[T IComparable[T]]() ...
+    // = (x T, y T) -> x.CompareTo(y)`) is hosted as a top-level `<Program>`
+    // static method. To emit verifiable IL that method must be a genuine
+    // GENERIC method declaring its OWN type parameters — cloned from the
+    // referenced enclosing ones (carrying their constraints) — otherwise the
+    // body's `!!0` references a method type parameter the method never declares
+    // (ilverify DelegateCtor at the delegate site + StackUnexpected on any
+    // `constrained.` call inside the body). While emitting such a lambda's
+    // signature and body, this remap translates each referenced ENCLOSING type
+    // parameter into the lambda method's own freshly-cloned method
+    // type-parameter ordinal (MVar(idx)). Pushed around the lambda's
+    // EmitFunction call; null everywhere else.
+    internal Dictionary<TypeParameterSymbol, int> activeLambdaMethodTypeParamRemap;
+
+    // Issue #2118: per-lambda-function original-enclosing-TP -> own-clone-ordinal
+    // remap, produced by ClosureEmitter.PromoteGenericLambda and consulted via
+    // PushLambdaMethodRemap while the lambda's MethodDef signature and body are
+    // emitted.
+    internal readonly Dictionary<FunctionSymbol, Dictionary<TypeParameterSymbol, int>> lambdaMethodTypeParamRemapsByFunction =
+        new Dictionary<FunctionSymbol, Dictionary<TypeParameterSymbol, int>>(ReferenceEqualityComparer.Instance);
+
+    // Issue #2118: per-lambda-function ordered ORIGINAL enclosing type
+    // parameters used as the MethodSpec type arguments when the lambda is
+    // referenced (`ldftn <lambda><...enclosing args...>`) at its delegate
+    // materialization site.
+    internal readonly Dictionary<FunctionSymbol, ImmutableArray<TypeParameterSymbol>> lambdaMethodTypeArgsByFunction =
+        new Dictionary<FunctionSymbol, ImmutableArray<TypeParameterSymbol>>(ReferenceEqualityComparer.Instance);
+
+    /// <summary>
+    /// Issue #2118: pushes the enclosing-TP -> own-clone-ordinal remap for a
+    /// generic-promoted non-capturing lambda so that every
+    /// <see cref="EncodeTypeSymbol"/> call made while its signature and body are
+    /// emitted translates references to the enclosing type parameters into the
+    /// lambda method's own <c>MVar(idx)</c> slots. Restores the previous remap
+    /// on dispose.
+    /// </summary>
+    /// <param name="function">The lambda function being emitted.</param>
+    /// <returns>A disposable scope that restores the previous remap.</returns>
+    internal LambdaMethodRemapScope PushLambdaMethodRemap(FunctionSymbol function)
+    {
+        if (function == null
+            || !this.lambdaMethodTypeParamRemapsByFunction.TryGetValue(function, out var remap)
+            || remap == null)
+        {
+            return new LambdaMethodRemapScope(this, null, restore: false);
+        }
+
+        var prev = this.activeLambdaMethodTypeParamRemap;
+        this.activeLambdaMethodTypeParamRemap = remap;
+        return new LambdaMethodRemapScope(this, prev, restore: true);
+    }
+
+    internal readonly struct LambdaMethodRemapScope : IDisposable
+    {
+        private readonly ReflectionMetadataEmitter owner;
+        private readonly Dictionary<TypeParameterSymbol, int> previous;
+        private readonly bool restore;
+
+        public LambdaMethodRemapScope(ReflectionMetadataEmitter owner, Dictionary<TypeParameterSymbol, int> previous, bool restore)
+        {
+            this.owner = owner;
+            this.previous = previous;
+            this.restore = restore;
+        }
+
+        public void Dispose()
+        {
+            if (this.restore)
+            {
+                this.owner.activeLambdaMethodTypeParamRemap = this.previous;
+            }
+        }
+    }
+
     /// <summary>
     /// Issue #1465: reifies an async state-machine struct over an
     /// ordinal-aligned copy of the type parameters in scope at its kickoff
@@ -2315,7 +2390,19 @@ internal sealed class ReflectionMetadataEmitter
                     continue;
                 }
 
-                this.lambdaBodies[literal.Function] = (BoundBlockStatement)Lowerer.Lower(literal.Body);
+                var loweredLambdaBody = (BoundBlockStatement)Lowerer.Lower(literal.Body);
+                this.lambdaBodies[literal.Function] = loweredLambdaBody;
+
+                // Issue #2118: a non-capturing lambda hosted as a top-level
+                // <Program> static method must be promoted to a GENERIC method
+                // declaring its own type parameters (cloned, with constraints,
+                // from the enclosing type parameters its signature/body
+                // references) — otherwise its body's `!!0`/`!0` references a
+                // type parameter the method never declares, producing
+                // unverifiable IL (DelegateCtor at the delegate site and
+                // StackUnexpected on any `constrained.` call in the body).
+                this.TryPromoteNonCapturingGenericLambda(literal, loweredLambdaBody);
+
                 hostBucket.Add(literal.Function);
             }
         }
@@ -2925,7 +3012,13 @@ internal sealed class ReflectionMetadataEmitter
                     body = this.lambdaBodies[fn];
                 }
 
-                this.EmitFunction(fn, body, isEntryPoint: false);
+                // Issue #2118: a generic-promoted non-capturing lambda's
+                // signature and body reference the enclosing type parameters;
+                // push the remap so they encode as this method's own MVar slots.
+                using (this.PushLambdaMethodRemap(fn))
+                {
+                    this.EmitFunction(fn, body, isEntryPoint: false);
+                }
             }
 
             if (this.emitCtx.Program.EntryPoint is not null && pkg == entryPointPackage && !entryPointIsClassOwned)
@@ -5018,7 +5111,32 @@ internal sealed class ReflectionMetadataEmitter
         // method immediately after AddMethodDefinition. The signature's
         // genericParameterCount above and these rows together make the method
         // a proper CLR generic method definition.
+        var gpRowStart = this.emitCtx.PendingGenericParameters.Count;
         TypeDefEmitter.EmitGenericParamRows(this.emitCtx, handle, function.TypeParameters);
+
+        // Issue #2118: a generic-promoted non-capturing lambda's type-parameter
+        // constraints textually reference the *enclosing* type parameters they
+        // were cloned from (the interface-constraint symbol is cached and does
+        // not carry the clone). Their deferred GenericParamConstraint rows would
+        // otherwise be resolved at flush time — after this method's remap is
+        // gone — encoding the enclosing Var/MVar slot instead of this method's
+        // own MVar. Resolve them now, while the remap is active, so the
+        // constraint encodes `!!idx` for both class- and method-parameter roots.
+        if (this.activeLambdaMethodTypeParamRemap != null)
+        {
+            var pendingRows = this.emitCtx.PendingGenericParameters;
+            for (var gi = gpRowStart; gi < pendingRows.Count; gi++)
+            {
+                var gpRow = pendingRows[gi];
+                if (gpRow.InterfaceConstraintType != null)
+                {
+                    pendingRows[gi] = gpRow with
+                    {
+                        PreResolvedConstraintHandle = this.GetElementTypeToken(gpRow.InterfaceConstraintType),
+                    };
+                }
+            }
+        }
 
         // Phase 4/5 (ADR-0027 §7.7a): hand the body's sequence points and
         // locals to the PDB emitter, keyed by the freshly minted MethodDef row
@@ -6054,7 +6172,15 @@ internal sealed class ReflectionMetadataEmitter
             // generic over enclosing TYPE parameters, so any TP present in the
             // active remap (class or method) maps to the synthesized class's
             // own VAR(idx) slot.
-            if (this.activeIteratorStateMachineRemap != null
+            if (this.activeLambdaMethodTypeParamRemap != null
+                && this.activeLambdaMethodTypeParamRemap.TryGetValue(tpSym, out var lambdaMethodOrd))
+            {
+                // Issue #2118: reference to an enclosing type parameter inside a
+                // generic-promoted non-capturing lambda's signature/body maps to
+                // the lambda method's own MVar(idx) slot.
+                encoder.GenericMethodTypeParameter(lambdaMethodOrd);
+            }
+            else if (this.activeIteratorStateMachineRemap != null
                 && this.activeIteratorStateMachineRemap.TryGetValue(tpSym, out var smClassOrd))
             {
                 encoder.GenericTypeParameter(smClassOrd);
@@ -6378,6 +6504,97 @@ internal sealed class ReflectionMetadataEmitter
     // bodies, the constructed instantiation `Box`1<int32>` for
     // external uses). The helpers below provide that routing.
     // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Issue #2118: promotes a non-capturing lambda that references enclosing
+    /// type parameters into a generic method. Clones the referenced enclosing
+    /// type parameters (with their constraints remapped onto the clones) as the
+    /// lambda function's own method type parameters, records the
+    /// enclosing-TP -> own-clone-ordinal remap (so the signature/body encode
+    /// translates references into the method's own <c>MVar</c> slots) and the
+    /// ordered originals (used as MethodSpec type arguments at the delegate
+    /// materialization site). No-op for a lambda that references no enclosing
+    /// type parameter or that already declares its own.
+    /// </summary>
+    /// <param name="literal">The non-capturing lambda literal being hosted as a top-level static method.</param>
+    /// <param name="loweredBody">The lambda's lowered body (walked for type-parameter references).</param>
+    private void TryPromoteNonCapturingGenericLambda(BoundFunctionLiteralExpression literal, BoundBlockStatement loweredBody)
+    {
+        var fn = literal?.Function;
+        if (fn == null || fn.IsGeneric)
+        {
+            return;
+        }
+
+        var referenced = new List<TypeParameterSymbol>();
+        foreach (var parameter in fn.Parameters)
+        {
+            TypeSymbol.CollectReferencedTypeParameters(parameter.Type, referenced);
+        }
+
+        TypeSymbol.CollectReferencedTypeParameters(fn.Type, referenced);
+        LambdaEnclosingTypeParameterCollector.Collect(loweredBody, referenced);
+
+        if (referenced.Count == 0)
+        {
+            return;
+        }
+
+        // Canonical order: class type parameters (Var) before method type
+        // parameters (MVar), each by original ordinal — matching
+        // SynthesizedClosureReifier.CollectOrdered so the clone list is
+        // deterministic.
+        referenced.Sort(static (a, b) =>
+        {
+            var ak = a.IsMethodTypeParameter ? 1 : 0;
+            var bk = b.IsMethodTypeParameter ? 1 : 0;
+            return ak != bk ? ak - bk : a.Ordinal - b.Ordinal;
+        });
+
+        var origTPs = referenced.ToImmutableArray();
+        var clones = SynthesizedClosureReifier.CloneWithRemappedConstraints(origTPs);
+
+        // Setting TypeParameters flips each clone's IsMethodTypeParameter flag,
+        // so the emitter encodes body/signature references as MVar(idx).
+        fn.TypeParameters = clones;
+
+        var remap = new Dictionary<TypeParameterSymbol, int>(origTPs.Length, ReferenceEqualityComparer.Instance);
+        for (var i = 0; i < origTPs.Length; i++)
+        {
+            remap[origTPs[i]] = i;
+        }
+
+        this.lambdaMethodTypeParamRemapsByFunction[fn] = remap;
+        this.lambdaMethodTypeArgsByFunction[fn] = origTPs;
+    }
+
+    /// <summary>
+    /// Issue #2118: resolves the <c>ldftn</c> target token for a non-capturing
+    /// lambda function. When the lambda was generic-promoted
+    /// (<see cref="TryPromoteNonCapturingGenericLambda"/>) the token is a
+    /// MethodSpec instantiating the open lambda method with the enclosing type
+    /// parameters (in the referencing method's context); otherwise it is the
+    /// bare MethodDef handle.
+    /// </summary>
+    /// <param name="fn">The lambda function whose function pointer is loaded.</param>
+    /// <returns>The MethodDef or MethodSpec token for the <c>ldftn</c>.</returns>
+    internal EntityHandle ResolveLambdaFunctionFtnToken(FunctionSymbol fn)
+    {
+        var methodHandle = this.cache.FunctionHandles[fn];
+        if (this.lambdaMethodTypeArgsByFunction.TryGetValue(fn, out var typeArgs)
+            && !typeArgs.IsDefaultOrEmpty)
+        {
+            var args = new TypeSymbol[typeArgs.Length];
+            for (var i = 0; i < typeArgs.Length; i++)
+            {
+                args[i] = typeArgs[i];
+            }
+
+            return this.BuildMethodSpec(methodHandle, args);
+        }
+
+        return methodHandle;
+    }
 
     /// <summary>
     /// ADR-0087 §3 R3+R4: builds a MethodSpec for a generic G# user
@@ -10109,6 +10326,15 @@ internal sealed class ReflectionMetadataEmitter
         }
         else if (type is TypeParameterSymbol tp)
         {
+            // Issue #2118: inside a generic-promoted non-capturing lambda's
+            // signature/body, references to the enclosing type parameters map to
+            // the lambda method's own MVar(idx) slots.
+            if (this.activeLambdaMethodTypeParamRemap != null
+                && this.activeLambdaMethodTypeParamRemap.TryGetValue(tp, out var lambdaMethodOrd))
+            {
+                encoder.GenericMethodTypeParameter(lambdaMethodOrd);
+            }
+
             // Issue #810: when emitting a state-machine method (or the
             // state-machine class itself), references to the OUTER
             // method's type parameters are encoded as the SM class's
@@ -10117,7 +10343,7 @@ internal sealed class ReflectionMetadataEmitter
             // `!0` on the SM class. The remap is pushed by
             // EmitIteratorStateMachineMember and is keyed by the
             // method TP's instance identity.
-            if (this.activeIteratorStateMachineRemap != null
+            else if (this.activeIteratorStateMachineRemap != null
                 && tp.IsMethodTypeParameter
                 && this.activeIteratorStateMachineRemap.TryGetValue(tp, out var classOrdinal))
             {

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -2018,7 +2018,7 @@ internal sealed class TypeDefEmitter
             {
                 metadata.AddGenericParameterConstraint(
                     gpHandle,
-                    resolveConstraintHandle(row.InterfaceConstraintType));
+                    row.PreResolvedConstraintHandle ?? resolveConstraintHandle(row.InterfaceConstraintType));
             }
 
             // Issue #1336: emit the `unmanaged` constraint as a

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2118ConstrainedCallLambdaEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2118ConstrainedCallLambdaEmitTests.cs
@@ -1,0 +1,317 @@
+// <copyright file="Issue2118ConstrainedCallLambdaEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #2118 — a non-capturing lambda whose body performs a constrained
+/// interface call on a value of an enclosing type parameter (<c>T</c>
+/// constrained to an interface) must emit verifiable IL. Before the fix the
+/// lambda was hosted as a plain (non-generic) static method that still
+/// referenced the enclosing parameter <c>T</c> in its signature, so its
+/// <c>constrained. !!T</c> call left a bare type-parameter value where the
+/// interface was expected (ilverify <c>StackUnexpected</c>), and the
+/// delegate <c>ldftn</c> referenced an ill-formed method (<c>DelegateCtor</c>).
+/// The fix promotes such lambdas into genuine generic methods that clone the
+/// referenced enclosing parameters — with their constraints — as their own
+/// method type parameters, so the emitted body is identical to the equivalent
+/// direct method and JIT-executes correctly. These tests JIT-run the promoted
+/// lambdas end-to-end (an invalid method body would throw at invoke time) and
+/// assert the structural shape of the promotion.
+/// </summary>
+public class Issue2118ConstrainedCallLambdaEmitTests
+{
+    [Fact]
+    public void MethodTypeParam_ConstrainedInterfaceCall_InLambda_Int_Executes()
+    {
+        const string Source = @"package P
+import System
+
+func Build[T IComparable[T]]() (T, T) -> int32 {
+    let f (T, T) -> int32 = (x T, y T) -> x.CompareTo(y)
+    return f
+}
+
+func RunLess() int32 {
+    let g = Build[int32]()
+    return g(3, 7)
+}
+
+func RunGreater() int32 {
+    let g = Build[int32]()
+    return g(7, 3)
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(MethodTypeParam_ConstrainedInterfaceCall_InLambda_Int_Executes));
+        try
+        {
+            Assert.True((int)GetProgramMethod(asm, "RunLess").Invoke(null, null)! < 0);
+            Assert.True((int)GetProgramMethod(asm, "RunGreater").Invoke(null, null)! > 0);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void MethodTypeParam_ConstrainedInterfaceCall_InLambda_String_Executes()
+    {
+        // Generalization: the same shape over a different type argument
+        // (System.String, also IComparable[String]) must work too.
+        const string Source = @"package P
+import System
+
+func Build[T IComparable[T]]() (T, T) -> int32 {
+    let f (T, T) -> int32 = (x T, y T) -> x.CompareTo(y)
+    return f
+}
+
+func Run() int32 {
+    let g = Build[string]()
+    return g(""apple"", ""banana"")
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(MethodTypeParam_ConstrainedInterfaceCall_InLambda_String_Executes));
+        try
+        {
+            Assert.True((int)GetProgramMethod(asm, "Run").Invoke(null, null)! < 0);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void ClassTypeParam_ConstrainedInterfaceCall_InLambda_Executes()
+    {
+        // The doubly-broken case before the fix: the enclosing parameter is a
+        // *class* type parameter. The promoted lambda must clone it as its own
+        // method type parameter and encode the constraint as `!!0`, not the
+        // (non-existent, on the top-level host) class slot `!0`.
+        const string Source = @"package P
+import System
+
+open class C[T IComparable[T]] {
+    func Make() (T, T) -> int32 {
+        let f (T, T) -> int32 = (x T, y T) -> x.CompareTo(y)
+        return f
+    }
+}
+
+func Run() int32 {
+    let c = C[int32]()
+    let g = c.Make()
+    return g(7, 3)
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ClassTypeParam_ConstrainedInterfaceCall_InLambda_Executes));
+        try
+        {
+            Assert.True((int)GetProgramMethod(asm, "Run").Invoke(null, null)! > 0);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void UserInterfaceMethod_ConstrainedCall_InLambda_Executes()
+    {
+        // Generalization to ANY interface method (not only IComparable.CompareTo)
+        // and a user-declared G# interface rather than an imported CLR one.
+        const string Source = @"package P
+
+interface IShout {
+    func Shout() int32;
+}
+
+class Loud : IShout {
+    func Shout() int32 -> 42
+}
+
+func Build[T IShout]() (T) -> int32 {
+    let f (T) -> int32 = (x T) -> x.Shout()
+    return f
+}
+
+func Run() int32 {
+    let g = Build[Loud]()
+    return g(Loud())
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(UserInterfaceMethod_ConstrainedCall_InLambda_Executes));
+        try
+        {
+            Assert.Equal(42, GetProgramMethod(asm, "Run").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void MultiTypeParamEnclosingMethod_LambdaUsesSubset_Executes()
+    {
+        // Only the referenced enclosing parameter (T) is cloned onto the
+        // promoted lambda; the unused U is not, so the lambda is a single-arity
+        // generic method and still JIT-runs.
+        const string Source = @"package P
+import System
+
+func Build[T IComparable[T], U]() (T, T) -> int32 {
+    let f (T, T) -> int32 = (x T, y T) -> x.CompareTo(y)
+    return f
+}
+
+func Run() int32 {
+    let g = Build[int32, string]()
+    return g(3, 7)
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(MultiTypeParamEnclosingMethod_LambdaUsesSubset_Executes));
+        try
+        {
+            Assert.True((int)GetProgramMethod(asm, "Run").Invoke(null, null)! < 0);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void ConcreteInterfaceReceiver_InLambda_Executes_NoRegression()
+    {
+        // Control: a lambda whose receiver is a *concrete* interface type
+        // legitimately does NOT need a `constrained.` prefix. Promotion must not
+        // fire (there is no enclosing type parameter) and the call must run.
+        const string Source = @"package P
+import System
+
+func Build() (IComparable[int32]) -> int32 {
+    let f (IComparable[int32]) -> int32 = (x IComparable[int32]) -> x.CompareTo(0)
+    return f
+}
+
+func Run() int32 {
+    let g = Build()
+    return g(5)
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ConcreteInterfaceReceiver_InLambda_Executes_NoRegression));
+        try
+        {
+            Assert.True((int)GetProgramMethod(asm, "Run").Invoke(null, null)! > 0);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void DirectMethod_ConstrainedInterfaceCall_Executes_NoRegression()
+    {
+        // Control: the equivalent direct (non-lambda) method already emitted the
+        // correct constrained call and must keep working unchanged.
+        const string Source = @"package P
+import System
+
+open class C[T IComparable[T]] {
+    func Cmp(x T, y T) int32 -> x.CompareTo(y)
+}
+
+func Run() int32 {
+    let c = C[int32]()
+    return c.Cmp(3, 7)
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(DirectMethod_ConstrainedInterfaceCall_Executes_NoRegression));
+        try
+        {
+            Assert.True((int)GetProgramMethod(asm, "Run").Invoke(null, null)! < 0);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void PromotedLambda_IsGenericMethodDefinition_WithConstrainedTypeParameter()
+    {
+        // Structural assertion of the fix: the synthesized lambda host is a
+        // proper generic method definition whose (cloned) type parameter carries
+        // the interface constraint — the missing GenericParamConstraint that made
+        // the pre-fix IL unverifiable.
+        const string Source = @"package P
+import System
+
+func Build[T IComparable[T]]() (T, T) -> int32 {
+    let f (T, T) -> int32 = (x T, y T) -> x.CompareTo(y)
+    return f
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(PromotedLambda_IsGenericMethodDefinition_WithConstrainedTypeParameter));
+        try
+        {
+            var programType = asm.GetTypes().First(t => t.Name == "<Program>");
+            var promoted = programType
+                .GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(m => m.IsGenericMethodDefinition)
+                .Where(m => m.GetGenericArguments()[0].GetGenericParameterConstraints().Length > 0)
+                .ToList();
+
+            Assert.NotEmpty(promoted);
+            var lambda = promoted.First(m => m.Name.Contains("lambda", StringComparison.Ordinal));
+            var typeParam = lambda.GetGenericArguments()[0];
+            var constraint = typeParam.GetGenericParameterConstraints().Single();
+            Assert.Equal(typeof(IComparable<>).Name, constraint.Name);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    private static MethodInfo GetProgramMethod(Assembly asm, string name)
+    {
+        var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+        Assert.NotNull(programType);
+        var method = programType!.GetMethod(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return method!;
+    }
+
+    private static (Assembly Asm, AssemblyLoadContext Ctx) CompileToAssembly(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        var asm = loadContext.LoadFromStream(peStream);
+        return (asm, loadContext);
+    }
+}


### PR DESCRIPTION
## Problem

gsc emitted invalid IL when a lambda/closure body called a constrained interface method on a value of a generic type parameter (`T : IComparable[T]`): the `constrained.` prefix / generic promotion was missing in the synthesized closure method, failing `ilverify` with `StackUnexpected [found ref '!0'][expected ref 'System.IComparable`1<!0>']`. The same call in a normal method emitted correctly.

## Root cause

`src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs`, closure/lambda emit. A zero-capture top-level lambda that references an enclosing type parameter is hosted as a plain static method on `<Program>` but was **never promoted to a generic method**. Its body still referenced the enclosing `T` and emitted `constrained. !!T; callvirt`, while the host method declared `genericParameterCount=0` with no `GenericParamConstraint` → invalid IL at the lambda body and the `ldftn`/delegate-ctor site.

A second, deeper defect surfaced for **class**-type-parameter roots: after promotion, the cloned type parameter's deferred `GenericParamConstraint` row (resolved after the method's remap was gone) encoded `!0` instead of `!!0`, invalid on a non-generic host.

## Fix (emit-only)

- Collect enclosing type parameters referenced by a non-capturing lambda (params, return, body) and clone them — with constraints — as the lambda's own method type parameters (`TryPromoteNonCapturingGenericLambda` + `LambdaEnclosingTypeParameterCollector`).
- Route signature/body references to the cloned MVar slots via a type-parameter remap during `EmitFunction`.
- Resolve the constraint handle eagerly while the remap is active (`PendingGenericParameter.PreResolvedConstraintHandle`) so it encodes `!!0` for both class- and method-parameter roots.
- Emit a `MethodSpec` at the `ldftn` site instantiating the open lambda with the enclosing type arguments (`ResolveLambdaFunctionFtnToken`).

## Impact (Oahu.Decrypt, Refs #914)

Fixes the `StackUnexpected` in `EnumerableExtensions.<closure_<lambda1>_11>::Invoke` (`Comparer<TResult>.Create((x, y) => keySelector(x).CompareTo(keySelector(y)))`, `TKey : IComparable<TKey>`).

## Controls preserved

Unconstrained method-TP lambda; class-TP constrained (was doubly broken, now clean); concrete interface-typed receiver (correctly emits **no** `constrained.`); multi-TP subset; user-defined G# interface method; direct-method path all verify clean / JIT-run correctly.

## Tests

`test/Core.Tests/CodeAnalysis/Emit/Issue2118ConstrainedCallLambdaEmitTests.cs` (8: JIT-execute int/string method-TP, class-TP, user-interface method, multi-TP subset, concrete-receiver control, direct-method control, structural generic-method+constraint assertion). Regression slices green: Emit 703, Generic 530, Constrained/Interface 345, Lambda 175, Closure 9, Interpreter Lambda 16.

Fixes #2118

Refs #914
