### PR TITLE
Fix #2164: emit non-null assertion on lazy-singleton field returns

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2164LazySingletonNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2164LazySingletonNullForgivenessTranslationTests.cs
@@ -1,0 +1,228 @@
+// <copyright file="Issue2164LazySingletonNullForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #2164: the classic lazy-singleton pattern
+/// initializes a nullable static/instance field (or auto-property) under a null
+/// guard (<c>if (F == null) { F = new(); } ... return F;</c> / <c>F ??= …;</c>),
+/// so <c>F</c> is provably non-null at every use dominated by the guard. gsc (by
+/// design, Kotlin-style smart casts) narrows only LOCALS, never fields/properties,
+/// so the guarded read <c>T? -&gt; T</c> is rejected (GS0155). The migrated corpus
+/// is nullable-<em>oblivious</em>, so Roslyn's flow state is empty; cs2gs detects
+/// the guard from SYNTAX and emits the established <c>F!!</c> non-null assertion
+/// on the guarded use instead.
+/// </summary>
+public class Issue2164LazySingletonNullForgivenessTranslationTests
+{
+    [Fact]
+    public void LazySingleton_StaticField_EqualsNullGuard_AssertsNonNullReturn()
+    {
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Service
+    {
+        private static Service instance;
+
+        public static Service Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = new Service();
+                }
+
+                return instance;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("private var instance Service?", printed);
+        Assert.Contains("return Service.instance!!", printed);
+    }
+
+    [Fact]
+    public void LazySingleton_StaticField_IsNullGuard_AssertsNonNullReturn()
+    {
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Service
+    {
+        private static Service instance;
+
+        public static Service Instance
+        {
+            get
+            {
+                if (instance is null)
+                {
+                    instance = new Service();
+                }
+
+                return instance;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("return Service.instance!!", printed);
+    }
+
+    [Fact]
+    public void LazySingleton_CoalesceAssign_AssertsNonNullReturn()
+    {
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Service
+    {
+        private static Service instance;
+
+        public static Service Instance
+        {
+            get
+            {
+                instance ??= new Service();
+                return instance;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("!!", printed);
+        Assert.Contains("return Service.instance!!", printed);
+    }
+
+    [Fact]
+    public void LazySingleton_LockWrappedGuard_AssertsNonNullReturn()
+    {
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Singleton<T> where T : class, new()
+    {
+        private static readonly object Lockable = new object();
+        private static T instance;
+
+        public static T Instance
+        {
+            get
+            {
+                lock (Lockable)
+                {
+                    if (instance is null)
+                    {
+                        instance = new T();
+                    }
+
+                    return instance;
+                }
+            }
+        }
+    }
+}");
+
+        Assert.Contains("private var instance T?", printed);
+        Assert.Contains("return Singleton[T].instance!!", printed);
+    }
+
+    [Fact]
+    public void LazySingleton_GuardedMemberAccess_AssertsNonNullReceiver()
+    {
+        // A use of `instance` dominated by the guard that is NOT a trailing
+        // `return` (here `instance.ToString()`) is asserted too.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Service
+    {
+        private static Service instance;
+
+        public static string Name
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = new Service();
+                }
+
+                return instance.ToString();
+            }
+        }
+    }
+}");
+
+        Assert.Contains("Service.instance!!.ToString()", printed);
+    }
+
+    [Fact]
+    public void NonNullableField_NoGuard_IsNotAsserted()
+    {
+        // A field that is never null-checked / null-assigned is not nullable in
+        // G#, so no `!!` must be emitted on its return.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Service
+    {
+        private static readonly Service instance = new Service();
+
+        public static Service Instance
+        {
+            get
+            {
+                return instance;
+            }
+        }
+    }
+}");
+
+        Assert.DoesNotContain("!!", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -12647,6 +12647,20 @@ public sealed class CSharpToGSharpTranslator
                 return false;
             }
 
+            // Issue #2164: the classic lazy-singleton pattern initializes a
+            // nullable static/instance field (or auto-property) under a null
+            // guard (`if (F == null) { F = new(); } ... return F;` / `F ??= …;`),
+            // so `F` is provably non-null at every use dominated by the guard.
+            // gsc (by design, Kotlin-style) smart-casts only LOCALS, never
+            // fields/properties, so the guarded read `T? -> T` is rejected
+            // (GS0155). The migrated corpus is nullable-OBLIVIOUS, so Roslyn's
+            // flow state is empty and the flow-based path below never fires;
+            // detect the guard from SYNTAX and assert `F!!` instead.
+            if (this.IsLazyInitGuardedFieldUse(recv))
+            {
+                return true;
+            }
+
             // Flow analysis must have proven the receiver non-null at this site.
             if (this.context.GetTypeInfo(recv).Nullability.FlowState != NullableFlowState.NotNull)
             {
@@ -12690,6 +12704,182 @@ public sealed class CSharpToGSharpTranslator
             // too, so its flow-proven uses need the same assertion for consistency.
             return declared.NullableAnnotation == NullableAnnotation.Annotated
                 || this.IsPromotedToNullableReference(symbol);
+        }
+
+        // Issue #2164: true when <paramref name="recv"/> reads a nullable
+        // (`T?`) field/property that is lazily initialized under a dominating
+        // null guard, so it is provably non-null here and needs an explicit
+        // `!!` (gsc never smart-casts fields/properties). The decision is purely
+        // syntactic because the migrated corpus compiles nullable-oblivious.
+        private bool IsLazyInitGuardedFieldUse(ExpressionSyntax recv)
+        {
+            // Only a bare/qualified field or property read is a candidate. A read
+            // that is itself the LHS of an assignment, the operand of a null
+            // comparison, or a `nameof` argument is handled by other paths and is
+            // never a value read that a lazy guard makes non-null.
+            ISymbol symbol = this.context.GetSymbolInfo(recv).Symbol;
+            if (symbol is not (IFieldSymbol or IPropertySymbol))
+            {
+                return false;
+            }
+
+            // The field/property must be emitted `T?` in G# — either declared
+            // nullable or promoted to nullable by this translator (the taint
+            // analysis / #1072 null-usage rules). Otherwise there is no `T? -> T`
+            // to forgive and asserting `!!` on a non-null value is wrong.
+            ITypeSymbol declared = symbol switch
+            {
+                IFieldSymbol field => field.Type,
+                IPropertySymbol property => property.Type,
+                _ => null,
+            };
+
+            if (declared is not { IsReferenceType: true })
+            {
+                return false;
+            }
+
+            bool emittedNullable = declared.NullableAnnotation == NullableAnnotation.Annotated
+                || this.IsPromotedToNullableReference(symbol);
+            if (!emittedNullable)
+            {
+                return false;
+            }
+
+            return this.IsDominatedByLazyInitGuard(recv, symbol);
+        }
+
+        // Walks outward from the statement containing <paramref name="use"/> to
+        // the enclosing accessor/method boundary, looking for a preceding
+        // statement (in the same block or an enclosing one, e.g. a `lock` body)
+        // that lazily initializes <paramref name="symbol"/> to a non-null value.
+        // Because a lazy-init guard leaves `symbol` non-null on BOTH the taken
+        // and skipped paths, every later use it dominates is non-null.
+        private bool IsDominatedByLazyInitGuard(ExpressionSyntax use, ISymbol symbol)
+        {
+            StatementSyntax useStatement = use.FirstAncestorOrSelf<StatementSyntax>();
+            if (useStatement == null)
+            {
+                return false;
+            }
+
+            for (SyntaxNode node = useStatement; node != null; node = node.Parent)
+            {
+                if (node.Parent is BlockSyntax block)
+                {
+                    foreach (StatementSyntax statement in block.Statements)
+                    {
+                        if (statement == node)
+                        {
+                            break;
+                        }
+
+                        if (this.IsLazyInitGuardStatement(statement, symbol))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                // Stop at the enclosing accessor / method / local-function body:
+                // dominance across a member boundary is not analyzed here.
+                if (node is AccessorDeclarationSyntax
+                    or BaseMethodDeclarationSyntax
+                    or LocalFunctionStatementSyntax
+                    or AnonymousFunctionExpressionSyntax
+                    or ArrowExpressionClauseSyntax)
+                {
+                    break;
+                }
+            }
+
+            return false;
+        }
+
+        // True when <paramref name="statement"/> is one of the lazy-init guard
+        // shapes that leaves <paramref name="symbol"/> non-null afterwards:
+        //   • `if (F == null) { F = expr; }` / `if (F is null) { F = expr; }`
+        //   • `F ??= expr;`
+        // (`expr` must not itself be a `null` literal). Lock-wrapped variants are
+        // covered because the enclosing walk descends into the `lock` body block.
+        private bool IsLazyInitGuardStatement(StatementSyntax statement, ISymbol symbol)
+        {
+            switch (statement)
+            {
+                case IfStatementSyntax ifStatement
+                    when this.IsNullCheckOf(ifStatement.Condition, symbol):
+                    return this.AssignsSymbolNonNull(ifStatement.Statement, symbol);
+
+                case ExpressionStatementSyntax { Expression: AssignmentExpressionSyntax coalesce }
+                    when coalesce.IsKind(SyntaxKind.CoalesceAssignmentExpression)
+                    && this.BindsTo(coalesce.Left, symbol)
+                    && !IsNullOrSuppressedNull(coalesce.Right):
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        // `F == null` / `null == F` / `F is null` (the null-path condition of a
+        // lazy-init guard), where `F` binds to <paramref name="symbol"/>.
+        private bool IsNullCheckOf(ExpressionSyntax condition, ISymbol symbol)
+        {
+            condition = StripParentheses(condition);
+
+            switch (condition)
+            {
+                case BinaryExpressionSyntax binary
+                    when binary.IsKind(SyntaxKind.EqualsExpression):
+                    return (IsNullLiteral(binary.Right) && this.BindsTo(binary.Left, symbol))
+                        || (IsNullLiteral(binary.Left) && this.BindsTo(binary.Right, symbol));
+
+                case IsPatternExpressionSyntax isPattern
+                    when this.BindsTo(isPattern.Expression, symbol):
+                    return IsNullConstantPattern(isPattern.Pattern)
+                        && isPattern.Pattern is not UnaryPatternSyntax;
+
+                default:
+                    return false;
+            }
+        }
+
+        // True when <paramref name="body"/> (a lazy-init guard's then-branch)
+        // contains an assignment of a non-null value to <paramref name="symbol"/>.
+        private bool AssignsSymbolNonNull(StatementSyntax body, ISymbol symbol)
+        {
+            if (body == null)
+            {
+                return false;
+            }
+
+            foreach (AssignmentExpressionSyntax assignment in
+                body.DescendantNodesAndSelf().OfType<AssignmentExpressionSyntax>())
+            {
+                if (!assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                    && !assignment.IsKind(SyntaxKind.CoalesceAssignmentExpression))
+                {
+                    continue;
+                }
+
+                if (this.BindsTo(assignment.Left, symbol)
+                    && !IsNullOrSuppressedNull(assignment.Right))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static ExpressionSyntax StripParentheses(ExpressionSyntax expression)
+        {
+            while (expression is ParenthesizedExpressionSyntax paren)
+            {
+                expression = paren.Expression;
+            }
+
+            return expression;
         }
 
         private GExpression TranslateInvocation(InvocationExpressionSyntax invocation)


### PR DESCRIPTION
## Root cause
The classic lazy-singleton pattern initializes a nullable static/instance field (or auto-property backing) under a null guard:

```csharp
if (instance == null) { instance = new(); }
return instance;          // or: instance ??= new(); return instance;
```

The taint analysis correctly types the backing field as `T?` (null until first access). gsc, by deliberate language design (Kotlin-style smart casts), narrows only **locals**, never fields/properties — so cs2gs's guarded read `T? -> T` was rejected with **GS0155**. The migrated corpus compiles nullable-oblivious, so Roslyn's flow state is empty and the existing flow-based `!!` pass never fired.

## Approach
Since gsc will not narrow fields, cs2gs now emits the established `!!` non-null assertion on the provably-non-null field/property use. The lazy-init guard is detected purely from **syntax** (not Roslyn flow state):

- `if (F == null) { F = expr; }` / `if (F is null) { F = expr; }` whose then-branch assigns `F` a non-null value
- `F ??= expr;`
- lock-wrapped variants (the walk descends into the `lock` body block)

`!!` is asserted at **every** use of `F` dominated by such a guard within the same accessor/method body — the trailing `return F`, a `F.Member` receiver, or a non-null sink — not just a literal `return F`. It only fires when `F` is emitted `T?` (declared nullable or promoted), so cases that already compile are untouched. Wired into the shared `ReceiverNeedsNullForgiveness` predicate, so both the receiver and value-position (`return`/conditional-arm/argument) paths pick it up.

## Before / after (GS0155 count, Oahu corpus)
| App | Before | After |
| --- | --- | --- |
| Oahu.SystemManagement | 17 | 14 |
| Oahu.Data | 17 | 14 |

The 3 singletons — `LogTmpFileMaintenance.Instance`, `Singleton<T>.Instance`, `TreeDecomposition<T>.Default` — clear in both apps; all other error counts are unchanged (no regressions).

## Tests
- New `Issue2164LazySingletonNullForgivenessTranslationTests` (6 cases: `==null`/`is null`/`??=`/lock-wrapped guards, guarded member-access receiver, and a non-guarded non-nullable field that must stay bare).
- All 1117 cs2gs tests pass.

Fixes #2164
Refs #914