### PR TITLE
Fix #2160: parenthesize nullable function types in SymbolDisplay

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
+++ b/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
@@ -653,7 +653,19 @@ public static class SymbolDisplay
         switch (type)
         {
             case NullableTypeSymbol nullable:
-                return $"{FormatType(nullable.UnderlyingType)}?";
+                // Issue #2160: a nullable function type must wrap the whole
+                // arrow shape in parentheses so the `?` applies to the function
+                // type and not just its return type (`((int32) -> void)?`,
+                // never `(int32) -> void?`). Because FormatType recurses,
+                // parenthesizing here also fixes nested occurrences (slice
+                // element, generic arg, tuple element). Non-function nullable
+                // types are rendered unchanged.
+                var underlying = FormatType(nullable.UnderlyingType);
+                return nullable.UnderlyingType is FunctionTypeSymbol
+                    ? $"({underlying})?"
+                    : $"{underlying}?";
+            case FunctionTypeSymbol function:
+                return FormatFunctionType(function);
             case SliceTypeSymbol slice:
                 return $"[]{FormatType(slice.ElementType)}";
             case AsyncSequenceTypeSymbol asyncSequence:
@@ -669,6 +681,44 @@ public static class SymbolDisplay
             default:
                 return type.Name;
         }
+    }
+
+    /// <summary>
+    /// Renders a <see cref="FunctionTypeSymbol"/> in its canonical arrow shape
+    /// <c>(P1, P2, ...) -> R</c> (ADR-0075 / issue #715), recursing through
+    /// <see cref="FormatType"/> so nested imported/wrapper element types render
+    /// consistently. A trailing variadic parameter is rendered with the
+    /// <c>...</c> prefix and its element type (ADR-0102 follow-up / issue #818),
+    /// and a void return renders as <c>void</c>.
+    /// </summary>
+    private static string FormatFunctionType(FunctionTypeSymbol function)
+    {
+        var hasVariadicFlags = !function.IsVariadic.IsDefaultOrEmpty;
+        var sb = new System.Text.StringBuilder();
+        sb.Append('(');
+        for (var i = 0; i < function.ParameterTypes.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(", ");
+            }
+
+            if (hasVariadicFlags && function.IsVariadic[i])
+            {
+                sb.Append("...");
+                sb.Append(function.ParameterTypes[i] is SliceTypeSymbol slice
+                    ? FormatType(slice.ElementType)
+                    : FormatType(function.ParameterTypes[i]));
+            }
+            else
+            {
+                sb.Append(FormatType(function.ParameterTypes[i]));
+            }
+        }
+
+        sb.Append(") -> ");
+        sb.Append(FormatType(function.ReturnType));
+        return sb.ToString();
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/NullableTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullableTypeSymbol.cs
@@ -68,6 +68,9 @@ public sealed class NullableTypeSymbol : TypeSymbol
     /// Issue #1212: a nullable array/slice must render with the <c>?</c> bound to
     /// the array itself (<c>[]?T</c> / <c>[N]?T</c>) so its display name is distinct
     /// from an array of nullable elements (<c>[]T?</c> = <c>Slice(Nullable(T))</c>).
+    /// Issue #2160: a nullable function type must wrap the whole arrow shape in
+    /// parentheses (<c>((int32) -> void)?</c>) so the <c>?</c> applies to the
+    /// function type and not just its return type (never <c>(int32) -> void?</c>).
     /// For all other underlying types the nullable marker trails the name (<c>T?</c>).
     /// </summary>
     /// <param name="underlyingType">The non-nullable underlying type.</param>
@@ -78,6 +81,7 @@ public sealed class NullableTypeSymbol : TypeSymbol
         {
             SliceTypeSymbol slice => $"[]?{slice.ElementType.Name}",
             ArrayTypeSymbol array => $"[{array.Length}]?{array.ElementType.Name}",
+            FunctionTypeSymbol function => $"({function.Name})?",
             _ => underlyingType.Name + "?",
         };
     }

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue2160NullableFunctionTypeDisplayTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue2160NullableFunctionTypeDisplayTests.cs
@@ -1,0 +1,70 @@
+// <copyright file="Issue2160NullableFunctionTypeDisplayTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Symbols.Display;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #2160: a nullable function type must render with the <c>?</c> wrapping
+/// the whole arrow shape (<c>((int32) -> void)?</c>), not bound to the return
+/// type (<c>(int32) -> void?</c>). Covers both the hover formatter
+/// (<see cref="SymbolDisplay"/>) and the raw <see cref="TypeSymbol.Name"/> used
+/// by diagnostics (e.g. GS0155).
+/// </summary>
+public class Issue2160NullableFunctionTypeDisplayTests
+{
+    private static FunctionTypeSymbol Func(TypeSymbol returnType, params TypeSymbol[] parameterTypes)
+        => FunctionTypeSymbol.Get(ImmutableArray.Create(parameterTypes), returnType);
+
+    private static string Render(TypeSymbol type)
+    {
+        var local = new LocalVariableSymbol("v", isReadOnly: true, type);
+        return SymbolDisplay.ToDisplayString(local, SymbolDisplayFormat.Hover);
+    }
+
+    [Fact]
+    public void NullableVoidReturningFunction_ParenthesizesWholeFunctionType()
+    {
+        var type = NullableTypeSymbol.Get(Func(TypeSymbol.Void, TypeSymbol.Int32));
+
+        Assert.Equal("(local variable) v ((int32) -> void)?", Render(type));
+        Assert.Equal("((int32) -> void)?", type.Name);
+    }
+
+    [Fact]
+    public void NullableStringReturningFunction_ParenthesizesWholeFunctionType()
+    {
+        var type = NullableTypeSymbol.Get(Func(TypeSymbol.String, TypeSymbol.Int32));
+
+        Assert.Equal("(local variable) v ((int32) -> string)?", Render(type));
+        Assert.Equal("((int32) -> string)?", type.Name);
+    }
+
+    [Fact]
+    public void NonNullableFunction_RendersWithoutExtraParentheses()
+    {
+        var type = Func(TypeSymbol.Void, TypeSymbol.Int32);
+
+        Assert.Equal("(local variable) v (int32) -> void", Render(type));
+    }
+
+    [Fact]
+    public void PlainNullablePrimitive_IsUnchanged()
+    {
+        Assert.Equal("(local variable) v string?", Render(NullableTypeSymbol.Get(TypeSymbol.String)));
+        Assert.Equal("(local variable) v int32?", Render(NullableTypeSymbol.Get(TypeSymbol.Int32)));
+    }
+
+    [Fact]
+    public void SliceOfNullableFunction_ParenthesizesNestedFunctionType()
+    {
+        var type = SliceTypeSymbol.Get(NullableTypeSymbol.Get(Func(TypeSymbol.Void, TypeSymbol.Int32)));
+
+        Assert.Equal("(local variable) v []((int32) -> void)?", Render(type));
+    }
+}


### PR DESCRIPTION
## Summary

gsc rendered a nullable function type `((...) -> R)?` incorrectly as `(...) -> R?`, binding the `?` to the return type instead of the whole function type. For void delegates this printed the nonsensical `... -> void?`. This is a display-only bug; the underlying type was always correct.

### Before / after (GS0155)

`func f(h ((int32) -> void)?)` assigned to `int32`:
- Before: `Cannot convert type '(int32) -> void?' to 'int32'.`
- After: `Cannot convert type '((int32) -> void)?' to 'int32'.`

`func f(h ((int32) -> string)?)`:
- Before: `Cannot convert type '(int32) -> string?' to 'int32'.`
- After: `Cannot convert type '((int32) -> string)?' to 'int32'.`

## Changes

- `SymbolDisplay.FormatType`: added a `FunctionTypeSymbol` case that renders the canonical arrow shape `(P1, P2, ...) -> R` by recursing through `FormatType` (so nested imported/wrapper element types render consistently), including trailing-variadic `...` handling. In the `NullableTypeSymbol` case, a function underlying type is now wrapped in parentheses before appending `?`. Because `FormatType` recurses, nested cases (slice/tuple/generic-arg) are handled automatically. Non-function nullable types are unchanged.
- `NullableTypeSymbol.ComputeDisplayName`: added a `FunctionTypeSymbol` case producing `((...) -> R)?`, analogous to the existing slice/array `?`-binding special cases. This is the path used by diagnostics (`TypeSymbol.Name`). Display-only; type interning/equality is by reference, unaffected.
- Added `Issue2160NullableFunctionTypeDisplayTests` covering nullable void/string-returning functions, non-nullable functions (no extra parens), plain nullable primitives (no over-parenthesizing), and a nested slice-of-nullable-function case.

## Tests

Filtered display/hover tests: 16 passed. Full `Core.Tests` suite: 5647 passed, 1 skipped, 0 failed. No golden/snapshot updates were needed.

Fixes #2160.
Refs #914.