### PR TITLE
Fix #2135: guard IsAssignableByName against NotSupportedException from TypeBuilderInstantiation

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -743,7 +743,14 @@ public sealed class Conversion
                             continue;
                         }
 
-                        if (ifaceClr == to.ClrType || to.ClrType.IsAssignableFrom(ifaceClr))
+                        // Issue #2135: `to.ClrType` may be a
+                        // TypeBuilderInstantiation (a same-compilation generic
+                        // user interface instantiated concretely) whose
+                        // IsAssignableFrom throws NotSupportedException at emit.
+                        // Route through the reference-context-independent
+                        // by-name helper, which guards that call and falls back
+                        // to the interface/base-class name walk.
+                        if (ifaceClr == to.ClrType || ClrTypeUtilities.IsAssignableByName(to.ClrType, ifaceClr))
                         {
                             return Conversion.Implicit;
                         }
@@ -847,7 +854,12 @@ public sealed class Conversion
                 foreach (var baseClrInterface in fromInterface.BaseClrInterfaces)
                 {
                     var clr = baseClrInterface?.ClrType;
-                    if (clr != null && (clr.IsSameAs(toClrInterface) || toClrInterface.IsAssignableFrom(clr)))
+
+                    // Issue #2135: `toClrInterface` may be a
+                    // TypeBuilderInstantiation whose IsAssignableFrom throws
+                    // NotSupportedException at emit; use the guarded by-name
+                    // helper instead of calling IsAssignableFrom directly.
+                    if (clr != null && (clr.IsSameAs(toClrInterface) || ClrTypeUtilities.IsAssignableByName(toClrInterface, clr)))
                     {
                         return Conversion.Implicit;
                     }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -578,7 +578,12 @@ internal sealed partial class MethodBodyEmitter
                 foreach (var baseClrInterface in srcInterface.BaseClrInterfaces)
                 {
                     var clr = baseClrInterface?.ClrType;
-                    if (clr != null && (clr.IsSameAs(targetClrInterface) || targetClrInterface.IsAssignableFrom(clr)))
+
+                    // Issue #2135: `targetClrInterface` may be a
+                    // TypeBuilderInstantiation whose IsAssignableFrom throws
+                    // NotSupportedException at emit; use the guarded by-name
+                    // helper instead of calling IsAssignableFrom directly.
+                    if (clr != null && (clr.IsSameAs(targetClrInterface) || ClrTypeUtilities.IsAssignableByName(targetClrInterface, clr)))
                     {
                         return true;
                     }
@@ -659,7 +664,11 @@ internal sealed partial class MethodBodyEmitter
                         continue;
                     }
 
-                    if (ifaceClr == b.ClrType || b.ClrType.IsAssignableFrom(ifaceClr))
+                    // Issue #2135: `b.ClrType` may be a
+                    // TypeBuilderInstantiation whose IsAssignableFrom throws
+                    // NotSupportedException at emit; use the guarded by-name
+                    // helper instead of calling IsAssignableFrom directly.
+                    if (ifaceClr == b.ClrType || ClrTypeUtilities.IsAssignableByName(b.ClrType, ifaceClr))
                     {
                         return true;
                     }

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -221,9 +221,13 @@ public static class ClrTypeUtilities
                 // by-name walk, which is reference-context independent and only
                 // ever returns true for real inheritance / implementation.
             }
-            catch (InvalidOperationException)
+            catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException)
             {
-                // MLC types throw for some cross-context paths; fall through.
+                // InvalidOperationException: MLC types throw for some cross-context paths.
+                // NotSupportedException: a TypeBuilderInstantiation (generic instantiation of
+                // a type still being defined by emit's TypeBuilders) throws from
+                // IsAssignableFrom. In both cases fall through to the reference-context-
+                // independent by-name walk below (issue #2135).
             }
         }
 

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2135EventSubscriptionGenericEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2135EventSubscriptionGenericEmitTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="Issue2135EventSubscriptionGenericEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #2135: an event subscription (<c>+=</c>) whose delegate/handler type
+/// involves a same-compilation generic user type — which is a
+/// <see cref="System.Reflection.Emit.TypeBuilderInstantiation"/> at emit — must
+/// compile all the way to a real PE without the
+/// <c>GS9998 NotSupportedException</c> that previously escaped from
+/// <c>ClrTypeUtilities.IsAssignableByName</c> (see
+/// <c>Issue2135TypeBuilderInstantiationTests</c> for the direct root-cause
+/// guard). These end-to-end tests compile generic user types that declare an
+/// event whose delegate references the type parameter and subscribe to it,
+/// asserting emit succeeds and produces no GS9998.
+/// </summary>
+public class Issue2135EventSubscriptionGenericEmitTests
+{
+    [Fact]
+    public void MethodGroupHandler_OnGenericTypeEvent_EmitsWithoutCrash()
+    {
+        const string Source = @"package Issue2135MethodGroup
+class Bus[T] {
+    event OnMsg (T) -> void
+    func Handle(v T) { }
+    func Wire() {
+        OnMsg += Handle
+    }
+}
+";
+        var asm = CompileToAssembly(Source, nameof(MethodGroupHandler_OnGenericTypeEvent_EmitsWithoutCrash));
+        Assert.Contains(asm.GetTypes(), t => t.Name == "Bus`1");
+    }
+
+    [Fact]
+    public void LambdaHandler_OnGenericTypeEvent_EmitsWithoutCrash()
+    {
+        const string Source = @"package Issue2135Lambda
+class Bus[T] {
+    event OnMsg (T) -> void
+    func Wire(x T) {
+        OnMsg += func(y T) { }
+    }
+}
+";
+        var asm = CompileToAssembly(Source, nameof(LambdaHandler_OnGenericTypeEvent_EmitsWithoutCrash));
+        Assert.Contains(asm.GetTypes(), t => t.Name == "Bus`1");
+    }
+
+    [Fact]
+    public void DelegateParamHandler_OnGenericUserDelegateEvent_EmitsWithoutCrash()
+    {
+        const string Source = @"package Issue2135UserDelegate
+type Handler[T] = delegate func(v T)
+class Bus[T] {
+    event OnMsg Handler[T]
+    func Wire(h Handler[T]) {
+        OnMsg += h
+    }
+}
+";
+        var asm = CompileToAssembly(Source, nameof(DelegateParamHandler_OnGenericUserDelegateEvent_EmitsWithoutCrash));
+        Assert.Contains(asm.GetTypes(), t => t.Name == "Bus`1");
+    }
+
+    private static Assembly CompileToAssembly(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        return loadContext.LoadFromStream(peStream);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue2135TypeBuilderInstantiationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue2135TypeBuilderInstantiationTests.cs
@@ -1,0 +1,89 @@
+// <copyright file="Issue2135TypeBuilderInstantiationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #2135: <see cref="ClrTypeUtilities.IsAssignableByName(Type, Type)"/>
+/// has a "same-context fast path" that calls <c>target.IsAssignableFrom(source)</c>
+/// whenever the two types share a reflection assembly / kind. During emit the
+/// target can be a <see cref="System.Reflection.Emit.TypeBuilderInstantiation"/>
+/// — a generic instantiation of a type still being defined by the emit's
+/// <see cref="TypeBuilder"/>s (e.g. a same-compilation generic user delegate
+/// closed over a concrete type argument). Its <c>IsAssignableFrom</c> throws
+/// <see cref="NotSupportedException"/>, which previously escaped all the way out
+/// of <c>Compilation.Emit</c> and surfaced as <c>GS9998</c> while binding an
+/// event subscription (<c>+=</c>).
+///
+/// The method is explicitly designed to fall through to a reference-context-
+/// independent by-name walk whenever the fast path cannot answer (that is why
+/// <see cref="InvalidOperationException"/> was already swallowed). This test
+/// builds a genuine <c>TypeBuilderInstantiation</c> in a dynamic assembly and a
+/// sibling type in the SAME assembly (so the same-context fast path fires) and
+/// asserts the call no longer throws and instead returns the by-name answer.
+///
+/// RED before the fix: <see cref="NotSupportedException"/> propagates.
+/// GREEN after: the exception is caught and the by-name walk decides.
+/// </summary>
+public class Issue2135TypeBuilderInstantiationTests
+{
+    [Fact]
+    public void IsAssignableByName_TypeBuilderInstantiationTarget_DoesNotThrow()
+    {
+        var (instantiation, sibling) = BuildTypeBuilderInstantiationAndSibling();
+
+        // The two types live in the same (dynamic) assembly, so the same-
+        // context fast path is entered and IsAssignableFrom is invoked on the
+        // TypeBuilderInstantiation target — the exact call that threw
+        // NotSupportedException before the fix.
+        Assert.True(ReferenceEquals(instantiation.Assembly, sibling.Assembly));
+        Assert.IsAssignableFrom<TypeBuilder>(sibling);
+        Assert.Equal("TypeBuilderInstantiation", instantiation.GetType().Name);
+
+        var exception = Record.Exception(() => ClrTypeUtilities.IsAssignableByName(instantiation, sibling));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void IsAssignableByName_TypeBuilderInstantiationTarget_FallsThroughToByNameWalk()
+    {
+        var (instantiation, sibling) = BuildTypeBuilderInstantiationAndSibling();
+
+        // `sibling` does not derive from / implement the constructed generic
+        // definition, so the reference-context-independent by-name walk the
+        // fast path falls through to correctly answers `false` (rather than
+        // crashing).
+        Assert.False(ClrTypeUtilities.IsAssignableByName(instantiation, sibling));
+    }
+
+    private static (Type Instantiation, Type Sibling) BuildTypeBuilderInstantiationAndSibling()
+    {
+        var assemblyName = new AssemblyName("Issue2135DynamicAssembly");
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("Issue2135Module");
+
+        // A generic type still under construction — its `.MakeGenericType(...)`
+        // produces a TypeBuilderInstantiation whose IsAssignableFrom throws.
+        var genericDefinition = moduleBuilder.DefineType(
+            "Bus`1",
+            TypeAttributes.Public | TypeAttributes.Class);
+        genericDefinition.DefineGenericParameters("T");
+
+        // A sibling type in the SAME dynamic assembly so the same-context fast
+        // path (`ReferenceEquals(target.Assembly, source.Assembly)`) is taken.
+        var sibling = moduleBuilder.DefineType(
+            "Consumer",
+            TypeAttributes.Public | TypeAttributes.Class);
+
+        var instantiation = genericDefinition.MakeGenericType(typeof(int));
+        return (instantiation, sibling);
+    }
+}


### PR DESCRIPTION
Fixes #2135.

`gsc` crashed with `GS9998: NotSupportedException: Specified method is not supported.` during emit when the conversion classifier compared against a generic type still under construction (a `System.Reflection.Emit.TypeBuilderInstantiation` — a generic instantiation of a same-compilation user type). Surfaced while migrating Oahu.Core via cs2gs (#914), through event-subscription (`+=`) binding at emit time.

## Root cause
`ClrTypeUtilities.IsAssignableByName` has a same-context fast path calling `target.IsAssignableFrom(source)` inside `try { ... } catch (InvalidOperationException) { /* fall through to by-name walk */ }`. `TypeBuilderInstantiation.IsAssignableFrom` throws **`NotSupportedException`**, which was not caught, so it escaped `Compilation.Emit` → GS9998. The method is designed to fall through to a reference-context-independent by-name walk whenever the fast path can't answer.

## Fix
- `ClrTypeUtilities.cs` (~L217): broadened the catch to `when (ex is InvalidOperationException or NotSupportedException)` → falls through to the by-name walk. General for any caller hitting a reflection-emit type-under-construction.
- Audited & guarded the four other raw `.IsAssignableFrom` sites whose LHS can be a generic user interface (TBI): `Conversion.cs:746`/`:850` and `MethodBodyEmitter.cs:581`/`:662` now route through the guarded `IsAssignableByName`.

## Tests
- `Issue2135TypeBuilderInstantiationTests` — builds a genuine `TypeBuilderInstantiation` in the same dynamic assembly; RED before (exact issue stack), GREEN after.
- `Issue2135EventSubscriptionGenericEmitTests` — 3 end-to-end emit tests (generic user type + event referencing the type param, `+=` via method-group/lambda/user-delegate) assert no GS9998.

Full Core.Tests: **5587 passed, 1 skipped, 0 failed**, 0 warnings.

Refs #914
