### PR TITLE
Add lambda-to-Expression<TDelegate> lowering (issue #2130)

### DIFF
--- a/docs/adr/0141-expression-tree-lambda-conversions.md
+++ b/docs/adr/0141-expression-tree-lambda-conversions.md
@@ -1,0 +1,148 @@
+# ADR-0141: lambda conversions to `Expression[TDelegate]`
+
+- **Status**: Accepted
+- **Date**: 2026-07-05
+- **Phase**: Phase 9 — language depth / CLR interop
+- **Related**: issue [#2130](https://github.com/DavidObando/gsharp/issues/2130)
+
+## Context
+
+G# already supported lambda/func literals targeting delegates and native
+function types, but it treated `System.Linq.Expressions.Expression[TDelegate]`
+like any other imported generic type. As a result, assignments and call-site
+arguments such as:
+
+```gsharp
+let selector Expression[Func[Book, int32]] = (b Book) -> b.Id
+```
+
+failed with GS0155 / GS0154 instead of producing a runtime expression tree.
+That blocked common .NET APIs whose surface is expression-tree based, including
+Entity Framework Core fluent mapping APIs (issue #2130).
+
+The compiler also had no expression-tree lowering path at all: no binder
+recognition, no legality checks, and no emit-time construction of
+`System.Linq.Expressions.Expression.*` nodes.
+
+## Decision
+
+Treat `Expression[TDelegate]` as a first-class lambda target when:
+
+1. the outer type is `System.Linq.Expressions.Expression\`1`, and
+2. `TDelegate` is delegate-like (native function type, imported CLR delegate,
+   or user-declared named delegate).
+
+The implementation has three parts:
+
+### 1. Target recognition and conversion binding
+
+`MemberLookup` now exposes a single “lambda target shape” probe that accepts:
+
+- G# function types
+- named delegates
+- imported CLR delegates
+- `Expression[TDelegate]`
+
+`ConversionClassifier` uses that probe so a lambda may bind to an
+expression-tree target anywhere ordinary implicit argument/assignment
+conversions run: local declarations, assignments, returns, and call arguments.
+
+Invalid `Expression[T]` targets report:
+
+| Code   | Message summary |
+| ------ | ---------------- |
+| GS0474 | `Expression[T]` requires `T` to be a delegate type. |
+
+### 2. Expression-tree restriction validation
+
+Before lowering, the compiler walks the already-bound lambda body and rejects
+constructs that do not have a safe `System.Linq.Expressions` representation in
+this compiler/runtime surface.
+
+The shared diagnostic is:
+
+| Code   | Message summary |
+| ------ | ---------------- |
+| GS0473 | Unsupported construct inside an expression-tree lambda. |
+
+The validator currently accepts the expression forms the lowerer can faithfully
+materialize and rejects the rest explicitly instead of silently compiling the
+wrong program.
+
+Supported inside an expression-tree lambda:
+
+- parameters and captured locals
+- literal/default/`typeof`
+- field and property access (instance/static)
+- imported and user member calls
+- indexers and array indexing
+- unary and binary operators with an expression-factory equivalent
+- conditional `?:`
+- null coalescing `??`
+- reference / numeric conversions
+- `is` type tests and `as`
+- object construction and array creation
+- nested lambda values when a runtime expression/delegate object is required
+
+Explicitly rejected with GS0473:
+
+- statement-bodied lambdas
+- async / `await`
+- assignment expressions
+- tuple literals / tuple assignment shapes
+- switch expressions and unsupported pattern forms
+- throw expressions
+- null-propagation
+- discards
+- local functions
+- `dynamic`
+- unsupported by-ref / pointer / unsafe shapes
+- collection/map literals and other constructs without a stable expression-tree
+  lowering in this compiler
+
+### 3. Emit-time lowering
+
+A dedicated lowering pass rewrites lambda-to-`Expression[TDelegate]`
+conversions into bound calls to `System.Linq.Expressions.Expression` factory
+methods. The lowered shape is equivalent to:
+
+1. allocate `ParameterExpression` locals for lambda parameters
+2. translate the bound body into `Expression.*` nodes
+3. call `Expression.Lambda(...)`
+4. cast the resulting `LambdaExpression` to the exact target
+   `Expression[TDelegate]`
+
+The lowerer runs after closure boxing so captured locals reuse the existing
+capture analysis. A captured variable is represented by building the runtime
+capture access first, then embedding that value into the tree through
+`Expression.Constant(...)` and normal member-access factories. This matches the
+existing closure representation instead of inventing a second capture model.
+
+Call-site conversions were also updated so a direct lambda argument can bind to
+an `Expression[TDelegate]` parameter the same way a direct delegate argument
+already could.
+
+## Consequences
+
+- Positive: G# lambdas can now flow into expression-tree APIs, including the
+  direct call/assignment shapes needed by issue #2130.
+- Positive: unsupported constructs fail early with dedicated diagnostics rather
+  than later with GS0155 or, worse, a malformed tree.
+- Positive: closure handling reuses the existing capture pipeline, so
+  expression-tree lambdas observe the same captured values as delegate lambdas.
+- Negative: the restriction set is intentionally conservative where the current
+  runtime/lowering surface lacks a verified representation; unsupported syntax
+  is rejected instead of partially lowered.
+
+## Alternatives considered
+
+- **Treat `Expression[TDelegate]` as just another imported generic and rely on
+  user-written factory calls.** Rejected: it does not support idiomatic .NET
+  APIs and leaves ordinary lambda syntax unusable for a large slice of the
+  ecosystem.
+- **Lower expression trees directly in the emitter without a dedicated pass.**
+  Rejected: the conversion needs whole-expression rewriting, legality checks,
+  and closure-aware synthesis before ordinary IL emission.
+- **Invent separate capture analysis for expression-tree lambdas.** Rejected:
+  the compiler already knows how to box and access captured locals; duplicating
+  that logic would drift quickly and risk semantic mismatches.

--- a/docs/adr/0141-expression-tree-lambda-conversions.md
+++ b/docs/adr/0141-expression-tree-lambda-conversions.md
@@ -75,14 +75,16 @@ Supported inside an expression-tree lambda:
 - literal/default/`typeof`
 - field and property access (instance/static)
 - imported and user member calls
-- indexers and array indexing
+- array indexing plus CLR/user-defined indexers
 - unary and binary operators with an expression-factory equivalent
 - conditional `?:`
 - null coalescing `??`
 - reference / numeric conversions
 - `is` type tests and `as`
-- object construction and array creation
-- nested lambda values when a runtime expression/delegate object is required
+- object construction, object-initializer member assignments, and array creation
+- nested lambdas as call arguments:
+  - delegate-typed parameters capture a real runtime delegate via `Expression.Constant`
+  - `Expression[TDelegate]`-typed parameters recursively lower to nested lambda trees
 
 Explicitly rejected with GS0473:
 
@@ -97,8 +99,9 @@ Explicitly rejected with GS0473:
 - local functions
 - `dynamic`
 - unsupported by-ref / pointer / unsafe shapes
-- collection/map literals and other constructs without a stable expression-tree
-  lowering in this compiler
+- collection/list initializer forms (including collection-member initializer
+  subforms inside object initializers), map literals, and other constructs
+  without a stable expression-tree lowering in this compiler
 
 ### 3. Emit-time lowering
 

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2480,21 +2480,7 @@ public sealed class Binder
                 // CLR shape so member / index / conversion resolution keeps
                 // working, while the symbolic `[T]` is preserved on the result
                 // for inference, substitution, and erased emit.
-                if (TypeSymbol.ContainsTypeParameter(ta))
-                {
-                    hasTypeParameterArg = true;
-                    clrArgs[i] = scope.References.MapClrTypeToReferences(typeof(object));
-                    continue;
-                }
-
-                // Issue #671: a user-defined G# type (class, struct,
-                // interface, enum, delegate) used as a type argument to a CLR
-                // generic has no ClrType at bind time — the CLR TypeDef is only
-                // produced during emit. Handle the same way as type parameters:
-                // project onto System.Object for the closed CLR shape and
-                // preserve the symbolic argument via GetConstructed so the
-                // emitter can recover the real type.
-                if (ta.ClrType == null)
+                if (TypeSymbol.ContainsTypeParameter(ta) || TypeSymbol.ContainsSameCompilationUserType(ta))
                 {
                     hasTypeParameterArg = true;
                     clrArgs[i] = scope.References.MapClrTypeToReferences(typeof(object));
@@ -3473,7 +3459,7 @@ public sealed class Binder
 
             // #313 / #671: in-scope type parameters and user types without a
             // ClrType project onto System.Object under the type-erased model.
-            if (TypeSymbol.ContainsTypeParameter(ta) || ta.ClrType == null)
+            if (TypeSymbol.ContainsTypeParameter(ta) || TypeSymbol.ContainsSameCompilationUserType(ta) || ta.ClrType == null)
             {
                 hasTypeParameterArg = true;
                 clrArgs[i] = scope.References.MapClrTypeToReferences(typeof(object));

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -334,6 +334,19 @@ internal sealed class ConversionClassifier
             return BindUserMethodGroupConversion(diagnosticLocation, userMethodGroup, type);
         }
 
+        if (expression is BoundFunctionLiteralExpression expressionTreeLiteral
+            && MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(type, out var expressionTreeDelegateType))
+        {
+            if (!MemberLookup.TryGetDelegateFunctionTypeFromSymbol(expressionTreeDelegateType, out _))
+            {
+                Diagnostics.ReportExpressionTreeTargetMustBeDelegate(diagnosticLocation, type);
+                return new BoundErrorExpression(null);
+            }
+
+            ExpressionTreeRestrictionValidator.Validate(expressionTreeLiteral, type, Diagnostics);
+            return new BoundConversionExpression(null, type, expressionTreeLiteral);
+        }
+
         if (expression is BoundFunctionLiteralExpression literal
             && type is FunctionTypeSymbol targetFunctionType
             && TypeSymbol.ContainsTypeParameter(targetFunctionType))
@@ -353,7 +366,7 @@ internal sealed class ConversionClassifier
             && voidCandidateLiteral.FunctionType is FunctionTypeSymbol voidCandidateFnType
             && voidCandidateFnType.ReturnType != TypeSymbol.Void
             && voidCandidateFnType.ReturnType != TypeSymbol.Error
-            && MemberLookup.TryGetDelegateFunctionTypeFromSymbol(type, out var voidTargetFnType)
+            && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(type, out var voidTargetFnType)
             && voidTargetFnType.ReturnType == TypeSymbol.Void
             && voidTargetFnType.Arity == voidCandidateFnType.Arity
             && !ReferenceEquals(type, voidCandidateFnType))
@@ -378,7 +391,7 @@ internal sealed class ConversionClassifier
             && widenCandidateLiteral.FunctionType is FunctionTypeSymbol widenCandidateFnType
             && widenCandidateFnType.ReturnType != TypeSymbol.Void
             && widenCandidateFnType.ReturnType != TypeSymbol.Error
-            && MemberLookup.TryGetDelegateFunctionTypeFromSymbol(type, out var widenTargetFnType)
+            && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(type, out var widenTargetFnType)
             && widenTargetFnType.ReturnType != TypeSymbol.Void
             && widenTargetFnType.ReturnType != TypeSymbol.Error
             && widenTargetFnType.Arity == widenCandidateFnType.Arity

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2818,7 +2818,7 @@ internal sealed partial class ExpressionBinder
                     }
 
                     if (idx < method.Parameters.Length
-                        && MemberLookup.TryGetDelegateFunctionTypeFromSymbol(method.Parameters[idx].Type, out var staticTarget)
+                        && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(method.Parameters[idx].Type, out var staticTarget)
                         && staticTarget != null)
                     {
                         rebound[idx] = lambdas.BindLambdaExpression(staticLambda, staticTarget);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1110,7 +1110,7 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            if (!MemberLookup.TryGetDelegateFunctionType(parameterType, out var candidate) || candidate == null)
+            if (!MemberLookup.TryGetLambdaTargetFunctionType(parameterType, out var candidate) || candidate == null)
             {
                 continue;
             }
@@ -1888,7 +1888,7 @@ internal sealed partial class ExpressionBinder
                     continue;
                 }
 
-                if (!MemberLookup.TryGetDelegateFunctionTypeFromSymbol(candidate.Parameters[paramPos].Type, out var fn) || fn == null)
+                if (!MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(candidate.Parameters[paramPos].Type, out var fn) || fn == null)
                 {
                     continue;
                 }
@@ -2334,7 +2334,7 @@ internal sealed partial class ExpressionBinder
                 var parameterType = parameters[paramIndex].ParameterType;
                 if (parameterType == null
                     || parameterType.ContainsGenericParameters
-                    || !MemberLookup.TryGetDelegateFunctionType(parameterType, out var fn)
+                    || !MemberLookup.TryGetLambdaTargetFunctionType(parameterType, out var fn)
                     || fn == null)
                 {
                     allMapped = false;
@@ -4868,7 +4868,7 @@ internal sealed partial class ExpressionBinder
             var rebound = argument;
             if (paramIndex < parameters.Length
                 && LambdaBinder.TryGetFunctionLiteral(argument, out var literal)
-                && MemberLookup.TryGetDelegateFunctionType(parameters[paramIndex].ParameterType, out var targetFunctionType)
+                && MemberLookup.TryGetLambdaTargetFunctionType(parameters[paramIndex].ParameterType, out var targetFunctionType)
                 && literal.FunctionType != targetFunctionType)
             {
                 // Issue #1512: when the call is a generic method whose delegate
@@ -4970,7 +4970,7 @@ internal sealed partial class ExpressionBinder
                 && literal.FunctionType is FunctionTypeSymbol literalFnType
                 && literalFnType.ReturnType != TypeSymbol.Void
                 && literalFnType.ReturnType != TypeSymbol.Error
-                && MemberLookup.TryGetDelegateFunctionType(parameters[paramIndex].ParameterType, out var targetFunctionType)
+                && MemberLookup.TryGetLambdaTargetFunctionType(parameters[paramIndex].ParameterType, out var targetFunctionType)
                 && targetFunctionType.ReturnType != TypeSymbol.Void
                 && targetFunctionType.ReturnType != TypeSymbol.Error
                 && targetFunctionType.Arity == literalFnType.Arity

--- a/src/Core/CodeAnalysis/Binding/ExpressionTreeRestrictionValidator.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionTreeRestrictionValidator.cs
@@ -332,7 +332,12 @@ internal static class ExpressionTreeRestrictionValidator
                 diagnostics.ReportExpressionTreeUnsupported(LocationOf(expression.Syntax), "a method group");
                 return;
 
-            case BoundBlockExpression:
+            case BoundBlockExpression block:
+                if (TryValidateObjectInitializer(block, diagnostics))
+                {
+                    return;
+                }
+
                 diagnostics.ReportExpressionTreeUnsupported(LocationOf(expression.Syntax), "a block expression");
                 return;
 
@@ -382,4 +387,86 @@ internal static class ExpressionTreeRestrictionValidator
 
     private static TextLocation LocationOf(SyntaxNode syntax)
         => syntax != null ? syntax.Location : default;
+
+    private static bool TryValidateObjectInitializer(BoundBlockExpression block, DiagnosticBag diagnostics)
+    {
+        if (!TryMatchObjectInitializer(block, out var receiver, out var initializer, out var statements))
+        {
+            return false;
+        }
+
+        ValidateExpression(initializer, diagnostics);
+
+        foreach (var statement in statements)
+        {
+            if (statement is not BoundExpressionStatement expressionStatement)
+            {
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(statement.Syntax), "a block expression");
+                return true;
+            }
+
+            switch (expressionStatement.Expression)
+            {
+                case BoundFieldAssignmentExpression field when ReferencesReceiver(field, receiver):
+                    ValidateExpression(field.Value, diagnostics);
+                    break;
+                case BoundPropertyAssignmentExpression property when ReferencesReceiver(property.Receiver, receiver):
+                    ValidateExpression(property.Value, diagnostics);
+                    break;
+                case BoundClrPropertyAssignmentExpression clrProperty when ReferencesReceiver(clrProperty.Receiver, receiver):
+                    ValidateExpression(clrProperty.Value, diagnostics);
+                    break;
+                case BoundImportedInstanceCallExpression importedCall when ReferencesReceiver(importedCall.Receiver, receiver):
+                case BoundUserInstanceCallExpression userCall when ReferencesReceiver(userCall.Receiver, receiver):
+                case BoundClrIndexAssignmentExpression clrIndexAssignment when ReferencesReceiver(clrIndexAssignment, receiver):
+                case BoundIndexAssignmentExpression indexAssignment when ReferencesReceiver(indexAssignment, receiver):
+                    diagnostics.ReportExpressionTreeUnsupported(LocationOf(expressionStatement.Expression.Syntax), "a collection initializer");
+                    return true;
+                default:
+                    diagnostics.ReportExpressionTreeUnsupported(LocationOf(expressionStatement.Expression.Syntax), "a block expression");
+                    return true;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryMatchObjectInitializer(
+        BoundBlockExpression block,
+        out VariableSymbol receiver,
+        out BoundExpression initializer,
+        out System.Collections.Immutable.ImmutableArray<BoundStatement> statements)
+    {
+        receiver = null;
+        initializer = null;
+        statements = default;
+
+        if (block.Expression is not BoundVariableExpression result
+            || block.Statements.IsDefaultOrEmpty
+            || block.Statements[0] is not BoundVariableDeclaration declaration
+            || !ReferenceEquals(declaration.Variable, result.Variable))
+        {
+            return false;
+        }
+
+        receiver = declaration.Variable;
+        initializer = declaration.Initializer;
+        statements = block.Statements.RemoveAt(0);
+        return true;
+    }
+
+    private static bool ReferencesReceiver(BoundExpression expression, VariableSymbol receiver)
+        => expression is BoundVariableExpression variable && ReferenceEquals(variable.Variable, receiver);
+
+    private static bool ReferencesReceiver(BoundFieldAssignmentExpression assignment, VariableSymbol receiver)
+        => ReferenceEquals(assignment.Receiver, receiver)
+            || ReferencesReceiver(assignment.ReceiverExpression, receiver);
+
+    private static bool ReferencesReceiver(BoundClrIndexAssignmentExpression assignment, VariableSymbol receiver)
+        => ReferenceEquals(assignment.Target, receiver)
+            || ReferencesReceiver(assignment.TargetExpression, receiver);
+
+    private static bool ReferencesReceiver(BoundIndexAssignmentExpression assignment, VariableSymbol receiver)
+        => ReferenceEquals(assignment.Target, receiver)
+            || ReferencesReceiver(assignment.TargetExpression, receiver);
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionTreeRestrictionValidator.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionTreeRestrictionValidator.cs
@@ -1,0 +1,385 @@
+// <copyright file="ExpressionTreeRestrictionValidator.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2130: validates that a lambda being converted to
+/// <c>System.Linq.Expressions.Expression&lt;TDelegate&gt;</c> only uses the
+/// subset of language constructs G# lowers to expression-tree factory calls.
+/// </summary>
+internal static class ExpressionTreeRestrictionValidator
+{
+    public static void Validate(
+        BoundFunctionLiteralExpression literal,
+        TypeSymbol targetType,
+        DiagnosticBag diagnostics)
+    {
+        if (literal == null || diagnostics == null)
+        {
+            return;
+        }
+
+        if (!MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(targetType, out var delegateType)
+            || !MemberLookup.TryGetDelegateFunctionTypeFromSymbol(delegateType, out _))
+        {
+            diagnostics.ReportExpressionTreeTargetMustBeDelegate(
+                literal.Syntax != null
+                    ? literal.Syntax.Location
+                    : literal.Function.Declaration != null ? literal.Function.Declaration.Location : default,
+                targetType ?? TypeSymbol.Error);
+            return;
+        }
+
+        if (literal.Syntax is LambdaExpressionSyntax lambdaSyntax)
+        {
+            if (lambdaSyntax.IsAsync)
+            {
+                diagnostics.ReportExpressionTreeUnsupported(lambdaSyntax.AsyncModifier.Location, "an async lambda");
+            }
+
+            if (lambdaSyntax.Body is BlockExpressionSyntax)
+            {
+                diagnostics.ReportExpressionTreeUnsupported(lambdaSyntax.Body.Location, "a statement body");
+            }
+        }
+
+        foreach (var parameter in literal.Function.Parameters)
+        {
+            if (parameter.Name == "_")
+            {
+                diagnostics.ReportExpressionTreeUnsupported(
+                    parameter.DeclaringSyntax != null ? parameter.DeclaringSyntax.Location : literal.Syntax.Location,
+                    "a discard parameter");
+            }
+
+            if (parameter.RefKind != RefKind.None)
+            {
+                diagnostics.ReportExpressionTreeUnsupported(
+                    parameter.DeclaringSyntax != null ? parameter.DeclaringSyntax.Location : literal.Syntax.Location,
+                    $"a '{parameter.RefKind.ToString().ToLowerInvariant()}' parameter");
+            }
+
+            if (parameter.IsVariadic)
+            {
+                diagnostics.ReportExpressionTreeUnsupported(
+                    parameter.DeclaringSyntax != null ? parameter.DeclaringSyntax.Location : literal.Syntax.Location,
+                    "a variadic parameter");
+            }
+
+            if (TypeSymbol.IsByRefLike(parameter.Type) || parameter.Type is ByRefTypeSymbol or PointerTypeSymbol)
+            {
+                diagnostics.ReportExpressionTreeUnsupported(
+                    parameter.DeclaringSyntax != null ? parameter.DeclaringSyntax.Location : literal.Syntax.Location,
+                    $"the restricted type '{parameter.Type}'");
+            }
+        }
+
+        ValidateStatement(literal.Body, diagnostics);
+    }
+
+    private static void ValidateStatement(BoundStatement statement, DiagnosticBag diagnostics)
+    {
+        switch (statement)
+        {
+            case null:
+                return;
+            case BoundBlockStatement block:
+                foreach (var child in block.Statements)
+                {
+                    ValidateStatement(child, diagnostics);
+                }
+
+                return;
+            case BoundReturnStatement ret:
+                ValidateExpression(ret.Expression, diagnostics);
+                return;
+            case BoundExpressionStatement exprStmt:
+                ValidateExpression(exprStmt.Expression, diagnostics);
+                return;
+            default:
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(statement.Syntax), "a statement");
+                return;
+        }
+    }
+
+    private static void ValidateExpression(BoundExpression expression, DiagnosticBag diagnostics)
+    {
+        if (expression == null)
+        {
+            return;
+        }
+
+        if (expression.Type is ByRefTypeSymbol or PointerTypeSymbol || TypeSymbol.IsByRefLike(expression.Type))
+        {
+            diagnostics.ReportExpressionTreeUnsupported(
+                LocationOf(expression.Syntax),
+                $"the restricted type '{expression.Type}'");
+        }
+
+        switch (expression)
+        {
+            case BoundErrorExpression:
+            case BoundLiteralExpression:
+            case BoundVariableExpression:
+            case BoundDefaultExpression:
+            case BoundTypeOfExpression:
+                return;
+
+            case BoundFunctionLiteralExpression:
+                // Nested delegate-valued lambdas are allowed; they become
+                // Expression.Constant(delegateValue, typeof(DelegateType)).
+                return;
+
+            case BoundConversionExpression conversion:
+                if (conversion.Expression is BoundFunctionLiteralExpression nestedLiteral
+                    && MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(conversion.Type, out _))
+                {
+                    Validate(nestedLiteral, conversion.Type, diagnostics);
+                    return;
+                }
+
+                if (conversion.Expression.Type is TupleTypeSymbol || conversion.Type is TupleTypeSymbol)
+                {
+                    diagnostics.ReportExpressionTreeUnsupported(LocationOf(conversion.Syntax), "a tuple conversion");
+                }
+
+                ValidateExpression(conversion.Expression, diagnostics);
+                return;
+
+            case BoundUnaryExpression unary:
+                if (unary.Op.Kind is BoundUnaryOperatorKind.ReferenceOf or BoundUnaryOperatorKind.DereferenceOf)
+                {
+                    diagnostics.ReportExpressionTreeUnsupported(LocationOf(unary.Syntax), "an unsafe pointer operation");
+                }
+                else if (unary.Op.Kind == BoundUnaryOperatorKind.NullAssertion)
+                {
+                    diagnostics.ReportExpressionTreeUnsupported(LocationOf(unary.Syntax), "a null-assertion operator");
+                }
+
+                ValidateExpression(unary.Operand, diagnostics);
+                return;
+
+            case BoundBinaryExpression binary:
+                if (binary.Op.Kind == BoundBinaryOperatorKind.NullCoalesce
+                    && binary.Left is BoundLiteralExpression { Value: null } or BoundDefaultExpression)
+                {
+                    diagnostics.ReportExpressionTreeUnsupported(LocationOf(binary.Syntax), "a coalescing operator with a null/default left operand");
+                }
+
+                ValidateExpression(binary.Left, diagnostics);
+                ValidateExpression(binary.Right, diagnostics);
+                return;
+
+            case BoundConditionalExpression conditional:
+                ValidateExpression(conditional.Condition, diagnostics);
+                ValidateExpression(conditional.WhenTrue, diagnostics);
+                ValidateExpression(conditional.WhenFalse, diagnostics);
+                return;
+
+            case BoundFieldAccessExpression field:
+                ValidateExpression(field.Receiver, diagnostics);
+                return;
+
+            case BoundPropertyAccessExpression property:
+                ValidateExpression(property.Receiver, diagnostics);
+                return;
+
+            case BoundClrPropertyAccessExpression clrProperty:
+                ValidateExpression(clrProperty.Receiver, diagnostics);
+                return;
+
+            case BoundIndexExpression index:
+                ValidateExpression(index.Target, diagnostics);
+                ValidateExpression(index.Index, diagnostics);
+                return;
+
+            case BoundClrIndexExpression clrIndex:
+                ValidateExpression(clrIndex.Target, diagnostics);
+                foreach (var argument in clrIndex.Arguments)
+                {
+                    ValidateExpression(argument, diagnostics);
+                }
+
+                return;
+
+            case BoundArrayCreationExpression array:
+                ValidateExpression(array.LengthExpression, diagnostics);
+                foreach (var element in array.Elements)
+                {
+                    ValidateExpression(element, diagnostics);
+                }
+
+                return;
+
+            case BoundConstructorCallExpression ctor:
+                foreach (var argument in ctor.Arguments)
+                {
+                    ValidateExpression(argument, diagnostics);
+                }
+
+                return;
+
+            case BoundClrConstructorCallExpression clrCtor:
+                foreach (var argument in clrCtor.Arguments)
+                {
+                    ValidateExpression(argument, diagnostics);
+                }
+
+                return;
+
+            case BoundCallExpression call:
+                if (call.Function.StaticOwnerType == null)
+                {
+                    diagnostics.ReportExpressionTreeUnsupported(LocationOf(call.Syntax), "a top-level function call");
+                    return;
+                }
+
+                ValidateArguments(call.Arguments, call.Function.Parameters, diagnostics);
+                return;
+
+            case BoundUserInstanceCallExpression userCall:
+                ValidateExpression(userCall.Receiver, diagnostics);
+                ValidateArguments(userCall.Arguments, userCall.Method.Parameters, diagnostics);
+                return;
+
+            case BoundImportedCallExpression importedCall:
+                ValidateClrArguments(importedCall.Arguments, importedCall.ArgumentRefKinds, importedCall.Function.Method, diagnostics);
+                return;
+
+            case BoundImportedInstanceCallExpression importedInstanceCall:
+                ValidateExpression(importedInstanceCall.Receiver, diagnostics);
+                ValidateClrArguments(importedInstanceCall.Arguments, importedInstanceCall.ArgumentRefKinds, importedInstanceCall.Method, diagnostics);
+                return;
+
+            case BoundClrStaticCallExpression clrStaticCall:
+                ValidateClrArguments(clrStaticCall.Arguments, clrStaticCall.ArgumentRefKinds, clrStaticCall.Method, diagnostics);
+                return;
+
+            case BoundClrBinaryOperatorExpression clrBinary:
+                ValidateExpression(clrBinary.Left, diagnostics);
+                ValidateExpression(clrBinary.Right, diagnostics);
+                return;
+
+            case BoundClrUnaryOperatorExpression clrUnary:
+                ValidateExpression(clrUnary.Operand, diagnostics);
+                return;
+
+            case BoundIsExpression isExpression:
+                ValidateExpression(isExpression.Expression, diagnostics);
+                return;
+
+            case BoundAsExpression asExpression:
+                ValidateExpression(asExpression.Expression, diagnostics);
+                return;
+
+            case BoundAssignmentExpression:
+            case BoundFieldAssignmentExpression:
+            case BoundPropertyAssignmentExpression:
+            case BoundClrPropertyAssignmentExpression:
+            case BoundIndexAssignmentExpression:
+            case BoundClrIndexAssignmentExpression:
+            case BoundIndirectAssignmentExpression:
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(expression.Syntax), "an assignment operator");
+                return;
+
+            case BoundAwaitExpression:
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(expression.Syntax), "an await expression");
+                return;
+
+            case BoundNullConditionalAccessExpression:
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(expression.Syntax), "a null-propagating operator");
+                return;
+
+            case BoundThrowExpression:
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(expression.Syntax), "a throw expression");
+                return;
+
+            case BoundSwitchExpression:
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(expression.Syntax), "a switch expression");
+                return;
+
+            case BoundTupleLiteralExpression:
+            case BoundTupleElementAccessExpression:
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(expression.Syntax), "a tuple expression");
+                return;
+
+            case BoundMapLiteralExpression:
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(expression.Syntax), "a map/dictionary literal");
+                return;
+
+            case BoundInterpolatedStringExpression:
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(expression.Syntax), "an interpolated string");
+                return;
+
+            case BoundAddressOfExpression:
+            case BoundDereferenceExpression:
+            case BoundFunctionPointerFromMethodExpression:
+            case BoundFunctionPointerInvocationExpression:
+            case BoundSizeOfExpression:
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(expression.Syntax), "an unsafe pointer operation");
+                return;
+
+            case BoundMethodGroupExpression:
+            case BoundClrMethodGroupExpression:
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(expression.Syntax), "a method group");
+                return;
+
+            case BoundBlockExpression:
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(expression.Syntax), "a block expression");
+                return;
+
+            default:
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(expression.Syntax), $"'{expression.Kind}'");
+                return;
+        }
+    }
+
+    private static void ValidateArguments(
+        System.Collections.Immutable.ImmutableArray<BoundExpression> arguments,
+        System.Collections.Immutable.ImmutableArray<ParameterSymbol> parameters,
+        DiagnosticBag diagnostics)
+    {
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            if (i < parameters.Length && parameters[i].RefKind != RefKind.None)
+            {
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(arguments[i].Syntax), $"a '{parameters[i].RefKind.ToString().ToLowerInvariant()}' argument");
+            }
+
+            ValidateExpression(arguments[i], diagnostics);
+        }
+    }
+
+    private static void ValidateClrArguments(
+        System.Collections.Immutable.ImmutableArray<BoundExpression> arguments,
+        System.Collections.Immutable.ImmutableArray<RefKind> argumentRefKinds,
+        MethodBase method,
+        DiagnosticBag diagnostics)
+    {
+        if (method != null && (method.CallingConvention & CallingConventions.VarArgs) != 0)
+        {
+            diagnostics.ReportExpressionTreeUnsupported(arguments.Length > 0 ? LocationOf(arguments[0].Syntax) : default, "a varargs call");
+        }
+
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            if (!argumentRefKinds.IsDefaultOrEmpty && i < argumentRefKinds.Length && argumentRefKinds[i] != RefKind.None)
+            {
+                diagnostics.ReportExpressionTreeUnsupported(LocationOf(arguments[i].Syntax), $"a '{argumentRefKinds[i].ToString().ToLowerInvariant()}' argument");
+            }
+
+            ValidateExpression(arguments[i], diagnostics);
+        }
+    }
+
+    private static TextLocation LocationOf(SyntaxNode syntax)
+        => syntax != null ? syntax.Location : default;
+}

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1198,6 +1198,119 @@ internal sealed class MemberLookup
     }
 
     /// <summary>
+    /// Issue #2130: resolves the effective lambda target shape for any target
+    /// type that may consume a source lambda — a native function type, a
+    /// delegate, or <c>System.Linq.Expressions.Expression&lt;TDelegate&gt;</c>.
+    /// Returns the underlying delegate/function signature that should be used
+    /// for target-typed lambda parameter/return binding.
+    /// </summary>
+    /// <param name="type">The candidate lambda target type.</param>
+    /// <param name="functionType">The effective function-type shape, on success.</param>
+    /// <returns><see langword="true"/> when <paramref name="type"/> is a valid lambda target.</returns>
+    public static bool TryGetLambdaTargetFunctionTypeFromSymbol(TypeSymbol type, out FunctionTypeSymbol functionType)
+    {
+        if (TryGetDelegateFunctionTypeFromSymbol(type, out functionType))
+        {
+            return true;
+        }
+
+        if (!TryGetExpressionTreeDelegateTypeFromSymbol(type, out var delegateType) || delegateType == null)
+        {
+            functionType = null;
+            return false;
+        }
+
+        return TryGetDelegateFunctionTypeFromSymbol(delegateType, out functionType);
+    }
+
+    /// <summary>
+    /// Issue #2130: resolves the effective lambda target shape for a CLR
+    /// delegate or expression-tree type.
+    /// </summary>
+    /// <param name="type">The candidate lambda target CLR type.</param>
+    /// <param name="functionType">The effective function-type shape, on success.</param>
+    /// <returns><see langword="true"/> when <paramref name="type"/> is a valid lambda target.</returns>
+    public static bool TryGetLambdaTargetFunctionType(Type type, out FunctionTypeSymbol functionType)
+    {
+        if (TryGetDelegateFunctionType(type, out functionType))
+        {
+            return true;
+        }
+
+        if (!TryGetExpressionTreeDelegateType(type, out var delegateType) || delegateType == null)
+        {
+            functionType = null;
+            return false;
+        }
+
+        return TryGetDelegateFunctionType(delegateType, out functionType);
+    }
+
+    /// <summary>
+    /// Issue #2130: returns the delegate type argument of a
+    /// <c>System.Linq.Expressions.Expression&lt;TDelegate&gt;</c> target.
+    /// </summary>
+    /// <param name="type">The candidate expression-tree target type.</param>
+    /// <param name="delegateType">The delegate type argument, on success.</param>
+    /// <returns><see langword="true"/> when <paramref name="type"/> is an expression-tree target.</returns>
+    public static bool TryGetExpressionTreeDelegateTypeFromSymbol(TypeSymbol type, out TypeSymbol delegateType)
+    {
+        delegateType = null;
+        if (type == null)
+        {
+            return false;
+        }
+
+        if (type is ImportedTypeSymbol imported
+            && imported.OpenDefinition != null
+            && string.Equals(imported.OpenDefinition.FullName, "System.Linq.Expressions.Expression`1", StringComparison.Ordinal)
+            && imported.TypeArguments.Length == 1)
+        {
+            delegateType = imported.TypeArguments[0];
+            return true;
+        }
+
+        if (type.ClrType == null || !TryGetExpressionTreeDelegateType(type.ClrType, out var delegateClrType))
+        {
+            return false;
+        }
+
+        delegateType = TypeSymbol.FromClrType(delegateClrType);
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #2130: returns the delegate type argument of a CLR
+    /// <c>Expression&lt;TDelegate&gt;</c> target.
+    /// </summary>
+    /// <param name="type">The candidate CLR expression-tree target type.</param>
+    /// <param name="delegateType">The delegate type argument, on success.</param>
+    /// <returns><see langword="true"/> when <paramref name="type"/> is an expression-tree target.</returns>
+    public static bool TryGetExpressionTreeDelegateType(Type type, out Type delegateType)
+    {
+        delegateType = null;
+        if (type == null || !type.IsGenericType)
+        {
+            return false;
+        }
+
+        var open = type.IsGenericTypeDefinition ? type : type.GetGenericTypeDefinition();
+        if (!string.Equals(open.FullName, "System.Linq.Expressions.Expression`1", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var args = type.GetGenericArguments();
+        if (args.Length != 1)
+        {
+            return false;
+        }
+
+        delegateType = args[0];
+        return true;
+    }
+
+    /// <summary>
     /// Probes <paramref name="delegateType"/> for the canonical delegate
     /// shape (<see cref="System.MulticastDelegate"/>-derived, or
     /// <c>System.Func`N</c>/<c>System.Action`N</c>) and exposes the

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -657,9 +657,29 @@ internal sealed class OverloadResolver
             || literal.FunctionType is not FunctionTypeSymbol literalFnType
             || literalFnType.ReturnType == TypeSymbol.Void
             || literalFnType.ReturnType == TypeSymbol.Error
-            || !MemberLookup.TryGetDelegateFunctionTypeFromSymbol(expectedType, out var targetFnType)
+            || !MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(expectedType, out var targetFnType)
             || targetFnType.ReturnType != TypeSymbol.Void
             || targetFnType.Arity != literalFnType.Arity)
+        {
+            return false;
+        }
+
+        var converted = conversions.BindConversion(location, literal, expectedType);
+        if (converted is BoundErrorExpression)
+        {
+            return false;
+        }
+
+        result = converted;
+        return true;
+    }
+
+    private bool TryConvertLiteralArgumentToExpressionTree(BoundExpression argument, TypeSymbol expectedType, TextLocation location, out BoundExpression result)
+    {
+        result = null;
+        if (expectedType == null
+            || !tryGetFunctionLiteral(argument, out var literal)
+            || !MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(expectedType, out _))
         {
             return false;
         }
@@ -2996,6 +3016,12 @@ internal sealed class OverloadResolver
             if (argument.Type != parameter.Type
                 && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit)
             {
+                if (TryConvertLiteralArgumentToExpressionTree(argument, parameter.Type, parameterSyntax[i].Location, out var expressionTreeArg))
+                {
+                    boundArguments[i] = expressionTreeArg;
+                    continue;
+                }
+
                 // Issue #889: arrow/func literal → void-returning delegate.
                 if (TryConvertLiteralArgumentToVoidDelegate(argument, parameter.Type, parameterSyntax[i].Location, out var voidDelegateArg))
                 {
@@ -3395,6 +3421,12 @@ internal sealed class OverloadResolver
             if (argument.Type != paramType
                 && !Conversion.Classify(argument.Type, paramType).IsImplicit)
             {
+                if (TryConvertLiteralArgumentToExpressionTree(argument, paramType, argLocation, out var expressionTreeArg))
+                {
+                    convertedArguments.Add(expressionTreeArg);
+                    continue;
+                }
+
                 // Issue #889: arrow/func literal → void-returning delegate.
                 if (TryConvertLiteralArgumentToVoidDelegate(argument, paramType, argLocation, out var voidDelegateArg))
                 {
@@ -3816,6 +3848,12 @@ internal sealed class OverloadResolver
             if (argument.Type != parameter.Type
                 && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit)
             {
+                if (TryConvertLiteralArgumentToExpressionTree(argument, parameter.Type, argLocation, out var expressionTreeArg))
+                {
+                    convertedArgs.Add(expressionTreeArg);
+                    continue;
+                }
+
                 // Issue #889: arrow/func literal → void-returning delegate.
                 if (TryConvertLiteralArgumentToVoidDelegate(argument, parameter.Type, argLocation, out var voidDelegateArg))
                 {
@@ -4045,7 +4083,7 @@ internal sealed class OverloadResolver
         result = null;
         if (syntax.NullableQuestionToken == null
             || variable.Type is not NullableTypeSymbol nullable
-            || !MemberLookup.TryGetDelegateFunctionTypeFromSymbol(nullable.UnderlyingType, out var functionType))
+            || !MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(nullable.UnderlyingType, out var functionType))
         {
             return false;
         }
@@ -5187,7 +5225,7 @@ internal sealed class OverloadResolver
                     && expectedType != null
                     && expectedType != TypeSymbol.Error
                     && !TypeSymbol.ContainsTypeParameter(expectedType)
-                    && MemberLookup.TryGetDelegateFunctionTypeFromSymbol(expectedType, out var deferredTarget)
+                    && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(expectedType, out var deferredTarget)
                     && deferredTarget != null)
                 {
                     var targeted = bindLambdaWithTarget(deferredLambda, deferredTarget);
@@ -5336,7 +5374,7 @@ internal sealed class OverloadResolver
                 && widenLiteralArg.FunctionType is FunctionTypeSymbol widenLiteralFnType
                 && widenLiteralFnType.ReturnType != TypeSymbol.Void
                 && widenLiteralFnType.ReturnType != TypeSymbol.Error
-                && MemberLookup.TryGetDelegateFunctionTypeFromSymbol(expectedType, out var widenTargetFn)
+                && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(expectedType, out var widenTargetFn)
                 && widenTargetFn != null
                 && widenTargetFn.Arity == widenLiteralFnType.Arity
                 && widenTargetFn.ReturnType != TypeSymbol.Void
@@ -5427,6 +5465,12 @@ internal sealed class OverloadResolver
             {
                 // Issue #889: arrow/func literal → void-returning delegate.
                 var voidDelegateLoc = i < parameterSyntax.Length ? parameterSyntax[i].Location : syntax.Identifier.Location;
+                if (TryConvertLiteralArgumentToExpressionTree(argument, expectedType, voidDelegateLoc, out var expressionTreeArg))
+                {
+                    boundArguments[i] = expressionTreeArg;
+                    continue;
+                }
+
                 if (TryConvertLiteralArgumentToVoidDelegate(argument, expectedType, voidDelegateLoc, out var voidDelegateArg))
                 {
                     boundArguments[i] = voidDelegateArg;
@@ -6175,7 +6219,7 @@ internal sealed class OverloadResolver
                     continue;
                 }
 
-                if (MemberLookup.TryGetDelegateFunctionType(paramType.ClrType ?? expectedType.ClrType, out var targetDelegateFunctionType)
+                if (MemberLookup.TryGetLambdaTargetFunctionType(paramType.ClrType ?? expectedType.ClrType, out var targetDelegateFunctionType)
                     && functionLiteralArgument.FunctionType != targetDelegateFunctionType)
                 {
                     convertedArgs.Add(createErasedFunctionLiteralAdapter(functionLiteralArgument, targetDelegateFunctionType));

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -919,7 +919,7 @@ internal sealed class StatementBinder
             else if (type != null
                 && syntax.Initializer is LambdaExpressionSyntax targetTypedLambda
                 && bindLambdaWithTargetType != null
-                && MemberLookup.TryGetDelegateFunctionTypeFromSymbol(type, out var targetFnType))
+                && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(type, out var targetFnType))
             {
                 // ADR-0076 / issue #716: when a binding has an explicit
                 // function-type and is initialised with an arrow lambda,

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -403,6 +403,12 @@ public class Compilation
         // enclosing type parameter don't erase it under cs2gs.
         program = Lowering.CaptureBoxingRewriter.Lower(program, (References ?? Symbols.ReferenceResolver.Default()).MapClrTypeToReferences);
 
+        // Issue #2130: after capture-boxing has introduced the closure cells
+        // expression trees must reference, rewrite lambda-to-expression-tree
+        // conversions into ordinary bound calls to System.Linq.Expressions
+        // factory methods.
+        program = Lowering.ExpressionTreeLowerer.Lower(program);
+
         var (lowered, loweredProgram, lowerDiagnostics) = LowerForEmit(program, References ?? Symbols.ReferenceResolver.Default());
         if (lowerDiagnostics.Any(d => d.IsError))
         {
@@ -517,6 +523,12 @@ public class Compilation
         // box classes hoisting an imported constructed generic over an
         // enclosing type parameter don't erase it under cs2gs.
         program = Lowering.CaptureBoxingRewriter.Lower(program, (References ?? Symbols.ReferenceResolver.Default()).MapClrTypeToReferences);
+
+        // Issue #2130: after capture-boxing has introduced the closure cells
+        // expression trees must reference, rewrite lambda-to-expression-tree
+        // conversions into ordinary bound calls to System.Linq.Expressions
+        // factory methods.
+        program = Lowering.ExpressionTreeLowerer.Lower(program);
 
         var (lowered, loweredProgram, lowerDiagnostics) = LowerForEmit(program, References ?? Symbols.ReferenceResolver.Default());
         if (lowerDiagnostics.Any(d => d.IsError))

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -4475,6 +4475,37 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Issue #2130: GS0473 — a lambda being converted to an expression tree
+    /// uses a language construct that G# deliberately rejects in expression-
+    /// tree form, matching the C#/Roslyn restriction model.
+    /// </summary>
+    /// <param name="location">The source location of the unsupported construct.</param>
+    /// <param name="feature">The rejected construct description.</param>
+    public void ReportExpressionTreeUnsupported(TextLocation location, string feature)
+    {
+        Report(
+            location,
+            "GS0473",
+            $"An expression-tree lambda may not contain {feature} (issue #2130).",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// Issue #2130: GS0474 — a target <c>Expression[T]</c> uses a type
+    /// argument that is not a delegate type, so a lambda cannot convert to it.
+    /// </summary>
+    /// <param name="location">The source location of the attempted conversion.</param>
+    /// <param name="targetType">The invalid target type.</param>
+    public void ReportExpressionTreeTargetMustBeDelegate(TextLocation location, TypeSymbol targetType)
+    {
+        Report(
+            location,
+            "GS0474",
+            $"Cannot convert a lambda expression to '{targetType}' because expression-tree targets must be 'System.Linq.Expressions.Expression[TDelegate]' where 'TDelegate' is a delegate type (issue #2130).",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
     /// Issue #1336: GS0415 — a <c>sizeof(T)</c> expression names a type that is
     /// not an unmanaged type. <c>sizeof</c> measures the unmanaged byte size of
     /// its operand, so the operand must be a blittable primitive, an enum, a

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -458,6 +458,25 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #2130: expression-tree lowering builds the lambda node with the
+        // non-generic Expression.Lambda(Type, ...) overload, whose static type
+        // is LambdaExpression. The runtime instance is the exact
+        // Expression<TDelegate> subtype requested by the supplied delegate
+        // Type, so the synthesized final step is an explicit reference cast
+        // from LambdaExpression to Expression<TDelegate>.
+        if (from?.ClrType?.FullName == "System.Linq.Expressions.LambdaExpression"
+            && to?.ClrType != null
+            && to.ClrType.IsGenericType
+            && string.Equals(
+                (to.ClrType.IsGenericTypeDefinition ? to.ClrType : to.ClrType.GetGenericTypeDefinition()).FullName,
+                "System.Linq.Expressions.Expression`1",
+                StringComparison.Ordinal))
+        {
+            this.il.OpCode(ILOpCode.Castclass);
+            this.il.Token(this.outer.GetElementTypeToken(to));
+            return;
+        }
+
         // Phase D: class → interface upcast is a CLR reference-level
         // no-op. The receiver already implements the interface; loading
         // the reference into an interface-typed slot needs no IL.

--- a/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
@@ -1,0 +1,1020 @@
+// <copyright file="ExpressionTreeLowerer.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+#pragma warning disable SA1137 // elements should have the same indentation
+#pragma warning disable SA1516 // elements should be separated by blank line
+
+namespace GSharp.Core.CodeAnalysis.Lowering;
+
+/// <summary>
+/// Issue #2130: lowers lambda-to-<c>Expression&lt;TDelegate&gt;</c>
+/// conversions into ordinary bound calls to
+/// <c>System.Linq.Expressions.Expression</c> factory methods.
+/// </summary>
+internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
+{
+    private static readonly TypeSymbol SystemTypeSymbol = TypeSymbol.FromClrType(typeof(Type));
+    private static readonly TypeSymbol ObjectTypeSymbol = TypeSymbol.Object;
+    private static readonly TypeSymbol ReflectionConstructorInfoTypeSymbol = TypeSymbol.FromClrType(typeof(ConstructorInfo));
+    private static readonly TypeSymbol ExpressionTypeSymbol = TypeSymbol.FromClrType(typeof(System.Linq.Expressions.Expression));
+    private static readonly TypeSymbol ParameterExpressionTypeSymbol = TypeSymbol.FromClrType(typeof(System.Linq.Expressions.ParameterExpression));
+
+    private static readonly MethodInfo ExpressionParameterMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Parameter),
+        typeof(Type),
+        typeof(string));
+    private static readonly MethodInfo ExpressionConstantMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Constant),
+        typeof(object),
+        typeof(Type));
+    private static readonly MethodInfo ExpressionConstantUntypedMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Constant),
+        typeof(object));
+    private static readonly MethodInfo ExpressionFieldInstanceMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Field),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(string));
+    private static readonly MethodInfo ExpressionFieldStaticMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Field),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(Type),
+        typeof(string));
+    private static readonly MethodInfo ExpressionPropertyInstanceMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Property),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(string));
+    private static readonly MethodInfo ExpressionPropertyStaticMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Property),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(Type),
+        typeof(string));
+    private static readonly MethodInfo ExpressionIndexerPropertyMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Property),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(string),
+        typeof(System.Linq.Expressions.Expression[]));
+    private static readonly MethodInfo ExpressionCallInstanceMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Call),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(string),
+        typeof(Type[]),
+        typeof(System.Linq.Expressions.Expression[]));
+    private static readonly MethodInfo ExpressionCallStaticMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Call),
+        typeof(Type),
+        typeof(string),
+        typeof(Type[]),
+        typeof(System.Linq.Expressions.Expression[]));
+    private static readonly MethodInfo ExpressionLambdaMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Lambda),
+        typeof(Type),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(System.Linq.Expressions.ParameterExpression[]));
+    private static readonly MethodInfo ExpressionQuoteMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Quote),
+        typeof(System.Linq.Expressions.Expression));
+    private static readonly MethodInfo ExpressionConvertMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Convert),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(Type));
+    private static readonly MethodInfo ExpressionConvertWithMethodMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Convert),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(Type),
+        typeof(MethodInfo));
+    private static readonly MethodInfo ExpressionTypeAsMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.TypeAs),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(Type));
+    private static readonly MethodInfo ExpressionTypeIsMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.TypeIs),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(Type));
+    private static readonly MethodInfo ExpressionConditionMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Condition),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(System.Linq.Expressions.Expression));
+    private static readonly MethodInfo ExpressionCoalesceMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Coalesce),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(System.Linq.Expressions.Expression));
+    private static readonly MethodInfo ExpressionNewTypeMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.New),
+        typeof(Type));
+    private static readonly MethodInfo ExpressionNewCtorMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.New),
+        typeof(ConstructorInfo),
+        typeof(System.Linq.Expressions.Expression[]));
+    private static readonly MethodInfo ExpressionNewArrayInitMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.NewArrayInit),
+        typeof(Type),
+        typeof(System.Linq.Expressions.Expression[]));
+    private static readonly MethodInfo ExpressionNewArrayBoundsMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.NewArrayBounds),
+        typeof(Type),
+        typeof(System.Linq.Expressions.Expression[]));
+    private static readonly MethodInfo ExpressionArrayIndexMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.ArrayIndex),
+        typeof(System.Linq.Expressions.Expression),
+        typeof(System.Linq.Expressions.Expression));
+    private static readonly MethodInfo ExpressionDefaultMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Default),
+        typeof(Type));
+    private static readonly MethodInfo TypeGetConstructorMethod = GetRequiredMethod(
+        typeof(Type),
+        nameof(Type.GetConstructor),
+        typeof(Type[]));
+
+    private int counter;
+
+    public static BoundProgram Lower(BoundProgram program)
+    {
+        var lowerer = new ExpressionTreeLowerer();
+        var changed = false;
+
+        var functions = ImmutableDictionary.CreateBuilder<FunctionSymbol, BoundBlockStatement>();
+        foreach (var pair in program.Functions)
+        {
+            var newBody = (BoundBlockStatement)lowerer.RewriteStatement(pair.Value);
+            functions[pair.Key] = newBody;
+            changed |= newBody != pair.Value;
+        }
+
+        var statement = program.Statement;
+        if (statement != null)
+        {
+            var newStatement = (BoundBlockStatement)lowerer.RewriteStatement(statement);
+            changed |= newStatement != statement;
+            statement = newStatement;
+        }
+
+        if (!changed)
+        {
+            return program;
+        }
+
+        return new BoundProgram(
+            program.EntryPointPackage,
+            program.Packages,
+            program.Diagnostics,
+            functions.ToImmutable(),
+            program.EntryPoint,
+            statement,
+            program.Structs,
+            program.Interfaces,
+            program.Enums,
+            program.Globals,
+            program.Delegates)
+        {
+            Imports = program.Imports,
+            FriendAssemblies = program.FriendAssemblies,
+        };
+    }
+
+    protected override BoundExpression RewriteConversionExpression(BoundConversionExpression node)
+    {
+        if (node.Expression is BoundFunctionLiteralExpression literal
+            && MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(node.Type, out _))
+        {
+            return this.BuildExpressionTreeValue(node.Syntax, literal, node.Type);
+        }
+
+        return base.RewriteConversionExpression(node);
+    }
+
+    private BoundExpression BuildExpressionTreeValue(
+        SyntaxNode syntax,
+        BoundFunctionLiteralExpression literal,
+        TypeSymbol targetType)
+    {
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        var parameterMap = new Dictionary<VariableSymbol, LocalVariableSymbol>();
+
+        foreach (var parameter in literal.Function.Parameters)
+        {
+            var local = new LocalVariableSymbol($"<>exprParam{this.counter++}", isReadOnly: true, ParameterExpressionTypeSymbol);
+            var initializer = new BoundClrStaticCallExpression(
+                syntax,
+                ExpressionParameterMethod,
+                ParameterExpressionTypeSymbol,
+                ImmutableArray.Create<BoundExpression>(
+                    CreateTypeOf(parameter.Type),
+                    new BoundLiteralExpression(null, parameter.Name, TypeSymbol.String)));
+            statements.Add(new BoundVariableDeclaration(syntax, local, initializer));
+            parameterMap[parameter] = local;
+        }
+
+        var bodySource = ExtractLambdaBodyExpression(literal.Body);
+        var body = this.TranslateExpression(bodySource, parameterMap);
+        var lambda = new BoundClrStaticCallExpression(
+            syntax,
+            ExpressionLambdaMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.LambdaExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                CreateTypeOf(MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(targetType, out var delegateType) ? delegateType : TypeSymbol.Error),
+                UpcastToExpression(body),
+                BuildParameterArray(parameterMap.Values)));
+
+        var cast = new BoundConversionExpression(syntax, targetType, lambda);
+        return new BoundBlockExpression(syntax, statements.ToImmutable(), cast);
+    }
+
+    private BoundExpression TranslateExpression(
+        BoundExpression expression,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        switch (expression)
+        {
+            case BoundLiteralExpression literal:
+                return BuildLiteralExpressionNode(literal);
+            case BoundDefaultExpression @default:
+                return new BoundClrStaticCallExpression(
+                    expression.Syntax,
+                    ExpressionDefaultMethod,
+                    TypeSymbol.FromClrType(typeof(System.Linq.Expressions.DefaultExpression)),
+                    ImmutableArray.Create<BoundExpression>(CreateTypeOf(@default.Type)));
+            case BoundTypeOfExpression typeOf:
+                return BuildRuntimeConstant(typeOf, SystemTypeSymbol);
+            case BoundVariableExpression variable:
+                if (parameterMap.TryGetValue(variable.Variable, out var parameterLocal))
+                {
+                    return new BoundVariableExpression(expression.Syntax, parameterLocal);
+                }
+
+                return BuildRuntimeConstant(variable, variable.Type);
+            case BoundFieldAccessExpression field:
+                return BuildFieldAccessExpression(field, parameterMap);
+            case BoundPropertyAccessExpression property:
+                return BuildPropertyAccessExpression(property, parameterMap);
+            case BoundClrPropertyAccessExpression clrProperty:
+                return BuildClrPropertyAccessExpression(clrProperty, parameterMap);
+            case BoundIndexExpression index:
+                return new BoundClrStaticCallExpression(
+                    expression.Syntax,
+                    ExpressionArrayIndexMethod,
+                    TypeSymbol.FromClrType(typeof(System.Linq.Expressions.BinaryExpression)),
+                    ImmutableArray.Create<BoundExpression>(
+                        UpcastToExpression(this.TranslateExpression(index.Target, parameterMap)),
+                        UpcastToExpression(this.TranslateExpression(index.Index, parameterMap))));
+            case BoundClrIndexExpression clrIndex:
+                return new BoundClrStaticCallExpression(
+                    expression.Syntax,
+                    ExpressionIndexerPropertyMethod,
+                    TypeSymbol.FromClrType(typeof(System.Linq.Expressions.IndexExpression)),
+                    ImmutableArray.Create<BoundExpression>(
+                        UpcastToExpression(this.TranslateExpression(clrIndex.Target, parameterMap)),
+                        new BoundLiteralExpression(null, clrIndex.Indexer.Name, TypeSymbol.String),
+                        BuildExpressionArray(TranslateArguments(clrIndex.Arguments, clrIndex.Indexer.GetIndexParameters(), parameterMap))));
+            case BoundUnaryExpression unary:
+                return BuildUnaryExpression(unary, parameterMap);
+            case BoundBinaryExpression binary:
+                return BuildBinaryExpression(binary, parameterMap);
+            case BoundConditionalExpression conditional:
+                return new BoundClrStaticCallExpression(
+                    expression.Syntax,
+                    ExpressionConditionMethod,
+                    TypeSymbol.FromClrType(typeof(System.Linq.Expressions.ConditionalExpression)),
+                    ImmutableArray.Create<BoundExpression>(
+                        UpcastToExpression(this.TranslateExpression(conditional.Condition, parameterMap)),
+                        UpcastToExpression(this.TranslateExpression(conditional.WhenTrue, parameterMap)),
+                        UpcastToExpression(this.TranslateExpression(conditional.WhenFalse, parameterMap))));
+            case BoundIsExpression isExpression:
+                return new BoundClrStaticCallExpression(
+                    expression.Syntax,
+                    ExpressionTypeIsMethod,
+                    TypeSymbol.FromClrType(typeof(System.Linq.Expressions.TypeBinaryExpression)),
+                    ImmutableArray.Create<BoundExpression>(
+                        UpcastToExpression(this.TranslateExpression(isExpression.Expression, parameterMap)),
+                        CreateTypeOf(isExpression.TargetType)));
+            case BoundAsExpression asExpression:
+                return new BoundClrStaticCallExpression(
+                    expression.Syntax,
+                    ExpressionTypeAsMethod,
+                    TypeSymbol.FromClrType(typeof(System.Linq.Expressions.UnaryExpression)),
+                    ImmutableArray.Create<BoundExpression>(
+                        UpcastToExpression(this.TranslateExpression(asExpression.Expression, parameterMap)),
+                        CreateTypeOf(asExpression.TargetType)));
+            case BoundArrayCreationExpression array:
+                return BuildArrayCreationExpression(array, parameterMap);
+            case BoundConstructorCallExpression ctor:
+                return BuildUserConstructorExpression(ctor, parameterMap);
+            case BoundClrConstructorCallExpression clrCtor:
+                return BuildClrConstructorExpression(clrCtor, parameterMap);
+            case BoundConversionExpression conversion:
+                return BuildConversionExpression(conversion, parameterMap);
+            case BoundImportedInstanceCallExpression importedInstance:
+                return BuildImportedInstanceCallExpression(importedInstance, parameterMap);
+            case BoundImportedCallExpression importedCall:
+                return BuildImportedStaticCallExpression(importedCall, parameterMap);
+            case BoundClrStaticCallExpression clrStaticCall:
+                return BuildClrStaticMethodCallExpression(clrStaticCall, parameterMap);
+            case BoundUserInstanceCallExpression userInstanceCall:
+                return BuildUserInstanceCallExpression(userInstanceCall, parameterMap);
+            case BoundCallExpression userStaticCall:
+                return BuildUserStaticCallExpression(userStaticCall, parameterMap);
+            case BoundClrBinaryOperatorExpression clrBinary:
+                return BuildClrBinaryOperatorExpression(clrBinary, parameterMap);
+            case BoundClrUnaryOperatorExpression clrUnary:
+                return BuildClrUnaryOperatorExpression(clrUnary, parameterMap);
+            case BoundFunctionLiteralExpression nestedDelegateLiteral:
+                return BuildRuntimeConstant(nestedDelegateLiteral, nestedDelegateLiteral.Type);
+            default:
+                throw new NotSupportedException($"Unsupported expression-tree lowering node: {expression.Kind}.");
+        }
+    }
+
+    private BoundExpression BuildLiteralExpressionNode(BoundLiteralExpression literal)
+    {
+        if (literal.Value == null && literal.Type == TypeSymbol.Null)
+        {
+            return new BoundClrStaticCallExpression(
+                literal.Syntax,
+                ExpressionConstantUntypedMethod,
+                TypeSymbol.FromClrType(typeof(System.Linq.Expressions.ConstantExpression)),
+                ImmutableArray.Create<BoundExpression>(new BoundLiteralExpression(null, null, TypeSymbol.Null)));
+        }
+
+        return BuildRuntimeConstant(literal, literal.Type);
+    }
+
+    private BoundExpression BuildRuntimeConstant(BoundExpression runtimeValue, TypeSymbol runtimeType)
+    {
+        return new BoundClrStaticCallExpression(
+            runtimeValue.Syntax,
+            ExpressionConstantMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.ConstantExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                new BoundConversionExpression(null, ObjectTypeSymbol, runtimeValue),
+                CreateTypeOf(runtimeType)));
+    }
+
+    private BoundExpression BuildFieldAccessExpression(
+        BoundFieldAccessExpression field,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        if (field.Receiver == null)
+        {
+            var owner = field.InterfaceType as TypeSymbol ?? field.StructType;
+            return new BoundClrStaticCallExpression(
+                field.Syntax,
+                ExpressionFieldStaticMethod,
+                TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MemberExpression)),
+                ImmutableArray.Create<BoundExpression>(
+                    new BoundLiteralExpression(null, null, TypeSymbol.Null),
+                    CreateTypeOf(owner),
+                    new BoundLiteralExpression(null, field.Field.Name, TypeSymbol.String)));
+        }
+
+        return new BoundClrStaticCallExpression(
+            field.Syntax,
+            ExpressionFieldInstanceMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MemberExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                UpcastToExpression(this.TranslateExpression(field.Receiver, parameterMap)),
+                new BoundLiteralExpression(null, field.Field.Name, TypeSymbol.String)));
+    }
+
+    private BoundExpression BuildPropertyAccessExpression(
+        BoundPropertyAccessExpression property,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        if (property.Receiver == null)
+        {
+            return new BoundClrStaticCallExpression(
+                property.Syntax,
+                ExpressionPropertyStaticMethod,
+                TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MemberExpression)),
+                ImmutableArray.Create<BoundExpression>(
+                    new BoundLiteralExpression(null, null, TypeSymbol.Null),
+                    CreateTypeOf(property.StructType),
+                    new BoundLiteralExpression(null, property.Property.Name, TypeSymbol.String)));
+        }
+
+        return new BoundClrStaticCallExpression(
+            property.Syntax,
+            ExpressionPropertyInstanceMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MemberExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                UpcastToExpression(this.TranslateExpression(property.Receiver, parameterMap)),
+                new BoundLiteralExpression(null, property.Property.Name, TypeSymbol.String)));
+    }
+
+    private BoundExpression BuildClrPropertyAccessExpression(
+        BoundClrPropertyAccessExpression property,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        var memberName = property.Member.Name;
+        var ownerType = property.StaticContainerType ?? TypeSymbol.FromClrType(property.Member.DeclaringType);
+        var isField = property.Member is FieldInfo;
+        var staticMethod = isField ? ExpressionFieldStaticMethod : ExpressionPropertyStaticMethod;
+        var instanceMethod = isField ? ExpressionFieldInstanceMethod : ExpressionPropertyInstanceMethod;
+
+        if (property.Receiver == null)
+        {
+            return new BoundClrStaticCallExpression(
+                property.Syntax,
+                staticMethod,
+                TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MemberExpression)),
+                ImmutableArray.Create<BoundExpression>(
+                    new BoundLiteralExpression(null, null, TypeSymbol.Null),
+                    CreateTypeOf(ownerType),
+                    new BoundLiteralExpression(null, memberName, TypeSymbol.String)));
+        }
+
+        return new BoundClrStaticCallExpression(
+            property.Syntax,
+            instanceMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MemberExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                UpcastToExpression(this.TranslateExpression(property.Receiver, parameterMap)),
+                new BoundLiteralExpression(null, memberName, TypeSymbol.String)));
+    }
+
+    private BoundExpression BuildUnaryExpression(
+        BoundUnaryExpression unary,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        var operand = UpcastToExpression(this.TranslateExpression(unary.Operand, parameterMap));
+        var method = unary.Op.Kind switch
+        {
+            BoundUnaryOperatorKind.Identity => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.UnaryPlus), typeof(System.Linq.Expressions.Expression)),
+            BoundUnaryOperatorKind.Negation => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.Negate), typeof(System.Linq.Expressions.Expression)),
+            BoundUnaryOperatorKind.LogicalNegation => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.Not), typeof(System.Linq.Expressions.Expression)),
+            BoundUnaryOperatorKind.OnesComplement => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.Not), typeof(System.Linq.Expressions.Expression)),
+            _ => throw new NotSupportedException($"Unsupported unary operator '{unary.Op.Kind}' in expression-tree lowering."),
+        };
+
+        return new BoundClrStaticCallExpression(
+            unary.Syntax,
+            method,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.UnaryExpression)),
+            ImmutableArray.Create(operand));
+    }
+
+    private BoundExpression BuildBinaryExpression(
+        BoundBinaryExpression binary,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        if (binary.Op.Kind == BoundBinaryOperatorKind.BitClear)
+        {
+            var left = UpcastToExpression(this.TranslateExpression(binary.Left, parameterMap));
+            var rightNot = new BoundClrStaticCallExpression(
+                binary.Syntax,
+                GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.Not), typeof(System.Linq.Expressions.Expression)),
+                TypeSymbol.FromClrType(typeof(System.Linq.Expressions.UnaryExpression)),
+                ImmutableArray.Create(UpcastToExpression(this.TranslateExpression(binary.Right, parameterMap))));
+            return new BoundClrStaticCallExpression(
+                binary.Syntax,
+                GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.And), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+                TypeSymbol.FromClrType(typeof(System.Linq.Expressions.BinaryExpression)),
+                ImmutableArray.Create(left, UpcastToExpression(rightNot)));
+        }
+
+        var leftExpr = UpcastToExpression(this.TranslateExpression(binary.Left, parameterMap));
+        var rightExpr = UpcastToExpression(this.TranslateExpression(binary.Right, parameterMap));
+        var method = binary.Op.Kind switch
+        {
+            BoundBinaryOperatorKind.Sum when binary.Type == TypeSymbol.String => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.Add), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression), typeof(MethodInfo)),
+            BoundBinaryOperatorKind.Sum => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.Add), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.Difference => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.Subtract), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.Product => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.Multiply), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.Quotient => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.Divide), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.Remainder => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.Modulo), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.ShiftLeft => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.LeftShift), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.ShiftRight => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.RightShift), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.BitwiseAnd => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.And), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.BitwiseOr => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.Or), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.BitwiseXor => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.ExclusiveOr), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.Equals => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.Equal), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.NotEquals => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.NotEqual), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.Less => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.LessThan), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.LessOrEquals => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.LessThanOrEqual), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.Greater => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.GreaterThan), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.GreaterOrEquals => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.GreaterThanOrEqual), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.LogicalAnd => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.AndAlso), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.LogicalOr => GetRequiredMethod(typeof(System.Linq.Expressions.Expression), nameof(System.Linq.Expressions.Expression.OrElse), typeof(System.Linq.Expressions.Expression), typeof(System.Linq.Expressions.Expression)),
+            BoundBinaryOperatorKind.NullCoalesce => ExpressionCoalesceMethod,
+            _ => throw new NotSupportedException($"Unsupported binary operator '{binary.Op.Kind}' in expression-tree lowering."),
+        };
+
+        if (binary.Op.Kind == BoundBinaryOperatorKind.Sum && binary.Type == TypeSymbol.String)
+        {
+            var concat = GetRequiredMethod(typeof(string), nameof(string.Concat), typeof(string), typeof(string));
+            return new BoundClrStaticCallExpression(
+                binary.Syntax,
+                method,
+                TypeSymbol.FromClrType(typeof(System.Linq.Expressions.BinaryExpression)),
+                ImmutableArray.Create<BoundExpression>(leftExpr, rightExpr, BuildMethodInfoConstant(concat)));
+        }
+
+        return new BoundClrStaticCallExpression(
+            binary.Syntax,
+            method,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.BinaryExpression)),
+            ImmutableArray.Create(leftExpr, rightExpr));
+    }
+
+    private BoundExpression BuildArrayCreationExpression(
+        BoundArrayCreationExpression array,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        if (array.LengthExpression != null)
+        {
+            return new BoundClrStaticCallExpression(
+                array.Syntax,
+                ExpressionNewArrayBoundsMethod,
+                TypeSymbol.FromClrType(typeof(System.Linq.Expressions.NewArrayExpression)),
+                ImmutableArray.Create<BoundExpression>(
+                    CreateTypeOf(array.ElementType),
+                    BuildExpressionArray(new[] { this.TranslateExpression(array.LengthExpression, parameterMap) })));
+        }
+
+        var elements = new List<BoundExpression>(array.Elements.Length);
+        foreach (var element in array.Elements)
+        {
+            elements.Add(this.TranslateExpression(element, parameterMap));
+        }
+
+        return new BoundClrStaticCallExpression(
+            array.Syntax,
+            ExpressionNewArrayInitMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.NewArrayExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                CreateTypeOf(array.ElementType),
+                BuildExpressionArray(elements)));
+    }
+
+    private BoundExpression BuildUserConstructorExpression(
+        BoundConstructorCallExpression constructor,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        if (constructor.Arguments.IsDefaultOrEmpty || constructor.Arguments.Length == 0)
+        {
+            return new BoundClrStaticCallExpression(
+                constructor.Syntax,
+                ExpressionNewTypeMethod,
+                TypeSymbol.FromClrType(typeof(System.Linq.Expressions.NewExpression)),
+                ImmutableArray.Create<BoundExpression>(CreateTypeOf(constructor.StructType)));
+        }
+
+        var ctorInfo = new BoundImportedInstanceCallExpression(
+            constructor.Syntax,
+            CreateTypeOf(constructor.StructType),
+            TypeGetConstructorMethod,
+            ReflectionConstructorInfoTypeSymbol,
+            ImmutableArray.Create<BoundExpression>(BuildTypeArray(GetArgumentTypes(constructor.Arguments))));
+
+        return new BoundClrStaticCallExpression(
+            constructor.Syntax,
+            ExpressionNewCtorMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.NewExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                ctorInfo,
+                BuildExpressionArray(TranslateArguments(constructor.Arguments, GetArgumentTypes(constructor.Arguments), parameterMap))));
+    }
+
+    private BoundExpression BuildClrConstructorExpression(
+        BoundClrConstructorCallExpression constructor,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        if (constructor.Arguments.IsDefaultOrEmpty || constructor.Arguments.Length == 0)
+        {
+            return new BoundClrStaticCallExpression(
+                constructor.Syntax,
+                ExpressionNewTypeMethod,
+                TypeSymbol.FromClrType(typeof(System.Linq.Expressions.NewExpression)),
+                ImmutableArray.Create<BoundExpression>(CreateTypeOf(constructor.Type)));
+        }
+
+        var ctorInfo = new BoundImportedInstanceCallExpression(
+            constructor.Syntax,
+            CreateTypeOf(constructor.Type),
+            TypeGetConstructorMethod,
+            ReflectionConstructorInfoTypeSymbol,
+            ImmutableArray.Create<BoundExpression>(BuildTypeArray(GetArgumentTypes(constructor.Arguments))));
+
+        return new BoundClrStaticCallExpression(
+            constructor.Syntax,
+            ExpressionNewCtorMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.NewExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                ctorInfo,
+                BuildExpressionArray(TranslateArguments(constructor.Arguments, GetArgumentTypes(constructor.Arguments), parameterMap))));
+    }
+
+    private BoundExpression BuildConversionExpression(
+        BoundConversionExpression conversion,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        if (conversion.Expression is BoundFunctionLiteralExpression nestedLiteral
+            && MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(conversion.Type, out _))
+        {
+            return this.BuildExpressionTreeValue(conversion.Syntax, nestedLiteral, conversion.Type);
+        }
+
+        if (conversion.Expression is BoundFunctionLiteralExpression
+            || conversion.Expression is BoundMethodGroupExpression
+            || conversion.Expression is BoundClrMethodGroupExpression)
+        {
+            return BuildRuntimeConstant(conversion, conversion.Type);
+        }
+
+        var methodInfo = conversion switch
+        {
+            BoundConversionExpression { Expression: BoundClrConversionCallExpression clrConversion } => BuildMethodInfoConstant(clrConversion.Method),
+            _ => null,
+        };
+
+        if (methodInfo != null)
+        {
+            return new BoundClrStaticCallExpression(
+                conversion.Syntax,
+                ExpressionConvertWithMethodMethod,
+                TypeSymbol.FromClrType(typeof(System.Linq.Expressions.UnaryExpression)),
+                ImmutableArray.Create<BoundExpression>(
+                    UpcastToExpression(this.TranslateExpression(conversion.Expression, parameterMap)),
+                    CreateTypeOf(conversion.Type),
+                    methodInfo));
+        }
+
+        return new BoundClrStaticCallExpression(
+            conversion.Syntax,
+            ExpressionConvertMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.UnaryExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                UpcastToExpression(this.TranslateExpression(conversion.Expression, parameterMap)),
+                CreateTypeOf(conversion.Type)));
+    }
+
+    private BoundExpression BuildImportedInstanceCallExpression(
+        BoundImportedInstanceCallExpression call,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        return new BoundClrStaticCallExpression(
+            call.Syntax,
+            ExpressionCallInstanceMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MethodCallExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                UpcastToExpression(this.TranslateExpression(call.Receiver, parameterMap)),
+                new BoundLiteralExpression(null, call.Method.Name, TypeSymbol.String),
+                BuildTypeArray(GetTypeSymbols(call.TypeArgumentSymbols)),
+                BuildExpressionArray(TranslateArguments(call.Arguments, call.Method.GetParameters(), parameterMap))));
+    }
+
+    private BoundExpression BuildImportedStaticCallExpression(
+        BoundImportedCallExpression call,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        return new BoundClrStaticCallExpression(
+            call.Syntax,
+            ExpressionCallStaticMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MethodCallExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                CreateTypeOf(TypeSymbol.FromClrType(call.Function.Method.DeclaringType)),
+                new BoundLiteralExpression(null, call.Function.Method.Name, TypeSymbol.String),
+                BuildTypeArray(GetTypeSymbols(call.TypeArgumentSymbols)),
+                BuildExpressionArray(TranslateArguments(call.Arguments, call.Function.Method.GetParameters(), parameterMap))));
+    }
+
+    private BoundExpression BuildClrStaticMethodCallExpression(
+        BoundClrStaticCallExpression call,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        return new BoundClrStaticCallExpression(
+            call.Syntax,
+            ExpressionCallStaticMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MethodCallExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                CreateTypeOf(TypeSymbol.FromClrType(call.Method.DeclaringType)),
+                new BoundLiteralExpression(null, call.Method.Name, TypeSymbol.String),
+                BuildTypeArray(ImmutableArray<TypeSymbol>.Empty),
+                BuildExpressionArray(TranslateArguments(call.Arguments, call.Method.GetParameters(), parameterMap))));
+    }
+
+    private BoundExpression BuildUserInstanceCallExpression(
+        BoundUserInstanceCallExpression call,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        return new BoundClrStaticCallExpression(
+            call.Syntax,
+            ExpressionCallInstanceMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MethodCallExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                UpcastToExpression(this.TranslateExpression(call.Receiver, parameterMap)),
+                new BoundLiteralExpression(null, call.Method.Name, TypeSymbol.String),
+                BuildTypeArray(GetTypeSymbols(call.MethodTypeArguments)),
+                BuildExpressionArray(TranslateArguments(call.Arguments, GetCallableParameters(call.Method), parameterMap))));
+    }
+
+    private BoundExpression BuildUserStaticCallExpression(
+        BoundCallExpression call,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        if (call.Function.StaticOwnerType == null)
+        {
+            throw new NotSupportedException($"Top-level function '{call.Function.Name}' is not supported inside expression trees.");
+        }
+
+        return new BoundClrStaticCallExpression(
+            call.Syntax,
+            ExpressionCallStaticMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MethodCallExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                CreateTypeOf(call.Function.StaticOwnerType),
+                new BoundLiteralExpression(null, call.Function.Name, TypeSymbol.String),
+                BuildTypeArray(GetTypeSymbols(call.MethodTypeArguments)),
+                BuildExpressionArray(TranslateArguments(call.Arguments, GetCallableParameters(call.Function), parameterMap))));
+    }
+
+    private BoundExpression BuildClrBinaryOperatorExpression(
+        BoundClrBinaryOperatorExpression expression,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        var methodName = expression.OperatorKind switch
+        {
+            SyntaxKind.PlusToken => nameof(System.Linq.Expressions.Expression.Add),
+            SyntaxKind.MinusToken => nameof(System.Linq.Expressions.Expression.Subtract),
+            SyntaxKind.StarToken => nameof(System.Linq.Expressions.Expression.Multiply),
+            SyntaxKind.SlashToken => nameof(System.Linq.Expressions.Expression.Divide),
+            SyntaxKind.PercentToken => nameof(System.Linq.Expressions.Expression.Modulo),
+            SyntaxKind.EqualsEqualsToken => nameof(System.Linq.Expressions.Expression.Equal),
+            SyntaxKind.BangEqualsToken => nameof(System.Linq.Expressions.Expression.NotEqual),
+            SyntaxKind.LessToken => nameof(System.Linq.Expressions.Expression.LessThan),
+            SyntaxKind.LessOrEqualsToken => nameof(System.Linq.Expressions.Expression.LessThanOrEqual),
+            SyntaxKind.GreaterToken => nameof(System.Linq.Expressions.Expression.GreaterThan),
+            SyntaxKind.GreaterOrEqualsToken => nameof(System.Linq.Expressions.Expression.GreaterThanOrEqual),
+            SyntaxKind.AmpersandToken => nameof(System.Linq.Expressions.Expression.And),
+            SyntaxKind.PipeToken => nameof(System.Linq.Expressions.Expression.Or),
+            SyntaxKind.HatToken => nameof(System.Linq.Expressions.Expression.ExclusiveOr),
+            SyntaxKind.ShiftLeftToken => nameof(System.Linq.Expressions.Expression.LeftShift),
+            SyntaxKind.ShiftRightToken => nameof(System.Linq.Expressions.Expression.RightShift),
+            SyntaxKind.AmpersandAmpersandToken => nameof(System.Linq.Expressions.Expression.AndAlso),
+            SyntaxKind.PipePipeToken => nameof(System.Linq.Expressions.Expression.OrElse),
+            _ => throw new NotSupportedException($"Unsupported CLR binary operator token '{expression.OperatorKind}'."),
+        };
+
+        var factory = GetRequiredMethod(
+            typeof(System.Linq.Expressions.Expression),
+            methodName,
+            typeof(System.Linq.Expressions.Expression),
+            typeof(System.Linq.Expressions.Expression),
+            typeof(MethodInfo));
+
+        return new BoundClrStaticCallExpression(
+            expression.Syntax,
+            factory,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.BinaryExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                UpcastToExpression(this.TranslateExpression(expression.Left, parameterMap)),
+                UpcastToExpression(this.TranslateExpression(expression.Right, parameterMap)),
+                BuildMethodInfoConstant(expression.Method)));
+    }
+
+    private BoundExpression BuildClrUnaryOperatorExpression(
+        BoundClrUnaryOperatorExpression expression,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        var methodName = expression.OperatorKind switch
+        {
+            SyntaxKind.PlusToken => nameof(System.Linq.Expressions.Expression.UnaryPlus),
+            SyntaxKind.MinusToken => nameof(System.Linq.Expressions.Expression.Negate),
+            SyntaxKind.BangToken => nameof(System.Linq.Expressions.Expression.Not),
+            SyntaxKind.HatToken => nameof(System.Linq.Expressions.Expression.Not),
+            _ => throw new NotSupportedException($"Unsupported CLR unary operator token '{expression.OperatorKind}'."),
+        };
+
+        var factory = GetRequiredMethod(
+            typeof(System.Linq.Expressions.Expression),
+            methodName,
+            typeof(System.Linq.Expressions.Expression),
+            typeof(MethodInfo));
+
+        return new BoundClrStaticCallExpression(
+            expression.Syntax,
+            factory,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.UnaryExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                UpcastToExpression(this.TranslateExpression(expression.Operand, parameterMap)),
+                BuildMethodInfoConstant(expression.Method)));
+    }
+
+    private ImmutableArray<BoundExpression> TranslateArguments(
+        ImmutableArray<BoundExpression> arguments,
+        ParameterInfo[] parameters,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        var builder = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var expectedType = i < parameters.Length ? TypeSymbol.FromClrType(parameters[i].ParameterType) : null;
+            builder.Add(this.TranslateArgument(arguments[i], expectedType, parameterMap));
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    private ImmutableArray<BoundExpression> TranslateArguments(
+        ImmutableArray<BoundExpression> arguments,
+        ImmutableArray<ParameterSymbol> parameters,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        var builder = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var expectedType = i < parameters.Length ? parameters[i].Type : null;
+            builder.Add(this.TranslateArgument(arguments[i], expectedType, parameterMap));
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    private ImmutableArray<BoundExpression> TranslateArguments(
+        ImmutableArray<BoundExpression> arguments,
+        ImmutableArray<TypeSymbol> parameterTypes,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        var builder = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var expectedType = i < parameterTypes.Length ? parameterTypes[i] : null;
+            builder.Add(this.TranslateArgument(arguments[i], expectedType, parameterMap));
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    private BoundExpression TranslateArgument(
+        BoundExpression argument,
+        TypeSymbol expectedType,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
+    {
+        if (expectedType != null
+            && MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(expectedType, out _)
+            && (argument is BoundFunctionLiteralExpression
+                || argument is BoundConversionExpression { Expression: BoundFunctionLiteralExpression }))
+        {
+            var lambda = argument is BoundFunctionLiteralExpression directLambda
+                ? directLambda
+                : (BoundFunctionLiteralExpression)((BoundConversionExpression)argument).Expression;
+            var nested = this.BuildExpressionTreeValue(argument.Syntax, lambda, expectedType);
+            return new BoundClrStaticCallExpression(
+                argument.Syntax,
+                ExpressionQuoteMethod,
+                TypeSymbol.FromClrType(typeof(System.Linq.Expressions.UnaryExpression)),
+                ImmutableArray.Create(UpcastToExpression(nested)));
+        }
+
+        if (expectedType != null
+            && IsDelegateLike(expectedType)
+            && (argument is BoundFunctionLiteralExpression
+                || argument is BoundConversionExpression { Expression: BoundFunctionLiteralExpression or BoundMethodGroupExpression or BoundClrMethodGroupExpression }
+                || argument is BoundMethodGroupExpression
+                || argument is BoundClrMethodGroupExpression))
+        {
+            var converted = argument.Type == expectedType
+                ? argument
+                : new BoundConversionExpression(argument.Syntax, expectedType, argument);
+            return BuildRuntimeConstant(converted, expectedType);
+        }
+
+        return this.TranslateExpression(argument, parameterMap);
+    }
+
+    private static BoundExpression BuildMethodInfoConstant(MethodInfo method)
+        => new BoundLiteralExpression(null, method, TypeSymbol.FromClrType(typeof(MethodInfo)));
+
+    private static BoundExpression CreateTypeOf(TypeSymbol type)
+        => new BoundTypeOfExpression(null, type, SystemTypeSymbol);
+
+    private static BoundExpression UpcastToExpression(BoundExpression expression)
+        => expression.Type == ExpressionTypeSymbol ? expression : new BoundConversionExpression(null, ExpressionTypeSymbol, expression);
+
+    private static BoundExpression BuildTypeArray(IEnumerable<TypeSymbol> types)
+    {
+        var elements = ImmutableArray.CreateBuilder<BoundExpression>();
+        foreach (var type in types)
+        {
+            elements.Add(CreateTypeOf(type));
+        }
+
+        return new BoundArrayCreationExpression(
+            null,
+            ArrayTypeSymbol.Get(SystemTypeSymbol, elements.Count),
+            elements.ToImmutable());
+    }
+
+    private static BoundExpression BuildExpressionArray(IEnumerable<BoundExpression> expressions)
+    {
+        var elements = ImmutableArray.CreateBuilder<BoundExpression>();
+        foreach (var expression in expressions)
+        {
+            elements.Add(UpcastToExpression(expression));
+        }
+
+        return new BoundArrayCreationExpression(
+            null,
+            ArrayTypeSymbol.Get(ExpressionTypeSymbol, elements.Count),
+            elements.ToImmutable());
+    }
+
+    private static BoundExpression BuildParameterArray(IEnumerable<LocalVariableSymbol> parameters)
+    {
+        var elements = ImmutableArray.CreateBuilder<BoundExpression>();
+        foreach (var parameter in parameters)
+        {
+            elements.Add(new BoundVariableExpression(null, parameter));
+        }
+
+        return new BoundArrayCreationExpression(
+            null,
+            ArrayTypeSymbol.Get(ParameterExpressionTypeSymbol, elements.Count),
+            elements.ToImmutable());
+    }
+
+    private static ImmutableArray<TypeSymbol> GetArgumentTypes(ImmutableArray<BoundExpression> arguments)
+    {
+        var builder = ImmutableArray.CreateBuilder<TypeSymbol>(arguments.Length);
+        foreach (var argument in arguments)
+        {
+            builder.Add(argument.Type);
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    private static ImmutableArray<TypeSymbol> GetTypeSymbols(ImmutableArray<TypeSymbol> types)
+        => types.IsDefault ? ImmutableArray<TypeSymbol>.Empty : types;
+
+    private static ImmutableArray<ParameterSymbol> GetCallableParameters(FunctionSymbol function)
+    {
+        if (function.ExplicitReceiverParameter == null)
+        {
+            return function.Parameters;
+        }
+
+        return function.Parameters.RemoveAt(0);
+    }
+
+    private static BoundExpression ExtractLambdaBodyExpression(BoundBlockStatement body)
+    {
+        BoundExpression candidate = null;
+        foreach (var statement in body.Statements)
+        {
+            switch (statement)
+            {
+                case BoundReturnStatement { Expression: not null } ret:
+                    return ret.Expression;
+                case BoundExpressionStatement exprStmt:
+                    candidate = exprStmt.Expression;
+                    break;
+            }
+        }
+
+        return candidate
+            ?? throw new NotSupportedException("Expression-tree lambda body did not contain a supported trailing expression.");
+    }
+
+    private static bool IsDelegateLike(TypeSymbol type)
+        => MemberLookup.TryGetDelegateFunctionTypeFromSymbol(type, out _);
+
+    private static MethodInfo GetRequiredMethod(Type type, string name, params Type[] parameterTypes)
+        => type.GetMethod(name, parameterTypes)
+            ?? throw new InvalidOperationException($"Required method '{type.FullName}.{name}' is not available.");
+}
+
+#pragma warning restore SA1516 // elements should be separated by blank line
+#pragma warning restore SA1137 // elements should have the same indentation

--- a/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
@@ -24,8 +24,14 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
 {
     private static readonly TypeSymbol SystemTypeSymbol = TypeSymbol.FromClrType(typeof(Type));
     private static readonly TypeSymbol ObjectTypeSymbol = TypeSymbol.Object;
+    private static readonly TypeSymbol BindingFlagsTypeSymbol = TypeSymbol.FromClrType(typeof(BindingFlags));
     private static readonly TypeSymbol ReflectionConstructorInfoTypeSymbol = TypeSymbol.FromClrType(typeof(ConstructorInfo));
+    private static readonly TypeSymbol ReflectionFieldInfoTypeSymbol = TypeSymbol.FromClrType(typeof(FieldInfo));
+    private static readonly TypeSymbol ReflectionPropertyInfoTypeSymbol = TypeSymbol.FromClrType(typeof(PropertyInfo));
+    private static readonly TypeSymbol ReflectionMemberInfoTypeSymbol = TypeSymbol.FromClrType(typeof(MemberInfo));
     private static readonly TypeSymbol ExpressionTypeSymbol = TypeSymbol.FromClrType(typeof(System.Linq.Expressions.Expression));
+    private static readonly TypeSymbol MemberBindingTypeSymbol = TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MemberBinding));
+    private static readonly TypeSymbol NewExpressionTypeSymbol = TypeSymbol.FromClrType(typeof(System.Linq.Expressions.NewExpression));
     private static readonly TypeSymbol ParameterExpressionTypeSymbol = TypeSymbol.FromClrType(typeof(System.Linq.Expressions.ParameterExpression));
 
     private static readonly MethodInfo ExpressionParameterMethod = GetRequiredMethod(
@@ -135,6 +141,16 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
         nameof(System.Linq.Expressions.Expression.New),
         typeof(ConstructorInfo),
         typeof(System.Linq.Expressions.Expression[]));
+    private static readonly MethodInfo ExpressionMemberInitMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.MemberInit),
+        typeof(System.Linq.Expressions.NewExpression),
+        typeof(System.Linq.Expressions.MemberBinding[]));
+    private static readonly MethodInfo ExpressionBindMethod = GetRequiredMethod(
+        typeof(System.Linq.Expressions.Expression),
+        nameof(System.Linq.Expressions.Expression.Bind),
+        typeof(MemberInfo),
+        typeof(System.Linq.Expressions.Expression));
     private static readonly MethodInfo ExpressionNewArrayInitMethod = GetRequiredMethod(
         typeof(System.Linq.Expressions.Expression),
         nameof(System.Linq.Expressions.Expression.NewArrayInit),
@@ -158,6 +174,16 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
         typeof(Type),
         nameof(Type.GetConstructor),
         typeof(Type[]));
+    private static readonly MethodInfo TypeGetFieldMethod = GetRequiredMethod(
+        typeof(Type),
+        nameof(Type.GetField),
+        typeof(string),
+        typeof(BindingFlags));
+    private static readonly MethodInfo TypeGetPropertyMethod = GetRequiredMethod(
+        typeof(Type),
+        nameof(Type.GetProperty),
+        typeof(string),
+        typeof(BindingFlags));
 
     private int counter;
 
@@ -352,6 +378,8 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
                 return BuildClrUnaryOperatorExpression(clrUnary, parameterMap);
             case BoundFunctionLiteralExpression nestedDelegateLiteral:
                 return BuildRuntimeConstant(nestedDelegateLiteral, nestedDelegateLiteral.Type);
+            case BoundBlockExpression block when this.TryBuildObjectInitializerExpression(block, parameterMap, out var objectInitializer):
+                return objectInitializer;
             default:
                 throw new NotSupportedException($"Unsupported expression-tree lowering node: {expression.Kind}.");
         }
@@ -832,6 +860,87 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
                 BuildMethodInfoConstant(expression.Method)));
     }
 
+    private bool TryBuildObjectInitializerExpression(
+        BoundBlockExpression block,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap,
+        out BoundExpression expression)
+    {
+        expression = null;
+
+        if (!TryMatchObjectInitializer(block, out var tempVariable, out var initializer, out var statements))
+        {
+            return false;
+        }
+
+        var translatedInitializer = this.TranslateExpression(initializer, parameterMap);
+        if (statements.Length == 0)
+        {
+            expression = translatedInitializer;
+            return true;
+        }
+
+        var bindings = ImmutableArray.CreateBuilder<BoundExpression>(statements.Length);
+        foreach (var statement in statements)
+        {
+            if (statement is not BoundExpressionStatement expressionStatement
+                || !this.TryBuildMemberBinding(expressionStatement.Expression, tempVariable, parameterMap, out var binding))
+            {
+                return false;
+            }
+
+            bindings.Add(binding);
+        }
+
+        expression = new BoundClrStaticCallExpression(
+            block.Syntax,
+            ExpressionMemberInitMethod,
+            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MemberInitExpression)),
+            ImmutableArray.Create<BoundExpression>(
+                translatedInitializer.Type == NewExpressionTypeSymbol
+                    ? translatedInitializer
+                    : new BoundConversionExpression(null, NewExpressionTypeSymbol, translatedInitializer),
+                BuildMemberBindingArray(bindings)));
+        return true;
+    }
+
+    private bool TryBuildMemberBinding(
+        BoundExpression expression,
+        VariableSymbol receiver,
+        Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap,
+        out BoundExpression binding)
+    {
+        binding = expression switch
+        {
+            BoundFieldAssignmentExpression field when ReferencesReceiver(field, receiver) =>
+                new BoundClrStaticCallExpression(
+                    field.Syntax,
+                    ExpressionBindMethod,
+                    TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MemberAssignment)),
+                    ImmutableArray.Create<BoundExpression>(
+                        BuildUserFieldInfoLookup(field.StructType, field.Field.Name),
+                        UpcastToExpression(this.TranslateExpression(field.Value, parameterMap)))),
+            BoundPropertyAssignmentExpression property when ReferencesReceiver(property.Receiver, receiver) =>
+                new BoundClrStaticCallExpression(
+                    property.Syntax,
+                    ExpressionBindMethod,
+                    TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MemberAssignment)),
+                    ImmutableArray.Create<BoundExpression>(
+                        BuildUserPropertyInfoLookup(property.StructType, property.Property.Name),
+                        UpcastToExpression(this.TranslateExpression(property.Value, parameterMap)))),
+            BoundClrPropertyAssignmentExpression clrProperty when ReferencesReceiver(clrProperty.Receiver, receiver) =>
+                new BoundClrStaticCallExpression(
+                    clrProperty.Syntax,
+                    ExpressionBindMethod,
+                    TypeSymbol.FromClrType(typeof(System.Linq.Expressions.MemberAssignment)),
+                    ImmutableArray.Create<BoundExpression>(
+                        BuildMemberInfoConstant(clrProperty.Member),
+                        UpcastToExpression(this.TranslateExpression(clrProperty.Value, parameterMap)))),
+            _ => null,
+        };
+
+        return binding != null;
+    }
+
     private ImmutableArray<BoundExpression> TranslateArguments(
         ImmutableArray<BoundExpression> arguments,
         ParameterInfo[] parameters,
@@ -917,6 +1026,33 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
     private static BoundExpression BuildMethodInfoConstant(MethodInfo method)
         => new BoundLiteralExpression(null, method, TypeSymbol.FromClrType(typeof(MethodInfo)));
 
+    private static BoundExpression BuildMemberInfoConstant(MemberInfo member)
+        => new BoundLiteralExpression(null, member, ReflectionMemberInfoTypeSymbol);
+
+    private static BoundExpression BuildUserFieldInfoLookup(TypeSymbol ownerType, string memberName)
+    {
+        return new BoundImportedInstanceCallExpression(
+            null,
+            CreateTypeOf(ownerType),
+            TypeGetFieldMethod,
+            ReflectionFieldInfoTypeSymbol,
+            ImmutableArray.Create<BoundExpression>(
+                new BoundLiteralExpression(null, memberName, TypeSymbol.String),
+                BuildBindingFlagsConstant(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)));
+    }
+
+    private static BoundExpression BuildUserPropertyInfoLookup(TypeSymbol ownerType, string memberName)
+    {
+        return new BoundImportedInstanceCallExpression(
+            null,
+            CreateTypeOf(ownerType),
+            TypeGetPropertyMethod,
+            ReflectionPropertyInfoTypeSymbol,
+            ImmutableArray.Create<BoundExpression>(
+                new BoundLiteralExpression(null, memberName, TypeSymbol.String),
+                BuildBindingFlagsConstant(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)));
+    }
+
     private static BoundExpression CreateTypeOf(TypeSymbol type)
         => new BoundTypeOfExpression(null, type, SystemTypeSymbol);
 
@@ -965,6 +1101,26 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
             elements.ToImmutable());
     }
 
+    private static BoundExpression BuildMemberBindingArray(IEnumerable<BoundExpression> bindings)
+    {
+        var elements = ImmutableArray.CreateBuilder<BoundExpression>();
+        foreach (var binding in bindings)
+        {
+            elements.Add(binding.Type == MemberBindingTypeSymbol ? binding : new BoundConversionExpression(null, MemberBindingTypeSymbol, binding));
+        }
+
+        return new BoundArrayCreationExpression(
+            null,
+            ArrayTypeSymbol.Get(MemberBindingTypeSymbol, elements.Count),
+            elements.ToImmutable());
+    }
+
+    private static BoundExpression BuildBindingFlagsConstant(BindingFlags flags)
+        => new BoundConversionExpression(
+            null,
+            BindingFlagsTypeSymbol,
+            new BoundLiteralExpression(null, (int)flags, TypeSymbol.Int32));
+
     private static ImmutableArray<TypeSymbol> GetArgumentTypes(ImmutableArray<BoundExpression> arguments)
     {
         var builder = ImmutableArray.CreateBuilder<TypeSymbol>(arguments.Length);
@@ -1007,6 +1163,37 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
         return candidate
             ?? throw new NotSupportedException("Expression-tree lambda body did not contain a supported trailing expression.");
     }
+
+    private static bool TryMatchObjectInitializer(
+        BoundBlockExpression block,
+        out VariableSymbol receiver,
+        out BoundExpression initializer,
+        out ImmutableArray<BoundStatement> statements)
+    {
+        receiver = null;
+        initializer = null;
+        statements = default;
+
+        if (block.Expression is not BoundVariableExpression result
+            || block.Statements.IsDefaultOrEmpty
+            || block.Statements[0] is not BoundVariableDeclaration declaration
+            || !ReferenceEquals(declaration.Variable, result.Variable))
+        {
+            return false;
+        }
+
+        receiver = declaration.Variable;
+        initializer = declaration.Initializer;
+        statements = block.Statements.RemoveAt(0);
+        return true;
+    }
+
+    private static bool ReferencesReceiver(BoundExpression expression, VariableSymbol receiver)
+        => expression is BoundVariableExpression variable && ReferenceEquals(variable.Variable, receiver);
+
+    private static bool ReferencesReceiver(BoundFieldAssignmentExpression assignment, VariableSymbol receiver)
+        => ReferenceEquals(assignment.Receiver, receiver)
+            || ReferencesReceiver(assignment.ReceiverExpression, receiver);
 
     private static bool IsDelegateLike(TypeSymbol type)
         => MemberLookup.TryGetDelegateFunctionTypeFromSymbol(type, out _);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2130ExpressionTreeBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2130ExpressionTreeBindingTests.cs
@@ -83,6 +83,108 @@ let expr Expression[int32] = (x int32) -> x
         Assert.Contains(diagnostics, d => d.Id == "GS0474");
     }
 
+    [Fact]
+    public void ConditionalOperator_IsAllowedInsideExpressionTree()
+    {
+        var diagnostics = GetDiagnostics(@"
+import System
+import System.Linq.Expressions
+
+let expr Expression[Func[int32, int32]] = (x int32) -> x > 0 ? x : -x
+");
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0473");
+    }
+
+    [Fact]
+    public void Indexers_AreAllowedInsideExpressionTree()
+    {
+        var diagnostics = GetDiagnostics(@"
+import System
+import System.Linq.Expressions
+
+class Repo(data [3]int32) {
+    prop this[index int32] int32 -> this.data[index]
+}
+
+let expr Expression[Func[int32]] = () -> [3]int32{ 10, 20, 30 }[1] + Repo([3]int32{ 1, 2, 3 })[1]
+");
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0473");
+    }
+
+    [Fact]
+    public void ObjectConstructionAndInitializers_AreAllowedInsideExpressionTree()
+    {
+        var diagnostics = GetDiagnostics(@"
+import System
+import System.Linq.Expressions
+
+class Box {
+    prop Width int32
+    prop Height int32
+    init() { }
+}
+
+let expr Expression[Func[int32]] = () -> Box() { Width = 40, Height = 2 }.Width
+");
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0473");
+    }
+
+    [Fact]
+    public void ArrayCreationAndTypeTests_AreAllowedInsideExpressionTree()
+    {
+        var diagnostics = GetDiagnostics(@"
+import System
+import System.Linq.Expressions
+
+let expr Expression[Func[object, int32]] = (value object) -> (value is string) ? [2]int32{ (value as string).Length, 40 }[0] : 0
+");
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0473");
+    }
+
+    [Fact]
+    public void NestedLambdaArguments_AreAllowedForDelegateAndExpressionParameters()
+    {
+        var diagnostics = GetDiagnostics(@"
+import System
+import System.Linq.Expressions
+
+class Helpers {
+    shared {
+        func UseDelegate(f (int32) -> int32, value int32) int32 {
+            return f(value)
+        }
+
+        func UseExpression(f Expression[(int32) -> int32], value int32) int32 {
+            let compiled = f.Compile()
+            return compiled(value)
+        }
+    }
+}
+
+let expr Expression[Func[int32, int32]] = (x int32) -> Helpers.UseDelegate((y int32) -> y + 1, x) + Helpers.UseExpression((z int32) -> z + 1, 0)
+");
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0473");
+    }
+
+    [Fact]
+    public void CollectionInitializer_RemainsRejectedInsideExpressionTree()
+    {
+        var diagnostics = GetDiagnostics(@"
+import System
+import System.Linq.Expressions
+import System.Collections.Generic
+
+let expr Expression[Func[List[int32]]] = () -> List[int32]{ 1, 2, 3 }
+");
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0473");
+    }
+
     private static System.Collections.Immutable.ImmutableArray<Diagnostic> GetDiagnostics(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2130ExpressionTreeBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2130ExpressionTreeBindingTests.cs
@@ -1,0 +1,94 @@
+// <copyright file="Issue2130ExpressionTreeBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2130: binding diagnostics for expression-tree conversions.
+/// </summary>
+public class Issue2130ExpressionTreeBindingTests
+{
+    [Fact]
+    public void StatementBodyLambda_IsRejectedForExpressionTree()
+    {
+        var diagnostics = GetDiagnostics(@"
+import System
+import System.Linq.Expressions
+
+let expr Expression[Func[int32, int32]] = (x int32) -> { return x + 1 }
+");
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0473" && d.Message.Contains("statement body"));
+    }
+
+    [Fact]
+    public void AsyncLambda_IsRejectedForExpressionTree()
+    {
+        var diagnostics = GetDiagnostics(@"
+import System
+import System.Linq.Expressions
+import System.Threading.Tasks
+
+let expr Expression[Func[int32, Task[int32]]] = async (x int32) -> x + 1
+");
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0473" && d.Message.Contains("async lambda"));
+    }
+
+    [Fact]
+    public void AssignmentInsideExpressionTree_IsRejected()
+    {
+        var diagnostics = GetDiagnostics(@"
+import System
+import System.Linq.Expressions
+
+var outer = 1
+let expr Expression[Func[int32, int32]] = (x int32) -> outer = x
+");
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0473" && d.Message.Contains("assignment"));
+    }
+
+    [Fact]
+    public void TupleLiteral_IsRejected()
+    {
+        var diagnostics = GetDiagnostics(@"
+import System
+import System.Linq.Expressions
+
+let expr Expression[Func[int32, (int32, int32)]] = (x int32) -> (x, x + 1)
+");
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0473" && d.Message.Contains("tuple"));
+    }
+
+    [Fact]
+    public void NonDelegateExpressionTreeTarget_IsRejected()
+    {
+        var diagnostics = GetDiagnostics(@"
+import System
+import System.Linq.Expressions
+
+let expr Expression[int32] = (x int32) -> x
+");
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0474");
+    }
+
+    private static System.Collections.Immutable.ImmutableArray<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        var result = compilation.Emit(peStream);
+        return result.Diagnostics;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2130ExpressionTreeEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2130ExpressionTreeEmitTests.cs
@@ -1,0 +1,186 @@
+// <copyright file="Issue2130ExpressionTreeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #2130: end-to-end emit coverage for lambda-to-expression-tree
+/// conversions.
+/// </summary>
+public class Issue2130ExpressionTreeEmitTests
+{
+    [Fact]
+    public void ExpressionTree_CompilesAndExecutesSimplePropertySelector()
+    {
+        const string Source = @"package ExprSimple
+import System
+import System.Linq.Expressions
+
+class Book(Id int32)
+
+func main() int32 {
+    let selector Expression[Func[Book, int32]] = (b Book) -> b.Id + 1
+    let compiled = selector.Compile()
+    return compiled(Book(41))
+}
+";
+
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ExpressionTree_CompilesAndExecutesSimplePropertySelector));
+        try
+        {
+            Assert.Equal(42, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void ExpressionTree_CapturedLocalSeesLatestValueThroughBox()
+    {
+        const string Source = @"package ExprCapture
+import System
+import System.Linq.Expressions
+
+func main() int32 {
+    var factor = 2
+    let expr Expression[Func[int32, int32]] = (x int32) -> x * factor
+    factor = 3
+    let compiled = expr.Compile()
+    return compiled(14)
+}
+";
+
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ExpressionTree_CapturedLocalSeesLatestValueThroughBox));
+        try
+        {
+            Assert.Equal(42, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void ExpressionTree_GenericHelperAcceptsBookSelector()
+    {
+        const string Source = @"package ExprCallArg
+import System
+import System.Linq.Expressions
+
+func useSelector(selector Expression[Func[int32, int32]], value int32) int32 {
+    let compiled = selector.Compile()
+    let result = compiled(value)
+    return result
+}
+
+func main() int32 {
+    let selector Expression[Func[int32, int32]] = (x int32) -> x + 1
+    return useSelector(selector, 41)
+}
+";
+
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ExpressionTree_GenericHelperAcceptsBookSelector));
+        try
+        {
+            Assert.Equal(42, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void ExpressionTree_MethodParameter_AcceptsDirectBookLambda()
+    {
+        const string Source = @"package ExprDirectBookArg
+import System
+import System.Linq.Expressions
+
+class Book(Id int32)
+
+func selectValue(selector Expression[Func[Book, int32]], value Book) int32 {
+    let compiled = selector.Compile()
+    return compiled(value)
+}
+
+func main() int32 {
+    return selectValue((b Book) -> b.Id, Book(42))
+}
+";
+
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ExpressionTree_MethodParameter_AcceptsDirectBookLambda));
+        try
+        {
+            Assert.Equal(42, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void ExpressionTree_ImportedMethodCalls_AreRepresentedAndExecuted()
+    {
+        const string Source = @"package ExprImportedCall
+import System
+import System.Linq.Expressions
+
+func main() int32 {
+    let expr Expression[Func[string, int32]] = (s string) -> s.Trim().Length
+    let compiled = expr.Compile()
+    return compiled(""  hi  "")
+}
+";
+
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ExpressionTree_ImportedMethodCalls_AreRepresentedAndExecuted));
+        try
+        {
+            Assert.Equal(2, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    private static MethodInfo GetProgramMethod(Assembly asm, string name)
+    {
+        var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+        Assert.NotNull(programType);
+        var method = programType!.GetMethod(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return method!;
+    }
+
+    private static (Assembly asm, AssemblyLoadContext ctx) CompileToAssembly(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Id + ":" + d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        var asm = loadContext.LoadFromStream(peStream);
+        return (asm, loadContext);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2130ExpressionTreeEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2130ExpressionTreeEmitTests.cs
@@ -158,6 +158,211 @@ func main() int32 {
         }
     }
 
+    [Fact]
+    public void ExpressionTree_ConditionalOperator_IsRepresentedAndExecuted()
+    {
+        const string Source = @"package ExprConditional
+import System
+import System.Linq.Expressions
+
+func main() int32 {
+    let expr Expression[Func[int32, int32]] = (x int32) -> x > 0 ? x : -x
+    let compiled = expr.Compile()
+    return compiled(-42)
+}
+";
+
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ExpressionTree_ConditionalOperator_IsRepresentedAndExecuted));
+        try
+        {
+            Assert.Equal(42, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void ExpressionTree_Indexers_AreRepresentedAndExecuted()
+    {
+        const string Source = @"package ExprIndexers
+import System
+import System.Linq.Expressions
+import System.Collections.Generic
+
+class Repo(data [3]int32) {
+    prop this[index int32] int32 -> this.data[index]
+}
+
+func main() int32 {
+    let expr Expression[Func[int32]] = () -> [3]int32{ 40, 1, 1 }[0] + Repo([3]int32{ 1, 2, 3 })[1]
+    let compiled = expr.Compile()
+    return compiled()
+}
+";
+
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ExpressionTree_Indexers_AreRepresentedAndExecuted));
+        try
+        {
+            Assert.Equal(42, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void ExpressionTree_ObjectConstructionAndArrayCreation_AreRepresentedAndExecuted()
+    {
+        const string Source = @"package ExprNewArray
+import System
+import System.Linq.Expressions
+
+class Book(Id int32)
+
+func main() int32 {
+    let expr Expression[Func[int32]] = () -> Book(40).Id + [2]int32{ 1, 2 }.Length
+    let compiled = expr.Compile()
+    return compiled()
+}
+";
+
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ExpressionTree_ObjectConstructionAndArrayCreation_AreRepresentedAndExecuted));
+        try
+        {
+            Assert.Equal(42, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void ExpressionTree_ObjectInitializer_IsRepresentedAndExecuted()
+    {
+        const string Source = @"package ExprObjectInit
+import System
+import System.Linq.Expressions
+
+class Box {
+    prop Width int32
+    prop Height int32
+    init() { }
+}
+
+func main() int32 {
+    let expr Expression[Func[int32]] = () -> Box() { Width = 40, Height = 2 }.Width
+    let compiled = expr.Compile()
+    return compiled()
+}
+";
+
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ExpressionTree_ObjectInitializer_IsRepresentedAndExecuted));
+        try
+        {
+            Assert.Equal(40, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void ExpressionTree_TypeTests_AreRepresentedAndExecuted()
+    {
+        const string Source = @"package ExprTypeTests
+import System
+import System.Linq.Expressions
+
+func main() int32 {
+    let expr Expression[Func[object, int32]] = (value object) -> (value is string) ? (value as string).Length : 0
+    let compiled = expr.Compile()
+    return compiled(""forty-two"") + compiled(0)
+}
+";
+
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ExpressionTree_TypeTests_AreRepresentedAndExecuted));
+        try
+        {
+            Assert.Equal(9, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void ExpressionTree_NestedLambdaArgument_ForDelegateParameter_Executes()
+    {
+        const string Source = @"package ExprNestedDelegate
+import System
+import System.Linq.Expressions
+
+class Helpers {
+    shared {
+        func ApplyDelegate(f (int32) -> int32, value int32) int32 {
+            return f(value)
+        }
+    }
+}
+
+func main() int32 {
+    let expr Expression[Func[int32, int32]] = (x int32) -> Helpers.ApplyDelegate((y int32) -> y + 2, x)
+    let compiled = expr.Compile()
+    return compiled(40)
+}
+";
+
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ExpressionTree_NestedLambdaArgument_ForDelegateParameter_Executes));
+        try
+        {
+            Assert.Equal(42, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void ExpressionTree_NestedLambdaArgument_ForExpressionParameter_Executes()
+    {
+        const string Source = @"package ExprNestedExpression
+import System
+import System.Linq.Expressions
+
+class Helpers {
+    shared {
+        func ApplyExpression(f Expression[(int32) -> int32], value int32) int32 {
+            let compiled = f.Compile()
+            return compiled(value)
+        }
+    }
+}
+
+func main() int32 {
+    let expr Expression[Func[int32, int32]] = (x int32) -> Helpers.ApplyExpression((y int32) -> y + 2, x)
+    let compiled = expr.Compile()
+    return compiled(40)
+}
+";
+
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ExpressionTree_NestedLambdaArgument_ForExpressionParameter_Executes));
+        try
+        {
+            Assert.Equal(42, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
     private static MethodInfo GetProgramMethod(Assembly asm, string name)
     {
         var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");


### PR DESCRIPTION
## Summary

Adds full compiler support for converting a G# lambda to
`System.Linq.Expressions.Expression<TDelegate>` ("expression trees"), matching
the scope of C#/Roslyn's expression-tree lowering. Closes the primary blocker
for EF Core fluent APIs (`HasKey`, `HasIndex`, `HasOne`, etc.) in the Oahu
migration.

Fixes #2130

## What's included

- **Binder/conversion**: `Expression<TDelegate>` is now recognized as a valid
  lambda conversion target.
- **Restriction validation**: `ExpressionTreeRestrictionValidator` enforces
  C#-equivalent expression-tree restrictions at bind time — statement-bodied
  lambdas, async lambdas, assignments, and collection/list initializer forms
  are rejected with `GS0473`; non-delegate target types are rejected with
  `GS0474`.
- **Lowering/emit**: `ExpressionTreeLowerer` emits real
  `System.Linq.Expressions.Expression.*` factory-call IL — `Parameter`,
  `Constant`, `Property`/`Field`, `Call`, `Condition`, `ArrayIndex`/
  `MakeIndex`, `New`/`NewArrayInit`, `TypeAs`/`TypeIs`, `Lambda<TDelegate>`,
  and closures over captured locals (via boxed-local field access).
- **Nested lambda arguments**: an argument lambda targeting a plain delegate
  type becomes a runtime delegate constant; one targeting `Expression<T>`
  recursively lowers as a nested `Expression.Lambda<T>` — matching Roslyn's
  distinction, and the exact shape needed for EF-style fluent chains.
- **ADR-0141** (`docs/adr/0141-expression-tree-lambda-conversions.md`)
  documents the conversion rule, supported constructs, restriction list, and
  closure handling as the source of truth for current scope.
- **Tests**: 23 new binding + emit tests
  (`Issue2130ExpressionTreeBindingTests.cs`,
  `Issue2130ExpressionTreeEmitTests.cs`). Emit tests compile real G# source,
  load it into a collectible `AssemblyLoadContext`, `.Compile()` the resulting
  expression tree, and assert the actual executed result — not just that it
  binds/compiles.

## Known intentional gap

Collection/list initializer expression forms remain rejected (`GS0473`),
consistent with edge cases Roslyn itself special-cases. Everything else in
scope (conditional `?:`, indexers, `new`/array construction, `as`/`is`, and
nested expression-typed lambda arguments) is fully implemented and executed
in tests, not just diagnosed.

## Validation

- `dotnet build GSharp.sln` — clean, 0 warnings/errors
- `dotnet test test/Core.Tests/Core.Tests.csproj` — 5610 passed, 1 skipped
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj` — 1095 passed
