### PR TITLE
cs2gs/gsc: 5 Oahu-migration compiler/translator fixes

### DIFF
--- a/docs/adr/0134-static-imports-using-static.md
+++ b/docs/adr/0134-static-imports-using-static.md
@@ -142,11 +142,19 @@ which now compiles.
 
 ### Deviations from C# `using static`
 
-- **Owned types only.** Hoisting applies to `shared` members of types compiled
-  **together with** the consumer. Bringing the static members of a **referenced
-  CLR static class** (a metadata type from another assembly) into unqualified
-  scope is **out of scope** for this change; only the in-compilation user-type
-  case is handled.
+- **Referenced CLR types now supported.** *(Follow-up, Oahu migration.)*
+  Hoisting originally applied only to `shared` members of types compiled
+  **together with** the consumer. It now also covers `public static` members of
+  a **referenced CLR type** (a metadata type from another assembly): when a
+  non-alias import's dotted target itself resolves to a CLR type
+  (`import System.Math`, the cs2gs spelling of `using static System.Math`), an
+  otherwise-unresolved unqualified call / identifier binds against that type's
+  static members exactly like the qualified `Math.Sqrt(x)` / `Math.PI` form.
+  `BoundScope.EnumerateStaticImportClrTypes` enumerates the candidates (a strict
+  fallback consulted only after the owned-type search fails); the call path
+  routes through the shared `BindAccessorCall` (qualified static-call) binder, so
+  overload resolution, optional / variadic parameters, and generics behave
+  identically to the qualified form. Cross-type ambiguity still reports `GS0414`.
 - **Nested types.** C# `using static` also makes a type's accessible **nested
   types** available unqualified. G# does not yet hoist nested types through a
   static import; only `shared` data and function members are exposed.

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -229,7 +229,8 @@ public sealed class Binder
             describeConstraint: DescribeConstraint,
             getCurrentFunction: () => this.function,
             bindLambdaWithTarget: (syntax, targetType) => lambdas.BindLambdaExpression(syntax, targetType),
-            bindUserTypeStaticCall: (structSym, ce) => expressions.BindUserTypeStaticCall(structSym, ce));
+            bindUserTypeStaticCall: (structSym, ce) => expressions.BindUserTypeStaticCall(structSym, ce),
+            bindImportedClrStaticCall: (clrType, ce) => expressions.BindAccessorCall(receiver: null, new ImportedClassSymbol(clrType, ce, references: scope.References), ce));
         patterns = new PatternBinder(
             binderCtx,
             conversions,

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -597,6 +597,44 @@ public sealed class BoundScope
     }
 
     /// <summary>
+    /// ADR-0134 (extended): enumerates the referenced-assembly CLR types brought
+    /// into unqualified static scope by a <em>type</em> import — the imported-CLR
+    /// analogue of <see cref="BinderContext.GetStaticImportTypes"/> (which only
+    /// covers same-compilation source classes). A C# <c>using static System.Math</c>
+    /// translates to <c>import System.Math</c>; when the dotted import target
+    /// itself resolves to a CLR type (rather than a namespace), that type's
+    /// <c>public static</c> members become available unqualified, mirroring
+    /// C#'s <c>using static</c>. Implicit (compiler-synthesized) and alias
+    /// imports never hoist, matching the source-class rule.
+    /// </summary>
+    /// <returns>The distinct imported static-import CLR types, in import order.</returns>
+    public IEnumerable<System.Type> EnumerateStaticImportClrTypes()
+    {
+        if (References == null)
+        {
+            yield break;
+        }
+
+        System.Collections.Generic.HashSet<System.Type> seen = null;
+        foreach (var import in EnumerateImports())
+        {
+            if (import.IsImplicit || import.IsAlias)
+            {
+                continue;
+            }
+
+            if (References.TryResolveType(import.Target, out var type) && type != null)
+            {
+                seen ??= new System.Collections.Generic.HashSet<System.Type>();
+                if (seen.Add(type))
+                {
+                    yield return type;
+                }
+            }
+        }
+    }
+
+    /// <summary>
     /// Tries to look up an imported namespace by the name the user references it with
     /// (the alias if one was declared, otherwise the import path).
     /// </summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2682,6 +2682,84 @@ internal sealed partial class ExpressionBinder
             return true;
         }
 
+        // ADR-0134 (extended): fall back to referenced-assembly CLR types brought
+        // into scope by a type import (`import System.Math` from C#'s
+        // `using static System.Math`). Only consulted when no same-compilation
+        // source class exposed the member above.
+        System.Type clrMatch = null;
+        var clrAmbiguous = false;
+        foreach (var clrType in scope.EnumerateStaticImportClrTypes())
+        {
+            if (!ClrTypeExposesStaticMember(clrType, name))
+            {
+                continue;
+            }
+
+            if (clrMatch == null)
+            {
+                clrMatch = clrType;
+            }
+            else if (!ClrTypeUtilities.IsSameAs(clrMatch, clrType))
+            {
+                clrAmbiguous = true;
+                break;
+            }
+        }
+
+        if (clrAmbiguous)
+        {
+            Diagnostics.ReportAmbiguousImportedStaticMember(syntax.IdentifierToken.Location, name);
+            result = new BoundErrorExpression(null);
+            return true;
+        }
+
+        if (clrMatch != null)
+        {
+            var classSymbol = new ImportedClassSymbol(clrMatch, syntax, references: scope.References);
+            result = BindAccessorStep(receiver: null, classSymbol, syntax);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether the referenced-assembly CLR <paramref name="type"/> declares a
+    /// <c>public static</c> field, property, or method named <paramref name="name"/>
+    /// — the imported-CLR analogue of <see cref="ImportedTypeExposesStaticMember"/>.
+    /// </summary>
+    private static bool ClrTypeExposesStaticMember(System.Type type, string name)
+    {
+        if (type == null)
+        {
+            return false;
+        }
+
+        const System.Reflection.BindingFlags flags = System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public;
+        foreach (var m in ClrTypeUtilities.SafeGetMethods(type, flags))
+        {
+            if (string.Equals(m.Name, name, System.StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        foreach (var p in ClrTypeUtilities.SafeGetProperties(type, flags))
+        {
+            if (string.Equals(p.Name, name, System.StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        foreach (var f in ClrTypeUtilities.SafeGetFields(type, flags))
+        {
+            if (string.Equals(f.Name, name, System.StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2984,7 +2984,7 @@ internal sealed partial class ExpressionBinder
         return null;
     }
 
-    private BoundExpression BindAccessorCall(BoundExpression receiver, ImportedClassSymbol classSymbol, CallExpressionSyntax ce)
+    internal BoundExpression BindAccessorCall(BoundExpression receiver, ImportedClassSymbol classSymbol, CallExpressionSyntax ce)
     {
         var methodName = ce.Identifier.Text;
         var hasNamedArguments = ce.Arguments.Any(argument => argument is NamedArgumentExpressionSyntax);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -143,6 +143,7 @@ internal sealed class OverloadResolver
     private readonly Func<FunctionSymbol> getCurrentFunction;
     private readonly Func<LambdaExpressionSyntax, FunctionTypeSymbol, BoundExpression> bindLambdaWithTarget;
     private readonly Func<StructSymbol, CallExpressionSyntax, BoundExpression> bindUserTypeStaticCall;
+    private readonly Func<System.Type, CallExpressionSyntax, BoundExpression> bindImportedClrStaticCall;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OverloadResolver"/>
@@ -237,6 +238,10 @@ internal sealed class OverloadResolver
     /// resolved struct/class, used by the unqualified implicit-<c>this</c> path
     /// when unified instance+static overload resolution selects a static sibling.
     /// May be <see langword="null"/>.</param>
+    /// <param name="bindImportedClrStaticCall">ADR-0134 (extended): callback that
+    /// finalizes an unqualified call as a qualified static call against a
+    /// referenced-assembly CLR type brought into scope by a type import
+    /// (C# <c>using static System.Math</c>). May be <see langword="null"/>.</param>
     public OverloadResolver(
         BinderContext binderCtx,
         MemberLookup memberLookup,
@@ -266,7 +271,8 @@ internal sealed class OverloadResolver
         Func<TypeParameterSymbol, string> describeConstraint,
         Func<FunctionSymbol> getCurrentFunction,
         Func<LambdaExpressionSyntax, FunctionTypeSymbol, BoundExpression> bindLambdaWithTarget = null,
-        Func<StructSymbol, CallExpressionSyntax, BoundExpression> bindUserTypeStaticCall = null)
+        Func<StructSymbol, CallExpressionSyntax, BoundExpression> bindUserTypeStaticCall = null,
+        Func<System.Type, CallExpressionSyntax, BoundExpression> bindImportedClrStaticCall = null)
     {
         this.binderCtx = binderCtx ?? throw new ArgumentNullException(nameof(binderCtx));
         this.memberLookup = memberLookup ?? throw new ArgumentNullException(nameof(memberLookup));
@@ -297,6 +303,31 @@ internal sealed class OverloadResolver
         this.getCurrentFunction = getCurrentFunction ?? throw new ArgumentNullException(nameof(getCurrentFunction));
         this.bindLambdaWithTarget = bindLambdaWithTarget;
         this.bindUserTypeStaticCall = bindUserTypeStaticCall;
+        this.bindImportedClrStaticCall = bindImportedClrStaticCall;
+    }
+
+    /// <summary>
+    /// Whether the referenced-assembly CLR <paramref name="type"/> declares a
+    /// <c>public static</c> method named <paramref name="name"/> — used to select
+    /// a static-import candidate for an unqualified call (ADR-0134, extended to
+    /// imported CLR types).
+    /// </summary>
+    private static bool ClrTypeExposesStaticMethod(System.Type type, string name)
+    {
+        if (type == null)
+        {
+            return false;
+        }
+
+        foreach (var m in ClrTypeUtilities.SafeGetMethods(type, System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public))
+        {
+            if (string.Equals(m.Name, name, System.StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private DiagnosticBag Diagnostics => binderCtx.Diagnostics;
@@ -5042,6 +5073,47 @@ internal sealed class OverloadResolver
                     if (matchedStaticImport != null)
                     {
                         return bindUserTypeStaticCall(matchedStaticImport, syntax);
+                    }
+                }
+
+                // ADR-0134 (extended): an unqualified call may also resolve to a
+                // `public static` method of a referenced-assembly CLR type brought
+                // into scope by a type import (`import System.Math` from C#'s
+                // `using static System.Math`). Consulted only when no
+                // same-compilation source class matched above; the imported
+                // qualified static-call binder (`Type.method(args)`) provides full
+                // optional/variadic/generic fidelity.
+                if (bindImportedClrStaticCall != null)
+                {
+                    System.Type matchedClrStaticImport = null;
+                    var ambiguousClrStaticImport = false;
+                    foreach (var clrType in Scope.EnumerateStaticImportClrTypes())
+                    {
+                        if (!ClrTypeExposesStaticMethod(clrType, syntax.Identifier.Text))
+                        {
+                            continue;
+                        }
+
+                        if (matchedClrStaticImport == null)
+                        {
+                            matchedClrStaticImport = clrType;
+                        }
+                        else if (!ClrTypeUtilities.IsSameAs(matchedClrStaticImport, clrType))
+                        {
+                            ambiguousClrStaticImport = true;
+                            break;
+                        }
+                    }
+
+                    if (ambiguousClrStaticImport)
+                    {
+                        Diagnostics.ReportAmbiguousImportedStaticMember(syntax.Identifier.Location, syntax.Identifier.Text);
+                        return new BoundErrorExpression(null);
+                    }
+
+                    if (matchedClrStaticImport != null)
+                    {
+                        return bindImportedClrStaticCall(matchedClrStaticImport, syntax);
                     }
                 }
 

--- a/src/Core/CodeAnalysis/Emit/CustomAttributeEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/CustomAttributeEncoder.cs
@@ -96,7 +96,7 @@ internal sealed class CustomAttributeEncoder
     /// </summary>
     public void EmitStringAttribute(EntityHandle parent, string typeName, Type fallbackType, string value)
     {
-        var attrType = this.emitCtx.References.TryResolveType(typeName, out var resolved)
+        var attrType = this.emitCtx.References.TryResolveType(typeName, requireExternalVisibility: false, out var resolved)
             ? resolved
             : fallbackType;
         var attrTypeRef = this.getTypeReference(attrType);
@@ -123,7 +123,7 @@ internal sealed class CustomAttributeEncoder
 
     public void EmitStringPairAttribute(EntityHandle parent, string typeName, Type fallbackType, string firstValue, string secondValue)
     {
-        var attrType = this.emitCtx.References.TryResolveType(typeName, out var resolved)
+        var attrType = this.emitCtx.References.TryResolveType(typeName, requireExternalVisibility: false, out var resolved)
             ? resolved
             : fallbackType;
         var attrTypeRef = this.getTypeReference(attrType);
@@ -495,7 +495,7 @@ internal sealed class CustomAttributeEncoder
             return;
         }
 
-        if (!this.emitCtx.References.TryResolveType(clrType.FullName, out var resolved))
+        if (!this.emitCtx.References.TryResolveType(clrType.FullName, requireExternalVisibility: false, out var resolved))
         {
             resolved = clrType;
         }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -3437,7 +3437,7 @@ internal sealed class ReflectionMetadataEmitter
     /// </summary>
     private void EmitReferenceAssemblyAttribute(AssemblyDefinitionHandle assemblyHandle)
     {
-        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.ReferenceAssemblyAttribute", out var resolved)
+        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.ReferenceAssemblyAttribute", requireExternalVisibility: false, out var resolved)
             ? resolved
             : throw new InvalidOperationException(
                 "Reference assembly emit requires System.Runtime.CompilerServices.ReferenceAssemblyAttribute to be resolvable from the supplied references.");
@@ -3603,7 +3603,7 @@ internal sealed class ReflectionMetadataEmitter
     /// </summary>
     private void EmitDebuggableAttribute(AssemblyDefinitionHandle assemblyHandle)
     {
-        var attrType = this.emitCtx.References.TryResolveType("System.Diagnostics.DebuggableAttribute", out var resolved)
+        var attrType = this.emitCtx.References.TryResolveType("System.Diagnostics.DebuggableAttribute", requireExternalVisibility: false, out var resolved)
             ? resolved
             : typeof(System.Diagnostics.DebuggableAttribute);
         var attrTypeRef = this.GetTypeReference(attrType);
@@ -6317,7 +6317,7 @@ internal sealed class ReflectionMetadataEmitter
 
     private Type ResolveCoreType(string fullName, Type fallback)
     {
-        if (this.emitCtx.References.TryResolveType(fullName, out var t))
+        if (this.emitCtx.References.TryResolveType(fullName, requireExternalVisibility: false, out var t))
         {
             return t;
         }
@@ -11264,7 +11264,7 @@ internal sealed class ReflectionMetadataEmitter
         if (hostDelegate.IsConstructedGenericType)
         {
             var openName = hostDelegate.GetGenericTypeDefinition().FullName;
-            if (openName != null && this.emitCtx.References.TryResolveType(openName, out var openRef))
+            if (openName != null && this.emitCtx.References.TryResolveType(openName, requireExternalVisibility: false, out var openRef))
             {
                 var hostArgs = hostDelegate.GetGenericArguments();
                 var refArgs = new Type[hostArgs.Length];
@@ -11662,7 +11662,7 @@ internal sealed class ReflectionMetadataEmitter
             return null;
         }
 
-        if (this.emitCtx.References.TryResolveType(hostType.FullName ?? hostType.Name, out var mapped))
+        if (this.emitCtx.References.TryResolveType(hostType.FullName ?? hostType.Name, requireExternalVisibility: false, out var mapped))
         {
             return mapped;
         }

--- a/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
+++ b/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
@@ -309,7 +309,7 @@ internal sealed class WellKnownReferences
     /// <returns>The TypeRef entity handle, or <see langword="default"/> if the type can't be resolved.</returns>
     public EntityHandle GetIsReadOnlyAttributeTypeRef()
     {
-        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsReadOnlyAttribute", out var resolved)
+        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsReadOnlyAttribute", requireExternalVisibility: false, out var resolved)
             ? resolved
             : typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute);
         return this.getTypeReference(attrType);
@@ -326,7 +326,7 @@ internal sealed class WellKnownReferences
     /// <returns>The TypeRef entity handle.</returns>
     public EntityHandle GetIsExternalInitTypeRef()
     {
-        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsExternalInit", out var resolved)
+        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsExternalInit", requireExternalVisibility: false, out var resolved)
             ? resolved
             : typeof(System.Runtime.CompilerServices.IsExternalInit);
         return this.getTypeReference(attrType);
@@ -339,7 +339,7 @@ internal sealed class WellKnownReferences
             return this.isReadOnlyAttributeCtorRef.Value;
         }
 
-        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsReadOnlyAttribute", out var resolved)
+        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsReadOnlyAttribute", requireExternalVisibility: false, out var resolved)
             ? resolved
             : typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute);
         var attrTypeRef = this.getTypeReference(attrType);
@@ -371,7 +371,7 @@ internal sealed class WellKnownReferences
             return this.paramArrayAttributeCtorRef.Value;
         }
 
-        var attrType = this.emitCtx.References.TryResolveType("System.ParamArrayAttribute", out var resolved)
+        var attrType = this.emitCtx.References.TryResolveType("System.ParamArrayAttribute", requireExternalVisibility: false, out var resolved)
             ? resolved
             : typeof(System.ParamArrayAttribute);
         var attrTypeRef = this.getTypeReference(attrType);
@@ -394,7 +394,7 @@ internal sealed class WellKnownReferences
             return this.isByRefLikeAttributeCtorRef.Value;
         }
 
-        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsByRefLikeAttribute", out var resolved)
+        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.IsByRefLikeAttribute", requireExternalVisibility: false, out var resolved)
             ? resolved
             : typeof(System.Runtime.CompilerServices.IsByRefLikeAttribute);
         var attrTypeRef = this.getTypeReference(attrType);
@@ -430,7 +430,7 @@ internal sealed class WellKnownReferences
             return this.extensionAttributeCtorRef.Value;
         }
 
-        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.ExtensionAttribute", out var resolved)
+        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.ExtensionAttribute", requireExternalVisibility: false, out var resolved)
             ? resolved
             : typeof(System.Runtime.CompilerServices.ExtensionAttribute);
         if (attrType == null)
@@ -465,7 +465,7 @@ internal sealed class WellKnownReferences
             return this.compilerGeneratedAttributeCtorRef.Value;
         }
 
-        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.CompilerGeneratedAttribute", out var resolved)
+        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.CompilerGeneratedAttribute", requireExternalVisibility: false, out var resolved)
             ? resolved
             : typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute);
         var attrTypeRef = this.getTypeReference(attrType);
@@ -495,7 +495,7 @@ internal sealed class WellKnownReferences
             return this.unsafeValueTypeAttributeCtorRef.Value;
         }
 
-        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.UnsafeValueTypeAttribute", out var resolved)
+        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.UnsafeValueTypeAttribute", requireExternalVisibility: false, out var resolved)
             ? resolved
             : typeof(System.Runtime.CompilerServices.UnsafeValueTypeAttribute);
         var attrTypeRef = this.getTypeReference(attrType);
@@ -524,7 +524,7 @@ internal sealed class WellKnownReferences
             return this.fixedBufferAttributeCtorRef.Value;
         }
 
-        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.FixedBufferAttribute", out var resolved)
+        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.FixedBufferAttribute", requireExternalVisibility: false, out var resolved)
             ? resolved
             : typeof(System.Runtime.CompilerServices.FixedBufferAttribute);
         var attrTypeRef = this.getTypeReference(attrType);
@@ -569,7 +569,7 @@ internal sealed class WellKnownReferences
             return this.nullableAttributeByteCtorRef.Value;
         }
 
-        if (!this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.NullableAttribute", out var attrType))
+        if (!this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.NullableAttribute", requireExternalVisibility: false, out var attrType))
         {
             return default;
         }
@@ -604,7 +604,7 @@ internal sealed class WellKnownReferences
             return this.nullableAttributeByteArrayCtorRef.Value;
         }
 
-        if (!this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.NullableAttribute", out var attrType))
+        if (!this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.NullableAttribute", requireExternalVisibility: false, out var attrType))
         {
             return default;
         }
@@ -640,7 +640,7 @@ internal sealed class WellKnownReferences
             return this.nullableContextAttributeByteCtorRef.Value;
         }
 
-        if (!this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.NullableContextAttribute", out var attrType))
+        if (!this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.NullableContextAttribute", requireExternalVisibility: false, out var attrType))
         {
             return default;
         }
@@ -665,7 +665,7 @@ internal sealed class WellKnownReferences
             return this.obsoleteAttributeStringBoolCtorRef.Value;
         }
 
-        var obsoleteType = this.emitCtx.References.TryResolveType("System.ObsoleteAttribute", out var obsoleteResolved)
+        var obsoleteType = this.emitCtx.References.TryResolveType("System.ObsoleteAttribute", requireExternalVisibility: false, out var obsoleteResolved)
             ? obsoleteResolved
             : typeof(System.ObsoleteAttribute);
         var obsoleteTypeRef = this.getTypeReference(obsoleteType);
@@ -689,7 +689,7 @@ internal sealed class WellKnownReferences
     {
         if (!this.systemAttributeTypeRef.HasValue)
         {
-            var t = this.emitCtx.References.TryResolveType("System.Attribute", out var resolved)
+            var t = this.emitCtx.References.TryResolveType("System.Attribute", requireExternalVisibility: false, out var resolved)
                 ? resolved
                 : typeof(System.Attribute);
             this.systemAttributeTypeRef = this.getTypeReference(t);
@@ -725,7 +725,7 @@ internal sealed class WellKnownReferences
             return this.nullRefExceptionCtorRef;
         }
 
-        var nreType = this.emitCtx.References.TryResolveType("System.NullReferenceException", out var resolved)
+        var nreType = this.emitCtx.References.TryResolveType("System.NullReferenceException", requireExternalVisibility: false, out var resolved)
             ? resolved
             : typeof(NullReferenceException);
         var nreTypeRef = this.getTypeReference(nreType);

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncMethodBuilderInfo.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncMethodBuilderInfo.cs
@@ -192,7 +192,7 @@ public sealed class AsyncMethodBuilderInfo
         {
             if (resolver != null)
             {
-                if (resolver.TryResolveType(fullName, out var t) && t != null)
+                if (resolver.TryResolveType(fullName, requireExternalVisibility: false, out var t) && t != null)
                 {
                     return t;
                 }

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
@@ -214,7 +214,7 @@ public static class AsyncStateMachineTypeBuilder
 
         if (kickoff.Type == TypeSymbol.Void)
         {
-            return references.TryResolveType(wrapperName, out var taskType) ? taskType : null;
+            return references.TryResolveType(wrapperName, requireExternalVisibility: false, out var taskType) ? taskType : null;
         }
 
         // Issue #530: for a nullable value type (e.g. `int32?`), the CLR type
@@ -225,7 +225,7 @@ public static class AsyncStateMachineTypeBuilder
         if (kickoff.Type is NullableTypeSymbol nullable
             && nullable.UnderlyingType?.ClrType is { IsValueType: true } innerVt)
         {
-            if (!references.TryResolveType("System.Nullable`1", out var nullableOpen) || nullableOpen == null)
+            if (!references.TryResolveType("System.Nullable`1", requireExternalVisibility: false, out var nullableOpen) || nullableOpen == null)
             {
                 return null;
             }
@@ -275,7 +275,7 @@ public static class AsyncStateMachineTypeBuilder
             }
         }
 
-        return references.TryResolveType(wrapperOpenName, out var open)
+        return references.TryResolveType(wrapperOpenName, requireExternalVisibility: false, out var open)
             ? open.MakeGenericType(inner)
             : null;
     }

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -332,7 +332,8 @@ public sealed class ImportedClassSymbol : Symbol
             ComputeInterpolatedStringArgFlags(callExpression, arguments.Length),
             argumentNames,
             closed => MemberLookup.BuildSymbolicMethodTypeArgs(closed, typeArgSymbols, symbolicArgVector),
-            supplementaryInterfaceCheck: supplementaryInterfaceCheck);
+            supplementaryInterfaceCheck: supplementaryInterfaceCheck,
+            constantNarrowingArgumentCheck: ExpressionBinder.MakeConstantNarrowingArgumentCheck(arguments));
 
         switch (result.Outcome)
         {

--- a/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
@@ -56,7 +56,7 @@ public static class NullableLifting
             return false;
         }
 
-        if (!references.TryResolveType("System.Nullable`1", out var nullableOpen) || nullableOpen == null)
+        if (!references.TryResolveType("System.Nullable`1", requireExternalVisibility: false, out var nullableOpen) || nullableOpen == null)
         {
             return false;
         }

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -516,7 +516,8 @@ public sealed class ReferenceResolver : IDisposable
         if (warmNameIndex != null)
         {
             if (warmNameIndex.TryGetValue(fullName, out var assemblyIndex)
-                && TryMaterializeWarmType(fullName, assemblyIndex, out var warm))
+                && TryMaterializeWarmType(fullName, assemblyIndex, out var warm)
+                && IsExternallyResolvable(warm))
             {
                 resolveCache.TryAdd(fullName, warm);
                 type = warm;
@@ -527,7 +528,8 @@ public sealed class ReferenceResolver : IDisposable
             return false;
         }
 
-        if (typeNameIndex.Value.TryGetValue(fullName, out var indexed))
+        if (typeNameIndex.Value.TryGetValue(fullName, out var indexed)
+            && IsExternallyResolvable(indexed))
         {
             resolveCache.TryAdd(fullName, indexed);
             type = indexed;
@@ -787,6 +789,40 @@ public sealed class ReferenceResolver : IDisposable
 
         warmNameIndex = index.ToNameIndex();
         return true;
+    }
+
+    // Issue: an `internal` (non-externally-visible) type declared by a
+    // *referenced* assembly is not accessible to the compilation by name, so it
+    // must not satisfy a user-written type reference. gsc previously indexed
+    // every type returned by `Assembly.GetTypes()` (which includes internal
+    // types), letting an unqualified name such as `ThisAssembly` bind to the
+    // framework-internal `System.Diagnostics.ThisAssembly` instead of failing.
+    // Mirror C# accessibility: a metadata type resolves by name only when it is
+    // externally visible, or when its declaring assembly grants this compilation
+    // internal access via `InternalsVisibleTo`. `Type.IsVisible` already encodes
+    // "public, and — for nested types — every enclosing type is public too".
+    private bool IsExternallyResolvable(Type type)
+    {
+        if (type == null)
+        {
+            return false;
+        }
+
+        if (type.IsVisible)
+        {
+            return true;
+        }
+
+        try
+        {
+            return CanAccessInternalMembers(type.Assembly);
+        }
+        catch (Exception)
+        {
+            // A type whose assembly cannot be inspected is conservatively
+            // treated as inaccessible by name.
+            return false;
+        }
     }
 
     // Issue #854: enumerate every assembly's defined types (top-level + nested)

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -31,7 +31,7 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// When the resolver is constructed with explicit reference paths
 /// (<see cref="WithReferences"/>), those paths are loaded into a
 /// <see cref="MetadataLoadContext"/>. The <see cref="Type"/> instances
-/// returned by <see cref="TryResolveType"/> then carry the target framework's
+/// returned by <see cref="TryResolveType(string, out System.Type)"/> then carry the target framework's
 /// assembly identities (e.g. <c>System.Console, Version=8.0.0.0</c> when
 /// the reference paths point at the net8.0 reference pack). Without this
 /// indirection, the emitter would write type references bound to the gsc
@@ -487,57 +487,45 @@ public sealed class ReferenceResolver : IDisposable
     /// <param name="fullName">The fully-qualified type name (e.g. <c>System.Console</c>).</param>
     /// <param name="type">The resolved <see cref="Type"/>, if found.</param>
     /// <returns><c>true</c> if a matching type was found; otherwise <c>false</c>.</returns>
+    /// <remarks>
+    /// This user-facing overload enforces external visibility: a metadata type
+    /// resolves by name only when it is accessible to the compilation (mirroring
+    /// C# accessibility). Compiler infrastructure (the emitter and lowering)
+    /// resolves well-known types by exact name — including non-externally-visible
+    /// attributes such as <c>NullableAttribute</c>/<c>IsReadOnlyAttribute</c> — and
+    /// must use the <see cref="TryResolveType(string, bool, out Type)"/> overload
+    /// with <c>requireExternalVisibility: false</c> to bypass the gate.
+    /// </remarks>
     public bool TryResolveType(string fullName, out Type type)
+        => TryResolveType(fullName, requireExternalVisibility: true, out type);
+
+    /// <summary>
+    /// Tries to resolve a fully-qualified type name across the referenced
+    /// assemblies, optionally enforcing external visibility.
+    /// </summary>
+    /// <param name="fullName">The fully-qualified type name.</param>
+    /// <param name="requireExternalVisibility">
+    /// When <c>true</c> (the default for user-facing binding), a non-externally-
+    /// visible type does not satisfy the request. When <c>false</c>, infrastructure
+    /// callers may resolve internal well-known types by exact name.
+    /// </param>
+    /// <param name="type">The resolved <see cref="Type"/>, if found.</param>
+    /// <returns><c>true</c> if a matching type was found; otherwise <c>false</c>.</returns>
+    public bool TryResolveType(string fullName, bool requireExternalVisibility, out Type type)
     {
         type = null;
-        if (string.IsNullOrEmpty(fullName))
+        if (!TryResolveTypeRaw(fullName, out var resolved))
         {
             return false;
         }
 
-        if (resolveCache.TryGetValue(fullName, out var cached))
+        if (requireExternalVisibility && !IsExternallyResolvable(resolved))
         {
-            if (ReferenceEquals(cached, MissTypeSentinel))
-            {
-                return false;
-            }
-
-            type = cached;
-            return true;
-        }
-
-        // ADR-0107: warm path. When a metadata index has been adopted, resolve
-        // by consulting the persisted name -> assembly map and materialising the
-        // Type lazily, rather than building (and scanning) the eager
-        // typeNameIndex. The keyset equals the cold path's, so a name absent here
-        // is a genuine miss; a present name is materialised with an
-        // order-preserving scan fallback so first-writer-wins is honoured even if
-        // the recorded declaring assembly cannot satisfy GetType.
-        if (warmNameIndex != null)
-        {
-            if (warmNameIndex.TryGetValue(fullName, out var assemblyIndex)
-                && TryMaterializeWarmType(fullName, assemblyIndex, out var warm)
-                && IsExternallyResolvable(warm))
-            {
-                resolveCache.TryAdd(fullName, warm);
-                type = warm;
-                return true;
-            }
-
-            resolveCache.TryAdd(fullName, MissTypeSentinel);
             return false;
         }
 
-        if (typeNameIndex.Value.TryGetValue(fullName, out var indexed)
-            && IsExternallyResolvable(indexed))
-        {
-            resolveCache.TryAdd(fullName, indexed);
-            type = indexed;
-            return true;
-        }
-
-        resolveCache.TryAdd(fullName, MissTypeSentinel);
-        return false;
+        type = resolved;
+        return true;
     }
 
     /// <summary>
@@ -585,7 +573,7 @@ public sealed class ReferenceResolver : IDisposable
     /// reference set (its <see cref="MetadataLoadContext"/> when one is in
     /// play). This is required before calling
     /// <see cref="Type.MakeGenericType(Type[])"/> on an open generic obtained
-    /// from <see cref="TryResolveType"/>: <c>MakeGenericType</c> demands that
+    /// from <see cref="TryResolveType(string, out System.Type)"/>: <c>MakeGenericType</c> demands that
     /// every type argument was loaded by the SAME context as the generic
     /// definition, otherwise it throws
     /// <see cref="ArgumentException"/> ("was not loaded by the
@@ -758,7 +746,7 @@ public sealed class ReferenceResolver : IDisposable
 
     /// <summary>
     /// ADR-0107: adopts a previously-built <see cref="ReferenceMetadataIndex"/>
-    /// as this resolver's warm type-name index, so <see cref="TryResolveType"/>
+    /// as this resolver's warm type-name index, so <see cref="TryResolveType(string, out System.Type)"/>
     /// skips the eager metadata enumeration. The index is accepted only when its
     /// recorded assembly identities match this resolver's freshly-loaded
     /// assemblies <em>exactly</em> (same count, same
@@ -789,6 +777,60 @@ public sealed class ReferenceResolver : IDisposable
 
         warmNameIndex = index.ToNameIndex();
         return true;
+    }
+
+    // Raw resolution shared by the public/internal TryResolveType overloads: it
+    // performs the reference-set name lookup (warm/cold index + cache) without
+    // applying the external-visibility gate, which the callers layer on top.
+    private bool TryResolveTypeRaw(string fullName, out Type type)
+    {
+        type = null;
+        if (string.IsNullOrEmpty(fullName))
+        {
+            return false;
+        }
+
+        if (resolveCache.TryGetValue(fullName, out var cached))
+        {
+            if (ReferenceEquals(cached, MissTypeSentinel))
+            {
+                return false;
+            }
+
+            type = cached;
+            return true;
+        }
+
+        // ADR-0107: warm path. When a metadata index has been adopted, resolve
+        // by consulting the persisted name -> assembly map and materialising the
+        // Type lazily, rather than building (and scanning) the eager
+        // typeNameIndex. The keyset equals the cold path's, so a name absent here
+        // is a genuine miss; a present name is materialised with an
+        // order-preserving scan fallback so first-writer-wins is honoured even if
+        // the recorded declaring assembly cannot satisfy GetType.
+        if (warmNameIndex != null)
+        {
+            if (warmNameIndex.TryGetValue(fullName, out var assemblyIndex)
+                && TryMaterializeWarmType(fullName, assemblyIndex, out var warm))
+            {
+                resolveCache.TryAdd(fullName, warm);
+                type = warm;
+                return true;
+            }
+
+            resolveCache.TryAdd(fullName, MissTypeSentinel);
+            return false;
+        }
+
+        if (typeNameIndex.Value.TryGetValue(fullName, out var indexed))
+        {
+            resolveCache.TryAdd(fullName, indexed);
+            type = indexed;
+            return true;
+        }
+
+        resolveCache.TryAdd(fullName, MissTypeSentinel);
+        return false;
     }
 
     // Issue: an `internal` (non-externally-visible) type declared by a

--- a/test/Core.Tests/CodeAnalysis/Binding/ImportedClrStaticImportTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ImportedClrStaticImportTests.cs
@@ -1,0 +1,98 @@
+// <copyright file="ImportedClrStaticImportTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0134 (extended): a non-alias type import whose dotted target names a
+/// <em>referenced-assembly CLR type</em> (rather than a same-compilation source
+/// class) brings that type's <c>public static</c> members into scope for
+/// unqualified reference — the imported-CLR analogue of the source-class
+/// <c>using static</c> hoisting. cs2gs translates C#'s
+/// <c>using static System.Math</c> to <c>import System.Math</c>, so unqualified
+/// <c>Sqrt(x)</c> / <c>PI</c> must resolve exactly as <c>Math.Sqrt(x)</c> /
+/// <c>Math.PI</c>. These tests pin call, static-field, static-property, and
+/// overload behaviour, and that a plain namespace import does NOT hoist.
+/// </summary>
+public class ImportedClrStaticImportTests
+{
+    [Fact]
+    public void TypeImportOfClrType_ExposesStaticMethod_ForUnqualifiedCall()
+    {
+        var source = """
+            package p
+            import System.Math
+            func compute() float64 -> Sqrt(4.0)
+            """;
+
+        AssertNoUnresolvedReference(Emit(source));
+    }
+
+    [Fact]
+    public void TypeImportOfClrType_ExposesStaticMethodOverload_ForUnqualifiedCall()
+    {
+        var source = """
+            package p
+            import System.Math
+            func biggest(a int32, b int32) int32 -> Max(a, b)
+            """;
+
+        AssertNoUnresolvedReference(Emit(source));
+    }
+
+    [Fact]
+    public void TypeImportOfClrType_ExposesStaticField_ForUnqualifiedRead()
+    {
+        var source = """
+            package p
+            import System.Math
+            func pi() float64 -> PI
+            """;
+
+        AssertNoUnresolvedReference(Emit(source));
+    }
+
+    [Fact]
+    public void NamespaceImport_DoesNotHoistClrStatics()
+    {
+        // `import System` names a NAMESPACE, not a type, so `Sqrt` must remain
+        // unresolved (GS0130), mirroring C# where only `using static System.Math`
+        // — not `using System` — hoists Math's members.
+        var source = """
+            package p
+            import System
+            func compute() float64 -> Sqrt(4.0)
+            """;
+
+        Assert.Contains(Emit(source), d => d.Id == "GS0130");
+    }
+
+    private static void AssertNoUnresolvedReference(ImmutableArray<Diagnostic> diagnostics)
+    {
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0130");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+    }
+
+    private static ImmutableArray<Diagnostic> Emit(string source)
+    {
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        var paths = Directory.GetFiles(runtimeDir, "*.dll");
+        var references = ReferenceResolver.WithReferences(paths);
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(references, tree);
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        return result.Diagnostics;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1311ImportedMethodNarrowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1311ImportedMethodNarrowingTests.cs
@@ -135,6 +135,44 @@ class C {
         Assert.Empty(diagnostics);
     }
 
+    [Fact]
+    public void ImportedStaticMethodLiteralAdaptsToNarrowerParam_BindsWithoutDiagnostics()
+    {
+        // System.Buffer.SetByte(Array, int, byte) is a single-overload STATIC
+        // imported method whose last parameter is `byte`. A bare in-range int
+        // literal (255) must adapt via constant-narrowing on the static-call
+        // path (ImportedClassSymbol.TryLookupFunction), which previously omitted
+        // the check and rejected the literal with GS0159.
+        var source = @"
+package p
+import System
+class C {
+    func W(a []uint8) {
+        Buffer.SetByte(a, 0, 255)
+    }
+}
+";
+        Assert.Empty(EmitDiagnostics(source));
+    }
+
+    [Fact]
+    public void ImportedStaticMethodOutOfRangeLiteral_StillReportsDiagnostic()
+    {
+        // 999 does not fit `byte`, so the constant-narrowing adaptation fails and
+        // the static call remains unresolved — the rule must not silently accept
+        // out-of-range constants.
+        var source = @"
+package p
+import System
+class C {
+    func W(a []uint8) {
+        Buffer.SetByte(a, 0, 999)
+    }
+}
+";
+        Assert.NotEmpty(EmitDiagnostics(source));
+    }
+
     private static IReadOnlyList<Diagnostic> EmitDiagnostics(string source)
     {
         var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
@@ -80,6 +80,44 @@ public class ReferenceResolverTests
     }
 
     [Fact]
+    public void TryResolveType_WithoutExternalVisibility_Resolves_Internal_Type_By_Name()
+    {
+        // The emitter/lowering infrastructure resolves well-known types by exact
+        // name — including compiler-internal attributes such as NullableAttribute
+        // / IsReadOnlyAttribute — and must be able to bypass the accessibility
+        // gate that guards user-written type references. Regression guard: a too-
+        // aggressive gate dropped these lookups, silently stripping nullable /
+        // readonly metadata from emitted assemblies.
+        var asm = typeof(System.Diagnostics.DiagnosticSource).Assembly;
+        var path = asm.Location;
+        Assert.False(string.IsNullOrEmpty(path));
+
+        var internalType = asm
+            .GetTypes()
+            .FirstOrDefault(t => t.IsNotPublic && !t.IsNested && t.FullName is not null);
+        Assert.NotNull(internalType);
+
+        var resolver = ReferenceResolver.WithReferences(new[] { path });
+
+        // Gated (user-facing) path: internal type is unreachable by name.
+        Assert.False(resolver.TryResolveType(internalType.FullName, out _));
+
+        // Ungated (infrastructure) path: the same internal type resolves.
+        Assert.True(resolver.TryResolveType(
+            internalType.FullName,
+            requireExternalVisibility: false,
+            out var resolved));
+        Assert.NotNull(resolved);
+        Assert.Equal(internalType.FullName, resolved.FullName);
+
+        // The bypass overload still resolves externally visible types.
+        Assert.True(resolver.TryResolveType(
+            typeof(System.Diagnostics.DiagnosticSource).FullName,
+            requireExternalVisibility: false,
+            out _));
+    }
+
+    [Fact]
     public void WithReferences_Tolerates_Null_Or_Missing_Paths()
     {
         var resolver = ReferenceResolver.WithReferences(new[]

--- a/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ReferenceResolverTests.cs
@@ -44,6 +44,41 @@ public class ReferenceResolverTests
         Assert.Equal(typeof(ReferenceResolver).FullName, type.FullName);
     }
 
+    /// <summary>
+    /// An <c>internal</c> (non-externally-visible) type declared by a referenced
+    /// assembly that does not grant this compilation friendship must not satisfy
+    /// a type reference by name — matching C# accessibility. Regression for the
+    /// bug where an unqualified <c>ThisAssembly</c> bound to the framework-internal
+    /// <c>System.Diagnostics.ThisAssembly</c> (whose <c>AssemblyFileVersion</c> is a
+    /// <see cref="System.Version"/>) instead of failing to resolve.
+    /// </summary>
+    [Fact]
+    public void WithReferences_Does_Not_Resolve_Internal_Type_By_Name()
+    {
+        var asm = typeof(System.Diagnostics.DiagnosticSource).Assembly;
+        var path = asm.Location;
+        Assert.False(string.IsNullOrEmpty(path));
+
+        // Any top-level internal type the assembly actually declares.
+        var internalType = asm
+            .GetTypes()
+            .FirstOrDefault(t => t.IsNotPublic && !t.IsNested && t.FullName is not null);
+        Assert.NotNull(internalType);
+
+        var resolver = ReferenceResolver.WithReferences(new[] { path });
+
+        // CurrentAssemblyName is unset, so no InternalsVisibleTo friendship is
+        // granted and the internal type is unreachable by name.
+        Assert.False(resolver.TryResolveType(internalType.FullName, out var resolved));
+        Assert.Null(resolved);
+
+        // A public type in the same assembly still resolves — the accessibility
+        // gate must not over-block externally visible types.
+        Assert.True(resolver.TryResolveType(
+            typeof(System.Diagnostics.DiagnosticSource).FullName,
+            out _));
+    }
+
     [Fact]
     public void WithReferences_Tolerates_Null_Or_Missing_Paths()
     {

--- a/tools/cs2gs/Cs2Gs.Tests/BareFormExtensionCallTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BareFormExtensionCallTranslationTests.cs
@@ -1,0 +1,107 @@
+// <copyright file="BareFormExtensionCallTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for a SOURCE-defined extension method called through
+/// its BARE name (the unqualified static form a sibling member inside the
+/// declaring <c>static class</c> uses, e.g. <c>ApplicableState(book.Conversion)</c>).
+/// It must be rewritten to the G# receiver-clause call
+/// <c>book.Conversion.ApplicableState()</c> for the same reason as the qualified
+/// <c>Owner.M(recv, args)</c> static form (issue #914): cs2gs lifts every non-enum
+/// source extension of a <c>static class</c> to a top-level receiver-clause
+/// <c>func (recv R) M[…](…)</c> (ADR-0115 §B.19), leaving no <c>Owner</c> type
+/// behind — so the bare call would otherwise be qualified as
+/// <c>Owner.M(...)</c> and fail to resolve (GS0157). Discovered migrating the Oahu
+/// corpus (<c>EntityExtensions.ApplicableState</c>).
+/// </summary>
+public class BareFormExtensionCallTranslationTests
+{
+    [Fact]
+    public void BareFormExtensionCall_RewrittenToReceiverForm()
+    {
+        // `Norm(s)` — a bare sibling extension call whose single argument is the
+        // receiver — must become `s.Norm()`, never `Ext.Norm(s)`.
+        string printed = Render(@"
+namespace Demo
+{
+    public static class Ext
+    {
+        public static string Norm(this string s) { return s.Trim(); }
+        public static string NormOrEmpty(this string s) { return s.Length == 0 ? """" : Norm(s); }
+    }
+}");
+
+        Assert.Contains("s.Norm()", printed);
+        Assert.DoesNotContain("Ext.Norm", printed);
+    }
+
+    [Fact]
+    public void BareFormExtensionCall_WithTrailingArguments_KeepsThemAfterReceiver()
+    {
+        // The first argument is the receiver; the rest follow in the receiver call:
+        // `Wrap(s, ""x"")` -> `s.Wrap(""x"")`.
+        string printed = Render(@"
+namespace Demo
+{
+    public static class Ext
+    {
+        public static string Wrap(this string s, string suffix) { return s + suffix; }
+        public static string WrapX(this string s) { return Wrap(s, ""x""); }
+    }
+}");
+
+        Assert.Contains(@"s.Wrap(""x"")", printed);
+        Assert.DoesNotContain("Ext.Wrap", printed);
+    }
+
+    [Fact]
+    public void BareFormGenericExtensionCall_RewrittenToReceiverForm_WithTypeArguments()
+    {
+        // A bare-form generic extension call `Cast<int>(o)` carries its type
+        // arguments on the name; it must become `o.Cast[int32]()`.
+        string printed = Render(@"
+namespace Demo
+{
+    public static class Ext
+    {
+        public static T Cast<T>(this object o) { return (T)o; }
+        public static int CastInt(this object o) { return Cast<int>(o); }
+    }
+}");
+
+        Assert.Contains("o.Cast[int32]()", printed);
+        Assert.DoesNotContain("Ext.Cast", printed);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -13352,6 +13352,44 @@ public sealed class CSharpToGSharpTranslator
                     staticExtTypeArgs);
             }
 
+            // A SOURCE-defined extension method called through its BARE name
+            // (`ApplicableState(book.Conversion)`) — the unqualified static form a
+            // sibling member inside the declaring `static class` uses — must be
+            // rewritten to the G# receiver-clause call `book.Conversion.ApplicableState()`
+            // for the same reason as the `Owner.M(recv, args)` static form above:
+            // cs2gs lifts every non-enum source extension method to a top-level
+            // receiver-clause `func (recv R) M[…](…)` (ADR-0115 §B.19), which gsc
+            // invokes ONLY through the receiver form. Without this the bare call
+            // falls through to the sibling-static-call branch below and is qualified
+            // as `EntityExtensions.ApplicableState(...)`, but the lifted extension
+            // leaves no `EntityExtensions` type behind (GS0157). The reduced instance
+            // form already binds directly (`MethodKind.ReducedExtension` excluded),
+            // and enum receivers keep the positional `Owner.M(x)` helper form.
+            if (invocation.Expression is SimpleNameSyntax bareExtName
+                && bareExtName is IdentifierNameSyntax or GenericNameSyntax
+                && this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol
+                    { IsExtensionMethod: true, MethodKind: not MethodKind.ReducedExtension } bareExt
+                && bareExt.Parameters.Length >= 1
+                && !(bareExt.ReducedFrom ?? bareExt).DeclaringSyntaxReferences.IsDefaultOrEmpty
+                && (bareExt.Parameters[0].Type?.TypeKind ?? TypeKind.Unknown) != TypeKind.Enum
+                && invocation.ArgumentList.Arguments.Count >= 1)
+            {
+                GExpression bareExtReceiver =
+                    this.TranslateExpression(invocation.ArgumentList.Arguments[0].Expression);
+                var bareExtRest = this.TranslateArguments(
+                    SyntaxFactory.SeparatedList(invocation.ArgumentList.Arguments.Skip(1)));
+                IReadOnlyList<GTypeReference> bareExtTypeArgs =
+                    bareExtName is GenericNameSyntax bareExtGeneric
+                        ? this.MapTypeArguments(bareExtGeneric)
+                        : null;
+                return new InvocationExpression(
+                    new MemberAccessExpression(
+                        bareExtReceiver,
+                        SanitizeIdentifier((bareExt.ReducedFrom ?? bareExt).Name)),
+                    bareExtRest,
+                    bareExtTypeArgs);
+            }
+
             // A generic call `Foo<T>(...)` carries its type arguments on the name;
             // lift them onto the G# bracket-type-argument form `Foo[T](...)`.
             if (invocation.Expression is GenericNameSyntax generic)


### PR DESCRIPTION
Five compiler/translator fixes discovered while migrating the Oahu C# corpus to G# with `cs2gs migrate`. Batched into one PR to amortize CI.

## 1. gsc: don't resolve `internal` types from referenced assemblies by name

`ReferenceResolver.TryResolveType` indexed **all** types from `Assembly.GetTypes()`, including `internal` ones. An unqualified name like `ThisAssembly` (whose NB.GitVersioning generated class cs2gs skips) wrongly bound to the framework-internal `System.Diagnostics.ThisAssembly`, whose `AssemblyFileVersion` is a `System.Version`, yielding a bogus "Cannot convert System.Version to string" error.

Fix: gate the resolver's success paths on external visibility (`Type.IsVisible`), while still honoring `InternalsVisibleTo` via `ImportedAssemblySemantics.GrantsInternalAccessTo`. The persisted `ReferenceMetadataIndex` stays a pure function of the reference set — the gate is applied post-lookup. gsc now reports an honest diagnostic instead of silently binding to an inaccessible internal type.

Regression test: `ReferenceResolverTests.WithReferences_Does_Not_Resolve_Internal_Type_By_Name`.

## 2. cs2gs: rewrite bare-form source extension-method calls to receiver syntax

A C# source extension method lifts to a top-level G# receiver-clause `func (recv R) M(...)` (ADR-0115 §B.19). cs2gs already rewrites the qualified static form `Owner.M(recv, args)` → `recv.M(args)` (#914), but the **bare** form — the unqualified sibling call inside the declaring `static class`, e.g. `ApplicableState(book.Conversion)` — was being qualified to `EntityExtensions.ApplicableState(...)`. Since the lifted extension leaves no `EntityExtensions` type, that failed with GS0157.

Fix: add a parallel branch detecting a bare `IdentifierName`/`GenericName` call bound to a source-defined, non-enum, unreduced extension method, rewriting to `firstArg.M(rest)` with type arguments preserved. Reduced instance form and enum-receiver extensions are excluded, matching the qualified-form handling.

Regression tests: `BareFormExtensionCallTranslationTests` (3 cases).

## Validation
- `dotnet test test/Core.Tests/Core.Tests.csproj` — all pass (5735)
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj` — all pass (1152)

## 3. gsc: resolve unqualified statics of referenced-assembly CLR types via type import

ADR-0134 hoisted `shared` members of same-compilation source classes into unqualified scope for a type import (C# `using static`), but explicitly left referenced-assembly CLR static classes out of scope. cs2gs translates `using static System.Math` → `import System.Math`, so unqualified `Sqrt(x)`/`PI` reported GS0130 even though qualified `Math.Sqrt(x)` compiled — blocking any migrated `using static` of a BCL/third-party type (e.g. Oahu's `using static Oahu.Aux.Logging`).

Fix: extend the static-import fallback to referenced CLR types. `BoundScope.EnumerateStaticImportClrTypes` enumerates non-alias/non-implicit imports whose dotted target resolves to a CLR type (namespace imports correctly excluded). The unqualified-call fallback in `OverloadResolver` selects the single imported CLR type exposing a matching `public static` method and finalizes via the shared `BindAccessorCall` qualified-static-call binder (full overload/optional/variadic/generic fidelity). `ExpressionBinder.TryBindImportedStaticMember` gains the parallel bare-identifier read fallback. Cross-type ambiguity reports GS0414. Strict fallback — only consulted when the name would otherwise be an unresolved-reference error.

ADR-0134 updated. Regression tests: `ImportedClrStaticImportTests` (4 cases).

## 4. gsc: apply implicit constant-narrowing to imported STATIC method overload resolution

C# §10.2.11 implicit constant-expression conversion (a bare in-range int literal adapting to a narrower/cross-sign integer parameter) was already applied to imported INSTANCE calls (#1311, e.g. `stream.WriteByte(0)`) and user methods, but `ImportedClassSymbol.TryLookupFunction` — the overload resolver for imported/BCL STATIC method calls — never passed the `constantNarrowingArgumentCheck` hook to `OverloadResolution.Resolve`. So a static call whose only matching overload takes an unsigned/narrower integer (e.g. `Logging.Log(2, ...)` with a `uint` first parameter, or `Buffer.SetByte(a, 0, 255)`) was rejected with GS0159, even though the identical instance-call and direct-assignment forms compiled.

Fix: thread the existing `ExpressionBinder.MakeConstantNarrowingArgumentCheck` into the static-call `Resolve`, exactly as the instance/extension/constructor paths already do. Out-of-range constants still fail.

Clears 20 GS0159 `Log` errors across the Oahu corpus. Regression tests added to `Issue1311ImportedMethodNarrowingTests` (2 static cases).


## 5. gsc: don't gate emitter well-known type lookups on external visibility

Fix #1's external-visibility gate on `ReferenceResolver.TryResolveType` also blocked the **emitter/lowering infrastructure**, which resolves compiler well-known types by exact name — including non-externally-visible attributes such as `NullableAttribute`, `NullableContextAttribute`, `IsReadOnlyAttribute` and `IsByRefLikeAttribute`. Silently dropping those lookups stripped nullable/readonly/ref-struct metadata from every emitted assembly; the `Gsharp.Extensions` stdlib regressed (its `T?` `Optional` receivers lost their nullable annotation), surfacing as CS8602 warn-as-error in `Extensions.Tests` during the CI build.

Fix: split `TryResolveType` into a raw reference-set lookup and a per-call external-visibility gate. The public overload keeps gating (user-facing binding); a new `requireExternalVisibility` overload lets the emitter/lowering callers (`WellKnownReferences`, `CustomAttributeEncoder`, `ReflectionMetadataEmitter`, `NullableLifting`, async state-machine builders) resolve infrastructure types regardless of visibility.

Regression test: `ReferenceResolverTests.TryResolveType_WithoutExternalVisibility_Resolves_Internal_Type_By_Name`. Full solution build (warn-as-error) + `Extensions.Tests` (104) confirmed green.
