### PR TITLE
Fix #2129: allow attributes on interface members (parse + bind + emit)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -5303,6 +5303,19 @@ internal sealed class DeclarationBinder
 
             Binder.AttachDocumentation(methodSymbol, methodSyntax);
 
+            // Issue #2129: bind @annotations on an interface method signature
+            // so they emit as CustomAttribute rows on the interface MethodDef,
+            // mirroring the class-method path.
+            if (!methodSyntax.Annotations.IsDefaultOrEmpty)
+            {
+                methodSymbol.SetAttributes(BindAttributes(
+                    methodSyntax.Annotations,
+                    AttributeTargetKind.Method,
+                    Binder.FunctionDeclarationAllowedTargets,
+                    "a method declaration",
+                    System.AttributeTargets.Method));
+            }
+
             // ADR-0085: reject `open` / `override` modifiers on interface
             // members — these are tracked as deferred follow-ups (GS0321).
             // The parser does not currently accept them on interface method
@@ -5525,6 +5538,20 @@ internal sealed class DeclarationBinder
                 }
 
                 Binder.AttachDocumentation(propSymbol, propSyntax);
+
+                // Issue #2129: bind @annotations on an interface property so
+                // they emit as real CustomAttribute rows on the interface
+                // PropertyDef, mirroring the class-property path.
+                if (!propSyntax.Annotations.IsDefaultOrEmpty)
+                {
+                    propSymbol.SetAttributes(BindAttributes(
+                        propSyntax.Annotations,
+                        AttributeTargetKind.Property,
+                        Binder.PropertyDeclarationAllowedTargets,
+                        "a property declaration",
+                        System.AttributeTargets.Property));
+                }
+
                 propertiesBuilder.Add(propSymbol);
             }
 
@@ -5560,6 +5587,20 @@ internal sealed class DeclarationBinder
                     declaration: eventSyntax);
 
                 Binder.AttachDocumentation(eventSymbol, eventSyntax);
+
+                // Issue #2129: bind @annotations on an interface event so they
+                // emit as CustomAttribute rows on the interface EventDef,
+                // mirroring the class-event path.
+                if (!eventSyntax.Annotations.IsDefaultOrEmpty)
+                {
+                    eventSymbol.SetAttributes(BindAttributes(
+                        eventSyntax.Annotations,
+                        AttributeTargetKind.Event,
+                        Binder.EventDeclarationAllowedTargets,
+                        "an event declaration",
+                        System.AttributeTargets.Event));
+                }
+
                 eventsBuilder.Add(eventSymbol);
             }
 

--- a/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
@@ -78,6 +78,7 @@ internal sealed class MemberDefEmitter
     private readonly Func<Type, EntityHandle> getTypeHandleForMember;
     private readonly Func<StructSymbol, FieldSymbol, EntityHandle> resolveFieldToken;
     private readonly Action<PropertyDefinitionHandle, TypeSymbol> emitNullableAttributeOnProperty;
+    private readonly Action<EntityHandle, Symbol, AttributeTargetKind> emitUserAttributes;
 
     public MemberDefEmitter(
         EmitContext emitCtx,
@@ -89,7 +90,8 @@ internal sealed class MemberDefEmitter
         Func<Type, TypeReferenceHandle> getTypeReference,
         Func<Type, EntityHandle> getTypeHandleForMember,
         Func<StructSymbol, FieldSymbol, EntityHandle> resolveFieldToken,
-        Action<PropertyDefinitionHandle, TypeSymbol> emitNullableAttributeOnProperty)
+        Action<PropertyDefinitionHandle, TypeSymbol> emitNullableAttributeOnProperty,
+        Action<EntityHandle, Symbol, AttributeTargetKind> emitUserAttributes)
     {
         this.emitCtx = emitCtx ?? throw new ArgumentNullException(nameof(emitCtx));
         this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
@@ -101,6 +103,7 @@ internal sealed class MemberDefEmitter
         this.getTypeHandleForMember = getTypeHandleForMember ?? throw new ArgumentNullException(nameof(getTypeHandleForMember));
         this.resolveFieldToken = resolveFieldToken ?? throw new ArgumentNullException(nameof(resolveFieldToken));
         this.emitNullableAttributeOnProperty = emitNullableAttributeOnProperty ?? throw new ArgumentNullException(nameof(emitNullableAttributeOnProperty));
+        this.emitUserAttributes = emitUserAttributes ?? throw new ArgumentNullException(nameof(emitUserAttributes));
     }
 
     public void EmitPropertyAccessors(StructSymbol structSym)
@@ -186,6 +189,10 @@ internal sealed class MemberDefEmitter
             }
 
             this.emitNullableAttributeOnProperty(propDef, prop.Type);
+
+            // Issue #2129: emit user @annotations as CustomAttribute rows on
+            // the PropertyDef (parity with the class/interface member path).
+            this.emitUserAttributes(propDef, prop, AttributeTargetKind.Property);
         }
 
         // PropertyMap row: links the TypeDef to its first PropertyDef.
@@ -449,6 +456,10 @@ internal sealed class MemberDefEmitter
             }
 
             this.emitNullableAttributeOnProperty(propDef, prop.Type);
+
+            // Issue #2129: emit user @annotations as CustomAttribute rows on
+            // the PropertyDef (parity with the class/interface member path).
+            this.emitUserAttributes(propDef, prop, AttributeTargetKind.Property);
         }
 
         // PropertyMap row: links the TypeDef to its first PropertyDef.
@@ -569,6 +580,10 @@ internal sealed class MemberDefEmitter
                 attributes: EventAttributes.None,
                 name: this.emitCtx.Metadata.GetOrAddString(ev.Name),
                 type: eventTypeHandle);
+
+            // Issue #2129: emit user @annotations as CustomAttribute rows on
+            // the EventDef (parity with the class/interface member path).
+            this.emitUserAttributes(eventDef, ev, AttributeTargetKind.Event);
 
             if (firstEventDef.IsNil)
             {
@@ -820,6 +835,10 @@ internal sealed class MemberDefEmitter
                 attributes: EventAttributes.None,
                 name: this.emitCtx.Metadata.GetOrAddString(ev.Name),
                 type: eventTypeHandle);
+
+            // Issue #2129: emit user @annotations as CustomAttribute rows on
+            // the EventDef (parity with the class/interface member path).
+            this.emitUserAttributes(eventDef, ev, AttributeTargetKind.Event);
 
             if (firstEventDef.IsNil)
             {
@@ -1349,6 +1368,10 @@ internal sealed class MemberDefEmitter
             }
 
             this.emitNullableAttributeOnProperty(propDef, prop.Type);
+
+            // Issue #2129: emit user @annotations as CustomAttribute rows on
+            // the PropertyDef (parity with the class/interface member path).
+            this.emitUserAttributes(propDef, prop, AttributeTargetKind.Property);
         }
 
         // PropertyMap row: links the TypeDef to its first PropertyDef.
@@ -1423,6 +1446,10 @@ internal sealed class MemberDefEmitter
                 attributes: EventAttributes.None,
                 name: this.emitCtx.Metadata.GetOrAddString(ev.Name),
                 type: eventTypeHandle);
+
+            // Issue #2129: emit user @annotations as CustomAttribute rows on
+            // the EventDef (parity with the class/interface member path).
+            this.emitUserAttributes(eventDef, ev, AttributeTargetKind.Event);
 
             if (firstEventDef.IsNil)
             {

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -938,7 +938,8 @@ internal sealed class ReflectionMetadataEmitter
             this.GetTypeReference,
             this.GetTypeHandleForMember,
             this.ResolveFieldToken,
-            this.customAttrEncoder.EmitNullableAttributeOnProperty);
+            this.customAttrEncoder.EmitNullableAttributeOnProperty,
+            this.customAttrEncoder.EmitUserAttributes);
 
         // PR-E-8: TypeDefEmitter wires up after MemberDefEmitter. It depends
         // on the same EmitContext/MetadataTokenCache/WellKnownReferences

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -1075,6 +1075,11 @@ internal sealed class TypeDefEmitter
         // user annotations same as the class-method path, or @Note-style
         // attributes silently vanish for interface members.
         this.EmitUserAttributesOnParameters(paramHandles, method.Parameters);
+
+        // Issue #2129: method-level @annotations on an abstract interface
+        // method signature emit as CustomAttribute rows on the MethodDef,
+        // mirroring the bodied (EmitFunction) path.
+        this.emitUserAttributes(handle, method, AttributeTargetKind.Method);
     }
 
     /// <summary>
@@ -1119,7 +1124,7 @@ internal sealed class TypeDefEmitter
             attrs |= MethodAttributes.Abstract;
         }
 
-        this.emitCtx.Metadata.AddMethodDefinition(
+        var handle = this.emitCtx.Metadata.AddMethodDefinition(
             attributes: attrs,
             implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
             name: this.emitCtx.Metadata.GetOrAddString(method.Name),
@@ -1130,6 +1135,10 @@ internal sealed class TypeDefEmitter
         // Issue #1913: same as EmitAbstractMethod — static-virtual interface
         // slots must keep their parameter annotations.
         this.EmitUserAttributesOnParameters(paramHandles, method.Parameters);
+
+        // Issue #2129: method-level @annotations on a static-virtual interface
+        // method emit as CustomAttribute rows on the MethodDef.
+        this.emitUserAttributes(handle, method, AttributeTargetKind.Method);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -1176,6 +1176,13 @@ public class Parser
         {
             var startToken = Current;
 
+            // Issue #2129: interface members accept Kotlin-style @annotations
+            // (ADR-0047) exactly like class/struct members. Parse the leading
+            // annotation list once and attach it to whichever member follows —
+            // property, event, or method signature — mirroring how ParseMember
+            // threads annotations onto class members.
+            var annotations = ParseAnnotations();
+
             if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "shared" && Peek(1).Kind == SyntaxKind.OpenBraceToken)
             {
                 // Issue #865 revision: static-virtual members live in a
@@ -1184,15 +1191,15 @@ public class Parser
             }
             else if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "prop")
             {
-                properties.Add(ParsePropertyDeclaration(accessibilityModifier: null, openModifier: null, overrideModifier: null));
+                properties.Add(ParsePropertyDeclaration(accessibilityModifier: null, openModifier: null, overrideModifier: null).WithAnnotations(annotations));
             }
             else if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "event")
             {
-                events.Add(ParseEventDeclaration(accessibilityModifier: null, openModifier: null, overrideModifier: null));
+                events.Add(ParseEventDeclaration(accessibilityModifier: null, openModifier: null, overrideModifier: null).WithAnnotations(annotations));
             }
             else if (IsInterfaceMethodSignatureStart())
             {
-                methods.Add(ParseInterfaceMethodSignature());
+                methods.Add((FunctionDeclarationSyntax)ParseInterfaceMethodSignature().WithAnnotations(annotations));
             }
             else
             {
@@ -2468,21 +2475,26 @@ public class Parser
             // Issue #865 revision: static-virtual members (ADR-0089) live in a
             // `shared { … }` block. No accessibility / open / override
             // modifiers are accepted on plain method signatures.
+            // Issue #2129: interface members accept Kotlin-style @annotations
+            // (ADR-0047) like class members — parse them here and attach to the
+            // property / event / method signature that follows.
+            var annotations = ParseAnnotations();
+
             if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "shared" && Peek(1).Kind == SyntaxKind.OpenBraceToken)
             {
                 ParseInterfaceSharedBlock(methods, properties, staticFields, ref seenSharedBlock, identifier.Text);
             }
             else if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "prop")
             {
-                properties.Add(ParsePropertyDeclaration(accessibilityModifier: null, openModifier: null, overrideModifier: null));
+                properties.Add(ParsePropertyDeclaration(accessibilityModifier: null, openModifier: null, overrideModifier: null).WithAnnotations(annotations));
             }
             else if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "event")
             {
-                events.Add(ParseEventDeclaration(accessibilityModifier: null, openModifier: null, overrideModifier: null));
+                events.Add(ParseEventDeclaration(accessibilityModifier: null, openModifier: null, overrideModifier: null).WithAnnotations(annotations));
             }
             else if (IsInterfaceMethodSignatureStart())
             {
-                methods.Add(ParseInterfaceMethodSignature());
+                methods.Add((FunctionDeclarationSyntax)ParseInterfaceMethodSignature().WithAnnotations(annotations));
             }
             else
             {

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2129InterfaceMemberAnnotationEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2129InterfaceMemberAnnotationEmitTests.cs
@@ -1,0 +1,118 @@
+// <copyright file="Issue2129InterfaceMemberAnnotationEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #2129: an attribute on an interface property (or event / method
+/// signature) previously failed to parse (GS0005). Once parsing is fixed the
+/// attribute must also be bound and emitted as a real CLR
+/// <c>CustomAttribute</c> row on the generated interface member so that,
+/// e.g., <c>[JsonPropertyName]</c> on an interface property survives to
+/// metadata. These tests compile a self-contained interface carrying a
+/// user-defined attribute on each member kind and read the emitted assembly's
+/// real metadata via reflection — the same empirical technique used by the
+/// param-attribute emit tests (issue #1913 / #2006).
+/// </summary>
+public class Issue2129InterfaceMemberAnnotationEmitTests
+{
+    private const string NoteAttributeDecl = @"
+class NoteAttribute(Text string) : Attribute {
+}
+";
+
+    [Fact]
+    public void InterfaceProperty_UserAttribute_RoundTripsThroughReflection()
+    {
+        const string Source = @"package Issue2129Prop
+import System
+" + NoteAttributeDecl + @"
+
+interface IPerson {
+    @Note(""asin"")
+    prop Asin string
+}
+";
+        var asm = CompileToAssembly(Source, nameof(InterfaceProperty_UserAttribute_RoundTripsThroughReflection));
+        var iface = asm.GetTypes().Single(t => t.Name == "IPerson");
+        Assert.True(iface.IsInterface);
+        var prop = iface.GetProperty("Asin", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(prop);
+
+        var attrs = prop!.GetCustomAttributesData();
+        var note = Assert.Single(attrs);
+        Assert.Equal("NoteAttribute", note.AttributeType.Name);
+        Assert.Equal("asin", note.ConstructorArguments.Single().Value);
+    }
+
+    [Fact]
+    public void InterfaceEvent_UserAttribute_RoundTripsThroughReflection()
+    {
+        const string Source = @"package Issue2129Event
+import System
+" + NoteAttributeDecl + @"
+
+interface IPerson {
+    @Note(""evt"")
+    event Changed Action
+}
+";
+        var asm = CompileToAssembly(Source, nameof(InterfaceEvent_UserAttribute_RoundTripsThroughReflection));
+        var iface = asm.GetTypes().Single(t => t.Name == "IPerson");
+        var ev = iface.GetEvent("Changed", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(ev);
+
+        var attrs = ev!.GetCustomAttributesData();
+        var note = Assert.Single(attrs);
+        Assert.Equal("NoteAttribute", note.AttributeType.Name);
+        Assert.Equal("evt", note.ConstructorArguments.Single().Value);
+    }
+
+    [Fact]
+    public void InterfaceMethodSignature_UserAttribute_RoundTripsThroughReflection()
+    {
+        const string Source = @"package Issue2129Method
+import System
+" + NoteAttributeDecl + @"
+
+interface IPerson {
+    @Note(""greet"")
+    func Greet() string;
+}
+";
+        var asm = CompileToAssembly(Source, nameof(InterfaceMethodSignature_UserAttribute_RoundTripsThroughReflection));
+        var iface = asm.GetTypes().Single(t => t.Name == "IPerson");
+        var method = iface.GetMethod("Greet", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(method);
+
+        var attrs = method!.GetCustomAttributesData();
+        var note = Assert.Single(attrs);
+        Assert.Equal("NoteAttribute", note.AttributeType.Name);
+        Assert.Equal("greet", note.ConstructorArguments.Single().Value);
+    }
+
+    private static Assembly CompileToAssembly(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        return loadContext.LoadFromStream(peStream);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue2129InterfaceMemberAnnotationParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue2129InterfaceMemberAnnotationParserTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="Issue2129InterfaceMemberAnnotationParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #2129: the interface-member parse loop had no branch for a leading
+/// <c>@</c> annotation, so an attribute applied to an interface property
+/// (or event / method signature) fell through to the recovery arm and
+/// reported GS0005 (<c>Unexpected token &lt;AtToken&gt;, expected
+/// &lt;FuncKeyword&gt;</c>) — even though the identical attribute parses on a
+/// class member. These tests verify that Kotlin-style <c>@annotations</c>
+/// (ADR-0047) now parse without diagnostics on all three interface member
+/// kinds and are attached to the produced syntax node.
+/// </summary>
+public class Issue2129InterfaceMemberAnnotationParserTests
+{
+    [Fact]
+    public void AnnotationOnInterfaceProperty_ParsesWithoutDiagnostics()
+    {
+        const string Source = "package P\ninterface IPerson {\n  @Note(\"asin\")\n  prop Asin string\n}\n";
+        var tree = SyntaxTree.Parse(Source);
+        Assert.Empty(tree.Diagnostics);
+
+        var iface = FindInterface(tree, "IPerson");
+        var prop = iface.Properties.Single();
+        Assert.Equal("Asin", prop.Identifier.Text);
+        var annotation = Assert.Single(prop.Annotations);
+        Assert.Equal("Note", annotation.NameSegments.Single().Text);
+    }
+
+    [Fact]
+    public void AnnotationOnInterfaceEvent_ParsesWithoutDiagnostics()
+    {
+        const string Source = "package P\ninterface IPerson {\n  @Note(\"evt\")\n  event Changed Action\n}\n";
+        var tree = SyntaxTree.Parse(Source);
+        Assert.Empty(tree.Diagnostics);
+
+        var iface = FindInterface(tree, "IPerson");
+        var ev = iface.Events.Single();
+        Assert.Equal("Changed", ev.Identifier.Text);
+        Assert.Single(ev.Annotations);
+    }
+
+    [Fact]
+    public void AnnotationOnInterfaceMethodSignature_ParsesWithoutDiagnostics()
+    {
+        const string Source = "package P\ninterface IPerson {\n  @Note(\"greet\")\n  func Greet() string;\n}\n";
+        var tree = SyntaxTree.Parse(Source);
+        Assert.Empty(tree.Diagnostics);
+
+        var iface = FindInterface(tree, "IPerson");
+        var method = iface.Methods.Single();
+        Assert.Equal("Greet", method.Identifier.Text);
+        Assert.Single(method.Annotations);
+    }
+
+    [Fact]
+    public void MultipleAnnotationsOnInterfaceMembers_ParseWithoutDiagnostics()
+    {
+        const string Source =
+            "package P\ninterface IPerson {\n"
+            + "  @Note(\"a\")\n  @Note(\"b\")\n  prop Asin string\n"
+            + "  @Note(\"c\")\n  func Greet() string;\n}\n";
+        var tree = SyntaxTree.Parse(Source);
+        Assert.Empty(tree.Diagnostics);
+
+        var iface = FindInterface(tree, "IPerson");
+        Assert.Equal(2, iface.Properties.Single().Annotations.Length);
+        Assert.Single(iface.Methods.Single().Annotations);
+    }
+
+    private static InterfaceDeclarationSyntax FindInterface(SyntaxTree tree, string name)
+    {
+        var root = (CompilationUnitSyntax)tree.Root;
+        foreach (var member in root.Members)
+        {
+            if (member is InterfaceDeclarationSyntax iface
+                && iface.Identifier.Text == name)
+            {
+                return iface;
+            }
+        }
+
+        throw new Xunit.Sdk.XunitException($"interface {name} not found");
+    }
+}


### PR DESCRIPTION
Fixes #2129.

`gsc` rejected `@attribute` annotations on interface members (properties, events, method signatures) with GS0005 (`Unexpected token <AtToken>`), even though the same attributes work on class members. This blocked cs2gs migration of Oahu's `LibraryResponse` interface (`@JsonPropertyName(...)` on interface properties).

## Fix
Attributes on interface property/event/method members now parse, bind, and **emit** as real CLR `CustomAttribute` rows.

- **Parser** (`ParseInterfaceDeclarationNew`, `ParseInterfaceDeclaration`): both interface-member loops now call `ParseAnnotations()` first and attach via `.WithAnnotations(...)`.
- **DeclarationBinder**: `SetAttributes(BindAttributes(...))` for interface Method/Property/Event, mirroring the class path.
- **Emit** (`MemberDefEmitter`/`ReflectionMetadataEmitter`/`TypeDefEmitter`): new `emitUserAttributes` delegate emits user attributes on every PropertyDef/EventDef and on abstract/static-virtual interface MethodDefs (this member-level emission was previously missing on all paths).

Verified via `PEReader`/`System.Reflection.Metadata` that attributes land on the emitted interface member (`parent=PropertyDefinition`/`EventDefinition`/`MethodDefinition`).

## Tests
New `Issue2129InterfaceMemberAnnotationParserTests` + `Issue2129InterfaceMemberAnnotationEmitTests` (7 pass). Full Emit (666), Syntax (854), Binding (3486) suites green. Release build StyleCop-clean.

Refs #914
