### PR TITLE
Fix #2165: is-interface smart-cast narrowing for type-parameter/interface operands

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -808,14 +808,11 @@ internal sealed partial class ExpressionBinder
                         return (null, null);
                     }
 
-                    // Issue #1636: mirror StatementBinder.IsStrictlyNarrower —
-                    // only install the narrowing when the candidate is
-                    // actually a subtype of the declared type (candidate
-                    // implicitly converts to declared). A supertype/interface/
-                    // unrelated candidate is a widening or unrelated test and
-                    // must not replace the declared type.
-                    var conversion = Conversion.Classify(targetType, declaredType);
-                    if (!conversion.Exists || !conversion.IsImplicit)
+                    // Issue #1636 / #2165: reuse the shared classifier so the
+                    // short-circuit (`x is T && …`) narrowing agrees with the
+                    // `if`-statement narrowing — including the type-parameter/
+                    // interface operand tested against an interface (#2165).
+                    if (!SmartCastStability.IsTypeTestNarrowing(declaredType, targetType))
                     {
                         return (null, null);
                     }

--- a/src/Core/CodeAnalysis/Binding/SmartCastStability.cs
+++ b/src/Core/CodeAnalysis/Binding/SmartCastStability.cs
@@ -236,9 +236,79 @@ internal static class SmartCastStability
         return true;
     }
 
+    /// <summary>
+    /// Decides whether an <c>is</c>-type-test of an operand whose static type is
+    /// <paramref name="declared"/> against <paramref name="candidate"/> should
+    /// smart-cast (narrow) the operand to <paramref name="candidate"/> in the
+    /// then-branch. Shared by the statement (<c>if x is T</c>) and short-circuit
+    /// (<c>x is T &amp;&amp; …</c>) narrowing classifiers so both agree.
+    /// <para>
+    /// <paramref name="candidate"/> must already have any nullable wrapper
+    /// stripped by the caller.
+    /// </para>
+    /// </summary>
+    /// <param name="declared">The operand's declared (static) type.</param>
+    /// <param name="candidate">The tested type (nullable wrapper stripped).</param>
+    /// <returns><see langword="true"/> when the test narrows the operand to <paramref name="candidate"/>.</returns>
+    public static bool IsTypeTestNarrowing(TypeSymbol declared, TypeSymbol candidate)
+    {
+        if (candidate == null || candidate == TypeSymbol.Error)
+        {
+            return false;
+        }
+
+        if (declared == candidate)
+        {
+            return false;
+        }
+
+        // Stripping the nullable wrapper alone counts as narrowing
+        // (`string? → string`).
+        if (declared is NullableTypeSymbol declaredNullable && declaredNullable.UnderlyingType == candidate)
+        {
+            return true;
+        }
+
+        // Issue #1636: a candidate distinct from the declared type is a genuine
+        // subtype narrowing when it implicitly converts to the declared type
+        // (candidate → declared): every candidate value is already usable as
+        // declared. `Conversion.Classify` encodes the full class/interface/
+        // base-type lattice (class → base class, class → implemented interface,
+        // interface → base interface, struct → interface, etc.).
+        var toDeclared = Conversion.Classify(candidate, declared);
+        if (toDeclared.Exists && toDeclared.IsImplicit)
+        {
+            return true;
+        }
+
+        // Issue #2165: when the operand's static type is a TYPE PARAMETER or an
+        // INTERFACE, the runtime value may implement additional, statically-
+        // unrelated interfaces. Testing such an operand against an interface is
+        // therefore meaningful, so narrow to the tested interface even though it
+        // does not implicitly convert back to the declared type — matching the
+        // Kotlin-parity behaviour already applied to `object`/concrete-class
+        // operands. Excluded: a widening to a base interface the declared type
+        // already satisfies (declared → candidate), which would only hide the
+        // declared type's own members without adding any.
+        if (IsInterfaceType(candidate)
+            && (declared is TypeParameterSymbol || IsInterfaceType(declared)))
+        {
+            var toCandidate = Conversion.Classify(declared, candidate);
+            if (!(toCandidate.Exists && toCandidate.IsImplicit))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static bool IsAcceptableBareVariable(VariableSymbol variable, bool restrictToLocalsAndParams)
     {
         // ParameterSymbol derives from LocalVariableSymbol and is covered here.
         return !restrictToLocalsAndParams || variable is LocalVariableSymbol;
     }
+
+    private static bool IsInterfaceType(TypeSymbol type)
+        => type is InterfaceSymbol || (type?.ClrType is System.Type clr && clr.IsInterface);
 }

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -2376,40 +2376,11 @@ internal sealed class StatementBinder
 
     private static bool IsStrictlyNarrower(TypeSymbol declared, TypeSymbol candidate)
     {
-        if (candidate == null || candidate == TypeSymbol.Error)
-        {
-            return false;
-        }
-
-        if (declared == candidate)
-        {
-            return false;
-        }
-
-        // Stripping the nullable wrapper alone counts as narrowing
-        // (`string? → string`).
-        if (declared is NullableTypeSymbol declaredNullable && declaredNullable.UnderlyingType == candidate)
-        {
-            return true;
-        }
-
-        // Issue #1636: a candidate distinct from the declared type is only a
-        // genuine narrowing if it is actually a subtype of the declared type
-        // (candidate implicitly converts to declared — every candidate value
-        // is already usable as declared). `Conversion.Classify` already
-        // encodes the full class/interface/base-type lattice (class → base
-        // class, class → implemented interface, interface → base interface,
-        // struct → interface, etc.), so reuse it instead of re-deriving the
-        // subtype relation here.
-        //
-        // A supertype/interface/unrelated candidate (e.g. `Circle is
-        // IDrawable`, `string is object`) does NOT implicitly convert back to
-        // the (narrower) declared type — that's a widening or unrelated test,
-        // and replacing the declared type with it would hide members the
-        // declared type actually has (C# keeps the declared type in that
-        // case).
-        var conversion = Conversion.Classify(candidate, declared);
-        return conversion.Exists && conversion.IsImplicit;
+        // Shared with the short-circuit (`x is T && …`) classifier in
+        // ExpressionBinder so `if`-statement and `&&` narrowing agree. Handles
+        // the subtype lattice (issue #1636) and the type-parameter/interface
+        // operand tested against an interface (issue #2165).
+        return SmartCastStability.IsTypeTestNarrowing(declared, candidate);
     }
 
     private (Dictionary<AccessPath, TypeSymbol> NonNil, Dictionary<AccessPath, TypeSymbol> Nil) TryClassifyNilGuard(BoundExpression condition)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1730,6 +1730,19 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #2165: an UNCONSTRAINED type-parameter operand (e.g. `x T`
+        // narrowed to a tested interface `IInit`) sits on the stack as a bare
+        // `!!T` slot, not an ObjRef — `castclass`/`unbox.any` both require an
+        // ObjRef and would fail ilverify (`StackObjRef`). Box the type parameter
+        // first (a no-op for reference-constrained T, matching the operand
+        // boxing already applied by `EmitIsExpression`) so the following
+        // reference/value cast operates on a boxed reference.
+        if (declared is TypeParameterSymbol)
+        {
+            this.il.OpCode(ILOpCode.Box);
+            this.il.Token(this.outer.GetElementTypeToken(declared));
+        }
+
         if (ReflectionMetadataEmitter.IsValueTypeSymbol(narrowed)
             || (narrowed.ClrType != null && narrowed.ClrType.IsValueType))
         {

--- a/test/Compiler.Tests/Emit/Issue2165IsInterfaceNarrowingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2165IsInterfaceNarrowingEmitTests.cs
@@ -1,0 +1,159 @@
+// <copyright file="Issue2165IsInterfaceNarrowingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2165: end-to-end CLR emit + ilverify coverage proving that an
+/// <c>is</c>-interface smart cast on a TYPE PARAMETER or INTERFACE operand
+/// narrows the operand so the tested interface's member is actually invoked at
+/// runtime (not just resolved at bind time).
+/// </summary>
+public class Issue2165IsInterfaceNarrowingEmitTests
+{
+    [Fact]
+    public void EndToEnd_IsInterface_OnInterfaceOperand_InvokesInterfaceMember()
+    {
+        var source = """
+            package p
+            interface IInit {
+                func Init() int32;
+            }
+            interface IShape {
+                func Area() int32;
+            }
+            class Circle : IShape, IInit {
+                func Area() int32 { return 2 }
+                func Init() int32 { return 41 }
+            }
+            func Probe(x IShape) int32 {
+                if x is IInit {
+                    return x.Init()
+                }
+                return -1
+            }
+            func Main() {
+                System.Console.WriteLine(Probe(Circle()))
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("41\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_IsInterface_OnTypeParameterOperand_InvokesInterfaceMember()
+    {
+        var source = """
+            package p
+            interface IInit {
+                func Init() int32;
+            }
+            class Circle : IInit {
+                func Init() int32 { return 7 }
+            }
+            func Probe[T](x T) int32 {
+                if x is IInit {
+                    return x.Init()
+                }
+                return -1
+            }
+            func Main() {
+                System.Console.WriteLine(Probe[Circle](Circle()))
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2165_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            RunCompiler(args);
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void RunCompiler(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2165IsInterfaceNarrowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2165IsInterfaceNarrowingTests.cs
@@ -1,0 +1,172 @@
+// <copyright file="Issue2165IsInterfaceNarrowingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2165 — <c>is</c>-pattern smart-cast narrowing to an INTERFACE must
+/// also take effect when the operand's static type is a TYPE PARAMETER
+/// (<c>T</c>) or ANOTHER INTERFACE, not only when it is <c>object</c> or a
+/// concrete class. A value of interface/type-parameter type may dynamically
+/// implement additional, statically-unrelated interfaces, so <c>if x is IInit</c>
+/// narrows <c>x</c> to <c>IInit</c> (Kotlin-parity) and <c>x.Init()</c> resolves.
+/// </summary>
+public class Issue2165IsInterfaceNarrowingTests
+{
+    [Fact]
+    public void If_IsInterface_OnInterfaceOperand_NarrowsToTestedInterface()
+    {
+        // Declared type is another (unrelated) interface. Narrowing to the
+        // tested interface must make its member resolvable.
+        var result = Evaluate(@"
+interface IInit {
+    func Init() void;
+}
+interface IShape {
+    func Area() int32;
+}
+func Run(x IShape) void {
+    if x is IInit {
+        x.Init()
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_IsInterface_OnTypeParameterOperand_NarrowsToTestedInterface()
+    {
+        // Declared type is an unconstrained type parameter.
+        var result = Evaluate(@"
+interface IInit {
+    func Init() void;
+}
+func Run[T](x T) void {
+    if x is IInit {
+        x.Init()
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void And_IsInterface_OnInterfaceOperand_NarrowsRightOperand()
+    {
+        // The short-circuit (`x is I && …`) classifier must agree with the
+        // `if`-statement classifier for interface operands.
+        var result = Evaluate(@"
+interface IInit {
+    func Init() int32;
+}
+interface IShape {
+    func Area() int32;
+}
+func Run(x IShape) bool {
+    return x is IInit && x.Init() > 0
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_IsInterface_OnObjectOperand_StillNarrows()
+    {
+        // Control (A): the pre-existing `object` operand case must keep working.
+        var result = Evaluate(@"
+interface IInit {
+    func Init() void;
+}
+func Run(x object) void {
+    if x is IInit {
+        x.Init()
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_IsConcreteClass_OnObjectOperand_StillNarrows()
+    {
+        // Control (B): the pre-existing concrete-class operand case must keep
+        // working.
+        var result = Evaluate(@"
+class Circle {
+    func Blah() void {}
+}
+func Run(x object) void {
+    if x is Circle {
+        x.Blah()
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_IsBaseInterface_OnInterfaceOperand_KeepsDeclaredMembers()
+    {
+        // A widening to a base interface the declared type already satisfies
+        // must NOT narrow — the declared interface's own members must remain
+        // resolvable (no regression, no member hiding).
+        var result = Evaluate(@"
+interface IBase {
+    func Base() void;
+}
+interface IShape : IBase {
+    func Area() int32;
+}
+func Run(x IShape) int32 {
+    if x is IBase {
+        return x.Area()
+    }
+    return 0
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void InterfaceOperand_TestedMemberUnavailableBeforeTest()
+    {
+        // Before the narrowing test, `x` is still `IShape` — `Init()` (an
+        // IInit-only member) must NOT resolve.
+        var result = Evaluate(@"
+interface IInit {
+    func Init() void;
+}
+interface IShape {
+    func Area() int32;
+}
+func Run(x IShape) void {
+    x.Init()
+}
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Init"));
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Root cause
`is`-pattern smart-cast narrowing to an interface only replaced the operand's declared type when the tested interface implicitly converted **back** to the declared type (a genuine subtype). That gate held for `object` and concrete-class operands, but silently dropped the narrowing when the operand's static type was a **type parameter** (`T`) or **another interface**, because a statically-unrelated interface never implicitly converts back to those declared types. So `x.Init()` after `if x is IInit` failed with `GS0159: Cannot find function Init`.

The gate lived in two parallel classifiers: `StatementBinder.IsStrictlyNarrower` (for `if x is T`) and `ExpressionBinder.ClassifyTypeTestNarrowing` (for `x is T && …`).

## Fix
- Extract the shared classification into `SmartCastStability.IsTypeTestNarrowing` (used by both call sites so they stay in sync).
- Add a Kotlin-parity rule: when the operand's static type is a **type parameter or interface**, testing against an **interface** narrows to the tested interface even without an implicit conversion back to the declared type — mirroring the existing `object`/concrete-class behaviour. A value of interface/type-parameter type may dynamically implement additional, statically-unrelated interfaces, so the test is meaningful.
- Exclude a widening to a **base interface the declared type already satisfies** (`declared -> candidate` implicit), so the declared type's own members are never hidden — no regression.
- Emit: `EmitNarrowingCastIfNeeded` now **boxes** a type-parameter operand before the reference/value cast, so the narrowed interface call is verifiable (fixes a `StackObjRef` ilverify error for the `T` case).

## Tests
- `Issue2165IsInterfaceNarrowingTests` (Core): interface operand, type-parameter operand, `&&` short-circuit form, `object`/concrete-class controls, base-interface widening (no member hiding), and pre-test member unavailability.
- `Issue2165IsInterfaceNarrowingEmitTests` (Compiler): end-to-end + ilverify proving the interface member is actually invoked at runtime for both interface and type-parameter operands.
- Full Core suite passes (5664). Related narrowing/smart-cast/pattern emit tests pass (87 + 2 new). The original A/B/C/D repro now compiles cleanly.

Fixes #2165
Refs #914