### PR TITLE
Fix #2188: reference-constrained type parameter T? convertible/comparable to object?

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -350,6 +350,70 @@ public sealed record BoundBinaryOperator
         => new BoundBinaryOperator(SyntaxKind.QuestionQuestionToken, BoundBinaryOperatorKind.NullCoalesce, leftType, rightType, resultType);
 
     /// <summary>
+    /// Issue #2188: builds a reference-equality (<c>==</c> / <c>!=</c>) operator
+    /// over two reference-type operands (nullable or not) — e.g. <c>object?</c>
+    /// versus a reference-constrained <c>T?</c>. Both operands compare by
+    /// reference identity, yielding <c>bool</c>. This is bound only as a final
+    /// fallback (after built-in, user-defined, and CLR operator resolution) so a
+    /// user-declared <c>operator ==</c> on a reference type always wins.
+    /// </summary>
+    /// <param name="syntaxKind">The <c>==</c> or <c>!=</c> token.</param>
+    /// <param name="leftType">The left operand type.</param>
+    /// <param name="rightType">The right operand type.</param>
+    /// <returns>The reference-equality operator.</returns>
+    internal static BoundBinaryOperator MakeReferenceEquality(SyntaxKind syntaxKind, TypeSymbol leftType, TypeSymbol rightType)
+    {
+        var kind = syntaxKind == SyntaxKind.EqualsEqualsToken
+            ? BoundBinaryOperatorKind.Equals
+            : BoundBinaryOperatorKind.NotEquals;
+        return new BoundBinaryOperator(syntaxKind, kind, leftType, rightType, TypeSymbol.Bool);
+    }
+
+    /// <summary>
+    /// Issue #2188: true when <paramref name="type"/> participates in reference
+    /// equality — a reference type (in nullable or non-nullable form) or a
+    /// reference-constrained type parameter. A nullable wrapper is unwrapped
+    /// first; the underlying is reference-comparable when it is an interface, a
+    /// delegate / function / sequence reference, a user class, a
+    /// reference-constrained type parameter (<c>[T class …]</c> or a class-base
+    /// constraint), or any CLR-backed non-value, non-pointer type (e.g.
+    /// <c>object</c>, <c>string</c>, imported classes/interfaces). Value types,
+    /// unconstrained and <c>struct</c>-constrained type parameters (whose
+    /// <c>T?</c> erases to <c>Nullable&lt;T&gt;</c>) are excluded.
+    /// </summary>
+    /// <param name="type">The operand type to classify.</param>
+    /// <returns><see langword="true"/> when the type participates in reference equality.</returns>
+    internal static bool IsReferenceEqualityOperand(TypeSymbol type)
+    {
+        var underlying = type is NullableTypeSymbol nullable ? nullable.UnderlyingType : type;
+        if (underlying == null)
+        {
+            return false;
+        }
+
+        if (underlying is TypeParameterSymbol tp)
+        {
+            return tp.HasReferenceTypeConstraint || tp.ClassConstraint != null;
+        }
+
+        if (underlying is InterfaceSymbol
+            || underlying is DelegateTypeSymbol
+            || underlying is FunctionTypeSymbol
+            || underlying is SequenceTypeSymbol
+            || underlying is AsyncSequenceTypeSymbol)
+        {
+            return true;
+        }
+
+        if (underlying is StructSymbol structSymbol)
+        {
+            return structSymbol.IsClass;
+        }
+
+        return underlying.ClrType is { } clr && !clr.IsValueType && !clr.IsPointer && !clr.IsByRef;
+    }
+
+    /// <summary>
     /// PR N-4: returns true for operator kinds that have a lifted
     /// counterpart per C# §7.3.7 — arithmetic, bitwise, equality, and
     /// ordering. Logical short-circuit (&amp;&amp;, ||), null-coalesce, and

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -1853,6 +1853,23 @@ public sealed class Conversion
             return true;
         }
 
+        // Issue #2188: a reference-constrained type parameter (`[T class …]`,
+        // i.e. `HasReferenceTypeConstraint`, or a class-base constraint such as
+        // `[T Box]`) is PROVABLY a reference type. It therefore participates in
+        // the reference-conversion arms exactly like any other reference type:
+        // `T -> object`/`T? -> object?`, `T -> Base`/`T? -> Base?`, and
+        // `T -> IFace`/`T? -> IFace?` for any interface in its constraint set.
+        // The type parameter carries no `ClrType` during binding (it is an open
+        // VAR/MVAR), so the CLR-backing check below cannot recognise it — this
+        // arm supplies the missing classification. Unconstrained and
+        // value-type-constrained parameters are intentionally excluded (their
+        // `T?` erases to `Nullable<T>`, a value type), so they keep their
+        // value-type conversion rules.
+        if (IsReferenceConstrainedTypeParameter(type))
+        {
+            return true;
+        }
+
         // Imported / CLR-backed types are reference-like when the CLR backing
         // is a class or interface (not a value type, pointer, or by-ref). User
         // value structs carry a null ClrType during binding and fall through.
@@ -1863,6 +1880,17 @@ public sealed class Conversion
 
         return false;
     }
+
+    /// <summary>
+    /// Issue #2188: true when <paramref name="type"/> is a type parameter that
+    /// is provably a reference type — it carries an explicit reference-type
+    /// (<c>class</c>) constraint or a base-class constraint. Such a parameter
+    /// behaves as a reference type for conversion and equality purposes in both
+    /// its nullable (<c>T?</c>) and non-nullable (<c>T</c>) forms.
+    /// </summary>
+    private static bool IsReferenceConstrainedTypeParameter(TypeSymbol type)
+        => type is TypeParameterSymbol tp
+            && (tp.HasReferenceTypeConstraint || tp.ClassConstraint != null);
 
     private static bool IsInterfaceLikeType(TypeSymbol type)
     {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -1391,6 +1391,29 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(syntax);
             }
 
+            // Issue #2188: reference equality (`==` / `!=`) between two reference
+            // types the built-in table's homogeneous arms did not cover — e.g. a
+            // nullable reference (`object?`, `string?`, `T?`), a base/interface
+            // reference, or a reference-constrained type parameter (`[T class …]`)
+            // against another reference. Both operands compare by reference
+            // identity, exactly as `object == object` does. This is tried LAST —
+            // after built-in, user-defined, and CLR `op_*` resolution — so a
+            // user-declared `operator ==` on a reference type always takes
+            // precedence. Value-type operands (whose `T?` erases to
+            // `Nullable<T>`) are excluded, so an unconstrained or
+            // `struct`-constrained `T?` still reports GS0129.
+            if ((syntax.OperatorToken.Kind == SyntaxKind.EqualsEqualsToken
+                    || syntax.OperatorToken.Kind == SyntaxKind.BangEqualsToken)
+                && BoundBinaryOperator.IsReferenceEqualityOperand(boundLeft.Type)
+                && BoundBinaryOperator.IsReferenceEqualityOperand(boundRight.Type))
+            {
+                var referenceOperator = BoundBinaryOperator.MakeReferenceEquality(
+                    syntax.OperatorToken.Kind,
+                    boundLeft.Type,
+                    boundRight.Type);
+                return new BoundBinaryExpression(null, boundLeft, referenceOperator, boundRight, binderCtx.IsCheckedContext);
+            }
+
             Diagnostics.ReportUndefinedBinaryOperator(syntax.OperatorToken.Location, syntax.OperatorToken.Text, boundLeft.Type, boundRight.Type);
             return new BoundErrorExpression(null);
         }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -702,6 +702,36 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #2188: reference equality (`==` / `!=`) where at least one
+        // operand is an open type parameter or its nullable form (`T`, `T?`)
+        // and the other side is another reference type (`object`, `object?`,
+        // an interface, a user class, `T`, `T?`). The homogeneous `object ==
+        // object` / bare `T == T` arms above do not own this mixed shape, and
+        // the generic `Ceq` tail cannot compare an opaque VAR/MVAR stack slot
+        // against a managed reference (ilverify rejects it — see the #831 note
+        // above). Box each type-parameter-shaped operand first (`box !!T`,
+        // which the JIT elides for a reference `T` and which yields a genuine
+        // reference for `T?`), leaving already-reference operands untouched,
+        // then compare the two references with `ceq`. This mirrors, for the
+        // nullable / type-parameter cases, the reference-identity semantics the
+        // `object == object` arm gets for free.
+        if ((b.Op.Kind == BoundBinaryOperatorKind.Equals || b.Op.Kind == BoundBinaryOperatorKind.NotEquals)
+            && (RefEqOperandNeedsBox(b.Left.Type) || RefEqOperandNeedsBox(b.Right.Type))
+            && BoundBinaryOperator.IsReferenceEqualityOperand(b.Left.Type)
+            && BoundBinaryOperator.IsReferenceEqualityOperand(b.Right.Type))
+        {
+            this.EmitReferenceEqualityOperand(b.Left);
+            this.EmitReferenceEqualityOperand(b.Right);
+            this.il.OpCode(ILOpCode.Ceq);
+            if (b.Op.Kind == BoundBinaryOperatorKind.NotEquals)
+            {
+                this.il.LoadConstantI4(0);
+                this.il.OpCode(ILOpCode.Ceq);
+            }
+
+            return;
+        }
+
         // Short-circuit evaluation for logical `&&` and `||`: the right
         // operand must not be evaluated when the left operand already
         // determines the result. Emit a dup + conditional branch so the
@@ -871,6 +901,30 @@ internal sealed partial class MethodBodyEmitter
         this.EmitExpression(operand);
         this.il.OpCode(ILOpCode.Box);
         this.il.Token(this.outer.GetElementTypeToken(operand.Type));
+    }
+
+    // Issue #2188: true when a reference-equality operand is an open type
+    // parameter (`T`) or its nullable form (`T?`) and therefore must be boxed
+    // to a genuine object reference before `ceq` — the verifier cannot compare
+    // an opaque VAR/MVAR stack slot against a managed reference. Already-
+    // reference operands (`object`, `object?`, interfaces, user classes) leave
+    // a reference on the stack and need no box.
+    private static bool RefEqOperandNeedsBox(TypeSymbol type)
+        => type is TypeParameterSymbol
+            || (type is NullableTypeSymbol nullable && nullable.UnderlyingType is TypeParameterSymbol);
+
+    // Issue #2188: pushes a reference-equality operand as an object reference,
+    // boxing an open type-parameter operand (`box !!T`, a JIT no-op for a
+    // reference `T`, and the reference-producing box for `T?`) and leaving
+    // already-reference operands unboxed.
+    private void EmitReferenceEqualityOperand(BoundExpression operand)
+    {
+        this.EmitExpression(operand);
+        if (RefEqOperandNeedsBox(operand.Type))
+        {
+            this.il.OpCode(ILOpCode.Box);
+            this.il.Token(this.outer.GetElementTypeToken(operand.Type));
+        }
     }
 
     private void EmitEqualityNegationIfNeeded(BoundBinaryOperatorKind kind)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2188ReferenceConstrainedTypeParamObjectTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2188ReferenceConstrainedTypeParamObjectTests.cs
@@ -1,0 +1,206 @@
+// <copyright file="Issue2188ReferenceConstrainedTypeParamObjectTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2188: a reference-constrained type parameter (<c>[T class …]</c> or a
+/// class-base constraint such as <c>[T Base]</c>) is provably a reference type,
+/// so it must participate in reference conversions and reference equality in
+/// both its nullable (<c>T?</c>) and non-nullable (<c>T</c>) forms, exactly like
+/// any other reference type:
+/// <list type="bullet">
+/// <item><c>T -&gt; object</c> and <c>T? -&gt; object?</c> are implicit (GS0155
+/// previously rejected the nullable form).</item>
+/// <item><c>object?/object == T?/T</c> and <c>!=</c> resolve to reference
+/// equality in either operand order (GS0129 previously rejected them).</item>
+/// </list>
+/// The fix generalises rather than special-casing <c>object</c>: the same rule
+/// covers base-class and interface targets in the constraint set. Unconstrained
+/// and <c>struct</c>-constrained parameters (whose <c>T?</c> erases to
+/// <c>Nullable&lt;T&gt;</c>, a value type) are intentionally excluded and keep
+/// their value-type rules — the negative cases below prove they still error.
+/// </summary>
+public class Issue2188ReferenceConstrainedTypeParamObjectTests
+{
+    [Fact]
+    public void ClassConstrainedNullableTypeParam_ToNullableObject_Assignment_Compiles()
+    {
+        var source = @"
+package p
+func Sink[T class init()]() {
+    var v T? = nil
+    var box object? = v
+    box = v
+}
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void ClassConstrainedNullableTypeParam_ToNullableObject_Return_Compiles()
+    {
+        var source = @"
+package p
+func Sink[T class](x T?) object? -> x
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void ClassConstrainedNonNullableTypeParam_ToObject_StillCompiles()
+    {
+        // Guard: the pre-existing `T -> object` reference conversion (#1540)
+        // must keep working alongside the new nullable form.
+        var source = @"
+package p
+func Sink[T class](x T) object -> x
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NullableObject_EqualsNullableClassTypeParam_Compiles()
+    {
+        var source = @"
+package p
+func Cmp[T class](x T?, o object?) bool -> o == x
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NullableClassTypeParam_NotEqualsNullableObject_Compiles()
+    {
+        // Reverse operand order must resolve identically.
+        var source = @"
+package p
+func Cmp[T class](x T?, o object?) bool -> x != o
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NonNullableObject_EqualsNonNullableClassTypeParam_Compiles()
+    {
+        var source = @"
+package p
+func Cmp[T class](x T, o object) bool -> o == x
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void BaseClassConstrainedNullableTypeParam_ToNullableObject_Compiles()
+    {
+        // Generalisation: a class-base constraint (`[T Animal]`) is also a
+        // provable reference type.
+        var source = @"
+package p
+class Animal { init() {} }
+func Sink[T Animal](x T?) object? -> x
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void BaseClassConstrainedNullableTypeParam_ToNullableBase_Compiles()
+    {
+        // Not special-cased to `object`: the reference conversion also reaches
+        // the base-class constraint target.
+        var source = @"
+package p
+class Animal { init() {} }
+func Sink[T Animal](x T?) Animal? -> x
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void BaseClassConstrained_NullableBaseEqualsNullableTypeParam_Compiles()
+    {
+        var source = @"
+package p
+class Animal { init() {} }
+func Cmp[T Animal](x T?, a Animal?) bool -> a == x
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void UnconstrainedNullableTypeParam_ToNullableObject_ReportsConversionError()
+    {
+        // Negative: an UNCONSTRAINED T's `T?` is `Nullable<T>` (a value type),
+        // NOT a reference — it must NOT convert to `object?`.
+        var source = @"
+package p
+func Sink[T](x T?) object? -> x
+";
+        var diagnostics = Evaluate(source).Diagnostics;
+        Assert.Contains(diagnostics, d => d.Id == "GS0155" || d.Message.Contains("Cannot convert"));
+    }
+
+    [Fact]
+    public void UnconstrainedNullableTypeParam_EqualsNullableObject_ReportsOperatorError()
+    {
+        // Negative: reference equality must NOT be admitted for an
+        // unconstrained (value-or-reference) `T?`.
+        var source = @"
+package p
+func Cmp[T](x T?, o object?) bool -> o == x
+";
+        var diagnostics = Evaluate(source).Diagnostics;
+        Assert.Contains(diagnostics, d => d.Id == "GS0129");
+    }
+
+    [Fact]
+    public void StructConstrainedNullableTypeParam_EqualsNullableObject_ReportsOperatorError()
+    {
+        // Negative: a `struct`-constrained `T?` is a genuine `Nullable<T>`
+        // value type and must not be reference-compared to `object?`.
+        var source = @"
+package p
+func Cmp[T struct](x T?, o object?) bool -> o == x
+";
+        var diagnostics = Evaluate(source).Diagnostics;
+        Assert.Contains(diagnostics, d => d.Id == "GS0129");
+    }
+
+    [Fact]
+    public void ExactIssueRepro_Compiles()
+    {
+        var source = @"
+package Repro
+class C {
+    shared {
+        var box object?
+        func Put[T class init()]() {
+            var v T? = nil
+            C.box = v
+            if C.box != v {
+                C.box = nil
+            }
+        }
+    }
+}
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree) { IsLibrary = true };
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2188ReferenceConstrainedTypeParamObjectEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2188ReferenceConstrainedTypeParamObjectEmitTests.cs
@@ -1,0 +1,154 @@
+// <copyright file="Issue2188ReferenceConstrainedTypeParamObjectEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #2188 (emit): storing a reference-constrained <c>T?</c> into an
+/// <c>object?</c> slot and comparing the two with <c>==</c> / <c>!=</c> must JIT
+/// and run with reference-identity semantics. The emitted body boxes the open
+/// type-parameter operand (<c>box !!T</c>, a no-op for a reference <c>T</c>) and
+/// compares with <c>ceq</c>; before the fix these forms failed to bind (GS0155 /
+/// GS0129), and a naive lowering would have produced ilverify-rejected IL
+/// comparing an opaque VAR/MVAR slot against a managed reference.
+/// </summary>
+public class Issue2188ReferenceConstrainedTypeParamObjectEmitTests
+{
+    [Fact]
+    public void NullableClassTypeParam_StoredInObjectAndCompared_JitsAndRuns()
+    {
+        const string Source = @"package Issue2188Run
+import System
+
+class Animal { init() {} }
+
+func RoundTrips[T class init()](v T?) bool {
+    var box object? = v
+    var same = box == v
+    var diff = box != v
+    return same && !diff
+}
+
+func DiffersFromOther[T class init()](v T?, other object?) bool -> other != v
+
+var a = Animal()
+Console.WriteLine(RoundTrips[Animal](a))
+Console.WriteLine(RoundTrips[Animal](nil))
+Console.WriteLine(DiffersFromOther[Animal](a, Animal()))
+Console.WriteLine(DiffersFromOther[Animal](a, a))
+";
+        var lines = CompileLoadInvokeCaptureStdout(Source, nameof(NullableClassTypeParam_StoredInObjectAndCompared_JitsAndRuns))
+            .Replace("\r\n", "\n").Trim().Split('\n');
+
+        Assert.Equal("True", lines[0].Trim());  // reference stored in object? equals itself
+        Assert.Equal("True", lines[1].Trim());  // nil stored in object? equals nil
+        Assert.Equal("True", lines[2].Trim());  // distinct instance differs
+        Assert.Equal("False", lines[3].Trim()); // same instance does not differ
+    }
+
+    [Fact]
+    public void NullableClassTypeParam_EmitsBoxAndCeqNoInvalidProgram()
+    {
+        // The emitted comparison must contain a `box` (for the type-parameter
+        // operand) and must JIT — the reflection invoke below throws
+        // InvalidProgramException on malformed IL.
+        const string Source = @"package Issue2188Emit
+import System
+
+func Eq[T class](v T?, o object?) bool -> o == v
+
+Console.WriteLine(Eq[string](""x"", ""x""))
+Console.WriteLine(Eq[string](""x"", ""y""))
+";
+        var lines = CompileLoadInvokeCaptureStdout(Source, nameof(NullableClassTypeParam_EmitsBoxAndCeqNoInvalidProgram))
+            .Replace("\r\n", "\n").Trim().Split('\n');
+
+        Assert.Equal("True", lines[0].Trim());
+        Assert.Equal("False", lines[1].Trim());
+    }
+
+    [Fact]
+    public void UserDefinedEqualityOperatorOnClass_StillTakesPrecedence()
+    {
+        // Regression guard: a reference type with a user-declared `operator ==`
+        // must keep using VALUE semantics — the #2188 reference-equality
+        // fallback must NOT preempt it.
+        const string Source = @"package Issue2188UserOp
+import System
+
+class Vector2 {
+    var X int32
+    var Y int32
+}
+
+func (a Vector2) operator ==(b Vector2) bool -> a.X == b.X && a.Y == b.Y
+func (a Vector2) operator !=(b Vector2) bool -> a.X != b.X || a.Y != b.Y
+
+var p = Vector2{X: 1, Y: 2}
+var q = Vector2{X: 1, Y: 2}
+Console.WriteLine(p == q)
+Console.WriteLine(p != q)
+";
+        var lines = CompileLoadInvokeCaptureStdout(Source, nameof(UserDefinedEqualityOperatorOnClass_StillTakesPrecedence))
+            .Replace("\r\n", "\n").Trim().Split('\n');
+
+        // Distinct instances with equal fields: user `==` returns True (value
+        // equality); a reference-identity fallback would have returned False.
+        Assert.Equal("True", lines[0].Trim());
+        Assert.Equal("False", lines[1].Trim());
+    }
+
+    private static string CompileLoadInvokeCaptureStdout(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var originalOut = Console.Out;
+            using var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

For a reference-constrained type parameter `T` (`[T class …]`, or a class-base constraint `[T Base]`), the compiler failed to treat `T?` as a reference type:

- **GS0155** — `T?` was not implicitly convertible to `object?` (nor to a base class / interface in the constraint set), even though the non-nullable `T -> object` conversion already worked.
- **GS0129** — `==` / `!=` between `object?`/`object` and `T?`/`T` were rejected. This latent gap also affected non-generic nullable references (`object? == string?`).

### Repro (failed on `main`, now compiles clean)
```gsharp
package Repro
class C {
    shared {
        var box object?
        func Put[T class init()]() {
            var v T? = nil
            C.box = v            // was GS0155
            if C.box != v {      // was GS0129
                C.box = nil
            }
        }
    }
}
```

## Root cause & fix (generalised — not special-cased to `object`)

- **Conversion** (`Conversion.cs`): `IsReferenceLikeTarget` classified reference-like types by CLR backing, which an open type parameter lacks. It now also recognises a reference-constrained type parameter, so the existing lifted / non-nullable reference-conversion arms cover `T -> object`, `T? -> object?`, and base/interface targets uniformly.
- **Equality** (`ExpressionBinder.Operators.cs` + `BoundBinaryOperator.cs` + `MethodBodyEmitter.Operators.cs`): reference equality is bound as a final fallback — **after** built-in, user-defined, and CLR `op_*` resolution, so a user-declared `operator ==` on a reference type still wins — whenever both operands are reference types, in either operand order. The emitter boxes any open type-parameter operand (`box !!T`, a JIT no-op for a reference `T`) and compares with `ceq`, matching `object == object` reference-identity semantics and staying verifier-clean.

## Generalisation & negatives

The rule is: a reference-constrained type parameter is a reference type; it participates in reference conversions (to `object`, base classes, implemented interfaces) and reference equality, in nullable and non-nullable forms, both operand orders. Unconstrained and `struct`-constrained parameters (whose `T?` erases to `Nullable<T>`) are excluded — negative tests confirm they still error (GS0155 / GS0129).

## Tests

- `Issue2188ReferenceConstrainedTypeParamObjectTests` (binder): positive `T? -> object?`, `T -> object`, `object? == T?` / `T? != object?` (both orders), base-class-constraint variants, the exact issue repro; negatives for unconstrained/`struct` `T?`.
- `Issue2188ReferenceConstrainedTypeParamObjectEmitTests` (emit, JIT-and-run): round-trip store/compare correctness; user-defined `operator ==` precedence guard.
- Full `Core.Tests` suite passes (5713 passed, 1 skipped); emitted IL for `samples/Operators.gs` remains byte-identical.

Fixes #2188
Refs #914