### PR TITLE
Fix #2140: []T converts to System.Array / non-generic ICollection/IEnumerable/IList

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -911,6 +911,21 @@ public sealed class Conversion
             }
         }
 
+        // Issue #2140: a G# slice `[]T` is backed at runtime by a CLR
+        // one-dimensional array, which derives from the base class
+        // `System.Array`. This upcast is element-INDEPENDENT and a no-op
+        // reference upcast at IL level. The concrete-element case already
+        // flows through the general #521 CLR reference-upcast arm below;
+        // this arm additionally accepts the generic-type-parameter /
+        // same-compilation-user element case whose backing `ClrType` is
+        // null during binding (so the #521 arm cannot fire). Use the
+        // cross-context-safe `IsSameAs` (reference identity is forbidden,
+        // guard test #835).
+        if (from is SliceTypeSymbol && to?.ClrType?.IsSameAs(typeof(System.Array)) == true)
+        {
+            return Conversion.Implicit;
+        }
+
         // Slice-to-interface: a G# slice `[]T` is backed by a CLR `T[]`
         // at runtime. Extend to every interface that `T[]` implements
         // (IEnumerable<T>, IReadOnlyList<T>, IList<T>, non-generic
@@ -2089,6 +2104,16 @@ public sealed class Conversion
     /// </summary>
     private static bool SliceImplementsInterfaceSymbolically(SliceTypeSymbol slice, TypeSymbol targetInterface)
     {
+        // Issue #2140: element-INDEPENDENT non-generic array interfaces.
+        // Every one-dimensional array implements these regardless of its
+        // element type, so a `[]T` (generic-type-parameter or same-
+        // compilation-user element, null backing ClrType) converts to them
+        // unconditionally. Match by the target's full name.
+        if (IsElementIndependentArrayInterface(targetInterface))
+        {
+            return true;
+        }
+
         if (targetInterface is not ImportedTypeSymbol imported
             || imported.OpenDefinition is null
             || imported.TypeArguments.Length != 1)
@@ -2115,6 +2140,40 @@ public sealed class Conversion
         }
 
         return AreTypeArgumentsEquivalent(imported.TypeArguments[0], slice.ElementType);
+    }
+
+    /// <summary>
+    /// Issue #2140: true when <paramref name="target"/> is one of the
+    /// element-INDEPENDENT array supertype interfaces that EVERY one-
+    /// dimensional array implements regardless of element type — the non-
+    /// generic collection interfaces plus <c>ICloneable</c>,
+    /// <c>IStructuralComparable</c> and <c>IStructuralEquatable</c>. Because
+    /// they carry no element type argument, a slice `[]T` (any element)
+    /// converts to them as a no-op reference upcast without loosening the
+    /// invariance enforced for the generic element interfaces
+    /// (<c>IEnumerable&lt;T&gt;</c> etc.). Uses the cross-context-safe
+    /// <c>IsSameAs</c> (reference identity is forbidden, guard test #835).
+    /// </summary>
+    /// <param name="target">The candidate target type.</param>
+    /// <returns>
+    /// <see langword="true"/> when <paramref name="target"/> is an element-
+    /// independent non-generic array supertype interface; otherwise
+    /// <see langword="false"/>.
+    /// </returns>
+    private static bool IsElementIndependentArrayInterface(TypeSymbol target)
+    {
+        var clr = target?.ClrType;
+        if (clr is null)
+        {
+            return false;
+        }
+
+        return clr.IsSameAs(typeof(System.Collections.IEnumerable))
+            || clr.IsSameAs(typeof(System.Collections.ICollection))
+            || clr.IsSameAs(typeof(System.Collections.IList))
+            || clr.IsSameAs(typeof(System.ICloneable))
+            || clr.IsSameAs(typeof(System.Collections.IStructuralComparable))
+            || clr.IsSameAs(typeof(System.Collections.IStructuralEquatable));
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -781,6 +781,33 @@ internal sealed partial class MethodBodyEmitter
             }
         }
 
+        // Issue #2140: a G# slice `[]T` (any element type) is backed at
+        // runtime by a one-dimensional CLR array. Upcasting it to the base
+        // class `System.Array` — or to any of the element-INDEPENDENT non-
+        // generic array supertype interfaces (IEnumerable, ICollection,
+        // IList, ICloneable, IStructuralComparable, IStructuralEquatable) —
+        // is a no-op reference conversion: the slot already holds an array
+        // reference that is assignment-compatible with the wider static
+        // type. The concrete-element case reaches emit through the #521 /
+        // #570 CLR arms above; these arms additionally recognise the
+        // generic-type-parameter / same-compilation-user element case whose
+        // backing `ClrType` is null during emit.
+        if (a is SliceTypeSymbol)
+        {
+            var bClr = b?.ClrType;
+            if (bClr != null
+                && (bClr.IsSameAs(typeof(System.Array))
+                    || bClr.IsSameAs(typeof(System.Collections.IEnumerable))
+                    || bClr.IsSameAs(typeof(System.Collections.ICollection))
+                    || bClr.IsSameAs(typeof(System.Collections.IList))
+                    || bClr.IsSameAs(typeof(System.ICloneable))
+                    || bClr.IsSameAs(typeof(System.Collections.IStructuralComparable))
+                    || bClr.IsSameAs(typeof(System.Collections.IStructuralEquatable))))
+            {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2140GenericArraySupertypesBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2140GenericArraySupertypesBinderTests.cs
@@ -1,0 +1,191 @@
+// <copyright file="Issue2140GenericArraySupertypesBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2140: a slice <c>[]T</c> whose element <c>T</c> is a generic type
+/// parameter (or same-compilation user type) has a null backing
+/// <c>ClrType</c> during binding. It must still convert to the element-
+/// INDEPENDENT array supertypes that EVERY one-dimensional array carries: the
+/// base class <see cref="System.Array"/> and the non-generic collection
+/// interfaces (<see cref="IEnumerable"/>, <see cref="ICollection"/>,
+/// <see cref="IList"/>), plus <see cref="System.ICloneable"/>,
+/// <see cref="IStructuralComparable"/>, <see cref="IStructuralEquatable"/>.
+/// These conversions carry no element type argument, so slice invariance for
+/// the generic element interfaces (<c>IEnumerable[T]</c> etc.) is unaffected.
+/// </summary>
+public class Issue2140GenericArraySupertypesBinderTests
+{
+    [Fact]
+    public void GenericParamElementArray_ToSystemArray_NoDiagnostics()
+    {
+        const string source = @"
+package P
+class G[T] {
+    func ToArr(arr []T) System.Array { return arr }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void GenericParamElementArray_ToNonGenericIEnumerable_NoDiagnostics()
+    {
+        const string source = @"
+package P
+class G[T] {
+    func ToEnum(arr []T) System.Collections.IEnumerable { return arr }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void GenericParamElementArray_ToNonGenericICollection_NoDiagnostics()
+    {
+        const string source = @"
+package P
+class G[T] {
+    func ToColl(arr []T) System.Collections.ICollection { return arr }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void GenericParamElementArray_ToNonGenericIList_NoDiagnostics()
+    {
+        const string source = @"
+package P
+class G[T] {
+    func ToList(arr []T) System.Collections.IList { return arr }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void GenericParamElementArray_ToICloneable_NoDiagnostics()
+    {
+        const string source = @"
+package P
+class G[T] {
+    func ToClone(arr []T) System.ICloneable { return arr }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void GenericParamElementArray_ToAllElementIndependentSupertypes_NoDiagnostics()
+    {
+        const string source = @"
+package P
+class G[T] {
+    func ToArr(arr []T) System.Array { return arr }
+    func ToEnum(arr []T) System.Collections.IEnumerable { return arr }
+    func ToColl(arr []T) System.Collections.ICollection { return arr }
+    func ToList(arr []T) System.Collections.IList { return arr }
+    func ToClone(arr []T) System.ICloneable { return arr }
+    func ToStructComp(arr []T) System.Collections.IStructuralComparable { return arr }
+    func ToStructEq(arr []T) System.Collections.IStructuralEquatable { return arr }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void UserTypeElementArray_ToSystemArray_NoDiagnostics()
+    {
+        const string source = @"
+package P
+struct Segment { let X uint32 }
+func ToArr(arr []Segment) System.Array { return arr }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ConcreteElementArray_ToSystemArray_StillNoDiagnostics()
+    {
+        // Control: the concrete-element path (backing ClrType non-null) must
+        // remain unaffected.
+        const string source = @"
+package P
+func ToArr(arr []string) System.Array { return arr }
+func ToColl(arr []string) System.Collections.ICollection { return arr }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void GenericParamElementArray_ToMismatchedGenericIEnumerable_StillRejected()
+    {
+        // Slice invariance for the generic element interfaces must be
+        // preserved: []T does NOT convert to IEnumerable[U] for a different U.
+        const string source = @"
+package P
+import System.Collections.Generic
+class G[T, U] {
+    func Bad(arr []T) IEnumerable[U] { return arr }
+}
+";
+        var diags = GetDiagnostics(source);
+        Assert.NotEmpty(diags);
+        Assert.Contains(diags, d => d.Id == "GS0154" || d.Id == "GS0155");
+    }
+
+    private static ImmutableArrayOfDiagnostic GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var parseDiagnostics = tree.Diagnostics;
+        var bindDiagnostics = compilation.GlobalScope.Diagnostics;
+        var programDiagnostics = compilation.BoundProgram.Diagnostics;
+        var all = parseDiagnostics
+            .Concat(bindDiagnostics)
+            .Concat(programDiagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+        return new ImmutableArrayOfDiagnostic(all);
+    }
+
+    /// <summary>
+    /// Thin wrapper so the test cases can call <c>Assert.Empty</c> against a
+    /// <see cref="ImmutableArray{T}"/> without exposing the GSharp diagnostic
+    /// surface to xUnit's enumerable inference.
+    /// </summary>
+    private readonly struct ImmutableArrayOfDiagnostic : IReadOnlyCollection<Diagnostic>
+    {
+        private readonly ImmutableArray<Diagnostic> diagnostics;
+
+        public ImmutableArrayOfDiagnostic(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public int Count => this.diagnostics.Length;
+
+        public IEnumerator<Diagnostic> GetEnumerator()
+        {
+            foreach (var diagnostic in this.diagnostics)
+            {
+                yield return diagnostic;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    }
+}


### PR DESCRIPTION
Fixes #2140. Refs #914.

Adds symbolic conversion of a slice whose element type is a generic type parameter (or same-compilation user type) — backing CLR array type null during binding — to the element-independent array supertypes: base class System.Array and non-generic IEnumerable/ICollection/IList/ICloneable/IStructuralComparable/IStructuralEquatable. Every 1-D array implements these regardless of element type, so the conversion is a no-op reference upcast (matching the already-working concrete-element path). Generic element-interface invariance (IEnumerable[T] etc.) is unchanged.