### PR TITLE
cs2gs: Foundation delegate-Invoke + primary-ctor param promotion

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914FoundationSinkTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914FoundationSinkTranslationTests.cs
@@ -1,0 +1,243 @@
+// <copyright file="Issue914FoundationSinkTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for the residual Oahu.Foundation oblivious-sink
+/// defects fixed under issue #914:
+/// <list type="number">
+/// <item>a T2-lifted primary-constructor parameter must receive the same
+/// oblivious-nullability promotion as an ordinary parameter,</item>
+/// <item>a null-conditional delegate invoke on a non-simple (call / <c>??</c>)
+/// receiver must spill the receiver into a local and invoke it directly,</item>
+/// <item>a promoted-nullable function value subscribed to a CLR event must be
+/// forgiven with <c>!!</c> at the subscription sink,</item>
+/// <item>a CLR reference cast <c>(T)expr</c> must emit the <c>expr as T</c>
+/// downcast form, not the value-conversion call <c>T(expr)</c>.</item>
+/// </list>
+/// Every promotion is gated to oblivious compilations, so a nullable-enabled
+/// compilation stays byte-identical (unpromoted).
+/// </summary>
+public class Issue914FoundationSinkTranslationTests
+{
+    [Fact]
+    public void Oblivious_LiftedPrimaryConstructorDelegateParameter_PromotesToNullable()
+    {
+        // `report` is copied into a field by the single constructor, so the class
+        // canonicalizes to a class-header primary constructor. It is invoked
+        // null-conditionally (`report?.Invoke`) and a derived ctor forwards a
+        // promoted-nullable `base(report)` argument, so the lifted primary-ctor
+        // parameter must render `((T) -> void)?` — otherwise the base ctor's
+        // 1-arg signature no longer matches (GS0214).
+        string printed = TranslateOblivious(@"
+using System;
+namespace Demo
+{
+    public abstract class ProgressBase<T>
+    {
+        private readonly Action<T> report;
+        protected ProgressBase(Action<T> report) { this.report = report; }
+        public void Fire(T v) { report?.Invoke(v); }
+    }
+
+    public class ProgressImpl : ProgressBase<int>
+    {
+        public ProgressImpl(Action<int> report = null) : base(report) { }
+    }
+}");
+
+        Assert.Contains("open class ProgressBase[T](report ((T) -> void)?)", printed);
+    }
+
+    [Fact]
+    public void Enabled_LiftedPrimaryConstructorDelegateParameter_StaysUnpromoted()
+    {
+        // Under a nullable-ENABLED compilation the whole-program taint analysis
+        // short-circuits to false and the base parameter carries no null default
+        // of its own, so the lifted primary-ctor parameter stays the non-nullable
+        // `(T) -> void` — proving enabled code is byte-identical.
+        string printed = TranslateEnabled(@"
+using System;
+namespace Demo
+{
+    public abstract class ProgressBase<T>
+    {
+        private readonly Action<T> report;
+        protected ProgressBase(Action<T> report) { this.report = report; }
+        public void Fire(T v) { report?.Invoke(v); }
+    }
+
+    public class ProgressImpl : ProgressBase<int>
+    {
+        public ProgressImpl(Action<int>? report = null) : base(report) { }
+    }
+}");
+
+        Assert.Contains("open class ProgressBase[T](report (T) -> void)", printed);
+        Assert.DoesNotContain("open class ProgressBase[T](report ((T) -> void)?)", printed);
+    }
+
+    [Fact]
+    public void Oblivious_NullConditionalDelegateInvokeOnCallReceiver_SpillsAndInvokesDirectly()
+    {
+        // `ToStringFunc<T>()?.Invoke(val)` — a null-conditional invoke whose
+        // receiver is a generic call — cannot use `.Invoke` (gsc can't resolve it
+        // on a type-parameter function type) nor `recv?(args)` (ternary collision),
+        // so the receiver spills into a local invoked directly as `local?(val)`.
+        string printed = TranslateOblivious(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+        private Func<T, string> ToStringFunc<T>() => null;
+        public string ToString<T>(T val) => ToStringFunc<T>()?.Invoke(val);
+    }
+}");
+
+        Assert.DoesNotContain(".Invoke", printed);
+        Assert.Contains("__spill", printed);
+        Assert.Contains("?(val)", printed);
+    }
+
+    [Fact]
+    public void Oblivious_PromotedDelegateSubscribedToEvent_ForgivesRhsWithBang()
+    {
+        // `handler` is a delegate parameter defaulted to `null`, so it promotes to
+        // `((object, EventArgs) -> void)?`. Subscribing it to the named-delegate
+        // event `Fired` needs a `!!` so the promoted `T?` converts to the event's
+        // non-nullable delegate type (GS0155 otherwise).
+        string printed = TranslateOblivious(@"
+using System;
+namespace Demo
+{
+    public delegate void MyHandler(object sender, EventArgs e);
+
+    public class Source
+    {
+        public event MyHandler Fired;
+    }
+
+    public class C
+    {
+        public void Sub(Source s, MyHandler handler = null)
+        {
+            s.Fired += handler;
+        }
+    }
+}");
+
+        Assert.Contains("s.Fired += handler!!", printed);
+    }
+
+    [Fact]
+    public void ReferenceDowncast_EmitsAsForm_NotConversionCall()
+    {
+        // `(IEnumerable)o` is a CLR reference downcast: it must render the
+        // `o as IEnumerable` downcast form, never the value-conversion call
+        // `IEnumerable(o)` (which gsc rejects for a reference target).
+        string printed = TranslateOblivious(@"
+using System.Collections;
+namespace Demo
+{
+    public class C
+    {
+        public void Iter(object o)
+        {
+            foreach (var x in (IEnumerable)o) { }
+        }
+    }
+}");
+
+        Assert.Contains("o as IEnumerable", printed);
+        Assert.DoesNotContain("IEnumerable(o", printed);
+    }
+
+    [Fact]
+    public void ReferenceDowncast_BetweenClasses_EmitsAsForm()
+    {
+        // A class-to-derived-class downcast is also a reference conversion and
+        // must use the `as` form rather than a constructor-shaped call, which
+        // would otherwise be parsed as instantiating the target type.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Animal { }
+    public class Dog : Animal { public void Bark() { } }
+
+    public class C
+    {
+        public void Run(Animal a)
+        {
+            ((Dog)a).Bark();
+        }
+    }
+}");
+
+        Assert.Contains("as Dog", printed);
+        Assert.DoesNotContain("Dog(a", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string TranslateEnabled(string source)
+    {
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.EnabledInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Select(r => r).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
@@ -396,11 +396,12 @@ namespace Demo
 
     /// <summary>
     /// A null-conditional delegate invocation whose receiver is a call (its text ends
-    /// in <c>)</c>) keeps the explicit <c>?.Invoke(...)</c>: G# would parse
-    /// <c>GetHandler()?(args)</c> as the ternary operator, so the rewrite is skipped.
+    /// in <c>)</c>) cannot render <c>GetHandler()?(args)</c> — G# would parse that as
+    /// the ternary operator — nor keep <c>.Invoke</c> reliably, so the receiver is
+    /// spilled into a local that is invoked directly as <c>local?(args)</c> (issue #914).
     /// </summary>
     [Fact]
-    public void NullConditionalInvoke_CallReceiver_KeepsExplicitInvoke()
+    public void NullConditionalInvoke_CallReceiver_SpillsReceiverAndInvokesDirectly()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -412,8 +413,9 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("GetHandler()?.Invoke(x)", printed);
-        Assert.DoesNotContain("?(x)", printed);
+        Assert.DoesNotContain(".Invoke", printed);
+        Assert.Contains("__spill0 = GetHandler()", printed);
+        Assert.Contains("__spill0?(x)", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -14959,6 +14959,23 @@ public sealed class CSharpToGSharpTranslator
                 operand = new NonNullAssertionExpression(operand);
             }
 
+            // Issue #914: a CLR REFERENCE conversion `(T)expr` (a downcast such as
+            // `(IEnumerable)o`, or a cross-cast between reference types) has no
+            // conversion-call form in G# — gsc's `T(expr)` is the value/numeric/
+            // string-conversion form and rejects a reference cast (GS0155/GS0130
+            // "IEnumerable(o)" / "List[int32](o)"). The reference downcast form is
+            // `expr as T`, which yields `T?`; the surrounding null-forgiveness pass
+            // (receiver / foreach-iterable / return / argument) re-asserts `!!`
+            // wherever the context needs the non-null `T`, preserving the C# hard
+            // cast's throw-on-misuse. Boxing/unboxing and user-defined conversions
+            // are NOT reference conversions and keep the conversion-call form.
+            if (targetSymbol is { IsReferenceType: true }
+                && sourceSymbol != null
+                && this.context.Compilation.ClassifyConversion(sourceSymbol, targetSymbol).IsReference)
+            {
+                return new BinaryExpression(operand, "as", new TypeExpression(targetType));
+            }
+
             return new ConversionExpression(targetType, operand);
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -10537,6 +10537,11 @@ public sealed class CSharpToGSharpTranslator
                         return enumExtResult;
                     }
 
+                    if (this.TryTranslateNullConditionalDelegateInvoke(conditionalAccess, out GExpression delegateInvokeResult))
+                    {
+                        return delegateInvokeResult;
+                    }
+
                     return new ConditionalAccessExpression(
                         this.TranslateExpression(conditionalAccess.Expression),
                         this.TranslateExpression(conditionalAccess.WhenNotNull));
@@ -13503,6 +13508,57 @@ public sealed class CSharpToGSharpTranslator
 
             result = new ParenthesizedExpression(
                 new IfExpression(guard, call, new IdentifierExpression("nil")));
+            return true;
+        }
+
+        // Issue #914 (oblivious sink): a null-conditional delegate/event invoke
+        // `recv?.Invoke(args)` whose receiver is a NON-simple expression (a call,
+        // parenthesized, or `??` expression) has no direct G# spelling —
+        // `recv?(args)` parses `recv` ending in `)`/`]` as a ternary condition
+        // (GS0155), and gsc cannot resolve the `.Invoke` MEMBER on a function
+        // whose type mentions a type parameter (`(T) -> R`, GS0159). The only
+        // form gsc accepts is the direct null-conditional call on a *local*, so
+        // spill the receiver into a single-evaluation `let` and invoke that:
+        // `recv?.Invoke(a)` → `let __spillN = recv` + `__spillN?(a)`. Requires an
+        // active spill seam (an arrow/statement body) to host the `let`; without
+        // one, defer to the existing `.Invoke` path, which is already correct for
+        // the non-type-parameter receiver shapes that reach here seam-less.
+        private bool TryTranslateNullConditionalDelegateInvoke(
+            ConditionalAccessExpressionSyntax conditionalAccess,
+            out GExpression result)
+        {
+            result = null;
+
+            if (this.pendingSpillPrologue == null
+                || conditionalAccess.WhenNotNull is not InvocationExpressionSyntax invocation
+                || invocation.Expression is not MemberBindingExpressionSyntax binding
+                || binding.Name.Identifier.Text != "Invoke")
+            {
+                return false;
+            }
+
+            if (this.context.GetSymbolInfo(invocation).Symbol
+                is not IMethodSymbol { MethodKind: MethodKind.DelegateInvoke })
+            {
+                return false;
+            }
+
+            // A simple identifier/member/`this` receiver already lowers to the
+            // direct `recv?(args)` form via TryGetDelegateInvokeReceiver — leave
+            // it untouched so the common case stays spill-free and byte-identical.
+            if (conditionalAccess.Expression is IdentifierNameSyntax
+                or MemberAccessExpressionSyntax
+                or ThisExpressionSyntax)
+            {
+                return false;
+            }
+
+            GExpression receiver = this.SpillOperand(
+                this.TranslateExpression(conditionalAccess.Expression));
+            var invokeArguments = this.TranslateArguments(invocation.ArgumentList.Arguments);
+            result = new ConditionalAccessExpression(
+                receiver,
+                new InvocationExpression(new ConditionalReceiverExpression(), invokeArguments, null));
             return true;
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -2138,6 +2138,20 @@ public sealed class CSharpToGSharpTranslator
             {
                 (string Name, ITypeSymbol Type, bool IsProperty) target = paramToTarget[param];
                 GTypeReference type = this.typeMapper.Map(target.Type, this.context, param.Locations.FirstOrDefault());
+
+                // Issue #914 (oblivious sink): a T2-lifted primary-constructor
+                // parameter must receive the SAME oblivious-nullability promotion
+                // as an ordinary parameter (MapParameter) — otherwise a reference
+                // (incl. function-typed) parameter that is null-conditionally used
+                // (`report?(…)`) or receives a promoted-nullable argument at a
+                // `base(...)`/`this(...)` call site keeps its non-nullable header
+                // type, so the lifted primary ctor's arity/signature no longer
+                // matches the promoted argument a derived ctor forwards (GS0214).
+                // Both helpers no-op for a nullable-enabled compilation and are
+                // already guarded to reference types, so value-type params are
+                // untouched.
+                type = this.PromoteIfUsedAsNullable(type, param);
+                type = this.PromoteDelegateParameterInvokedWithNull(type, param);
                 GExpression liftedDefault = this.BuildOptionalParameterDefault(param, type, node);
                 primaryParameters.Add(new Parameter(SanitizeIdentifier(target.Name), type, defaultValue: liftedDefault));
                 if (target.IsProperty)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5849,6 +5849,36 @@ public sealed class CSharpToGSharpTranslator
             return this.context.GetTypeInfo(assignment.Left).Type?.TypeKind == TypeKind.Delegate;
         }
 
+        // Issue #914 (oblivious sink): a CLR event subscription `e += handler` /
+        // `e -= handler` whose right-hand side is an oblivious-promoted nullable
+        // function value (e.g. a `DataReceivedEventHandler eventHandler = null`
+        // parameter that promotes to `((object, DataReceivedEventArgs) -> void)?`)
+        // assigns a `T?` into the event's NAMED delegate type. gsc imports that
+        // delegate target as a non-nullable reference — even when the C# BCL event
+        // is annotated `DataReceivedEventHandler?`, the metadata annotation is not
+        // carried onto the arrow type gsc converts through — so the extra `?` on
+        // the promoted RHS is rejected (GS0155). Forgive it at the sink with `!!`,
+        // exactly like every other promoted-nullable-into-non-nullable sink
+        // (return/argument/tuple). Gated to a promoted RHS, so a nullable-enabled
+        // compilation (nothing is promoted) and every non-promoted RHS are
+        // byte-identical.
+        private GExpression ForgiveEventSubscriptionRhs(
+            AssignmentExpressionSyntax assignment, GExpression translatedRhs)
+        {
+            if ((!assignment.IsKind(SyntaxKind.AddAssignmentExpression)
+                    && !assignment.IsKind(SyntaxKind.SubtractAssignmentExpression))
+                || translatedRhs is NonNullAssertionExpression
+                || this.context.GetSymbolInfo(assignment.Left).Symbol is not IEventSymbol eventSymbol
+                || eventSymbol.Type is not { IsReferenceType: true })
+            {
+                return translatedRhs;
+            }
+
+            return this.IsNullablePromotedValue(assignment.Right)
+                ? new NonNullAssertionExpression(translatedRhs)
+                : translatedRhs;
+        }
+
         // For a compound numeric assignment `x OP= y` (`+= -= *= /= %= &= |= ^=`),
         // G# requires the RHS to share the LHS's numeric type; a mismatched RHS is
         // coerced to the LHS type via the conversion-call form (e.g. `x += int64(y)`).
@@ -6815,6 +6845,7 @@ public sealed class CSharpToGSharpTranslator
                         this.TranslateExpression(assignment.Right));
                     assignRhs = this.CoerceCompoundAssignmentRhs(assignment, assignRhs);
                     assignRhs = this.CoercePointerConversion(assignment.Right, assignRhs);
+                    assignRhs = this.ForgiveEventSubscriptionRhs(assignment, assignRhs);
                     return new AssignmentStatement(
                         this.TranslateAssignmentTarget(assignment.Left),
                         assignRhs,


### PR DESCRIPTION
## Summary
Clears cs2gs-side residual gsc compile errors in the Oahu.Foundation translation. Each fix generalizes an oblivious-nullability / delegate translator rule (not a one-file patch). cs2gs-only — no `src/` changes, no new SyntaxKind/BoundNodeKind.

**Oahu.Foundation: 13 → 6 gsc errors** (refs_ef), translate=PASS.

## Fixes
- **A. Primary-constructor parameter promotion** (`ThreadProgress` GS0214). A T2-lifted C# primary/only constructor parameter now receives the same oblivious taint/promotion as ordinary and designated-init params, so a delegate-typed primary-ctor param used null-conditionally (or forwarded to `base(...)` with a promoted argument) is promoted to `T?`. Generalizes to any reference-typed (incl. function-typed) primary-ctor param, generic or not.
- **B. Null-conditional delegate invoke on a non-simple receiver** (`AbstractPrimitiveTypes` GS0159/GS0155). `recv?.Invoke(args)` on a call / parenthesized / `??` receiver now spills the receiver into a local invoked directly as `local?(args)`, avoiding both the unresolved `.Invoke` on type-parameter function types and the `recv?(args)` ternary parse collision.
- **C. Promoted-nullable function value into a named-delegate event** (`ProcessHost` GS0155). A promoted `((...) -> void)?` value subscribed via `+=`/`-=` to a CLR event is forgiven with `!!` at the subscription sink.
- **D. Reference downcast** (`TreeDecomposition` GS0155, also incidentally cleared `CustomAttributes` #987). A CLR reference cast `(T)expr` now emits `expr as T` instead of the value-conversion call `T(expr)` that gsc rejects for reference targets.

## Deferred
- **E. `parts[i] = punct.Infix?[x]`** (`EnumUtil` GS0156). Promoting the array local to `[]string?` turns 1 error into 5 (read-site cascade where oblivious receiver/index null-forgiveness never fires), and `!!`-on-RHS is semantically wrong (C# stores null without throwing inside `try/catch(IndexOutOfRangeException)`). Left deferred — net error count would rise.

## Regression guard (refs_ef, all translate=PASS)
| App | Before | After |
|---|---|---|
| Oahu.Foundation | 13 | 6 |
| Oahu.Decrypt | 76 | 76 |
| Oahu.Data | 28 | 20 |

## Tests
Added `Issue914FoundationSinkTranslationTests` (round-trip translation tests for A–D, including a nullable-ENABLED assertion that the primary-ctor param stays unpromoted), and updated the existing call-receiver invoke test for the new spill behavior. Full cs2gs suite: **1147 passing**.

Refs #914
