### PR TITLE
Fix #2193: user extension participates in overload resolution vs same-named BCL instance method

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -3055,15 +3055,33 @@ internal sealed partial class ExpressionBinder
                 // type from the delegate target yields `() -> Stream` directly so
                 // the call resolves and the produced delegate is created over a
                 // method whose return already matches the parameter.
-                if (!delegateTargetCandidatesComputed)
-                {
-                    delegateTargetCandidatesComputed = true;
-                    delegateTargetCandidateParams = CollectDelegateTargetCandidateParameterLists(receiver, classSymbol, methodName);
-                }
-
+                //
+                // Issue #2193: but if a same-named user extension function has a
+                // function-typed parameter at this position, the CLR candidate
+                // set is not authoritative — target-typing the lambda to a CLR
+                // delegate (e.g. the void `SendOrPostCallback` of
+                // `SynchronizationContext.Send`) would erase the lambda's return
+                // type and break inference of the extension's result type
+                // parameter (GS0151). Bind the lambda with its natural type so
+                // both the CLR instance method and the user extension can compete
+                // (delegate-reshaping conversions still make it applicable to a
+                // concrete CLR delegate parameter when that path is chosen).
                 var argName = argumentNames.IsDefault ? null : argumentNames[argSlot];
-                boundArguments.Add(BindCallArgumentWithDelegateTargetTyping(
-                    argument, delegateTargetCandidateParams, sourceArgIndex: argSlot, argName: argName, paramOffset: 0));
+                if (UserExtensionHasFunctionTypedParameterAt(receiver, methodName, argSlot))
+                {
+                    boundArguments.Add(BindExpression(inner));
+                }
+                else
+                {
+                    if (!delegateTargetCandidatesComputed)
+                    {
+                        delegateTargetCandidatesComputed = true;
+                        delegateTargetCandidateParams = CollectDelegateTargetCandidateParameterLists(receiver, classSymbol, methodName);
+                    }
+
+                    boundArguments.Add(BindCallArgumentWithDelegateTargetTyping(
+                        argument, delegateTargetCandidateParams, sourceArgIndex: argSlot, argName: argName, paramOffset: 0));
+                }
             }
             else
             {
@@ -3608,6 +3626,24 @@ internal sealed partial class ExpressionBinder
                 switch (resolution.Outcome)
                 {
                     case OverloadResolution.ResolutionOutcome.Resolved:
+                        // Issue #2193: a CLR/imported instance method that shares a
+                        // name with a user extension function must not automatically
+                        // win overload resolution when it is only applicable through
+                        // a lossy delegate-reshaping conversion (e.g. a G# function
+                        // value `(T) -> TResult` discarding its result to satisfy a
+                        // named void delegate parameter like
+                        // `SynchronizationContext.Send(SendOrPostCallback, object)`)
+                        // while an in-scope user extension is a strictly better
+                        // (identity/standard) match. Merge the user-extension
+                        // candidate set into the decision and prefer the extension
+                        // when it is strictly better; instance methods that are a
+                        // good (non-reshaping) match still win unconditionally.
+                        if (receiver != null
+                            && TryPreferBetterExtensionOverClrInstanceMethod(receiver, methodName, resolution.Best, argTypes, arguments, ce, argumentNames, out var betterExtensionCall))
+                        {
+                            return betterExtensionCall;
+                        }
+
                         // Issue #977: now that the overload is chosen, re-bind
                         // any inline `out var`/`out let`/`out _` placeholders
                         // against the resolved by-ref parameter so the new
@@ -3718,6 +3754,227 @@ internal sealed partial class ExpressionBinder
 
         Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
         return new BoundErrorExpression(null);
+    }
+
+    /// <summary>
+    /// Issue #2193: returns <see langword="true"/> when a user-defined extension
+    /// function for the <c>(receiver, name)</c> pair declares a function-typed
+    /// (arrow / delegate) parameter at the given user-argument position. The
+    /// extension's synthetic receiver occupies <c>Parameters[0]</c>, so user
+    /// argument <paramref name="argSlot"/> aligns with <c>Parameters[argSlot + 1]</c>.
+    /// Used to suppress CLR-derived lambda target-typing that would otherwise
+    /// erase the lambda's return type and break the extension's type-argument
+    /// inference.
+    /// </summary>
+    private bool UserExtensionHasFunctionTypedParameterAt(BoundExpression receiver, string methodName, int argSlot)
+    {
+        if (receiver?.Type == null)
+        {
+            return false;
+        }
+
+        var extCandidates = scope.TryLookupExtensionFunctions(receiver.Type, methodName);
+        if (extCandidates.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        var paramIndex = argSlot + 1;
+        foreach (var candidate in extCandidates)
+        {
+            if (candidate != null
+                && paramIndex < candidate.Parameters.Length
+                && candidate.Parameters[paramIndex].Type is FunctionTypeSymbol)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #2193: overload-resolution tie-break that merges the user-defined
+    /// extension-function candidate set for <c>(receiver type, name)</c> into a
+    /// resolved CLR/imported instance-method call and prefers the extension when
+    /// it is a strictly better match.
+    /// <para>
+    /// The defect: a same-named BCL instance method can be <em>applicable</em> to
+    /// a call only through a lossy delegate-reshaping conversion — e.g. a G#
+    /// function value <c>(T) -&gt; TResult</c> discarding its result to satisfy the
+    /// named void delegate parameter of
+    /// <c>SynchronizationContext.Send(SendOrPostCallback, object)</c>. Because the
+    /// CLR-instance path commits as soon as it resolves, the user extension
+    /// <c>Send[T, TResult]((T) -&gt; TResult, T) TResult</c> — an exact match — never
+    /// competed, so the call bound to the <c>void</c> member (GS0124 / GS0151).
+    /// </para>
+    /// <para>
+    /// The fix is deliberately conservative so it does not disturb normal
+    /// instance-method resolution: the extension is only preferred when (a) the
+    /// resolved instance method's <em>worst</em> argument conversion is a
+    /// delegate-reshaping conversion (rank ≥
+    /// <see cref="OverloadResolution.ImplicitConversionKind.LambdaToVoidDelegate"/>),
+    /// and (b) some applicable user extension matches the same arguments with a
+    /// strictly better worst-case conversion. An instance method that matches by
+    /// identity / standard implicit conversion always wins, so a genuine member
+    /// that is the better match is never shadowed.
+    /// </para>
+    /// </summary>
+    private bool TryPreferBetterExtensionOverClrInstanceMethod(
+        BoundExpression receiver,
+        string methodName,
+        MethodInfo clrBest,
+        Type[] argTypes,
+        ImmutableArray<BoundExpression> arguments,
+        CallExpressionSyntax ce,
+        ImmutableArray<string> argumentNames,
+        out BoundExpression result)
+    {
+        result = null;
+        if (receiver?.Type == null || clrBest == null || argTypes == null)
+        {
+            return false;
+        }
+
+        var extCandidates = scope.TryLookupExtensionFunctions(receiver.Type, methodName);
+        if (extCandidates.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        // Only intervene when the CLR instance method is applicable solely via a
+        // lossy delegate-reshaping conversion; a good (identity/standard implicit)
+        // instance match is never overridden.
+        var clrWorst = ComputeClrCandidateWorstConversionRank(clrBest, argTypes);
+        if (!IsDelegateReshapingConversion(clrWorst))
+        {
+            return false;
+        }
+
+        // The extension must be a strictly better match than the instance method.
+        var extWorst = ComputeBestApplicableExtensionWorstConversionRank(extCandidates, argTypes);
+        if (extWorst == OverloadResolution.ImplicitConversionKind.None
+            || (int)extWorst >= (int)clrWorst)
+        {
+            return false;
+        }
+
+        if (TryBindExtensionFunctionOverload(receiver, methodName, arguments, ce, argumentNames, out var extResult)
+            && extResult is not BoundErrorExpression)
+        {
+            result = extResult;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #2193: a delegate-reshaping implicit conversion (rank ≥
+    /// <see cref="OverloadResolution.ImplicitConversionKind.LambdaToVoidDelegate"/>
+    /// and ≤
+    /// <see cref="OverloadResolution.ImplicitConversionKind.DelegateReturnNumericWidening"/>)
+    /// reshapes a G# function value to satisfy a differently-shaped or
+    /// differently-named CLR delegate parameter (discarding a return value,
+    /// widening/covarying a return type, or retargeting to a named delegate).
+    /// These are the "worst"-ranked conversions and are the loose applicability
+    /// that lets a same-named BCL instance method shadow an exact user extension.
+    /// </summary>
+    private static bool IsDelegateReshapingConversion(OverloadResolution.ImplicitConversionKind kind)
+    {
+        return kind is OverloadResolution.ImplicitConversionKind.LambdaToVoidDelegate
+            or OverloadResolution.ImplicitConversionKind.DelegateReturnCovariance
+            or OverloadResolution.ImplicitConversionKind.DelegateStructuralMatch
+            or OverloadResolution.ImplicitConversionKind.DelegateReturnNumericWidening;
+    }
+
+    /// <summary>
+    /// Issue #2193: classifies each supplied argument against the corresponding
+    /// parameter of a resolved CLR candidate and returns the <em>worst</em>
+    /// (highest-ordinal) implicit-conversion rank across all arguments. Returns
+    /// <see cref="OverloadResolution.ImplicitConversionKind.None"/> when the
+    /// arities do not line up positionally (the candidate matched in an expanded
+    /// / named / defaulted form this cheap check cannot reason about, so the
+    /// tie-break is skipped and the instance method keeps winning).
+    /// </summary>
+    private static OverloadResolution.ImplicitConversionKind ComputeClrCandidateWorstConversionRank(MethodInfo candidate, Type[] argTypes)
+    {
+        var parameters = candidate.GetParameters();
+        if (parameters.Length != argTypes.Length)
+        {
+            return OverloadResolution.ImplicitConversionKind.None;
+        }
+
+        var worst = OverloadResolution.ImplicitConversionKind.Identity;
+        for (var i = 0; i < argTypes.Length; i++)
+        {
+            var kind = OverloadResolution.ClassifyImplicit(parameters[i].ParameterType, argTypes[i]);
+            if (kind == OverloadResolution.ImplicitConversionKind.None)
+            {
+                return OverloadResolution.ImplicitConversionKind.None;
+            }
+
+            if ((int)kind > (int)worst)
+            {
+                worst = kind;
+            }
+        }
+
+        return worst;
+    }
+
+    /// <summary>
+    /// Issue #2193: across every user extension overload for the
+    /// <c>(receiver, name)</c> pair, computes each applicable overload's worst
+    /// argument-conversion rank (using the same CLR-type projection that produced
+    /// <paramref name="argTypes"/>) and returns the <em>best</em> (lowest-ordinal)
+    /// worst-rank. The extension's synthetic receiver slot lives in
+    /// <c>Parameters[0]</c>, so user arguments align against <c>Parameters[1..]</c>.
+    /// Returns <see cref="OverloadResolution.ImplicitConversionKind.None"/> when
+    /// no overload lines up positionally with the arguments.
+    /// </summary>
+    private OverloadResolution.ImplicitConversionKind ComputeBestApplicableExtensionWorstConversionRank(
+        ImmutableArray<FunctionSymbol> extCandidates,
+        Type[] argTypes)
+    {
+        var best = OverloadResolution.ImplicitConversionKind.None;
+        foreach (var candidate in extCandidates)
+        {
+            if (candidate == null || candidate.Parameters.Length != argTypes.Length + 1)
+            {
+                continue;
+            }
+
+            var worst = OverloadResolution.ImplicitConversionKind.Identity;
+            var applicable = true;
+            for (var i = 0; i < argTypes.Length; i++)
+            {
+                var paramClr = GetEffectiveArgumentClrTypeForOverloadResolution(candidate.Parameters[i + 1].Type);
+                var kind = OverloadResolution.ClassifyImplicit(paramClr, argTypes[i]);
+                if (kind == OverloadResolution.ImplicitConversionKind.None)
+                {
+                    applicable = false;
+                    break;
+                }
+
+                if ((int)kind > (int)worst)
+                {
+                    worst = kind;
+                }
+            }
+
+            if (!applicable)
+            {
+                continue;
+            }
+
+            if (best == OverloadResolution.ImplicitConversionKind.None || (int)worst < (int)best)
+            {
+                best = worst;
+            }
+        }
+
+        return best;
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2193ExtensionOverloadShadowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2193ExtensionOverloadShadowTests.cs
@@ -1,0 +1,141 @@
+// <copyright file="Issue2193ExtensionOverloadShadowTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2193. A user-defined extension function that shares a name with an
+/// instance method on a BCL/imported receiver type must participate in overload
+/// resolution alongside the instance method. The best type-compatible candidate
+/// must win: when the BCL instance method is not applicable (or is a worse
+/// match) the user extension must be selected instead of resolving to the
+/// incompatible instance method.
+/// </summary>
+public class Issue2193ExtensionOverloadShadowTests
+{
+    [Fact]
+    public void UserExtension_Chosen_Over_NonMatching_BclInstanceMethod_ExplicitTypeArgs()
+    {
+        // SynchronizationContext.Send(SendOrPostCallback, object) returns void
+        // and shadows the user extension Send[T, TResult]((T) -> TResult, T)
+        // TResult. The extension is the correct (and only type-compatible)
+        // match, so the call must return TResult and compile clean.
+        const string source = @"
+package Repro
+import System.Threading
+
+func (ctx SynchronizationContext) Send[T, TResult](delgat (T) -> TResult, p T) TResult -> delgat(p)
+
+class Wrap {
+    private let sync SynchronizationContext?
+    init(s SynchronizationContext?) { this.sync = s }
+    func Call[T, TResult](delgat (T) -> TResult, p T) TResult {
+        return sync!!.Send[T, TResult](delgat, p)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void UserExtension_Chosen_Over_NonMatching_BclInstanceMethod_InferredTypeArgs()
+    {
+        const string source = @"
+package Repro
+import System.Threading
+
+func (ctx SynchronizationContext) Send[T, TResult](delgat (T) -> TResult, p T) TResult -> delgat(p)
+
+class Wrap {
+    private let sync SynchronizationContext?
+    init(s SynchronizationContext?) { this.sync = s }
+    func Call[T, TResult](delgat (T) -> TResult, p T) TResult {
+        return sync!!.Send(delgat, p)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void SameNamedInstanceMethod_ThatIsBetterMatch_StillWins_NoRegression()
+    {
+        // Guard: both a genuine string instance method StartsWith(string) and a
+        // same-named user extension StartsWith(string) are applicable. The
+        // instance method is an identity (exact) match, so it must still win —
+        // the extension (which would return false) must NOT shadow it.
+        const string source = @"
+import System
+
+func (s string) StartsWith(prefix string) bool {
+    return false
+}
+
+var text = ""hello world""
+text.StartsWith(""hello"")
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void UserExtension_Chosen_Over_NonMatching_BclInstanceMethod_InferredLambdaArgs_Emits()
+    {
+        // GS0151 variant: with inferred type arguments from a literal lambda the
+        // mixed candidate set (BCL void Send + user extension Send) must resolve
+        // to the extension, which returns TResult; the program then evaluates.
+        const string source = @"
+package Repro
+import System.Threading
+
+func (ctx SynchronizationContext) Send[T, TResult](delgat (T) -> TResult, p T) TResult -> delgat(p)
+
+var ctx = SynchronizationContext()
+ctx.Send((x int32) -> x + 1, 5)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(6, result.Value);
+    }
+
+    [Fact]
+    public void UserExtension_NonColliding_Name_Control_StillBinds()
+    {
+        const string source = @"
+package Repro
+import System.Threading
+
+func (ctx SynchronizationContext) Run[T, TResult](delgat (T) -> TResult, p T) TResult -> delgat(p)
+
+class Wrap {
+    private let sync SynchronizationContext?
+    init(s SynchronizationContext?) { this.sync = s }
+    func Call[T, TResult](delgat (T) -> TResult, p T) TResult {
+        return sync!!.Run(delgat, p)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Problem

When a user-defined extension function shares a **name** with an instance method on a BCL/imported receiver type, gsc's overload resolution picked the BCL instance method even when it was **not** type-compatible and the user extension **was** the correct match.

Concretely, `SynchronizationContext.Send(SendOrPostCallback, object)` (returns `void`) shadowed a user extension `Send[T, TResult]((T) -> TResult, T) TResult`:

- **Explicit / method-type-parameter args:** `sync!!.Send(delgat, p)` bound to the `void` member → **GS0124** ("Expression must have a value").
- **Inferred lambda args:** `ctx.Send((x int32) -> x + 1, 5)` → **GS0151** ("Cannot infer type argument 'TResult'").

Renaming the extension to a non-colliding name (e.g. `Run`) compiled clean, proving the extension was valid and the fault was name-collision overload resolution.

## Root cause

In the imported member-call path (`BindAccessorCall`):

1. The CLR-instance overload path **committed as soon as it resolved**. The void `Send` was *applicable* only through a lossy delegate-reshaping conversion (a G# function value `(T) -> TResult`, erased to `Func<object,object>`, discarding its result to satisfy the named void delegate `SendOrPostCallback` — `LambdaToVoidDelegate`). The exact-typed user extension never competed.
2. For the inferred-lambda form, the lambda argument was **target-typed to the void CLR delegate before overload resolution**, erasing its return type so the extension's `TResult` could not be inferred.

## Fix

Two coordinated, generalized changes (no special-casing of `SynchronizationContext`/`Send`):

1. **Candidate-set merging + betterness.** After a CLR instance method resolves, if an in-scope user extension for `(receiver, name)` is a *strictly better* match, prefer it. Intervention is gated to the case where the instance method's **worst** argument conversion is a delegate-reshaping conversion (rank ≥ `LambdaToVoidDelegate`), so a genuine instance method that matches by identity/standard implicit conversion always wins — normal instance-method resolution is untouched.
2. **Suppress CLR-derived lambda target-typing** when a same-named user extension declares a function-typed parameter at that argument position, so the lambda binds with its natural type and the extension's result type parameter can be inferred.

## Tests

`Issue2193ExtensionOverloadShadowTests`:
- extension chosen over the non-matching BCL `Send` with **explicit** type args;
- extension chosen with **inferred** (method-type-parameter) type args (original GS0124 repro);
- **negative guard:** a same-named `string.StartsWith(string)` instance method that *is* the exact match still wins over a colliding extension (no regression);
- **inferred-lambda emit/run** case `ctx.Send((x int32) -> x + 1, 5)` evaluates to `6` (GS0151 variant);
- non-colliding `Run` control.

Both repros compile clean. Targeted regression subsets (extension/overload: 345, lambda/delegate/call: 912) pass.

Fixes #2193
Refs #914