### PR TITLE
Fix #2154: support compound-operator overrides on member-access LHS

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -902,7 +902,7 @@ internal sealed partial class ExpressionBinder
             {
                 var inheritedReceiver = new BoundVariableExpression(null, effThis);
                 var inheritedCompound = TryBindChainedClrCompoundAssignment(
-                    inheritedReceiver, inheritedBaseClr, name, bareName, syntax, isAdd, includeInherited: true);
+                    inheritedReceiver, inheritedBaseClr, name, bareName, syntax, isAdd ? SyntaxKind.PlusToken : SyntaxKind.MinusToken, includeInherited: true);
                 if (inheritedCompound != null)
                 {
                     return inheritedCompound;
@@ -1005,24 +1005,23 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
-    /// ADR-0053: bind <c>Type.StaticField +=/-= rhs</c> or
-    /// <c>Type.StaticProp +=/-= rhs</c> where <paramref name="staticStruct"/>
+    /// ADR-0053 / issue #2154: bind <c>Type.StaticField op= rhs</c> or
+    /// <c>Type.StaticProp op= rhs</c> where <paramref name="staticStruct"/>
     /// is the user-defined receiver type. Returns <c>true</c> if the named
     /// member was a static field/property and the compound assignment was
     /// produced; <c>false</c> if no static field or property by that name
     /// exists on the type (caller falls through to error reporting).
     /// Mirrors the static branch of <see cref="BindFieldAssignmentExpression"/>
-    /// (lines ~6586–6619) but for compound `+=` / `-=`.
+    /// (lines ~6586–6619) but for any compound operator.
     /// </summary>
     private bool TryBindUserTypeStaticCompoundAssignment(
         StructSymbol staticStruct,
         NameExpressionSyntax memberNameSyntax,
         EventSubscriptionExpressionSyntax syntax,
-        bool isAdd,
+        SyntaxKind baseOpSyntaxKind,
         out BoundExpression result)
     {
         var memberName = memberNameSyntax.IdentifierToken.Text;
-        var baseOpSyntaxKind = isAdd ? SyntaxKind.PlusToken : SyntaxKind.MinusToken;
         var boundRhs = BindExpression(syntax.Value);
 
         if (TypeMemberModel.TryGetStaticField(staticStruct, memberName, out var staticField))
@@ -1074,29 +1073,29 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
-    /// ADR-0089 / issue #1030: binds <c>IName.StaticField +=/-= rhs</c> for an
-    /// interface static field. <paramref name="interfaceSym"/> may be the open
-    /// definition (non-generic, or self-instantiation) or a constructed generic
-    /// interface (<c>IBox[int32]</c>); the field is resolved on the definition
-    /// and the carried interface symbol drives per-construction emit/storage.
-    /// Returns <c>true</c> when the named member was an interface static field;
+    /// ADR-0089 / issue #1030 (generalized by issue #2154): binds
+    /// <c>IName.StaticField op= rhs</c> for an interface static field.
+    /// <paramref name="interfaceSym"/> may be the open definition (non-generic,
+    /// or self-instantiation) or a constructed generic interface
+    /// (<c>IBox[int32]</c>); the field is resolved on the definition and the
+    /// carried interface symbol drives per-construction emit/storage. Returns
+    /// <c>true</c> when the named member was an interface static field;
     /// <c>false</c> otherwise (caller reports "unable to find member").
     /// </summary>
     /// <param name="interfaceSym">The interface receiver (definition or constructed).</param>
     /// <param name="memberNameSyntax">The member-name syntax.</param>
     /// <param name="syntax">The originating compound-assignment syntax.</param>
-    /// <param name="isAdd">Whether the operator is <c>+=</c> (else <c>-=</c>).</param>
+    /// <param name="baseOpSyntaxKind">The base binary operator token kind (e.g. <c>+</c> for <c>+=</c>).</param>
     /// <param name="result">The bound compound assignment on success.</param>
     /// <returns>Whether the member resolved to an interface static field.</returns>
     private bool TryBindInterfaceStaticCompoundAssignment(
         InterfaceSymbol interfaceSym,
         NameExpressionSyntax memberNameSyntax,
         EventSubscriptionExpressionSyntax syntax,
-        bool isAdd,
+        SyntaxKind baseOpSyntaxKind,
         out BoundExpression result)
     {
         var memberName = memberNameSyntax.IdentifierToken.Text;
-        var baseOpSyntaxKind = isAdd ? SyntaxKind.PlusToken : SyntaxKind.MinusToken;
         var fieldOwner = interfaceSym.Definition ?? interfaceSym;
         var staticField = fieldOwner.GetStaticField(memberName);
         if (staticField == null)
@@ -1126,8 +1125,9 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
-    /// Issue #648: compound assignment fallback for chained member access on
-    /// user-defined struct/class types (e.g. <c>a.B.C += 1</c>). Synthesizes
+    /// Issue #648 (generalized by issue #2154): compound assignment fallback
+    /// for chained member access on user-defined struct/class types (e.g.
+    /// <c>a.B.C += 1</c>, <c>a.B.C *= 2</c>). Synthesizes
     /// <c>receiver.field = receiver.field op rhs</c>.
     /// </summary>
     private BoundExpression TryBindChainedCompoundAssignment(
@@ -1136,9 +1136,8 @@ internal sealed partial class ExpressionBinder
         string memberName,
         NameExpressionSyntax memberNameSyntax,
         EventSubscriptionExpressionSyntax syntax,
-        bool isAdd)
+        SyntaxKind baseOpSyntaxKind)
     {
-        var baseOpSyntaxKind = isAdd ? SyntaxKind.PlusToken : SyntaxKind.MinusToken;
         var boundRhs = BindExpression(syntax.Value);
 
         // ADR-0112 A3: this-first base-chain instance field walk, using the
@@ -1220,15 +1219,16 @@ internal sealed partial class ExpressionBinder
         if (GetInheritedClrBaseType(structSym) is System.Type inheritedBaseClr)
         {
             return TryBindChainedClrCompoundAssignment(
-                boundReceiver, inheritedBaseClr, memberName, memberNameSyntax, syntax, isAdd, includeInherited: true);
+                boundReceiver, inheritedBaseClr, memberName, memberNameSyntax, syntax, baseOpSyntaxKind, includeInherited: true);
         }
 
         return null;
     }
 
     /// <summary>
-    /// Issue #648: compound assignment fallback for chained CLR member access
-    /// (e.g. <c>obj.Prop += 1</c> where Prop is a property/field on a CLR type).
+    /// Issue #648 (generalized by issue #2154): compound assignment fallback
+    /// for chained CLR member access (e.g. <c>obj.Prop += 1</c>, <c>obj.Prop *=
+    /// 2</c> where Prop is a property/field on a CLR type).
     /// </summary>
     private BoundExpression TryBindChainedClrCompoundAssignment(
         BoundExpression boundReceiver,
@@ -1236,11 +1236,9 @@ internal sealed partial class ExpressionBinder
         string memberName,
         NameExpressionSyntax memberNameSyntax,
         EventSubscriptionExpressionSyntax syntax,
-        bool isAdd,
+        SyntaxKind baseOpSyntaxKind,
         bool includeInherited = false)
     {
-        var baseOpSyntaxKind = isAdd ? SyntaxKind.PlusToken : SyntaxKind.MinusToken;
-
         MemberInfo instanceMember;
         if (includeInherited)
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -60,6 +60,15 @@ internal sealed partial class ExpressionBinder
         var eventName = eventNameSyntax.IdentifierToken.Text;
         var isAdd = syntax.OperatorToken.Kind == SyntaxKind.PlusEqualsToken;
 
+        // Issue #2154: events only support `+=`/`-=` subscription semantics —
+        // any OTHER compound operator (`*=`, `/=`, ...) on the same
+        // member-access LHS can never denote an event and must go straight to
+        // compound-assignment (operator-overload) resolution below, carrying
+        // the actual base operator instead of the +/- `isAdd` bool.
+        var isEventCapableOperator = syntax.OperatorToken.Kind == SyntaxKind.PlusEqualsToken
+            || syntax.OperatorToken.Kind == SyntaxKind.MinusEqualsToken;
+        SyntaxFacts.TryGetCompoundAssignmentBaseOperator(syntax.OperatorToken.Kind, out var baseOpSyntaxKind);
+
         // Resolve receiver: either an ImportedClassSymbol (static event) or
         // any value-producing expression with a CLR-backed type (instance event).
         BoundExpression boundReceiver = null;
@@ -78,17 +87,19 @@ internal sealed partial class ExpressionBinder
             // Issue #263: static event subscription on a user-defined type.
             // Try matching an event first; if no match, fall through to
             // ADR-0053 static field/property compound assignment instead of
-            // reporting an immediate "unable to find member".
-            if (TypeMemberModel.TryGetStaticEvent(staticStruct, eventName, out var ev))
+            // reporting an immediate "unable to find member". Non-+/-
+            // operators (issue #2154) can never be an event, so skip straight
+            // to the compound-assignment fallback.
+            if (isEventCapableOperator && TypeMemberModel.TryGetStaticEvent(staticStruct, eventName, out var ev))
             {
                 var userHandler = BindEventSubscriptionHandler(syntax.Value, ev.Type);
                 return new BoundEventSubscriptionExpression(null, receiver: null, staticStruct, ev, userHandler, isAdd);
             }
 
-            // ADR-0053: `Type.StaticField += rhs` / `Type.StaticProp += rhs`.
+            // ADR-0053: `Type.StaticField op= rhs` / `Type.StaticProp op= rhs`.
             // The simple-assignment path is handled by BindFieldAssignmentExpression
             // (lines ~6586–6619); this is the compound counterpart.
-            if (TryBindUserTypeStaticCompoundAssignment(staticStruct, eventNameSyntax, syntax, isAdd, out var compoundResult))
+            if (TryBindUserTypeStaticCompoundAssignment(staticStruct, eventNameSyntax, syntax, baseOpSyntaxKind, out var compoundResult))
             {
                 return compoundResult;
             }
@@ -100,9 +111,9 @@ internal sealed partial class ExpressionBinder
             && scope.TryLookupTypeAlias(ifaceLeftName.IdentifierToken.Text, out var ifaceTypeAlias)
             && ifaceTypeAlias is InterfaceSymbol staticInterface)
         {
-            // ADR-0089 / issue #1030: `IName.StaticField += rhs` — compound
+            // ADR-0089 / issue #1030: `IName.StaticField op= rhs` — compound
             // assignment to a (non-generic) interface static field.
-            if (TryBindInterfaceStaticCompoundAssignment(staticInterface, eventNameSyntax, syntax, isAdd, out var ifaceCompound))
+            if (TryBindInterfaceStaticCompoundAssignment(staticInterface, eventNameSyntax, syntax, baseOpSyntaxKind, out var ifaceCompound))
             {
                 return ifaceCompound;
             }
@@ -119,20 +130,20 @@ internal sealed partial class ExpressionBinder
         {
             // Issue #1559 (extends ADR-0089 / issue #1030): compound assignment
             // to a static field/property through a constructed generic *type*
-            // receiver — `Foo[int32].x += rhs` (class/struct) or
-            // `IBox[int32].StaticField += rhs` (interface). The receiver is a
+            // receiver — `Foo[int32].x op= rhs` (class/struct) or
+            // `IBox[int32].StaticField op= rhs` (interface). The receiver is a
             // TYPE, resolved to the constructed symbol (mirroring the READ /
             // simple-write paths) rather than bound as element access, and the
             // carried construction drives per-construction emit/storage.
             _ = ctorImported;
             if (ctorStruct != null
-                && TryBindUserTypeStaticCompoundAssignment(ctorStruct, eventNameSyntax, syntax, isAdd, out var ctorStructCompound))
+                && TryBindUserTypeStaticCompoundAssignment(ctorStruct, eventNameSyntax, syntax, baseOpSyntaxKind, out var ctorStructCompound))
             {
                 return ctorStructCompound;
             }
 
             if (ctorInterface != null
-                && TryBindInterfaceStaticCompoundAssignment(ctorInterface, eventNameSyntax, syntax, isAdd, out var ctorCompound))
+                && TryBindInterfaceStaticCompoundAssignment(ctorInterface, eventNameSyntax, syntax, baseOpSyntaxKind, out var ctorCompound))
             {
                 return ctorCompound;
             }
@@ -153,7 +164,8 @@ internal sealed partial class ExpressionBinder
             // events on `open class` bases now resolve (parity with the bare-`this`
             // path in BindBareEventOrCompoundAssignment). The owner symbol remains
             // `userStruct` (the receiver's static type) to preserve the bound-node shape.
-            if (boundReceiver.Type is StructSymbol userStruct && TypeMemberModel.TryGetEvent(userStruct, eventName, out var ev))
+            // Non-+/- operators (issue #2154) can never be an event.
+            if (isEventCapableOperator && boundReceiver.Type is StructSymbol userStruct && TypeMemberModel.TryGetEvent(userStruct, eventName, out var ev))
             {
                 var userHandler = BindEventSubscriptionHandler(syntax.Value, ev.Type);
                 return new BoundEventSubscriptionExpression(null, boundReceiver, userStruct, ev, userHandler, isAdd);
@@ -162,14 +174,15 @@ internal sealed partial class ExpressionBinder
             receiverClrType = boundReceiver.Type?.ClrType;
             if (receiverClrType == null)
             {
-                // Issue #648: compound assignment fallback for chained member access
-                // on user-defined struct/class types (e.g. `a.B.C += 1`). The parser
-                // routes all `lhs.member +=/-=` through EventSubscriptionExpression;
-                // when the member is not an event we fall back to compound assignment.
+                // Issue #648 (generalized by #2154): compound assignment fallback for
+                // chained member access on user-defined struct/class types (e.g.
+                // `a.B.C += 1`, `a.B.C *= 2`). The parser routes all `lhs.member op=
+                // rhs` through EventSubscriptionExpression; when the member is not an
+                // event we fall back to compound assignment.
                 if (boundReceiver.Type is StructSymbol compoundStruct)
                 {
                     var compoundResult = TryBindChainedCompoundAssignment(
-                        compoundStruct, boundReceiver, eventName, eventNameSyntax, syntax, isAdd);
+                        compoundStruct, boundReceiver, eventName, eventNameSyntax, syntax, baseOpSyntaxKind);
                     if (compoundResult != null)
                     {
                         return compoundResult;
@@ -183,15 +196,16 @@ internal sealed partial class ExpressionBinder
             flags = BindingFlags.Public | BindingFlags.Instance;
         }
 
-        var eventInfo = ClrTypeUtilities.SafeGetEvent(receiverClrType, eventName, flags);
+        var eventInfo = isEventCapableOperator ? ClrTypeUtilities.SafeGetEvent(receiverClrType, eventName, flags) : null;
         if (eventInfo == null)
         {
-            // Issue #648: compound assignment fallback for chained CLR member access
-            // (e.g. `obj.Prop += 1` where Prop is a field/property, not an event).
+            // Issue #648 (generalized by #2154): compound assignment fallback for
+            // chained CLR member access (e.g. `obj.Prop += 1`, `obj.Prop *= 2` where
+            // Prop is a field/property, not an event).
             if (boundReceiver != null)
             {
                 var clrCompound = TryBindChainedClrCompoundAssignment(
-                    boundReceiver, receiverClrType, eventName, eventNameSyntax, syntax, isAdd);
+                    boundReceiver, receiverClrType, eventName, eventNameSyntax, syntax, baseOpSyntaxKind);
                 if (clrCompound != null)
                 {
                     return clrCompound;

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -7047,8 +7047,18 @@ public class Parser
         // is captured as an EventSubscriptionExpressionSyntax once the LHS has
         // been parsed as a member-access chain. The binder later validates that
         // the LHS resolves to a CLR EventInfo.
+        //
+        // Issue #2154: any OTHER compound operator (`*=`, `/=`, `%=`, `^=`,
+        // `&=`, `|=`, ...) on the same member-access LHS can never denote an
+        // event (events only support `+=`/`-=`), but it MAY denote a compound
+        // assignment through a user-defined `operator` overload (e.g.
+        // `obj.Field *= 2` where Field's type declares `operator *`). Route it
+        // through the same EventSubscriptionExpressionSyntax node — the binder
+        // dispatches on the actual operator token kind, skipping event lookup
+        // entirely for non-`+=`/`-=` operators and going straight to compound
+        // assignment.
         if (expression is AccessorExpressionSyntax accessor
-            && (Current.Kind == SyntaxKind.PlusEqualsToken || Current.Kind == SyntaxKind.MinusEqualsToken))
+            && SyntaxFacts.TryGetCompoundAssignmentBaseOperator(Current.Kind, out _))
         {
             var opToken = NextToken();
             var rhs = ParseAssignmentExpression();

--- a/test/Compiler.Tests/Emit/Issue2154CompoundOperatorOverrideTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2154CompoundOperatorOverrideTests.cs
@@ -1,0 +1,255 @@
+// <copyright file="Issue2154CompoundOperatorOverrideTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2154 — issue #1554 taught compound assignment (<c>x op= y</c>) to
+/// fall back to a USER-DEFINED <c>operator</c> overload the same way the
+/// equivalent binary expression <c>x = x op y</c> does, but that fallback was
+/// only reachable for a BARE local variable and for the built-in event-style
+/// <c>+=</c>/<c>-=</c> operators on member access. The parser only emitted an
+/// <see cref="GSharp.Core.CodeAnalysis.Syntax.EventSubscriptionExpressionSyntax"/>
+/// (the node whose binder falls back to compound-assignment semantics for a
+/// non-event member) for <c>+=</c>/<c>-=</c> — ANY other compound operator
+/// (<c>*=</c>, <c>/=</c>, <c>%=</c>, <c>^=</c>, <c>&amp;=</c>, <c>|=</c>, ...)
+/// on a member-access LHS (<c>obj.Field *= 2</c>, <c>Type.StaticField *= 2</c>,
+/// <c>a.B.C *= 2</c>) failed to even PARSE (<c>GS0005 Unexpected token
+/// &lt;StarEqualsToken&gt;</c>), even though the member's type declared a
+/// matching <c>operator *</c> overload and <c>obj.Field = obj.Field * 2</c>
+/// bound and ran fine.
+/// <para>
+/// The fix widens the parser's member-access compound-assignment gate from
+/// <c>+=</c>/<c>-=</c>-only to ANY compound operator (mirroring the
+/// already-generalized bare-identifier and indexer paths), and threads the
+/// actual base operator kind through the binder's compound-assignment helpers
+/// (previously hard-coded to a <c>bool isAdd</c> that only ever produced
+/// <c>+</c>/<c>-</c>) so every LHS shape works uniformly for every compound
+/// operator.
+/// </para>
+/// </summary>
+public class Issue2154CompoundOperatorOverrideTests
+{
+    [Fact]
+    public void EndToEnd_UserOperatorStarEquals_InstanceField_Runs()
+    {
+        const string source = """
+            package i2154ifieldmul
+            import System
+            class VecD {
+              var X int32
+              var Y int32
+            }
+            func (a VecD) operator *(s int32) VecD {
+              return VecD{X: a.X * s, Y: a.Y * s}
+            }
+            class HolderD { var V VecD }
+            func Main() {
+              var h = HolderD{}
+              h.V = VecD{X: 2, Y: 3}
+              h.V *= 3
+              Console.WriteLine(h.V.X)
+              Console.WriteLine(h.V.Y)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("6\n9\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_UserOperatorStarEquals_StaticField_Runs()
+    {
+        const string source = """
+            package i2154sfieldmul
+            import System
+            struct MoneyT {
+              var Cents int32
+            }
+            func (a MoneyT) operator *(s int32) MoneyT {
+              return MoneyT{Cents: a.Cents * s}
+            }
+            class BankT {
+              shared {
+                var Total MoneyT
+              }
+            }
+            func Main() {
+              BankT.Total = MoneyT{Cents: 3}
+              BankT.Total *= 4
+              Console.WriteLine(BankT.Total.Cents)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("12\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_UserOperatorStarEquals_ChainedMember_Runs()
+    {
+        const string source = """
+            package i2154chainmul
+            import System
+            struct VecE {
+              var X int32
+            }
+            func (a VecE) operator *(s int32) VecE {
+              return VecE{X: a.X * s}
+            }
+            class InnerE { var V VecE }
+            class OuterE { var In InnerE }
+            func Main() {
+              var o = OuterE{In: InnerE{V: VecE{X: 2}}}
+              o.In.V *= 5
+              Console.WriteLine(o.In.V.X)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("10\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_UserOperatorSlashEquals_InstanceField_Runs()
+    {
+        const string source = """
+            package i2154ifielddiv
+            import System
+            class VecF {
+              var X int32
+            }
+            func (a VecF) operator /(s int32) VecF {
+              return VecF{X: a.X / s}
+            }
+            class HolderF { var V VecF }
+            func Main() {
+              var h = HolderF{}
+              h.V = VecF{X: 20}
+              h.V /= 4
+              Console.WriteLine(h.V.X)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n", output);
+    }
+
+    /// <summary>
+    /// A real event on a member-access LHS must still bind as event
+    /// subscription for <c>+=</c>/<c>-=</c> (regression guard: generalizing the
+    /// parser/binder to accept any compound operator on a member-access LHS
+    /// must not break the pre-existing event path).
+    /// </summary>
+    [Fact]
+    public void EndToEnd_EventSubscription_MemberAccess_StillRuns()
+    {
+        const string source = """
+            package i2154eventregress
+            import System
+            class ClickerG {
+              event Clicked () -> void
+              func Raise() {
+                Clicked?.Invoke()
+              }
+            }
+            func Main() {
+              var c = ClickerG{}
+              c.Clicked += func() { Console.WriteLine(1) }
+              c.Raise()
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2154_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2154CompoundOperatorTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2154CompoundOperatorTranslationTests.cs
@@ -1,0 +1,89 @@
+// <copyright file="Issue2154CompoundOperatorTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2154: cs2gs already emitted a C# compound-assignment EXPRESSION
+/// (<c>lhs op= rhs</c>) verbatim as its G# translation target — including when
+/// the LHS is a member access into a type with a user-defined operator
+/// overload (<c>obj.Field *= 2</c>) — via the generic
+/// <c>AssignmentStatement(target, rhs, op)</c> path in
+/// <c>TranslateExpressionStatement</c>. That emission was correct G# syntax,
+/// but it failed to ROUND-TRIP PARSE in gsc, because gsc's parser only
+/// recognized <c>+=</c>/<c>-=</c> on a member-access LHS (any other compound
+/// operator on <c>obj.Field</c> reported <c>GS0005</c>). Now that gsc accepts
+/// any compound operator on a member-access LHS (issue #2154's gsc-side fix),
+/// cs2gs's existing pass-through translation for compound-assignment
+/// expressions on a member with a user-defined operator overload round-trips
+/// cleanly with no code changes needed on the cs2gs side — this is a
+/// regression test proving that end-to-end.
+/// </summary>
+public class Issue2154CompoundOperatorTranslationTests
+{
+    [Theory]
+    [InlineData("*=")]
+    [InlineData("/=")]
+    [InlineData("%=")]
+    public void MemberAccessCompoundAssignment_WithUserOperatorOverload_TranslatesAndRoundTrips(
+        string compoundToken)
+    {
+        string source = $@"
+using System;
+namespace Demo
+{{
+    public struct Vec
+    {{
+        public int X;
+
+        public static Vec operator *(Vec a, int s) => new Vec {{ X = a.X * s }};
+        public static Vec operator /(Vec a, int s) => new Vec {{ X = a.X / s }};
+        public static Vec operator %(Vec a, int s) => new Vec {{ X = a.X % s }};
+    }}
+
+    public class Holder
+    {{
+        public Vec V;
+    }}
+
+    public class C
+    {{
+        public void M()
+        {{
+            var h = new Holder();
+            h.V {compoundToken} 3;
+            Console.WriteLine(h.V.X);
+        }}
+    }}
+}}
+";
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+
+        Assert.Contains($"h.V {compoundToken} 3", printed);
+
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated compound-assignment member access must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+    }
+}


### PR DESCRIPTION
Fixes #2154.

`x op= y` (issue #1554) already fell back to a user-defined `operator` overload the same way `x = x op y` does, but that fallback was only reachable for a bare local variable and for `+=`/`-=` on a member access (the parser routed `lhs.member +=/-=` through `EventSubscriptionExpressionSyntax` to disambiguate event subscription from compound assignment). Any OTHER compound operator (`*=`, `/=`, `%=`, `^=`, `&=`, `|=`, `<<=`, `>>=`, `>>>=`) on a member-access LHS (`obj.Field *= 2`, `Type.StaticField *= 2`, `a.B.C *= 2`) failed to even parse (`GS0005`), even though the member's type declared a matching `operator *` overload and `obj.Field = obj.Field * 2` bound and ran fine.

### Changes

- `Parser.cs`: widen the member-access compound-assignment gate from `+=`/`-=` only to any compound operator, mirroring the already-general bare-identifier and indexer paths.
- `ExpressionBinder.Async.cs` / `ExpressionBinder.Assignments.cs`: thread the actual base operator `SyntaxKind` through the compound-assignment helpers, replacing a `bool isAdd` that only ever produced `+`/`-`, and skip event lookup entirely for non-`+`/`-` operators since events only ever support `+=`/`-=` subscription semantics.
- Added `Compiler.Tests` coverage for `*=` and `/=` on instance field, static field, and chained member with user operator overloads, plus an event-subscription regression guard.
- Added a `Cs2Gs.Tests` regression test proving cs2gs's existing pass-through translation of member-access compound assignment now round-trips cleanly against the fixed gsc parser (no cs2gs code changes were needed there - cs2gs already emitted the compound operator verbatim; it was only blocked by the gsc parser gap).

### Testing

- dotnet test test/Core.Tests/Core.Tests.csproj - 5637 passed, 1 skipped.
- dotnet test test/Compiler.Tests/Compiler.Tests.csproj - 2740 passed (full run before adding new tests), plus the 5 new tests pass individually.
- dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj - 1101 passed, plus the 3 new tests pass individually.
