### PR TITLE
cs2gs: lower discarded switch expression to a switch statement

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914DiscardedSwitchExpressionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914DiscardedSwitchExpressionTranslationTests.cs
@@ -1,0 +1,119 @@
+// <copyright file="Issue914DiscardedSwitchExpressionTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #914: a C# switch EXPRESSION used in statement position (a discard
+/// <c>_ = x switch { ... };</c>, or any other expression-statement) was
+/// translated as a G# switch-EXPRESSION with <c>case P: expr</c> arms emitted
+/// at statement position. That arm form is only valid in value position; at
+/// statement position G# parses a switch STATEMENT, whose arms require a
+/// <c>case P { block }</c> body, so the emitted G# failed to round-trip
+/// (GS0005 "Unexpected token ColonToken, expected OpenBraceToken").
+///
+/// The fix lowers such a discarded switch expression into a genuine G# switch
+/// STATEMENT, running each arm's expression for its side effect.
+/// </summary>
+public class Issue914DiscardedSwitchExpressionTranslationTests
+{
+    private const string Prelude = @"
+namespace Demo
+{
+    public enum EState { LocalLocked, LocalUnlocked, Exported, Converted }
+";
+
+    /// <summary>
+    /// The dominant Oahu shape: a discarded switch expression whose arms are
+    /// side-effecting method calls, with a value-only <c>_ =&gt; false</c>
+    /// default. It must round-trip (the helper asserts that) as a switch
+    /// STATEMENT, not a bare colon-arm expression at statement position.
+    /// </summary>
+    [Fact]
+    public void DiscardedSwitchExpression_WithSideEffectingArms_LowersToSwitchStatement()
+    {
+        string printed = TranslateUnit(Prelude + @"
+    public static class Ops
+    {
+        private static bool Check(EState s) => true;
+
+        public static void Run(EState state)
+        {
+            _ = state switch
+            {
+                EState.LocalLocked => Check(state),
+                EState.LocalUnlocked => Check(state),
+                EState.Exported => Check(state),
+                EState.Converted => Check(state),
+                _ => false
+            };
+        }
+    }
+}");
+
+        // Lowered to a switch STATEMENT: arms carry brace bodies, never a bare
+        // `case ...:` colon arm at statement position.
+        Assert.Contains("switch state", printed);
+        Assert.Contains("Check(state)", printed);
+        Assert.DoesNotContain("_ =", printed);
+    }
+
+    /// <summary>
+    /// A discarded switch expression with no total (<c>_</c>/<c>var</c>/default)
+    /// arm is exhaustive in C# by its type arms; the lowering must still
+    /// round-trip by synthesizing a throwing default (mirroring C#'s runtime
+    /// <c>SwitchExpressionException</c>), so gsc's total-arm rule is satisfied.
+    /// </summary>
+    [Fact]
+    public void DiscardedSwitchExpression_NonTotalArms_SynthesizesThrowingDefault()
+    {
+        string printed = TranslateUnit(Prelude + @"
+    public static class Ops
+    {
+        private static bool Check(EState s) => true;
+
+        public static void Run(bool flag)
+        {
+            _ = flag switch
+            {
+                true => Check(EState.Exported),
+                false => Check(EState.Converted)
+            };
+        }
+    }
+}");
+
+        Assert.Contains("switch flag", printed);
+        Assert.Contains("default", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -6739,6 +6739,21 @@ public sealed class CSharpToGSharpTranslator
                         this.TranslateExpression(prefix.Operand),
                         prefix.OperatorToken.Text);
 
+                case SwitchExpressionSyntax switchExpression:
+                    // A C# switch EXPRESSION used in statement position — reached
+                    // via a discard (`_ = x switch { ... };`, lowered by
+                    // TranslateExpressionStatements) or any other expression-
+                    // statement context. G#'s switch-EXPRESSION arm form uses
+                    // `case P: expr` (an expression per arm) and is only valid in
+                    // value position; a bare switch expression at statement
+                    // position is parsed as a switch STATEMENT, whose arms require
+                    // a `case P { block }` body — so emitting the expression form
+                    // here produces invalid G# (GS0005 "expected OpenBraceToken").
+                    // Lower to a genuine switch STATEMENT instead, running each
+                    // arm's expression for its side effect (the value is discarded,
+                    // exactly as in C#'s `_ = <switch expr>`); issue #914.
+                    return this.TranslateSwitchExpressionAsStatement(switchExpression);
+
                 default:
                     return new ExpressionStatement(this.TranslateExpression(expression));
             }
@@ -14610,6 +14625,90 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return new SwitchExpression(subject, arms);
+        }
+
+        // Lowers a C# switch EXPRESSION that appears in statement position
+        // (a discard `_ = x switch { ... };` or any other expression-statement)
+        // into a G# switch STATEMENT. Each arm's expression is run for its side
+        // effect only — the switch value is discarded, exactly as in C# — so the
+        // arm body becomes a single-statement block wrapping the arm expression.
+        // Mirrors TranslateSwitchExpression's pattern/guard/binding handling and
+        // its exhaustiveness rule (issue #914).
+        private GStatement TranslateSwitchExpressionAsStatement(SwitchExpressionSyntax node)
+        {
+            GExpression subject = this.TranslateExpression(node.GoverningExpression);
+            var cases = new List<SwitchStatementCase>();
+            bool hasTotalArm = false;
+
+            foreach (SwitchExpressionArmSyntax arm in node.Arms)
+            {
+                var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
+                var usedDesignators = new HashSet<string>(StringComparer.Ordinal);
+                var guards = new List<GExpression>();
+
+                this.ReportIndexOrRangeDesignationsInPattern(arm.Pattern);
+                GPattern pattern = this.TranslatePattern(arm.Pattern, subject, bindings, usedDesignators, guards);
+
+                foreach ((ISymbol symbol, GExpression replacement) in bindings)
+                {
+                    this.patternBindings[symbol] = replacement;
+                }
+
+                GExpression guard;
+                GStatement body;
+                try
+                {
+                    guard = arm.WhenClause != null
+                        ? this.TranslateExpression(arm.WhenClause.Condition)
+                        : null;
+                    guard = CombinePatternGuards(guards, guard);
+                    body = this.TranslateSwitchArmExpressionAsStatement(arm.Expression);
+                }
+                finally
+                {
+                    foreach ((ISymbol symbol, _) in bindings)
+                    {
+                        this.patternBindings.Remove(symbol);
+                    }
+                }
+
+                cases.Add(new SwitchStatementCase(pattern, new BlockStatement(new[] { body }), guard));
+
+                hasTotalArm |= guard == null && (pattern == null || pattern is DiscardPattern);
+            }
+
+            // As in TranslateSwitchExpression: a C# switch expression is
+            // exhaustive by construction, but gsc's switch only treats a literal
+            // unguarded discard/`default` as total (GS0176). When none is present,
+            // synthesize a trailing default that throws — mirroring C#'s own
+            // runtime SwitchExpressionException for an unmatched value.
+            if (!hasTotalArm)
+            {
+                GExpression unmatchedThrow = new ThrowExpression(
+                    BuildConstruction(
+                        new NamedTypeReference("InvalidOperationException"),
+                        new List<GExpression> { LiteralExpression.String("Unmatched switch expression value.") }),
+                    null);
+                cases.Add(new SwitchStatementCase(
+                    null,
+                    new BlockStatement(new[] { (GStatement)new ExpressionStatement(unmatchedThrow) })));
+            }
+
+            return new SwitchStatement(subject, cases);
+        }
+
+        // Renders a switch-expression arm's value expression as a single G#
+        // statement for the discarded switch-statement lowering above. A `throw`
+        // arm becomes a throw statement; every other expression is emitted as an
+        // expression statement (its value is discarded).
+        private GStatement TranslateSwitchArmExpressionAsStatement(ExpressionSyntax expression)
+        {
+            if (expression is ThrowExpressionSyntax throwExpression)
+            {
+                return new ThrowStatement(this.TranslateExpression(throwExpression.Expression));
+            }
+
+            return new ExpressionStatement(this.TranslateExpression(expression));
         }
 
         private GStatement TranslateSwitchStatement(SwitchStatementSyntax node)


### PR DESCRIPTION
## Summary

A C# switch **expression** used in statement position — a discard `_ = x switch { ... };`, or any other expression-statement — was translated with G# switch-**expression** `case P: expr` arms emitted at statement position. That arm form is valid only in value position; at statement position G# parses a switch **statement**, whose arms require a `case P { block }` body. The result failed to round-trip:

```
error GS0005: Unexpected token <ColonToken>, expected <OpenBraceToken>
```

Found in `Oahu.Core` (`BookLibrary.cs`: `_ = conv.State switch { ... };`).

## Fix

Lower a discarded/statement-position switch expression to a genuine G# switch **statement**, running each arm's expression for its side effect (the value is discarded, exactly as in C#). A `throw` arm becomes a throw statement; other arms become expression statements. When no total (`_`/`var`/default) arm is present, a throwing default is synthesized — mirroring both the existing switch-expression lowering and C#'s runtime `SwitchExpressionException` — so gsc's total-arm rule (GS0176) is satisfied.

Handled centrally in `TranslateExpressionStatement`, so it covers the discard path (`TranslateExpressionStatements`) and any other expression-statement context.

## Tests

- New `Issue914DiscardedSwitchExpressionTranslationTests` (2 cases): side-effecting-arm discard lowers + round-trips as a switch statement; non-total-arm discard synthesizes a throwing default and round-trips.
- Full cs2gs suite green: 1018 passed.

Refs #914
