### PR TITLE
Fix #2176: imported unmanaged pointer members bind as non-nullable *T

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
@@ -358,6 +358,12 @@ public static class ClrNullability
     {
         var baseSymbol = TypeSymbol.FromClrType(clrType);
 
+        // Issue #2176: pointers are not reference types — never nullable-wrap on import.
+        if (clrType.IsPointer || baseSymbol is PointerTypeSymbol or FunctionPointerTypeSymbol)
+        {
+            return baseSymbol;
+        }
+
         if (clrType.IsValueType)
         {
             // Value types carry no reference-nullability byte for themselves.
@@ -398,6 +404,18 @@ public static class ClrNullability
         }
 
         if (clrType == null || clrType.IsValueType)
+        {
+            return baseSymbol;
+        }
+
+        // Issue #2176 (Refs #914, ADR-0122): unmanaged pointers (`T*` / `void*`,
+        // ELEMENT_TYPE_PTR) are NOT reference types and must never be wrapped in a
+        // nullable reference annotation on import. The oblivious-nullable promotion
+        // applies only to genuine reference types — mirror the source-side
+        // `IsPromotedToNullableReference` gate (`declared is { IsReferenceType: true }`)
+        // which structurally excludes pointers. This covers every imported member
+        // position (return, parameter, field, property, indexer) that flows through here.
+        if (clrType.IsPointer || baseSymbol is PointerTypeSymbol or FunctionPointerTypeSymbol)
         {
             return baseSymbol;
         }

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue2176ImportedPointerNullabilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue2176ImportedPointerNullabilityTests.cs
@@ -1,0 +1,66 @@
+// <copyright file="Issue2176ImportedPointerNullabilityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #2176 (Refs #914, ADR-0122): when gsc imports a BCL/metadata member
+/// whose type is an unmanaged pointer (<c>void*</c> / <c>T*</c>,
+/// <c>ELEMENT_TYPE_PTR</c>), the oblivious-nullable-reference promotion must NOT
+/// wrap it in a nullable annotation. Pointers are <see cref="TypeKind.Pointer"/>
+/// with <c>IsReferenceType == false</c>, so they are structurally excluded from
+/// the promotion — exactly as the source-side <c>IsPromotedToNullableReference</c>
+/// gate already excludes them. The imported return of
+/// <c>System.IntPtr.ToPointer()</c> (declared <c>public void* ToPointer()</c>)
+/// must bind as non-nullable <c>*void</c>, not <c>*void?</c>.
+/// </summary>
+public class Issue2176ImportedPointerNullabilityTests
+{
+    [Fact]
+    public void ImportedVoidPointerReturn_AssignedToNonNullablePointer_NoGS0155()
+    {
+        const string source = @"
+package R
+import System
+unsafe class P {
+    var pBuffer *void
+    unsafe func Init(pAddr System.IntPtr) void {
+        pBuffer = *void(pAddr.ToPointer())
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0155");
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void ImportedVoidPointerReturn_BindsAsNonNullablePointer()
+    {
+        var toPointer = typeof(System.IntPtr)
+            .GetMethods()
+            .First(m => m.Name == "ToPointer" && m.GetParameters().Length == 0);
+
+        var returnType = ClrNullability.GetReturnTypeSymbol(toPointer);
+
+        Assert.IsType<PointerTypeSymbol>(returnType);
+        Assert.IsNotType<NullableTypeSymbol>(returnType);
+    }
+
+    private static IEnumerable<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics;
+    }
+}


### PR DESCRIPTION
## Root cause
The gsc metadata/symbol importer applies an oblivious-nullable-reference promotion (the Kotlin-style "unannotated imported reference types are nullable" reading, issue #1354) to imported member types. `ApplyReferenceNullabilityFull` only short-circuited for `clrType.IsValueType`, so **unmanaged pointer types** (`void*` / `T*`, `ELEMENT_TYPE_PTR`) — which are neither value types nor reference types — fell through and were wrapped in a nullable annotation.

Because `System.IntPtr.ToPointer()` is declared `public void* ToPointer()`, its return imported as `*void?` instead of `*void`. Assigning that to a non-nullable pointer field produced `error GS0155: Cannot convert type '*void?' to '*void'`.

## Fix
Pointers are `TypeKind.Pointer` with `IsReferenceType == false` and must never be nullable-wrapped on import — exactly as the source-side `IsPromotedToNullableReference` gate (`declared is { IsReferenceType: true }`, ADR-0122) already excludes them. This adds a structural pointer exclusion (`clrType.IsPointer` / `PointerTypeSymbol` / `FunctionPointerTypeSymbol`) at the single import chokepoint `ApplyReferenceNullabilityFull`, which serves every imported member position (return, parameter, field, property, indexer), plus the same guard in `SymbolFromFlagsOffset` for inner positions. Genuine reference-type oblivious promotion is unchanged.

## Verification
- `System.IntPtr.ToPointer()` repro now compiles CLEAN (previously GS0155).
- New test class `Issue2176ImportedPointerNullabilityTests` asserts the imported return binds as a non-nullable `PointerTypeSymbol` and the repro binds without GS0155.
- Pointer/Unsafe/Nullable subset: 435 passed, 0 failed. Import/oblivious-nullability subset: 235 passed, 0 failed.

Fixes #2176
Refs #914
