### PR TITLE
cs2gs/gsc: sanitize `lock` keyword and resolve type-alias static member access

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1544,6 +1544,20 @@ internal sealed partial class ExpressionBinder
 
         var currentPath = import.Target;
         var currentRight = rightPart;
+
+        // A type alias (`import R = System.Console`) names a type outright: the
+        // import target itself resolves as a type, and the accessor's right part
+        // is a *static member* of it (`R.WriteLine`, `R.EncryptedFileExt`) rather
+        // than a further namespace/type segment. Resolve the target as a type
+        // first and leave the right part unconsumed so the caller binds it as the
+        // member access on the aliased type. (A plain namespace import target does
+        // not resolve as a type, so the segment-walk below still owns that case.)
+        if (scope.References.TryResolveType(currentPath, out var aliasTargetType))
+        {
+            importedClass = new ImportedClassSymbol(aliasTargetType, rightPart, references: scope.References);
+            return true;
+        }
+
         while (true)
         {
             NameExpressionSyntax typeNameSyntax;

--- a/test/Core.Tests/CodeAnalysis/Binding/ImportAliasTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ImportAliasTests.cs
@@ -52,6 +52,20 @@ public class ImportAliasTests
         Assert.Empty(diagnostics);
     }
 
+    /// <summary>
+    /// A C# <c>using R = Some.Type;</c> alias whose target is a *type* (not a
+    /// namespace) must let a bare <c>R.StaticMember</c> resolve to that type's
+    /// static member. The alias target itself names the type, and the accessor's
+    /// right part is a static member of it — so the member access binds without a
+    /// "cannot find type R" error.
+    /// </summary>
+    [Fact]
+    public void Aliased_Type_Resolves_Static_Member_Access()
+    {
+        var diagnostics = Bind("import R = System.Console\n\nfunc F() {\n R.WriteLine(\"hi\")\n }\n");
+        Assert.Empty(diagnostics);
+    }
+
     private static ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/tools/cs2gs/Cs2Gs.Tests/LockKeywordSanitizationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LockKeywordSanitizationTranslationTests.cs
@@ -1,0 +1,88 @@
+// <copyright file="LockKeywordSanitizationTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// <c>lock</c> is a hard G# keyword (it introduces the <c>lock</c> statement),
+/// so a C# member literally named <c>lock</c> — most commonly the verbatim
+/// identifier <c>@lock</c> guarding a <c>lock (@lock) { ... }</c> block, an
+/// idiomatic C# monitor pattern — must be sanitized to <c>lock_</c> at both its
+/// declaration and every reference site (including the lock-statement operand).
+/// It was missing from the translator's reserved-word set, so the field emitted
+/// as the bare keyword <c>lock</c> and the statement as <c>lock lock { ... }</c>,
+/// which failed to round-trip-parse (GS0005: unexpected <c>LockKeyword</c>).
+/// </summary>
+public class LockKeywordSanitizationTranslationTests
+{
+    private const string Source = @"
+namespace Corpus.LockSanitize
+{
+    public class Guarded
+    {
+        private readonly object @lock = new object();
+        private int count;
+
+        public int Increment()
+        {
+            lock (@lock)
+            {
+                return ++this.count;
+            }
+        }
+    }
+}
+";
+
+    [Fact]
+    public void VerbatimLockField_IsSanitizedToLockUnderscore()
+    {
+        string rendered = Render();
+
+        Assert.Contains("lock_", rendered, StringComparison.Ordinal);
+
+        // The bare `lock` keyword must never appear as an identifier: neither the
+        // field declaration nor the lock-statement operand may leak it.
+        Assert.DoesNotContain("@lock", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("lock lock ", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("let lock ", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SanitizedOutput_RoundTripParses()
+    {
+        string rendered = Render();
+
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Guarded.cs", Source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -507,7 +507,7 @@ public sealed class CSharpToGSharpTranslator
             "as", "async", "await", "break", "case", "catch", "chan", "class", "const",
             "continue", "default", "defer", "do", "else", "enum", "false", "fallthrough",
             "finally", "for", "func", "go", "goto", "guard", "if", "import", "interface",
-            "internal", "is", "let", "map", "nil", "open", "operator", "override",
+            "internal", "is", "let", "lock", "map", "nil", "open", "operator", "override",
             "package", "private", "protected", "public", "range", "return", "scope",
             "sealed", "select", "sequence", "struct", "switch", "throw", "true", "try",
             "type", "using", "var", "while",


### PR DESCRIPTION
## Summary

Two small, independent fixes discovered while migrating the [Oahu](https://github.com/DavidObando/Oahu) C# codebase to G# via `cs2gs`.

### 1. cs2gs — `lock` was missing from the reserved-word set
`lock` is a hard G# keyword (it introduces the `lock` statement), but it was absent from the translator's `GSharpReservedWords`. A C# member literally named `lock` — most commonly the verbatim `@lock` field guarding an idiomatic `lock (@lock) { ... }` monitor block — therefore emitted as the bare keyword. The field printed as `let lock ...` and the statement as `lock lock { ... }`, which failed to round-trip-parse (`GS0005: Unexpected token <LockKeyword>`). It now sanitizes to `lock_` at every declaration and reference site, matching the existing `default_`/`type_` handling. This was the only difference between the translator's set and gsc's `SyntaxFacts.GetKeywordKind`.

### 2. gsc — type-alias static member access (`import R = System.Console`)
An `import R = <Type>` alias whose target is a **type** (not a namespace) did not resolve a bare `R.StaticMember` access, raising `GS0157: Cannot find type R`. `TryBindImportAccessor` always appended the accessor's next segment to the import target before probing for a type (correct for namespace imports like `import io = System.IO` → `io.Directory`), so it never tried the target itself as a type. It now resolves the import target as a type first and leaves the right part unconsumed as the member access. Namespace imports are unaffected (a namespace target does not resolve as a type, so the existing segment-walk still owns that case).

## Tests
- `LockKeywordSanitizationTranslationTests` — verbatim `@lock` field + `lock(...)` block sanitizes to `lock_` and round-trip-parses.
- `ImportAliasTests.Aliased_Type_Resolves_Static_Member_Access` — `import R = System.Console; R.WriteLine(...)` binds cleanly.

Full `Core.Tests` (5727 passed) and `Cs2Gs.Tests` (1149 passed) are green locally.