### PR TITLE
Fix #2175: lower pointer compound-assignment p += i / p -= i

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -846,6 +846,23 @@ internal sealed partial class ExpressionBinder
     {
         var left = leftRead;
         var right = boundRhs;
+
+        // ADR-0122 §5 / issue #2175: a compound assignment `p op= i` where the
+        // target is an unmanaged pointer (`*T`) is `p = p op i`, so reuse the
+        // SAME pointer binary-operator lowering that `p + i` / `p - i` uses
+        // (scaled native-int arithmetic), instead of failing to find a built-in
+        // `+=`/`-=` operator (GS0129). This generalizes to every legal pointee
+        // type, both `+=` and `-=`, and any integer RHS the binary path accepts;
+        // a `*void` target is rejected exactly as the binary path rejects it.
+        if (left.Type is PointerTypeSymbol)
+        {
+            var pointerResult = TryBindPointerBinaryOperation(baseOperatorKind, rhsLocation, left, right);
+            if (pointerResult != null)
+            {
+                return pointerResult;
+            }
+        }
+
         var op = BindBinaryOperatorWithNumericAdaptation(baseOperatorKind, ref left, ref right, rhsLocation, rhsLocation);
         if (op != null)
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -351,11 +351,27 @@ internal sealed partial class ExpressionBinder
     /// <param name="left">The bound left operand.</param>
     /// <param name="right">The bound right operand.</param>
     /// <returns>The lowered bound expression, or <see langword="null"/>.</returns>
-    private BoundExpression TryBindPointerBinaryExpression(BinaryExpressionSyntax syntax, BoundExpression left, BoundExpression right)
+    private BoundExpression TryBindPointerBinaryExpression(BinaryExpressionSyntax syntax, BoundExpression left, BoundExpression right) =>
+        TryBindPointerBinaryOperation(syntax.OperatorToken.Kind, syntax.OperatorToken.Location, left, right);
+
+    /// <summary>
+    /// ADR-0122 / issue #1014: lowers a pointer arithmetic or comparison
+    /// operation given the base operator token kind (not tied to a
+    /// <see cref="BinaryExpressionSyntax"/>), so that both the binary form
+    /// <c>p + i</c> and the compound-assignment form <c>p += i</c> (issue
+    /// #2175) share the SAME pointer lowering. Returns <see langword="null"/>
+    /// when the operator/operand shape is not a supported pointer operation.
+    /// </summary>
+    /// <param name="operatorKind">The base binary operator token kind.</param>
+    /// <param name="operatorLocation">The source location used for diagnostics.</param>
+    /// <param name="left">The bound left operand.</param>
+    /// <param name="right">The bound right operand.</param>
+    /// <returns>The lowered bound expression, or <see langword="null"/>.</returns>
+    private BoundExpression TryBindPointerBinaryOperation(SyntaxKind operatorKind, TextLocation operatorLocation, BoundExpression left, BoundExpression right)
     {
         var leftPtr = left.Type as PointerTypeSymbol;
         var rightPtr = right.Type as PointerTypeSymbol;
-        switch (syntax.OperatorToken.Kind)
+        switch (operatorKind)
         {
             case SyntaxKind.PlusToken:
                 // ADR-0122 §3 / issue #1033: a `*void` pointer has no element
@@ -363,7 +379,7 @@ internal sealed partial class ExpressionBinder
                 // GS0403 (cast to a typed pointer `*T` first).
                 if (TypeSymbol.IsVoidPointer(left.Type) || TypeSymbol.IsVoidPointer(right.Type))
                 {
-                    Diagnostics.ReportVoidPointerOperationNotAllowed(syntax.OperatorToken.Location, "perform arithmetic on");
+                    Diagnostics.ReportVoidPointerOperationNotAllowed(operatorLocation, "perform arithmetic on");
                     return new BoundErrorExpression(null);
                 }
 
@@ -385,7 +401,7 @@ internal sealed partial class ExpressionBinder
                 // size, so a `*void` operand is rejected (GS0403).
                 if (TypeSymbol.IsVoidPointer(left.Type) || TypeSymbol.IsVoidPointer(right.Type))
                 {
-                    Diagnostics.ReportVoidPointerOperationNotAllowed(syntax.OperatorToken.Location, "perform arithmetic on");
+                    Diagnostics.ReportVoidPointerOperationNotAllowed(operatorLocation, "perform arithmetic on");
                     return new BoundErrorExpression(null);
                 }
 
@@ -412,7 +428,7 @@ internal sealed partial class ExpressionBinder
             case SyntaxKind.LessOrEqualsToken:
             case SyntaxKind.GreaterToken:
             case SyntaxKind.GreaterOrEqualsToken:
-                return LowerPointerComparison(syntax.OperatorToken.Kind, left, right);
+                return LowerPointerComparison(operatorKind, left, right);
 
             default:
                 return null;

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2175PointerCompoundAssignmentEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2175PointerCompoundAssignmentEmitTests.cs
@@ -1,0 +1,197 @@
+// <copyright file="Issue2175PointerCompoundAssignmentEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #2175 / ADR-0122 §5: inside an <c>unsafe</c> context the binary
+/// pointer arithmetic forms <c>p + i</c> / <c>p - i</c> bind and lower to
+/// scaled native-int arithmetic, but the compound-assignment forms
+/// <c>p += i</c> / <c>p -= i</c> were rejected with GS0129 even though
+/// <c>p += i</c> is exactly <c>p = p + i</c>. The fix makes the compound
+/// binder reuse the SAME pointer binary-operator lowering when the target is
+/// an unmanaged pointer (<c>*T</c>), generalizing across every legal pointee
+/// type, both <c>+=</c> and <c>-=</c>, and any integer RHS the binary path
+/// accepts.
+/// </summary>
+public class Issue2175PointerCompoundAssignmentEmitTests
+{
+    [Fact]
+    public void PointerCompoundAssignment_UInt8_Binds()
+    {
+        // The exact repro from issue #2175: `ArithBinary` already compiled;
+        // `ArithCompound` used to error GS0129 on both `+=` and `-=`.
+        const string Source = @"
+package R
+unsafe class P {
+    unsafe func ArithBinary(pBuf *uint8, n int32) *uint8 {
+        var q = pBuf + n
+        return q
+    }
+    unsafe func ArithCompound(pBuf *uint8, n int32) *uint8 {
+        var q = pBuf
+        q += n
+        q -= n
+        return q
+    }
+}
+";
+        var diagnostics = GetDiagnostics(Source);
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void PointerCompoundAssignment_Int32Pointee_Binds()
+    {
+        // Generalizes beyond `*uint8`: a `*int32` pointee scales by 4.
+        const string Source = @"
+package P
+import System
+
+unsafe func run() {
+    var arr = []int32{1, 2, 3, 4}
+    var p *int32 = &arr[0]
+    var q = p
+    q += 2
+    q -= 1
+}
+";
+        var diagnostics = GetDiagnostics(Source);
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void PointerCompoundAssignment_VoidPointee_ReportsGS0403()
+    {
+        // A `*void` pointer has no element size, so compound arithmetic must be
+        // rejected exactly as the binary `p + i` form rejects it (ADR-0122 §3).
+        const string Source = @"
+package P
+import System
+
+unsafe func run() {
+    var arr = []int32{1, 2}
+    var p *int32 = &arr[0]
+    var v = *void(p)
+    v += 1
+}
+";
+        var diagnostics = GetDiagnostics(Source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0403");
+    }
+
+    [Fact]
+    public void PointerCompoundAssignment_PlusEquals_Int32_AdvancesScaledByElementSize()
+    {
+        // `q += 2` on a `*int32` must advance by 2 elements (8 bytes), landing
+        // on arr[2], identical to `q = q + 2`.
+        const string Source = @"package Issue2175PlusEq
+import System
+
+unsafe func run() {
+    var arr = []int32{3, 5, 7, 11}
+    var p *int32 = &arr[0]
+    var q = p
+    q += 2
+    Console.WriteLine(*q)
+    q -= 1
+    Console.WriteLine(*q)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue2175PlusEq");
+        var lines = output.Split(new[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("7", lines[0]);
+        Assert.Equal("5", lines[1]);
+    }
+
+    [Fact]
+    public void PointerCompoundAssignment_UInt8_AdvancesByOneByteElement()
+    {
+        // A `*uint8` pointee scales by 1: `q += 3` lands on arr[3].
+        const string Source = @"package Issue2175UInt8
+import System
+
+unsafe func run() {
+    var arr = []uint8{10, 20, 30, 40}
+    var p *uint8 = &arr[0]
+    var q = p
+    q += 3
+    Console.WriteLine(*q)
+    q -= 2
+    Console.WriteLine(*q)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue2175UInt8");
+        var lines = output.Split(new[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("40", lines[0]);
+        Assert.Equal("20", lines[1]);
+    }
+
+    private static IEnumerable<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        return compilation.Emit(peStream).Diagnostics;
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Inside an `unsafe` context, binary pointer arithmetic `p + i` / `p - i` binds and lowers correctly (ADR-0122 §5), but the compound-assignment forms `p += i` / `p -= i` were rejected with **GS0129** (`Binary operator '+=' is not defined for types '*uint8' and 'int32'`), even though `p += i` is exactly `p = p + i`.

## Root cause
`TryBindCompoundBinaryOperation` only attempted built-in numeric adaptation and user/CLR `op_*` fallback. It never routed through the pointer binary-operator lowering, so for a pointer target no `+=`/`-=` operator was found → GS0129.

## Fix
- Extracted the pointer binary lowering into `TryBindPointerBinaryOperation(operatorKind, operatorLocation, left, right)`; the existing `TryBindPointerBinaryExpression(syntax, …)` now delegates to it.
- In `TryBindCompoundBinaryOperation`, when the target type is an unmanaged pointer (`*T`), reuse that SAME lowering so `p op= i` binds and lowers identically to `p = p op i` (scaled native-int arithmetic).

Generalizes across every legal pointee type (`*uint8`, `*int32`, struct pointers, …), both `+=` and `-=`, and any integer RHS the binary path accepts. A `*void` target is rejected with GS0403 exactly as the binary path rejects it. No new `BoundNodeKind` / `SyntaxKind` was added, matching ADR-0122's approach (no coverage-matrix churn).

## Tests
Added `Issue2175PointerCompoundAssignmentEmitTests` covering: the exact repro binds clean, `*int32` pointee binds, `*void` compound is rejected (GS0403), and runtime execution proving `+=`/`-=` advance the pointer scaled by element size for both `*int32` and `*uint8`.

Verified:
- Repro compiles CLEAN via gsc.
- `--filter "FullyQualifiedName~Pointer|FullyQualifiedName~Unsafe"` → 135 passed.
- `--filter "FullyQualifiedName~Compound|FullyQualifiedName~Assignment"` → 242 passed.
- New class → 5 passed.

Fixes #2175
Refs #914
