### PR TITLE
Fix #2157: taint oblivious property/indexer return types for nullable bodies

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2157ObliviousPropertyTaintTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2157ObliviousPropertyTaintTranslationTests.cs
@@ -1,0 +1,235 @@
+// <copyright file="Issue2157ObliviousPropertyTaintTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #2157: in a nullable-<em>oblivious</em>
+/// compilation the whole-program taint analysis
+/// (<see cref="ObliviousNullabilityAnalyzer"/>) must scan property / indexer
+/// getters (expression body, <c>get =&gt; expr;</c>, and block-bodied
+/// <c>get { ... return x; }</c>) so a getter whose body yields a nullable value
+/// (<c>?.</c>, <c>??</c> with a nullable fallback, <c>return null</c>) is emitted
+/// with a <c>T?</c> return type. Before the fix such a property was emitted as a
+/// non-null <c>T</c> even though its <c>?.</c> body types as <c>T?</c>, producing
+/// GS0156 "Cannot convert type 'string?' to 'string'". The analysis is gated to
+/// oblivious compilations, so a nullable-<em>enabled</em> compilation is untouched.
+/// </summary>
+public class Issue2157ObliviousPropertyTaintTranslationTests
+{
+    [Fact]
+    public void Oblivious_ExpressionBodiedProperty_WithConditionalAccessBody_RendersNullable()
+    {
+        // `Meta?.Asin` is a conditional access → its result is `string?`. The
+        // property must therefore be emitted `string?` or gsc reports GS0156.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Meta { public string Asin = ""x""; }
+
+    public class Book
+    {
+        public Meta Meta = new Meta();
+
+        public string Asin => Meta?.Asin;
+    }
+}");
+
+        Assert.Contains("prop Asin string?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_ExpressionBodiedProperty_WithCoalesceNullableFallbackBody_RendersNullable()
+    {
+        // `First()?.Name ?? Other` — the `??` fallback (`Other`) is itself a `?.`
+        // result, so the whole expression is nullable and the property is `string?`.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Meta { public string Name = ""x""; }
+
+    public class Book
+    {
+        public Meta Meta = new Meta();
+        public Meta Other = new Meta();
+
+        public string Display => Meta?.Name ?? Other?.Name;
+    }
+}");
+
+        Assert.Contains("prop Display string?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_BlockBodiedGetter_WithReturnNull_RendersNullable()
+    {
+        // A block-bodied `get { ... return null; }` taints the property return.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Book
+    {
+        public bool Missing = true;
+
+        public string Title
+        {
+            get
+            {
+                if (Missing) { return null; }
+                return ""t"";
+            }
+        }
+    }
+}");
+
+        Assert.Contains("prop Title string?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_UntaintedComputedProperty_StaysNonNull()
+    {
+        // A getter that can never yield null keeps the idiomatic non-null `string`.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Book
+    {
+        public string First = ""a"";
+        public string Last = ""b"";
+
+        public string Full => First + Last;
+    }
+}");
+
+        Assert.Contains("prop Full string", printed);
+        Assert.DoesNotContain("prop Full string?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_ValueTypedComputedProperty_IsNotPromoted()
+    {
+        // A value-typed property is never promoted even when the body is a `?.`
+        // chain (its type is not a reference type).
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Meta { public int Count = 3; }
+
+    public class Book
+    {
+        public Meta Meta = new Meta();
+
+        public int Count => Meta == null ? 0 : Meta.Count;
+    }
+}");
+
+        Assert.Contains("prop Count int32", printed);
+        Assert.DoesNotContain("prop Count int32?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_IndexerWithConditionalAccessBody_RendersNullable()
+    {
+        // An indexer getter yielding `string?` must be emitted `T?` too.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Meta { public string Get(int i) { return ""x""; } }
+
+    public class Book
+    {
+        public Meta Meta = new Meta();
+
+        public string this[int i] => Meta?.Get(i);
+    }
+}");
+
+        Assert.Contains("prop this[i int32] string?", printed);
+    }
+
+    [Fact]
+    public void NullableEnabled_ComputedPropertyWithConditionalAccessBody_StaysNonNull()
+    {
+        // Same `?.` body but in a nullable-ENABLED compilation: the oblivious
+        // taint analysis must NOT run, and the property is emitted exactly as its
+        // declared non-null `string`.
+        string printed = TranslateEnabled(@"
+#nullable enable
+namespace Demo
+{
+    public class Meta { public string Asin = ""x""; }
+
+    public class Book
+    {
+        public Meta Meta = new Meta();
+
+        public string Asin => Meta.Asin;
+    }
+}");
+
+        Assert.Contains("prop Asin string", printed);
+        Assert.DoesNotContain("prop Asin string?", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string TranslateEnabled(string source)
+    {
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.EnabledInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Select(r => r).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3807,6 +3807,15 @@ public sealed class CSharpToGSharpTranslator
                 ? this.typeMapper.Map(symbol.Type, this.context, node.GetLocation())
                 : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
 
+            // Issue #2157 / #1354: an oblivious indexer whose getter yields a
+            // nullable value (`?.` / `??` / `return null`), or one null-checked
+            // in its declaring type, is rendered `T?` so the getter body
+            // type-checks.
+            if (symbol != null)
+            {
+                type = this.PromoteIfUsedAsNullable(type, symbol);
+            }
+
             List<Parameter> indexParameters = symbol != null
                 ? symbol.Parameters.Select(p => this.MapParameter(p, node)).ToList()
                 : this.MapParameterList(node.ParameterList);

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -319,43 +319,140 @@ internal static class ObliviousNullabilityAnalyzer
     {
         foreach (SyntaxNode node in root.DescendantNodes())
         {
-            ExpressionSyntax arrowBody = null;
-            ISymbol returnSymbol = null;
-
             switch (node)
             {
                 case MethodDeclarationSyntax method:
-                    returnSymbol = model.GetDeclaredSymbol(method);
-                    arrowBody = method.ExpressionBody?.Expression;
+                    SeedMethodLikeReturnTaint(
+                        model.GetDeclaredSymbol(method),
+                        method.ExpressionBody?.Expression,
+                        method.Body,
+                        model,
+                        tainted,
+                        edges);
                     break;
 
                 case LocalFunctionStatementSyntax localFunction:
-                    returnSymbol = model.GetDeclaredSymbol(localFunction);
-                    arrowBody = localFunction.ExpressionBody?.Expression;
+                    SeedMethodLikeReturnTaint(
+                        model.GetDeclaredSymbol(localFunction),
+                        localFunction.ExpressionBody?.Expression,
+                        localFunction.Body,
+                        model,
+                        tainted,
+                        edges);
                     break;
 
-                default:
-                    continue;
+                // Property / indexer getters: the "return type" is the
+                // property's own type and the taint TARGET is the property
+                // symbol itself. A getter whose expression body / `get` accessor
+                // yields a nullable (`?.` / `??` / ternary / `return null`)
+                // value must be emitted as `T?` (issue #2157).
+                case PropertyDeclarationSyntax property:
+                    SeedPropertyLikeReturnTaint(
+                        model.GetDeclaredSymbol(property),
+                        property.ExpressionBody?.Expression,
+                        property.AccessorList,
+                        model,
+                        tainted,
+                        edges);
+                    break;
+
+                case IndexerDeclarationSyntax indexer:
+                    SeedPropertyLikeReturnTaint(
+                        model.GetDeclaredSymbol(indexer),
+                        indexer.ExpressionBody?.Expression,
+                        indexer.AccessorList,
+                        model,
+                        tainted,
+                        edges);
+                    break;
             }
+        }
+    }
 
-            if (returnSymbol is not IMethodSymbol { ReturnsVoid: false } methodSymbol)
+    private static void SeedMethodLikeReturnTaint(
+        ISymbol returnSymbol,
+        ExpressionSyntax arrowBody,
+        BlockSyntax body,
+        SemanticModel model,
+        HashSet<ISymbol> tainted,
+        List<(ISymbol Target, ISymbol Source)> edges)
+    {
+        if (returnSymbol is not IMethodSymbol { ReturnsVoid: false })
+        {
+            return;
+        }
+
+        ISymbol canonicalReturn = Canonical(returnSymbol);
+
+        if (arrowBody != null)
+        {
+            ApplyReturnValue(canonicalReturn, arrowBody, model, tainted, edges, transitive: true);
+        }
+
+        foreach (ReturnStatementSyntax statement in EnumerateOwnReturns(body))
+        {
+            if (statement.Expression != null)
             {
-                continue;
+                ApplyReturnValue(canonicalReturn, statement.Expression, model, tainted, edges, transitive: true);
             }
+        }
+    }
 
-            ISymbol canonicalReturn = Canonical(methodSymbol);
+    private static void SeedPropertyLikeReturnTaint(
+        IPropertySymbol propertySymbol,
+        ExpressionSyntax propertyArrowBody,
+        AccessorListSyntax accessorList,
+        SemanticModel model,
+        HashSet<ISymbol> tainted,
+        List<(ISymbol Target, ISymbol Source)> edges)
+    {
+        // Only reference-typed, not-already-nullable property/indexer types are
+        // governed by this analysis; value types and `T?` declarations are left
+        // untouched.
+        if (propertySymbol is not { Type.IsReferenceType: true } ||
+            propertySymbol.Type.NullableAnnotation == NullableAnnotation.Annotated)
+        {
+            return;
+        }
 
-            if (arrowBody != null)
+        ISymbol canonicalReturn = Canonical(propertySymbol);
+
+        // A property/indexer getter is DIRECT-taint only: a syntactically
+        // nullable body (`?.` / `??`-with-nullable-fallback / ternary /
+        // `return null`) promotes the property to `T?` (issue #2157). We do NOT
+        // record transitive edges here — a getter that merely FORWARDS another
+        // (only-transitively-nullable) declaration keeps its declared type and
+        // relies on the translator's null-forgiveness pass (issue #1354) to
+        // assert the forwarded value non-null, preserving the property contract
+        // for overrides / interface members.
+
+        // `Prop => expr;`
+        if (propertyArrowBody != null)
+        {
+            ApplyReturnValue(canonicalReturn, propertyArrowBody, model, tainted, edges, transitive: false);
+        }
+
+        // Only the `get` accessor produces the property value; `set`/`init`
+        // return void and are ignored.
+        AccessorDeclarationSyntax getter = accessorList?.Accessors
+            .FirstOrDefault(a => a.IsKind(SyntaxKind.GetAccessorDeclaration));
+        if (getter == null)
+        {
+            return;
+        }
+
+        // `get => expr;`
+        if (getter.ExpressionBody?.Expression is ExpressionSyntax getterArrow)
+        {
+            ApplyReturnValue(canonicalReturn, getterArrow, model, tainted, edges, transitive: false);
+        }
+
+        // `get { ... return x; }`
+        foreach (ReturnStatementSyntax statement in EnumerateOwnReturns(getter.Body))
+        {
+            if (statement.Expression != null)
             {
-                ApplyReturnValue(canonicalReturn, arrowBody, model, tainted, edges);
-            }
-
-            foreach (ReturnStatementSyntax statement in EnumerateOwnReturns(node))
-            {
-                if (statement.Expression != null)
-                {
-                    ApplyReturnValue(canonicalReturn, statement.Expression, model, tainted, edges);
-                }
+                ApplyReturnValue(canonicalReturn, statement.Expression, model, tainted, edges, transitive: false);
             }
         }
     }
@@ -365,30 +462,24 @@ internal static class ObliviousNullabilityAnalyzer
         ExpressionSyntax value,
         SemanticModel model,
         HashSet<ISymbol> tainted,
-        List<(ISymbol Target, ISymbol Source)> edges)
+        List<(ISymbol Target, ISymbol Source)> edges,
+        bool transitive)
     {
         if (IsDirectlyNullable(value, model))
         {
             tainted.Add(returnSymbol);
         }
-        else
+        else if (transitive)
         {
             AddEdges(returnSymbol, value, model, edges);
         }
     }
 
-    // The `return` statements that belong to <paramref name="member"/> itself,
+    // The `return` statements that belong to <paramref name="body"/> itself,
     // excluding those inside a nested lambda / local function (which have their
     // own return contract).
-    private static IEnumerable<ReturnStatementSyntax> EnumerateOwnReturns(SyntaxNode member)
+    private static IEnumerable<ReturnStatementSyntax> EnumerateOwnReturns(BlockSyntax body)
     {
-        SyntaxNode body = member switch
-        {
-            MethodDeclarationSyntax m => (SyntaxNode)m.Body,
-            LocalFunctionStatementSyntax l => l.Body,
-            _ => null,
-        };
-
         if (body == null)
         {
             yield break;


### PR DESCRIPTION
## Summary
In a nullable-**oblivious** C# project, `ObliviousNullabilityAnalyzer.SeedReturnTaint` only scanned `MethodDeclarationSyntax`/`LocalFunctionStatementSyntax` for return taint — it never scanned **property getters, indexer getters, or accessor bodies**. So an expression-bodied property whose body is a nullable `?.`/`??` expression (e.g. `public string Author => Authors?.Select(a => a.Name).First();`) was emitted by cs2gs with a **non-null** return type, while gsc types the emitted `?.` body as `T?` → `GS0156: Cannot convert type 'string?' to 'string'`. This was the dominant remaining error cluster migrating Oahu.Data (`Entities.gs` Author/Narrator/Asin/MultiAuthors).

## Fix
- **`ObliviousNullabilityAnalyzer`**: `SeedReturnTaint` now also scans `PropertyDeclarationSyntax` and `IndexerDeclarationSyntax`, targeting the property/indexer symbol (its `Type` treated as the "return"). It scans the property expression body, the `get` accessor expression body, and block-bodied `get { ... return x; }` (via the generalized `EnumerateOwnReturns(BlockSyntax)`), excluding nested lambdas/local functions. `set`/`init` accessors are ignored (they return void). Only reference-typed, not-already-annotated property types are considered; value types and `T?` are skipped.
  - Property/indexer getters seed **direct** taint only (`?.` / `??`-with-nullable-fallback / ternary / `return null`); they do **not** record transitive edges. A getter that merely forwards another only-transitively-nullable declaration keeps its declared type and relies on the existing null-forgiveness pass (issue #1354), preserving the property contract for overrides/interface members. Methods keep transitive edges as before.
- **`CSharpToGSharpTranslator.TranslateIndexer`**: routes the indexer type through `PromoteIfUsedAsNullable` so a tainted indexer is emitted `T?` (the property path already did this via `IsPromotedToNullableReference` → `IsTainted`).

Gated strictly to oblivious compilations: `IsTainted` short-circuits to `false` for nullable-enabled compilations, so enabled projects are byte-identical.

## Validation
Full cs2gs unit suite: **1108 passed, 0 failed** (7 new focused tests in `Issue2157ObliviousPropertyTaintTranslationTests`, plus the existing #1354 forgiveness test still passes).

Corpus (gsc, GS9100 filtered):

| Corpus | Metric | Before | After |
|---|---|---|---|
| Oahu.Data | GS0156 | 23 | 7 |
| Oahu.Data | GS0155 | 22 | 21 |
| Oahu.SystemManagement | GS0156 (deduped) | 3 | 2 |
| Oahu.Foundation | GS0155 (deduped) | 15 | 15 (no regression) |
| Oahu.Decrypt (nullable-ENABLED) | compile errors | 0 | 0 |

The `Entities.gs` Author/Narrator/Asin/MultiAuthors computed-property cluster is now correctly emitted `string?`. Oahu.Decrypt (nullable-enabled) compile stays at 0 errors (its only failure is a pre-existing, unrelated ilverify IL-emission gap).

Fixes #2157.
Refs #914.
