### PR TITLE
Fix #2171: is-interface narrowing for nullable type-parameter/interface operands

### DIFF
--- a/src/Core/CodeAnalysis/Binding/SmartCastStability.cs
+++ b/src/Core/CodeAnalysis/Binding/SmartCastStability.cs
@@ -290,10 +290,18 @@ internal static class SmartCastStability
         // operands. Excluded: a widening to a base interface the declared type
         // already satisfies (declared → candidate), which would only hide the
         // declared type's own members without adding any.
+        // Issue #2171: a NULLABLE type-parameter (`T?`) or nullable interface
+        // (`IShape?`) operand behaves identically for this rule — the nullable
+        // wrapper does not change which interfaces the runtime value may
+        // implement — so strip it before applying the type-parameter/interface
+        // test.
+        var declaredCore = declared is NullableTypeSymbol declaredNullableCore
+            ? declaredNullableCore.UnderlyingType
+            : declared;
         if (IsInterfaceType(candidate)
-            && (declared is TypeParameterSymbol || IsInterfaceType(declared)))
+            && (declaredCore is TypeParameterSymbol || IsInterfaceType(declaredCore)))
         {
-            var toCandidate = Conversion.Classify(declared, candidate);
+            var toCandidate = Conversion.Classify(declaredCore, candidate);
             if (!(toCandidate.Exists && toCandidate.IsImplicit))
             {
                 return true;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1737,10 +1737,19 @@ internal sealed partial class MethodBodyEmitter
         // first (a no-op for reference-constrained T, matching the operand
         // boxing already applied by `EmitIsExpression`) so the following
         // reference/value cast operates on a boxed reference.
+        // Issue #2171: a NULLABLE type-parameter operand (`x T?`) has the same
+        // bare-slot representation over its underlying type parameter, so box
+        // the underlying type parameter in that case too.
         if (declared is TypeParameterSymbol)
         {
             this.il.OpCode(ILOpCode.Box);
             this.il.Token(this.outer.GetElementTypeToken(declared));
+        }
+        else if (declared is NullableTypeSymbol declaredNullable
+            && declaredNullable.UnderlyingType is TypeParameterSymbol underlyingTypeParameter)
+        {
+            this.il.OpCode(ILOpCode.Box);
+            this.il.Token(this.outer.GetElementTypeToken(underlyingTypeParameter));
         }
 
         if (ReflectionMetadataEmitter.IsValueTypeSymbol(narrowed)

--- a/test/Compiler.Tests/Emit/Issue2171NullableIsInterfaceNarrowingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2171NullableIsInterfaceNarrowingEmitTests.cs
@@ -1,0 +1,162 @@
+// <copyright file="Issue2171NullableIsInterfaceNarrowingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2171 (follow-up to #2165): end-to-end CLR emit + ilverify coverage
+/// proving that an <c>is</c>-interface smart cast on a NULLABLE type-parameter
+/// (<c>T?</c>) or nullable interface (<c>IShape?</c>) operand narrows the
+/// operand so the tested interface's member is actually invoked at runtime. A
+/// nullable type-parameter operand sits on the stack as a bare slot over its
+/// underlying type parameter, so it needs the same box-before-cast handling as
+/// the bare <c>T</c> case.
+/// </summary>
+public class Issue2171NullableIsInterfaceNarrowingEmitTests
+{
+    [Fact]
+    public void EndToEnd_IsInterface_OnNullableTypeParameterOperand_InvokesInterfaceMember()
+    {
+        var source = """
+            package p
+            interface IInit {
+                func Init() int32;
+            }
+            class Circle : IInit {
+                func Init() int32 { return 13 }
+            }
+            func Probe[T](x T?) int32 {
+                if x is IInit {
+                    return x.Init()
+                }
+                return -1
+            }
+            func Main() {
+                System.Console.WriteLine(Probe[Circle](Circle()))
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("13\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_IsInterface_OnNullableInterfaceOperand_InvokesInterfaceMember()
+    {
+        var source = """
+            package p
+            interface IInit {
+                func Init() int32;
+            }
+            interface IShape {
+                func Area() int32;
+            }
+            class Circle : IShape, IInit {
+                func Area() int32 { return 2 }
+                func Init() int32 { return 29 }
+            }
+            func Probe(x IShape?) int32 {
+                if x is IInit {
+                    return x.Init()
+                }
+                return -1
+            }
+            func Main() {
+                System.Console.WriteLine(Probe(Circle()))
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("29\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2171_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            RunCompiler(args);
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void RunCompiler(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2171NullableIsInterfaceNarrowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2171NullableIsInterfaceNarrowingTests.cs
@@ -1,0 +1,144 @@
+// <copyright file="Issue2171NullableIsInterfaceNarrowingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2171 (follow-up to #2165) — <c>is</c>-pattern smart-cast narrowing to
+/// an INTERFACE must also take effect when the operand's static type is a
+/// NULLABLE type parameter (<c>T?</c>) or a nullable interface (<c>IShape?</c>),
+/// not only the non-nullable forms fixed by #2165. Stripping the nullable
+/// wrapper before applying the type-parameter/interface rule makes <c>T?</c>
+/// behave like <c>T</c> (and <c>IShape?</c> like <c>IShape</c>), so
+/// <c>if x is IInit</c> narrows <c>x</c> to <c>IInit</c> and <c>x.Init()</c>
+/// resolves.
+/// </summary>
+public class Issue2171NullableIsInterfaceNarrowingTests
+{
+    [Fact]
+    public void If_IsInterface_OnNullableTypeParameterOperand_NarrowsToTestedInterface()
+    {
+        // Declared type is a NULLABLE unconstrained type parameter (`T?`).
+        var result = Evaluate(@"
+interface IInit {
+    func Init() void;
+}
+func Run[T](x T?) void {
+    if x is IInit {
+        x.Init()
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_IsInterface_OnNullableInterfaceOperand_NarrowsToTestedInterface()
+    {
+        // Declared type is a NULLABLE (unrelated) interface (`IShape?`).
+        var result = Evaluate(@"
+interface IInit {
+    func Init() void;
+}
+interface IShape {
+    func Area() int32;
+}
+func Run(x IShape?) void {
+    if x is IInit {
+        x.Init()
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void And_IsInterface_OnNullableTypeParameterOperand_NarrowsRightOperand()
+    {
+        // The short-circuit (`x is I && …`) classifier must agree with the
+        // `if`-statement classifier for nullable type-parameter operands.
+        var result = Evaluate(@"
+interface IInit {
+    func Init() int32;
+}
+func Run[T](x T?) bool {
+    return x is IInit && x.Init() > 0
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void And_IsInterface_OnNullableInterfaceOperand_NarrowsRightOperand()
+    {
+        var result = Evaluate(@"
+interface IInit {
+    func Init() int32;
+}
+interface IShape {
+    func Area() int32;
+}
+func Run(x IShape?) bool {
+    return x is IInit && x.Init() > 0
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_IsInterface_OnNonNullableTypeParameterOperand_StillNarrows()
+    {
+        // Control: the non-nullable type-parameter operand case fixed by #2165
+        // must keep working.
+        var result = Evaluate(@"
+interface IInit {
+    func Init() void;
+}
+func Run[T](x T) void {
+    if x is IInit {
+        x.Init()
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_IsInterface_OnNullableObjectOperand_StillNarrows()
+    {
+        // Control: the pre-existing `object?` operand case must keep working.
+        var result = Evaluate(@"
+interface IInit {
+    func Init() void;
+}
+func Run(x object?) void {
+    if x is IInit {
+        x.Init()
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Root cause
`is`-pattern smart-cast narrowing to an interface failed when the operand's static type was a **nullable type parameter** (`T?`). #2165 fixed the non-nullable `T` and interface operand cases; `object?` already worked (via the candidate→declared implicit conversion to `object`), but `T?` (and `IShape?`) fell through:

- In `SmartCastStability.IsTypeTestNarrowing`, the type-parameter/interface narrowing rule inspected the declared type directly (`declared is TypeParameterSymbol || IsInterfaceType(declared)`). A `T?` operand is a `NullableTypeSymbol` wrapping the type parameter, so it matched neither branch and no narrowing was recorded → `x.Init()` reported `GS0159 Cannot find function Init`.
- In the emit path, `EmitNarrowingCastIfNeeded` only boxed a bare `TypeParameterSymbol` operand before the cast; a `T?` operand's underlying type parameter sits on the stack as a bare slot too, so `castclass`/`unbox.any` would fail ilverify.

## Fix
- **`SmartCastStability.IsTypeTestNarrowing`**: strip the `NullableTypeSymbol` wrapper from the declared type before applying the type-parameter/interface rule, so `T?` is treated like `T` and `IShape?` like `IShape`. Shared by both the `if` and `&&` classifiers.
- **`MethodBodyEmitter.EmitNarrowingCastIfNeeded`**: box the underlying type parameter when the declared type is a nullable type parameter (`T?`), mirroring the bare-`T` boxing #2165 added, so the following reference/value cast operates on an ObjRef and passes ilverify.

No regression to the `T` / interface cases from #2165 or the pre-existing `object`/`object?`/concrete-class cases.

## Tests
- `Issue2171NullableIsInterfaceNarrowingTests` (Core): nullable type-parameter and nullable interface operands in both `if` and `&&` forms, plus non-nullable and `object?` controls.
- `Issue2171NullableIsInterfaceNarrowingEmitTests` (Compiler): end-to-end compile + ilverify + run, proving the interface method is actually invoked at runtime for the `T?` and `IShape?` operands.

Verified the minimal repro (G1 `T?`, G2 `object?`, G3 `T`) all compile cleanly. Core tests: 5670 passed, 0 failed.

Fixes #2171
Refs #914