### PR TITLE
Fix #2172: prefer Func[Task[X]] overload for async/task-returning lambda arguments

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -192,6 +192,23 @@ internal static class OverloadResolution
     }
 
     /// <summary>
+    /// Issue #2172: the shape of an OPEN generic delegate parameter's return
+    /// type, used to prefer <c>Func&lt;Task&lt;TResult&gt;&gt;</c> over
+    /// <c>Func&lt;TResult&gt;</c> for a task-returning lambda argument.
+    /// </summary>
+    private enum TaskLambdaDelegateShape
+    {
+        /// <summary>Neither a bare type parameter nor a Task-shaped return.</summary>
+        Other,
+
+        /// <summary>The delegate return type is a bare method type parameter (<c>Func&lt;TResult&gt;</c>).</summary>
+        BareTypeParameter,
+
+        /// <summary>The delegate return type is <c>Task</c>/<c>Task&lt;...&gt;</c> (<c>Func&lt;Task&lt;TResult&gt;&gt;</c>).</summary>
+        TaskShaped,
+    }
+
+    /// <summary>
     /// Gets or sets the optional hook invoked when no built-in implicit
     /// conversion exists. Returns <see langword="true"/> when the caller has
     /// a user-defined <c>op_Implicit</c> method that converts the source type
@@ -2938,11 +2955,217 @@ internal static class OverloadResolution
             }
         }
 
+        // Phase 2f — issue #2172: when an argument is a task-returning lambda
+        // (its natural delegate type returns Task/Task<T>), prefer the candidate
+        // whose OPEN delegate parameter is shaped Func<Task<TResult>> (binding
+        // the whole task to a Task-typed delegate result) over one shaped
+        // Func<TResult> (binding the whole task to a bare method type parameter).
+        // Both close to the same Func<Task<X>> after inference — e.g.
+        // Task.Run<TResult>(Func<TResult>) with TResult = Task<X> versus
+        // Task.Run<TResult>(Func<Task<TResult>>) with TResult = X — so neither
+        // dominates on conversion kind and the earlier tie-breaks cannot choose.
+        // This mirrors C#'s preference for the task-returning delegate overload
+        // for an async/task-returning lambda argument. Generalised: it fires for
+        // ANY overload set differing by Func<X> vs Func<Task<X>> at a slot whose
+        // argument is a task-returning delegate, not just Task.Run.
+        if (pool.Count > 1)
+        {
+            var preferred = PreferTaskShapedDelegateForTaskLambda(pool, argTypes);
+            if (preferred.Count >= 1 && preferred.Count < pool.Count)
+            {
+                pool = preferred;
+            }
+
+            if (pool.Count == 1)
+            {
+                return Result<T>.Single(pool[0].Method, BuildMappingArray(pool[0].Mapping, argumentNames), pool[0].IsExpanded);
+            }
+        }
+
         // If nothing dominated above, report the surviving pool as ambiguous.
         var ambiguous = pool
             .Select(c => c.Method)
             .ToImmutableArray();
         return Result<T>.AmbiguousResult(ambiguous);
+    }
+
+    /// <summary>
+    /// Issue #2172: narrows <paramref name="pool"/> to prefer, for each argument
+    /// slot whose argument is a task-returning delegate (a lambda whose natural
+    /// return type is <c>Task</c>/<c>Task&lt;T&gt;</c>), the candidates whose
+    /// OPEN delegate parameter at that slot is shaped <c>Func&lt;Task&lt;TResult&gt;&gt;</c>
+    /// over those shaped <c>Func&lt;TResult&gt;</c>. Only narrows when the pool
+    /// genuinely splits into both shapes at such a slot, so non-task-lambda calls
+    /// and single-shape overload sets are unaffected. Returns the (possibly
+    /// unchanged) surviving list.
+    /// </summary>
+    private static List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> PreferTaskShapedDelegateForTaskLambda<T>(
+        List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> pool,
+        IReadOnlyList<Type> argTypes)
+        where T : MethodBase
+    {
+        if (argTypes == null || argTypes.Count == 0)
+        {
+            return pool;
+        }
+
+        var current = pool;
+        for (var argIndex = 0; argIndex < argTypes.Count; argIndex++)
+        {
+            if (current.Count <= 1)
+            {
+                break;
+            }
+
+            // The argument must itself be a task-returning delegate value
+            // (an async / task-returning lambda's natural Func<...> type).
+            if (!IsTaskReturningDelegate(argTypes[argIndex]))
+            {
+                continue;
+            }
+
+            var taskShaped = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)>(current.Count);
+            var bareTypeParam = false;
+            foreach (var c in current)
+            {
+                switch (ClassifyOpenDelegateReturnShape(c.Method, c.Mapping, argIndex))
+                {
+                    case TaskLambdaDelegateShape.TaskShaped:
+                        taskShaped.Add(c);
+                        break;
+                    case TaskLambdaDelegateShape.BareTypeParameter:
+                        bareTypeParam = true;
+                        break;
+                    default:
+                        // Neither shape — keep it eligible so an unrelated
+                        // sibling overload is never silently dropped.
+                        taskShaped.Add(c);
+                        break;
+                }
+            }
+
+            // Only narrow when the split is a genuine Func<Task<X>> vs Func<X>
+            // discrimination (at least one of each) — otherwise leave the pool
+            // untouched.
+            if (bareTypeParam && taskShaped.Count >= 1 && taskShaped.Count < current.Count)
+            {
+                current = taskShaped;
+            }
+        }
+
+        return current;
+    }
+
+    /// <summary>
+    /// Issue #2172: classifies the OPEN (generic-definition) delegate parameter
+    /// bound to argument <paramref name="argIndex"/> as either
+    /// <see cref="TaskLambdaDelegateShape.TaskShaped"/> (its delegate return type
+    /// is <c>Task</c>/<c>Task&lt;...&gt;</c>, i.e. <c>Func&lt;Task&lt;TResult&gt;&gt;</c>),
+    /// <see cref="TaskLambdaDelegateShape.BareTypeParameter"/> (its delegate
+    /// return type is a bare method type parameter, i.e. <c>Func&lt;TResult&gt;</c>),
+    /// or <see cref="TaskLambdaDelegateShape.Other"/>.
+    /// </summary>
+    private static TaskLambdaDelegateShape ClassifyOpenDelegateReturnShape<T>(T method, int[] mapping, int argIndex)
+        where T : MethodBase
+    {
+        var paramIndex = mapping != null && argIndex < mapping.Length ? mapping[argIndex] : argIndex;
+        if (paramIndex < 0)
+        {
+            return TaskLambdaDelegateShape.Other;
+        }
+
+        MethodBase openMethod = method;
+        if (method is MethodInfo mi && mi.IsGenericMethod && !mi.IsGenericMethodDefinition)
+        {
+            try
+            {
+                openMethod = mi.GetGenericMethodDefinition();
+            }
+            catch (Exception)
+            {
+                return TaskLambdaDelegateShape.Other;
+            }
+        }
+
+        ParameterInfo[] parameters;
+        try
+        {
+            parameters = openMethod.GetParameters();
+        }
+        catch (Exception)
+        {
+            return TaskLambdaDelegateShape.Other;
+        }
+
+        if (paramIndex >= parameters.Length)
+        {
+            return TaskLambdaDelegateShape.Other;
+        }
+
+        var openParamType = parameters[paramIndex].ParameterType;
+        if (openParamType == null || openParamType.IsByRef)
+        {
+            return TaskLambdaDelegateShape.Other;
+        }
+
+        if (!TryGetDelegateSignature(openParamType, out _, out var openReturn) || openReturn == null)
+        {
+            return TaskLambdaDelegateShape.Other;
+        }
+
+        if (IsTaskType(openReturn))
+        {
+            return TaskLambdaDelegateShape.TaskShaped;
+        }
+
+        if (openReturn.IsGenericParameter)
+        {
+            return TaskLambdaDelegateShape.BareTypeParameter;
+        }
+
+        return TaskLambdaDelegateShape.Other;
+    }
+
+    /// <summary>
+    /// Issue #2172: whether <paramref name="type"/> is a delegate type whose
+    /// return type is <c>Task</c>/<c>Task&lt;T&gt;</c> (the natural type of an
+    /// async / task-returning lambda argument).
+    /// </summary>
+    private static bool IsTaskReturningDelegate(Type type)
+    {
+        if (type == null || !ClrTypeUtilities.IsDelegateType(type))
+        {
+            return false;
+        }
+
+        return TryGetDelegateSignature(type, out _, out var returnType)
+            && IsTaskType(returnType);
+    }
+
+    /// <summary>
+    /// Issue #2172: whether <paramref name="type"/> is <c>System.Threading.Tasks.Task</c>
+    /// or <c>Task&lt;T&gt;</c> (or the <c>ValueTask</c> equivalents), compared by
+    /// name so it works across reflection contexts and for constructed types
+    /// closed over open generic parameters (whose <see cref="Type.FullName"/> is
+    /// <see langword="null"/>).
+    /// </summary>
+    private static bool IsTaskType(Type type)
+    {
+        if (type == null)
+        {
+            return false;
+        }
+
+        if (!string.Equals(type.Namespace, "System.Threading.Tasks", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var name = type.Name;
+        return string.Equals(name, "Task", StringComparison.Ordinal)
+            || string.Equals(name, "Task`1", StringComparison.Ordinal)
+            || string.Equals(name, "ValueTask", StringComparison.Ordinal)
+            || string.Equals(name, "ValueTask`1", StringComparison.Ordinal);
     }
 
     private static bool IsGenericMethod(MethodBase method)

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -1212,6 +1212,23 @@ internal sealed class OverloadResolver
             }
         }
 
+        // Phase 2e — issue #2172: when an argument is a task-returning lambda
+        // (its natural function type returns Task/Task<T>), prefer a candidate
+        // whose delegate parameter is shaped `(...) -> Task[TResult]` (binding
+        // the whole task to a Task-typed delegate result) over one shaped
+        // `(...) -> TResult` (binding the whole task to a bare method type
+        // parameter). Both close to the same `(...) -> Task[X]` after inference,
+        // so neither dominates on conversion kind and the earlier tie-breaks
+        // cannot choose. Mirrors C#'s preference for the task-returning delegate
+        // overload for an async/task-returning lambda argument, and the parallel
+        // rule in OverloadResolution.RankApplicable for imported (BCL) overloads.
+        // Generalised: fires for ANY user overload set differing by `(...) -> X`
+        // vs `(...) -> Task[X]` at a task-returning-lambda argument slot.
+        if (pool.Count > 1)
+        {
+            pool = PreferTaskShapedDelegateForTaskLambda(pool, boundArguments);
+        }
+
         if (pool.Count == 1)
         {
             return pool[0].Candidate;
@@ -1219,6 +1236,103 @@ internal sealed class OverloadResolver
 
         ambiguous = true;
         return null;
+    }
+
+    /// <summary>
+    /// Issue #2172: narrows <paramref name="pool"/> to prefer, for each argument
+    /// slot whose argument is a task-returning lambda (its function type returns
+    /// <c>Task</c>/<c>Task&lt;T&gt;</c>), the candidates whose OPEN delegate
+    /// parameter at that slot is shaped <c>(...) -&gt; Task[TResult]</c> over
+    /// those shaped <c>(...) -&gt; TResult</c>. Only narrows when the pool
+    /// genuinely splits into both shapes at such a slot, so non-task-lambda calls
+    /// and single-shape overload sets are unaffected.
+    /// </summary>
+    private static List<UserCandidateRankData> PreferTaskShapedDelegateForTaskLambda(
+        List<UserCandidateRankData> pool,
+        ImmutableArray<BoundExpression>.Builder boundArguments)
+    {
+        var current = pool;
+        for (var argIndex = 0; argIndex < boundArguments.Count; argIndex++)
+        {
+            if (current.Count <= 1)
+            {
+                break;
+            }
+
+            // The argument must itself be a task-returning function value (an
+            // async / task-returning lambda's natural function type).
+            if (!(boundArguments[argIndex]?.Type is FunctionTypeSymbol argFn)
+                || !IsTaskReturnTypeSymbol(argFn.ReturnType))
+            {
+                continue;
+            }
+
+            var taskShaped = new List<UserCandidateRankData>(current.Count);
+            var bareTypeParam = false;
+            foreach (var w in current)
+            {
+                var openParam = argIndex < w.ParamTypes.Length ? w.ParamTypes[argIndex] : null;
+                if (openParam is FunctionTypeSymbol paramFn)
+                {
+                    if (IsTaskReturnTypeSymbol(paramFn.ReturnType))
+                    {
+                        taskShaped.Add(w);
+                        continue;
+                    }
+
+                    if (paramFn.ReturnType is TypeParameterSymbol)
+                    {
+                        bareTypeParam = true;
+                        continue;
+                    }
+                }
+
+                // Neither shape — keep it eligible so an unrelated sibling
+                // overload is never silently dropped.
+                taskShaped.Add(w);
+            }
+
+            if (bareTypeParam && taskShaped.Count >= 1 && taskShaped.Count < current.Count)
+            {
+                current = taskShaped;
+            }
+        }
+
+        return current;
+    }
+
+    /// <summary>
+    /// Issue #2172: whether <paramref name="type"/> is
+    /// <c>System.Threading.Tasks.Task</c>/<c>Task&lt;T&gt;</c> (or the
+    /// <c>ValueTask</c> equivalents). Detected via the erased CLR type so it
+    /// also matches an open construction like <c>Task[T]</c> (whose closed CLR
+    /// form is <c>Task&lt;object&gt;</c>).
+    /// </summary>
+    private static bool IsTaskReturnTypeSymbol(TypeSymbol type)
+    {
+        var clr = type?.ClrType;
+        if (clr == null)
+        {
+            return false;
+        }
+
+        if (clr.IsSameAs(typeof(System.Threading.Tasks.Task))
+            || clr.IsSameAs(typeof(System.Threading.Tasks.ValueTask)))
+        {
+            return true;
+        }
+
+        if (clr.IsGenericType)
+        {
+            var definition = clr.GetGenericTypeDefinition();
+            if (definition.IsSameAs(typeof(System.Threading.Tasks.Task<>))
+                || definition.IsSameAs(typeof(System.Threading.Tasks.ValueTask<>)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue2172TaskRunAsyncLambdaEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2172TaskRunAsyncLambdaEmitTests.cs
@@ -1,0 +1,178 @@
+// <copyright file="Issue2172TaskRunAsyncLambdaEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2172: <c>Task.Run(async () -&gt; await ...)</c>, where the async
+/// lambda awaits a <c>Task[T]</c>, must resolve to the
+/// <c>Task.Run(Func&lt;Task&lt;TResult&gt;&gt;)</c> overload (returning
+/// <c>Task[X]</c>) rather than being ambiguous with
+/// <c>Task.Run(Func&lt;TResult&gt;)</c> (which would return
+/// <c>Task[Task[X]]</c>). These emit tests prove the resolved call not only
+/// compiles but produces IL that runs and returns the awaited result correctly.
+/// A parallel test covers a user-defined overload set (NOT <c>Task.Run</c>) to
+/// prove the betterness rule is generalized, not hard-coded to the BCL method.
+/// </summary>
+public class Issue2172TaskRunAsyncLambdaEmitTests
+{
+    [Fact]
+    public void TaskRun_AsyncLambda_ReturnsAwaitedResult()
+    {
+        const string source = """
+            package i2172run
+            import System
+            import System.Threading.Tasks
+
+            func makeAsync() Task[int32] -> Task.FromResult(42)
+
+            func get() int32 {
+                let task = Task.Run(async () -> await makeAsync())
+                return task.Result
+            }
+
+            Console.WriteLine(get())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void TaskRun_AsyncLambda_StringResult_ReturnsAwaitedResult()
+    {
+        const string source = """
+            package i2172str
+            import System
+            import System.Threading.Tasks
+
+            func makeAsync() Task[string] -> Task.FromResult("hello")
+
+            func get() string {
+                let task = Task.Run(async () -> await makeAsync())
+                return task.Result
+            }
+
+            Console.WriteLine(get())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\n", output);
+    }
+
+    [Fact]
+    public void UserOverloadSet_FuncXVersusFuncTaskX_PrefersTaskReturningOverloadAtRuntime()
+    {
+        // Generalized (NOT Task.Run): a user-defined overload set differing only
+        // by `() -> T` vs `() -> Task[T]`. The task-returning async lambda must
+        // bind to the `() -> Task[T]` overload; the awaited result flows back
+        // through `.Result`. If the `() -> T` overload were chosen, `run` would
+        // return a Task and the `int32`-typed local would not compile.
+        const string source = """
+            package i2172gen
+            import System
+            import System.Threading.Tasks
+
+            func makeAsync() Task[int32] -> Task.FromResult(7)
+
+            func run(f () -> int32) int32 -> f()
+            func run(f () -> Task[int32]) int32 -> f().Result
+
+            func use() int32 -> run(async () -> await makeAsync())
+
+            Console.WriteLine(use())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2172_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2172TaskRunAsyncLambdaOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2172TaskRunAsyncLambdaOverloadTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="Issue2172TaskRunAsyncLambdaOverloadTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2172 — <c>Task.Run(async () -&gt; await ...)</c>, where the async
+/// lambda awaits a <c>Task[T]</c>, previously failed overload resolution with
+/// GS0160 ("Call to 'Run' is ambiguous"). The lambda's natural type is
+/// <c>Func&lt;Task&lt;T&gt;&gt;</c>, which is an identity conversion to BOTH
+/// <c>Run&lt;TResult&gt;(Func&lt;TResult&gt;)</c> (TResult = Task&lt;T&gt;) and
+/// <c>Run&lt;TResult&gt;(Func&lt;Task&lt;TResult&gt;&gt;)</c> (TResult = T), so
+/// neither dominated on conversion kind and the call was reported ambiguous —
+/// which cascaded into GS0158 on the follow-up <c>.Result</c> access. C# prefers
+/// the task-returning delegate overload; gsc now applies the same betterness
+/// rule (prefer <c>Func[Task[X]]</c> over <c>Func[X]</c> for a task-returning
+/// lambda argument), so the call resolves to the <c>Func[Task[TResult]]</c>
+/// overload with <c>task : Task[T]</c> and <c>task.Result : T</c>.
+/// The rule is generalized: it is not keyed on <c>Task.Run</c> and also fires
+/// for a user-defined overload set differing by <c>() -&gt; X</c> vs
+/// <c>() -&gt; Task[X]</c>.
+/// </summary>
+public class Issue2172TaskRunAsyncLambdaOverloadTests
+{
+    [Fact]
+    public void TaskRun_AsyncLambda_ResolvesWithoutAmbiguityOrCascade()
+    {
+        // The minimal issue repro: if resolution picked Func<TResult>
+        // (TResult = Task[T]), `task` would be Task[Task[T]], `task.Result`
+        // would be Task[T], and `return task.Result` (declared T) would be a
+        // type error. A clean bind therefore proves the Func[Task[TResult]]
+        // overload (task : Task[T], task.Result : T) was selected.
+        var source = @"
+package R
+import System.Threading.Tasks
+struct S {
+    func Get[T]() T {
+        let task = Task.Run(async () -> await MakeAsync[T]())
+        return task.Result
+    }
+    func MakeAsync[T]() Task[T] -> Task.FromResult(default(T)!!)
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void UserOverloadSet_FuncXVersusFuncTaskX_PrefersTaskReturningOverload()
+    {
+        // Generalized (NOT Task.Run): a user-defined overload set that differs
+        // only by `() -> T` vs `() -> Task[T]`. The task-returning async lambda
+        // must select the `() -> Task[T]` overload so `Use[T]() T` returns T.
+        // If the `() -> T` overload were chosen, T would infer to Task[T] and
+        // the declared `T` return would mismatch.
+        var source = @"
+package R
+import System.Threading.Tasks
+struct S {
+    func Wrap[T](f () -> T) T -> f()
+    func Wrap[T](f () -> Task[T]) T -> f().Result
+    func Use[T]() T {
+        let r = Wrap(async () -> await MakeAsync[T]())
+        return r
+    }
+    func MakeAsync[T]() Task[T] -> Task.FromResult(default(T)!!)
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void NonAsyncLambda_StillResolvesValueReturningOverload()
+    {
+        // Guard: a plain (non-task) lambda must keep binding to the `() -> T`
+        // overload — the new betterness rule must not disturb it.
+        var source = @"
+package R
+struct S {
+    func Wrap[T](f () -> T) T -> f()
+    func Wrap[T](f () -> S) S -> f()
+    func Use() int32 {
+        let r = Wrap(() -> 42)
+        return r
+    }
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    private static void AssertBindsWithoutErrors(string source)
+    {
+        var paths = new List<string>();
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (!string.IsNullOrEmpty(tpa))
+        {
+            foreach (var p in tpa.Split(Path.PathSeparator))
+            {
+                if (!string.IsNullOrWhiteSpace(p) && File.Exists(p))
+                {
+                    paths.Add(p);
+                }
+            }
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(paths);
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), resolver);
+        var program = Binder.BindProgram(globalScope, resolver);
+        var diagnostics = globalScope.Diagnostics.AddRange(program.Diagnostics);
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -392,6 +393,54 @@ public class OverloadResolutionTests
         var result = OverloadResolution.Resolve(new[] { first, second }, argTypes);
         Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
         return result.Best;
+    }
+
+    [Fact]
+    public void Resolve_TaskReturningLambda_PrefersFuncOfTaskOverload()
+    {
+        // Issue #2172: a task-returning lambda argument (natural type
+        // Func<Task<object>>) is applicable to BOTH Run(Func<TResult>)
+        // (TResult = Task<object>) and Run(Func<Task<TResult>>)
+        // (TResult = object) as identity conversions. The betterness rule must
+        // pick the Func<Task<TResult>> overload so the whole task binds to
+        // Task<TResult>, matching C#'s preference for the task-returning
+        // delegate overload for an async lambda.
+        var funcTResult = typeof(Fixture).GetMethod(nameof(Fixture.Run_FuncTResult), BindingFlags.Public | BindingFlags.Static);
+        var funcTaskTResult = typeof(Fixture).GetMethod(nameof(Fixture.Run_FuncTaskTResult), BindingFlags.Public | BindingFlags.Static);
+        var argType = typeof(System.Func<System.Threading.Tasks.Task<object>>);
+
+        // Candidate order must not matter — both orderings resolve to the
+        // Func<Task<TResult>> overload without ambiguity.
+        var forward = OverloadResolution.Resolve(new[] { funcTResult, funcTaskTResult }, new[] { argType });
+        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, forward.Outcome);
+        Assert.Equal(nameof(Fixture.Run_FuncTaskTResult), forward.Best.Name);
+
+        var reverse = OverloadResolution.Resolve(new[] { funcTaskTResult, funcTResult }, new[] { argType });
+        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, reverse.Outcome);
+        Assert.Equal(nameof(Fixture.Run_FuncTaskTResult), reverse.Best.Name);
+
+        // The winning overload closes over TResult = object, so its return type
+        // is Task<object>, NOT Task<Task<object>>.
+        var closedReturn = forward.Best.ReturnType;
+        Assert.True(closedReturn.IsGenericType);
+        Assert.True(closedReturn.GetGenericTypeDefinition().IsSameAs(typeof(System.Threading.Tasks.Task<>)));
+        Assert.Equal(typeof(object), closedReturn.GetGenericArguments()[0]);
+    }
+
+    [Fact]
+    public void Resolve_NonTaskLambda_KeepsFuncOfTResultOverload()
+    {
+        // Guard: a NON-task-returning lambda argument (natural type
+        // Func<object>) must NOT be pulled onto the Func<Task<TResult>>
+        // overload — only the Func<TResult> overload applies, so the new
+        // betterness rule must leave this case untouched.
+        var funcTResult = typeof(Fixture).GetMethod(nameof(Fixture.Run_FuncTResult), BindingFlags.Public | BindingFlags.Static);
+        var funcTaskTResult = typeof(Fixture).GetMethod(nameof(Fixture.Run_FuncTaskTResult), BindingFlags.Public | BindingFlags.Static);
+        var argType = typeof(System.Func<object>);
+
+        var result = OverloadResolution.Resolve(new[] { funcTResult, funcTaskTResult }, new[] { argType });
+        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        Assert.Equal(nameof(Fixture.Run_FuncTResult), result.Best.Name);
     }
 
     [Fact]
@@ -889,6 +938,15 @@ public class OverloadResolutionTests
         public static void F_FormattableString(System.FormattableString fs) { _ = fs; }
 
         public static void F_IFormattable(System.IFormattable f) { _ = f; }
+
+        // Issue #2172: mirrors the Task.Run overload pair — a Func<TResult> form
+        // and a Func<Task<TResult>> form. For a task-returning lambda argument
+        // (natural type Func<Task<object>>) the Func<Task<TResult>> form must
+        // win (TResult = object → returns Task<object>), not the Func<TResult>
+        // form (TResult = Task<object> → returns Task<Task<object>>).
+        public static System.Threading.Tasks.Task<TResult> Run_FuncTResult<TResult>(System.Func<TResult> function) => System.Threading.Tasks.Task.Run(function);
+
+        public static System.Threading.Tasks.Task<TResult> Run_FuncTaskTResult<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> function) => System.Threading.Tasks.Task.Run(function);
     }
 
     /// <summary>


### PR DESCRIPTION
## Root cause
`Task.Run(async () -> await MakeAsync[T]())` failed overload resolution with **GS0160** ("Call to Run is ambiguous"), cascading into **GS0158** ("Cannot find member Result").

The async lambda's inferred return type is `Task[T]`, so its natural type is `Func[Task[T]]`. That is an **identity** conversion to *both* candidates:

- `Task.Run[TResult](Func[TResult])` with `TResult = Task[T]` -> returns `Task[Task[T]]`
- `Task.Run[TResult](Func[Task[TResult]])` with `TResult = T` -> returns `Task[T]`

Both close to the same `Func[Task[T]]` parameter, so neither dominated on conversion kind and every existing tie-break (fewer-params, more-specific, non-generic, method-hiding, constraint-specificity) left them tied -> ambiguous. Once `Run` failed, `task` was an error type and `.Result` could not bind (GS0158 was a pure cascade).

C# resolves this by preferring the task-returning delegate overload (`Func<Task<TResult>>`) for an async/task-returning lambda argument. gsc lacked that tie-break.

## Fix
Added a betterness rule to **both** overload resolvers: when an argument is a **task-returning delegate** (its natural function type returns `Task`/`Task[T]`/`ValueTask`), prefer candidates whose **open** delegate parameter is shaped `Func[Task[TResult]]` (binding the whole task to a Task-typed delegate result) over those shaped `Func[TResult]` (binding it to a bare method type parameter).

- **`OverloadResolution.RankApplicable`** (imported/BCL methods): new `PreferTaskShapedDelegateForTaskLambda` phase inspects each closed candidate's generic *definition* (`GetGenericMethodDefinition`) to classify the open delegate parameter's return shape (`TaskShaped` vs `BareTypeParameter`), comparing Task by namespace+name so it works across reflection contexts and for open-constructed types.
- **`OverloadResolver.SelectBestUserOverloadCore`** (user methods): the same rule over `FunctionTypeSymbol` delegate parameters, using the already-computed open `ParamTypes` and detecting Task via the erased CLR type (guard #835 - uses `IsSameAs`, never `== typeof`).

The rule is **generalized** (not keyed on `Task.Run`), only narrows when the pool genuinely splits into both shapes at a task-returning-lambda argument slot, and leaves non-task lambdas and single-shape overload sets untouched.

## Files changed
- `src/Core/CodeAnalysis/Binding/OverloadResolution.cs`
- `src/Core/CodeAnalysis/Binding/OverloadResolver.cs`
- `test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionTests.cs` (direct unit tests + fixtures)
- `test/Core.Tests/CodeAnalysis/Binding/Issue2172TaskRunAsyncLambdaOverloadTests.cs` (new)
- `test/Compiler.Tests/Emit/Issue2172TaskRunAsyncLambdaEmitTests.cs` (new)

## Tests
- **Unit**: `Resolve_TaskReturningLambda_PrefersFuncOfTaskOverload` (forward *and* reverse candidate order; asserts closed return type is `Task[object]`, not `Task[Task[object]]`) and a `Resolve_NonTaskLambda_KeepsFuncOfTResultOverload` guard.
- **Core binding**: issue repro (generic `Get[T]`) plus a generalized user overload set (`() -> T` vs `() -> Task[T]`) both bind clean; a non-async guard.
- **Emit**: `Task.Run` async lambda returns the awaited `int32`/`string` result at runtime, plus a **non-`Task.Run`** user overload set proving the rule is not hard-coded.
- Full Core.Tests: **5669 passed, 1 skipped**. Minimal repro compiles cleanly (no GS0160/GS0158).

Note: a pre-existing, orthogonal emit defect (a *generic* async-lambda closure inside a generic method crashes with `BadImageFormatException`, reproducible without any overloading via `let f = async () -> ...`) is out of scope for this overload-resolution fix; the emit tests therefore use runnable non-generic forms.

Fixes #2172
Refs #914
