### PR TITLE
cs2gs: emit explicit pointer cast *Target(expr) for C# implicit pointer→pointer conversions

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914PointerConversionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914PointerConversionTranslationTests.cs
@@ -1,0 +1,184 @@
+// <copyright file="Issue914PointerConversionTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #914: in C# a pointer→pointer conversion between different pointee
+/// types (<c>byte* → void*</c>) is IMPLICIT, but per ADR-0122 §6 G# requires
+/// it to be spelled explicitly as the conversion-call <c>*&lt;TargetPointee&gt;(expr)</c>
+/// (<c>*void(expr)</c>, <c>*uint8(expr)</c>). Emitting the bare operand fails
+/// gsc with GS0156 ("An explicit conversion exists"). These tests cover the
+/// implicit conversion at argument, assignment, return, and local-initializer
+/// positions, verify a same-pointee argument is NOT wrapped, and verify an
+/// already-explicit C# cast is not double-wrapped.
+/// </summary>
+public class Issue914PointerConversionTranslationTests
+{
+    [Fact]
+    public void ImplicitBytePtrToVoidPtr_Argument_EmitsExplicitConversion()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue914
+{
+    public static unsafe class Holder
+    {
+        public static void Sink(void* p) { }
+
+        public static void Pass(byte* pBuf)
+        {
+            Sink(pBuf);
+        }
+    }
+}
+");
+
+        Assert.Contains("Sink(*void(pBuf))", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ImplicitBytePtrToVoidPtr_Assignment_EmitsExplicitConversion()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue914
+{
+    public static unsafe class Holder
+    {
+        public static void Assign(byte* p)
+        {
+            void* q = null;
+            q = p;
+        }
+    }
+}
+");
+
+        Assert.Contains("q = *void(p)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ImplicitIntPtrToVoidPtr_Return_EmitsExplicitConversion()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue914
+{
+    public static unsafe class Holder
+    {
+        public static void* Widen(int* p)
+        {
+            return p;
+        }
+    }
+}
+");
+
+        Assert.Contains("return *void(p)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ImplicitBytePtrToVoidPtr_LocalInitializer_EmitsExplicitConversion()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue914
+{
+    public static unsafe class Holder
+    {
+        public static void Init(byte* pBuf)
+        {
+            void* p = pBuf;
+        }
+    }
+}
+");
+
+        Assert.Contains("*void(pBuf)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SamePointeeArgument_IsNotWrapped()
+    {
+        // `void* → void*` needs no conversion; the argument must stay bare.
+        string rendered = Render(@"
+namespace Corpus.Issue914
+{
+    public static unsafe class Holder
+    {
+        public static void Sink(void* p) { }
+
+        public static void Pass(void* pBuffer)
+        {
+            Sink(pBuffer);
+        }
+    }
+}
+");
+
+        Assert.Contains("Sink(pBuffer)", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("*void(pBuffer)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ExplicitCastArgument_IsNotDoubleWrapped()
+    {
+        // An explicit C# `(void*)pBuf` already renders as `*void(pBuf)`; the
+        // implicit-conversion pass must not wrap it again.
+        string rendered = Render(@"
+namespace Corpus.Issue914
+{
+    public static unsafe class Holder
+    {
+        public static void Sink(void* p) { }
+
+        public static void Pass(byte* pBuf)
+        {
+            Sink((void*)pBuf);
+        }
+    }
+}
+");
+
+        Assert.Contains("Sink(*void(pBuf))", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("*void(*void(pBuf))", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5277,7 +5277,9 @@ public sealed class CSharpToGSharpTranslator
                         }
                     }
 
-                    returnPrologue.Add(new ReturnStatement(returnValue, isRef: ret.Expression is RefExpressionSyntax));
+                    returnPrologue.Add(new ReturnStatement(
+                        this.CoercePointerConversion(ret.Expression, returnValue),
+                        isRef: ret.Expression is RefExpressionSyntax));
                     return returnPrologue;
                 }
 
@@ -5421,9 +5423,11 @@ public sealed class CSharpToGSharpTranslator
 
                     try
                     {
-                        initializer = this.CoerceConstantToUnsigned(
+                        initializer = this.CoercePointerConversion(
                             declarator.Initializer.Value,
-                            this.TranslateExpression(declarator.Initializer.Value));
+                            this.CoerceConstantToUnsigned(
+                                declarator.Initializer.Value,
+                                this.TranslateExpression(declarator.Initializer.Value)));
                     }
                     finally
                     {
@@ -6272,6 +6276,41 @@ public sealed class CSharpToGSharpTranslator
                 new BinaryExpression(expression, "as", new TypeExpression(target)));
         }
 
+        // Wraps a translated expression in an explicit G# pointer conversion-call
+        // (`*void(expr)`, `*uint8(expr)`, ...) when C# performed an IMPLICIT
+        // pointer→pointer conversion at this position. In C# a pointer→pointer
+        // conversion between DIFFERENT pointee types (`byte* → void*`,
+        // `void* → byte*`, `int* → void*`, ...) is implicit, but per ADR-0122 §6
+        // G# requires it to be spelled explicitly as the conversion-call
+        // `*<TargetPointee>(expr)`; the bare operand is rejected with GS0156
+        // ("An explicit conversion exists"). Applied at argument, assignment,
+        // return, and local-initializer positions (issue #914).
+        //
+        // No wrap is emitted when the pointee types are identical (no conversion
+        // is needed) — this also naturally covers an already-explicit C# cast
+        // `(void*)x` bound to a `void*` target (source == converted == `void*`),
+        // which cs2gs already renders as `*void(x)`, avoiding a double wrap. The
+        // full target pointer type is mapped through the standard type mapper so
+        // the pointee (`void`, `uint8`, `int32`, ...) is spelled with G# names.
+        private GExpression CoercePointerConversion(ExpressionSyntax expression, GExpression translated)
+        {
+            if (expression == null)
+            {
+                return translated;
+            }
+
+            TypeInfo info = this.context.GetTypeInfo(expression);
+            if (info.Type is IPointerTypeSymbol source &&
+                info.ConvertedType is IPointerTypeSymbol target &&
+                !SymbolEqualityComparer.Default.Equals(source.PointedAtType, target.PointedAtType))
+            {
+                GTypeReference targetRef = this.typeMapper.Map(target, this.context, expression.GetLocation());
+                return new ConversionExpression(targetRef, translated);
+            }
+
+            return translated;
+        }
+
         // Reports whether `type` is a value type that is not `System.Nullable<T>`,
         // i.e. a target for which G#'s `as` operator is invalid (GS0270) and the
         // conversion-call form must be used instead.
@@ -6738,6 +6777,7 @@ public sealed class CSharpToGSharpTranslator
                         assignment.Right,
                         this.TranslateExpression(assignment.Right));
                     assignRhs = this.CoerceCompoundAssignmentRhs(assignment, assignRhs);
+                    assignRhs = this.CoercePointerConversion(assignment.Right, assignRhs);
                     return new AssignmentStatement(
                         this.TranslateAssignmentTarget(assignment.Left),
                         assignRhs,
@@ -13723,9 +13763,11 @@ public sealed class CSharpToGSharpTranslator
             // CoerceNumericArgumentToConverted (issue #1281) emits the bare operand
             // when gsc accepts the conversion on its own and keeps the explicit
             // `T(x)` wrap only where gsc still needs it.
-            return this.CoerceNumericArgumentToConverted(
-                argument,
-                this.TranslateExpression(argument.Expression));
+            return this.CoercePointerConversion(
+                argument.Expression,
+                this.CoerceNumericArgumentToConverted(
+                    argument,
+                    this.TranslateExpression(argument.Expression)));
         }
 
         // Coerce an argument expression to the numeric type C# implicitly converted


### PR DESCRIPTION
## Problem
In C# a pointer→pointer conversion between different pointee types (e.g. `byte* → void*`) is **implicit**, but per ADR-0122 §6 G# requires pointer↔pointer conversions to be written **explicitly** as the conversion-call `*<TargetPointee>(expr)` (e.g. `*void(pBuf)`, `*uint8(p)`). cs2gs previously emitted the bare operand, which gsc rejects with **GS0156** ("Cannot convert '*uint8' to '*void'. An explicit conversion exists").

This surfaced in Oahu's `Win32FileIO.cs`, where a `byte*` argument passed to a `void*` extern parameter (`ReadFile(handle, pBuf, ...)`) translated to bare `pBuf`.

## Fix
Add `CoercePointerConversion`, which uses the Roslyn semantic model (source `GetTypeInfo(expr).Type` vs target `.ConvertedType`) to detect when **both** are `IPointerTypeSymbol` with **different** `PointedAtType`, and wraps the translated expression in a conversion-call. The target pointer type is mapped through the existing type mapper, so pointees are spelled with G# names (`byte`→`uint8`, `void`→`void`, `int`→`int32`) — no hardcoding.

- Generalized to any pointee pair (`byte*`/`int*`→`void*`, etc.).
- Applied at **argument**, **assignment**, **return**, and **local-initializer** positions.
- **No wrap** when pointee types match (no conversion needed).
- **No double-wrap**: an already-explicit `(void*)x` cast has equal source/converted pointee types, so it is skipped and keeps its existing `*void(x)` rendering.

Translator-only change; nothing under `src/` is touched.

## Tests
Adds `Issue914PointerConversionTranslationTests` (6 cases): implicit `byte*→void*` at argument/assignment/local-init, implicit `int*→void*` at return, same-pointee no-wrap, and already-cast no-double-wrap. Each asserts the emitted G# and round-trip-parses.

```
dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-restore \
  --filter "FullyQualifiedName~Issue914PointerConversionTranslationTests"
# Passed! - Failed: 0, Passed: 6
```
Full cs2gs suite: `Passed! - Failed: 0, Passed: 1128`.

Refs #914
