### PR TITLE
cs2gs: resolve NuGet package and sibling-project references in migrate pipeline

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -47,7 +47,7 @@ public sealed class CompileStage : IMigrationStage
             gsFiles,
             outputPath,
             context.App.TargetKind,
-            BuildReferenceSet(context.App.ReferencedAssemblies));
+            BuildReferenceSet(context.App.ReferencedAssemblies, context.ExternalReferencePaths));
 
         File.WriteAllText(
             Path.Combine(context.AppRunDir, "gsc.compile.log"),
@@ -64,7 +64,25 @@ public sealed class CompileStage : IMigrationStage
         foreach (GscDiagnostic diagnostic in result.Errors)
         {
             EmittedGsFile file = MatchEmittedFile(context.EmittedFiles, diagnostic.File);
+
+            // Errors located in a referenced sibling project's emitted file are
+            // that project's own concern (measured in its own run), not charged
+            // against this app. Sibling files are compile inputs only, so the
+            // app's uses of sibling types resolve (Refs #914).
+            if (file is not null && file.IsFromReferencedProject)
+            {
+                continue;
+            }
+
             artifacts.Add(context.Triage.CompileError(diagnostic, file));
+        }
+
+        // Every parsed error was in a referenced sibling file: the app's own G#
+        // compiled cleanly. gsc still produced no assembly (the whole
+        // compilation failed), so IL-verify simply has nothing to read.
+        if (artifacts.Count == 0 && result.Errors.Count > 0)
+        {
+            return Task.FromResult(StageOutcome.Passed());
         }
 
         // Exit was non-zero but no structured GSxxxx error was parsed (e.g. a
@@ -98,8 +116,16 @@ public sealed class CompileStage : IMigrationStage
     /// <c>Span</c>) resolvable while keeping the app's own sibling references.
     /// </summary>
     /// <param name="appReferences">The app's sibling assembly references.</param>
+    /// <param name="externalReferences">
+    /// External (NuGet package) assembly paths captured from the C# compilation
+    /// by the Translate stage. Any whose file name matches a framework assembly
+    /// is skipped to avoid ref-pack / runtime double-identity; the rest let
+    /// package types (e.g. <c>System.Management</c>) resolve (Refs #914).
+    /// </param>
     /// <returns>The deduplicated reference path set.</returns>
-    private static IReadOnlyList<string> BuildReferenceSet(IReadOnlyList<string> appReferences)
+    private static IReadOnlyList<string> BuildReferenceSet(
+        IReadOnlyList<string> appReferences,
+        IReadOnlyList<string> externalReferences = null)
     {
         var references = new List<string>();
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -115,11 +141,34 @@ public sealed class CompileStage : IMigrationStage
             }
         }
 
+        var frameworkFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (string frameworkReference in FrameworkReferencePaths())
         {
+            frameworkFileNames.Add(Path.GetFileName(frameworkReference));
             if (seen.Add(frameworkReference))
             {
                 references.Add(frameworkReference);
+            }
+        }
+
+        if (externalReferences is not null)
+        {
+            foreach (string reference in externalReferences)
+            {
+                if (string.IsNullOrWhiteSpace(reference) || !seen.Add(reference))
+                {
+                    continue;
+                }
+
+                // Skip package copies of framework assemblies to avoid the
+                // gsc MetadataLoadContext resolving two identities for the same
+                // assembly (the shared-framework version already covers them).
+                if (frameworkFileNames.Contains(Path.GetFileName(reference)))
+                {
+                    continue;
+                }
+
+                references.Add(reference);
             }
         }
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -79,6 +79,16 @@ public sealed class StageExecutionContext
     public List<EmittedGsFile> EmittedFiles { get; } = new List<EmittedGsFile>();
 
     /// <summary>
+    /// Gets the absolute paths of the external (NuGet package) assemblies the
+    /// C# project resolved against, captured by the Translate stage from the
+    /// Roslyn compilation's metadata references. The Compile stage adds these to
+    /// gsc's <c>/reference:</c> set so package types (e.g. <c>System.Management</c>,
+    /// EF Core, Spectre.Console) resolve. Framework assemblies and stripped
+    /// sibling-project outputs are excluded downstream (Refs #914).
+    /// </summary>
+    public List<string> ExternalReferencePaths { get; } = new List<string>();
+
+    /// <summary>
     /// Gets or sets the absolute path of the assembly emitted by the Compile
     /// stage, published for the IL-verify stage to read (ADR-0115 §C). It is
     /// <see langword="null"/> until a green stage-2 compile has run.
@@ -152,6 +162,16 @@ public sealed class EmittedGsFile
     /// limitation in gsc).
     /// </summary>
     public IReadOnlyList<string> BaseClassNames { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this file was emitted from a
+    /// referenced (<c>ProjectReference</c>) project rather than the app under
+    /// migration. Such files are included as compile inputs so the app's uses of
+    /// sibling types resolve, but the Compile stage attributes errors only to
+    /// app-owned files — a referenced project's own gaps are measured in its own
+    /// run, not charged against every dependent (Refs #914).
+    /// </summary>
+    public bool IsFromReferencedProject { get; set; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
@@ -248,8 +248,19 @@ public class IlVerifyRunner
 
         if (additionalReferences is not null)
         {
+            // Skip package copies of framework assemblies so ilverify does not
+            // load two identities for the same assembly (Refs #914).
+            var runtimeFileNames = new HashSet<string>(
+                BuildDefaultRuntimeReferences().Select(Path.GetFileName),
+                StringComparer.OrdinalIgnoreCase);
             foreach (string reference in additionalReferences)
             {
+                if (!string.IsNullOrEmpty(reference)
+                    && runtimeFileNames.Contains(Path.GetFileName(reference)))
+                {
+                    continue;
+                }
+
                 Add(reference);
             }
         }

--- a/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyStage.cs
@@ -64,9 +64,12 @@ public sealed class IlVerifyStage : IMigrationStage
             return Task.FromResult(StageOutcome.Passed());
         }
 
+        IReadOnlyList<string> verifyReferences = context.App.ReferencedAssemblies is { Count: > 0 } appRefs
+            ? appRefs.Concat(context.ExternalReferencePaths).ToList()
+            : context.ExternalReferencePaths;
         IlVerifyResult result = this.runner.Verify(
             context.EmittedAssemblyPath,
-            context.App.ReferencedAssemblies);
+            verifyReferences);
 
         File.WriteAllText(
             Path.Combine(context.AppRunDir, "ilverify.log"),

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -13,6 +13,7 @@ using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
 
 namespace Cs2Gs.Pipeline;
 
@@ -38,9 +39,10 @@ public sealed class TranslateStage : IMigrationStage
             throw new ArgumentNullException(nameof(context));
         }
 
-        LoadedCSharpProject project = await CSharpProjectLoader
-            .LoadProjectAsync(context.App.ProjectPath, cancellationToken)
+        IReadOnlyList<LoadedCSharpProject> projects = await CSharpProjectLoader
+            .LoadProjectWithReferencesAsync(context.App.ProjectPath, cancellationToken)
             .ConfigureAwait(false);
+        LoadedCSharpProject project = projects[0];
 
         var artifacts = new List<TriageArtifact>();
         Directory.CreateDirectory(context.AppRunDir);
@@ -63,48 +65,88 @@ public sealed class TranslateStage : IMigrationStage
 
         var usedGsFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (LoadedDocument document in project.Documents)
+        // Translate the app itself (index 0) plus its transitively referenced
+        // sibling projects (Refs #914). Sibling G# is emitted so the app's uses
+        // of sibling types resolve at the gsc compile stage; those files are
+        // flagged IsFromReferencedProject so the Compile stage attributes errors
+        // only to the app's own files (a sibling's own gaps are measured in its
+        // own run, not charged against every dependent).
+        for (int projectIndex = 0; projectIndex < projects.Count; projectIndex++)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            LoadedCSharpProject currentProject = projects[projectIndex];
+            bool isReferencedProject = projectIndex > 0;
 
-            var translationContext = new TranslationContext(
-                project.Compilation,
-                document.SemanticModel,
-                document.FilePath);
-
-            CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, translationContext);
-            string printed = GSharpPrinter.Print(unit);
-
-            string gsFileName = EmittedFileNaming.UniqueGsFileName(document.FilePath, usedGsFileNames);
-            string gsPath = Path.Combine(context.AppRunDir, gsFileName);
-            File.WriteAllText(gsPath, printed);
-
-            var declaredTypeNames = new List<string>();
-            var baseClassNames = new List<string>();
-            CollectTypeGraph(unit.Members, declaredTypeNames, baseClassNames);
-
-            string relativeGsPath = MigrationPipeline.SanitizeAppId(context.App.Id) + "/" + gsFileName;
-            var emitted = new EmittedGsFile(
-                gsPath,
-                relativeGsPath,
-                document.FilePath,
-                printed,
-                declaredTypeNames,
-                baseClassNames);
-            context.EmittedFiles.Add(emitted);
-
-            foreach (TranslationDiagnostic diagnostic in translationContext.Diagnostics
-                .Where(d => d.Severity == TranslationSeverity.Unsupported))
+            // Capture the external (NuGet package) assemblies each project
+            // resolved against so the Compile stage can add them to gsc's
+            // reference set. Only on-disk file-backed references are recorded
+            // here; the Compile stage further excludes any whose file name
+            // collides with a framework assembly (ref-pack / runtime
+            // double-identity) and stripped sibling outputs are already absent
+            // from disk (Refs #914).
+            foreach (PortableExecutableReference peReference in currentProject.Compilation.References
+                .OfType<PortableExecutableReference>())
             {
-                artifacts.Add(context.Triage.TranslationUnsupported(diagnostic));
+                string referencePath = peReference.FilePath;
+                if (!string.IsNullOrEmpty(referencePath) && File.Exists(referencePath))
+                {
+                    context.ExternalReferencePaths.Add(referencePath);
+                }
             }
 
-            RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
-            if (!roundTrip.Success)
+            foreach (LoadedDocument document in currentProject.Documents)
             {
-                artifacts.Add(context.Triage.RoundTripFailure(
-                    emitted,
-                    roundTrip.Errors.FirstOrDefault() ?? "unknown parse error"));
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var translationContext = new TranslationContext(
+                    currentProject.Compilation,
+                    document.SemanticModel,
+                    document.FilePath);
+
+                CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, translationContext);
+                string printed = GSharpPrinter.Print(unit);
+
+                string gsFileName = EmittedFileNaming.UniqueGsFileName(document.FilePath, usedGsFileNames);
+                string gsPath = Path.Combine(context.AppRunDir, gsFileName);
+                File.WriteAllText(gsPath, printed);
+
+                var declaredTypeNames = new List<string>();
+                var baseClassNames = new List<string>();
+                CollectTypeGraph(unit.Members, declaredTypeNames, baseClassNames);
+
+                string relativeGsPath = MigrationPipeline.SanitizeAppId(context.App.Id) + "/" + gsFileName;
+                var emitted = new EmittedGsFile(
+                    gsPath,
+                    relativeGsPath,
+                    document.FilePath,
+                    printed,
+                    declaredTypeNames,
+                    baseClassNames)
+                {
+                    IsFromReferencedProject = isReferencedProject,
+                };
+                context.EmittedFiles.Add(emitted);
+
+                // Only the app's own files gate the Translate stage and produce
+                // triage artifacts; a referenced sibling's translation issues are
+                // its own run's concern.
+                if (isReferencedProject)
+                {
+                    continue;
+                }
+
+                foreach (TranslationDiagnostic diagnostic in translationContext.Diagnostics
+                    .Where(d => d.Severity == TranslationSeverity.Unsupported))
+                {
+                    artifacts.Add(context.Triage.TranslationUnsupported(diagnostic));
+                }
+
+                RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+                if (!roundTrip.Success)
+                {
+                    artifacts.Add(context.Triage.RoundTripFailure(
+                        emitted,
+                        roundTrip.Errors.FirstOrDefault() ?? "unknown parse error"));
+                }
             }
         }
 

--- a/tools/cs2gs/Cs2Gs.Tests/CSharpProjectLoaderDiagnosticsTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/CSharpProjectLoaderDiagnosticsTests.cs
@@ -158,6 +158,59 @@ namespace Sample
         Assert.Contains(project.Documents, d => d.FilePath.Replace('\\', '/').EndsWith("src/obji/Foo.cs", StringComparison.Ordinal));
     }
 
+    /// <summary>
+    /// Refs #914: an app that references a sibling class-library project must be
+    /// loaded together with that sibling so the app's uses of sibling types can
+    /// be resolved at the gsc compile stage.
+    /// <see cref="CSharpProjectLoader.LoadProjectWithReferencesAsync"/> returns
+    /// the app first followed by its transitively referenced C# projects, so the
+    /// sibling's source documents are available for translation.
+    /// </summary>
+    [Fact]
+    public async Task LoadProjectWithReferencesAsync_IncludesReferencedSiblingProject()
+    {
+        string root = NewScratchDir("with-references");
+        File.WriteAllText(Path.Combine(root, "Directory.Build.props"), "<Project></Project>");
+
+        string libDir = Path.Combine(root, "Lib");
+        Directory.CreateDirectory(libDir);
+        File.WriteAllText(Path.Combine(libDir, "Lib.csproj"), @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+");
+        File.WriteAllText(
+            Path.Combine(libDir, "IWidget.cs"),
+            "namespace Lib { public interface IWidget { int Value { get; } } }");
+
+        string appDir = Path.Combine(root, "App");
+        Directory.CreateDirectory(appDir);
+        File.WriteAllText(Path.Combine(appDir, "App.csproj"), @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include=""..\Lib\Lib.csproj"" />
+  </ItemGroup>
+</Project>
+");
+        File.WriteAllText(
+            Path.Combine(appDir, "Widget.cs"),
+            "namespace App { public class Widget : Lib.IWidget { public int Value => 42; } }");
+
+        System.Collections.Generic.IReadOnlyList<LoadedCSharpProject> projects =
+            await CSharpProjectLoader.LoadProjectWithReferencesAsync(Path.Combine(appDir, "App.csproj"));
+
+        Assert.True(projects.Count >= 2, "Expected the app project plus its referenced sibling.");
+        Assert.Contains(
+            projects[0].Documents,
+            d => d.FilePath.Replace('\\', '/').EndsWith("App/Widget.cs", StringComparison.Ordinal));
+        Assert.Contains(
+            projects.Skip(1).SelectMany(p => p.Documents),
+            d => d.FilePath.Replace('\\', '/').EndsWith("Lib/IWidget.cs", StringComparison.Ordinal));
+    }
+
     private static string NewScratchDir(string label)
     {
         string root = Path.Combine(AppContext.BaseDirectory, "loader-tests", label, Guid.NewGuid().ToString("N"));

--- a/tools/cs2gs/Cs2Gs.Translator/Loading/CSharpProjectLoader.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/Loading/CSharpProjectLoader.cs
@@ -129,18 +129,63 @@ public static class CSharpProjectLoader
                 .Where(d => d.Kind == WorkspaceDiagnosticKind.Failure)
                 .Select(d => Diagnostic.Create(MSBuildWorkspaceLoadFailureDescriptor, Location.None, d.Message)));
 
-        Compilation compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-        if (compilation is not CSharpCompilation csharpCompilation)
+        return await BuildLoadedProjectAsync(project, loadDiagnostics, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Loads a C# project together with the transitive closure of its
+    /// same-solution <c>ProjectReference</c>s, each as its own bound
+    /// <see cref="LoadedCSharpProject"/>. The primary (requested) project is
+    /// returned first and carries any MSBuild workspace load-failure diagnostics;
+    /// the referenced projects follow. This lets the migration pipeline translate
+    /// sibling-project source into G# so an app's uses of sibling types resolve at
+    /// the gsc compile stage (Refs #914). Package references are unaffected — they
+    /// remain metadata references on each compilation.
+    /// </summary>
+    /// <param name="projectPath">The absolute or relative path to the app's <c>.csproj</c>.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The primary project followed by its transitively referenced C# projects.</returns>
+    public static async Task<IReadOnlyList<LoadedCSharpProject>> LoadProjectWithReferencesAsync(
+        string projectPath,
+        CancellationToken cancellationToken = default)
+    {
+        if (projectPath is null)
         {
-            throw new InvalidOperationException(
-                $"Project '{fullPath}' did not produce a C# compilation (language: {project.Language}).");
+            throw new ArgumentNullException(nameof(projectPath));
         }
 
-        string projectDirectory = Path.GetDirectoryName(fullPath);
-        IReadOnlyList<LoadedDocument> documents = BuildDocuments(csharpCompilation, projectDirectory, loadDiagnostics);
-        loadDiagnostics.AddRange(SignificantDiagnostics(csharpCompilation));
+        string fullPath = Path.GetFullPath(projectPath);
+        if (!File.Exists(fullPath))
+        {
+            throw new FileNotFoundException($"Project file not found: {fullPath}", fullPath);
+        }
 
-        return new LoadedCSharpProject(csharpCompilation, documents, loadDiagnostics);
+        EnsureMSBuildRegistered();
+
+        var workspaceFailures = new List<Diagnostic>();
+        using var workspace = MSBuildWorkspace.Create();
+        workspace.LoadMetadataForReferencedProjects = true;
+
+        Project project = await workspace.OpenProjectAsync(fullPath, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        workspaceFailures.AddRange(
+            workspace.Diagnostics
+                .Where(d => d.Kind == WorkspaceDiagnosticKind.Failure)
+                .Select(d => Diagnostic.Create(MSBuildWorkspaceLoadFailureDescriptor, Location.None, d.Message)));
+
+        var results = new List<LoadedCSharpProject>
+        {
+            await BuildLoadedProjectAsync(project, workspaceFailures, cancellationToken).ConfigureAwait(false),
+        };
+
+        foreach (Project referenced in TransitiveCSharpProjectReferences(project))
+        {
+            results.Add(await BuildLoadedProjectAsync(referenced, new List<Diagnostic>(), cancellationToken)
+                .ConfigureAwait(false));
+        }
+
+        return results;
     }
 
     /// <summary>
@@ -211,6 +256,73 @@ public static class CSharpProjectLoader
             .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && File.Exists(path))
             .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
             .ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Enumerates the transitive closure of a project's same-solution
+    /// <c>ProjectReference</c>s that produce a C# compilation, each visited once
+    /// (breadth-first). The root project itself is excluded.
+    /// </summary>
+    private static IEnumerable<Project> TransitiveCSharpProjectReferences(Project root)
+    {
+        Solution solution = root.Solution;
+        var seen = new HashSet<ProjectId>();
+        var queue = new Queue<Project>();
+        foreach (ProjectReference reference in root.ProjectReferences)
+        {
+            Project referenced = solution.GetProject(reference.ProjectId);
+            if (referenced is not null)
+            {
+                queue.Enqueue(referenced);
+            }
+        }
+
+        while (queue.Count > 0)
+        {
+            Project current = queue.Dequeue();
+            if (!seen.Add(current.Id))
+            {
+                continue;
+            }
+
+            if (string.Equals(current.Language, LanguageNames.CSharp, StringComparison.Ordinal))
+            {
+                yield return current;
+            }
+
+            foreach (ProjectReference reference in current.ProjectReferences)
+            {
+                Project referenced = solution.GetProject(reference.ProjectId);
+                if (referenced is not null && !seen.Contains(referenced.Id))
+                {
+                    queue.Enqueue(referenced);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds a <see cref="LoadedCSharpProject"/> from a bound Roslyn
+    /// <see cref="Project"/>, seeding its diagnostics with the supplied list
+    /// (e.g. workspace load failures for the primary project).
+    /// </summary>
+    private static async Task<LoadedCSharpProject> BuildLoadedProjectAsync(
+        Project project,
+        List<Diagnostic> seedDiagnostics,
+        CancellationToken cancellationToken)
+    {
+        Compilation compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+        if (compilation is not CSharpCompilation csharpCompilation)
+        {
+            throw new InvalidOperationException(
+                $"Project '{project.FilePath}' did not produce a C# compilation (language: {project.Language}).");
+        }
+
+        string projectDirectory = Path.GetDirectoryName(project.FilePath);
+        IReadOnlyList<LoadedDocument> documents = BuildDocuments(csharpCompilation, projectDirectory, seedDiagnostics);
+        seedDiagnostics.AddRange(SignificantDiagnostics(csharpCompilation));
+
+        return new LoadedCSharpProject(csharpCompilation, documents, seedDiagnostics);
     }
 
     private static IReadOnlyList<LoadedDocument> BuildDocuments(


### PR DESCRIPTION
## Summary

The `cs2gs migrate` pipeline compiled each app against the shared framework assemblies plus the app's own emitted G# only. Two classes of Oahu projects therefore failed the compile stage with errors that were **not** cs2gs translator or gsc defects:

1. **NuGet-package projects** (e.g. `System.Management`, EF Core, Spectre.Console): the C# translate stage resolved the package types (full restore), but the gsc compile stage never referenced the package DLLs, so package types reported `GS0113 Type doesn't exist` / `GS0130 Function doesn't exist`.
2. **Multi-project apps** (`ProjectReference` to a sibling): the app's uses of sibling types (e.g. `Oahu.SystemManagement` → `Oahu.Foundation.IHardwareIdProvider`) failed because the sibling's G# was never emitted into the compile set.

## Changes

- **Translate** captures each project's resolved `PortableExecutableReference` paths (on-disk, file-backed) into a new `StageExecutionContext.ExternalReferencePaths`.
- **Compile / IlVerify** add those to gsc's `/reference:` set, skipping any whose file name collides with a framework assembly (avoids ref-pack / runtime double-identity).
- **Translate** now loads the transitive closure of same-solution `ProjectReference` projects (`CSharpProjectLoader.LoadProjectWithReferencesAsync`) and emits their G# as compile inputs.
- Sibling files are flagged `EmittedGsFile.IsFromReferencedProject`; the Compile stage attributes errors only to the app's own files, so a sibling's own gaps are measured in its own run rather than charged against every dependent.

## Validation

- Full `Cs2Gs.Tests` suite green (1015 + 1 new test; the pre-existing report-generation host-crash integration test excluded).
- New `LoadProjectWithReferencesAsync_IncludesReferencedSiblingProject` test asserts the app + referenced sibling are both loaded.
- End-to-end on Oahu: `Oahu.SystemManagement` compile errors dropped from 10 → 4 (the WMI `System.Management` types and the `IHardwareIdProvider` sibling interface now resolve; the residual 4 are all the known nullable-oblivious `#2113` design bucket).

Refs #914
