### PR TITLE
Fix #2146: prefer more-derived reference overload in betterness (reference better-conversion-target tie-break)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -852,6 +852,44 @@ internal static class OverloadResolution
     }
 
     /// <summary>
+    /// Issue #2146: implements the C# §7.5.3.4 "better conversion target" rule
+    /// for reference-type targets, mirroring <see cref="CompareNumericTargets"/>.
+    /// Returns a negative value when <paramref name="t1"/> is the better
+    /// (more-derived) target, positive when <paramref name="t2"/> is, and 0 when
+    /// the two targets are unrelated (neither implicitly converts to the other),
+    /// preserving genuine ambiguity. Convertibility is probed one-directionally
+    /// via <see cref="ClassifyImplicit"/> so user classes, interfaces, and
+    /// imported/BCL reference types are handled uniformly.
+    /// </summary>
+    /// <param name="t1">The first candidate target type.</param>
+    /// <param name="t2">The second candidate target type.</param>
+    /// <returns>-1, 0, or +1 per the description above.</returns>
+    public static int CompareReferenceTargets(Type t1, Type t2)
+    {
+        if (t1 is null || t2 is null || ClrTypeUtilities.AreSame(t1, t2))
+        {
+            return 0;
+        }
+
+        // T1 is a better target than T2 when an implicit conversion T1->T2
+        // exists (T1 is more derived) and none exists T2->T1.
+        var t1ToT2 = ClassifyImplicit(t2, t1) is not ImplicitConversionKind.None and not ImplicitConversionKind.Identity;
+        var t2ToT1 = ClassifyImplicit(t1, t2) is not ImplicitConversionKind.None and not ImplicitConversionKind.Identity;
+
+        if (t1ToT2 && !t2ToT1)
+        {
+            return -1;
+        }
+
+        if (t2ToT1 && !t1ToT2)
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
     /// Compares two candidate conversion targets for the same source type per
     /// C# §7.5.3.4 "Better conversion target". Returns a negative value when
     /// <paramref name="t1"/> is the better target, a positive value when
@@ -3059,6 +3097,19 @@ internal static class OverloadResolution
         if (ka == ImplicitConversionKind.ConstantNarrowing)
         {
             return CompareNumericTargets(paramA, paramB, source);
+        }
+
+        // Issue #2146: reference "better conversion target" tie-break
+        // (C# §7.5.3.4). When both candidates convert the SAME argument by a
+        // non-identity implicit reference/boxing conversion to related targets
+        // (e.g. Dog->object vs Dog->Animal, or Type->object vs Type->Type?),
+        // prefer the MORE DERIVED target instead of tying and relying solely on
+        // IsAtLeastAsSpecific: target T1 is better than T2 when an implicit
+        // conversion exists from T1 to T2 but not from T2 to T1. Unrelated
+        // targets stay tied (0), preserving genuine ambiguity.
+        if (ka == ImplicitConversionKind.Reference || ka == ImplicitConversionKind.Boxing)
+        {
+            return CompareReferenceTargets(paramA, paramB);
         }
 
         // Issue #1150: when two candidates both convert a delegate argument by

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -1314,6 +1314,56 @@ internal sealed class OverloadResolver
             return OverloadResolution.CompareNumericTargets(paramA?.ClrType, paramB?.ClrType, source?.ClrType);
         }
 
+        // Issue #2146: reference "better conversion target" tie-break
+        // (C# §7.5.3.2 / §7.5.3.4). When both conversions for the same argument
+        // fold into the Reference bucket (both are non-identity implicit
+        // reference/boxing/interface conversions, e.g. Dog->object vs
+        // Dog->Animal, or Type->object vs Type->Type?), the previous code tied
+        // (returned 0) and the call was reported ambiguous (GS0266) even though
+        // C# prefers the MORE DERIVED target. Apply the reference-type rule:
+        // target T1 is a better conversion target than T2 when an implicit
+        // conversion exists from T1 to T2 but not from T2 to T1. That makes the
+        // more-derived reference parameter win (Animal over object; Type? over
+        // object). If neither target converts to the other (genuinely unrelated
+        // reference types), leave the tie (0) so real ambiguity is preserved.
+        if (ka == OverloadResolution.ImplicitConversionKind.Reference && paramA != null && paramB != null && !ReferenceEquals(paramA, paramB))
+        {
+            return CompareReferenceTargets(paramA, paramB);
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Issue #2146: implements the C# §7.5.3.4 "better conversion target" rule
+    /// for reference-type targets. Returns a negative value when
+    /// <paramref name="targetA"/> is the better (more-derived) target, positive
+    /// when <paramref name="targetB"/> is, and 0 when the two targets are
+    /// unrelated (neither implicitly converts to the other) — preserving genuine
+    /// ambiguity. Convertibility is probed one-directionally via
+    /// <see cref="Conversion.Classify"/> rather than hand-rolled type checks so
+    /// user classes, interfaces, and imported/BCL reference types are all
+    /// handled uniformly.
+    /// </summary>
+    private static int CompareReferenceTargets(TypeSymbol targetA, TypeSymbol targetB)
+    {
+        var aToB = Conversion.Classify(targetA, targetB);
+        var bToA = Conversion.Classify(targetB, targetA);
+
+        var aToBImplicit = aToB.IsImplicit && !aToB.IsIdentity;
+        var bToAImplicit = bToA.IsImplicit && !bToA.IsIdentity;
+
+        if (aToBImplicit && !bToAImplicit)
+        {
+            // A converts to B but not vice versa => A is more derived => A better.
+            return -1;
+        }
+
+        if (bToAImplicit && !aToBImplicit)
+        {
+            return 1;
+        }
+
         return 0;
     }
 
@@ -1348,7 +1398,21 @@ internal sealed class OverloadResolver
 
         if (paramType is NullableTypeSymbol nullableParam && argType == nullableParam.UnderlyingType)
         {
-            return OverloadResolution.ImplicitConversionKind.NullableWrap;
+            // Issue #2146: `T -> T?` is a genuine value-type nullable WRAP only
+            // when the underlying is a value type. For a REFERENCE-type nullable
+            // (e.g. `Type -> Type?`) the wrap carries no runtime cost — it is a
+            // reference conversion (a nullability annotation) — and ranking it as
+            // NullableWrap (worse than Reference) would make an unrelated
+            // `object` reference upcast spuriously win. Classify it as Reference
+            // so the reference "better conversion target" tie-break (below, in
+            // CompareUserConversions) correctly prefers the more-derived `T?`
+            // target over `object`.
+            if (NullableLifting.IsValueTypeNullable(nullableParam))
+            {
+                return OverloadResolution.ImplicitConversionKind.NullableWrap;
+            }
+
+            return OverloadResolution.ImplicitConversionKind.Reference;
         }
 
         // ponytail: widening-then-wrap (e.g. int32 -> int64?) is not caught by

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2146ReferenceBetternessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2146ReferenceBetternessTests.cs
@@ -1,0 +1,214 @@
+// <copyright file="Issue2146ReferenceBetternessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2146: overload resolution's "better function member" pass now applies
+/// the C# §7.5.3.4 "better conversion target" rule for REFERENCE types, not just
+/// numeric ones. When an argument's static type is a proper subtype of BOTH
+/// candidate parameter types (so both argument→parameter conversions are
+/// non-identity implicit reference conversions), the more-derived parameter type
+/// wins instead of the call being reported ambiguous (GS0266). Genuinely
+/// unrelated reference targets still tie and report GS0266.
+/// </summary>
+public class Issue2146ReferenceBetternessTests
+{
+    [Fact]
+    public void ObjectVsUserBaseClass_DerivedArgument_PrefersBaseClassOverload()
+    {
+        // U(object) vs U(Animal) called with a Dog argument: Dog->object and
+        // Dog->Animal are both non-identity implicit reference conversions, so
+        // they tie on conversion kind. Animal is the better conversion target
+        // (Animal->object is implicit, object->Animal is not), so U(Animal) must
+        // win. Before the fix this reported a spurious GS0266.
+        const string source = @"
+package p
+open class Issue2146Animal {}
+class Issue2146Dog : Issue2146Animal {}
+func Issue2146U(x object) int32 -> 1
+func Issue2146U(x Issue2146Animal) int32 -> 2
+func Issue2146Use(d Issue2146Dog) int32 -> Issue2146U(d)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue2146U");
+        Assert.NotNull(selected);
+        Assert.Equal("Issue2146Animal", selected.Parameters[0].Type.Name);
+    }
+
+    [Fact]
+    public void IdentityArgument_StillWinsOverObject()
+    {
+        // Control (already-working case): U(object) vs U(Animal) called with an
+        // Animal argument. Animal->Animal is IDENTITY, which beats the
+        // Animal->object reference conversion, so U(Animal) resolves without any
+        // reference tie-break needing to run.
+        const string source = @"
+package p
+open class Issue2146AnimalId {}
+func Issue2146UId(x object) int32 -> 1
+func Issue2146UId(x Issue2146AnimalId) int32 -> 2
+func Issue2146UseId(a Issue2146AnimalId) int32 -> Issue2146UId(a)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue2146UId");
+        Assert.NotNull(selected);
+        Assert.Equal("Issue2146AnimalId", selected.Parameters[0].Type.Name);
+    }
+
+    [Fact]
+    public void ThreeLevelHierarchy_PrefersMostDerivedApplicableTarget()
+    {
+        // U(object) vs U(Animal) with a Dog argument where Dog : Animal : object.
+        // The more-derived applicable target (Animal) must win over object.
+        const string source = @"
+package p
+open class Issue2146Base {}
+open class Issue2146Mid : Issue2146Base {}
+class Issue2146Leaf : Issue2146Mid {}
+func Issue2146H(x Issue2146Base) int32 -> 1
+func Issue2146H(x Issue2146Mid) int32 -> 2
+func Issue2146HUse(leaf Issue2146Leaf) int32 -> Issue2146H(leaf)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue2146H");
+        Assert.NotNull(selected);
+        Assert.Equal("Issue2146Mid", selected.Parameters[0].Type.Name);
+    }
+
+    [Fact]
+    public void ObjectVsImportedNullableType_TypeofArgument_PrefersTypeOverload()
+    {
+        // The real-world Oahu case: Log(object) vs Log(Type?) with a typeof(...)
+        // argument. Type->object and Type->Type? are both non-identity implicit
+        // reference/nullable conversions; Type? is the better (more-derived)
+        // target, so Log(Type?) must win instead of GS0266.
+        const string source = @"
+package p
+import System
+class Issue2146LogC {}
+func Issue2146L(caller object) int32 -> 1
+func Issue2146L(caller Type?) int32 -> 2
+func Issue2146LUse() int32 -> Issue2146L(typeof(Issue2146LogC))
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue2146L");
+        Assert.NotNull(selected);
+        Assert.NotEqual("object", selected.Parameters[0].Type.Name);
+    }
+
+    [Fact]
+    public void UnrelatedReferenceTargets_StillReportsAmbiguity()
+    {
+        // Guard against over-fixing: two UNRELATED interface parameter types,
+        // both satisfied by the argument, with neither convertible to the other.
+        // This is a genuine ambiguity and must still report GS0266.
+        const string source = @"
+package p
+interface Issue2146IA {}
+interface Issue2146IB {}
+class Issue2146Both : Issue2146IA, Issue2146IB {}
+func Issue2146A(x Issue2146IA) int32 -> 1
+func Issue2146A(x Issue2146IB) int32 -> 2
+func Issue2146AUse(b Issue2146Both) int32 -> Issue2146A(b)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0266");
+    }
+
+    [Fact]
+    public void ObjectVsInterface_ImplementingArgument_PrefersInterfaceOverload()
+    {
+        // U(object) vs U(IShape) with an argument that implements IShape. Both
+        // conversions are non-identity implicit reference conversions; IShape is
+        // the more-derived (more specific) target versus object, so U(IShape)
+        // must win rather than tie at GS0266.
+        const string source = @"
+package p
+interface Issue2146IShape {}
+class Issue2146Square : Issue2146IShape {}
+func Issue2146S(x object) int32 -> 1
+func Issue2146S(x Issue2146IShape) int32 -> 2
+func Issue2146SUse(sq Issue2146Square) int32 -> Issue2146S(sq)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue2146S");
+        Assert.NotNull(selected);
+        Assert.Equal("Issue2146IShape", selected.Parameters[0].Type.Name);
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree) { IsLibrary = true };
+    }
+
+    private static FunctionSymbol FindCall(Compilation compilation, string callName)
+    {
+        var collector = new CallCollector(callName);
+        foreach (var body in compilation.BoundProgram.Functions.Values)
+        {
+            collector.Visit(body);
+        }
+
+        return collector.Collected.FirstOrDefault();
+    }
+
+    private sealed class CallCollector : GSharp.Core.CodeAnalysis.Binding.BoundTreeWalker
+    {
+        private readonly string callName;
+
+        public CallCollector(string callName)
+        {
+            this.callName = callName;
+        }
+
+        public List<FunctionSymbol> Collected { get; } = new();
+
+        public override void VisitExpression(GSharp.Core.CodeAnalysis.Binding.BoundExpression node)
+        {
+            switch (node)
+            {
+                case GSharp.Core.CodeAnalysis.Binding.BoundCallExpression call when call.Function.Name == callName:
+                    Collected.Add(call.Function);
+                    break;
+                case GSharp.Core.CodeAnalysis.Binding.BoundUserInstanceCallExpression instanceCall when instanceCall.Method.Name == callName:
+                    Collected.Add(instanceCall.Method);
+                    break;
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Overload resolution reported **GS0266 (ambiguous)** when it should have picked the more-derived reference-type overload. When an argument's static type is a proper subtype of BOTH candidate parameter types (so both argument→parameter conversions are non-identity implicit reference conversions), gsc failed to apply the C# §7.5.3.2/§7.5.3.4 "better conversion target" tie-break for reference types — that tie-break existed only for numeric conversions.

Example (previously GS0266, now resolves to `U(Animal)`):

```gsharp
open class Animal {}
class Dog : Animal {}
func U(x object) int32 -> 1
func U(x Animal) int32 -> 2
U(d)   // d: Dog — now picks U(Animal)
```

## Root cause

Both resolvers ranked candidate conversions by `ImplicitConversionKind`, but two non-identity reference conversions both folded into the `Reference` bucket and tied (comparison returned 0), yielding a spurious GS0266. Additionally, `T -> T?` over a **reference** underlying (e.g. `Type -> Type?`) was mis-classified as `NullableWrap` (ranked worse than `Reference`), so an unrelated `object` upcast won outright.

## Fix

- **Symbolic resolver** (`OverloadResolver.cs`): added a reference "better conversion target" tie-break in `CompareUserConversions` — when both conversions are `Reference`, target T1 beats T2 iff T1 implicitly converts to T2 but not vice versa (probed via `Conversion.Classify`). Unrelated targets stay tied (genuine ambiguity preserved). Also gated the `NullableWrap` classification to value-type nullables only; reference-type nullable wraps (`Type?`) are now `Reference` so they compete correctly with `object`.
- **Reflection resolver** (`OverloadResolution.cs`): added a matching `CompareReferenceTargets` helper (mirroring `CompareNumericTargets`) and applied it in `CompareConversions` for `Reference`/`Boxing` ties, using one-directional `ClassifyImplicit` probes.

Generalizes to any base-vs-derived reference pair — user classes, interfaces, and imported/BCL types (`object` vs `Type`/`Type?`).

## Tests

Added `Issue2146ReferenceBetternessTests.cs`: `object` vs user base class with derived arg; identity control; three-level hierarchy; `object` vs imported `Type?` with `typeof(...)`; `object` vs interface; and a genuinely ambiguous unrelated-interface case that still reports GS0266. Full Core.Tests suite (5628 tests) passes.

Fixes #2146.
Refs #914.
