### PR TITLE
Fix #2195: infer Task.Run TResult from awaited element type of async lambda

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1051,13 +1051,37 @@ internal sealed partial class ExpressionBinder
     private static bool TryGetTaskElementType(TypeSymbol type, out TypeSymbol element)
     {
         element = null;
+
+        // Issue #2195: for an imported generic awaitable (e.g. `Task[T]`,
+        // `ValueTask[T]`) recover the awaited ELEMENT type from the SYMBOLIC
+        // type argument rather than the awaiter's CLR `GetResult()` return
+        // type. A same-compilation user type or an open type parameter is
+        // erased to `object` in the awaitable's CLR type, so the CLR fallback
+        // below would surface `object` — collapsing e.g. `Task.Run`'s inferred
+        // `TResult` to `object` when inferred from an async-lambda body. Locate
+        // which of the awaitable's own type parameters its `GetResult()`
+        // surfaces (a `!n` declared on the open awaitable), then project that
+        // position out of the symbolic `TypeArguments`. This generalizes the
+        // former `Task`1`-only fast path to every generic awaitable whose
+        // `GetResult()` returns its own type parameter (covers `Task[T]` and
+        // `ValueTask[T]` without special-casing either).
         if (type is ImportedTypeSymbol importedTask
             && !importedTask.TypeArguments.IsDefaultOrEmpty
-            && importedTask.TypeArguments.Length == 1
-            && importedTask.OpenDefinition?.FullName == "System.Threading.Tasks.Task`1")
+            && importedTask.ClrType is System.Type importedTaskClr
+            && importedTaskClr.IsGenericType
+            && !importedTaskClr.IsGenericTypeDefinition)
         {
-            element = importedTask.TypeArguments[0];
-            return true;
+            var openDef = importedTaskClr.GetGenericTypeDefinition();
+            var openShape = AwaitableShape.Resolve(openDef);
+            if (openShape?.ResultType is System.Type openResult
+                && openResult.IsGenericParameter
+                && ClrTypeUtilities.IsSameAs(openResult.DeclaringType, openDef)
+                && openResult.GenericParameterPosition >= 0
+                && openResult.GenericParameterPosition < importedTask.TypeArguments.Length)
+            {
+                element = importedTask.TypeArguments[openResult.GenericParameterPosition];
+                return true;
+            }
         }
 
         var clr = type?.ClrType;

--- a/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
@@ -729,7 +729,17 @@ public static class MoveNextBodyRewriter
                 {
                     // Value-type awaitables require a managed pointer (byref) for the
                     // instance GetAwaiter() call. Spill to a temp local and take address.
-                    var awaitableTypeSymbol = TypeSymbol.FromClrType(awaitableClrType);
+                    // Issue #2195: use the operand's SYMBOLIC type (e.g.
+                    // `ValueTask[Box]` / `ValueTask[T]`) for the spill temp rather
+                    // than its erased CLR type (`ValueTask<object>`). The symbolic
+                    // type argument is erased to `object` for a same-compilation
+                    // user type or an open type parameter; typing the temp with the
+                    // erased shape produced unverifiable IL (a `ValueTask<Box>`
+                    // value stored into a `ValueTask<object>` slot) that also failed
+                    // to load (`BadImageFormatException`) inside a generic async
+                    // lambda closure. The reference-type awaitable path below
+                    // already threads the symbolic operand type through unchanged.
+                    var awaitableTypeSymbol = awaitExpr.Expression?.Type ?? TypeSymbol.FromClrType(awaitableClrType);
                     var tempLocal = new LocalVariableSymbol(
                         "<>awaitable_" + resumePoint.State, isReadOnly: false, awaitableTypeSymbol);
                     ctx.allLocals.Add(tempLocal);

--- a/test/Compiler.Tests/Emit/Issue2195TaskRunAsyncLambdaInferenceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2195TaskRunAsyncLambdaInferenceEmitTests.cs
@@ -1,0 +1,175 @@
+// <copyright file="Issue2195TaskRunAsyncLambdaInferenceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2195: inferring a generic method's type argument from an ASYNC lambda
+/// whose body <c>await</c>s a generic awaitable. When <c>Task.Run(async () -&gt;
+/// await Inner[T]())</c> awaits a <c>ValueTask[T]</c>, the awaited element type
+/// must be recovered as <c>T</c> (not the erased <c>object</c>), so
+/// <c>Task.Run</c>'s <c>TResult</c> infers to <c>T</c> and <c>task.Result</c>
+/// round-trips the value. These emit tests prove the inferred call runs and
+/// returns the awaited result for both <c>ValueTask[T]</c> and <c>Task[T]</c>.
+/// </summary>
+public class Issue2195TaskRunAsyncLambdaInferenceEmitTests
+{
+    [Fact]
+    public void TaskRun_InfersFromAwaitedValueTask_ReturnsAwaitedResult()
+    {
+        // The awaited element is a same-compilation user type (`Box`), whose
+        // CLR type is erased to `object` inside `ValueTask[Box]`. Before the
+        // fix, `Task.Run`'s TResult inferred to `object`, so `task.Result`
+        // could not convert to the declared `Box`. The recovered element type
+        // must be `Box`, so `task.Result.Value` round-trips 42.
+        const string source = """
+            package i2195vt
+            import System
+            import System.Threading.Tasks
+
+            class Box {
+                var Value int32
+                init(v int32) {
+                    Value = v
+                }
+            }
+
+            func inner(b Box) ValueTask[Box] -> ValueTask[Box](b)
+
+            func get(b Box) Box {
+                let task = Task.Run(async () -> await inner(b))
+                return task.Result
+            }
+
+            Console.WriteLine(get(Box(42)).Value)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void TaskRun_InfersFromAwaitedTask_ReturnsAwaitedResult()
+    {
+        // The `Task[Box]` variant of the same erased-user-type awaitable.
+        const string source = """
+            package i2195t
+            import System
+            import System.Threading.Tasks
+
+            class Box {
+                var Value int32
+                init(v int32) {
+                    Value = v
+                }
+            }
+
+            func inner(b Box) Task[Box] -> Task.FromResult(b)
+
+            func get(b Box) Box {
+                let task = Task.Run(async () -> await inner(b))
+                return task.Result
+            }
+
+            Console.WriteLine(get(Box(7)).Value)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2195_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2195TaskRunAsyncLambdaInferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2195TaskRunAsyncLambdaInferenceTests.cs
@@ -1,0 +1,180 @@
+// <copyright file="Issue2195TaskRunAsyncLambdaInferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2195 — inferring a generic method's type argument from an ASYNC
+/// lambda argument whose body <c>await</c>s a generic awaitable.
+/// <para>
+/// <c>Task.Run(async () -&gt; await Inner[T]())</c>, where <c>Inner[T]</c>
+/// returns <c>ValueTask[T]</c>, inferred <c>TResult = object</c> instead of
+/// <c>T</c>: the awaited element type of the <c>ValueTask[T]</c> was recovered
+/// from the awaiter's CLR <c>GetResult()</c> return type, which is erased to
+/// <c>object</c> for a same-compilation user type / open type parameter. The
+/// async lambda's return type therefore inferred as <c>Task[object]</c>, fixing
+/// <c>Task.Run</c>'s <c>TResult</c> to <c>object</c>, and <c>task.Result</c>
+/// (<c>object</c>) failed to convert to the declared <c>T</c> (GS0156).
+/// </para>
+/// <para>
+/// The fix recovers the awaited element type from the awaitable's SYMBOLIC
+/// type argument. It is generalized to every generic awaitable whose
+/// <c>GetResult()</c> surfaces the awaitable's own type parameter — covering
+/// both <c>Task[U]</c> and <c>ValueTask[U]</c>, for any element type <c>U</c>
+/// (an open type parameter or a concrete BCL/user type) — and is not keyed on
+/// <c>Task.Run</c> or <c>ValueTask</c>.
+/// </para>
+/// </summary>
+public class Issue2195TaskRunAsyncLambdaInferenceTests
+{
+    [Fact]
+    public void TaskRun_InfersTResult_FromAwaitedValueTaskElement_OpenTypeParameter()
+    {
+        // The minimal issue repro: awaiting a `ValueTask[T]` must contribute
+        // `T` (not `object`) so `Task.Run`'s TResult infers to `T` and
+        // `task.Result : T` converts to the declared return `T`.
+        var source = @"
+package R
+import System.Threading.Tasks
+struct S {
+    func Inner[T]() ValueTask[T] -> ValueTask[T](default(T))
+    func Get[T]() T {
+        let task = Task.Run(async () -> await Inner[T]())
+        return task.Result
+    }
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void TaskRun_InfersTResult_FromAwaitedTaskElement_OpenTypeParameter()
+    {
+        // The `Task[T]` variant of the awaitable must behave identically.
+        var source = @"
+package R
+import System.Threading.Tasks
+struct S {
+    func Inner[T]() Task[T] -> Task.FromResult(default(T)!!)
+    func Get[T]() T {
+        let task = Task.Run(async () -> await Inner[T]())
+        return task.Result
+    }
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void TaskRun_InfersTResult_FromAwaitedValueTaskElement_ConcreteType()
+    {
+        // The awaited element type is a concrete BCL type (`string`): the
+        // async lambda's return type must infer `Task[string]`, so
+        // `Task.Run`'s TResult fixes to `string` and `task.Result : string`.
+        var source = @"
+package R
+import System.Threading.Tasks
+struct S {
+    func Inner() ValueTask[string] -> ValueTask[string](""hi"")
+    func Get() string {
+        let task = Task.Run(async () -> await Inner())
+        return task.Result
+    }
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void UserGenericMethod_InfersTResult_FromAwaitedValueTaskElement()
+    {
+        // Generalized (NOT Task.Run): a user-defined generic method with a
+        // `Func[Task[TResult]]`-shaped parameter must infer `TResult` from the
+        // async lambda that awaits a `ValueTask[T]`.
+        var source = @"
+package R
+import System.Threading.Tasks
+struct S {
+    func Run2[TResult](f () -> Task[TResult]) TResult -> f().Result
+    func Inner[T]() ValueTask[T] -> ValueTask[T](default(T))
+    func Get[T]() T {
+        let r = Run2(async () -> await Inner[T]())
+        return r
+    }
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void ExplicitTypeArgument_StillBinds_NoRegression()
+    {
+        // Guard: the explicit-type-argument oracle path must keep binding.
+        var source = @"
+package R
+import System.Threading.Tasks
+struct S {
+    func Inner[T]() ValueTask[T] -> ValueTask[T](default(T))
+    func Get[T]() T {
+        let task = Task.Run[T](async () -> await Inner[T]())
+        return task.Result
+    }
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
+    public void NonAsyncLambda_StillResolvesValueReturningOverload_NoRegression()
+    {
+        // Guard: a plain (non-task) lambda must keep binding to the `() -> T`
+        // overload — the generalized element-type recovery must not disturb it.
+        var source = @"
+package R
+struct S {
+    func Wrap[T](f () -> T) T -> f()
+    func Use() int32 {
+        let r = Wrap(() -> 42)
+        return r
+    }
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    private static void AssertBindsWithoutErrors(string source)
+    {
+        var paths = new List<string>();
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (!string.IsNullOrEmpty(tpa))
+        {
+            foreach (var p in tpa.Split(Path.PathSeparator))
+            {
+                if (!string.IsNullOrWhiteSpace(p) && File.Exists(p))
+                {
+                    paths.Add(p);
+                }
+            }
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(paths);
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), resolver);
+        var program = Binder.BindProgram(globalScope, resolver);
+        var diagnostics = globalScope.Diagnostics.AddRange(program.Diagnostics);
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
+    }
+}


### PR DESCRIPTION
## Summary
`Task.Run(async () -> await X())`, where the async lambda awaits a `ValueTask[T]` (or any generic awaitable whose element is a same-compilation user type / open type parameter), inferred `TResult = object` instead of the awaited element type. `.Result` then yielded `object`, failing to convert to `T` (GS0156). Supplying the type argument explicitly (`Task.Run[T](...)`) already worked.

## Root cause
`TryGetTaskElementType` special-cased only `Task\`1`, reading its symbolic type argument. Every other awaitable fell through to the CLR `GetAwaiter().GetResult()` result type, which is **erased to `object`** for a same-compilation user type or an open type parameter. The async lambda's return type therefore inferred as `Task[object]`, fixing `Task.Run`'s `TResult` to `object`.

## Fix (generalized — not keyed on `Task.Run`/`ValueTask`)
Recover the awaited element type from the awaitable's **symbolic** `TypeArguments`: locate which of the awaitable's own type parameters its `GetResult()` surfaces (a `!n` declared on the open awaitable) and project that position out of the symbolic type arguments. This works for any generic awaitable whose `GetResult()` returns its own type parameter — covering both `Task[U]` and `ValueTask[U]` for any element `U` (type parameter, user type, or BCL type).

Also fixes a tightly-coupled emit gap this exposed: the async state machine's value-type-awaitable spill temp (`ValueTask` is a struct) was typed with the erased CLR awaitable type (`ValueTask<object>`) instead of the operand's symbolic type, producing unverifiable IL for a same-compilation element type and `BadImageFormatException` inside a generic closure. It now threads the symbolic operand type, matching the reference-type (`Task`) path.

## Files changed
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.cs` — generalized `TryGetTaskElementType`.
- `src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs` — value-type-awaitable spill temp uses the symbolic operand type.
- `test/Core.Tests/.../Issue2195TaskRunAsyncLambdaInferenceTests.cs` — binder inference tests.
- `test/Compiler.Tests/Emit/Issue2195TaskRunAsyncLambdaInferenceEmitTests.cs` — emit/run round-trip tests.

## Verification
- Standalone issue repro (`func Get[T]()` awaiting `ValueTask[T]`) compiles clean (no GS0156).
- Emit/run tests prove the awaited value round-trips for `ValueTask[Box]` and `Task[Box]` (non-generic).
- Regression suites green: Core.Tests async/inference/overload/lambda (750), Compiler.Tests async/await/valuetask/task (185) and iterator/spill (149).

## Known limitation (pre-existing, out of scope)
Emitting an async lambda inside a **generic** method closure fails at runtime with `BadImageFormatException` due to a type-level (`!0`) vs method-level (`!!0`) generic-parameter mismatch in the `AsyncTaskMethodBuilder`. This reproduces on the untouched `Task` path and is independent of this inference fix; the emit/run tests here therefore use the non-generic case. Filing/fixing that generic-closure async-lowering bug is left as separate work.

## Note re: #2194
This touches async-inference (`TryGetTaskElementType`) and async lowering, not the extension-vs-instance overload logic in flight on #2194; no expected overlap.

Fixes #2195
Refs #914