### PR TITLE
Fix #2142: lambda -> Expression<Func<T,...>> for imported generic-class instance methods (EF fluent API)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -765,8 +765,27 @@ internal sealed class ConversionClassifier
                     }
 
                     var targetType = substituted ?? TypeSymbol.FromClrType(parameterType);
+
+                    // Issue #2142 (follow-up to #2130/#2139): a lambda/arrow
+                    // literal flowing into an imported method's
+                    // `Expression<Func<…>>` parameter must be routed through
+                    // `BindConversion`, which lowers it to an expression tree
+                    // (#2139). The general `Conversion.Classify` gate below does
+                    // NOT recognise a function-literal → `Expression<TDelegate>`
+                    // conversion (that classification lives only inside
+                    // `BindConversion` itself), so without this the argument was
+                    // left as a bare `Func<…>` delegate and either mismatched the
+                    // parameter (verifier failure) or, for imported generic-class
+                    // instance methods whose delegate depends on the receiver's
+                    // class type argument, caused the candidate to be dropped
+                    // entirely (GS0159). Scoping the routing to this imported-call
+                    // site keeps the same-compilation user-method path (which has
+                    // its own expression-tree handling) unchanged.
+                    var isExpressionTreeLiteralTarget = argument is BoundFunctionLiteralExpression
+                        && MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(targetType, out _);
+
                     if (argument.Type != targetType
-                        && Conversion.Classify(argument.Type, targetType).Exists
+                        && (Conversion.Classify(argument.Type, targetType).Exists || isExpressionTreeLiteralTarget)
                         && NeedsBindClrParameterConversion(argument.Type, parameterType, substituted))
                     {
                         // Issue #506: the source-argument list may not align with

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1305,6 +1305,30 @@ internal sealed partial class ExpressionBinder
             return typeof(object);
         }
 
+        // Issue #2142: a nullable user reference type (`UserClass?`) erases to
+        // the same CLR ride-through as its non-nullable form — nullability is an
+        // annotation only for reference types, so overload resolution (and the
+        // erased-delegate build used for a lambda whose return is `UserClass?`,
+        // e.g. `(e Book) -> e.Conversion` where `Conversion` is a
+        // same-compilation class) must not bail out. Without this, a lambda
+        // argument returning `UserClass?` produced no effective CLR type, so the
+        // whole call failed overload resolution with GS0159 (e.g. EF Core's
+        // `EntityTypeBuilder<Book>.HasOne((e) -> e.Conversion)` where the
+        // navigation property is nullable).
+        if (typeSymbol is NullableTypeSymbol { UnderlyingType: StructSymbol { IsClass: true } nullableUserClass })
+        {
+            return nullableUserClass.ImportedBaseType?.ClrType ?? typeof(object);
+        }
+
+        // A nullable user value struct / interface / named delegate rides
+        // through the same `object` boundary as its non-nullable form.
+        if (typeSymbol is NullableTypeSymbol { UnderlyingType: StructSymbol }
+            || typeSymbol is NullableTypeSymbol { UnderlyingType: InterfaceSymbol }
+            || typeSymbol is NullableTypeSymbol { UnderlyingType: DelegateTypeSymbol })
+        {
+            return typeof(object);
+        }
+
         // User-defined G# class: provide the imported base type's CLR type
         // so that overload resolution can proceed (base-class assignability
         // and the supplementary interface check handle the rest).

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -516,6 +516,18 @@ internal static class OverloadResolution
             return ImplicitConversionKind.DelegateStructuralMatch;
         }
 
+        // Issue #2142: a lambda/arrow literal (natural CLR type Func<…>/Action<…>)
+        // converts to an expression-tree parameter Expression<TDelegate> when its
+        // TDelegate is structurally compatible with the source delegate. The
+        // conversion is ranked identically to the underlying delegate conversion
+        // (so a competing plain-delegate overload is decided purely on parameter
+        // specificity, as in C#: e.g. Queryable.Where over Enumerable.Where for an
+        // IQueryable receiver).
+        if (TryClassifyLambdaToExpressionTree(target, source, supplementaryInterfaceCheck, out var expressionTreeKind))
+        {
+            return expressionTreeKind;
+        }
+
         return ImplicitConversionKind.None;
     }
 
@@ -1628,6 +1640,138 @@ internal static class OverloadResolution
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Issue #2142: determines whether a source delegate (a lambda/arrow
+    /// literal's natural <c>Func&lt;...&gt;</c>/<c>Action&lt;...&gt;</c> type, or
+    /// any delegate value) converts to an expression-tree parameter
+    /// <c>System.Linq.Expressions.Expression&lt;TDelegate&gt;</c>. Mirrors the
+    /// symbolic-path helper <c>MemberLookup.TryGetExpressionTreeDelegateType</c>:
+    /// the target must be a closed <c>Expression`1</c> whose single type argument
+    /// (<c>TDelegate</c>) is a delegate type, and the source must be a delegate
+    /// that is <em>compatible</em> with <c>TDelegate</c> — identity, a
+    /// structural delegate match, or reference/covariant/numeric-widening return
+    /// adaptation (the same conversions the resolver already accepts between two
+    /// plain delegate types). A genuine signature mismatch (different arity or
+    /// incompatible parameter/return types) yields <see langword="false"/> so the
+    /// candidate is still dropped, preserving overload-resolution rejection of a
+    /// truly non-matching lambda. The <c>TDelegate</c> must be fully closed (no
+    /// open generic parameters); open candidates are closed by
+    /// <see cref="EvaluateCandidate"/> before applicability runs, so this holds at
+    /// every real call site.
+    /// </summary>
+    /// <param name="target">The candidate parameter type.</param>
+    /// <param name="source">The argument's natural delegate type.</param>
+    /// <param name="supplementaryInterfaceCheck">Optional user-class interface hook, threaded through the recursive inner-delegate classification.</param>
+    /// <param name="kind">On success, the underlying delegate conversion kind (identity or a delegate adaptation) so the expression-tree conversion ranks identically to the plain-delegate conversion.</param>
+    /// <returns><see langword="true"/> when the lambda-to-expression-tree conversion applies.</returns>
+    private static bool TryClassifyLambdaToExpressionTree(Type target, Type source, Func<Type, Type, bool> supplementaryInterfaceCheck, out ImplicitConversionKind kind)
+    {
+        kind = ImplicitConversionKind.None;
+
+        if (source is null || !ClrTypeUtilities.IsDelegateType(source))
+        {
+            return false;
+        }
+
+        if (target is null
+            || !target.IsGenericType
+            || target.ContainsGenericParameters)
+        {
+            return false;
+        }
+
+        var openDefinition = target.GetGenericTypeDefinition();
+        if (!string.Equals(openDefinition.FullName, "System.Linq.Expressions.Expression`1", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var typeArguments = target.GetGenericArguments();
+        if (typeArguments.Length != 1)
+        {
+            return false;
+        }
+
+        var targetDelegate = typeArguments[0];
+        if (targetDelegate is null || !ClrTypeUtilities.IsDelegateType(targetDelegate))
+        {
+            return false;
+        }
+
+        // A lambda converts to Expression<TDelegate> when its natural delegate
+        // shape is compatible with TDelegate. Accept an exact/adaptable delegate
+        // match (identity or one of the delegate adaptations the resolver already
+        // recognises between two plain delegates), OR — mirroring C#'s lambda
+        // conversion — a signature whose parameter types match and whose body
+        // (source return) is implicitly convertible to TDelegate's return type,
+        // including value-type→object boxing (e.g. `(e) -> e.Id` [int32] into
+        // `Expression<Func<T, object?>>`). A genuine parameter/arity mismatch, or
+        // a return that does not convert, yields false so the candidate is still
+        // dropped.
+        var inner = ClassifyImplicit(targetDelegate, source, supplementaryInterfaceCheck);
+        switch (inner)
+        {
+            case ImplicitConversionKind.Identity:
+            case ImplicitConversionKind.DelegateStructuralMatch:
+            case ImplicitConversionKind.DelegateReturnCovariance:
+            case ImplicitConversionKind.DelegateReturnNumericWidening:
+                kind = inner;
+                return true;
+        }
+
+        if (IsLambdaBodyConvertibleToDelegate(targetDelegate, source, supplementaryInterfaceCheck))
+        {
+            kind = ImplicitConversionKind.DelegateReturnCovariance;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #2142: determines whether a source delegate's signature is
+    /// compatible with a target delegate under a lambda conversion — the
+    /// parameter types are pairwise identical and the source's return type is
+    /// implicitly convertible (identity, reference, boxing, numeric widening,
+    /// nullable-wrap, or user-defined) to the target's return type. This is the
+    /// delegate-return counterpart of a lambda-body conversion and is used only
+    /// when unwrapping an <c>Expression&lt;TDelegate&gt;</c> target, so a lambda
+    /// whose body converts to <c>TDelegate</c>'s return (e.g. an <c>int32</c>
+    /// body boxing into an <c>object?</c> return) still binds the expression
+    /// tree. A <c>void</c> return on either side, a parameter mismatch, or a
+    /// non-convertible return yields <see langword="false"/>.
+    /// </summary>
+    private static bool IsLambdaBodyConvertibleToDelegate(Type targetDelegate, Type source, Func<Type, Type, bool> supplementaryInterfaceCheck)
+    {
+        if (!TryGetDelegateSignature(targetDelegate, out var targetParams, out var targetReturn)
+            || !TryGetDelegateSignature(source, out var sourceParams, out var sourceReturn)
+            || targetReturn is null
+            || sourceReturn is null
+            || targetParams.Length != sourceParams.Length)
+        {
+            return false;
+        }
+
+        // A void return has no body value to convert; the identity / structural
+        // delegate paths already handle exact void-return matches.
+        if (string.Equals(targetReturn.FullName, "System.Void", StringComparison.Ordinal)
+            || string.Equals(sourceReturn.FullName, "System.Void", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        for (var i = 0; i < targetParams.Length; i++)
+        {
+            if (!ClrTypeUtilities.AreSame(targetParams[i], sourceParams[i]))
+            {
+                return false;
+            }
+        }
+
+        var returnConversion = ClassifyImplicit(targetReturn, sourceReturn, supplementaryInterfaceCheck);
+        return returnConversion != ImplicitConversionKind.None;
     }
 
     /// <summary>
@@ -3734,6 +3878,20 @@ internal static class OverloadResolution
         {
             var openDef = parameterType.GetGenericTypeDefinition();
             var paramArgs = parameterType.GetGenericArguments();
+
+            // Issue #2142: an expression-tree parameter Expression<TDelegate>
+            // never matches a delegate argument's class hierarchy (a Func<…> is
+            // not an Expression<…>), so FindClosedGeneric below returns null and
+            // any method type parameter mentioned only inside TDelegate (e.g.
+            // HasOne<TRelated>(Expression<Func<TEntity, TRelated?>>)) would never
+            // be inferred. Unwrap the expression tree and unify its delegate type
+            // argument directly against the supplied delegate argument.
+            if (string.Equals(openDef.FullName, "System.Linq.Expressions.Expression`1", StringComparison.Ordinal)
+                && paramArgs.Length == 1
+                && ClrTypeUtilities.IsDelegateType(argumentType))
+            {
+                return UnifyForInference(paramArgs[0], argumentType, bounds);
+            }
 
             // Find the argument type (or any of its base types or interfaces)
             // matching the parameter's open generic definition. Walk class

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2142ExpressionTreeImportedGenericTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2142ExpressionTreeImportedGenericTests.cs
@@ -1,0 +1,148 @@
+// <copyright file="Issue2142ExpressionTreeImportedGenericTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2142 (follow-up to #2130/#2139): a lambda argument must bind to an
+/// <c>Expression&lt;Func&lt;T, …&gt;&gt;</c> parameter of an IMPORTED
+/// generic-class INSTANCE method whose delegate type argument is the enclosing
+/// class's type parameter (substituted at the call site). Before the fix the
+/// lambda-&gt;expression-tree candidate was silently discarded during
+/// reflection-based overload resolution, so no overload matched and the
+/// compiler emitted GS0159 "Cannot find function …" (e.g. EF Core's
+/// <c>EntityTypeBuilder&lt;T&gt;.HasKey(Expression&lt;Func&lt;T, object?&gt;&gt;)</c>).
+/// </summary>
+public class Issue2142ExpressionTreeImportedGenericTests
+{
+    [Fact]
+    public void LambdaBindsToImportedGenericClassInstanceExpressionParameter()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2142");
+        Directory.CreateDirectory(outputDir);
+
+        var libraryPath = Path.Combine(outputDir, "Issue2142.Library.dll");
+        EmitLibraryAssembly(libraryPath);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Demo
+                import Lib
+
+                class Book { prop Id int32 { get set } prop Title string { get set } }
+
+                func Run(repo Repo[Book]) {
+                    repo.HasKey((e Book) -> e.Id)
+                    repo.HasIndex((e Book) -> e.Title)
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2142.Consumer");
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0159");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void NonLambdaOverloadOnImportedGenericClassStillResolves()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2142NonLambda");
+        Directory.CreateDirectory(outputDir);
+
+        var libraryPath = Path.Combine(outputDir, "Issue2142NonLambda.Library.dll");
+        EmitLibraryAssembly(libraryPath);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Demo
+                import Lib
+
+                class Book { prop Id int32 { get set } }
+
+                func Run(repo Repo[Book]) {
+                    repo.HasKey("Id")
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2142.NonLambda.Consumer");
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0159");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void GenuineArityMismatchStillFails()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2142Mismatch");
+        Directory.CreateDirectory(outputDir);
+
+        var libraryPath = Path.Combine(outputDir, "Issue2142Mismatch.Library.dll");
+        EmitLibraryAssembly(libraryPath);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Demo
+                import Lib
+
+                class Book { prop Id int32 { get set } }
+
+                func Run(repo Repo[Book]) {
+                    repo.HasKey((e Book, x int32) -> e.Id)
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2142.Mismatch.Consumer");
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0159");
+    }
+
+    private static void EmitLibraryAssembly(string libraryPath)
+    {
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Lib
+                import System
+                import System.Linq.Expressions
+
+                class Repo[T] {
+                    func HasKey(key Expression[Func[T, object?]]) {}
+                    func HasKey(name string) {}
+                    func HasIndex(index Expression[Func[T, object?]]) {}
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using var peStream = File.Create(libraryPath);
+        var result = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2142.Library");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+}


### PR DESCRIPTION
Fixes #2142.

Substitutes the receiver's class-level generic arguments into an imported generic-class instance method's Expression<Func<...>> parameter before the lambda->expression-tree applicability check and final conversion, so e.g. EntityTypeBuilder<Book>.HasKey((e Book) -> e.Id) resolves (Expression<Func<Book, object?>>) instead of being dropped (GS0159). Generalizes to any imported generic type instance method whose Expression<TDelegate> parameter depends on the receiver's type arguments. User-class methods, imported generic extension methods (Queryable.Where), and non-lambda overloads (params string[]) are unaffected.

Refs #914