### PR TITLE
cs2gs: promote reference-constrained type-parameter positions to T? in oblivious code

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914ObliviousSinkTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914ObliviousSinkTranslationTests.cs
@@ -1,0 +1,220 @@
+// <copyright file="Issue914ObliviousSinkTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #914: the oblivious-nullability taint
+/// analysis (<see cref="ObliviousNullabilityAnalyzer"/>) already promotes
+/// null-reachable reference SOURCES (returns, fields, locals, null-checked
+/// params) to <c>T?</c>. These tests cover the complementary SINK positions
+/// that must also be promoted so a promoted <c>T?</c> value flows without a
+/// GS0154/GS0155/GS0156 "T? vs T" error:
+/// <list type="number">
+/// <item>tuple return-element types,</item>
+/// <item>lambda / local-function return types,</item>
+/// <item>property-getter return types that forward a promoted backing field,</item>
+/// <item>designated-constructor parameters reached via a <c>: this(...)</c>
+/// delegation carrying null,</item>
+/// <item>delegate parameters invoked with a null argument.</item>
+/// </list>
+/// All promotions are gated to oblivious compilations, so a
+/// nullable-<em>enabled</em> compilation stays byte-identical (unpromoted).
+/// </summary>
+public class Issue914ObliviousSinkTranslationTests
+{
+    [Fact]
+    public void Oblivious_TupleReturn_PromotesElementTypesToNullable()
+    {
+        // `dir`/`file` are null-tainted locals; the `(string, string)` return
+        // type must promote its element types so `return (dir, file)` (which
+        // yields `(string?, string?)`) does not trip GS0155.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        public (string, string) Get(bool b)
+        {
+            string dir = ""d"";
+            string file = ""f"";
+            if (b) { dir = null; file = null; }
+            return (dir, file);
+        }
+    }
+}");
+
+        Assert.Contains("Get(b bool) (string?, string?)", printed);
+    }
+
+    [Fact]
+    public void Oblivious_LocalFunctionReturn_PromotesToNullable()
+    {
+        // The local function `Parse` returns null on a path, so its return type
+        // must render `string?` exactly like a method return.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Run(string s)
+        {
+            string Parse(string v)
+            {
+                if (v == null) { return null; }
+                return v;
+            }
+
+            var x = Parse(s);
+        }
+    }
+}");
+
+        Assert.Contains("func (v string?) string?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_PropertyGetterForwardingPromotedField_PromotesPropertyType()
+    {
+        // `writer` is null-tainted (assigned null), so the backing field is
+        // `StreamWriter?`; the expression-bodied getter `Writer => writer`
+        // forwards it, so the property type must promote to `TextWriter?`.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        private System.IO.StreamWriter writer;
+
+        public System.IO.TextWriter Writer => this.writer;
+
+        public void Clear() { this.writer = null; }
+    }
+}");
+
+        Assert.Contains("Writer TextWriter?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_DesignatedConstructorReachedWithNull_PromotesParameters()
+    {
+        // The convenience ctor `C() : this(null, null)` delegates to the
+        // designated ctor; the analyzer follows the constructor-initializer
+        // arg->param edges, so `context`/`message` must render `string?`.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        public C(string context, string message) { }
+
+        public C() : this(null, null) { }
+    }
+}");
+
+        Assert.Contains("init(context string?, message string?)", printed);
+    }
+
+    [Fact]
+    public void Enabled_DesignatedConstructorReachedWithNull_StaysUnpromoted()
+    {
+        // The SAME shape under a nullable-ENABLED compilation: the analyzer
+        // short-circuits, the annotations are non-null, so the designated ctor
+        // parameters stay `string` (byte-identical, unpromoted).
+        string printed = TranslateEnabled(@"
+namespace Demo
+{
+    public class C
+    {
+        public C(string context, string message) { }
+
+        public C() : this(null, null) { }
+    }
+}");
+
+        Assert.Contains("init(context string, message string)", printed);
+        Assert.DoesNotContain("string?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_DelegateParameterInvokedWithNull_PromotesArrowParameter()
+    {
+        // `cb` is invoked with a null argument, so its delegate parameter type
+        // must promote to `object?` (an arrow parameter position).
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Run(System.Action<object> cb)
+        {
+            cb(null);
+        }
+    }
+}");
+
+        Assert.Contains("(object?) -> void", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string TranslateEnabled(string source)
+    {
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.EnabledInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Select(r => r).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914ObliviousTypeParameterReturnPromotionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914ObliviousTypeParameterReturnPromotionTests.cs
@@ -1,0 +1,178 @@
+// <copyright file="Issue914ObliviousTypeParameterReturnPromotionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #914 (Oahu.Foundation oblivious
+/// deferred-return-promotion): the whole-program oblivious taint analysis
+/// (<see cref="ObliviousNullabilityAnalyzer"/>) now also promotes a
+/// <em>reference-constrained</em> type-parameter position (<c>where T : class</c>)
+/// to <c>T?</c> when it is null-tainted. Previously #2113 excluded ALL type
+/// parameters, so a generic method like
+/// <c>T DeserializeJsonFile&lt;T&gt;() where T : class { … return null; }</c>
+/// kept a non-null <c>T</c> return and its <c>return null</c> / <c>T?</c> flow
+/// collided with the non-null return (GS0129 <c>T == nil</c>, GS0155 <c>nil</c>/
+/// <c>T?</c> → <c>T</c>). Unconstrained type parameters remain excluded because
+/// their <c>IsReferenceType</c> is <c>false</c> and <c>T?</c> would mean
+/// <c>Nullable&lt;T&gt;</c>.
+/// </summary>
+public class Issue914ObliviousTypeParameterReturnPromotionTests
+{
+    [Fact]
+    public void Oblivious_NullReturningReferenceConstrainedTypeParam_RendersNullableReturn()
+    {
+        // `Deserialize` returns null on a path and `T : class`, so its return is a
+        // well-defined nullable reference `T?`. Without promotion, `return null`
+        // is GS0155 "cannot convert nil to T".
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        public T Deserialize<T>(bool b) where T : class, new()
+        {
+            if (b) { return null; }
+            return new T();
+        }
+    }
+}");
+
+        Assert.Contains("Deserialize[T class init()](b bool) T?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_TaintedTypeParamLocal_RendersNullableLocalAndFlows()
+    {
+        // `settings` is assigned `x as T` (nullable) and null-checked, so it is
+        // T? locally; when it also flows to the return, the tainted return is
+        // promoted to `T?` too — mirroring Oahu.Foundation SettingsManager.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        private object cached;
+
+        public T Get<T>() where T : class, new()
+        {
+            var settings = this.cached as T;
+            if (settings == null)
+            {
+                settings = new T();
+            }
+            return settings;
+        }
+    }
+}");
+
+        Assert.Contains("settings T?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_UnconstrainedTypeParam_StaysNonNull()
+    {
+        // Without a `class` constraint, `T` may be a value type, so `T?` would
+        // mean `Nullable<T>`. The analysis must NOT promote it — the return stays
+        // bare `T` (the `return default` is faithful to the C# default(T)).
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class C
+    {
+        public T OrDefault<T>(bool b, T value)
+        {
+            if (b) { return value; }
+            return default;
+        }
+    }
+}");
+
+        Assert.Contains("OrDefault[T](b bool, value T) T", printed);
+        Assert.DoesNotContain("OrDefault[T](b bool, value T) T?", printed);
+    }
+
+    [Fact]
+    public void NullableEnabled_ReferenceConstrainedTypeParam_Unchanged()
+    {
+        // In a nullable-ENABLED compilation the oblivious analysis must not run:
+        // a declared non-null `T` return stays `T` (the `return null!` is the
+        // developer's explicit suppression, not a promotion trigger).
+        string printed = TranslateEnabled(@"
+namespace Demo
+{
+    public class C
+    {
+        public T Make<T>() where T : class, new()
+        {
+            return new T();
+        }
+    }
+}");
+
+        Assert.Contains("Make[T class init()]() T", printed);
+        Assert.DoesNotContain("Make[T class init()]() T?", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string TranslateEnabled(string source)
+    {
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.EnabledInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914StaticFormExtensionCallTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914StaticFormExtensionCallTranslationTests.cs
@@ -1,0 +1,124 @@
+// <copyright file="Issue914StaticFormExtensionCallTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #914: a SOURCE-defined extension method
+/// called in STATIC (unreduced) form <c>Owner.M&lt;T&gt;(recv, args)</c> must be
+/// rewritten to the G# receiver-clause call <c>recv.M[T](args)</c>. cs2gs lifts
+/// every non-enum source extension of a <c>static class</c> to a top-level
+/// receiver-clause <c>func (recv R) M[…](…)</c> (ADR-0115 §B.19), which gsc
+/// invokes only through the receiver form; the static-form call site would
+/// otherwise resolve to a non-existent static member (GS0158). The reduced
+/// instance form already binds directly and is unaffected.
+/// </summary>
+public class Issue914StaticFormExtensionCallTranslationTests
+{
+    [Fact]
+    public void StaticFormExtensionCall_RewrittenToReceiverForm()
+    {
+        // `JsonLike.FromFile<T>(path)` — static-form generic call whose first
+        // argument is the extension receiver — must become `path.FromFile[T]()`.
+        string printed = Render(@"
+namespace Demo
+{
+    public static class JsonLike
+    {
+        public static T FromFile<T>(this string path) where T : class, new() { return new T(); }
+    }
+
+    public class Consumer
+    {
+        public T Load<T>(string path) where T : class, new()
+        {
+            return JsonLike.FromFile<T>(path);
+        }
+    }
+}");
+
+        Assert.Contains("path.FromFile[T]()", printed);
+        Assert.DoesNotContain("JsonLike.FromFile", printed);
+    }
+
+    [Fact]
+    public void StaticFormExtensionCall_WithTrailingArguments_KeepsThemAfterReceiver()
+    {
+        // The first argument is the receiver; the rest follow in the receiver call:
+        // `StringExt.Repeat(s, 3)` -> `s.Repeat(3)`.
+        string printed = Render(@"
+namespace Demo
+{
+    public static class StringExt
+    {
+        public static string Repeat(this string s, int n) { return s; }
+    }
+
+    public class Consumer
+    {
+        public string Run(string s)
+        {
+            return StringExt.Repeat(s, 3);
+        }
+    }
+}");
+
+        Assert.Contains("s.Repeat(3)", printed);
+        Assert.DoesNotContain("StringExt.Repeat", printed);
+    }
+
+    [Fact]
+    public void InstanceFormExtensionCall_Unchanged()
+    {
+        // The reduced instance form already binds to the receiver-clause func and
+        // must be left exactly as-is (`s.Repeat(3)`), never re-qualified.
+        string printed = Render(@"
+namespace Demo
+{
+    public static class StringExt
+    {
+        public static string Repeat(this string s, int n) { return s; }
+    }
+
+    public class Consumer
+    {
+        public string Run(string s)
+        {
+            return s.Repeat(3);
+        }
+    }
+}");
+
+        Assert.Contains("s.Repeat(3)", printed);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -14849,7 +14849,19 @@ public sealed class CSharpToGSharpTranslator
                     : null;
             }
 
-            return this.typeMapper.Map(returnType, this.context, location);
+            // Issue #914 (oblivious sink): promote a LOCAL FUNCTION's (or
+            // lambda's) mapped return type to `T?` when the whole-program taint
+            // analysis proved its RETURN null-tainted — exactly like a top-level
+            // method return (see MapReturnType/PromoteReturnIfTainted). The
+            // analyzer seeds return taint for local functions and lambdas, so a
+            // `static Version TryParse(string s) { … return succ ? version :
+            // null; }` local function whose body yields `Version?` renders
+            // `func (s string) Version?`, avoiding a `Version? -> Version` return
+            // rejection (GS0155). No-op for a nullable-enabled compilation.
+            return this.PromoteReturnIfTainted(
+                this.typeMapper.Map(returnType, this.context, location),
+                symbol,
+                returnType);
         }
 
         private Parameter MapLambdaParameter(ParameterSyntax parameter)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -13009,6 +13009,44 @@ public sealed class CSharpToGSharpTranslator
                     extTypeArgs);
             }
 
+            // A SOURCE-defined extension method called in STATIC (unreduced) form
+            // `Owner.M<T>(recv, args)` — as opposed to the instance form
+            // `recv.M<T>(args)` — must be rewritten to the G# receiver-clause call
+            // `recv.M[T](args)`. cs2gs lifts every non-enum source extension method
+            // of a `static class` to a top-level receiver-clause `func (recv R) M[…](…)`
+            // (ADR-0115 §B.19), which gsc invokes ONLY through the receiver form; the
+            // static-form call site (`JsonSerialization.FromJsonFile<T>(path)`) would
+            // otherwise resolve to a non-existent static member (GS0158). The reduced
+            // instance form already binds directly, so it is excluded via
+            // `MethodKind.ReducedExtension`. Scoped to source-defined, non-enum
+            // extensions to avoid rewriting BCL static-form calls (enum receivers
+            // take the positional path above).
+            if (invocation.Expression is MemberAccessExpressionSyntax staticExtMember
+                && staticExtMember.Expression is TypeSyntax or IdentifierNameSyntax or MemberAccessExpressionSyntax
+                && this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol
+                    { IsExtensionMethod: true, MethodKind: not MethodKind.ReducedExtension } staticExt
+                && staticExt.Parameters.Length >= 1
+                && !(staticExt.ReducedFrom ?? staticExt).DeclaringSyntaxReferences.IsDefaultOrEmpty
+                && (staticExt.Parameters[0].Type?.TypeKind ?? TypeKind.Unknown) != TypeKind.Enum
+                && this.context.SemanticModel.GetSymbolInfo(staticExtMember.Expression).Symbol is not (IParameterSymbol or ILocalSymbol or IFieldSymbol or IPropertySymbol)
+                && invocation.ArgumentList.Arguments.Count >= 1)
+            {
+                GExpression staticExtReceiver =
+                    this.TranslateExpression(invocation.ArgumentList.Arguments[0].Expression);
+                var staticExtRest = this.TranslateArguments(
+                    SyntaxFactory.SeparatedList(invocation.ArgumentList.Arguments.Skip(1)));
+                IReadOnlyList<GTypeReference> staticExtTypeArgs =
+                    staticExtMember.Name is GenericNameSyntax staticExtGeneric
+                        ? this.MapTypeArguments(staticExtGeneric)
+                        : null;
+                return new InvocationExpression(
+                    new MemberAccessExpression(
+                        staticExtReceiver,
+                        SanitizeIdentifier((staticExt.ReducedFrom ?? staticExt).Name)),
+                    staticExtRest,
+                    staticExtTypeArgs);
+            }
+
             // A generic call `Foo<T>(...)` carries its type arguments on the name;
             // lift them onto the G# bracket-type-argument form `Foo[T](...)`.
             if (invocation.Expression is GenericNameSyntax generic)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4450,6 +4450,20 @@ public sealed class CSharpToGSharpTranslator
                 type = this.PromoteIfUsedAsNullable(type, symbol);
             }
 
+            // Issue #914 (oblivious sink): a DELEGATE-typed parameter that is
+            // invoked inside its method with a null (or promoted-nullable)
+            // argument at some position must render that arrow-parameter position
+            // as `T?` — e.g. `SendOrPost(Action<SendOrPostCallback, object>
+            // sendOrPost, …)` whose body does `sendOrPost(o => …, null)` needs the
+            // second arrow parameter to be `object?`, otherwise the `nil -> object`
+            // call argument is rejected (GS0155). The delegate's own invoke
+            // signature carries no nullability in oblivious metadata, so the
+            // evidence is the null argument flowing to it at the call site.
+            if (!variadic)
+            {
+                type = this.PromoteDelegateParameterInvokedWithNull(type, symbol);
+            }
+
             GExpression defaultValue = this.BuildOptionalParameterDefault(symbol, type, fallbackNode);
 
             // Issue #1913: a parameter's own attributes (e.g. `[Note] int x`) live on
@@ -9977,6 +9991,102 @@ public sealed class CSharpToGSharpTranslator
                     this.IsPromotedToNullableReference(symbol),
                 IMethodSymbol method =>
                     ObliviousNullabilityAnalyzer.IsTainted(this.context.Compilation, method),
+                _ => false,
+            };
+        }
+
+        // Issue #914 (oblivious sink): promote the arrow (delegate) parameter
+        // positions of <paramref name="symbol"/>'s type to `T?` for every position
+        // that receives a null / promoted-nullable argument at an invocation of the
+        // parameter inside its own method. A delegate parameter carries no
+        // nullability in oblivious metadata, so a call like `sendOrPost(o => …,
+        // null)` is the only evidence that the delegate's second position is really
+        // `object?`; without it the `nil -> object` argument is rejected (GS0155).
+        // Gated to an oblivious compilation; only reference-typed, non-nullable
+        // arrow positions are eligible.
+        private GTypeReference PromoteDelegateParameterInvokedWithNull(
+            GTypeReference type,
+            IParameterSymbol symbol)
+        {
+            if (!this.IsObliviousCompilation()
+                || type is not ArrowTypeReference arrow
+                || symbol.Type is not INamedTypeSymbol { TypeKind: TypeKind.Delegate } delegateType
+                || delegateType.DelegateInvokeMethod is not { } invoke
+                || invoke.Parameters.Length != arrow.ParameterTypes.Count)
+            {
+                return type;
+            }
+
+            SyntaxNode methodSyntax = symbol.ContainingSymbol?
+                .DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
+            if (methodSyntax == null)
+            {
+                return type;
+            }
+
+            var nullablePositions = new HashSet<int>();
+            foreach (InvocationExpressionSyntax invocation in methodSyntax
+                .DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                if (!SymbolEqualityComparer.Default.Equals(
+                        this.context.GetSymbolInfo(invocation.Expression).Symbol, symbol))
+                {
+                    continue;
+                }
+
+                ArgumentListSyntax argumentList = invocation.ArgumentList;
+                for (int i = 0; i < argumentList.Arguments.Count && i < arrow.ParameterTypes.Count; i++)
+                {
+                    ExpressionSyntax argument = argumentList.Arguments[i].Expression;
+                    if (IsNullOrDefaultLiteral(argument) || this.IsNullablePromotedValue(argument))
+                    {
+                        nullablePositions.Add(i);
+                    }
+                }
+            }
+
+            if (nullablePositions.Count == 0)
+            {
+                return type;
+            }
+
+            var parameterTypes = new List<GTypeReference>(arrow.ParameterTypes.Count);
+            bool changed = false;
+            for (int i = 0; i < arrow.ParameterTypes.Count; i++)
+            {
+                GTypeReference parameterType = arrow.ParameterTypes[i];
+                ITypeSymbol invokeParameterType = invoke.Parameters[i].Type;
+                if (nullablePositions.Contains(i)
+                    && !parameterType.IsNullable
+                    && invokeParameterType is { IsReferenceType: true }
+                    && invokeParameterType.NullableAnnotation != NullableAnnotation.Annotated)
+                {
+                    parameterType = MakeNullable(parameterType);
+                    changed = true;
+                }
+
+                parameterTypes.Add(parameterType);
+            }
+
+            return changed
+                ? new ArrowTypeReference(parameterTypes, arrow.ReturnTypes, arrow.IsAsync) { IsNullable = arrow.IsNullable }
+                : type;
+        }
+
+        // Issue #914: whether <paramref name="expression"/> is a bare `null` /
+        // `null!` literal or a `default` / `default(T)` expression — the direct
+        // null-argument forms used to detect a null flowing into a delegate
+        // parameter position.
+        private static bool IsNullOrDefaultLiteral(ExpressionSyntax expression)
+        {
+            return expression switch
+            {
+                LiteralExpressionSyntax { RawKind: (int)SyntaxKind.NullLiteralExpression } => true,
+                LiteralExpressionSyntax { RawKind: (int)SyntaxKind.DefaultLiteralExpression } => true,
+                DefaultExpressionSyntax => true,
+                PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression } suppress =>
+                    IsNullOrDefaultLiteral(suppress.Operand),
+                ParenthesizedExpressionSyntax paren => IsNullOrDefaultLiteral(paren.Expression),
                 _ => false,
             };
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4579,6 +4579,15 @@ public sealed class CSharpToGSharpTranslator
                 // ref-return (`func F(...) ref T`, issue #490/ADR-0060).
                 GTypeReference mapped = this.typeMapper.Map(returnType, this.context, node.ReturnType.GetLocation());
 
+                // Issue #914 (oblivious sink): a TUPLE return whose returned tuple
+                // expression carries a promoted-nullable element (e.g. `return
+                // (dir, file)` where `dir`/`file` are promoted `string?` locals)
+                // is promoted per-element to `(string?, string?)`, otherwise the
+                // `(string?, string?) -> (string, string)` return is rejected
+                // (GS0155). Applied before the scalar promotion below (which is a
+                // no-op for a tuple value type).
+                mapped = this.PromoteTupleReturnIfTainted(mapped, returnType, node);
+
                 // Issue #2113: promote the return type to `T?` when the
                 // whole-program taint analysis proved this method's RETURN
                 // null-tainted (an oblivious compilation with a `return null` /
@@ -9834,6 +9843,142 @@ public sealed class CSharpToGSharpTranslator
             return ObliviousNullabilityAnalyzer.IsTainted(this.context.Compilation, symbol)
                 ? MakeNullable(type)
                 : type;
+        }
+
+        // Issue #914 (oblivious sink): promote the ELEMENT types of a tuple return
+        // to `T?` for every position whose returned tuple-expression element is a
+        // promoted-nullable value. A method returning `(string Dir, string Path)`
+        // whose body does `return (dir, file)` — where `dir`/`file` are promoted
+        // `string?` locals — must render `(string?, string?)`, otherwise the
+        // `(string?, string?) -> (string, string)` return is rejected (GS0155).
+        // Gated to an oblivious compilation so a nullable-enabled project stays
+        // byte-identical; only reference-typed, non-nullable elements are eligible
+        // (mirroring the scalar-return and declaration-site guards).
+        private GTypeReference PromoteTupleReturnIfTainted(
+            GTypeReference mapped,
+            ITypeSymbol returnType,
+            SyntaxNode node)
+        {
+            if (!this.IsObliviousCompilation()
+                || mapped is not TupleTypeReference tuple
+                || returnType is not INamedTypeSymbol { IsTupleType: true } tupleType
+                || tupleType.TupleElements.Length != tuple.ElementTypes.Count)
+            {
+                return mapped;
+            }
+
+            List<TupleExpressionSyntax> returnedTuples = this.EnumerateMemberReturnExpressions(node)
+                .Select(UnwrapParenthesized)
+                .OfType<TupleExpressionSyntax>()
+                .Where(t => t.Arguments.Count == tuple.ElementTypes.Count)
+                .ToList();
+
+            if (returnedTuples.Count == 0)
+            {
+                return mapped;
+            }
+
+            var elements = new List<GTypeReference>(tuple.ElementTypes.Count);
+            bool changed = false;
+            for (int i = 0; i < tuple.ElementTypes.Count; i++)
+            {
+                GTypeReference element = tuple.ElementTypes[i];
+                IFieldSymbol elementField = tupleType.TupleElements[i];
+                if (!element.IsNullable
+                    && elementField.Type is { IsReferenceType: true }
+                    && elementField.Type.NullableAnnotation != NullableAnnotation.Annotated
+                    && returnedTuples.Any(t => this.IsNullablePromotedValue(t.Arguments[i].Expression)))
+                {
+                    element = MakeNullable(element);
+                    changed = true;
+                }
+
+                elements.Add(element);
+            }
+
+            return changed
+                ? new TupleTypeReference(elements) { IsNullable = tuple.IsNullable }
+                : mapped;
+        }
+
+        // Issue #914: the `return`-position value expressions that belong to a
+        // method/accessor <paramref name="node"/> itself — its arrow expression
+        // body and every `return` statement not nested inside a lambda / local
+        // function (whose returns have their own contract). Used to inspect the
+        // returned tuple shapes for per-element nullable promotion.
+        private IEnumerable<ExpressionSyntax> EnumerateMemberReturnExpressions(SyntaxNode node)
+        {
+            ExpressionSyntax arrowBody = node switch
+            {
+                MethodDeclarationSyntax method => method.ExpressionBody?.Expression,
+                AccessorDeclarationSyntax accessor => accessor.ExpressionBody?.Expression,
+                _ => null,
+            };
+            if (arrowBody != null)
+            {
+                yield return arrowBody;
+            }
+
+            SyntaxNode body = node switch
+            {
+                MethodDeclarationSyntax method => method.Body,
+                AccessorDeclarationSyntax accessor => accessor.Body,
+                _ => null,
+            };
+            if (body == null)
+            {
+                yield break;
+            }
+
+            foreach (SyntaxNode descendant in body.DescendantNodes(
+                n => n is not (AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax)))
+            {
+                if (descendant is ReturnStatementSyntax { Expression: { } returned })
+                {
+                    yield return returned;
+                }
+            }
+        }
+
+        private static ExpressionSyntax UnwrapParenthesized(ExpressionSyntax expression)
+        {
+            while (expression is ParenthesizedExpressionSyntax paren)
+            {
+                expression = paren.Expression;
+            }
+
+            return expression;
+        }
+
+        // Issue #914: whether <paramref name="expression"/> yields a
+        // promoted-nullable value in an oblivious compilation — either a
+        // syntactically nullable form (`?.` / `??` / ternary, via
+        // <see cref="IsNullableInitializer"/>, which also consults declared BCL
+        // annotations) OR a field / property / local / parameter the whole-program
+        // taint analysis promoted to `T?`, OR a method / local function whose
+        // return the analysis proved null-tainted. Shared by the tuple-return
+        // element promotion.
+        private bool IsNullablePromotedValue(ExpressionSyntax expression)
+        {
+            if (expression == null)
+            {
+                return false;
+            }
+
+            if (this.IsNullableInitializer(expression))
+            {
+                return true;
+            }
+
+            ISymbol symbol = this.context.GetSymbolInfo(expression).Symbol;
+            return symbol switch
+            {
+                IFieldSymbol or IPropertySymbol or ILocalSymbol or IParameterSymbol =>
+                    this.IsPromotedToNullableReference(symbol),
+                IMethodSymbol method =>
+                    ObliviousNullabilityAnalyzer.IsTainted(this.context.Compilation, method),
+                _ => false,
+            };
         }
 
         // Issue #1072 (field/property initializer form): when a field or property is

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -14726,7 +14726,29 @@ public sealed class CSharpToGSharpTranslator
                 ? this.typeMapper.Map(targetSymbol, this.context, cast.Type.GetLocation())
                 : new NamedTypeReference(cast.Type.ToString());
 
-            return new ConversionExpression(targetType, this.TranslateExpression(cast.Expression));
+            GExpression operand = this.TranslateExpression(cast.Expression);
+
+            // Issue #914 (oblivious sink): an oblivious promoted-`T?` operand cast
+            // to a NON-NULL reference target (e.g. `(IEnumerable)o` where `o` is a
+            // promoted `object?`) is rejected by gsc — its `IEnumerable(o)`
+            // conversion requires a non-null operand (GS0155). C# performs the
+            // reference cast on the (possibly null) value and throws only on the
+            // subsequent non-null use (e.g. `foreach`), so asserting the operand
+            // `!!` here both compiles and preserves the throw-on-null semantics —
+            // the same mechanism the receiver / foreach-iterable null-forgiveness
+            // pass uses. Gated to oblivious; a `(object)`/`(object?)` reference
+            // upcast is already dropped above, and an already-`!` operand is not
+            // re-asserted.
+            if (this.IsObliviousCompilation()
+                && targetSymbol is { IsReferenceType: true }
+                && targetSymbol.NullableAnnotation != NullableAnnotation.Annotated
+                && cast.Expression is not PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
+                && this.IsNullablePromotedValue(cast.Expression))
+            {
+                operand = new NonNullAssertionExpression(operand);
+            }
+
+            return new ConversionExpression(targetType, operand);
         }
 
         private GExpression TranslateWith(WithExpressionSyntax with)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -9816,12 +9816,21 @@ public sealed class CSharpToGSharpTranslator
                 || type.IsNullable
                 || symbol == null
                 || returnType is not { IsReferenceType: true }
-                || returnType is ITypeParameterSymbol
                 || returnType.NullableAnnotation == NullableAnnotation.Annotated)
             {
                 return type;
             }
 
+            // Issue #914 (oblivious deferred-return-promotion): a REFERENCE-
+            // constrained type-parameter return (`where T : class`) is promoted
+            // to `T?` when its return is null-tainted, exactly like a concrete
+            // reference return. For such a `T`, `T?` is an unambiguous nullable
+            // reference (the generated locals already use `var x T? = …`), and
+            // the promotion leaves `Cast[T]`/`typeof(T)`/`T()` NAME positions
+            // untouched. Unconstrained type parameters are excluded automatically:
+            // their `IsReferenceType` is false, so the guard above already
+            // returned. (Method-return-of-`T` was the residual blocking
+            // Oahu.Foundation's `DeserializeJsonFile[T]() T { … return nil }`.)
             return ObliviousNullabilityAnalyzer.IsTainted(this.context.Compilation, symbol)
                 ? MakeNullable(type)
                 : type;
@@ -9961,11 +9970,18 @@ public sealed class CSharpToGSharpTranslator
             // null-taint analysis proved this symbol null-tainted. This is the
             // ONLY behavioral change for oblivious code — for a nullable-enabled
             // compilation `IsTainted` short-circuits to false, so every existing
-            // path stays byte-identical. Type parameters are excluded: promoting
-            // a `where T : class` declaration to `T?` would break `Cast[T]`/
-            // `typeof(T)` name positions.
-            if (declared is not ITypeParameterSymbol
-                && ObliviousNullabilityAnalyzer.IsTainted(this.context.Compilation, symbol))
+            // path stays byte-identical.
+            //
+            // Issue #914 (oblivious deferred-return-promotion): a REFERENCE-
+            // constrained type parameter (`where T : class`) is eligible too. The
+            // top-of-method guard already required `declared.IsReferenceType`, so
+            // an UNCONSTRAINED `T` (whose `IsReferenceType` is false, and for whom
+            // `T?` would mean `Nullable<T>`) never reaches here. For a class-
+            // constrained `T`, `T?` is an unambiguous nullable reference — the
+            // generated `var settings T? = …` locals already rely on it — and
+            // `Cast[T]`/`typeof(T)`/`T()` NAME positions are unaffected because
+            // they reference `T`, not the promoted symbol.
+            if (ObliviousNullabilityAnalyzer.IsTainted(this.context.Compilation, symbol))
             {
                 return true;
             }

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -226,7 +226,20 @@ internal static class ObliviousNullabilityAnalyzer
         // a parameter that ever receives null becomes `T?` too. This keeps a
         // pass-through call `Callee(maybeNull)` from demanding a non-null
         // parameter (GS0154) once `maybeNull` is promoted.
-        if (node is InvocationExpressionSyntax or ObjectCreationExpressionSyntax)
+        //
+        // Issue #914 (oblivious sink): a constructor initializer delegation
+        // (`: this(...)` / `: base(...)`) is an argument-passing call site too.
+        // A convenience initializer that forwards its own (possibly promoted)
+        // parameters to the designated initializer — e.g. `LogMessage(string
+        // context, string message) : this(DateTime.Now, threadId, context,
+        // message)` where `context`/`message` are themselves promoted `string?`
+        // — must promote the designated initializer's matching parameters, else
+        // the delegating call demands a non-null value (GS0154). Roslyn models a
+        // constructor initializer as an `IInvocationOperation`, so it flows
+        // through the same argument→parameter edge collection.
+        if (node is InvocationExpressionSyntax
+            or ObjectCreationExpressionSyntax
+            or ConstructorInitializerSyntax)
         {
             CollectArgumentEdges(node, model, tainted, edges);
         }

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -60,6 +60,29 @@ internal static class ObliviousNullabilityAnalyzer
     // subclassed-base-types / partial-type-parts caches in the translator.
     private static readonly ConditionalWeakTable<Compilation, TaintResult> Cache = new();
 
+    // Which source expressions a transitive return/forwarding edge follows.
+    private enum SourceScope
+    {
+        // Follow method-call returns AND every value declaration the value
+        // reads (fields, properties, locals, parameters). Default for method /
+        // local-function / lambda return seeding.
+        AllSources,
+
+        // Follow ONLY method-call returns (`m(args)`); plain identifier/member
+        // forwarding is skipped. Property-getter contract guardrail path where
+        // no forwarding may be followed.
+        CallsOnly,
+
+        // Follow method-call returns AND field/local/parameter forwarding, but
+        // NOT property forwarding. Used for a NON-CONTRACT property getter
+        // (issue #914 oblivious sink): `TextWriter Writer => logStreamWriter;`
+        // over a promoted `StreamWriter?` backing FIELD must itself be `T?`,
+        // yet `string Forward => Work;` forwarding another PROPERTY must keep
+        // its declared type and rely on the null-forgiveness `!!` pass, so the
+        // property contract with #1354 / #2167 is preserved.
+        CallsAndNonPropertyDeclarations,
+    }
+
     /// <summary>
     /// Whether <paramref name="symbol"/> (a declaration symbol: field / property
     /// / parameter / local, or a method whose RETURN is under test) is
@@ -461,22 +484,25 @@ internal static class ObliviousNullabilityAnalyzer
         // contract with the base / interface declaration.
         //
         // Issue #914 (oblivious sink): a NON-CONTRACT getter that merely FORWARDS
-        // a promoted-nullable field/property/local (e.g. `TextWriter Writer =>
+        // a promoted-nullable field/local/parameter (e.g. `TextWriter Writer =>
         // logStreamWriter;` where the backing field is a promoted `StreamWriter?`
         // — null-assigned in `CloseWriter`) must itself be `T?`, otherwise the
         // `StreamWriter? -> TextWriter` getter return is rejected (GS0155). Such
-        // a property genuinely can be null, so plain identifier/member forwarding
-        // is followed too (`callSourcesOnly: false`); every downstream member use
-        // (`Writer.WriteLine(...)`) then gets its `!!` assertion from the
-        // translator's null-forgiveness pass, which keys off the same promotion.
-        // A contract member stays direct-taint-only (transitive is false below,
-        // so the forwarding edges are not recorded for it regardless).
+        // a property genuinely can be null, so field/local/param forwarding is
+        // followed (`SourceScope.CallsAndNonPropertyDeclarations`); every
+        // downstream member use (`Writer.WriteLine(...)`) then gets its `!!`
+        // assertion from the translator's null-forgiveness pass, which keys off
+        // the same promotion. Forwarding ANOTHER PROPERTY is deliberately NOT
+        // followed, so `string Forward => Work;` keeps its declared type and the
+        // #1354 / #2167 property-contract guardrail is preserved. A contract
+        // member stays direct-taint-only (transitive is false below, so the
+        // forwarding edges are not recorded for it regardless).
         bool transitive = !ImplementsBaseOrInterfaceMember(propertySymbol);
 
         // `Prop => expr;`
         if (propertyArrowBody != null)
         {
-            ApplyReturnValue(canonicalReturn, propertyArrowBody, model, tainted, edges, transitive, callSourcesOnly: false);
+            ApplyReturnValue(canonicalReturn, propertyArrowBody, model, tainted, edges, transitive, SourceScope.CallsAndNonPropertyDeclarations);
         }
 
         // Only the `get` accessor produces the property value; `set`/`init`
@@ -491,7 +517,7 @@ internal static class ObliviousNullabilityAnalyzer
         // `get => expr;`
         if (getter.ExpressionBody?.Expression is ExpressionSyntax getterArrow)
         {
-            ApplyReturnValue(canonicalReturn, getterArrow, model, tainted, edges, transitive, callSourcesOnly: false);
+            ApplyReturnValue(canonicalReturn, getterArrow, model, tainted, edges, transitive, SourceScope.CallsAndNonPropertyDeclarations);
         }
 
         // `get { ... return x; }`
@@ -499,7 +525,7 @@ internal static class ObliviousNullabilityAnalyzer
         {
             if (statement.Expression != null)
             {
-                ApplyReturnValue(canonicalReturn, statement.Expression, model, tainted, edges, transitive, callSourcesOnly: false);
+                ApplyReturnValue(canonicalReturn, statement.Expression, model, tainted, edges, transitive, SourceScope.CallsAndNonPropertyDeclarations);
             }
         }
     }
@@ -546,7 +572,7 @@ internal static class ObliviousNullabilityAnalyzer
         HashSet<ISymbol> tainted,
         List<(ISymbol Target, ISymbol Source)> edges,
         bool transitive,
-        bool callSourcesOnly = false)
+        SourceScope scope = SourceScope.AllSources)
     {
         if (IsDirectlyNullable(value, model))
         {
@@ -554,7 +580,7 @@ internal static class ObliviousNullabilityAnalyzer
         }
         else if (transitive)
         {
-            AddEdges(returnSymbol, value, model, edges, callSourcesOnly);
+            AddEdges(returnSymbol, value, model, edges, scope);
         }
     }
 
@@ -581,21 +607,22 @@ internal static class ObliviousNullabilityAnalyzer
     // Adds transitive edges `target <- source` for every declaration symbol the
     // value expression reads (identifier/member) or the method it calls
     // (invocation), unwrapping the compositional forms `??`, `?:`, `(cast)`.
-    // When <paramref name="callSourcesOnly"/> is set, ONLY method-call returns
-    // (`m(args)`) are followed — plain identifier/member forwarding is skipped.
-    // This is the interprocedural edge used for property/indexer getters (issue
-    // #2167): a getter returning a nullable-returning method call is promoted,
-    // but a getter that merely FORWARDS a tainted field/property keeps its
-    // declared type and relies on the translator's null-forgiveness `!!` pass
-    // (issue #1354 / #2157), preserving the property contract.
+    // <paramref name="scope"/> selects which forwarding sources are followed
+    // (see <see cref="SourceScope"/>). This is the interprocedural edge used for
+    // property/indexer getters (issue #2167 / #914): a getter returning a
+    // nullable-returning method call is promoted; a non-contract getter that
+    // forwards a tainted field/local/param is promoted; but a getter that merely
+    // FORWARDS another PROPERTY keeps its declared type and relies on the
+    // translator's null-forgiveness `!!` pass (issue #1354 / #2157), preserving
+    // the property contract.
     private static void AddEdges(
         ISymbol target,
         ExpressionSyntax value,
         SemanticModel model,
         List<(ISymbol Target, ISymbol Source)> edges,
-        bool callSourcesOnly = false)
+        SourceScope scope = SourceScope.AllSources)
     {
-        foreach (ISymbol source in ResolveSources(value, model, callSourcesOnly))
+        foreach (ISymbol source in ResolveSources(value, model, scope))
         {
             edges.Add((target, source));
         }
@@ -604,7 +631,7 @@ internal static class ObliviousNullabilityAnalyzer
     private static IEnumerable<ISymbol> ResolveSources(
         ExpressionSyntax expression,
         SemanticModel model,
-        bool callSourcesOnly = false)
+        SourceScope scope = SourceScope.AllSources)
     {
         switch (expression)
         {
@@ -612,7 +639,7 @@ internal static class ObliviousNullabilityAnalyzer
                 yield break;
 
             case ParenthesizedExpressionSyntax paren:
-                foreach (ISymbol source in ResolveSources(paren.Expression, model, callSourcesOnly))
+                foreach (ISymbol source in ResolveSources(paren.Expression, model, scope))
                 {
                     yield return source;
                 }
@@ -626,7 +653,7 @@ internal static class ObliviousNullabilityAnalyzer
             // `a ?? b`: the result is `b`'s value when `a` is null.
             case BinaryExpressionSyntax coalesce
                 when coalesce.IsKind(SyntaxKind.CoalesceExpression):
-                foreach (ISymbol source in ResolveSources(coalesce.Right, model, callSourcesOnly))
+                foreach (ISymbol source in ResolveSources(coalesce.Right, model, scope))
                 {
                     yield return source;
                 }
@@ -635,8 +662,8 @@ internal static class ObliviousNullabilityAnalyzer
 
             // `cond ? a : b`: either branch may flow through.
             case ConditionalExpressionSyntax ternary:
-                foreach (ISymbol source in ResolveSources(ternary.WhenTrue, model, callSourcesOnly)
-                    .Concat(ResolveSources(ternary.WhenFalse, model, callSourcesOnly)))
+                foreach (ISymbol source in ResolveSources(ternary.WhenTrue, model, scope)
+                    .Concat(ResolveSources(ternary.WhenFalse, model, scope)))
                 {
                     yield return source;
                 }
@@ -644,7 +671,7 @@ internal static class ObliviousNullabilityAnalyzer
                 break;
 
             case CastExpressionSyntax cast:
-                foreach (ISymbol source in ResolveSources(cast.Expression, model, callSourcesOnly))
+                foreach (ISymbol source in ResolveSources(cast.Expression, model, scope))
                 {
                     yield return source;
                 }
@@ -662,13 +689,27 @@ internal static class ObliviousNullabilityAnalyzer
 
             case IdentifierNameSyntax:
             case MemberAccessExpressionSyntax:
-                if (callSourcesOnly)
+                if (scope == SourceScope.CallsOnly)
                 {
                     yield break;
                 }
 
                 ISymbol symbol = model.GetSymbolInfo(expression).Symbol;
-                if (symbol != null && (IsValueDeclarationSymbol(symbol) || symbol is IMethodSymbol))
+                if (symbol == null)
+                {
+                    break;
+                }
+
+                // A NON-CONTRACT getter follows field/local/param forwarding but
+                // never PROPERTY forwarding (that would regress the #1354 /
+                // #2167 property-contract guardrail).
+                if (scope == SourceScope.CallsAndNonPropertyDeclarations
+                    && symbol is IPropertySymbol)
+                {
+                    yield break;
+                }
+
+                if (IsValueDeclarationSymbol(symbol) || symbol is IMethodSymbol)
                 {
                     yield return Canonical(symbol);
                 }

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -459,12 +459,24 @@ internal static class ObliviousNullabilityAnalyzer
         // behavior and rely on the translator's null-forgiveness pass (issue
         // #1354) to assert the forwarded value non-null, preserving the property
         // contract with the base / interface declaration.
+        //
+        // Issue #914 (oblivious sink): a NON-CONTRACT getter that merely FORWARDS
+        // a promoted-nullable field/property/local (e.g. `TextWriter Writer =>
+        // logStreamWriter;` where the backing field is a promoted `StreamWriter?`
+        // — null-assigned in `CloseWriter`) must itself be `T?`, otherwise the
+        // `StreamWriter? -> TextWriter` getter return is rejected (GS0155). Such
+        // a property genuinely can be null, so plain identifier/member forwarding
+        // is followed too (`callSourcesOnly: false`); every downstream member use
+        // (`Writer.WriteLine(...)`) then gets its `!!` assertion from the
+        // translator's null-forgiveness pass, which keys off the same promotion.
+        // A contract member stays direct-taint-only (transitive is false below,
+        // so the forwarding edges are not recorded for it regardless).
         bool transitive = !ImplementsBaseOrInterfaceMember(propertySymbol);
 
         // `Prop => expr;`
         if (propertyArrowBody != null)
         {
-            ApplyReturnValue(canonicalReturn, propertyArrowBody, model, tainted, edges, transitive, callSourcesOnly: true);
+            ApplyReturnValue(canonicalReturn, propertyArrowBody, model, tainted, edges, transitive, callSourcesOnly: false);
         }
 
         // Only the `get` accessor produces the property value; `set`/`init`
@@ -479,7 +491,7 @@ internal static class ObliviousNullabilityAnalyzer
         // `get => expr;`
         if (getter.ExpressionBody?.Expression is ExpressionSyntax getterArrow)
         {
-            ApplyReturnValue(canonicalReturn, getterArrow, model, tainted, edges, transitive, callSourcesOnly: true);
+            ApplyReturnValue(canonicalReturn, getterArrow, model, tainted, edges, transitive, callSourcesOnly: false);
         }
 
         // `get { ... return x; }`
@@ -487,7 +499,7 @@ internal static class ObliviousNullabilityAnalyzer
         {
             if (statement.Expression != null)
             {
-                ApplyReturnValue(canonicalReturn, statement.Expression, model, tainted, edges, transitive, callSourcesOnly: true);
+                ApplyReturnValue(canonicalReturn, statement.Expression, model, tainted, edges, transitive, callSourcesOnly: false);
             }
         }
     }


### PR DESCRIPTION
## Summary
Scopes in the oblivious **deferred-return-promotion** residual that was blocking a fully-translatable `Oahu.Foundation`.

The #2113 whole-program oblivious null-taint promotion (`ObliviousNullabilityAnalyzer.IsTainted`) excluded **all** type parameters from both promotion gates:
- `PromoteReturnIfTainted` (method return types), and
- `IsPromotedToNullableReference` (field / property / local / parameter declarations, and the `!!` assertion pass).

That left generic reference-returning methods stranded. A method like
```csharp
T DeserializeJsonFile<T>(string path) where T : class, new() { try { ... } catch { return null; } }
```
kept a non-null `T` return, so its `return nil` and the `T?` locals consuming its result collided with the non-null return — surfacing as GS0129 (`T == nil`), GS0155 (`nil`/`T?` → `T`) in `SettingsManager`, `ApplEnv`, etc.

## Fix
Both gates **already** required the declaration/return to be `IsReferenceType`. For a type parameter that predicate is true only under a reference constraint (`where T : class`) and false for an unconstrained `T` (whose `T?` would mean `Nullable<T>`). Removing the explicit `ITypeParameterSymbol` exclusion therefore promotes exactly the well-defined `where T : class` case to `T?` when the taint analysis proves it null-tainted, and leaves unconstrained type parameters non-null automatically.

`Cast[T]` / `typeof(T)` / `T()` **name** positions are unaffected — they reference `T`, not the promoted symbol; the generated code already emits `var settings T? = …` locals for the same type parameter.

## Impact (measured on the Oahu corpus)
| app | before | after |
|---|---|---|
| Oahu.Foundation | 29 | **23** |
| Oahu.Data | 43 | **37** |
| Oahu.Decrypt | 76 | 76 (no regression) |

Translate stays PASS for all three.

## Tests
All 1128 existing cs2gs translator tests pass. Adds `Issue914ObliviousTypeParameterReturnPromotionTests` (4 cases): class-constrained null-returning type-param → `T?` return; tainted type-param local → `T?`; unconstrained type-param stays non-null; nullable-enabled compilation unchanged.

Refs #914