### PR TITLE
cs2gs: map C# static constructor to shared { init { ... } } block

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
@@ -358,6 +358,27 @@ public sealed class SharedBlock : GMember
 }
 
 /// <summary>
+/// A static-initializer block mapped to the canonical G# <c>init { … }</c> form
+/// that lives inside a <c>shared { }</c> block (ADR-0140, ADR-0115 §B.11). It
+/// carries the body of a non-foldable C# <c>static</c> constructor, lowering
+/// into the type's <c>.cctor</c> after static field initializers.
+/// </summary>
+public sealed class StaticInitializerBlock : GMember
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StaticInitializerBlock"/> class.
+    /// </summary>
+    /// <param name="body">The static-initializer body.</param>
+    public StaticInitializerBlock(BlockStatement body)
+    {
+        Body = body;
+    }
+
+    /// <summary>Gets the static-initializer body.</summary>
+    public BlockStatement Body { get; }
+}
+
+/// <summary>
 /// A class finalizer / destructor mapped to the canonical G# <c>deinit { … }</c>
 /// form (ADR-0068; class-only, no parameters or return type). Maps the C#
 /// <c>~Type() { … }</c> destructor.

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1255,6 +1255,8 @@ public static class GSharpPrinter
                 return RenderEvent(eventDeclaration, indent);
             case SharedBlock sharedBlock:
                 return RenderSharedBlock(sharedBlock, indent);
+            case StaticInitializerBlock staticInitializer:
+                return $"{Indent(indent)}init {RenderBlock(staticInitializer.Body, indent)}";
             default:
                 throw new ArgumentException($"Unsupported member: {member?.GetType().Name}");
         }

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
@@ -192,6 +192,10 @@ public static class GNodeSamples
                 TypeDeclarationKind.Class,
                 "C",
                 members: Members(new DestructorDeclaration(Block())))),
+            [typeof(StaticInitializerBlock)] = () => Unit(new TypeDeclaration(
+                TypeDeclarationKind.Class,
+                "C",
+                members: Members(new SharedBlock(Members(new StaticInitializerBlock(Block())))))),
             [typeof(EventDeclaration)] = () => Unit(new TypeDeclaration(
                 TypeDeclarationKind.Class,
                 "C",

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
@@ -77,6 +77,7 @@ MethodDeclaration
 NamedDelegateDeclaration
 PropertyDeclaration
 SharedBlock
+StaticInitializerBlock
 TypeDeclaration
 
 [GPattern]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1729StaticCtorFoldTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1729StaticCtorFoldTranslationTests.cs
@@ -12,15 +12,17 @@ using Xunit;
 namespace Cs2Gs.Tests;
 
 /// <summary>
-/// Issue #1729 — G# has no static-constructor form, so <c>cs2gs</c> folds a
-/// "simple" static constructor into its fields' initializers and drops the
-/// constructor. The foldability check and the consumption chain had six silent
-/// divergence modes; each is covered here. Modes that CAN be represented
-/// faithfully as a folded initializer are asserted to fold to the CORRECT
-/// value/shape; modes that cannot (cross-type writes, order-dependent RHS,
-/// side-effecting/duplicate instance-lift hoists) are asserted to surface a
-/// visible <see cref="TranslationSeverity.Unsupported"/> diagnostic instead of
-/// silently emitting wrong code.
+/// Issue #1729 — <c>cs2gs</c> folds a "simple" static constructor into its
+/// fields' initializers and drops the constructor. The foldability check and
+/// the consumption chain had six silent divergence modes; each is covered here.
+/// Modes that CAN be represented faithfully as a folded initializer are asserted
+/// to fold to the CORRECT value/shape; modes that cannot fold safely
+/// (cross-type writes, order-dependent RHS) now map the constructor body to a
+/// G# <c>init { }</c> static-initializer block (ADR-0140, ADR-0115 §B.11)
+/// instead of folding, while side-effecting/duplicate instance-lift hoists still
+/// surface a visible <see cref="TranslationSeverity.Unsupported"/> diagnostic or
+/// keep the explicit constructor intact rather than silently emitting wrong
+/// code.
 /// </summary>
 public class Issue1729StaticCtorFoldTranslationTests
 {
@@ -126,12 +128,13 @@ namespace Demo
     /// <summary>
     /// Mode 2: a static constructor that assigns another TYPE's static field is
     /// not foldable (the entry would be keyed by the other type's field symbol
-    /// and never consumed by this type's fields, silently vanishing). It must
-    /// surface an Unsupported diagnostic instead, and the other type's own
-    /// initializer must be left untouched.
+    /// and never consumed by this type's fields, silently vanishing). Instead of
+    /// folding, its body maps to a G# <c>init { }</c> static-initializer block
+    /// (ADR-0140) that assigns the other type's field directly, and the other
+    /// type's own initializer is left untouched.
     /// </summary>
     [Fact]
-    public void StaticCtorAssignsOtherTypesField_ReportsUnsupported_DoesNotFold()
+    public void StaticCtorAssignsOtherTypesField_MapsToInitBlock_DoesNotFold()
     {
         (string printed, TranslationContext context) = Translate(@"
 namespace Demo
@@ -147,7 +150,9 @@ namespace Demo
     }
 }");
 
-        Assert.Contains(context.Diagnostics, d => d.IsUnsupported);
+        Assert.DoesNotContain(context.Diagnostics, d => d.IsUnsupported);
+        Assert.Contains("init {", printed);
+        Assert.Contains("Other.Field = 5", printed);
         Assert.Contains("var Field int32 = 0", printed);
         Assert.DoesNotContain("var Field int32 = 5", printed);
     }
@@ -156,11 +161,12 @@ namespace Demo
     /// Mode 3: a static constructor whose assignment RHS reads the type's OWN
     /// static state cannot be hoisted to the assigned field's declaration
     /// position without risking a change to C#'s
-    /// initializers-then-cctor evaluation order. It must report Unsupported
-    /// rather than silently reorder.
+    /// initializers-then-cctor evaluation order. Instead of folding, its body
+    /// maps to a G# <c>init { }</c> static-initializer block (ADR-0140) that
+    /// preserves the original evaluation order.
     /// </summary>
     [Fact]
-    public void StaticCtorRhsReferencesOwnStaticField_ReportsUnsupported_DoesNotFold()
+    public void StaticCtorRhsReferencesOwnStaticField_MapsToInitBlock_DoesNotFold()
     {
         (string printed, TranslationContext context) = Translate(@"
 namespace Demo
@@ -173,9 +179,10 @@ namespace Demo
     }
 }");
 
-        Assert.Contains(context.Diagnostics, d => d.IsUnsupported);
+        Assert.DoesNotContain(context.Diagnostics, d => d.IsUnsupported);
+        Assert.Contains("init {", printed);
+        Assert.Contains("C.A = C.B * 2", printed);
         Assert.DoesNotContain("var A int32 = B * 2", printed);
-        _ = printed;
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914StaticInitializerBlockTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914StaticInitializerBlockTranslationTests.cs
@@ -1,0 +1,154 @@
+// <copyright file="Issue914StaticInitializerBlockTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #914 (cs2gs): a non-foldable C# <c>static</c> constructor now maps to
+/// the G# <c>init { ... }</c> static-initializer block inside the type's
+/// <c>shared { }</c> block (ADR-0140, ADR-0115 §B.11). Previously such a
+/// constructor was reported as unsupported and dropped. A foldable static
+/// constructor (only simple <c>Field = value;</c> assignments) must still fold
+/// its initializers onto the field declarations and emit NO <c>init { }</c>.
+/// </summary>
+public class Issue914StaticInitializerBlockTranslationTests
+{
+    /// <summary>
+    /// The canonical CRC-table shape: a static constructor whose body is a
+    /// nested loop populating a static array. It maps to a G# <c>init { }</c>
+    /// static-initializer block inside the <c>shared { }</c> block, and must
+    /// round-trip.
+    /// </summary>
+    [Fact]
+    public void StaticConstructor_CrcTableLoop_MapsToStaticInitializerBlock()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class Crc32
+    {
+        private const uint Polynomial = 0xEDB88320;
+        private static readonly uint[] Table = new uint[256];
+
+        static Crc32()
+        {
+            for (uint i = 0; i < Table.Length; i++)
+            {
+                uint value = i;
+                for (int j = 0; j < 8; j++)
+                {
+                    value = ((value & 1) != 0) ? (value >> 1) ^ Polynomial : value >> 1;
+                }
+
+                Table[i] = value;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("shared {", printed);
+        Assert.Contains("init {", printed);
+        Assert.Contains("Table[i]", printed);
+        // The field initializer stays on the field declaration; it is not
+        // re-emitted inside the init block.
+        Assert.DoesNotContain("Table = uint", printed);
+    }
+
+    /// <summary>
+    /// A static constructor initializing multiple interdependent static fields
+    /// with non-trivial logic (loops, accumulation) maps to a single
+    /// <c>init { }</c> block preserving statement order, and round-trips.
+    /// </summary>
+    [Fact]
+    public void StaticConstructor_InterdependentFields_MapsToStaticInitializerBlock()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class Config
+    {
+        private static readonly int Base;
+        private static readonly int Scaled;
+        private static readonly int Total;
+
+        static Config()
+        {
+            Base = 10;
+            int acc = 0;
+            for (int i = 0; i < Base; i++)
+            {
+                acc += i;
+            }
+
+            Scaled = Base * 2;
+            Total = acc + Scaled;
+        }
+    }
+}");
+
+        Assert.Contains("shared {", printed);
+        Assert.Contains("init {", printed);
+        Assert.Contains("Total", printed);
+        Assert.Contains("Scaled", printed);
+    }
+
+    /// <summary>
+    /// Regression guard for the unchanged foldable path: a static constructor
+    /// whose body is only simple <c>Field = value;</c> assignments still folds
+    /// the initializers onto the field declarations and emits NO
+    /// <c>init { }</c> block.
+    /// </summary>
+    [Fact]
+    public void StaticConstructor_FoldableOnly_StillFoldsAndEmitsNoInitBlock()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class Constants
+    {
+        private static readonly int A;
+        private static readonly int B;
+
+        static Constants()
+        {
+            A = 1;
+            B = 2;
+        }
+    }
+}");
+
+        Assert.DoesNotContain("init {", printed);
+        Assert.Contains("A", printed);
+        Assert.Contains("B", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4004,10 +4004,14 @@ public sealed class CSharpToGSharpTranslator
                     return null;
                 }
 
-                this.context.ReportUnsupported(
-                    node,
-                    "a non-trivial static constructor has no canonical G# form yet (ADR-0115 §B.11).");
-                return null;
+                // ADR-0140 / ADR-0115 §B.11: a non-foldable static constructor
+                // maps to a G# `init { ... }` static-initializer block inside the
+                // type's `shared { }` block. Simple static-field initializers are
+                // hoisted onto their field declarations separately (see
+                // CollectStaticFieldInitializers); the remaining ctor body is
+                // translated as-is here.
+                BlockStatement staticInitBody = this.TranslateBody(node, "static initializer");
+                return new StaticInitializerBlock(staticInitBody);
             }
 
             List<Parameter> parameters = this.MapParameters(symbol, node.ParameterList, skipFirst: false);


### PR DESCRIPTION
Maps a C# static constructor body to the new G# `shared { init { ... } }` static-initializer block (gsc feature landed in #2133 / issue #2131; ADR-0140, ADR-0115 §B.11). Previously cs2gs emitted `CS2GS-GAP: a non-trivial static constructor has no canonical G# form yet` for any static ctor that did more than simple `Field = value;` folding — this blocked Oahu.Core's `Cryptography/Crc32.cs` (CRC32 lookup-table built in a `static Crc32()`).

## Change
- **New CodeModel node** `StaticInitializerBlock : GMember` (holds a `BlockStatement`).
- **`TranslateConstructor`**: for a non-foldable static ctor, translate the body and return a `StaticInitializerBlock` (which flows into the `shared { }` block because a static ctor is a static member) instead of reporting unsupported. The foldable path (simple static-field assignments → field initializers) is unchanged; field-declaration initializers still fold separately (no double-emit).
- **Printer**: `RenderMember` emits `init { <body> }`, matching the `deinit` style.

## Coverage obligations
- `GNodeSamples` entry for `StaticInitializerBlock` (PrinterExhaustiveness).
- `code-model-surface.golden.txt` regenerated.

## Tests
New `Issue914StaticInitializerBlockTranslationTests` (CRC-table loop, interdependent static fields, foldable-only regression guard). Updated `Issue1729StaticCtorFoldTranslationTests` mode-2/mode-3 (non-foldable ctors now map to `init { }` rather than emitting an unsupported diagnostic). Full cs2gs suite: **1095 passed, 0 failed**. Release build 0 warnings.

## End-to-end
cs2gs emits `shared { ... init { for ... { Crc32.Table[i] = value } } }` for the Crc32 shape, and the freshly built gsc compiles it to `Crc32.dll` (exit 0).

Refs #914
