### PR TITLE
cs2gs: emit T? for null-tainted oblivious reference declarations (#2113)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1182OptionalDefaultParameterTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1182OptionalDefaultParameterTranslationTests.cs
@@ -77,8 +77,10 @@ namespace Corpus.Issue1182
     {
         string rendered = Render();
 
-        // A reference-type `= null` and a nullable value-type `= null` both become `= nil`.
-        Assert.Contains("name string = nil", rendered, StringComparison.Ordinal);
+        // A reference-type `= null` default is null-tainted, so under a
+        // nullable-oblivious compilation issue #2113 promotes it to `string?`; a
+        // nullable value-type `= null` is `int32?`. Both render `= nil`.
+        Assert.Contains("name string? = nil", rendered, StringComparison.Ordinal);
         Assert.Contains("count int32? = nil", rendered, StringComparison.Ordinal);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2113ObliviousNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2113ObliviousNullableTranslationTests.cs
@@ -1,0 +1,177 @@
+// <copyright file="Issue2113ObliviousNullableTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #2113: in a nullable-<em>oblivious</em>
+/// compilation (<c>NullableContextOptions.Disable</c>, i.e. a project with no
+/// <c>&lt;Nullable&gt;</c> setting) Roslyn reports every reference type as
+/// <c>NullableAnnotation.None</c> with no flow state, so an oblivious reference
+/// <c>T</c> used to always map to non-null G# <c>T</c>. That collided with the
+/// <c>T?</c> values cs2gs legitimately introduces (<c>?.</c>, <c>= null</c>
+/// defaults, nullable-returning BCL), producing GS0154/GS0155/GS0156 "T? vs T"
+/// errors. The whole-program taint analysis
+/// (<see cref="ObliviousNullabilityAnalyzer"/>) now promotes a reference
+/// declaration to <c>T?</c> exactly when it is reachable from a null value, and
+/// keeps a provably non-null declaration as <c>T</c>. The analysis is gated to
+/// oblivious compilations, so a nullable-<em>enabled</em> compilation is untouched.
+/// </summary>
+public class Issue2113ObliviousNullableTranslationTests
+{
+    [Fact]
+    public void Oblivious_NullTaintedField_RendersNullableType()
+    {
+        // `field` is assigned null on one path, so it is null-tainted and must
+        // render `string?`; without promotion the later `field = null` assignment
+        // is a GS0155 "cannot convert nil to string".
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        private string field = ""seed"";
+
+        public void Clear() { this.field = null; }
+    }
+}");
+
+        Assert.Contains("field string?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_NullTaintedParameterAndReturn_RenderNullableTypes()
+    {
+        // `Find` returns null on a path (return type tainted) and its result flows
+        // into the `value` parameter of `Use` via a call argument (interprocedural
+        // taint), so both the return and the parameter must render `string?`.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Find(bool b)
+        {
+            if (b) { return null; }
+            return ""x"";
+        }
+
+        public void Use(string value) { }
+
+        public void Run() { Use(Find(true)); }
+    }
+}");
+
+        Assert.Contains("Find(b bool) string?", printed);
+        Assert.Contains("Use(value string?)", printed);
+    }
+
+    [Fact]
+    public void Oblivious_UntaintedReference_StaysNonNull()
+    {
+        // No null ever reaches `Name`, `Greet`, or its parameter, so all stay
+        // non-null `string` — the idiomatic G# form.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        private string Name = ""hello"";
+
+        public string Greet(string who) { return who; }
+    }
+}");
+
+        Assert.Contains("Name string", printed);
+        Assert.DoesNotContain("Name string?", printed);
+        Assert.Contains("Greet(who string) string", printed);
+        Assert.DoesNotContain("string?", printed);
+    }
+
+    [Fact]
+    public void NullableEnabled_DeclarationsUnchanged_NoObliviousPromotion()
+    {
+        // Same null-assignment shape as the oblivious field test, but in a
+        // nullable-ENABLED compilation. The oblivious taint analysis must NOT run:
+        // `field` is a declared non-null `string` (assigning null is a C# warning,
+        // not a promotion trigger), so it stays non-null `string` exactly as
+        // before #2113. `maybe` is declared `string?` and stays nullable.
+        string printed = TranslateEnabled(@"
+namespace Demo
+{
+    public class C
+    {
+        private string field = ""seed"";
+        private string? maybe = null;
+
+        public void Keep() { this.field = this.field; }
+    }
+}");
+
+        Assert.Contains("field string", printed);
+        Assert.DoesNotContain("field string?", printed);
+        Assert.Contains("maybe string?", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string TranslateEnabled(string source)
+    {
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.EnabledInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Select(r => r).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4568,7 +4568,14 @@ public sealed class CSharpToGSharpTranslator
                 // `ref` modifier itself is reinstated at the MethodDeclaration
                 // (IsRefReturn) by the caller, mapping to G#'s native
                 // ref-return (`func F(...) ref T`, issue #490/ADR-0060).
-                return this.typeMapper.Map(returnType, this.context, node.ReturnType.GetLocation());
+                GTypeReference mapped = this.typeMapper.Map(returnType, this.context, node.ReturnType.GetLocation());
+
+                // Issue #2113: promote the return type to `T?` when the
+                // whole-program taint analysis proved this method's RETURN
+                // null-tainted (an oblivious compilation with a `return null` /
+                // nullable-returning path). Type-parameter returns are excluded
+                // for the same reason as declaration sites.
+                return this.PromoteReturnIfTainted(mapped, symbol, returnType);
             }
 
             return node.ReturnType is PredefinedTypeSyntax predefined &&
@@ -9744,6 +9751,33 @@ public sealed class CSharpToGSharpTranslator
             return this.IsPromotedToNullableReference(symbol) ? MakeNullable(type) : type;
         }
 
+        // Issue #2113: promote a method's mapped return type to `T?` when the
+        // whole-program oblivious taint analysis proved the method's RETURN
+        // null-tainted. Value-type returns, already-nullable returns, and
+        // type-parameter returns are left untouched (the last for the same
+        // reason declaration sites exclude type parameters — a `T?` return of an
+        // unconstrained parameter has no faithful non-null call site). No-op for
+        // a nullable-enabled compilation, where `IsTainted` is always false.
+        private GTypeReference PromoteReturnIfTainted(
+            GTypeReference type,
+            IMethodSymbol symbol,
+            ITypeSymbol returnType)
+        {
+            if (type == null
+                || type.IsNullable
+                || symbol == null
+                || returnType is not { IsReferenceType: true }
+                || returnType is ITypeParameterSymbol
+                || returnType.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                return type;
+            }
+
+            return ObliviousNullabilityAnalyzer.IsTainted(this.context.Compilation, symbol)
+                ? MakeNullable(type)
+                : type;
+        }
+
         // Issue #1072 (field/property initializer form): when a field or property is
         // emitted with an explicit declared type plus an initializer whose
         // Roslyn-inferred type is nullable (e.g. the value comes from a `?.`
@@ -9869,6 +9903,20 @@ public sealed class CSharpToGSharpTranslator
             if (symbol is IParameterSymbol { HasExplicitDefaultValue: true } defaulted
                 && defaulted.ExplicitDefaultValue is null
                 && defaulted.Type.TypeKind == TypeKind.Delegate)
+            {
+                return true;
+            }
+
+            // Issue #2113: in a nullable-OBLIVIOUS compilation, a reference
+            // declaration is rendered `T?` iff the whole-program transitive
+            // null-taint analysis proved this symbol null-tainted. This is the
+            // ONLY behavioral change for oblivious code — for a nullable-enabled
+            // compilation `IsTainted` short-circuits to false, so every existing
+            // path stays byte-identical. Type parameters are excluded: promoting
+            // a `where T : class` declaration to `T?` would break `Cast[T]`/
+            // `typeof(T)` name positions.
+            if (declared is not ITypeParameterSymbol
+                && ObliviousNullabilityAnalyzer.IsTainted(this.context.Compilation, symbol))
             {
                 return true;
             }
@@ -12401,6 +12449,21 @@ public sealed class CSharpToGSharpTranslator
 
             ISymbol symbol = this.context.GetSymbolInfo(recv).Symbol;
 
+            // Issue #2113: in a nullable-OBLIVIOUS compilation the whole-program
+            // taint analysis may promote a LOCAL or PARAMETER receiver to `T?`.
+            // gsc smart-casts locals only after a flow-proven guard (inert under
+            // oblivious metadata), so an unguarded `x.Member` / `x[i]` / `for … in
+            // x` on such a receiver is rejected (GS0158/GS0116). Assert `x!!` to
+            // both compile and preserve C#'s throw-on-null semantics for the same
+            // access. Gated to oblivious so nullable-enabled projects (whose
+            // locals gsc DOES smart-cast) keep their flow-driven path untouched.
+            if (this.IsObliviousCompilation()
+                && symbol is ILocalSymbol or IParameterSymbol
+                && this.IsPromotedToNullableReference(symbol))
+            {
+                return true;
+            }
+
             ITypeSymbol declared = symbol switch
             {
                 IPropertySymbol property => property.Type,
@@ -12416,6 +12479,14 @@ public sealed class CSharpToGSharpTranslator
             return declared.NullableAnnotation == NullableAnnotation.Annotated
                 || this.IsPromotedToNullableReference(symbol);
         }
+
+        // Issue #2113: true for a nullable-oblivious compilation
+        // (NullableContextOptions.Disable) — the only mode in which the
+        // whole-program taint analysis runs and its declaration/receiver
+        // adjustments apply. A nullable-enabled compilation is byte-identical to
+        // pre-#2113 behavior.
+        private bool IsObliviousCompilation() =>
+            this.context.Compilation.Options.NullableContextOptions == NullableContextOptions.Disable;
 
         // True when <paramref name="member"/> binds to an extension method whose
         // (reduced) `this` parameter is nullable-annotated (`this T? x`). Such a
@@ -12662,10 +12733,15 @@ public sealed class CSharpToGSharpTranslator
             // field/property chain, so an unforgiven nullable delegate field is
             // "not a function" (GS0131) even inside an `if handler != nil` guard.
             // This is the invocation-callee analog of the receiver `!!` pass
-            // (#1594); locals are excluded by the shared helper. It fires for any
-            // nullable delegate field/property callee, not just this one shape.
+            // (#1594). It is restricted to a field/property callee: a `!!`-asserted
+            // callee only parses as `recv!!.member`, never as a standalone `recv!!`
+            // invocation target, so a nullable LOCAL/PARAMETER delegate callee is
+            // NOT forgiven here — gsc smart-casts those from an `if d != nil` guard
+            // instead (the promotion that made them `T?` comes from #2113).
             if (this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol
                     { MethodKind: MethodKind.DelegateInvoke }
+                && this.context.GetSymbolInfo(invocation.Expression).Symbol
+                    is IFieldSymbol or IPropertySymbol
                 && this.ReceiverIsNullableReferenceFieldOrProperty(invocation.Expression))
             {
                 target = new NonNullAssertionExpression(target);

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -1,0 +1,645 @@
+// <copyright file="ObliviousNullabilityAnalyzer.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Cs2Gs.Translator;
+
+/// <summary>
+/// Issue #2113: a whole-program, symbol-keyed null-TAINT analysis for a
+/// nullable-<em>oblivious</em> compilation (one whose
+/// <see cref="CSharpCompilationOptions.NullableContextOptions"/> is
+/// <see cref="NullableContextOptions.Disable"/>).
+///
+/// <para>
+/// In oblivious C# Roslyn reports every reference type as
+/// <c>NullableAnnotation.None</c> with no flow state, so the translator
+/// cannot tell a "definitely non-null" declaration apart from a "maybe null"
+/// one (<c>NullableAnnotation.None</c> with no flow state). Mapping every
+/// oblivious reference `T` to a non-null G# `T` then collides
+/// with the `T?` values cs2gs legitimately introduces (`?.`, `= null` defaults,
+/// nullable-returning BCL members), producing a cluster of GS0154/0155/0156
+/// "T? vs T" errors. Mapping every oblivious reference to `T?` instead over-
+/// promotes and forces a use-site explosion of `!!` assertions and idiomatic
+/// non-null decls become nullable.
+/// </para>
+///
+/// <para>
+/// This analyzer instead decides, per reference-type declaration symbol S
+/// (field / auto-property / parameter / method-return / local), whether S is
+/// null-TAINTED. A tainted S is rendered `T?`; an untainted S stays non-null
+/// `T` (the idiomatic default). Taint is seeded from direct null evidence
+/// (== null, = null, ??=, is null, `?.`, `= null|default` initializers,
+/// nullable-returning BCL members, and `return null` paths) and then propagated
+/// to a fixpoint along assignment / initializer / return edges: if S is
+/// assigned/initialized/returned a value that reads a tainted symbol or calls a
+/// tainted method's return, S becomes tainted too.
+/// </para>
+///
+/// <para>
+/// The whole result is keyed on the declaration's <see cref="ISymbol"/> and is
+/// consulted ONLY at declaration sites (see
+/// <c>CSharpToGSharpTranslator.DeclarationVisitor.IsPromotedToNullableReference</c>
+/// and the method-return path), so name positions (typeof/construction/base
+/// list) and — because the analyzer never runs for a nullable-enabled
+/// compilation — enabled projects are provably untouched.
+/// </para>
+/// </summary>
+internal static class ObliviousNullabilityAnalyzer
+{
+    // Keyed by Compilation identity so an edited/new compilation naturally gets
+    // a fresh entry and stale ones are collectible — same pattern as the
+    // subclassed-base-types / partial-type-parts caches in the translator.
+    private static readonly ConditionalWeakTable<Compilation, TaintResult> Cache = new();
+
+    /// <summary>
+    /// Whether <paramref name="symbol"/> (a declaration symbol: field / property
+    /// / parameter / local, or a method whose RETURN is under test) is
+    /// null-tainted in <paramref name="compilation"/>. Always returns
+    /// <see langword="false"/> for a non-oblivious (nullable-enabled) compilation
+    /// — the analysis never runs there, so enabled projects are untouched.
+    /// </summary>
+    /// <param name="compilation">The C# compilation being translated.</param>
+    /// <param name="symbol">The declaration symbol to test.</param>
+    /// <returns><see langword="true"/> when the symbol is null-tainted.</returns>
+    public static bool IsTainted(CSharpCompilation compilation, ISymbol symbol)
+    {
+        if (symbol == null ||
+            compilation == null ||
+            compilation.Options.NullableContextOptions != NullableContextOptions.Disable)
+        {
+            return false;
+        }
+
+        return Cache.GetValue(compilation, Compute).Tainted.Contains(Canonical(symbol));
+    }
+
+    private static TaintResult Compute(Compilation compilation)
+    {
+        var tainted = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+
+        // Transitive edges: (target <- source). If `source` is tainted then
+        // `target` becomes tainted. Both are canonicalized declaration symbols
+        // (field/property/parameter/local for a value target; method for a
+        // return target; field/property/parameter/local/method for a source).
+        var edges = new List<(ISymbol Target, ISymbol Source)>();
+
+        foreach (SyntaxTree tree in compilation.SyntaxTrees)
+        {
+            SemanticModel model = compilation.GetSemanticModel(tree);
+            SyntaxNode root = tree.GetRoot();
+
+            foreach (SyntaxNode node in root.DescendantNodes())
+            {
+                SeedDirectTaint(node, model, tainted);
+                CollectEdges(node, model, tainted, edges);
+            }
+
+            // Method / accessor / local-function RETURN taint: a `return null`,
+            // `return default`, or `return <nullable-expr>` path taints the
+            // enclosing member's return symbol; a non-directly-null `return`
+            // records a transitive edge from the return symbol to the returned
+            // value's source.
+            SeedReturnTaint(root, model, tainted, edges);
+        }
+
+        // Fixpoint: propagate taint along the edge set until it stabilizes.
+        bool changed = true;
+        while (changed)
+        {
+            changed = false;
+            foreach ((ISymbol target, ISymbol source) in edges)
+            {
+                if (!tainted.Contains(target) && tainted.Contains(source))
+                {
+                    tainted.Add(target);
+                    changed = true;
+                }
+            }
+        }
+
+        return new TaintResult(tainted);
+    }
+
+    // Seeds direct null evidence for a value declaration symbol (field /
+    // property / parameter / local): the exact forms the translator's local
+    // ComputeIsUsedAsNullable / IsNullableInitializer already recognize, applied
+    // whole-program.
+    private static void SeedDirectTaint(
+        SyntaxNode node,
+        SemanticModel model,
+        HashSet<ISymbol> tainted)
+    {
+        switch (node)
+        {
+            // `x == null` / `null == x` / `x != null` / `null != x`.
+            case BinaryExpressionSyntax binary
+                when binary.IsKind(SyntaxKind.EqualsExpression)
+                    || binary.IsKind(SyntaxKind.NotEqualsExpression):
+                if (IsNullLiteral(binary.Right))
+                {
+                    TaintTarget(binary.Left, model, tainted);
+                }
+                else if (IsNullLiteral(binary.Left))
+                {
+                    TaintTarget(binary.Right, model, tainted);
+                }
+
+                break;
+
+            // `x = null` / `x = null!`.
+            case AssignmentExpressionSyntax assign
+                when assign.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                    && IsNullOrSuppressedNull(assign.Right):
+                TaintTarget(assign.Left, model, tainted);
+                break;
+
+            // `x ??= y`: `x` is a legal `??=` target only if it is nullable.
+            case AssignmentExpressionSyntax coalesceAssign
+                when coalesceAssign.IsKind(SyntaxKind.CoalesceAssignmentExpression):
+                TaintTarget(coalesceAssign.Left, model, tainted);
+                break;
+
+            // `x is null` / `x is not null`.
+            case IsPatternExpressionSyntax isPattern
+                when IsNullConstantPattern(isPattern.Pattern):
+                TaintTarget(isPattern.Expression, model, tainted);
+                break;
+
+            // `x?.M` / `x?[i]`: the receiver before the `?` is nullable.
+            case ConditionalAccessExpressionSyntax conditionalAccess:
+                TaintTarget(conditionalAccess.Expression, model, tainted);
+                break;
+
+            // `T x = null|default`, `field = null|default`, parameter `= null`.
+            case VariableDeclaratorSyntax declarator
+                when declarator.Initializer != null:
+                if (model.GetDeclaredSymbol(declarator) is ISymbol declared
+                    && IsValueDeclarationSymbol(declared)
+                    && IsDirectlyNullable(declarator.Initializer.Value, model))
+                {
+                    tainted.Add(Canonical(declared));
+                }
+
+                break;
+
+            case PropertyDeclarationSyntax property
+                when property.Initializer != null:
+                if (model.GetDeclaredSymbol(property) is IPropertySymbol propertySymbol
+                    && IsDirectlyNullable(property.Initializer.Value, model))
+                {
+                    tainted.Add(Canonical(propertySymbol));
+                }
+
+                break;
+
+            case ParameterSyntax parameter
+                when parameter.Default != null:
+                if (model.GetDeclaredSymbol(parameter) is IParameterSymbol parameterSymbol
+                    && IsDirectlyNullable(parameter.Default.Value, model))
+                {
+                    tainted.Add(Canonical(parameterSymbol));
+                }
+
+                break;
+        }
+    }
+
+    // Records transitive taint edges for the assignment / initializer forms
+    // whose RHS is not itself directly-null but reads another declaration.
+    private static void CollectEdges(
+        SyntaxNode node,
+        SemanticModel model,
+        HashSet<ISymbol> tainted,
+        List<(ISymbol Target, ISymbol Source)> edges)
+    {
+        // Interprocedural parameter taint: an argument that is directly null or
+        // reads a (possibly tainted) declaration flows to the bound parameter, so
+        // a parameter that ever receives null becomes `T?` too. This keeps a
+        // pass-through call `Callee(maybeNull)` from demanding a non-null
+        // parameter (GS0154) once `maybeNull` is promoted.
+        if (node is InvocationExpressionSyntax or ObjectCreationExpressionSyntax)
+        {
+            CollectArgumentEdges(node, model, tainted, edges);
+        }
+
+        switch (node)
+        {
+            case AssignmentExpressionSyntax assign
+                when assign.IsKind(SyntaxKind.SimpleAssignmentExpression):
+                ISymbol assignTarget = ResolveAssignable(assign.Left, model);
+                if (assignTarget != null && !IsDirectlyNullable(assign.Right, model))
+                {
+                    AddEdges(assignTarget, assign.Right, model, edges);
+                }
+
+                break;
+
+            case VariableDeclaratorSyntax declarator
+                when declarator.Initializer != null:
+                if (model.GetDeclaredSymbol(declarator) is ISymbol declared
+                    && IsValueDeclarationSymbol(declared)
+                    && !IsDirectlyNullable(declarator.Initializer.Value, model))
+                {
+                    AddEdges(Canonical(declared), declarator.Initializer.Value, model, edges);
+                }
+
+                break;
+
+            case PropertyDeclarationSyntax property
+                when property.Initializer != null:
+                if (model.GetDeclaredSymbol(property) is IPropertySymbol propertySymbol
+                    && !IsDirectlyNullable(property.Initializer.Value, model))
+                {
+                    AddEdges(Canonical(propertySymbol), property.Initializer.Value, model, edges);
+                }
+
+                break;
+        }
+    }
+
+    // Interprocedural: map each call argument to its bound parameter and add a
+    // taint edge (or a direct taint for a directly-null argument), so a parameter
+    // that ever receives a nullable value is itself promoted to `T?`.
+    private static void CollectArgumentEdges(
+        SyntaxNode call,
+        SemanticModel model,
+        HashSet<ISymbol> tainted,
+        List<(ISymbol Target, ISymbol Source)> edges)
+    {
+        ImmutableArray<IArgumentOperation> arguments = model.GetOperation(call) switch
+        {
+            IInvocationOperation invocation => invocation.Arguments,
+            IObjectCreationOperation creation => creation.Arguments,
+            _ => default,
+        };
+
+        if (arguments.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        foreach (IArgumentOperation argument in arguments)
+        {
+            if (argument.Parameter is not IParameterSymbol parameter
+                || argument.Value?.Syntax is not ExpressionSyntax value)
+            {
+                continue;
+            }
+
+            ISymbol parameterSymbol = Canonical(parameter);
+            if (IsDirectlyNullable(value, model))
+            {
+                tainted.Add(parameterSymbol);
+            }
+            else
+            {
+                AddEdges(parameterSymbol, value, model, edges);
+            }
+        }
+    }
+
+    // Return taint: for each method / accessor / local function, examine every
+    // `return` (or arrow expression body) that belongs to it (not to a nested
+    // lambda / local function). A directly-null return taints the member's
+    // return symbol immediately; any other return records a transitive edge.
+    private static void SeedReturnTaint(
+        SyntaxNode root,
+        SemanticModel model,
+        HashSet<ISymbol> tainted,
+        List<(ISymbol Target, ISymbol Source)> edges)
+    {
+        foreach (SyntaxNode node in root.DescendantNodes())
+        {
+            ExpressionSyntax arrowBody = null;
+            ISymbol returnSymbol = null;
+
+            switch (node)
+            {
+                case MethodDeclarationSyntax method:
+                    returnSymbol = model.GetDeclaredSymbol(method);
+                    arrowBody = method.ExpressionBody?.Expression;
+                    break;
+
+                case LocalFunctionStatementSyntax localFunction:
+                    returnSymbol = model.GetDeclaredSymbol(localFunction);
+                    arrowBody = localFunction.ExpressionBody?.Expression;
+                    break;
+
+                default:
+                    continue;
+            }
+
+            if (returnSymbol is not IMethodSymbol { ReturnsVoid: false } methodSymbol)
+            {
+                continue;
+            }
+
+            ISymbol canonicalReturn = Canonical(methodSymbol);
+
+            if (arrowBody != null)
+            {
+                ApplyReturnValue(canonicalReturn, arrowBody, model, tainted, edges);
+            }
+
+            foreach (ReturnStatementSyntax statement in EnumerateOwnReturns(node))
+            {
+                if (statement.Expression != null)
+                {
+                    ApplyReturnValue(canonicalReturn, statement.Expression, model, tainted, edges);
+                }
+            }
+        }
+    }
+
+    private static void ApplyReturnValue(
+        ISymbol returnSymbol,
+        ExpressionSyntax value,
+        SemanticModel model,
+        HashSet<ISymbol> tainted,
+        List<(ISymbol Target, ISymbol Source)> edges)
+    {
+        if (IsDirectlyNullable(value, model))
+        {
+            tainted.Add(returnSymbol);
+        }
+        else
+        {
+            AddEdges(returnSymbol, value, model, edges);
+        }
+    }
+
+    // The `return` statements that belong to <paramref name="member"/> itself,
+    // excluding those inside a nested lambda / local function (which have their
+    // own return contract).
+    private static IEnumerable<ReturnStatementSyntax> EnumerateOwnReturns(SyntaxNode member)
+    {
+        SyntaxNode body = member switch
+        {
+            MethodDeclarationSyntax m => (SyntaxNode)m.Body,
+            LocalFunctionStatementSyntax l => l.Body,
+            _ => null,
+        };
+
+        if (body == null)
+        {
+            yield break;
+        }
+
+        foreach (SyntaxNode descendant in body.DescendantNodes(
+            n => n is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax)))
+        {
+            if (descendant is ReturnStatementSyntax statement)
+            {
+                yield return statement;
+            }
+        }
+    }
+
+    // Adds transitive edges `target <- source` for every declaration symbol the
+    // value expression reads (identifier/member) or the method it calls
+    // (invocation), unwrapping the compositional forms `??`, `?:`, `(cast)`.
+    private static void AddEdges(
+        ISymbol target,
+        ExpressionSyntax value,
+        SemanticModel model,
+        List<(ISymbol Target, ISymbol Source)> edges)
+    {
+        foreach (ISymbol source in ResolveSources(value, model))
+        {
+            edges.Add((target, source));
+        }
+    }
+
+    private static IEnumerable<ISymbol> ResolveSources(ExpressionSyntax expression, SemanticModel model)
+    {
+        switch (expression)
+        {
+            case null:
+                yield break;
+
+            case ParenthesizedExpressionSyntax paren:
+                foreach (ISymbol source in ResolveSources(paren.Expression, model))
+                {
+                    yield return source;
+                }
+
+                break;
+
+            case PostfixUnaryExpressionSyntax suppress
+                when suppress.IsKind(SyntaxKind.SuppressNullableWarningExpression):
+                yield break;
+
+            // `a ?? b`: the result is `b`'s value when `a` is null.
+            case BinaryExpressionSyntax coalesce
+                when coalesce.IsKind(SyntaxKind.CoalesceExpression):
+                foreach (ISymbol source in ResolveSources(coalesce.Right, model))
+                {
+                    yield return source;
+                }
+
+                break;
+
+            // `cond ? a : b`: either branch may flow through.
+            case ConditionalExpressionSyntax ternary:
+                foreach (ISymbol source in ResolveSources(ternary.WhenTrue, model)
+                    .Concat(ResolveSources(ternary.WhenFalse, model)))
+                {
+                    yield return source;
+                }
+
+                break;
+
+            case CastExpressionSyntax cast:
+                foreach (ISymbol source in ResolveSources(cast.Expression, model))
+                {
+                    yield return source;
+                }
+
+                break;
+
+            case InvocationExpressionSyntax invocation:
+                if (model.GetSymbolInfo(invocation).Symbol is IMethodSymbol called
+                    && !called.ReturnsVoid)
+                {
+                    yield return Canonical(called);
+                }
+
+                break;
+
+            case IdentifierNameSyntax:
+            case MemberAccessExpressionSyntax:
+                ISymbol symbol = model.GetSymbolInfo(expression).Symbol;
+                if (symbol != null && (IsValueDeclarationSymbol(symbol) || symbol is IMethodSymbol))
+                {
+                    yield return Canonical(symbol);
+                }
+
+                break;
+        }
+    }
+
+    // Taints the declaration symbol an lvalue-ish expression binds to (the
+    // receiver of a null-check / null-assignment / `?.`).
+    private static void TaintTarget(ExpressionSyntax expression, SemanticModel model, HashSet<ISymbol> tainted)
+    {
+        ISymbol symbol = ResolveAssignable(expression, model);
+        if (symbol != null)
+        {
+            tainted.Add(symbol);
+        }
+    }
+
+    // Resolves the field/property/parameter/local a reference expression binds
+    // to (canonicalized), or null when the expression is not a simple binding to
+    // one of those (e.g. an element access, a method group, a `this`).
+    private static ISymbol ResolveAssignable(ExpressionSyntax expression, SemanticModel model)
+    {
+        switch (expression)
+        {
+            case ParenthesizedExpressionSyntax paren:
+                return ResolveAssignable(paren.Expression, model);
+
+            case IdentifierNameSyntax:
+            case MemberAccessExpressionSyntax:
+                ISymbol symbol = model.GetSymbolInfo(expression).Symbol;
+                return symbol != null && IsValueDeclarationSymbol(symbol) ? Canonical(symbol) : null;
+
+            default:
+                return null;
+        }
+    }
+
+    // Whether a reference expression is directly (syntactically or by declared
+    // BCL annotation) nullable, independent of any other declaration's taint.
+    // Mirrors the translator's IsNullableInitializer, plus the `null`/`default`
+    // literal forms used in initializer/return positions.
+    private static bool IsDirectlyNullable(ExpressionSyntax expression, SemanticModel model)
+    {
+        switch (expression)
+        {
+            case null:
+                return false;
+
+            case ParenthesizedExpressionSyntax paren:
+                return IsDirectlyNullable(paren.Expression, model);
+
+            case PostfixUnaryExpressionSyntax suppress
+                when suppress.IsKind(SyntaxKind.SuppressNullableWarningExpression):
+                return false;
+
+            case LiteralExpressionSyntax literal:
+                return literal.IsKind(SyntaxKind.NullLiteralExpression)
+                    || (literal.IsKind(SyntaxKind.DefaultLiteralExpression)
+                        && IsReferenceLike(model.GetTypeInfo(literal).ConvertedType));
+
+            case DefaultExpressionSyntax defaultExpression:
+                return IsReferenceLike(model.GetTypeInfo(defaultExpression).Type);
+
+            // `a?.b` / `a?[i]`.
+            case ConditionalAccessExpressionSyntax:
+                return true;
+
+            // `a ?? b`: nullable iff the `b` fallback is nullable.
+            case BinaryExpressionSyntax coalesce
+                when coalesce.IsKind(SyntaxKind.CoalesceExpression):
+                return IsDirectlyNullable(coalesce.Right, model);
+
+            // `cond ? a : b`: nullable iff either branch is.
+            case ConditionalExpressionSyntax ternary:
+                return IsDirectlyNullable(ternary.WhenTrue, model)
+                    || IsDirectlyNullable(ternary.WhenFalse, model);
+        }
+
+        // Flow nullability when the context happens to be enabled (inert in a
+        // truly oblivious compilation, but harmless).
+        TypeInfo info = model.GetTypeInfo(expression);
+        if (info.Nullability.Annotation == NullableAnnotation.Annotated)
+        {
+            return true;
+        }
+
+        // Otherwise consult the bound symbol's DECLARED annotation, which
+        // survives in BCL/source metadata regardless of the consuming context
+        // (e.g. `AssemblyName.Name` and `Path.GetFileNameWithoutExtension(...)`
+        // are declared `string?`).
+        ISymbol symbol = model.GetSymbolInfo(expression).Symbol;
+        ITypeSymbol symbolType = symbol switch
+        {
+            IMethodSymbol m => m.ReturnType,
+            IPropertySymbol p => p.Type,
+            IFieldSymbol f => f.Type,
+            ILocalSymbol l => l.Type,
+            IParameterSymbol pr => pr.Type,
+            _ => null,
+        };
+
+        return symbolType is { IsReferenceType: true }
+            && symbolType.NullableAnnotation == NullableAnnotation.Annotated;
+    }
+
+    private static bool IsReferenceLike(ITypeSymbol type) =>
+        type is { IsReferenceType: true } || type is ITypeParameterSymbol;
+
+    // The declaration kinds whose emitted reference type this analysis governs.
+    private static bool IsValueDeclarationSymbol(ISymbol symbol) =>
+        symbol is IFieldSymbol or IPropertySymbol or IParameterSymbol or ILocalSymbol;
+
+    private static ISymbol Canonical(ISymbol symbol)
+    {
+        // A reduced extension-method invocation (`value.Ext(...)`) binds to the
+        // REDUCED method symbol, whereas the extension's own declaration node
+        // binds to the UNREDUCED static method; normalize to the unreduced
+        // original so a return-taint keyed on the declaration matches a call-site
+        // edge that reads it (issue #2113 — otherwise chained extension methods
+        // like `values.FirstEtAlImpl(...)` never propagate their nullable return).
+        if (symbol is IMethodSymbol method)
+        {
+            return (method.ReducedFrom ?? method).OriginalDefinition;
+        }
+
+        return symbol?.OriginalDefinition ?? symbol;
+    }
+
+    // `x is null` / `x is not null` constant pattern.
+    private static bool IsNullConstantPattern(PatternSyntax pattern)
+    {
+        if (pattern is UnaryPatternSyntax unary && unary.IsKind(SyntaxKind.NotPattern))
+        {
+            pattern = unary.Pattern;
+        }
+
+        return pattern is ConstantPatternSyntax constant && IsNullLiteral(constant.Expression);
+    }
+
+    private static bool IsNullLiteral(ExpressionSyntax expression) =>
+        expression is LiteralExpressionSyntax literal
+            && literal.IsKind(SyntaxKind.NullLiteralExpression);
+
+    // `null` or `null!` (a SuppressNullableWarning over a null literal).
+    private static bool IsNullOrSuppressedNull(ExpressionSyntax expression)
+    {
+        if (expression is PostfixUnaryExpressionSyntax suppress
+            && suppress.IsKind(SyntaxKind.SuppressNullableWarningExpression))
+        {
+            expression = suppress.Operand;
+        }
+
+        return IsNullLiteral(expression);
+    }
+
+    private sealed class TaintResult
+    {
+        public TaintResult(HashSet<ISymbol> tainted) => this.Tainted = tainted;
+
+        public HashSet<ISymbol> Tainted { get; }
+    }
+}


### PR DESCRIPTION
Implements a separate nullability-mapping layer for nullable-**oblivious** C# projects (issue #2113): a reference-type declaration is emitted as G# `T?` iff a whole-program transitive null-taint analysis proves the declaration null-tainted; otherwise it stays idiomatic non-null `T`.

## Why

An oblivious C# project (`<Nullable>` unset — Roslyn reports every reference type as `NullableAnnotation.None` with no flow state) previously mapped `T` to non-null `T`. That collides with the `T?` values cs2gs legitimately introduces (`?.`, `= null` defaults, nullable-returning BCL such as `AssemblyName.Name` / `Path.GetFileNameWithoutExtension`), yielding a cluster of `GS0154/GS0155/GS0156` "T? vs T" errors.

## Design

`ObliviousNullabilityAnalyzer` (new) computes, once per `Compilation` (cached via `ConditionalWeakTable`, gated to `NullableContextOptions.Disable`), the set of null-tainted declaration symbols:
- **Direct taint** (all syntax trees), reusing the existing evidence rules: `== null`/`!= null`, `= null`/`= null!`, `??=`, `is null`/`is not null`, `?.`/`?[`, initializer/default `= null|default`, and nullable-typed initializer/return expressions.
- **Method return taint** for any `return null|default|<nullable-expr>` path.
- **Transitive closure** over assignment / initializer / return / interprocedural call-arg->parameter edges to a fixpoint.

Emitted decision (oblivious only): reference declaration -> `T?` iff tainted, else `T`. Type parameters are excluded (a `where T:class` `T?` would break `Cast[T]`/`typeof(T)` name positions). Tainted local/parameter receivers that gsc cannot smart-cast under oblivious metadata get a `!!` assertion, preserving C#'s throw-on-null semantics.

There are **no changes to `CSharpTypeMapper.Map` or the printer**, so type-name positions and nullable-**enabled** compilations are byte-identical to before: `IsTainted` short-circuits to `false` whenever the compilation is not oblivious.

## Results (Oahu corpus; translate = PASS throughout)

| Project | Before | After |
|---|---|---|
| Oahu.Foundation | 58 | **37** |
| Oahu.SystemManagement | 4 | **2** |
| Oahu.Decrypt (nullable-enabled) | 0 | **0** (invariant held) |

The "T? vs T" cluster is resolved. The Foundation residual (37) is genuine other gsc/translator gaps unrelated to this change (unsafe pointer conversions, unconstrained type-parameter `T?`, missing ctors, abstract-instantiation #987, and tainted values flowing into external non-null BCL sinks — the latter needing argument-site forgiveness the issue scoped as a future optimization).

## Tests

New `Issue2113ObliviousNullableTranslationTests` (oblivious tainted field/param/return -> `T?`; oblivious untainted -> `T`; nullable-enabled unchanged). Full cs2gs suite: **1099 passed, 0 failed**.

Fixes #2113
Refs #914
