### PR TITLE
Fix generic async lambda emit crash (#2180)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -843,21 +843,46 @@ internal sealed class LambdaBinder
             ? TypeSymbol.Void
             : GetAdapterSlotType(literal.Function.Type, targetFunctionType.ReturnType);
 
+        // Issue #2180: an async literal carries a DUAL return shape — the
+        // FunctionSymbol's result type is the UNWRAPPED value (`T`), while its
+        // observable delegate return is the `Task[T]` wrapper. The erasure
+        // above collapses that to a single slot and, for a type-parameter
+        // result, erases it to `object` (the target delegate return `Task[T]`
+        // contains `T`). That erasure produces an async state machine whose
+        // builder / SetResult are `AsyncTaskMethodBuilder[object]` and forces a
+        // bogus `(Task[T])(object)` reference-cast at the call site — correct
+        // for reference `T` but a silent miscompile for a value-type `T`
+        // (the boxed result is reinterpreted, not unboxed). A generic closure
+        // reifies per instantiation exactly like the SYNC generic-lambda path,
+        // so keep the async result symbolic: the FunctionSymbol result stays
+        // the unwrapped `T` (threaded into the SM as `Var(idx)`), while the
+        // delegate observable return keeps the `Task[T]` wrapper.
+        var adapterResultType = adapterReturnType;
+        var adapterDelegateReturnType = adapterReturnType;
+        if (literal.Function.IsAsync
+            && targetFunctionType.ReturnType != TypeSymbol.Void
+            && literal.Function.Type != null
+            && TypeSymbol.ContainsTypeParameter(targetFunctionType.ReturnType))
+        {
+            adapterResultType = literal.Function.Type;
+            adapterDelegateReturnType = targetFunctionType.ReturnType;
+        }
+
         // ADR-0102 follow-up / issue #818: preserve the target's variadic
         // flag shape through the erased adapter so call-site dispatch keeps
         // its pack / pass-through semantics.
         var adapterFunctionType = FunctionTypeSymbol.Get(
             adapterParameters.Select(p => p.Type).ToImmutableArray(),
             targetFunctionType.IsVariadic,
-            adapterReturnType);
+            adapterDelegateReturnType);
         var adapterFunction = new FunctionSymbol(
             $"<lambda_erased{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
             adapterParameters.ToImmutable(),
-            adapterReturnType,
+            adapterResultType,
             package: literal.Function.Package);
         adapterFunction.IsAsync = literal.Function.IsAsync;
 
-        var body = (BoundBlockStatement)new ErasedFunctionLiteralAdapterRewriter(replacementMap, adapterReturnType)
+        var body = (BoundBlockStatement)new ErasedFunctionLiteralAdapterRewriter(replacementMap, adapterResultType)
             .RewriteStatement(literal.Body);
 
         return new BoundFunctionLiteralExpression(

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -476,9 +476,10 @@ internal sealed class ReflectionMetadataEmitter
     /// <param name="kickoff">The async kickoff method.</param>
     private void RegisterStateMachineEnclosingGenerics(StructSymbol smStruct, FunctionSymbol kickoff)
     {
-        var classTPs = kickoff?.ReceiverType is StructSymbol receiver
-            ? (receiver.Definition ?? receiver).TypeParameters
-            : ImmutableArray<TypeParameterSymbol>.Empty;
+        var receiverDef = kickoff?.ReceiverType is StructSymbol receiver
+            ? (receiver.Definition ?? receiver)
+            : null;
+        var classTPs = receiverDef?.TypeParameters ?? ImmutableArray<TypeParameterSymbol>.Empty;
         var methodTPs = kickoff == null || kickoff.TypeParameters.IsDefaultOrEmpty
             ? ImmutableArray<TypeParameterSymbol>.Empty
             : kickoff.TypeParameters;
@@ -508,6 +509,28 @@ internal sealed class ReflectionMetadataEmitter
         {
             remap[src] = ordinal;
             ordinal++;
+        }
+
+        // Issue #2180: when the async state machine nests inside a synthesized
+        // closure that was itself reified over an enclosing generic method /
+        // type (`RunG[T]`'s `T`), the receiver's own type parameters (`T`
+        // cloned onto the closure) are 1:1 with the ORIGINAL enclosing
+        // parameters recorded on ReifiedFromTypeParameters. The MoveNext body
+        // still references those originals — e.g. the capture-box type argument
+        // `<>__Box_val_1[T]` carries `RunG`'s `T`, not the closure's clone — so
+        // without an entry keyed by the original parameter, EncodeTypeSymbol
+        // falls through to `MVar(idx)` (a method type-variable with no slot in
+        // MoveNext), producing malformed metadata (BadImageFormatException at
+        // runtime). Map each original enclosing parameter to the SM class slot
+        // its clone occupies. Real user receivers have an empty reified list,
+        // so this is a no-op there.
+        var reifiedFrom = receiverDef?.ReifiedFromTypeParameters ?? ImmutableArray<TypeParameterSymbol>.Empty;
+        if (!reifiedFrom.IsDefaultOrEmpty && reifiedFrom.Length == classTPs.Length)
+        {
+            for (var i = 0; i < reifiedFrom.Length; i++)
+            {
+                remap[reifiedFrom[i]] = i;
+            }
         }
 
         smStruct.SetTypeParameters(smTPs);

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2180GenericAsyncLambdaEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2180GenericAsyncLambdaEmitTests.cs
@@ -1,0 +1,109 @@
+// <copyright file="Issue2180GenericAsyncLambdaEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #2180: a generic async lambda captured inside a generic method used to
+/// emit a malformed state machine — the capture-box type argument inside
+/// <c>MoveNext</c> referenced a method type-variable (<c>MVar</c>) with no slot
+/// in the state-machine context (BadImageFormatException at runtime), and the
+/// async result type was erased to <c>object</c> (silently miscompiling a
+/// value-type result via a bogus <c>(Task[T])(object)</c> reference-cast). These
+/// end-to-end tests run the emitted assembly to prove both the metadata and the
+/// returned value are correct.
+/// </summary>
+public class Issue2180GenericAsyncLambdaEmitTests
+{
+    [Fact]
+    public void GenericAsyncLambda_ValueTypeResult_ReturnsCapturedValue()
+    {
+        const string Source = @"package R
+import System
+import System.Threading.Tasks
+
+func RunG[T](val T) Task[T] {
+    let f = async () -> {
+        return val
+    }
+    return f()
+}
+
+Console.WriteLine(RunG[int32](42).Result)
+";
+        Assert.Equal("42", CompileAndRun(Source, "Issue2180Value").Trim());
+    }
+
+    [Fact]
+    public void GenericAsyncLambda_ReferenceTypeResult_ReturnsCapturedValue()
+    {
+        const string Source = @"package R
+import System
+import System.Threading.Tasks
+
+func RunG[T](val T) Task[T] {
+    let f = async () -> {
+        return val
+    }
+    return f()
+}
+
+Console.WriteLine(RunG[String](""hello"").Result)
+";
+        Assert.Equal("hello", CompileAndRun(Source, "Issue2180Ref").Trim());
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2180.

A generic async lambda captured inside a generic method (e.g. `func RunG[T](val T) Task[T] { let f = async () -> { return val }; return f() }`) compiled cleanly but crashed at runtime with `System.BadImageFormatException`. Non-generic or non-async-lambda equivalents worked.

## Root causes & fixes

**1. Emit remap — malformed MoveNext metadata (the crash).**
When the async state machine nests inside a synthesized closure that was itself reified over an enclosing generic method's type parameter, the MoveNext body still references the *original* enclosing parameter — e.g. the capture-box type argument `<>__Box_val_1[T]` carries `RunG`'s `T`, not the closure's clone. `RegisterStateMachineEnclosingGenerics` only registered the closure's cloned class TPs in the remap, so the original fell through to `MVar(idx)` (a method type-variable with no slot in MoveNext), producing malformed metadata leading to `BadImageFormatException`. Fix: also map each `ReifiedFromTypeParameters` original to the SM class slot its clone occupies (no-op for real user receivers, whose reified list is empty).

**2. Async adapter result-type erasure (a silent value miscompile exposed by fix #1).**
An async literal carries a dual return shape: the `FunctionSymbol` result is the unwrapped `T`, while the observable delegate return is `Task[T]`. `CreateErasedFunctionLiteralAdapter` collapsed that and erased the result `T` to `object`, yielding `AsyncTaskMethodBuilder[object]` and a bogus `(Task[T])(object)` reference-cast — correct for reference `T` but a silent miscompile for value-type `T` (the boxed result is reinterpreted, not unboxed). Fix: keep the async result symbolic (matching the sync generic-lambda path) while the delegate return keeps the `Task[T]` wrapper, so the closure reifies per instantiation.

## Tests
- New `Issue2180GenericAsyncLambdaEmitTests`: value-type `T` produces `42`, reference-type `T` produces `"hello"` (end-to-end emit + run).
- Full `Core.Tests`: 5726 passed, 0 failed.
- `Cs2Gs.Tests`: 616 passed, 0 failed.
