### PR TITLE
Fix #2181: recognize explicit implementation of generic interface methods

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -7122,13 +7122,20 @@ internal sealed class DeclarationBinder
     /// to issue #2010: bare simple names collided across namespaces
     /// (<c>Foo.IBar</c> vs <c>Baz.IBar</c>); qualifying by package name (G#'s
     /// analogue of a C# namespace) plus any containing-type nesting fixes it.
+    /// Issue #2181: the generic-arity/type-argument suffix (e.g. the
+    /// <c>[T, TResult]</c> a constructed generic interface carries in its
+    /// <c>Name</c>) is stripped so the result matches the
+    /// cs2gs-side mangle, which formats the interface component with
+    /// <c>SymbolDisplayGenericsOptions.None</c> (simple name only, no type
+    /// parameters) — otherwise a class's mangled explicit implementation of a
+    /// generic interface method never name-matches its slot.
     /// </summary>
     private static string QualifyInterfaceName(InterfaceSymbol iface)
     {
         var parts = new List<string>();
         for (TypeSymbol current = iface; current != null; current = GetContainingType(current))
         {
-            parts.Insert(0, current.Name);
+            parts.Insert(0, StripGenericSuffix(current.Name));
         }
 
         if (!string.IsNullOrEmpty(iface.PackageName))
@@ -7141,6 +7148,24 @@ internal sealed class DeclarationBinder
         }
 
         return string.Join("_", parts);
+    }
+
+    /// <summary>
+    /// Issue #2181: returns <paramref name="name"/> with any trailing generic
+    /// type-parameter / type-argument suffix removed — a constructed or open
+    /// generic type's <c>Name</c> is formatted as
+    /// <c>Simple[Arg1, Arg2]</c>, and only the simple leading identifier
+    /// participates in the mangled explicit-interface-implementation name.
+    /// </summary>
+    private static string StripGenericSuffix(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return name;
+        }
+
+        var bracket = name.IndexOf('[', System.StringComparison.Ordinal);
+        return bracket < 0 ? name : name.Substring(0, bracket);
     }
 
     private static TypeSymbol GetContainingType(TypeSymbol type) => type switch

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -11781,15 +11781,25 @@ internal sealed class ReflectionMetadataEmitter
             EntityHandle? slotHandle = null;
             foreach (var iface in structSymbol.Interfaces)
             {
-                var defIface = iface.Definition ?? iface;
-                if (defIface.Methods.IsDefaultOrEmpty || !defIface.Methods.Contains(ifaceMember))
+                // Issue #2181: for a constructed generic interface, the linked
+                // `ExplicitInterfaceMember` is the SUBSTITUTED method surfaced
+                // on the constructed instance (`iface.Methods`), not the open
+                // definition's slot — so match against the constructed
+                // instance's methods here, then map back to the open slot for
+                // the MethodDef / MemberRef token resolution (the open slot is
+                // what `MethodHandles` and `ResolveUserInterfaceInstanceMethodToken`
+                // are keyed by). For a non-generic interface `iface.Methods` is
+                // the definition's own table and the map is an identity, so the
+                // pre-existing behavior is unchanged.
+                if (iface.Methods.IsDefaultOrEmpty || !iface.Methods.Contains(ifaceMember))
                 {
                     continue;
                 }
 
+                var openSlot = ResolveOpenInterfaceInstanceMethod(iface, ifaceMember);
                 slotHandle = IsUserGenericInterfaceReference(iface)
-                    ? this.ResolveUserInterfaceInstanceMethodToken(iface, ifaceMember)
-                    : this.cache.MethodHandles.TryGetValue(ifaceMember, out var slotDefHandle)
+                    ? this.ResolveUserInterfaceInstanceMethodToken(iface, openSlot)
+                    : this.cache.MethodHandles.TryGetValue(openSlot, out var slotDefHandle)
                         ? slotDefHandle
                         : (EntityHandle?)null;
                 break;
@@ -11881,6 +11891,45 @@ internal sealed class ReflectionMetadataEmitter
     /// interface is not a constructed instance, or when no open counterpart is
     /// found.
     /// </summary>
+    /// <summary>
+    /// Issue #2181: maps a (possibly substituted) instance method slot on a
+    /// constructed generic interface back to its open declaration on the
+    /// interface definition — the counterpart of
+    /// <see cref="ResolveOpenInterfaceStaticMethod"/> for the (non-static)
+    /// <see cref="InterfaceSymbol.Methods"/> table. Positional match first
+    /// (the constructed instance's <c>Methods</c> mirror the definition's
+    /// order), with a name/arity fallback; returns <paramref name="slot"/>
+    /// unchanged when the interface is a plain definition (identity map).
+    /// </summary>
+    private static FunctionSymbol ResolveOpenInterfaceInstanceMethod(InterfaceSymbol iface, FunctionSymbol slot)
+    {
+        var def = iface.Definition ?? iface;
+        if (ReferenceEquals(def, iface))
+        {
+            return slot;
+        }
+
+        var constructedMethods = iface.Methods;
+        var defMethods = def.Methods;
+        for (var i = 0; i < constructedMethods.Length; i++)
+        {
+            if (ReferenceEquals(constructedMethods[i], slot) && i < defMethods.Length)
+            {
+                return defMethods[i];
+            }
+        }
+
+        foreach (var m in defMethods)
+        {
+            if (m.Name == slot.Name && m.Parameters.Length == slot.Parameters.Length)
+            {
+                return m;
+            }
+        }
+
+        return slot;
+    }
+
     private static FunctionSymbol ResolveOpenInterfaceStaticMethod(InterfaceSymbol iface, FunctionSymbol slot)
     {
         var def = iface.Definition ?? iface;

--- a/test/Compiler.Tests/Emit/Issue2181GenericExplicitInterfaceImplEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2181GenericExplicitInterfaceImplEmitTests.cs
@@ -1,0 +1,290 @@
+// <copyright file="Issue2181GenericExplicitInterfaceImplEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2181 (follow-up to #2010): a method using the reserved
+/// <c>__explicit_&lt;Interface&gt;__&lt;Member&gt;</c> mangled convention
+/// correctly satisfied a NON-generic interface member, but was not recognized
+/// when the interface was GENERIC — the class was wrongly reported as not
+/// implementing the interface method (GS0187).
+/// <para>
+/// Two defects were fixed. (1) The binder-side
+/// <c>DeclarationBinder.QualifyInterfaceName</c> included the generic
+/// type-parameter suffix (<c>ICallback[T, TResult]</c>) in the name it matched
+/// against the mangled component, while cs2gs formats that component with
+/// <c>SymbolDisplayGenericsOptions.None</c> (simple name only); the suffix is
+/// now stripped so the names match. (2) The emitter's
+/// <c>EmitExplicitInterfaceMethodImpls</c> looked for the linked interface
+/// member on the interface DEFINITION's method table, but for a constructed
+/// generic interface the linked member is the SUBSTITUTED instance on the
+/// constructed interface — so no <c>MethodImpl</c> row was emitted and the
+/// type failed to load. The emitter now matches the constructed instance's
+/// methods and maps back to the open slot for token resolution.
+/// </para>
+/// <para>The non-generic path (issue #2010) is intentionally unchanged.</para>
+/// </summary>
+public class Issue2181GenericExplicitInterfaceImplEmitTests
+{
+    private const string GenericReproSource = """
+        package Oahu.Aux
+
+        interface ICallback[T, TResult] {
+            func Interact(value T) TResult;
+        }
+
+        open class Callback[T, TResult] : ICallback[T, TResult] {
+            private func __explicit_Oahu_Aux_ICallback__Interact(value T) TResult -> OnInteract(value)
+
+            protected open func OnInteract(value T) TResult {
+                return default(TResult)
+            }
+        }
+
+        open class Doubler : Callback[int32, int32] {
+            protected override func OnInteract(value int32) int32 {
+                return value * 2
+            }
+        }
+        """;
+
+    private const string NonGenericReproSource = """
+        package Oahu.Aux
+
+        interface ICallback2 {
+            func Interact(value int32) string;
+        }
+
+        open class Callback2 : ICallback2 {
+            private func __explicit_Oahu_Aux_ICallback2__Interact(value int32) string -> OnInteract(value)
+
+            protected open func OnInteract(value int32) string {
+                return "base"
+            }
+        }
+        """;
+
+    [Fact]
+    public void GenericExplicitImpl_Compiles_EmitsMethodImplRow_IlVerifies()
+    {
+        var dllPath = CompileLibrary(GenericReproSource);
+        try
+        {
+            using var stream = File.OpenRead(dllPath);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+
+            TypeDefinition callback = default;
+            bool foundCallback = false;
+            foreach (var typeHandle in reader.TypeDefinitions)
+            {
+                var td = reader.GetTypeDefinition(typeHandle);
+                if (reader.GetString(td.Name).StartsWith("Callback", StringComparison.Ordinal) &&
+                    reader.GetString(td.Name) != "Callback2")
+                {
+                    callback = td;
+                    foundCallback = true;
+                    break;
+                }
+            }
+
+            Assert.True(foundCallback, "expected to find the generic Callback type");
+
+            // The mangled explicit-impl body survives as its own MethodDef.
+            int mangledBodies = callback.GetMethods()
+                .Select(mh => reader.GetString(reader.GetMethodDefinition(mh).Name))
+                .Count(n => n == "__explicit_Oahu_Aux_ICallback__Interact");
+            Assert.Equal(1, mangledBodies);
+
+            // Issue #2181: a MethodImpl row must bind the mangled body to the
+            // (generic) interface's Interact slot — without it the type fails
+            // to load at runtime with a TypeLoadException.
+            int methodImplRows = callback.GetMethodImplementations().Count();
+            Assert.Equal(1, methodImplRows);
+        }
+        finally
+        {
+            TryCleanup(dllPath);
+        }
+    }
+
+    [Fact]
+    public void GenericExplicitImpl_DispatchesThroughConstructedInterface()
+    {
+        // End-to-end: an ICallback[int32, int32]-typed reference routes into
+        // the mangled explicit implementation, which forwards to the overriding
+        // OnInteract body (value * 2). Proves the constructed-generic slot is
+        // wired up at the CLR level.
+        var source = GenericReproSource + """
+
+
+            var obj = Doubler{}
+            var cb ICallback[int32, int32] = obj
+            Console.WriteLine(cb.Interact(21))
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NonGenericExplicitImpl_StillCompilesAndDispatches()
+    {
+        // Regression guard: the issue #2010 non-generic path is unchanged.
+        var source = NonGenericReproSource + """
+
+
+            var obj = Callback2{}
+            var cb ICallback2 = obj
+            Console.WriteLine(cb.Interact(7))
+            """;
+
+        Assert.Equal("base\n", CompileAndRun(source));
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2181_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2181_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A method using the reserved `__explicit_<Interface>__<Member>` mangled-name convention (issue #2010 — the form cs2gs synthesizes for a C# explicit interface implementation) correctly satisfied a **non-generic** interface member, but was **not recognized** when the interface was **generic**. The class was wrongly reported as not implementing the interface method → `GS0187`.

## Root cause

Two defects, both specific to the generic case:

1. **Binder name mismatch.** `DeclarationBinder.QualifyInterfaceName` derived the string it compares against the mangled component from the interface symbol's `Name`. For a constructed generic interface that `Name` includes the type-argument suffix (`ICallback[T, TResult]`), whereas the cs2gs side formats the interface component with `SymbolDisplayGenericsOptions.None` (simple name only, e.g. `Oahu_Aux_ICallback`). The strings never matched, so the mangled method was never linked to the interface slot.

2. **Emitter missing MethodImpl row.** Once the name match was fixed, the class bound, but the emitted type failed to load with a `TypeLoadException`: `EmitExplicitInterfaceMethodImpls` searched for the linked `ExplicitInterfaceMember` in the interface **definition's** method table, but for a constructed generic interface the linked member is the **substituted** instance surfaced on the constructed interface (`iface.Methods`). No `MethodImpl` row was emitted.

## Fix

1. `QualifyInterfaceName` strips the generic suffix (`StripGenericSuffix`) from every name segment, matching cs2gs. Handles any arity, multiple type parameters, and nested generic containing types. Non-generic names are untouched.

2. `EmitExplicitInterfaceMethodImpls` matches against the constructed interface's `Methods`, maps the substituted member back to the open definition slot via a new `ResolveOpenInterfaceInstanceMethod` helper (the instance-method counterpart of the existing `ResolveOpenInterfaceStaticMethod`), and resolves the slot token against the constructed interface's TypeSpec. For a non-generic interface the map is an identity, so the issue #2010 path is unchanged.

## Tests

New `Issue2181GenericExplicitInterfaceImplEmitTests` covering: generic explicit-impl binding + emitted `MethodImpl` row + IL verification, end-to-end dispatch through the constructed interface (`ICallback[int32,int32].Interact(21)` → `42`), and a non-generic regression guard. Existing issue #2010 / #1007 / #1911 / explicit-interface tests and the full 226-test interface suite pass.

Fixes #2181
Refs #914
