### PR TITLE
Fix #2148: resolve inherited Dispose/DisposeAsync from imported base for using

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1602,7 +1602,10 @@ internal sealed class ConversionClassifier
 
         // Extended CLR-type path: walk self + transitive interfaces so a
         // CLR class inheriting Dispose solely through IDisposable is found.
-        var clrType = variable.Type?.ClrType;
+        // Issue #2148: a same-compilation user class deriving from an imported
+        // IDisposable base has no ClrType of its own, so fall back to the
+        // nearest imported base's ClrType to find the inherited Dispose.
+        var clrType = variable.Type?.ClrType ?? GetNearestImportedBaseClrType(variable.Type);
         if (clrType == null)
         {
             Diagnostics.ReportTypeNotDisposable(location, variable.Type ?? TypeSymbol.Error);
@@ -1646,7 +1649,9 @@ internal sealed class ConversionClassifier
         }
 
         // CLR-type path: walk self + transitive interfaces for DisposeAsync.
-        var clrType = variable.Type?.ClrType;
+        // Issue #2148: fall back to the nearest imported base's ClrType for a
+        // same-compilation user class deriving from an imported IAsyncDisposable.
+        var clrType = variable.Type?.ClrType ?? GetNearestImportedBaseClrType(variable.Type);
         if (clrType == null)
         {
             Diagnostics.ReportTypeNotAsyncDisposable(location, variable.Type ?? TypeSymbol.Error);
@@ -1676,6 +1681,36 @@ internal sealed class ConversionClassifier
     }
 
     // ----- Private helpers (kept here because they are only used by methods in this class) -----
+
+    /// <summary>
+    /// Issue #2148: returns the <see cref="TypeSymbol.ClrType"/> of the nearest
+    /// imported base class in <paramref name="type"/>'s inheritance chain, or
+    /// <see langword="null"/> if none exists. A same-compilation user class has
+    /// no <c>ClrType</c> of its own; when it derives (transitively) from an
+    /// imported CLR base, that base's reflectible type carries the inherited
+    /// members (e.g. <c>Dispose</c>/<c>DisposeAsync</c>) that duck-typed
+    /// protocol probes need to see.
+    /// </summary>
+    private static Type GetNearestImportedBaseClrType(TypeSymbol type)
+    {
+        if (type is StructSymbol structSymbol)
+        {
+            for (var current = structSymbol; current != null; current = current.BaseClass)
+            {
+                if (current.ClrType != null)
+                {
+                    return current.ClrType;
+                }
+
+                if (current.ImportedBaseType?.ClrType != null)
+                {
+                    return current.ImportedBaseType.ClrType;
+                }
+            }
+        }
+
+        return null;
+    }
 
     /// <summary>
     /// Issue #1017: resolves a user-defined conversion declared on a

--- a/test/Compiler.Tests/Emit/Issue568UsingLetUserIDisposableTests.cs
+++ b/test/Compiler.Tests/Emit/Issue568UsingLetUserIDisposableTests.cs
@@ -87,6 +87,60 @@ public class Issue568UsingLetUserIDisposableTests
         Assert.Contains(errors, e => e.Contains("GS0119"));
     }
 
+    [Fact]
+    public void UsingLet_GSharpClassInheritsDispose_FromImportedBaseClass()
+    {
+        // Issue #2148: a G# class deriving from an imported IDisposable CLR base
+        // (MemoryStream : Stream : IDisposable) must be usable in a `using`
+        // statement — the inherited Dispose lives on the imported base's CLR type.
+        var source = """
+            package Probe
+            import System
+            import System.IO
+
+            open class MyStream : MemoryStream {
+                init() : base() {}
+            }
+
+            func test() {
+                using let s = MyStream()
+                s.WriteByte(1)
+                Console.WriteLine("used")
+            }
+            test()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("used\n", output);
+    }
+
+    [Fact]
+    public void AwaitUsingLet_GSharpClassInheritsDisposeAsync_FromImportedBaseClass()
+    {
+        // Issue #2148: the same fallback applies to `await using` — a G# class
+        // deriving from an imported IAsyncDisposable base (Stream implements
+        // IAsyncDisposable) resolves the inherited DisposeAsync on the CLR base.
+        var source = """
+            package Probe
+            import System
+            import System.IO
+
+            open class MyAsyncStream : MemoryStream {
+                init() : base() {}
+            }
+
+            async func test() {
+                await using let s = MyAsyncStream()
+                s.WriteByte(1)
+                Console.WriteLine("aused")
+            }
+            test().GetAwaiter().GetResult()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("aused\n", output);
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue568_").FullName;


### PR DESCRIPTION
## Problem
A `using` (or `await using`) statement on a **same-compilation user class that inherits `IDisposable`/`IAsyncDisposable` from an imported CLR base class** was rejected with **GS0119** even though the class inherits a public `Dispose()`/`DisposeAsync()` from its imported base.

```gsharp
open class MyStream : MemoryStream {   // MemoryStream : Stream : IDisposable/IAsyncDisposable
    init() : base() {}
}
func M() {
    using let s = MyStream()   // was: GS0119 'MyStream' ... does not provide a public Dispose()
    s.WriteByte(1)
}
```

Worked already: imported type directly; user class directly implementing `IDisposable`; user class inheriting from a *user* base. Only the *imported base* case failed.

## Root cause
`ConversionClassifier.TryBuildDisposeCall` (and `TryBuildDisposeAsyncCall`):
1. **User path** — `TypeMemberModel.TryGetMethodIncludingInherited` walks the `StructSymbol.BaseClass` chain, but an imported base is stored in `StructSymbol.ImportedBaseType`, not `BaseClass`, and its members aren't G# `FunctionSymbol`s.
2. **CLR path** — `variable.Type?.ClrType` is `null` for a same-compilation user class, so it immediately reported the type non-disposable.

The imported base's `ClrType` (which exposes the inherited `Dispose`/`DisposeAsync`) was never consulted.

## Fix
Both dispose-call builders now fall back to `GetNearestImportedBaseClrType`, which walks the `BaseClass` chain and returns the first `ImportedBaseType.ClrType` (mirroring the existing `DerivesFromSystemAttribute` chain-walk). The existing `MemberLookup.SafeGetMethodIncludingSelfAndInterfaces` then finds the inherited method. Generalizes to any depth of user-class inheritance ending in an imported disposable base.

## Tests
Added two emit tests to `Issue568UsingLetUserIDisposableTests` that **compile + ilverify + run**:
- `using let` on a class deriving from imported `MemoryStream`
- `await using let` on a class deriving from imported `MemoryStream` (Stream is `IAsyncDisposable`)

All 26 using/dispose tests pass; the minimal repro goes from GS0119 to clean.

Fixes #2148. Refs #914.