### PR TITLE
gsc: erase inline out-var resolution sentinel before reference-set projection (GS9998)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -231,6 +231,24 @@ internal static class OverloadResolution
     public static readonly Type DefaultLiteralArgumentType = typeof(DefaultLiteralArgumentMarker);
 #pragma warning restore SA1201
 
+    /// <summary>
+    /// Issue #2126: reports whether <paramref name="argType"/> is a resolution
+    /// sentinel — the inline <c>out var</c> placeholder
+    /// (<see cref="InlineOutVarArgumentType"/>) or the untyped <c>default</c>
+    /// literal (<see cref="DefaultLiteralArgumentType"/>). These are synthetic
+    /// marker types defined in <c>GSharp.Core</c> that stand in for an argument
+    /// whose real type is not yet known (an inline <c>out var</c>) or is supplied
+    /// by the chosen parameter (a bare <c>default</c>). A sentinel must never be
+    /// projected into a reference set's <see cref="MetadataLoadContext"/> — it has
+    /// no name there — and must never leak into emitted IL; it is normalised to
+    /// its erased <see cref="object"/> form before a generic candidate is closed
+    /// (see the projection loop in <c>EvaluateCandidate</c>).
+    /// </summary>
+    /// <param name="argType">The candidate argument/type-argument CLR type.</param>
+    /// <returns><see langword="true"/> when the type is a resolution sentinel.</returns>
+    public static bool IsResolutionSentinel(Type argType) =>
+        ReferenceEquals(argType, InlineOutVarArgumentType) || ReferenceEquals(argType, DefaultLiteralArgumentType);
+
     // Issue #658 / #1311 / #1634: the supplementary-interface and constant-
     // narrowing checks used to live here as mutable (later [ThreadStatic])
     // fields, set immediately before and nulled immediately after each
@@ -1906,7 +1924,22 @@ internal static class OverloadResolution
                 {
                     for (var t = 0; t < typeArgs.Length; t++)
                     {
-                        typeArgs[t] = projectTypeArgument(typeArgs[t]) ?? typeArgs[t];
+                        // Issue #2126: a resolution sentinel (the inline `out var`
+                        // placeholder — issue #977/#1599/#1601 — or the untyped
+                        // `default` literal — issue #1391) was bound to this type
+                        // parameter because the corresponding argument's real type
+                        // is a same-compilation value type with no reference-context
+                        // CLR type (so it is erased to `object` everywhere else).
+                        // The sentinel is a GSharp.Core marker with no name in the
+                        // reference set: projecting it threw and surfaced as a fatal
+                        // GS9998 ICE during emit. Normalise it to its erased `object`
+                        // form (projected into the candidate's context) — the same
+                        // erasure the argument types already carry — so the generic
+                        // candidate closes via the issue #1325 value-type-placeholder
+                        // path and emit uses the recovered symbolic type argument.
+                        typeArgs[t] = IsResolutionSentinel(typeArgs[t])
+                            ? (projectTypeArgument(typeof(object)) ?? typeof(object))
+                            : (projectTypeArgument(typeArgs[t]) ?? typeArgs[t]);
                     }
                 }
 
@@ -2088,7 +2121,13 @@ internal static class OverloadResolution
             {
                 for (var t = 0; t < typeArgs.Length; t++)
                 {
-                    typeArgs[t] = projectTypeArgument(typeArgs[t]) ?? typeArgs[t];
+                    // Issue #2126: see the primary projection loop above — a
+                    // resolution sentinel must be normalised to its erased
+                    // `object` form rather than projected, or it throws a fatal
+                    // GS9998 ICE when projected into a MetadataLoadContext.
+                    typeArgs[t] = IsResolutionSentinel(typeArgs[t])
+                        ? (projectTypeArgument(typeof(object)) ?? typeof(object))
+                        : (projectTypeArgument(typeArgs[t]) ?? typeArgs[t]);
                 }
             }
 

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -615,6 +615,25 @@ public sealed class ReferenceResolver : IDisposable
             return null;
         }
 
+        // Issue #2126: the overload-resolution sentinels (the inline `out var`
+        // placeholder and the untyped `default` literal) are synthetic marker
+        // types defined in GSharp.Core purely for betterness ranking. They must
+        // be rebound to the resolved parameter's real type before binding
+        // completes and must NEVER be projected — a sentinel reaching here means
+        // an inline `out var`/`default` argument leaked out of a binder exit path
+        // without being rebound. Fail with an actionable internal-compiler-error
+        // that names the bug instead of the opaque MetadataLoadContext projection
+        // failure it would otherwise cause.
+        if (ReferenceEquals(hostType, GSharp.Core.CodeAnalysis.Binding.OverloadResolution.InlineOutVarArgumentType)
+            || ReferenceEquals(hostType, GSharp.Core.CodeAnalysis.Binding.OverloadResolution.DefaultLiteralArgumentType))
+        {
+            throw new InvalidOperationException(
+                $"Internal compiler error: the overload-resolution sentinel '{hostType.FullName}' escaped the " +
+                "binder and reached type projection. An inline `out var`/`out let`/`out _` or `default` argument " +
+                "was not rebound to its resolved parameter type on some binder exit path (issue #2126). This is a " +
+                "compiler bug; the sentinel must never participate in generic inference, projection, or emit.");
+        }
+
         // The Default resolver searches host-runtime assemblies, so host types
         // already share identity with anything TryResolveType returns. No
         // projection is needed (and attempting one would be wasted work).

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2126InlineOutVarMarkerLeakTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2126InlineOutVarMarkerLeakTests.cs
@@ -1,0 +1,172 @@
+// <copyright file="Issue2126InlineOutVarMarkerLeakTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #2126: the overload-resolution sentinel type
+/// <c>OverloadResolution+InlineOutVarArgumentMarker</c> must never escape the
+/// binder into type projection or emit.
+/// <para>
+/// When an inline <c>out var</c> (or a pre-declared <c>out</c> whose pointee is a
+/// same-compilation value type with no reference-context CLR type) is passed to a
+/// generic method whose type parameter is inferable only from that <c>out</c>
+/// slot — e.g. <c>Enum.TryParse&lt;TEnum&gt;(string, bool, out TEnum)</c> — the
+/// sentinel marker was bound to <c>TEnum</c> during type inference and then
+/// projected into the reference set's
+/// <see cref="System.Reflection.MetadataLoadContext"/>. Projecting the
+/// GSharp.Core-defined marker (which has no name in the reference set) threw
+/// <c>InvalidOperationException</c>, surfaced as a fatal <c>GS9998</c> ICE.
+/// </para>
+/// <para>
+/// The crash only reproduces on the <c>/reference:</c> resolver path (MLC), which
+/// is why <c>Issue1601GenericEnumTryParseForwardTests</c> — running on the
+/// host-runtime resolver — never caught it. The fix normalises the sentinel to
+/// its erased <see cref="object"/> form before a generic candidate is closed.
+/// </para>
+/// </summary>
+public class Issue2126InlineOutVarMarkerLeakTests
+{
+    /// <summary>
+    /// Build a <see cref="ReferenceResolver"/> rooted at the full shared-
+    /// framework assembly set, forcing gsc into the
+    /// <see cref="System.Reflection.MetadataLoadContext"/> resolution path —
+    /// the same path the cs2gs migration pipeline and the MSBuild task drive
+    /// gsc through via <c>/reference:</c>. The full closure is required to
+    /// reproduce issue #2126: with only a handful of assemblies the leaking
+    /// <c>Enum.TryParse</c> candidate is not projected through the load context.
+    /// </summary>
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        var paths = Directory.GetFiles(runtimeDir, "*.dll");
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    private static ImmutableArray<Diagnostic> EmitWithMlc(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(MetadataLoadContextResolver(), tree);
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        return result.Diagnostics;
+    }
+
+    /// <summary>
+    /// The minimal reproduction: a generic <c>Enum.TryParse&lt;TEnum&gt;</c> whose
+    /// only type-parameter binding site is a pre-declared <c>out</c> argument of a
+    /// same-compilation enum. Pre-fix this threw the <c>GS9998</c> marker-projection
+    /// ICE under the MLC resolver.
+    /// </summary>
+    [Fact]
+    public void GenericEnumTryParse_PredeclaredUserEnumOut_UnderMlc_DoesNotLeakMarker()
+    {
+        var source = """
+            package Repro
+            import System
+
+            enum ECodec { A, B }
+
+            class ExCodec {
+                shared {
+                    func TryParseCodec(format string?, out codec ECodec) bool {
+                        if format == nil {
+                            codec = default(ECodec)
+                            return false
+                        }
+                        return Enum.TryParse(format, true, &codec)
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = EmitWithMlc(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9998");
+        Assert.DoesNotContain(
+            diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// The inline <c>out var</c> variant: the type parameter is inferable only
+    /// from the inline <c>out var</c> slot, whose element type is a
+    /// same-compilation enum. Must bind without leaking the marker.
+    /// </summary>
+    [Fact]
+    public void GenericEnumTryParse_InlineOutVarUserEnum_UnderMlc_DoesNotLeakMarker()
+    {
+        var source = """
+            package Repro
+            import System
+
+            enum EStatus { Off, On }
+
+            class Reader {
+                shared {
+                    func Read(text string) string {
+                        if Enum.TryParse[EStatus](text, out var status) {
+                            return status.ToString()
+                        }
+                        return ""
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = EmitWithMlc(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9998");
+        Assert.DoesNotContain(
+            diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// The originally-reported shape: an inline <c>out var</c> passed to
+    /// <c>Dictionary&lt;TKey, TValue&gt;.TryGetValue</c> where the receiver is a
+    /// qualified static field and the value type is a same-compilation enum. Must
+    /// bind cleanly under the MLC resolver with no marker leak.
+    /// </summary>
+    [Fact]
+    public void DictionaryTryGetValue_QualifiedStaticFieldReceiver_UserEnumValue_UnderMlc_DoesNotLeakMarker()
+    {
+        var source = """
+            package Repro
+            import System
+            import System.Collections.Generic
+
+            enum EPseudoAsinId { None, First }
+
+            class BookDbContext {
+                shared {
+                    let PseudoAsinsValue Dictionary[Type, EPseudoAsinId] = Dictionary[Type, EPseudoAsinId]()
+
+                    func Lookup(t Type) string {
+                        let succ = BookDbContext.PseudoAsinsValue.TryGetValue(t, out var pseudoAsinId)
+                        if succ {
+                            return pseudoAsinId.ToString()
+                        }
+                        return ""
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = EmitWithMlc(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9998");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a fatal `GS9998` InternalCompilerError during **emit** when compiling `Oahu.Data` (and any code that infers a generic type parameter solely from an inline `out var`).

## Root cause

An inline `out var` (and a pre-declared `out` whose pointee is a same-compilation value type) is fed the synthetic sentinel `OverloadResolution+InlineOutVarArgumentMarker` while probing overload candidates, before the out-parameter type is known. When that argument is the **only** binding site for a generic method's type parameter — canonically `Enum.TryParse<TEnum>(string, bool, out TEnum)` — type inference bound the marker to `TEnum`. `EvaluateCandidate` then projected the inferred type arguments onto the candidate's reference set. Under a `MetadataLoadContext` (the `/reference:` path used by cs2gs/MSBuild), projecting the `GSharp.Core`-defined marker (which has no name in the reference set) threw `InvalidOperationException` → fatal `GS9998`. Under host-runtime refs projection is identity, so the marker slipped through and existing tests missed it. The actual corpus trigger was `AudioQuality`'s `Enum.TryParse`, not `Dictionary.TryGetValue`.

## Fix

- `src/Core/CodeAnalysis/Binding/OverloadResolution.cs` — added `IsResolutionSentinel` helper; in both `EvaluateCandidate` projection loops, normalise a sentinel to its erased `object` form instead of projecting the marker. Generalised for any inline `out var`/`default` sentinel bound to any generic type parameter.
- `src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs` — safety guard in `MapClrTypeToReferences` throwing an actionable ICE if a sentinel ever reaches projection again.
- `test/Core.Tests/CodeAnalysis/Binding/Issue2126InlineOutVarMarkerLeakTests.cs` — new (3 tests, `Compilation.Emit` over the full shared-framework MetadataLoadContext reference set). Tests fail pre-fix, pass post-fix.

## Validation

Full corpus `.rsp` reproduced `GS9998` pre-fix; 0 `GS9998` post-fix, clean compile. Regression subsets: Binding 3486 passed, Emit 663 passed, targeted overload/out-var/inference/MLC subsets passed. Compiler + Core build StyleCop-clean.

Fixes #2126
Refs #914
