### PR TITLE
Fix #2185: invoke non-identifier function-typed expression (parenthesized / null-forgiven / smart-cast-narrowed) callee

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -4494,11 +4494,143 @@ internal sealed class OverloadResolver
             }
         }
 
+        // Issue #2185: a bare field/property callee (`hn(value)` after an
+        // `if hn == nil { return }` guard) records its null-guard narrowing under
+        // the stable member access path (`this.hn`), not the bare variable symbol.
+        // Look that path up too, so a smart-cast-narrowed nullable function-typed
+        // field is recognised as callable exactly like a narrowed local. Only
+        // nullable-typed implicit members can carry such a narrowing, and the
+        // guard avoids invoking the diagnostic-emitting member-load path for any
+        // other symbol shape.
+        var isNarrowableImplicitMember = variable.Type is NullableTypeSymbol
+            && (variable is ImplicitFieldVariableSymbol
+                || (variable is ImplicitPropertyVariableSymbol prop && prop.Property.HasGetter));
+        if (isNarrowableImplicitMember
+            && TryBuildImplicitMemberLoad(variable, default, out var memberLoad)
+            && memberLoad is not BoundErrorExpression
+            && SmartCastStability.TryGetStablePath(memberLoad) is AccessPath memberPath
+            && memberPath.HasMembers)
+        {
+            for (var i = binderCtx.NarrowedVariables.Count - 1; i >= 0; i--)
+            {
+                if (binderCtx.NarrowedVariables[i].TryGetValue(memberPath, out var narrowedMember))
+                {
+                    return narrowedMember;
+                }
+            }
+        }
+
         return null;
+    }
+
+    /// <summary>
+    /// Issue #2185: binds an <em>indirect</em> invocation <c>callee(args)</c> whose
+    /// <see cref="CallExpressionSyntax.Callee"/> is an arbitrary expression (a parenthesized
+    /// expression, a null-forgiveness <c>expr!!</c>, a curried <c>f()</c>, an indexer read, ...).
+    /// The callee is bound as an ordinary expression — so smart-cast narrowing and null-forgiveness
+    /// already produce its non-null (function) type — and the call is accepted whenever that bound
+    /// type is a G# <see cref="FunctionTypeSymbol"/>, a user-declared <see cref="DelegateTypeSymbol"/>,
+    /// or a CLR delegate. Any other callee type reports GS0131 ("is not a function").
+    /// </summary>
+    private BoundExpression BindIndirectCallExpression(CallExpressionSyntax syntax)
+    {
+        var callee = bindExpression(syntax.Callee);
+        if (callee is BoundErrorExpression)
+        {
+            return callee;
+        }
+
+        // The verbatim source spelling of the callee (`(value)`, `handler!!`, ...)
+        // used in diagnostics — SyntaxNode.ToString() pretty-prints the whole tree.
+        var calleeName = syntax.Callee.SyntaxTree.Text.ToString(syntax.Callee.Span);
+
+        // Named args have no meaning without preserved parameter names.
+        if (!TryAnalyzeCallArgumentLayout(syntax.Arguments, out _, out var argumentNames))
+        {
+            return new BoundErrorExpression(null);
+        }
+
+        if (!argumentNames.IsDefault)
+        {
+            Diagnostics.ReportNamedArgumentParameterNotFound(syntax.Callee.Location, calleeName, FirstNamedArgumentName(argumentNames));
+            return new BoundErrorExpression(null);
+        }
+
+        var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
+        var deferredArrowLambdaIndices = new HashSet<int>();
+        for (var i = 0; i < syntax.Arguments.Count; i++)
+        {
+            var argSyntax = UnwrapNamedArgumentValue(syntax.Arguments[i]);
+            if (bindLambdaWithTarget != null && IsUntypedArrowLambda(argSyntax))
+            {
+                // Defer: TryBindFunctionTypeArguments re-binds the lambda once the
+                // callee's parameter delegate shape is known (mirrors the direct path).
+                deferredArrowLambdaIndices.Add(i);
+                boundArguments.Add(new BoundErrorExpression(argSyntax));
+            }
+            else
+            {
+                boundArguments.Add(BindOverloadArgumentValue(argSyntax));
+            }
+        }
+
+        if (deferredArrowLambdaIndices.Count == 0)
+        {
+            foreach (var boundArgument in boundArguments)
+            {
+                if (boundArgument is BoundErrorExpression)
+                {
+                    return new BoundErrorExpression(null);
+                }
+            }
+        }
+
+        if (callee.Type is FunctionTypeSymbol fnType)
+        {
+            if (!TryBindFunctionTypeArguments(calleeName, fnType, syntax, boundArguments.ToImmutable(), out var convertedArgs))
+            {
+                return new BoundErrorExpression(null);
+            }
+
+            return new BoundIndirectCallExpression(syntax, callee, fnType, convertedArgs);
+        }
+
+        if (callee.Type is DelegateTypeSymbol delegateSym)
+        {
+            if (!TryBindFunctionTypeArguments(calleeName, delegateSym.EquivalentFunctionType, syntax, boundArguments.ToImmutable(), out var convertedDelegateArgs))
+            {
+                return new BoundErrorExpression(null);
+            }
+
+            return new BoundIndirectCallExpression(syntax, callee, delegateSym.EquivalentFunctionType, convertedDelegateArgs);
+        }
+
+        // A value whose CLR type is a delegate (e.g. `Func[int32, int32]`) is
+        // callable through its `Invoke` method, mirroring the direct-call path.
+        if (callee.Type?.ClrType is System.Type calleeClrType && ClrTypeUtilities.IsDelegateType(calleeClrType))
+        {
+            if (tryBindInheritedClrInstanceCall(callee, calleeClrType, "Invoke", boundArguments.ToImmutable(), syntax, out var invokeCall, null, default, argumentNames))
+            {
+                return invokeCall;
+            }
+        }
+
+        Diagnostics.ReportNotAFunction(syntax.Callee.Location, calleeName);
+        return new BoundErrorExpression(null);
     }
 
     public BoundExpression BindCallExpression(CallExpressionSyntax syntax)
     {
+        // Issue #2185: an indirect invocation whose callee is an arbitrary
+        // function-typed expression (`(expr)(args)`, `expr!!(args)`, a curried
+        // `f()(x)`, ...). The parser tags these with a non-null Callee (there is
+        // no identifier to resolve), so dispatch on the bound callee expression's
+        // (narrowed / null-forgiven) type rather than any syntactic callee shape.
+        if (syntax.Callee != null)
+        {
+            return BindIndirectCallExpression(syntax);
+        }
+
         // ADR-0065 §2: a bare `init(args)` call inside a constructor body is
         // a self-delegation to a sibling constructor on the same class. This
         // is the only legal use of `init` as a callable identifier. Recognise

--- a/src/Core/CodeAnalysis/Syntax/CallExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/CallExpressionSyntax.cs
@@ -72,6 +72,41 @@ public sealed class CallExpressionSyntax : ExpressionSyntax
         CloseParenthesisToken = closeParenthesisToken;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="CallExpressionSyntax"/> class for an
+    /// <em>indirect</em> invocation whose callee is an arbitrary function-typed expression
+    /// (issue #2185): <c>(expr)(args)</c>, <c>expr!!(args)</c>, and any other postfix
+    /// <c>callee(args)</c> where <paramref name="callee"/> is not a bare identifier / member-access
+    /// name. The synthetic <see cref="Identifier"/> is an empty token positioned at the callee so
+    /// span computation stays monotonic; the binder dispatches on <see cref="Callee"/> being
+    /// non-<see langword="null"/> before any identifier-based resolution.</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="callee">The expression evaluated to obtain the function value to invoke.</param>
+    /// <param name="openParenthesisToken">The open parenthesis token.</param>
+    /// <param name="arguments">The arguments.</param>
+    /// <param name="closeParenthesisToken">The close parenthesis token.</param>
+    public CallExpressionSyntax(
+        SyntaxTree syntaxTree,
+        ExpressionSyntax callee,
+        SyntaxToken openParenthesisToken,
+        SeparatedSyntaxList<ExpressionSyntax> arguments,
+        SyntaxToken closeParenthesisToken)
+        : base(syntaxTree)
+    {
+        Callee = callee;
+        Identifier = new SyntaxToken(syntaxTree, SyntaxKind.IdentifierToken, callee.Span.Start, string.Empty, null);
+        NullableQuestionToken = null;
+        TypeArgumentList = null;
+        OpenParenthesisToken = openParenthesisToken;
+        Arguments = arguments;
+        CloseParenthesisToken = closeParenthesisToken;
+    }
+
+    /// <summary>Gets the callee expression for an indirect invocation (issue #2185), or
+    /// <see langword="null"/> for the ordinary identifier / member-access call forms. When
+    /// non-<see langword="null"/> the call target is the value produced by evaluating this
+    /// expression, which must have a function (or delegate) type.</summary>
+    public ExpressionSyntax Callee { get; }
+
     /// <inheritdoc/>
     public override SyntaxKind Kind => SyntaxKind.CallExpression;
 

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -7586,6 +7586,44 @@ public class Parser
                 var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
                 current = new IndexExpressionSyntax(syntaxTree, current, openBracket, index, closeBracket);
             }
+            else if (Current.Kind == SyntaxKind.OpenParenthesisToken
+                && !IsCurrentOnNewLineAfter(current))
+            {
+                // Issue #2185: a same-line `(args)` following an arbitrary
+                // postfix expression is an *indirect* invocation of that
+                // expression's (function-typed) value — e.g. `(h)(value)`,
+                // `handler!!(value)`, or a curried `f()(x)`. Bare-identifier and
+                // `.member` callees never reach here (their `(args)` is consumed
+                // by ParseNameOrCallExpression), so this handles exactly the
+                // non-name callee shapes. The newline guard preserves the
+                // pre-existing reading of a parenthesised expression on the next
+                // line as a separate statement (G# is otherwise
+                // newline-insensitive, but a leading-`(` continuation is never
+                // written). The binder validates the callee is function-typed.
+                var openParen = NextToken();
+
+                var savedInvokeSuppress = suppressTrailingObjectInitializer;
+                suppressTrailingObjectInitializer = 0;
+                var savedInvokeStructLiteral = suppressStructLiteral;
+                suppressStructLiteral = 0;
+                var savedInvokeRange = suppressRangeOperator;
+                suppressRangeOperator = 0;
+                SeparatedSyntaxList<ExpressionSyntax> arguments;
+                try
+                {
+                    arguments = ParseArguments();
+                }
+                finally
+                {
+                    suppressTrailingObjectInitializer = savedInvokeSuppress;
+                    suppressStructLiteral = savedInvokeStructLiteral;
+                    suppressRangeOperator = savedInvokeRange;
+                }
+
+                var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+                arguments = MaybeAppendTrailingLambda(arguments);
+                current = new CallExpressionSyntax(syntaxTree, current, openParen, arguments, closeParen);
+            }
             else
             {
                 break;

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2185IndirectCalleeInvocationEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2185IndirectCalleeInvocationEmitTests.cs
@@ -1,0 +1,267 @@
+// <copyright file="Issue2185IndirectCalleeInvocationEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #2185: <c>callee(args)</c> must be recognized as an invocation whenever
+/// the bound callee expression has a function type, regardless of the callee's
+/// syntactic shape. Previously only a bare identifier or member-access callee was
+/// invoked; a parenthesized expression (<c>(h)(value)</c>), a null-forgiveness
+/// (<c>handler!!(value)</c>), or a smart-cast-narrowed nullable function field
+/// (<c>hn(value)</c> after an <c>== nil</c> guard) were not, producing a bogus
+/// GS0155 conversion error or GS0131 "is not a function". These tests confirm all
+/// three shapes bind AND execute with correct results (including the generic
+/// substitution preserved for <c>(T) -&gt; TResult</c> fields), while a callee that
+/// is genuinely not function-typed still errors.
+/// </summary>
+public class Issue2185IndirectCalleeInvocationEmitTests
+{
+    [Fact]
+    public void NullForgivenParenthesizedAndNarrowedCallees_Bind()
+    {
+        // The exact repros from issue #2185 (all three previously errored).
+        const string Source = @"
+package R
+
+class C[T, TResult] {
+    private let handler ((T) -> TResult)?
+    func Use(value T) TResult {
+        if handler == nil { return default(TResult) }
+        return handler!!(value)
+    }
+}
+
+class E[T, TResult] {
+    private let h (T) -> TResult
+    func A(value T) TResult { return (h)(value) }
+}
+
+class F[T, TResult] {
+    private let hn ((T) -> TResult)?
+    func B(value T) TResult {
+        if hn == nil { return default(TResult) }
+        return hn(value)
+    }
+}
+";
+        var diagnostics = GetDiagnostics(Source);
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void BareIdentifierAndAssignedLocalCallees_StillBind()
+    {
+        // The issue's controls: a bare non-null identifier callee and an
+        // asserted-to-local callee already compiled and must not regress.
+        const string Source = @"
+package R
+
+class D[T, TResult] {
+    private let h (T) -> TResult
+    func A(value T) TResult { return h(value) }
+}
+
+class G[T, TResult] {
+    private let handler ((T) -> TResult)?
+    func A(value T) TResult {
+        let h = handler!!
+        return h(value)
+    }
+}
+";
+        var diagnostics = GetDiagnostics(Source);
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void NonFunctionParenthesizedCallee_ReportsNotAFunction()
+    {
+        // Negative check: invoking a non-function-typed expression must still be
+        // rejected (GS0131) — the generalization keys off the bound function type,
+        // so an int32-typed `(value)` callee is not over-accepted.
+        const string Source = @"
+package R
+class N {
+    func A(value int32) int32 { return (value)(1) }
+}
+";
+        var diagnostics = GetDiagnostics(Source).ToList();
+        Assert.Contains(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void NullForgivenCallee_ExecutesAndReturnsValue()
+    {
+        // `handler!!(value)` on a populated nullable field runs the delegate.
+        const string Source = @"package Issue2185NullForgiven
+import System
+
+class C {
+    private let handler ((int32) -> int32)?
+    init(h ((int32) -> int32)?) { handler = h }
+    func Use(value int32) int32 {
+        if handler == nil { return -1 }
+        return handler!!(value)
+    }
+}
+
+func run() {
+    let dbl = (x int32) -> x * 2
+    var c = C(dbl)
+    Console.WriteLine(c.Use(21))
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue2185NullForgiven");
+        var lines = output.Split(new[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("42", lines[0]);
+    }
+
+    [Fact]
+    public void ParenthesizedCallee_ExecutesAndReturnsValue()
+    {
+        // `(h)(value)` on a non-null function field runs the delegate.
+        const string Source = @"package Issue2185Parenthesized
+import System
+
+class E {
+    private let h (int32) -> int32
+    init(f (int32) -> int32) { h = f }
+    func A(value int32) int32 { return (h)(value) }
+}
+
+func run() {
+    let inc = (x int32) -> x + 1
+    var e = E(inc)
+    Console.WriteLine(e.A(41))
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue2185Parenthesized");
+        var lines = output.Split(new[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("42", lines[0]);
+    }
+
+    [Fact]
+    public void NarrowedNullableFieldCallee_ExecutesAndReturnsValue()
+    {
+        // `hn(value)` after an `== nil` guard invokes the smart-cast-narrowed
+        // (now non-null) function field.
+        const string Source = @"package Issue2185Narrowed
+import System
+
+class F {
+    private let hn ((int32) -> int32)?
+    init(h ((int32) -> int32)?) { hn = h }
+    func B(value int32) int32 {
+        if hn == nil { return -1 }
+        return hn(value)
+    }
+}
+
+func run() {
+    let dbl = (x int32) -> x * 2
+    var f = F(dbl)
+    Console.WriteLine(f.B(21))
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue2185Narrowed");
+        var lines = output.Split(new[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("42", lines[0]);
+    }
+
+    [Fact]
+    public void CurriedCallAndParenthesizedLocal_ExecuteAndReturnValues()
+    {
+        // A curried `f()(x)` and a parenthesized-local `(f)(x)` are both indirect
+        // invocations of the returned/parenthesized function value.
+        const string Source = @"package Issue2185Curried
+import System
+
+func makeAdder(delta int32) (int32) -> int32 {
+    return (x int32) -> x + delta
+}
+
+func run() {
+    Console.WriteLine(makeAdder(10)(5))
+    let f = makeAdder(3)
+    Console.WriteLine((f)(4))
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue2185Curried");
+        var lines = output.Split(new[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("15", lines[0]);
+        Assert.Equal("7", lines[1]);
+    }
+
+    private static IEnumerable<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        return compilation.Emit(peStream).Diagnostics;
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
`callee(args)` is now treated as an invocation whenever the **bound callee expression** has a function type, regardless of the callee's syntactic shape — generalizing the previous identifier/member-access-only gate.

### Root cause
- For a parenthesized (`(h)(value)`), null-forgiveness (`handler!!(value)`), or curried (`f()(x)`) callee, the parser's postfix chain never consumed the trailing `(args)`: it was parsed as a separate no-op parenthesized-expression statement, so the call bound to just the function value and reported **GS0155** (conversion error).
- For a bare nullable function field (`hn(value)` after an `== nil` guard), the null-guard narrowing is recorded under the stable member access path (`this.hn`), but the call-target narrowing lookup only consulted the bare variable symbol, so the callee stayed nullable and reported **GS0131** ("is not a function").

### Fix
- **Parser**: a same-line `(args)` following any postfix expression is now an indirect invocation, built as a `CallExpressionSyntax` carrying a `Callee` expression (no new `SyntaxKind`). Newline-guarded so a parenthesized expression on the next line remains a separate statement.
- **Binder**: an indirect call binds its callee as an ordinary expression (so smart-cast narrowing and `!!` already yield the non-null function type) and accepts any `FunctionTypeSymbol` / `DelegateTypeSymbol` / CLR delegate, lowering to the existing `BoundIndirectCallExpression` (no new `BoundNodeKind`). Non-function callees still report GS0131.
- **Binder**: the call-target narrowing lookup now also consults the stable member path for a nullable implicit field/property callee.

Generic substitution (`(T) -> TResult`) and delegate `Invoke` emission are preserved. No new `SyntaxKind`/`BoundNodeKind`, so the coverage matrix is unchanged.

### Tests
Added `Issue2185IndirectCalleeInvocationEmitTests` (7 tests): binds all three repro shapes, keeps the two controls green, rejects a non-function callee (GS0131), and executes the invocations at runtime asserting correct results (including a curried call). Related Syntax, Binding, Emit, call/delegate/lambda, narrowing, coverage-matrix, and language-conformance suites pass.

Fixes #2185
Refs #914