### PR TITLE
Fix #2150: data-class positional params satisfy get-only interface properties

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -3615,6 +3615,17 @@ internal sealed class DeclarationBinder
             var inheritedDefaultsBySignature = new Dictionary<string, (FunctionSymbol Method, InterfaceSymbol Iface)>(System.StringComparer.Ordinal);
             var conflictsReported = new HashSet<string>(System.StringComparer.Ordinal);
 
+            // Issue #2150: data-class positional parameters that satisfy an
+            // interface property are materialized only as public fields, so the
+            // CLR interface slot (get_/set_ accessor) would be missing and the
+            // emitted type would fail to load. Collect the parameters that
+            // satisfy an interface property here, then synthesize backing
+            // auto-property accessor members below so the interface contract is
+            // fulfilled at the IL level. Keyed by parameter name; the flag
+            // tracks whether any satisfied interface property also requires a
+            // setter.
+            var positionalInterfaceProps = new Dictionary<string, (ParameterSymbol Param, bool NeedsSetter)>(System.StringComparer.Ordinal);
+
             foreach (var iface in structSymbol.Interfaces)
             {
                 foreach (var imethod in iface.Methods)
@@ -3796,6 +3807,44 @@ internal sealed class DeclarationBinder
                         }
                     }
 
+                    // Issue #2150: a data-class positional (primary-constructor)
+                    // parameter is materialized as a public instance field and,
+                    // like a C# record's positional property, may satisfy a
+                    // matching get/set interface property. It never appears in
+                    // `.Properties`, so `TryGetProperty` misses it. Walk the
+                    // this-first BaseClass chain (mirroring `TryGetProperty` and
+                    // issue #1066) and treat a same-name, type-compatible
+                    // positional parameter as satisfying the property contract.
+                    if (!found && TypeMemberModel.TryGetPrimaryConstructorParameter(structSymbol, iprop.Name, out var positionalParam))
+                    {
+                        found = true;
+
+                        if (!System.Collections.Generic.EqualityComparer<TypeSymbol>.Default.Equals(positionalParam.Type, iprop.Type))
+                        {
+                            // Name matches but the type is incompatible: the
+                            // positional parameter does not satisfy the contract.
+                            // Fall through to the single GS0187 report below.
+                            found = false;
+                        }
+                        else
+                        {
+                            // Record the positional parameter so a backing
+                            // auto-property is synthesized below, filling the
+                            // interface's get_/set_ accessor slots. A data-class
+                            // positional parameter is a mutable public field, so
+                            // it can satisfy a setter requirement too.
+                            var needsSetter = iprop.HasSetter;
+                            if (positionalInterfaceProps.TryGetValue(iprop.Name, out var existing))
+                            {
+                                positionalInterfaceProps[iprop.Name] = (existing.Param, existing.NeedsSetter || needsSetter);
+                            }
+                            else
+                            {
+                                positionalInterfaceProps[iprop.Name] = (positionalParam, needsSetter);
+                            }
+                        }
+                    }
+
                     if (!found)
                     {
                         Diagnostics.ReportInterfaceMethodNotImplemented(
@@ -3804,6 +3853,58 @@ internal sealed class DeclarationBinder
                             iface.Name,
                             iprop.Name);
                     }
+                }
+            }
+
+            // Issue #2150: materialize synthesized backing auto-properties for
+            // every data-class positional parameter that satisfied an interface
+            // property above. Member access still resolves to the underlying
+            // field (fields are probed before properties), so this only adds the
+            // get_/set_ accessor methods the CLR interface slot requires. The
+            // existing property-emission path (planning, accessor IL, PropertyDef
+            // rows, and Virtual|NewSlot promotion for interface implementation)
+            // consumes these uniformly.
+            //
+            // The synthesized property is attached to the class that actually
+            // declares the backing field (this class or a base). Emitting it on
+            // the declaring type keeps it a same-type auto-property — the field
+            // planner only reserves a backing-field row when the auto-property's
+            // backing field is NOT one of the type's own fields, so a
+            // cross-type backing reference would corrupt the FieldDef range.
+            // The accessor is virtual (NewSlot), so a derived class that lists
+            // the interface satisfies the slot through inheritance.
+            if (positionalInterfaceProps.Count > 0)
+            {
+                foreach (var entry in positionalInterfaceProps.Values)
+                {
+                    var param = entry.Param;
+                    if (!structSymbol.TryGetFieldIncludingInherited(param.Name, out var backingField, out var declaringType))
+                    {
+                        continue;
+                    }
+
+                    // Skip if the declaring type already exposes a property of
+                    // this name (a real one that already satisfies the slot, or
+                    // one synthesized by an earlier derived-class check).
+                    if (TypeMemberModel.TryGetProperty(declaringType, param.Name, out _))
+                    {
+                        continue;
+                    }
+
+                    var synthProp = new PropertySymbol(
+                        name: param.Name,
+                        type: param.Type,
+                        accessibility: Accessibility.Public,
+                        hasGetter: true,
+                        hasSetter: entry.NeedsSetter,
+                        isAutoProperty: true,
+                        isVirtual: true,
+                        isOverride: false)
+                    {
+                        BackingField = backingField,
+                    };
+
+                    declaringType.SetProperties(declaringType.Properties.Add(synthProp));
                 }
             }
 

--- a/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
@@ -310,6 +310,46 @@ public static class TypeMemberModel
         return false;
     }
 
+    /// <summary>
+    /// Issue #2150: tries to find a data-class positional (primary-constructor)
+    /// parameter named <paramref name="name"/> on <paramref name="type"/> or any
+    /// class in its base chain. Positional parameters are materialized as public
+    /// instance fields (not <see cref="StructSymbol.Properties"/>), yet — like a
+    /// C# record's positional property — they satisfy a matching interface
+    /// property contract. The base-chain walk is this-first, mirroring
+    /// <see cref="TryGetProperty(TypeSymbol, string, out PropertySymbol)"/> and
+    /// issue #1066 semantics.
+    /// </summary>
+    /// <param name="type">The type to resolve against.</param>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="parameter">The found positional parameter on success.</param>
+    /// <returns>True if found.</returns>
+    public static bool TryGetPrimaryConstructorParameter(TypeSymbol type, string name, out ParameterSymbol parameter)
+    {
+        if (type is StructSymbol structSymbol)
+        {
+            for (var c = structSymbol; c != null; c = c.BaseClass)
+            {
+                if (c.PrimaryConstructorParameters.IsDefaultOrEmpty)
+                {
+                    continue;
+                }
+
+                foreach (var p in c.PrimaryConstructorParameters)
+                {
+                    if (p.Name == name)
+                    {
+                        parameter = p;
+                        return true;
+                    }
+                }
+            }
+        }
+
+        parameter = null;
+        return false;
+    }
+
     /// <summary>Tries to find a static property named <paramref name="name"/> on <paramref name="type"/>.</summary>
     /// <param name="type">The type to resolve against.</param>
     /// <param name="name">The property name.</param>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2150DataClassInterfacePropertyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2150DataClassInterfacePropertyTests.cs
@@ -1,0 +1,200 @@
+// <copyright file="Issue2150DataClassInterfacePropertyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2150: a data-class positional (primary-constructor) parameter is
+/// materialized as a public instance field, yet — like a C# record's
+/// positional property (<c>record R(int X) : IHasX</c>) — it must satisfy a
+/// matching get-only (or get/set) interface property. Before the fix the
+/// interface-satisfaction walk only scanned <c>StructSymbol.Properties</c>, so
+/// the positional field never satisfied the contract and GS0187 fired. The fix
+/// recognises the positional parameter as an implementation AND synthesises a
+/// backing auto-property accessor so the emitted type carries the CLR
+/// <c>get_/set_</c> interface slot (otherwise the assembly would fail to load
+/// with a <see cref="TypeLoadException"/>).
+/// </summary>
+public class Issue2150DataClassInterfacePropertyTests
+{
+    [Fact]
+    public void PositionalParams_SatisfyGetOnlyInterfaceProperties_NoDiagnostics()
+    {
+        // The exact issue repro: two positional parameters satisfy two get-only
+        // interface properties. Previously reported GS0187 twice.
+        const string source = """
+            package Test
+            interface IQuality {
+                prop SampleRate int32? { get; }
+                prop BitRate int32? { get; }
+            }
+            open data class Quality(SampleRate int32?, BitRate int32?) : IQuality {
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void RegularProperty_StillSatisfiesInterface_NoDiagnostics()
+    {
+        // Guard: a hand-written property still satisfies the same interface.
+        const string source = """
+            package Test
+            interface IQuality {
+                prop SampleRate int32? { get; }
+            }
+            class QualityOk : IQuality {
+                prop SampleRate int32? -> nil
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void MissingInterfaceProperty_StillReportsGS0187()
+    {
+        // Don't over-fix: a genuinely missing member is still an error. The
+        // positional parameter X satisfies the interface, but Y has no
+        // corresponding member.
+        const string source = """
+            package Test
+            interface IHas {
+                prop X int32 { get; }
+                prop Y int32 { get; }
+            }
+            open data class D(X int32) : IHas {
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0187" && d.Message.Contains("Y"));
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0187" && d.Message.Contains(".X"));
+    }
+
+    [Fact]
+    public void TypeMismatchedPositionalParam_ReportsSingleGS0187()
+    {
+        // A positional parameter whose name matches but whose type is
+        // incompatible does NOT satisfy the contract, and the diagnostic is
+        // reported exactly once (not duplicated by the fallback path).
+        const string source = """
+            package Test
+            interface IHas {
+                prop X int32 { get; }
+            }
+            open data class D(X string) : IHas {
+            }
+            """;
+
+        var gs0187 = Bind(source).Where(d => d.Id == "GS0187").ToList();
+        Assert.Single(gs0187);
+    }
+
+    [Fact]
+    public void PositionalParam_SatisfiesSetterRequiringInterfaceProperty_NoDiagnostics()
+    {
+        // A data-class positional parameter is a mutable public field, so it can
+        // satisfy an interface property that also requires a setter.
+        const string source = """
+            package Test
+            interface IHas {
+                prop X int32 { get; set; }
+            }
+            open data class D(X int32) : IHas {
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void BaseDataClassParam_SatisfiesInterfaceListedOnDerived_NoDiagnostics()
+    {
+        // Issue #1066 semantics: a positional parameter on a base data class
+        // satisfies an interface listed on a derived data class.
+        const string source = """
+            package Test
+            interface IHas {
+                prop X int32 { get; }
+            }
+            open data class Base(X int32) {
+            }
+            open data class Derived(Y int32) : Base(0), IHas {
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void EmittedType_ImplementsInterface_AndDispatchesThroughIt()
+    {
+        // The binder no longer reports GS0187, but the emitted assembly must
+        // also be loadable: the data class needs a real get_ accessor to fill
+        // the CLR interface slot. This test emits, loads, and dispatches a call
+        // through the interface accessor — a missing accessor would surface here
+        // as a TypeLoadException at load time.
+        const string source = """
+            package Test
+            interface IQuality {
+                prop SampleRate int32? { get; }
+            }
+            open data class Quality(SampleRate int32?) : IQuality {
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext("Issue2150_EmitDispatch", isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+
+            // Loading the type graph exercises the CLR interface-slot check.
+            var quality = asm.GetTypes().First(t => t.Name == "Quality");
+            var iquality = asm.GetTypes().First(t => t.Name == "IQuality");
+            Assert.True(iquality.IsAssignableFrom(quality), "Quality must implement IQuality");
+
+            var instance = Activator.CreateInstance(quality, new object[] { (int?)44100 });
+
+            // Dispatch through the interface's get accessor (not the field).
+            var getter = iquality.GetMethod("get_SampleRate");
+            Assert.NotNull(getter);
+            var viaInterface = getter.Invoke(instance, null);
+            Assert.Equal((int?)44100, (int?)viaInterface);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.GlobalScope.Diagnostics.ToList();
+    }
+}


### PR DESCRIPTION
## Summary

A **data class** whose positional (primary-constructor) parameters were meant to satisfy a get-only interface property was rejected with `GS0187` ("does not implement interface method"), even though an equivalent hand-written property satisfies the same interface. Like C# records (`record R(int X) : IHasX` satisfies `int X { get; }`), a G# data-class positional parameter should satisfy a matching get-only interface property.

### Repro (was `GS0187` x2, now clean)
```gsharp
package Test
interface IQuality {
    prop SampleRate int32? { get; }
    prop BitRate int32? { get; }
}
open data class Quality(SampleRate int32?, BitRate int32?) : IQuality { }
```

## Root cause

The interface property-satisfaction loop in `DeclarationBinder` used `TypeMemberModel.TryGetProperty`, which only scans `StructSymbol.Properties` along the `BaseClass` chain. Data-class positional parameters are stored in `PrimaryConstructorParameters` and materialized as instance **fields**, never appearing in `.Properties`, so the lookup failed and `GS0187` fired.

Crucially, positional params emit only as fields — there is no CLR `get_X` accessor — so merely suppressing the diagnostic produced an **unloadable** assembly (`TypeLoadException: Method 'get_X' ... does not have an implementation`). The fix therefore addresses both the binder check *and* IL emission.

## Fix

- **`TypeMemberModel.TryGetPrimaryConstructorParameter`** — new helper that walks the this-first `BaseClass` chain to find a positional parameter by name (mirrors `TryGetProperty` / issue #1066).
- **`DeclarationBinder.VerifyInterfaceImplementations`** — when `TryGetProperty` fails, a same-name, type-compatible positional parameter now satisfies the property contract (get, and set since positional params are mutable public fields). For each satisfied parameter, a backing **auto-property** is synthesized on the class that declares the field, so the existing property-emission path emits the `get_/set_` accessor (`Virtual|NewSlot`) that fills the CLR interface slot. Member access is unaffected: fields are probed before properties, so `q.SampleRate` still resolves to the field.

The synthesized property is attached to the field's declaring type so it stays a same-type auto-property (avoids corrupting the FieldDef range); an inherited virtual accessor satisfies interfaces listed on derived classes.

## Preserved behavior

- A regular property still satisfies the interface.
- A genuinely missing member still reports `GS0187`.
- A name-matching but type-incompatible positional param reports a single `GS0187`.
- Getter/setter mismatch handling is unchanged.

## Tests

New `Issue2150DataClassInterfacePropertyTests` (7 tests): the primary repro, regular-property guard, missing-member `GS0187`, type-mismatch `GS0187`, setter-requiring property, base-chain inheritance, and an emit+load test that dispatches through the interface accessor (guards the `TypeLoadException`).

- New tests: **7 passed**
- Interface/DataClass/Property regression slice: **556 passed**
- Full `Core.Tests` suite: **5637 passed, 1 skipped, 0 failed**

Fixes #2150.
Refs #914.
