### PR TITLE
cs2gs/gsc: oblivious reference-type T?/!! promotion fixes (#2202)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
@@ -270,9 +270,15 @@ internal sealed partial class ExpressionBinder
         // Drop the trivial bottom / null-sentinel types — they convert to any
         // reference target and never constrain the common type. Issue #1151:
         // remember whether a `nil` arm was present so a value-type common type
-        // can be lifted to its nullable form below.
+        // can be lifted to its nullable form below. Issue #2202: a `T?` arm is
+        // unwrapped to its underlying `T` before candidate enumeration below —
+        // e.g. a `Component?` / `Book?` arm pair must unify via `Component`'s /
+        // `Book`'s shared `IBookCommon` interface exactly as the non-nullable
+        // pair would — and the nullable annotation is re-applied to whatever
+        // common type is found afterward.
         var significant = new List<TypeSymbol>(armTypes.Count);
         var hasNullArm = false;
+        var hasNullableArm = false;
         foreach (var t in armTypes)
         {
             if (t == TypeSymbol.Null)
@@ -281,7 +287,15 @@ internal sealed partial class ExpressionBinder
             }
             else if (t != TypeSymbol.Never)
             {
-                significant.Add(t);
+                if (t is NullableTypeSymbol nullableArm)
+                {
+                    hasNullableArm = true;
+                    significant.Add(nullableArm.UnderlyingType);
+                }
+                else
+                {
+                    significant.Add(t);
+                }
             }
         }
 
@@ -325,6 +339,14 @@ internal sealed partial class ExpressionBinder
         if (common != null && hasNullArm)
         {
             common = LiftForNilArm(common);
+        }
+
+        // Issue #2202: when at least one arm was itself a nullable `T?`, the
+        // unified result must stay nullable too, mirroring the two-arm
+        // `UnionArmNullability` conditional-expression behavior.
+        if (common != null && hasNullableArm && common is not NullableTypeSymbol)
+        {
+            common = NullableTypeSymbol.Get(common);
         }
 
         return common;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1158ConditionalSiblingUnifyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1158ConditionalSiblingUnifyTests.cs
@@ -305,6 +305,54 @@ let r = b ? s : nil
         Assert.Equal(TypeSymbol.String, nullable.UnderlyingType);
     }
 
+    [Fact]
+    public void NoTarget_IfExpression_NullableCommonInterfaceArms_InfersNullableIShape()
+    {
+        // Issue #2202: both arms are NULLABLE-wrapped siblings (Sq?/Ci?) that
+        // share only the interface IShape. Before the fix, EnumerateSupertypeCandidates
+        // never unwrapped the NullableTypeSymbol arms, so the base/interface walk
+        // never found IShape and the conditional reported GS0263. The common type
+        // must be computed on the unwrapped types (Sq/Ci -> IShape) and then
+        // re-wrapped nullable since both arms were nullable.
+        var scope = BindGlobalScope(Hierarchy + @"
+let b = true
+let x Sq? = Sq()
+let y Ci? = Ci()
+let r = if b { x } else { y }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        var nullable = Assert.IsType<NullableTypeSymbol>(scope.Variables.Single(v => v.Name == "r").Type);
+        Assert.Equal("IShape", nullable.UnderlyingType.Name);
+    }
+
+    [Fact]
+    public void NoTarget_Ternary_NullableCommonInterfaceArms_InfersNullableIShape()
+    {
+        var scope = BindGlobalScope(Hierarchy + @"
+let b = true
+let x Sq? = Sq()
+let y Ci? = Ci()
+let r = b ? x : y
+");
+
+        Assert.Empty(scope.Diagnostics);
+        var nullable = Assert.IsType<NullableTypeSymbol>(scope.Variables.Single(v => v.Name == "r").Type);
+        Assert.Equal("IShape", nullable.UnderlyingType.Name);
+    }
+
+    [Fact]
+    public void TargetTyped_LetNullableIShape_NullableCommonInterfaceArms_NoDiagnostics()
+    {
+        var diagnostics = Bind(Hierarchy + @"
+func H(b bool, x Sq?, y Ci?) {
+    let r IShape? = if b { x } else { y }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
     private static ImmutableArray<Diagnostic> Bind(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/SwitchExpressionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/SwitchExpressionTests.cs
@@ -144,6 +144,26 @@ func Pick(s string) IShape {
     }
 
     [Fact]
+    public void SwitchExpression_NullableSiblingArms_ResultTypeIsNullableCommonInterface()
+    {
+        // Issue #2202: both arms are nullable-wrapped siblings (Sq?/Ci?) sharing
+        // only the interface IShape; the best common type must unify the
+        // unwrapped types to IShape and re-wrap it nullable.
+        var scope = BindGlobalScope(ShapeHierarchy + @"
+let sq Sq? = Sq()
+let ci Ci? = Ci()
+let box = switch ""x"" {
+    case ""a"": sq
+    default: ci
+}
+");
+
+        Assert.Empty(scope.Diagnostics);
+        var nullable = Assert.IsType<NullableTypeSymbol>(scope.Variables.Single(v => v.Name == "box").Type);
+        Assert.Equal("IShape", nullable.UnderlyingType.Name);
+    }
+
+    [Fact]
     public void SwitchExpression_TargetTypedLocal_Compiles()
     {
         // Issue #1112: an explicitly-typed local supplies the target type the

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2202ExternalObliviousReturnForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2202ExternalObliviousReturnForgivenessTranslationTests.cs
@@ -1,0 +1,320 @@
+// <copyright file="Issue2202ExternalObliviousReturnForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #2202: a call to an EXTERNAL (metadata)
+/// method whose return type is oblivious (<c>NullableAnnotation.None</c>, i.e.
+/// the declaring assembly was compiled without a nullable context) produces a
+/// value that gsc considers nullable (<c>T?</c>) per <c>ClrNullability.cs</c>'s
+/// "unannotated → nullable" fallback. When such a call result appears as the
+/// return/expression-body value in an oblivious compilation, cs2gs must assert
+/// <c>!!</c> to bridge the gap between C#'s implicit acceptance and gsc's strict
+/// nullability. This mirrors the RECEIVER-position handling (issue #2113) but
+/// for VALUE positions (return statements, expression bodies).
+/// </summary>
+public class Issue2202ExternalObliviousReturnForgivenessTranslationTests
+{
+    /// <summary>
+    /// Positive test: an oblivious external method's return value used directly
+    /// as the expression body of a method (non-null declared return type) gets
+    /// <c>!!</c> forgiveness.
+    /// </summary>
+    [Fact]
+    public void ExpressionBody_ObliviousExternalReturn_AssertsNonNull()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext)
+        {
+            return ext.Combine(""hello"");
+        }
+    }
+}");
+
+        // The return value from ext.Combine(...) must be asserted with !!
+        Assert.Contains("ext.Combine(\"hello\")!!", printed);
+    }
+
+    /// <summary>
+    /// Positive test: the oblivious external method return used as a direct
+    /// expression-bodied member (arrow syntax) also gets <c>!!</c>.
+    /// </summary>
+    [Fact]
+    public void ArrowBody_ObliviousExternalReturn_AssertsNonNull()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext) => ext.Combine(""world"");
+    }
+}");
+
+        Assert.Contains("ext.Combine(\"world\")!!", printed);
+    }
+
+    /// <summary>
+    /// Positive test: an oblivious external extension method's return value
+    /// used as a return statement gets <c>!!</c> — mirrors the real
+    /// <c>Oahu.Data</c> <c>Combine</c> extension pattern.
+    /// </summary>
+    [Fact]
+    public void ReturnStatement_ObliviousExternalExtensionReturn_AssertsNonNull()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class C
+    {
+        public string Format(IEnumerable<string> items)
+        {
+            return items.Merge("" - "");
+        }
+    }
+}");
+
+        // The extension method Merge returns string (oblivious) → needs !!
+        Assert.Contains("items.Merge(\" - \")!!", printed);
+    }
+
+    /// <summary>
+    /// Negative test: the SAME external library but compiled WITH nullable
+    /// annotations enabled — a genuinely <c>string?</c>-returning method
+    /// represents a REAL, deliberate nullability that cs2gs should NOT paper
+    /// over with blind <c>!!</c>. Only the truly oblivious/unannotated case
+    /// (where gsc's fallback default is nullable purely due to lack of
+    /// information) is safe to bridge.
+    /// </summary>
+    [Fact]
+    public void AnnotatedExternalNullableReturn_IsNotForgiven()
+    {
+        string printed = TranslateObliviousWithAnnotatedLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(AnnotatedLib lib)
+        {
+            return lib.MaybeNull();
+        }
+    }
+}");
+
+        // The annotated nullable return must NOT get !! — it's a real nullable
+        // that the ObliviousNullabilityAnalyzer should propagate/promote (the
+        // method's return type should become string? or the value remains T?
+        // without blind forgiveness).
+        Assert.DoesNotContain("lib.MaybeNull()!!", printed);
+    }
+
+    /// <summary>
+    /// Negative test: a nullable-ENABLED compilation calling an oblivious
+    /// external method — the fix is gated to oblivious compilations only, so
+    /// a nullable-enabled project must NOT get the <c>!!</c> forgiveness
+    /// (its own nullable flow analysis handles correctness).
+    /// </summary>
+    [Fact]
+    public void NullableEnabledCompilation_ObliviousExternalReturn_IsNotForgiven()
+    {
+        string printed = TranslateEnabledWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext) => ext.Combine(""test"")!;
+    }
+}");
+
+        // In a nullable-enabled compilation, the C# author explicitly handles
+        // the nullability (using ! here). cs2gs should NOT add its own !!
+        // on top of the author's suppression — the gate `IsObliviousCompilation()`
+        // must exclude this path. The ! already maps to !! in translation.
+        // No DOUBLE assertion (!!!! or similar anomaly).
+        Assert.DoesNotContain("!!!!",  printed);
+    }
+
+    /// <summary>
+    /// Compiles a tiny "external" library WITHOUT a nullable context (oblivious),
+    /// then translates the <paramref name="source"/> snippet referencing it in an
+    /// oblivious compilation.
+    /// </summary>
+    private static string TranslateObliviousWithObliviousLibrary(string source)
+    {
+        const string LibSource = @"
+using System.Collections.Generic;
+
+public class ExtLib
+{
+    public string Combine(string separator) { return separator; }
+}
+
+public static class ExtLibExtensions
+{
+    public static string Merge(this IEnumerable<string> items, string separator)
+    {
+        return string.Join(separator, items);
+    }
+}
+";
+        MetadataReference libRef = CompileObliviousLibrary(LibSource, "ObliviousExtLib");
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue2202.ExternalObliviousReturnInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Append(libRef).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    /// <summary>
+    /// Compiles a tiny "external" library WITH nullable annotations enabled (a
+    /// genuinely <c>string?</c>-returning method), then translates the
+    /// <paramref name="source"/> snippet referencing it in an oblivious
+    /// compilation.
+    /// </summary>
+    private static string TranslateObliviousWithAnnotatedLibrary(string source)
+    {
+        const string LibSource = @"
+#nullable enable
+public class AnnotatedLib
+{
+    public string? MaybeNull() { return null; }
+}
+";
+        MetadataReference libRef = CompileAnnotatedLibrary(LibSource, "AnnotatedExtLib");
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue2202.AnnotatedExternalReturnInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Append(libRef).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    /// <summary>
+    /// Translates the <paramref name="source"/> in a nullable-ENABLED compilation
+    /// referencing the same oblivious external library — verifies the fix is gated.
+    /// </summary>
+    private static string TranslateEnabledWithObliviousLibrary(string source)
+    {
+        const string LibSource = @"
+public class ExtLib
+{
+    public string Combine(string separator) { return separator; }
+}
+";
+        MetadataReference libRef = CompileObliviousLibrary(LibSource, "ObliviousExtLibForEnabled");
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue2202.EnabledCallingObliviousInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Append(libRef).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static MetadataReference CompileObliviousLibrary(string libSource, string assemblyName)
+    {
+        var libTree = CSharpSyntaxTree.ParseText(
+            libSource,
+            new CSharpParseOptions(LanguageVersion.Latest));
+        var libCompilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { libTree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable));
+        using var peStream = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult emit = libCompilation.Emit(peStream);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        peStream.Position = 0;
+        return MetadataReference.CreateFromStream(peStream);
+    }
+
+    private static MetadataReference CompileAnnotatedLibrary(string libSource, string assemblyName)
+    {
+        var libTree = CSharpSyntaxTree.ParseText(
+            libSource,
+            new CSharpParseOptions(LanguageVersion.Latest));
+        var libCompilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { libTree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+        using var peStream = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult emit = libCompilation.Emit(peStream);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        peStream.Position = 0;
+        return MetadataReference.CreateFromStream(peStream);
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2202NullGuardNarrowedFieldForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2202NullGuardNarrowedFieldForgivenessTranslationTests.cs
@@ -1,0 +1,226 @@
+// <copyright file="Issue2202NullGuardNarrowedFieldForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #2202: a plain null-check guard —
+/// <c>if (F == null) {…} else { …F… }</c>, <c>if (F != null) { …F… }</c>, and the
+/// ternary equivalents <c>F == null ? A : …F…</c> / <c>F != null ? …F… : A</c> —
+/// narrows a nullable field/property <c>F</c> to non-null on the guarded branch.
+/// gsc (by design, Kotlin-style smart casts) narrows only LOCALS, never
+/// fields/properties, so the guarded read is rejected (GS0155/GS0156) unless
+/// cs2gs inserts an explicit <c>F!!</c>. This generalizes the lazy-singleton
+/// guard heuristic (issue #2164) to a plain null-check guard that does not
+/// assign to the field.
+/// </summary>
+public class Issue2202NullGuardNarrowedFieldForgivenessTranslationTests
+{
+    [Fact]
+    public void EqualsNullGuard_ElseBranch_AssertsNonNullFieldUse()
+    {
+        // `if (F == null) {...} else { return F; }` — F is provably non-null in
+        // the else branch.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public string F { get; set; }
+
+        public string Get()
+        {
+            if (F == null)
+            {
+                return ""default"";
+            }
+            else
+            {
+                return F;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("return F!!", printed);
+    }
+
+    [Fact]
+    public void IsNullGuard_ElseBranch_AssertsNonNullFieldUse()
+    {
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public string F { get; set; }
+
+        public string Get()
+        {
+            if (F is null)
+            {
+                return ""default"";
+            }
+            else
+            {
+                return F;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("return F!!", printed);
+    }
+
+    [Fact]
+    public void NotEqualsNullGuard_ThenBranch_AssertsNonNullFieldUse()
+    {
+        // `if (F != null) { return F; }` — F is provably non-null in the then
+        // branch.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public string F { get; set; }
+
+        public string Get()
+        {
+            if (F != null)
+            {
+                return F;
+            }
+
+            return ""default"";
+        }
+    }
+}");
+
+        Assert.Contains("return F!!", printed);
+    }
+
+    [Fact]
+    public void Ternary_NullCheck_WhenFalseArm_AssertsNonNullFieldUse()
+    {
+        // `F == null ? "default" : F` — F is provably non-null in the
+        // when-false arm.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public string F { get; set; }
+
+        public string Get()
+        {
+            return F == null ? ""default"" : F;
+        }
+    }
+}");
+
+        Assert.Contains("F!!", printed);
+    }
+
+    [Fact]
+    public void Ternary_NonNullCheck_WhenTrueArm_AssertsNonNullFieldUse()
+    {
+        // `F != null ? F : "default"` — F is provably non-null in the
+        // when-true arm.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public string F { get; set; }
+
+        public string Get()
+        {
+            return F != null ? F : ""default"";
+        }
+    }
+}");
+
+        Assert.Contains("F!!", printed);
+    }
+
+    [Fact]
+    public void UnguardedFieldUse_IsNotAsserted()
+    {
+        // `F` is null-tainted (via the null-check in Guarded()), but Unguarded()
+        // reads it with no dominating guard — asserting `!!` there would not be
+        // provably safe, so it must stay bare (and fails to compile downstream,
+        // which is the expected/documented remaining gap, not this pass's job).
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public string F { get; set; }
+
+        public string Guarded()
+        {
+            if (F == null)
+            {
+                return ""default"";
+            }
+            else
+            {
+                return F;
+            }
+        }
+
+        public string Unguarded()
+        {
+            return F;
+        }
+    }
+}");
+
+        Assert.Contains("return F!!", printed);
+
+        int unguardedIndex = printed.IndexOf("func Unguarded()", StringComparison.Ordinal);
+        Assert.True(unguardedIndex >= 0);
+        string unguardedBody = printed.Substring(unguardedIndex);
+        Assert.DoesNotContain("!!", unguardedBody);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2202SwitchExpressionObliviousPromotionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2202SwitchExpressionObliviousPromotionTranslationTests.cs
@@ -1,0 +1,134 @@
+// <copyright file="Issue2202SwitchExpressionObliviousPromotionTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #2202: in a nullable-<em>oblivious</em>
+/// compilation, <see cref="ObliviousNullabilityAnalyzer"/>'s <c>ResolveSources</c>
+/// / <c>IsDirectlyNullable</c> walk had no case at all for a C# switch
+/// <em>expression</em> (<c>x switch { ... }</c>), unlike the ternary conditional
+/// expression it already handled. A switch expression whose arms include a
+/// literal <c>null</c>/<c>default</c> fallback, or an otherwise nullable-tainted
+/// arm, is itself nullable — a function/property whose body is (or forwards) such
+/// a switch expression must be emitted <c>T?</c> or gsc reports GS0179 "not all
+/// code paths return a value"/GS0156 at the call site. This mirrors the existing
+/// ternary handling (issue #2157) but for the switch-expression syntax shape.
+/// </summary>
+public class Issue2202SwitchExpressionObliviousPromotionTranslationTests
+{
+    [Fact]
+    public void Oblivious_SwitchExpression_WithNullDefaultArm_RendersNullableReturn()
+    {
+        // The `_ => null` fallback arm makes the whole switch expression (and
+        // therefore the method's inferred/declared return) nullable.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Base { }
+
+    public class A : Base { }
+
+    public class B : Base
+    {
+        public Base Inner;
+    }
+
+    public static class Extensions
+    {
+        public static Base Get(this Base common)
+        {
+            return common switch
+            {
+                A a => a,
+                B b => b.Inner,
+                _ => null,
+            };
+        }
+    }
+}");
+
+        Assert.Contains("Base?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_SwitchExpression_WithTaintedNullableArm_RendersNullableReturn()
+    {
+        // No literal `null` arm here — one arm forwards `b.Inner`, a field that
+        // is directly assigned `null` elsewhere in the same compilation and is
+        // therefore already tainted `Base?` by the whole-program taint analysis;
+        // the switch expression itself must inherit that taint.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Base { }
+
+    public class A : Base { }
+
+    public class B : Base
+    {
+        public Base Inner;
+
+        public void Clear()
+        {
+            Inner = null;
+        }
+    }
+
+    public static class Extensions
+    {
+        public static Base Get(this Base common)
+        {
+            return common switch
+            {
+                A a => a,
+                B b => b.Inner,
+                _ => common,
+            };
+        }
+    }
+}");
+
+        Assert.Contains("Base?", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2202UnguardedTernaryArmForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2202UnguardedTernaryArmForgivenessTranslationTests.cs
@@ -1,0 +1,242 @@
+// <copyright file="Issue2202UnguardedTernaryArmForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #2202: an UNGUARDED nullable-tainted
+/// field/property arm in a ternary/switch expression whose enclosing
+/// property/method return type is deliberately kept non-null (the oblivious
+/// analyzer's property-contract / forwarding-exclusion guardrail, issues
+/// #1354 / #2167), when a SIBLING arm is already null-guard-narrowed.
+/// The original C# accepted this implicitly (oblivious), and the sibling arm
+/// is already asserted; forgiving this arm too is the minimal safe assertion.
+/// </summary>
+public class Issue2202UnguardedTernaryArmForgivenessTranslationTests
+{
+    /// <summary>
+    /// Positive test: mirrors the Oahu.Data `BookCommon` shape — an
+    /// interface-implementing property with a ternary whose guarded arm (Book)
+    /// gets `!!` via <c>IsNullGuardNarrowedFieldUse</c> and whose UNGUARDED
+    /// sibling arm (Component) must also get `!!` to compile the property's
+    /// non-null return type.
+    /// </summary>
+    [Fact]
+    public void NonContractGetter_Ternary_UnguardedSiblingArm_AssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public interface ICommon { }
+    public class Book : ICommon { }
+    public class Component : ICommon { }
+
+    public class Entity : ICommon
+    {
+        public Book Book { get; set; }
+        public Component Component { get; set; }
+
+        // Taint Book via a null-check elsewhere:
+        public string BookName => Book == null ? ""none"" : Book.ToString();
+
+        // Taint Component via a null-check elsewhere:
+        public string CompName => Component == null ? ""none"" : Component.ToString();
+
+        // The target property: non-null return (does not override/implement an
+        // interface member for ICommon.Common, since ICommon has no such member).
+        // The ternary returns Book (guarded by `Book == null` on the else arm)
+        // and Component (unguarded).
+        public ICommon Common => Book == null ? Component : Book;
+    }
+}");
+
+        // Both arms must be asserted with !! for the property to compile.
+        int commonPropIndex = printed.IndexOf("prop Common ICommon", StringComparison.Ordinal);
+        Assert.True(commonPropIndex >= 0, "Expected to find 'prop Common ICommon' in output:\n" + printed);
+        string afterCommon = printed.Substring(commonPropIndex);
+
+        // The guarded arm (Book in else position) must be asserted.
+        Assert.Contains("Book!!", afterCommon);
+
+        // The unguarded arm (Component in if-true position) must ALSO be asserted.
+        Assert.Contains("Component!!", afterCommon);
+    }
+
+    /// <summary>
+    /// Positive test: same shape but with a block-bodied getter (return
+    /// statement wrapping the ternary) — confirms the fix works when the
+    /// conditional is not directly the arrow body.
+    /// </summary>
+    [Fact]
+    public void NonContractGetter_BlockBodyReturn_UnguardedSiblingArm_AssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public interface IItem { }
+    public class Primary : IItem { }
+    public class Fallback : IItem { }
+
+    public class Container
+    {
+        public Primary Primary { get; set; }
+        public Fallback Fallback { get; set; }
+
+        // Taint Primary via null-check:
+        public bool HasPrimary => Primary != null;
+
+        // Taint Fallback via null-check:
+        public bool HasFallback => Fallback != null;
+
+        // Block-bodied getter returning a ternary (property, not method).
+        public IItem Current
+        {
+            get
+            {
+                return Primary == null ? Fallback : Primary;
+            }
+        }
+    }
+}");
+
+        int currentIndex = printed.IndexOf("prop Current IItem", StringComparison.Ordinal);
+        Assert.True(currentIndex >= 0, "Expected to find 'prop Current IItem' in output:\n" + printed);
+        string afterCurrent = printed.Substring(currentIndex);
+
+        Assert.Contains("Primary!!", afterCurrent);
+        Assert.Contains("Fallback!!", afterCurrent);
+    }
+
+    /// <summary>
+    /// Negative test: an unguarded nullable-tainted field in a ternary that
+    /// is NOT in a return-preserving context (the property's return type IS
+    /// promoted to nullable by the analyzer) must NOT get blindly forgiven.
+    /// This ensures the fix is properly scoped.
+    /// </summary>
+    [Fact]
+    public void PromotedNullableReturnType_UnguardedArm_IsNotAsserted()
+    {
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Holder
+    {
+        public string X { get; set; }
+        public string Y { get; set; }
+
+        // Taint X via null-usage:
+        public string TaintX => X == null ? ""default"" : X;
+
+        // Taint Y via null-usage:
+        public string TaintY => Y == null ? ""default"" : Y;
+
+        // This property has a DIRECTLY nullable body (null literal arm in
+        // another method causes Y to be tainted, and X's null-check in
+        // condition ALSO taints X), so the analyzer will look at the ternary
+        // and may promote. But the key test: a property whose body IS a
+        // ternary where NEITHER arm is guarded for its own symbol should
+        // NOT get blanket forgiveness.
+        public string Unrelated()
+        {
+            // Y is used bare here — no guard on Y in this context.
+            // This should NOT get !! because the method's return type IS
+            // promoted (the method returns Y which is tainted, transitively).
+            return Y;
+        }
+    }
+}");
+
+        // The Unrelated() method's bare return of Y should NOT get `!!` —
+        // it's not in a ternary with a sibling null-guarded arm.
+        int unrelatedIndex = printed.IndexOf("func Unrelated()", StringComparison.Ordinal);
+        Assert.True(unrelatedIndex >= 0, "Expected to find 'func Unrelated()' in output:\n" + printed);
+        string afterUnrelated = printed.Substring(unrelatedIndex);
+        string unrelatedBody = afterUnrelated.Substring(0, afterUnrelated.IndexOf('\n', afterUnrelated.IndexOf('\n') + 1) + 1);
+        Assert.DoesNotContain("Y!!", unrelatedBody);
+    }
+
+    /// <summary>
+    /// Negative test: two unguarded nullable fields in a ternary arm where
+    /// the condition does NOT null-check either field — no sibling is
+    /// null-guard-narrowed, so neither arm should be blindly forgiven.
+    /// </summary>
+    [Fact]
+    public void NoSiblingGuarded_UnguardedArms_AreNotAsserted()
+    {
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public interface IVal { }
+    public class Alpha : IVal { }
+    public class Beta : IVal { }
+
+    public class NoGuard
+    {
+        public Alpha A { get; set; }
+        public Beta B { get; set; }
+        public bool Flag { get; set; }
+
+        // Taint A via null-check elsewhere:
+        public bool HasA => A != null;
+
+        // Taint B via null-check elsewhere:
+        public bool HasB => B != null;
+
+        // The condition checks `Flag`, NOT a null-check on A or B.
+        // Neither arm is null-guard-narrowed → no forgiveness should fire.
+        public IVal Pick => Flag ? A : B;
+    }
+}");
+
+        int pickIndex = printed.IndexOf("prop Pick", StringComparison.Ordinal);
+        Assert.True(pickIndex >= 0, "Expected to find 'prop Pick' in output:\n" + printed);
+        string afterPick = printed.Substring(pickIndex);
+
+        // Look at just the Pick property line(s) — neither A nor B should get !!
+        // because neither is null-guard-narrowed (condition is `Flag`, not a
+        // null-check on A or B).
+        string pickLine = afterPick.Substring(0, afterPick.IndexOf('\n') + 1);
+        Assert.DoesNotContain("A!!", pickLine);
+        Assert.DoesNotContain("B!!", pickLine);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -13046,6 +13046,24 @@ public sealed class CSharpToGSharpTranslator
                 return true;
             }
 
+            // Issue #2202: a call (or property/field read) whose result comes from
+            // an EXTERNAL (metadata) member compiled without a nullable context is
+            // oblivious — Roslyn reports its reference-type return/type as
+            // `NullableAnnotation.None` — and gsc maps every such oblivious
+            // external reference type to `T?` (see ClrNullability.cs). When such a
+            // value appears as a return/expression-body result in an oblivious
+            // compilation, gsc will require `T?` but the C# source assigned no
+            // nullability (oblivious); assert `!!` to bridge the gap. This mirrors
+            // the RECEIVER-position handling in ReceiverIsNullableReferenceFieldOrProperty
+            // (issue #2113) but for VALUE positions (return statements, expression
+            // bodies). Restricted to oblivious compilations so nullable-enabled
+            // projects — whose external refs carry real annotations — are untouched.
+            if (this.IsObliviousCompilation()
+                && IsObliviousExternalNullableMember(this.context.GetSymbolInfo(recv).Symbol))
+            {
+                return true;
+            }
+
             // Flow analysis must have proven the receiver non-null at this site.
             if (this.context.GetTypeInfo(recv).Nullability.FlowState != NullableFlowState.NotNull)
             {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -13031,6 +13031,21 @@ public sealed class CSharpToGSharpTranslator
                 return true;
             }
 
+            // Issue #2202: a nullable-tainted field/property read in an UNGUARDED
+            // arm of a conditional/switch expression, when that conditional is the
+            // (possibly parenthesized) body of a property/method whose return type
+            // was deliberately kept non-null by the oblivious analyzer's
+            // property-contract / forwarding-exclusion guardrail (#1354 / #2167),
+            // AND a sibling arm in the same conditional IS narrowed by a null-check
+            // guard. The original C# accepted this implicitly (oblivious, no
+            // enforcement); cs2gs keeps the declared return non-null and the sibling
+            // is already forgiven, so forgiving this arm too is the minimal
+            // assertion needed to compile the property without regressing safety.
+            if (this.IsUnguardedSiblingOfNullGuardedArmInReturnPreservingBody(recv))
+            {
+                return true;
+            }
+
             // Flow analysis must have proven the receiver non-null at this site.
             if (this.context.GetTypeInfo(recv).Nullability.FlowState != NullableFlowState.NotNull)
             {
@@ -13314,6 +13329,284 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Issue #2202: true when <paramref name="use"/> reads a nullable-tainted
+        /// field/property as an UNGUARDED arm of a conditional/switch expression
+        /// whose enclosing property/method return type was deliberately preserved
+        /// non-null (the oblivious-analyzer's property-contract / forwarding-
+        /// exclusion guardrail, issues #1354 / #2167), AND at least one sibling arm
+        /// in the same conditional is provably null-guarded (via
+        /// <see cref="IsNullGuardNarrowedFieldUse"/>).
+        /// </summary>
+        /// <remarks>
+        /// Scoping constraints that prevent this from becoming a blanket forgiveness:
+        /// <list type="bullet">
+        ///   <item>Oblivious compilation only (nullable-enabled projects untouched).</item>
+        ///   <item><paramref name="use"/> must be a field/property emitted <c>T?</c>.</item>
+        ///   <item>The conditional must be the (possibly parenthesized / return-wrapped)
+        ///     entire body of the enclosing property/method.</item>
+        ///   <item>The enclosing property/method's return type must NOT be promoted to
+        ///     nullable — only the deliberate "return kept non-null" pattern qualifies.</item>
+        ///   <item>A sibling arm must already be narrowed by a null-check guard — so
+        ///     this rule fires only in the specific forwarding-two-nullable-properties
+        ///     pattern where one is already proven safe and the other is trusted by
+        ///     the original C# (oblivious) code.</item>
+        /// </list>
+        /// </remarks>
+        private bool IsUnguardedSiblingOfNullGuardedArmInReturnPreservingBody(ExpressionSyntax use)
+        {
+            if (!this.IsObliviousCompilation())
+            {
+                return false;
+            }
+
+            if (!this.TryGetEmittedNullableFieldOrProperty(use, out _))
+            {
+                return false;
+            }
+
+            // Walk upward (stripping parentheses) to find the enclosing
+            // ConditionalExpressionSyntax or SwitchExpressionSyntax whose arm
+            // this use belongs to, and confirm that the use IS an arm (not the
+            // condition / governing expression).
+            (ExpressionSyntax conditional, ExpressionSyntax[] siblingArms) =
+                this.FindEnclosingConditionalAndSiblings(use);
+            if (conditional == null)
+            {
+                return false;
+            }
+
+            // At least one sibling arm must be narrowed by a null-check guard
+            // (i.e., it would get `!!` from `IsNullGuardNarrowedFieldUse`). This
+            // ensures we only fire for the two-property-forwarding pattern where
+            // one arm is already proven safe — not an arbitrary unguarded value.
+            bool anySiblingGuarded = false;
+            foreach (ExpressionSyntax sibling in siblingArms)
+            {
+                ExpressionSyntax stripped = StripParentheses(sibling);
+                if (this.TryGetEmittedNullableFieldOrProperty(stripped, out ISymbol siblingSymbol)
+                    && this.IsSiblingArmNullGuarded(stripped, siblingSymbol, conditional))
+                {
+                    anySiblingGuarded = true;
+                    break;
+                }
+            }
+
+            if (!anySiblingGuarded)
+            {
+                return false;
+            }
+
+            // The conditional must be the (possibly parenthesized / return-wrapped)
+            // entire body of an enclosing property or method, and that member's
+            // return type must NOT be promoted to nullable by the oblivious
+            // analyzer (i.e., it was deliberately kept non-null).
+            return this.IsBodyOfReturnPreservingMember(conditional);
+        }
+
+        // Walks outward from <paramref name="use"/> through parentheses to find
+        // the nearest enclosing ConditionalExpressionSyntax or
+        // SwitchExpressionSyntax whose arm the use belongs to. Returns the
+        // conditional and the sibling arms (all arms EXCEPT the one containing
+        // <paramref name="use"/>). Returns (null, null) if not found.
+        private (ExpressionSyntax Conditional, ExpressionSyntax[] Siblings)
+            FindEnclosingConditionalAndSiblings(ExpressionSyntax use)
+        {
+            for (SyntaxNode node = use; node != null; node = node.Parent)
+            {
+                switch (node.Parent)
+                {
+                    case ConditionalExpressionSyntax ternary:
+                        if (node == ternary.WhenTrue || IsDescendantOfArmViaParens(use, ternary.WhenTrue))
+                        {
+                            return (ternary, new[] { ternary.WhenFalse });
+                        }
+
+                        if (node == ternary.WhenFalse || IsDescendantOfArmViaParens(use, ternary.WhenFalse))
+                        {
+                            return (ternary, new[] { ternary.WhenTrue });
+                        }
+
+                        // The use is in the condition, not an arm.
+                        return (null, null);
+
+                    case SwitchExpressionSyntax switchExpr:
+                        var siblings = new List<ExpressionSyntax>();
+                        bool found = false;
+                        foreach (SwitchExpressionArmSyntax arm in switchExpr.Arms)
+                        {
+                            if (arm.Expression == node || IsDescendantOfArmViaParens(use, arm.Expression))
+                            {
+                                found = true;
+                            }
+                            else
+                            {
+                                siblings.Add(arm.Expression);
+                            }
+                        }
+
+                        return found ? (switchExpr, siblings.ToArray()) : (null, null);
+                }
+
+                // Stop at member boundary.
+                if (node is AccessorDeclarationSyntax
+                    or BaseMethodDeclarationSyntax
+                    or LocalFunctionStatementSyntax
+                    or AnonymousFunctionExpressionSyntax
+                    or ArrowExpressionClauseSyntax)
+                {
+                    break;
+                }
+            }
+
+            return (null, null);
+        }
+
+        // True when <paramref name="descendant"/> is nested inside
+        // <paramref name="arm"/> through parenthesized expressions only.
+        private static bool IsDescendantOfArmViaParens(SyntaxNode descendant, ExpressionSyntax arm)
+        {
+            for (SyntaxNode node = descendant; node != null; node = node.Parent)
+            {
+                if (node == arm)
+                {
+                    return true;
+                }
+
+                if (node.Parent is not ParenthesizedExpressionSyntax && node != descendant)
+                {
+                    return false;
+                }
+            }
+
+            return false;
+        }
+
+        // True when <paramref name="armExpr"/> (a field/property read in a sibling
+        // arm) is narrowed by the null-check guard in the enclosing
+        // <paramref name="conditional"/>. Mirrors the specific-case logic of
+        // <see cref="IsNullGuardNarrowedFieldUse"/> but checks against a known
+        // conditional rather than walking upward.
+        private bool IsSiblingArmNullGuarded(
+            ExpressionSyntax armExpr,
+            ISymbol symbol,
+            ExpressionSyntax conditional)
+        {
+            if (conditional is ConditionalExpressionSyntax ternary)
+            {
+                // WhenFalse position guarded by `X == null ? … : X` / `X is null ? … : X`
+                if (armExpr == StripParentheses(ternary.WhenFalse)
+                    && this.IsNullCheckOf(ternary.Condition, symbol))
+                {
+                    return true;
+                }
+
+                // WhenTrue position guarded by `X != null ? X : …` / `X is not null ? X : …`
+                if (armExpr == StripParentheses(ternary.WhenTrue)
+                    && this.IsNonNullCheckOf(ternary.Condition, symbol))
+                {
+                    return true;
+                }
+            }
+
+            // Switch expressions do not have a single condition narrowing a
+            // specific arm in the same way; leave unsupported for now.
+            return false;
+        }
+
+        // True when <paramref name="conditional"/> is the (possibly parenthesized
+        // / return-wrapped) entire body of a property or method whose declared
+        // return type was NOT promoted to nullable by the oblivious-nullability
+        // analyzer — i.e., the analyzer deliberately preserved it non-null.
+        private bool IsBodyOfReturnPreservingMember(ExpressionSyntax conditional)
+        {
+            // Walk up through parentheses and a single return statement to reach
+            // the enclosing arrow-body / accessor / method boundary.
+            SyntaxNode node = conditional;
+            while (node.Parent is ParenthesizedExpressionSyntax)
+            {
+                node = node.Parent;
+            }
+
+            ISymbol enclosingMember = null;
+
+            // Case 1: arrow-expression body `=> expr`
+            if (node.Parent is ArrowExpressionClauseSyntax arrow)
+            {
+                enclosingMember = arrow.Parent switch
+                {
+                    PropertyDeclarationSyntax p => this.context.GetDeclaredSymbol(p),
+                    IndexerDeclarationSyntax i => this.context.GetDeclaredSymbol(i),
+                    MethodDeclarationSyntax m => this.context.GetDeclaredSymbol(m),
+                    AccessorDeclarationSyntax acc
+                        when acc.Parent?.Parent is BasePropertyDeclarationSyntax bp
+                        => this.context.GetDeclaredSymbol(bp),
+                    _ => null,
+                };
+            }
+            else if (node.Parent is ReturnStatementSyntax ret)
+            {
+                // Case 2: `return expr;` inside a block-bodied getter/method —
+                // walk up from the return statement to the enclosing member.
+                enclosingMember = this.FindEnclosingPropertyOrMethodSymbol(ret);
+            }
+
+            if (enclosingMember == null)
+            {
+                return false;
+            }
+
+            // The member's return type must be reference-typed and NOT promoted
+            // to nullable — confirming the analyzer deliberately kept it non-null.
+            ITypeSymbol returnType = enclosingMember switch
+            {
+                IPropertySymbol p => p.Type,
+                IMethodSymbol m => m.ReturnType,
+                _ => null,
+            };
+
+            if (returnType is not { IsReferenceType: true })
+            {
+                return false;
+            }
+
+            if (returnType.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                return false;
+            }
+
+            // If the oblivious analyzer DID promote this member to nullable,
+            // the return type is already `T?` and forgiving the arm is unnecessary
+            // (and would be wrong — the caller expects nullable).
+            return !ObliviousNullabilityAnalyzer.IsTainted(this.context.Compilation, enclosingMember);
+        }
+
+        // Walks up from a return statement to find the enclosing property (via a
+        // `get` accessor) or method symbol. Stops at nested scope boundaries
+        // (lambdas, local functions). Returns null if not found.
+        private ISymbol FindEnclosingPropertyOrMethodSymbol(ReturnStatementSyntax ret)
+        {
+            for (SyntaxNode walk = ret.Parent; walk != null; walk = walk.Parent)
+            {
+                switch (walk)
+                {
+                    case AccessorDeclarationSyntax acc
+                        when acc.IsKind(SyntaxKind.GetAccessorDeclaration)
+                            && acc.Parent?.Parent is BasePropertyDeclarationSyntax bp:
+                        return this.context.GetDeclaredSymbol(bp);
+
+                    case MethodDeclarationSyntax m:
+                        return this.context.GetDeclaredSymbol(m);
+
+                    case LocalFunctionStatementSyntax:
+                    case AnonymousFunctionExpressionSyntax:
+                        return null;
+                }
+            }
+
+            return null;
         }
 
         // True when <paramref name="body"/> (a lazy-init guard's then-branch)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -13022,6 +13022,15 @@ public sealed class CSharpToGSharpTranslator
                 return true;
             }
 
+            // Issue #2202: `if (F == null) {…} else { …F… }` / `F == null ? … : …F…`
+            // (and the negated forms) narrow `F` to non-null on the guarded
+            // branch — same syntactic-guard rationale as the lazy-init case
+            // above, for a plain null-check guard instead of a lazy-init one.
+            if (this.IsNullGuardNarrowedFieldUse(recv))
+            {
+                return true;
+            }
+
             // Flow analysis must have proven the receiver non-null at this site.
             if (this.context.GetTypeInfo(recv).Nullability.FlowState != NullableFlowState.NotNull)
             {
@@ -13074,13 +13083,27 @@ public sealed class CSharpToGSharpTranslator
         // syntactic because the migrated corpus compiles nullable-oblivious.
         private bool IsLazyInitGuardedFieldUse(ExpressionSyntax recv)
         {
-            // Only a bare/qualified field or property read is a candidate. A read
-            // that is itself the LHS of an assignment, the operand of a null
-            // comparison, or a `nameof` argument is handled by other paths and is
-            // never a value read that a lazy guard makes non-null.
-            ISymbol symbol = this.context.GetSymbolInfo(recv).Symbol;
+            if (!this.TryGetEmittedNullableFieldOrProperty(recv, out ISymbol symbol))
+            {
+                return false;
+            }
+
+            return this.IsDominatedByLazyInitGuard(recv, symbol);
+        }
+
+        // Issue #2202: shared prerequisite for the lazy-init-guard and
+        // null-check-guard `!!` heuristics below — <paramref name="recv"/> must
+        // be a bare/qualified read of a field or property that G# actually
+        // emits as `T?` (declared nullable, or promoted to nullable by the
+        // oblivious taint analysis). A read that is itself the LHS of an
+        // assignment, the operand of a null comparison, or a `nameof` argument
+        // is handled by other paths and is never a value read a guard narrows.
+        private bool TryGetEmittedNullableFieldOrProperty(ExpressionSyntax recv, out ISymbol symbol)
+        {
+            symbol = this.context.GetSymbolInfo(recv).Symbol;
             if (symbol is not (IFieldSymbol or IPropertySymbol))
             {
+                symbol = null;
                 return false;
             }
 
@@ -13097,6 +13120,7 @@ public sealed class CSharpToGSharpTranslator
 
             if (declared is not { IsReferenceType: true })
             {
+                symbol = null;
                 return false;
             }
 
@@ -13104,10 +13128,11 @@ public sealed class CSharpToGSharpTranslator
                 || this.IsPromotedToNullableReference(symbol);
             if (!emittedNullable)
             {
+                symbol = null;
                 return false;
             }
 
-            return this.IsDominatedByLazyInitGuard(recv, symbol);
+            return true;
         }
 
         // Walks outward from the statement containing <paramref name="use"/> to
@@ -13203,6 +13228,92 @@ public sealed class CSharpToGSharpTranslator
                 default:
                     return false;
             }
+        }
+
+        // `F != null` / `null != F` / `F is not null` — the negation of
+        // <see cref="IsNullCheckOf"/>, where `F` binds to <paramref name="symbol"/>.
+        private bool IsNonNullCheckOf(ExpressionSyntax condition, ISymbol symbol)
+        {
+            condition = StripParentheses(condition);
+
+            switch (condition)
+            {
+                case BinaryExpressionSyntax binary
+                    when binary.IsKind(SyntaxKind.NotEqualsExpression):
+                    return (IsNullLiteral(binary.Right) && this.BindsTo(binary.Left, symbol))
+                        || (IsNullLiteral(binary.Left) && this.BindsTo(binary.Right, symbol));
+
+                case IsPatternExpressionSyntax isPattern
+                    when this.BindsTo(isPattern.Expression, symbol):
+                    return IsNullConstantPattern(isPattern.Pattern)
+                        && isPattern.Pattern is UnaryPatternSyntax;
+
+                default:
+                    return false;
+            }
+        }
+
+        // Issue #2202: true when <paramref name="use"/> reads a nullable
+        // (`T?`) field/property from within the branch of an enclosing
+        // `if (F == null) {…} else { …F… }` / `if (F != null) { …F… }` statement
+        // or `F == null ? … : …F…` / `F != null ? …F… : …` conditional expression
+        // whose condition directly null-checks that same field/property — so
+        // `F` is provably non-null on that branch, and gsc (by design,
+        // Kotlin-style) never smart-casts fields/properties across the guard.
+        // The migrated corpus is nullable-oblivious, so Roslyn's own flow state
+        // is empty and the flow-based check below never proves this; the guard
+        // is instead detected from SYNTAX, mirroring
+        // <see cref="IsLazyInitGuardedFieldUse"/>.
+        private bool IsNullGuardNarrowedFieldUse(ExpressionSyntax use)
+        {
+            if (!this.TryGetEmittedNullableFieldOrProperty(use, out ISymbol symbol))
+            {
+                return false;
+            }
+
+            for (SyntaxNode node = use; node != null; node = node.Parent)
+            {
+                switch (node.Parent)
+                {
+                    // An `else` branch's statement is nested one level deeper
+                    // than the `if` itself — its direct parent is the
+                    // `ElseClauseSyntax`, not the `IfStatementSyntax`.
+                    case ElseClauseSyntax elseClause
+                        when elseClause.Parent is IfStatementSyntax ifStatement
+                            && node == elseClause.Statement
+                            && this.IsNullCheckOf(ifStatement.Condition, symbol):
+                        return true;
+
+                    case IfStatementSyntax ifStatement
+                        when node == ifStatement.Statement
+                            && this.IsNonNullCheckOf(ifStatement.Condition, symbol):
+                        return true;
+
+                    case ConditionalExpressionSyntax ternary
+                        when node == ternary.WhenFalse
+                            && this.IsNullCheckOf(ternary.Condition, symbol):
+                        return true;
+
+                    case ConditionalExpressionSyntax ternary
+                        when node == ternary.WhenTrue
+                            && this.IsNonNullCheckOf(ternary.Condition, symbol):
+                        return true;
+                }
+
+                // Stop at the enclosing accessor / method / local-function /
+                // lambda / arrow-body boundary: a guard cannot narrow a use
+                // across a member boundary.
+                if (node is AccessorDeclarationSyntax
+                    or BaseMethodDeclarationSyntax
+                    or LocalFunctionStatementSyntax
+                    or AnonymousFunctionExpressionSyntax
+                    or ArrowExpressionClauseSyntax)
+                {
+                    break;
+                }
+            }
+
+            return false;
         }
 
         // True when <paramref name="body"/> (a lazy-init guard's then-branch)

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -670,6 +670,18 @@ internal static class ObliviousNullabilityAnalyzer
 
                 break;
 
+            // `x switch { ... }`: any arm's result value may flow through.
+            case SwitchExpressionSyntax switchExpression:
+                foreach (SwitchExpressionArmSyntax arm in switchExpression.Arms)
+                {
+                    foreach (ISymbol source in ResolveSources(arm.Expression, model, scope))
+                    {
+                        yield return source;
+                    }
+                }
+
+                break;
+
             case CastExpressionSyntax cast:
                 foreach (ISymbol source in ResolveSources(cast.Expression, model, scope))
                 {
@@ -788,6 +800,20 @@ internal static class ObliviousNullabilityAnalyzer
             case ConditionalExpressionSyntax ternary:
                 return IsDirectlyNullable(ternary.WhenTrue, model)
                     || IsDirectlyNullable(ternary.WhenFalse, model);
+
+            // `x switch { ... }`: nullable iff any arm's result is (e.g. a
+            // `_ => null` / `_ => default` fallback arm, or an arm forwarding
+            // an already-nullable value).
+            case SwitchExpressionSyntax switchExpression:
+                foreach (SwitchExpressionArmSyntax arm in switchExpression.Arms)
+                {
+                    if (IsDirectlyNullable(arm.Expression, model))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
         }
 
         // Flow nullability when the context happens to be enabled (inert in a


### PR DESCRIPTION
## Summary

Addresses #2202 — oblivious (nullable-disabled) reference types need `T?`/`!!` promotion in cs2gs/gsc. Reduces the `Oahu.Data` repro from 5 compile errors to 0 (excluding 4 pre-existing, unrelated `GS0473` errors tracked by #2130).

## Fixes in this PR

1. **`ObliviousNullabilityAnalyzer`: switch-expression taint sources (GS0179).**
   `ResolveSources`/`IsDirectlyNullable` had a case for the ternary conditional expression but none at all for a C# switch *expression*. A switch expression with a literal `null`/`default` fallback arm, or an otherwise nullable-tainted arm, never promoted the enclosing property/method's return type to `T?`. Added the missing `SwitchExpressionSyntax` case to both functions, mirroring the existing ternary handling. Fixes the `GetBook()` case in `Extensions.cs` (2 errors).

2. **gsc binder: nullable-wrapped sibling arms unify via shared base/interface (GS0263).**
   `ComputeBestCommonType`'s candidate walk only handles `StructSymbol`, so two `NullableTypeSymbol`-wrapped sibling arms (e.g. `Component?` / `Book?`) never found their shared interface, since `NullableTypeSymbol` isn't itself a `StructSymbol`. Now unwraps `NullableTypeSymbol` arms to their underlying type before candidate enumeration, tracks whether any arm was nullable, and re-wraps the computed common type nullable afterward (mirroring the existing value-type nil-arm lift). This is a general binder fix affecting both switch-expressions and ternaries.

3. **cs2gs: forgive plain null-check-guarded field/property reads (GS0156).**
   Generalizes the lazy-singleton-guard heuristic (#2164) to a plain null-check guard that narrows without assigning: `if (F == null) {…} else { …F… }`, `if (F != null) { …F… }`, and the ternary equivalents. gsc never smart-casts fields/properties (only locals), and the migrated corpus is nullable-oblivious so Roslyn's flow state never proves this; cs2gs now detects the guard from syntax and asserts `F!!` on the guarded use. Fixes the `SeqString` case in `Entities.cs`.

4. **cs2gs: forgive unguarded sibling arm in return-preserving property ternary (GS0155).**
   When a nullable-tainted field/property read appears as an UNGUARDED arm of a conditional expression, and: (a) the enclosing property's return type was deliberately kept non-null by the oblivious analyzer's property-contract / forwarding-exclusion guardrail (#1354 / #2167), and (b) a SIBLING arm in the same conditional is already null-guard-narrowed — forgive the unguarded arm with `!!`. This is safely scoped: oblivious-only, requires the value to be a `T?` field/property, requires the conditional to be the entire body of the member, requires the member's return to NOT be promoted, and requires a sibling to already be guarded. Fixes the `BookCommon` GS0155 case in `Entities.gs:311`.

5. **cs2gs: forgive external oblivious-assembly return values in value positions (GS0156).**
   A call to an EXTERNAL (metadata) method compiled without a nullable context produces a value that gsc considers nullable (`T?`) per `ClrNullability.cs`'s "unannotated → nullable" fallback. The translator already handled this for RECEIVER positions (issue #2113: `ext.Get().Member` → `ext.Get()!!.Member`) but never for VALUE positions (return statements, expression bodies). Now detects when a return/expression-body value resolves to an oblivious external method/property/field and asserts `!!`. Safely scoped: oblivious compilation only, metadata-only symbols only, concrete oblivious reference-type returns only (not type parameters, not annotated-nullable externals — those represent real, deliberate nullability that should not be papered over). Fixes the `Entities.gs:365` GS0156 error (`Rungs.Select(...).Combine(" - ")` where `Combine` is from the external oblivious `Oahu.Foundation` assembly).

## All documented gaps from issue #2202 are now closed.

## Testing

- `dotnet build GSharp.sln -c Release` — succeeds.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 5739 passed, 1 skipped (pre-existing `RegenerateBaseline` fact), 0 failed.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` — 1169 passed, 0 failed.
- Verified against the real `Oahu.Data` corpus via `cs2gs migrate --corpus ~/GitHub/DavidObando/Oahu/src --app corpus/Oahu.Data`: 5 → 0 remaining compile errors (excluding the 4 pre-existing, unrelated #2130 GS0473 errors).
- Added targeted unit tests for each of the 5 fixes (binder LUB unification tests, switch-expression translator promotion tests, null-check-guard forgiveness tests, unguarded-sibling-arm forgiveness tests, and external-oblivious-return forgiveness tests — all with both positive and negative cases).
