### PR TITLE
Fix #2167: transitive/interprocedural nullability promotion for oblivious sinks

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2167TransitiveNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2167TransitiveNullabilityTranslationTests.cs
@@ -1,0 +1,198 @@
+// <copyright file="Issue2167TransitiveNullabilityTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #2167: in a nullable-<em>oblivious</em>
+/// compilation the whole-program taint analysis
+/// (<see cref="ObliviousNullabilityAnalyzer"/>) must be TRANSITIVE /
+/// INTERPROCEDURAL, so a <c>T?</c> value that flows into a sink cs2gs would
+/// otherwise type as non-null <c>T</c> promotes that sink to <c>T?</c>. This
+/// covers two canonical flows from Oahu.SystemManagement:
+/// <list type="number">
+/// <item><description><b>Local-type widening</b> — a <c>var</c> local whose
+/// initializer is non-null but which is later assigned a nullable value takes
+/// the JOIN over all assignments (<c>string?</c>).</description></item>
+/// <item><description><b>Interprocedural return promotion</b> — a property /
+/// method whose body returns the result of calling a method with a nullable
+/// return type is itself promoted to <c>T?</c> (the callee's return taint flows
+/// to the caller's return through the call edge).</description></item>
+/// </list>
+/// The analysis is gated to oblivious compilations, so a nullable-<em>enabled</em>
+/// compilation is untouched.
+/// </summary>
+public class Issue2167TransitiveNullabilityTranslationTests
+{
+    [Fact]
+    public void Oblivious_VarLocal_LaterAssignedNullableValue_IsPromotedToNullable()
+    {
+        // `var id = String.Empty` infers a non-null `string` from the initializer,
+        // but `id = mo.ToString()` assigns a `string?` (`object.ToString()` is
+        // declared `string?`). The local's emitted type is the JOIN over the
+        // initializer AND every assignment, so it must be `string?`; otherwise
+        // gsc rejects the `string? -> string` assignment (GS0156).
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        public string GetId(object mo)
+        {
+            var id = System.String.Empty;
+            id = mo.ToString();
+            return id;
+        }
+    }
+}");
+
+        Assert.Contains("var id string? =", printed);
+    }
+
+    [Fact]
+    public void Oblivious_VarLocal_OnlyNonNullAssignments_StaysNonNull()
+    {
+        // Precision guard: a `var` local that is only ever assigned non-null
+        // values keeps its inferred non-null type (no spurious `?`).
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        public string GetId()
+        {
+            var id = System.String.Empty;
+            id = ""x"";
+            return id;
+        }
+    }
+}");
+
+        Assert.DoesNotContain("string?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_PropertyReturningNullableReturningCall_IsPromotedToNullable()
+    {
+        // `InstallDate` returns `ConvertToDateTime(...)`, whose OWN return is
+        // nullable (it returns `s?.Trim()`). Knowing `InstallDate` must be
+        // `string?` requires analyzing the CALLEE's return type — the
+        // interprocedural edge. Without it gsc reports GS0156 on the return.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static string InstallDate
+        {
+            get
+            {
+                return ConvertToDateTime(""x"");
+            }
+        }
+
+        private static string ConvertToDateTime(string s)
+        {
+            return s?.Trim();
+        }
+    }
+}");
+
+        Assert.Contains("prop InstallDate string?", printed);
+        Assert.Contains("func ConvertToDateTime(s string?) string?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_MethodReturningNullableReturningCall_IsPromotedToNullable()
+    {
+        // The same interprocedural return propagation for a METHOD sink: a method
+        // whose body returns a call to a nullable-returning method must itself be
+        // `string?`. Iterated to a fixpoint, promoting the callee promotes the
+        // caller.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Outer()
+        {
+            return Inner(""x"");
+        }
+
+        private string Inner(string s)
+        {
+            return s?.Trim();
+        }
+    }
+}");
+
+        Assert.Contains("func Outer() string?", printed);
+        Assert.Contains("func Inner(s string?) string?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_PropertyForwardingTaintedProperty_IsNotPromotedThroughCallOnlyEdge()
+    {
+        // Guardrail (issue #1354 / #2157): only CALL returns are followed
+        // interprocedurally for a property sink. `Work => Make()` returns a
+        // (transitively-nullable) method call, so `Work` is promoted to
+        // `string?`. But `Forward => Work` merely FORWARDS the property `Work`
+        // (not a call), so `Forward` keeps its declared non-null `string` type
+        // and relies on the null-forgiveness `!!` pass, preserving the property
+        // contract. Promoting every forwarder would regress #1354's golden
+        // `OperationTask => Work` behavior.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        private string Make() { return null; }
+        public string Work => Make();
+        public void Guard() { if (Work == null) { } }
+        public string Forward => Work;
+    }
+}");
+
+        Assert.Contains("prop Work string?", printed);
+        Assert.Contains("prop Forward string ", printed);
+        Assert.DoesNotContain("prop Forward string?", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -236,9 +236,24 @@ internal static class ObliviousNullabilityAnalyzer
             case AssignmentExpressionSyntax assign
                 when assign.IsKind(SyntaxKind.SimpleAssignmentExpression):
                 ISymbol assignTarget = ResolveAssignable(assign.Left, model);
-                if (assignTarget != null && !IsDirectlyNullable(assign.Right, model))
+                if (assignTarget != null)
                 {
-                    AddEdges(assignTarget, assign.Right, model, edges);
+                    // A declaration's emitted type is the JOIN over its
+                    // initializer AND every assignment to it. A later `lhs =
+                    // <nullable>` (e.g. `id = mo["ProcessorID"]!!.ToString()`,
+                    // where `object.ToString()` is declared `string?`) therefore
+                    // promotes `lhs` even when the declaration's initializer was
+                    // non-null (issue #2167, the `var` local-join case). A
+                    // directly-nullable RHS taints immediately; any other RHS
+                    // records a transitive edge so a nullable source propagates.
+                    if (IsDirectlyNullable(assign.Right, model))
+                    {
+                        tainted.Add(assignTarget);
+                    }
+                    else
+                    {
+                        AddEdges(assignTarget, assign.Right, model, edges);
+                    }
                 }
 
                 break;
@@ -417,19 +432,26 @@ internal static class ObliviousNullabilityAnalyzer
 
         ISymbol canonicalReturn = Canonical(propertySymbol);
 
-        // A property/indexer getter is DIRECT-taint only: a syntactically
+        // A property/indexer getter is direct-taint always: a syntactically
         // nullable body (`?.` / `??`-with-nullable-fallback / ternary /
-        // `return null`) promotes the property to `T?` (issue #2157). We do NOT
-        // record transitive edges here — a getter that merely FORWARDS another
-        // (only-transitively-nullable) declaration keeps its declared type and
-        // relies on the translator's null-forgiveness pass (issue #1354) to
-        // assert the forwarded value non-null, preserving the property contract
-        // for overrides / interface members.
+        // `return null`) promotes the property to `T?` (issue #2157).
+        //
+        // Issue #2167: it is ALSO transitive for a property that neither
+        // overrides a base member nor implements an interface member — a getter
+        // that returns a nullable-returning method / forwards a tainted
+        // declaration (e.g. `MotherboardInfo.InstallDate` returning
+        // `ConvertToDateTime(...)` whose own return is `string?`) must itself be
+        // `T?`, otherwise gsc rejects the `T? -> T` return (GS0156). For an
+        // OVERRIDE / interface implementation we keep the direct-taint-only
+        // behavior and rely on the translator's null-forgiveness pass (issue
+        // #1354) to assert the forwarded value non-null, preserving the property
+        // contract with the base / interface declaration.
+        bool transitive = !ImplementsBaseOrInterfaceMember(propertySymbol);
 
         // `Prop => expr;`
         if (propertyArrowBody != null)
         {
-            ApplyReturnValue(canonicalReturn, propertyArrowBody, model, tainted, edges, transitive: false);
+            ApplyReturnValue(canonicalReturn, propertyArrowBody, model, tainted, edges, transitive, callSourcesOnly: true);
         }
 
         // Only the `get` accessor produces the property value; `set`/`init`
@@ -444,7 +466,7 @@ internal static class ObliviousNullabilityAnalyzer
         // `get => expr;`
         if (getter.ExpressionBody?.Expression is ExpressionSyntax getterArrow)
         {
-            ApplyReturnValue(canonicalReturn, getterArrow, model, tainted, edges, transitive: false);
+            ApplyReturnValue(canonicalReturn, getterArrow, model, tainted, edges, transitive, callSourcesOnly: true);
         }
 
         // `get { ... return x; }`
@@ -452,9 +474,44 @@ internal static class ObliviousNullabilityAnalyzer
         {
             if (statement.Expression != null)
             {
-                ApplyReturnValue(canonicalReturn, statement.Expression, model, tainted, edges, transitive: false);
+                ApplyReturnValue(canonicalReturn, statement.Expression, model, tainted, edges, transitive, callSourcesOnly: true);
             }
         }
+    }
+
+    // Whether the property/indexer overrides a base member or implements an
+    // interface member (explicitly or implicitly). Such a member's emitted G#
+    // return type must stay in lock-step with the base / interface declaration,
+    // so it is excluded from TRANSITIVE return promotion (issue #2167 guardrail;
+    // preserves issue #2157 / #1354 behavior for contract members).
+    private static bool ImplementsBaseOrInterfaceMember(IPropertySymbol property)
+    {
+        if (property.IsOverride || !property.ExplicitInterfaceImplementations.IsDefaultOrEmpty)
+        {
+            return true;
+        }
+
+        INamedTypeSymbol containingType = property.ContainingType;
+        if (containingType == null)
+        {
+            return false;
+        }
+
+        foreach (INamedTypeSymbol iface in containingType.AllInterfaces)
+        {
+            foreach (ISymbol member in iface.GetMembers())
+            {
+                if (member is IPropertySymbol
+                    && SymbolEqualityComparer.Default.Equals(
+                        containingType.FindImplementationForInterfaceMember(member),
+                        property))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private static void ApplyReturnValue(
@@ -463,7 +520,8 @@ internal static class ObliviousNullabilityAnalyzer
         SemanticModel model,
         HashSet<ISymbol> tainted,
         List<(ISymbol Target, ISymbol Source)> edges,
-        bool transitive)
+        bool transitive,
+        bool callSourcesOnly = false)
     {
         if (IsDirectlyNullable(value, model))
         {
@@ -471,7 +529,7 @@ internal static class ObliviousNullabilityAnalyzer
         }
         else if (transitive)
         {
-            AddEdges(returnSymbol, value, model, edges);
+            AddEdges(returnSymbol, value, model, edges, callSourcesOnly);
         }
     }
 
@@ -498,19 +556,30 @@ internal static class ObliviousNullabilityAnalyzer
     // Adds transitive edges `target <- source` for every declaration symbol the
     // value expression reads (identifier/member) or the method it calls
     // (invocation), unwrapping the compositional forms `??`, `?:`, `(cast)`.
+    // When <paramref name="callSourcesOnly"/> is set, ONLY method-call returns
+    // (`m(args)`) are followed — plain identifier/member forwarding is skipped.
+    // This is the interprocedural edge used for property/indexer getters (issue
+    // #2167): a getter returning a nullable-returning method call is promoted,
+    // but a getter that merely FORWARDS a tainted field/property keeps its
+    // declared type and relies on the translator's null-forgiveness `!!` pass
+    // (issue #1354 / #2157), preserving the property contract.
     private static void AddEdges(
         ISymbol target,
         ExpressionSyntax value,
         SemanticModel model,
-        List<(ISymbol Target, ISymbol Source)> edges)
+        List<(ISymbol Target, ISymbol Source)> edges,
+        bool callSourcesOnly = false)
     {
-        foreach (ISymbol source in ResolveSources(value, model))
+        foreach (ISymbol source in ResolveSources(value, model, callSourcesOnly))
         {
             edges.Add((target, source));
         }
     }
 
-    private static IEnumerable<ISymbol> ResolveSources(ExpressionSyntax expression, SemanticModel model)
+    private static IEnumerable<ISymbol> ResolveSources(
+        ExpressionSyntax expression,
+        SemanticModel model,
+        bool callSourcesOnly = false)
     {
         switch (expression)
         {
@@ -518,7 +587,7 @@ internal static class ObliviousNullabilityAnalyzer
                 yield break;
 
             case ParenthesizedExpressionSyntax paren:
-                foreach (ISymbol source in ResolveSources(paren.Expression, model))
+                foreach (ISymbol source in ResolveSources(paren.Expression, model, callSourcesOnly))
                 {
                     yield return source;
                 }
@@ -532,7 +601,7 @@ internal static class ObliviousNullabilityAnalyzer
             // `a ?? b`: the result is `b`'s value when `a` is null.
             case BinaryExpressionSyntax coalesce
                 when coalesce.IsKind(SyntaxKind.CoalesceExpression):
-                foreach (ISymbol source in ResolveSources(coalesce.Right, model))
+                foreach (ISymbol source in ResolveSources(coalesce.Right, model, callSourcesOnly))
                 {
                     yield return source;
                 }
@@ -541,8 +610,8 @@ internal static class ObliviousNullabilityAnalyzer
 
             // `cond ? a : b`: either branch may flow through.
             case ConditionalExpressionSyntax ternary:
-                foreach (ISymbol source in ResolveSources(ternary.WhenTrue, model)
-                    .Concat(ResolveSources(ternary.WhenFalse, model)))
+                foreach (ISymbol source in ResolveSources(ternary.WhenTrue, model, callSourcesOnly)
+                    .Concat(ResolveSources(ternary.WhenFalse, model, callSourcesOnly)))
                 {
                     yield return source;
                 }
@@ -550,7 +619,7 @@ internal static class ObliviousNullabilityAnalyzer
                 break;
 
             case CastExpressionSyntax cast:
-                foreach (ISymbol source in ResolveSources(cast.Expression, model))
+                foreach (ISymbol source in ResolveSources(cast.Expression, model, callSourcesOnly))
                 {
                     yield return source;
                 }
@@ -568,6 +637,11 @@ internal static class ObliviousNullabilityAnalyzer
 
             case IdentifierNameSyntax:
             case MemberAccessExpressionSyntax:
+                if (callSourcesOnly)
+                {
+                    yield break;
+                }
+
                 ISymbol symbol = model.GetSymbolInfo(expression).Symbol;
                 if (symbol != null && (IsValueDeclarationSymbol(symbol) || symbol is IMethodSymbol))
                 {


### PR DESCRIPTION
## Root cause
cs2gs migrates nullable-**oblivious** C# by mapping a reference type `T` to G# `T?` only for null-tainted declarations (`ObliviousNullabilityAnalyzer`, per #2113). That taint was missing two flows, so a `T?` value flowing into a sink cs2gs typed as non-null `T` made gsc reject the `T? -> T` conversion (GS0154/GS0155/GS0156):

1. **`var` local-join widening** — `var id = String.Empty` infers a non-null `string`, but a later `id = mo["ProcessorID"]!!.ToString()` assigns a `string?` (`object.ToString()` is declared `string?`). The assignment edge only recorded a transitive edge for a **non**-directly-nullable RHS, so a directly-nullable RHS neither tainted nor propagated the local (`HardwareId.GetCpuId`).
2. **Interprocedural return promotion** — `MotherboardInfo.InstallDate`'s getter returns `ConvertToDateTime(...)`, whose own return is `string?`. Property getters were *direct-taint only* (#2157 inspected only the return expression syntax, not the callee's return type), so the property was never promoted.

## Algorithm / edges implemented (all inside `ObliviousNullabilityAnalyzer`, oblivious-only)
- **assignment** `lhs = rhs`: a **directly-nullable** RHS now taints `lhs` immediately (in addition to the existing transitive edge for non-directly-nullable RHS), so a local's emitted type is the **JOIN** over its initializer and every assignment. Covers case 1.
- **property/indexer return** now follows the interprocedural **CALL** edge: a getter returning `m(args)` is promoted iff `m`'s (possibly already-promoted) return is tainted, iterated to the existing monotone worklist fixpoint. Covers case 2. Method returns, `??`/ternary/cast/paren unwrapping, and the pre-existing argument→parameter edges are unchanged.

## Parameters
No new parameter promotion was added. Parameters are promoted only through the **pre-existing** argument→parameter edges (local, monotone); no BCL/external parameter is promoted. The `?.` receiver of a call still taints its own receiver as before.

## Guardrails
- **Oblivious only**: every change is inside `ObliviousNullabilityAnalyzer`, which `IsTainted` short-circuits to `false` for nullable-enabled compilations — enabled-project output stays byte-identical.
- **#1354 / #2157 preserved**: property edges are followed **call-sources-only** (`callSourcesOnly`). A getter that merely **forwards** a tainted field/property (not a call) is **not** promoted and keeps relying on null-forgiveness `!!` (`Forward => Work` stays non-null with `Work!!`). This is why property forwarding is deliberately excluded — promoting it regresses #1354's golden `OperationTask => Work` test.
- **Overrides / interface implementations** are excluded from transitive promotion (`ImplementsBaseOrInterfaceMember`) so their emitted return type stays in lock-step with the base/interface declaration.
- Type parameters remain excluded (unchanged).

## Before/after Oahu (no net-new errors of any id in any app)
| App | GS0155 | GS0156 | GS0154 |
|---|---|---|---|
| SystemManagement (before) | 17 | 7 | 2 |
| SystemManagement (after) | 17 | **5** | 2 |
| Data (before/after) | 17 / 17 | 7 / 7 | 2 / 2 |
| Foundation (before/after) | 17 / 17 | 5 / 5 | 2 / 2 |

`HardwareId.gs` and `MotherboardInfo.gs` GS0156 both **cleared** (count 0). A line-by-line diff of every gsc error across all three apps shows **no genuine net-new error** — the only delta besides the two cleared GS0156 is a pre-existing `AffineSynchronizationContext.gs:174` GS0124 whose end column shifted 40→42 because a promoted parameter added `!!` earlier on the line (same error, same count).

> Note: the two canonical files are SystemManagement-only, so Data/Foundation are unchanged (no regressions). A broader property-*forwarding* promotion would drop ~3 additional GS0155/app but regresses the #1354 golden test, so it is intentionally not applied.

## Tests
Adds `Issue2167TransitiveNullabilityTranslationTests` (5 tests): `var` local-join widening, interprocedural return promotion for a **property** and a **method**, a non-null local precision guard, and a forwarding-property guardrail (call-return promotes `Work`, property-forward `Forward` stays non-null). All **1116** cs2gs tests pass; #1354/#2157 tests re-run green.

Fixes #2167
Refs #914