### PR TITLE
cs2gs: null-forgive receivers/foreach-sources over oblivious external members

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2113ObliviousNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2113ObliviousNullableTranslationTests.cs
@@ -126,6 +126,93 @@ namespace Demo
         Assert.Contains("maybe string?", printed);
     }
 
+    [Fact]
+    public void Oblivious_ForEachOverObliviousExternalCall_ForgivesSource()
+    {
+        // `Ext.Get()` comes from an assembly compiled WITHOUT a nullable context,
+        // so Roslyn reports its `List<int>` return as oblivious (NullableAnnotation
+        // .None) and gsc maps it to `List[int32]?`. A plain `for x in ext.Get()`
+        // is then rejected (GS0116 "not indexable"); the source must be asserted
+        // non-null (`ext.Get()!!`), matching C#'s throw-on-null foreach semantics.
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Run(Ext ext)
+        {
+            foreach (var x in ext.Get()) { }
+        }
+    }
+}");
+
+        Assert.Contains("for x in ext.Get()!!", printed);
+    }
+
+    [Fact]
+    public void Oblivious_ForEachOverLocalFromObliviousExternalCall_ForgivesSource()
+    {
+        // Same as above but the oblivious external result is bound to a `let` local
+        // first (`let items = ext.Get()`). gsc infers the local as `List[int32]?`,
+        // so the foreach source needs `items!!`. Promoting the local's declaration
+        // to `T?` would cascade nullable-conversion errors at its non-null uses, so
+        // the `!!` is applied at the use site only.
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Run(Ext ext)
+        {
+            var items = ext.Get();
+            foreach (var x in items) { }
+        }
+    }
+}");
+
+        Assert.Contains("for x in items!!", printed);
+    }
+
+    private static string TranslateObliviousWithObliviousLibrary(string source)
+    {
+        // A tiny "external" library compiled WITHOUT a nullable context: its
+        // `Get()` return type is oblivious (NullableAnnotation.None), exactly like
+        // an unannotated NuGet package (e.g. System.Management).
+        var libTree = CSharpSyntaxTree.ParseText(
+            @"public class Ext { public System.Collections.Generic.List<int> Get() { return null; } }",
+            new CSharpParseOptions(LanguageVersion.Latest));
+        var libCompilation = CSharpCompilation.Create(
+            "ObliviousLib",
+            new[] { libTree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable));
+        using var peStream = new System.IO.MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult emit = libCompilation.Emit(peStream);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        peStream.Position = 0;
+        MetadataReference libReference = MetadataReference.CreateFromStream(peStream);
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.ObliviousExternalInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Append(libReference).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
     private static string TranslateOblivious(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -12464,6 +12464,24 @@ public sealed class CSharpToGSharpTranslator
                 return true;
             }
 
+            // Issue #2113 follow-up: a value produced by an EXTERNAL (metadata)
+            // member compiled WITHOUT a nullable context is oblivious — Roslyn
+            // reports its reference-type return/type as `NullableAnnotation.None`
+            // — and gsc maps every such oblivious external reference type to `T?`.
+            // A method-call/property/field receiver like `searcher.Get()` (from an
+            // unannotated package, e.g. System.Management) is therefore rejected on
+            // `recv.Member` / `recv[i]` / `for … in recv` (GS0158/GS0116) even
+            // though C# accepts it (it would `NullReferenceException` on null just
+            // the same). Assert `recv!!` to compile and preserve that throw-on-null
+            // behavior. Gated to oblivious so nullable-enabled projects — whose
+            // external refs carry real annotations — are untouched.
+            if (this.IsObliviousCompilation()
+                && (IsObliviousExternalNullableMember(symbol)
+                    || this.LocalInitializedFromObliviousExternalNullable(symbol)))
+            {
+                return true;
+            }
+
             ITypeSymbol declared = symbol switch
             {
                 IPropertySymbol property => property.Type,
@@ -12487,6 +12505,73 @@ public sealed class CSharpToGSharpTranslator
         // pre-#2113 behavior.
         private bool IsObliviousCompilation() =>
             this.context.Compilation.Options.NullableContextOptions == NullableContextOptions.Disable;
+
+        // Issue #2113 follow-up: true when <paramref name="symbol"/> is an EXTERNAL
+        // (metadata) method/property/field whose reference-type return/type is
+        // oblivious (<c>NullableAnnotation.None</c>, i.e. the declaring assembly was
+        // compiled without a nullable context, e.g. System.Management). gsc maps
+        // every such oblivious external reference type to <c>T?</c>, so a value
+        // read from one is nullable from gsc's point of view. Restricted to
+        // external symbols because a SOURCE symbol in an oblivious compilation is
+        // also <c>None</c> but its nullability is decided by the whole-program
+        // taint analysis instead, not treated as unconditionally nullable.
+        private static bool IsObliviousExternalNullableMember(ISymbol symbol)
+        {
+            if (symbol is not (IMethodSymbol or IPropertySymbol or IFieldSymbol)
+                || !symbol.DeclaringSyntaxReferences.IsDefaultOrEmpty)
+            {
+                return false;
+            }
+
+            // Use the member's ORIGINAL (unsubstituted) return/type: gsc maps a
+            // member to `T?` based on the nullable context of the assembly that
+            // DECLARES it, not on a type argument the consumer supplies. An
+            // annotated BCL member like `IReadOnlyList<T>.this[int]` returns the
+            // type parameter `T` (excluded below), so `list[i]` stays non-null even
+            // in oblivious consumer code — only a member whose own declared return
+            // is a concrete oblivious reference type (e.g. System.Management's
+            // `ManagementObjectSearcher.Get()` -> `ManagementObjectCollection`) is
+            // treated as nullable.
+            ISymbol original = symbol.OriginalDefinition;
+            ITypeSymbol type = original switch
+            {
+                IMethodSymbol m => m.ReturnType,
+                IPropertySymbol p => p.Type,
+                IFieldSymbol f => f.Type,
+                _ => null,
+            };
+
+            return type is { IsReferenceType: true }
+                and not ITypeParameterSymbol
+                && type.NullableAnnotation == NullableAnnotation.None;
+        }
+
+        // Issue #2113 follow-up: true when <paramref name="symbol"/> is a `let`
+        // local whose type is inferred from an initializer that reads an oblivious
+        // external nullable member (e.g. `let coll = searcher.Get()`). gsc infers
+        // such a local as `T?`, so a `coll.Member` / `for … in coll` use needs a
+        // `!!` — but promoting the local's DECLARATION to `T?` cascades
+        // nullable-conversion errors at its other (non-null) uses, so the
+        // assertion is applied only here at the receiver/foreach-source use site.
+        private bool LocalInitializedFromObliviousExternalNullable(ISymbol symbol)
+        {
+            if (symbol is not ILocalSymbol local)
+            {
+                return false;
+            }
+
+            foreach (SyntaxReference reference in local.DeclaringSyntaxReferences)
+            {
+                if (reference.GetSyntax() is VariableDeclaratorSyntax { Initializer.Value: { } initializer }
+                    && IsObliviousExternalNullableMember(
+                        this.context.GetSymbolInfo(initializer).Symbol))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         // True when <paramref name="member"/> binds to an extension method whose
         // (reduced) `this` parameter is nullable-annotated (`this T? x`). Such a


### PR DESCRIPTION
## Summary
In a nullable-**oblivious** compilation, `gsc` maps every reference type read from an **external** member declared in an assembly compiled without a nullable context (e.g. an unannotated package such as `System.Management`) to `T?`. A member/element/`for..in` use of such a value was rejected (`GS0158`/`GS0116`) even though C# accepts it obliviously (it would throw a `NullReferenceException` on `null` just the same — as would `!!`).

This extends the oblivious `!!` receiver-forgiveness pass so a receiver/foreach-source that reads a concrete oblivious external reference member is asserted non-null. A `let` local whose inferred type comes from such a call is forgiven **at the use site** (not by promoting its declaration, which would cascade nullable-conversion errors at its other non-null uses).

The predicate uses the member's **original (unsubstituted)** declared return type, so an annotated BCL generic like `IReadOnlyList<T>.this[int]` (returns type parameter `T`) stays non-null even when an oblivious consumer supplies an oblivious type argument. Gated to oblivious compilations — nullable-enabled projects are byte-identical.

## Effect on the Oahu corpus
- **Oahu.SystemManagement**: the `GS0116` "not indexable" blockers on `for queryObj in searcher.Get()` (MotherboardInfo) and `for mo in mbsList` where `mbsList = mbs.Get()` (HardwareId) are cleared. Iteration now compiles; the previously-masked next-layer oblivious `string?` errors are surfaced (tracked separately).
- **Oahu.Foundation**: unchanged (37).
- **Oahu.Decrypt** (nullable-**enabled** invariant): unchanged (0).

## Tests
- Two new tests in `Issue2113ObliviousNullableTranslationTests` compile a small oblivious-context "library" to metadata and assert the foreach source (direct call and via a `let` local) is emitted with `!!`.
- Full `Cs2Gs.Tests` suite: **1101 passed**.

Refs #914
