### PR TITLE
Fix #2152: infer void for block lambda with trailing assignment

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1249,6 +1249,25 @@ internal sealed class LambdaBinder
         var trailingIsVoidPlaceholder = boundBody is BoundBlockExpression { Expression: BoundLiteralExpression { Type: var trailingLit } }
             && trailingLit == TypeSymbol.Void;
 
+        // Issue #2152: in G#'s Kotlin-like semantics an assignment yields
+        // Unit/void, so a block-body lambda whose trailing expression is an
+        // assignment (simple `=` or a compound `+=`/`-=`/... which the binder
+        // represents with the same assignment bound nodes) contributes `void`
+        // — not the assigned value's type — to target-less return-type
+        // inference. Without this, `(x bool) -> { field = x }` was inferred as
+        // `(bool) -> bool` and failed to match an `Action`-style
+        // `(bool) -> void` delegate parameter during overload resolution
+        // (GS0266/GS0154). This mirrors the target-typed void-discard branch
+        // (issue #889) below and the value-discarding statement the emitter
+        // produces (see EmitTrailingExpression). It only fires on the
+        // target-less path (targetFunctionType == null); the target-typed
+        // paths already reconcile the assignment against the delegate's return
+        // type and are left untouched.
+        var trailingExpression = boundBody is BoundBlockExpression trailingBlock
+            ? trailingBlock.Expression
+            : boundBody;
+        var trailingIsAssignment = IsAssignmentExpression(trailingExpression);
+
         // Issue #891: a block-body arrow lambda whose body never completes
         // normally — every path throws (or otherwise terminates) without a
         // value-producing `return` — has no natural return value. C# treats
@@ -1273,7 +1292,12 @@ internal sealed class LambdaBinder
         var candidates = new List<TypeSymbol>();
         if (!(hasExplicitReturn && trailingIsVoidPlaceholder))
         {
-            candidates.Add(trailingType);
+            // Issue #2152: a trailing assignment contributes void on the
+            // target-less inference path (see the note above).
+            var trailingCandidate = trailingIsAssignment && targetFunctionType == null
+                ? TypeSymbol.Void
+                : trailingType;
+            candidates.Add(trailingCandidate);
         }
 
         candidates.AddRange(returnTypes);
@@ -1337,6 +1361,22 @@ internal sealed class LambdaBinder
 
         return result ?? TypeSymbol.Error;
     }
+
+    // Issue #2152: recognizes every bound-node shape the binder uses to
+    // represent an assignment — the simple `=` variants across the different
+    // assignment targets (locals, fields, properties, indexers, CLR members,
+    // pointers) as well as compound `+=`/`-=`/... forms, which the binder
+    // lowers into these same nodes. Used by InferLambdaReturnType to treat a
+    // trailing assignment as contributing `void` (G#'s Kotlin-like Unit
+    // semantics) on the target-less inference path.
+    private static bool IsAssignmentExpression(BoundExpression expression)
+        => expression?.Kind is BoundNodeKind.AssignmentExpression
+            or BoundNodeKind.FieldAssignmentExpression
+            or BoundNodeKind.PropertyAssignmentExpression
+            or BoundNodeKind.IndexAssignmentExpression
+            or BoundNodeKind.ClrPropertyAssignmentExpression
+            or BoundNodeKind.ClrIndexAssignmentExpression
+            or BoundNodeKind.IndirectAssignmentExpression;
 
     // ADR-0076 / issue #716: a trimmed copy of ExpressionBinder's common-
     // type rule (ADR-0062). Kept here to avoid widening the binder API

--- a/test/Compiler.Tests/Emit/Issue2152LambdaAssignmentInferenceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2152LambdaAssignmentInferenceEmitTests.cs
@@ -1,0 +1,146 @@
+// <copyright file="Issue2152LambdaAssignmentInferenceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2152 — a block-body lambda whose trailing expression is an
+/// assignment infers a <c>void</c> return type on the target-less inference
+/// path (overload resolution), so it matches an <c>Action</c>-style
+/// <c>(int32) -&gt; void</c> delegate parameter. These tests compile,
+/// IL-verify, and run a lambda-with-assignment-body invoked through an
+/// inferred void-delegate parameter, asserting the assignment took effect.
+/// </summary>
+public class Issue2152LambdaAssignmentInferenceEmitTests
+{
+    [Fact]
+    public void OverloadedVoidDelegate_AssignmentBodyLambda_InfersVoid_AndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            func run(a () -> void) { a() }
+            func run(b (int32) -> void) { b(9) }
+
+            var total = 0
+            run((x int32) -> { total = total + x })
+            Console.WriteLine(total)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("9\n", output);
+    }
+
+    [Fact]
+    public void OverloadedVoidDelegate_CompoundAssignmentBodyLambda_InfersVoid_AndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            func run(a () -> void) { a() }
+            func run(b (int32) -> void) { b(5) }
+
+            var total = 3
+            run((x int32) -> { total += x })
+            Console.WriteLine(total)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("8\n", output);
+    }
+
+    private static string CompileAndRun(string source, string[] referencePaths = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2152_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            if (referencePaths != null)
+            {
+                foreach (var reference in referencePaths)
+                {
+                    args.Add("/reference:" + reference);
+                    File.Copy(reference, Path.Combine(tempDir, Path.GetFileName(reference)), overwrite: true);
+                }
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath, additionalReferences: referencePaths);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2152LambdaAssignmentInferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2152LambdaAssignmentInferenceTests.cs
@@ -1,0 +1,152 @@
+// <copyright file="Issue2152LambdaAssignmentInferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2152 — a block-body lambda whose trailing expression is an
+/// assignment (e.g. <c>(x bool) -&gt; { field = x }</c>) must infer a
+/// <c>void</c> return type on the target-less inference path (overload
+/// resolution), not the assigned value's type. In G#'s Kotlin-like
+/// semantics an assignment yields Unit/void, so such a lambda matches an
+/// <c>Action</c>-style <c>(bool) -&gt; void</c> delegate parameter. Before the
+/// fix the lambda was inferred as <c>(bool) -&gt; bool</c>, producing spurious
+/// GS0266 (ambiguous overloads) / GS0154 (parameter type mismatch). The
+/// target-typed path (issue #889) was already correct; these tests pin the
+/// target-less path and guard that value-producing bodies still infer their
+/// real value type.
+/// </summary>
+public class Issue2152LambdaAssignmentInferenceTests
+{
+    [Fact]
+    public void OverloadResolution_TrailingSimpleAssignment_InfersVoidAndResolvesVoidDelegate()
+    {
+        var source = @"
+package Test
+class C {
+    var inProgress bool
+    func M() {
+        let g = G((x bool) -> { inProgress = x })
+    }
+}
+class G {
+    init(b () -> void) {}
+    init(c (bool) -> void) {}
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void OverloadResolution_TrailingCompoundAssignment_InfersVoid()
+    {
+        var source = @"
+package Test
+class C {
+    var count int32
+    func M() {
+        let g = G((x int32) -> { count += x })
+    }
+}
+class G {
+    init(b () -> void) {}
+    init(c (int32) -> void) {}
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void OverloadResolution_TrailingFieldAssignment_DoesNotMatchFuncOverload()
+    {
+        // Only a value-returning overload would match if inference wrongly
+        // produced (bool) -> bool. With the fix the lambda infers void, so the
+        // (bool) -> void overload is selected and binding is clean.
+        var source = @"
+package Test
+class C {
+    var inProgress bool
+    func M() {
+        let g = G((x bool) -> { inProgress = x })
+    }
+}
+class G {
+    init(c (bool) -> void) {}
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void OverloadResolution_ValueProducingTrailing_StillInfersValueType()
+    {
+        // Guard: a genuine value-producing trailing expression must keep its
+        // value type so it resolves to the (int32) -> int32 overload.
+        var source = @"
+package Test
+class C {
+    func M() {
+        let g = G((x int32) -> { x + 1 })
+    }
+}
+class G {
+    init(c (int32) -> int32) {}
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void OverloadResolution_ExplicitReturn_StillInfersReturnType()
+    {
+        // Guard: an explicit `return expr` continues to pin the value type.
+        var source = @"
+package Test
+class C {
+    func M() {
+        let g = G((x int32) -> { return x + 1 })
+    }
+}
+class G {
+    init(c (int32) -> int32) {}
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    private static void AssertBindsWithoutErrors(string source)
+    {
+        var paths = new List<string>();
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (!string.IsNullOrEmpty(tpa))
+        {
+            foreach (var p in tpa.Split(Path.PathSeparator))
+            {
+                if (!string.IsNullOrWhiteSpace(p) && File.Exists(p))
+                {
+                    paths.Add(p);
+                }
+            }
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(paths);
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), resolver);
+        var program = Binder.BindProgram(globalScope, resolver);
+        var diagnostics = globalScope.Diagnostics.AddRange(program.Diagnostics);
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
+    }
+}


### PR DESCRIPTION
## Problem

A block-bodied lambda whose trailing expression is an assignment — e.g. `(x bool) -> { field = x }` — had its return type inferred as the assignment's value type (`bool`) instead of `void` on the **target-less** inference path used during overload resolution. The lambda was inferred as `(bool) -> bool` instead of `(bool) -> void`, so it failed to match `Action`-style `(T) -> void` delegate parameters, producing spurious `GS0266` (ambiguous overloads) or `GS0154` (type mismatch).

The target-typed path (issue #889) was already correct — assigning the same lambda to an explicit `(bool) -> void` slot discards the trailing value and treats it as `void`. Only the target-less inference path disagreed. G# is Kotlin-like, where an assignment yields Unit/void, so a trailing assignment should contribute `void`.

## Fix

In `LambdaBinder.InferLambdaReturnType`, when there is no target function type, a trailing expression that is an assignment bound node contributes `TypeSymbol.Void` (rather than the assigned value's type) to the inferred-return-type candidate set. This generalizes across all assignment bound-node shapes (simple `=` for locals/fields/properties/indexers/CLR members/pointers, plus compound `+=`/`-=`/… which the binder lowers into these same nodes). The emitter already produces a value-discarding expression-statement for a void return (see `EmitTrailingExpression`), so the emitted IL is correct.

Value-producing bodies (`-> { a + b }`, `-> { compute() }`) and explicit `return expr` are unaffected, and the target-typed paths are left untouched.

## Tests

- `Issue2152LambdaAssignmentInferenceTests` (binder): overload repro binds with no diagnostics and resolves the `(T) -> void` overload; guards that value-producing trailing expressions and explicit `return` still infer their value type; covers compound assignment.
- `Issue2152LambdaAssignmentInferenceEmitTests` (emit): compiles + IL-verifies + runs a lambda-with-assignment-body passed through an inferred void-delegate parameter, asserting the assignment took effect.

Full Core.Tests (5635) and Compiler.Tests (2742) suites pass.

Fixes #2152.
Refs #914.
