### PR TITLE
Fix #2144: null-safe TextLocation comparison + diagnostic rendering for location-less diagnostics

### DIFF
--- a/src/Core/CodeAnalysis/Text/TextLocation.cs
+++ b/src/Core/CodeAnalysis/Text/TextLocation.cs
@@ -55,7 +55,7 @@ public struct TextLocation : IComparable<TextLocation>
     /// <summary>
     /// Gets the file name.
     /// </summary>
-    public string FileName => Text.FileName;
+    public string FileName => Text?.FileName;
 
     /// <summary>
     /// Compares two text locations, useful for sorting sets of text locations.
@@ -64,7 +64,18 @@ public struct TextLocation : IComparable<TextLocation>
     /// <returns>A value indicating the relation of the first text span to the second one.</returns>
     public int CompareTo(TextLocation other)
     {
-        int cmp = Text.FileName.CompareTo(other.Text.FileName);
+        // A `default(TextLocation)` (e.g. a synthesized or assembly-level
+        // diagnostic with no source location) has a null `Text`, and even a
+        // present `Text` may expose a null `FileName`. Guard both so the
+        // comparer is total and never throws: location-less entries sort
+        // consistently ahead of located ones. A non-total comparer here makes
+        // `OrderBy`/`Array.Sort` throw `InvalidOperationException: Failed to
+        // compare two elements in the array`, which the compiler surfaces as
+        // GS9998 and which masks every other diagnostic in the batch.
+        string thisFile = Text?.FileName;
+        string otherFile = other.Text?.FileName;
+
+        int cmp = string.CompareOrdinal(thisFile, otherFile);
         if (cmp == 0)
         {
             cmp = Span.CompareTo(other.Span);

--- a/src/Core/IO/TextWriterExtensions.cs
+++ b/src/Core/IO/TextWriterExtensions.cs
@@ -131,6 +131,20 @@ public static class TextWriterExtensions
                 _ => "info",
             };
 
+            // Issue #2144: a location-less diagnostic (default(TextLocation),
+            // so Text == null — e.g. a synthesized or assembly-level
+            // diagnostic) has no file/position/snippet to render. Emit just
+            // the severity/id/message so a single such diagnostic no longer
+            // NREs and masks the whole batch.
+            if (diagnostic.Location.Text is null)
+            {
+                writer.SetForeground(severityColor);
+                writer.Write($"{severityLabel} {diagnostic.Id}: ");
+                writer.WriteLine(diagnostic.Message);
+                writer.ResetColor();
+                continue;
+            }
+
             writer.SetForeground(severityColor);
             writer.Write($"{diagnostic.Location.FileName}({diagnostic.Location.StartLine + 1},{diagnostic.Location.StartCharacter + 1},{diagnostic.Location.EndLine + 1},{diagnostic.Location.EndCharacter + 1}): ");
             writer.Write($"{severityLabel} {diagnostic.Id}: ");

--- a/test/Core.Tests/IO/TextWriterExtensionsTests.cs
+++ b/test/Core.Tests/IO/TextWriterExtensionsTests.cs
@@ -61,4 +61,44 @@ public class TextWriterExtensionsTests
         Assert.Null(exception);
         Assert.Contains("unexpected end of file", writer.ToString());
     }
+
+    [Fact]
+    public void WriteDiagnostics_MixedWithLocationLessDiagnostic_DoesNotThrow()
+    {
+        // Issue #2144: a location-less diagnostic (default(TextLocation), so
+        // Text == null) mixed with located ones must not make the location
+        // sort throw "Failed to compare two elements in the array" (which the
+        // compiler otherwise surfaces as GS9998, masking every diagnostic).
+        var sourceText = SourceText.From("let x = boom", "test.gs");
+        var located = new Diagnostic(
+            new TextLocation(sourceText, TextSpan.FromBounds(8, 12)),
+            "GS0001",
+            DiagnosticSeverity.Error,
+            "bad value");
+        var locationLess = new Diagnostic(default, "GS9999", DiagnosticSeverity.Error, "no location here");
+
+        using var writer = new StringWriter();
+
+        var exception = Record.Exception(() => writer.WriteDiagnostics(new[] { located, locationLess }));
+
+        Assert.Null(exception);
+        var output = writer.ToString();
+        Assert.Contains("bad value", output);
+        Assert.Contains("no location here", output);
+    }
+
+    [Fact]
+    public void TextLocation_CompareTo_IsTotalAndNullSafe()
+    {
+        // Issue #2144: CompareTo must never throw and must be a consistent
+        // total order, even when either side is a default(TextLocation).
+        var text = SourceText.From("abc", "a.gs");
+        var located = new TextLocation(text, new TextSpan(0, 1));
+        TextLocation none = default;
+
+        Assert.Equal(0, none.CompareTo(default));
+        Assert.True(none.CompareTo(located) < 0);
+        Assert.True(located.CompareTo(none) > 0);
+        Assert.Equal(0, located.CompareTo(located));
+    }
 }


### PR DESCRIPTION
Fixes #2144. Refs #914.

A diagnostic with a `default(TextLocation)` (no source location — e.g. a synthesized or assembly-level diagnostic) has `Text == null`. `TextLocation.CompareTo` dereferenced `Text.FileName`, so sorting diagnostics for output (`TextWriterExtensions.WriteDiagnostics`) threw `InvalidOperationException: Failed to compare two elements in the array`, which the compiler reports as GS9998 — masking **every** real diagnostic in the batch.

Changes:
- `TextLocation.CompareTo`: null-safe and total (uses `string.CompareOrdinal` on `Text?.FileName`; location-less entries sort consistently ahead of located ones, never throws).
- `TextLocation.FileName`: `Text?.FileName` (null-safe).
- `TextWriterExtensions.WriteDiagnostics`: renders a location-less diagnostic as just `severity id: message` (no file position/snippet) instead of NRE-ing on `Location.Text`.
- Tests: mixed located + location-less batch renders both without throwing; `CompareTo` total-order/null-safety.

Surfaced while compiling Oahu.Data: a location-less diagnostic was crashing the sort and hiding the project's genuine remaining diagnostics.