### PR TITLE
gsc: resolve GS0158 when a type's simple name equals its package's last segment

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -582,6 +582,25 @@ internal sealed partial class ExpressionBinder
             {
                 return BindExpression(syntax.RightPart);
             }
+
+            // Issue #2203: a type whose simple name equals the last segment of
+            // its own containing package (e.g. `class Tokens` in `package
+            // Oahu.Cli.Tui.Tokens`) is referenced from outside that package as
+            // `Tokens.Tokens.Member` — mirroring the C# idiom where a nested
+            // namespace is visible unqualified from a sibling namespace under a
+            // shared ancestor, which cs2gs translates literally since G# has no
+            // equivalent namespace-visibility rule. The leading "Tokens" plays
+            // the namespace's role and is redundant (G# resolves the trailing
+            // "Tokens" type by simple name from its flat, cross-package type
+            // scope regardless), so peel it off the same way as the
+            // nested-type case above whenever the qualifier names the type's own
+            // simple name AND that name is also the tail of its package.
+            if (headIdentifier == enclosingNameSyntax.IdentifierToken.Text
+                && GetSymbolPackageName(enclosingAliasType) is string ownPackageName
+                && (ownPackageName == headIdentifier || ownPackageName.EndsWith("." + headIdentifier, StringComparison.Ordinal)))
+            {
+                return BindExpression(syntax.RightPart);
+            }
         }
 
         // Determine what the left side of the accessor is: either an imported
@@ -974,6 +993,19 @@ internal sealed partial class ExpressionBinder
         StructSymbol s => s.ContainingType,
         EnumSymbol e => e.ContainingType,
         InterfaceSymbol i => i.ContainingType,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Issue #2203: returns the dotted package name a user-defined aggregate
+    /// type was declared in, or <see langword="null"/> for a kind that has no
+    /// package (or isn't a user aggregate type at all).
+    /// </summary>
+    private static string GetSymbolPackageName(TypeSymbol type) => type switch
+    {
+        StructSymbol s => s.PackageName,
+        EnumSymbol e => e.PackageName,
+        InterfaceSymbol i => i.PackageName,
         _ => null,
     };
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2203PackageNameTypeCollisionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2203PackageNameTypeCollisionTests.cs
@@ -1,0 +1,97 @@
+// <copyright file="Issue2203PackageNameTypeCollisionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2203: a type whose simple name equals the last segment of its own
+/// containing package (e.g. <c>class Tokens</c> in <c>package
+/// Oahu.Cli.Tui.Tokens</c>) failed member resolution with GS0158 when
+/// referenced from a sibling package as <c>Tokens.Tokens.Member</c>. This
+/// double-qualified form arises from cs2gs translating C# source that relies
+/// on the sibling-namespace-visibility rule (a nested namespace is visible
+/// unqualified from a sibling namespace under a shared ancestor) — the
+/// leading "Tokens" plays the namespace's role there, but G# has no namespace
+/// concept and instead resolves the type by simple name from its flat,
+/// cross-package type scope, so the leading qualifier is redundant and must
+/// be peeled off.
+/// </summary>
+public class Issue2203PackageNameTypeCollisionTests
+{
+    [Fact]
+    public void TypeNameEqualsPackageTail_DoubleQualifiedStaticMethodCall_Resolves()
+    {
+        var tree1 = SyntaxTree.Parse(SourceText.From("""
+            package Oahu.Cli.Tui.Tokens
+            open class Tokens {
+                shared {
+                    func Hello() string { return "hi" }
+                }
+            }
+            """));
+        var tree2 = SyntaxTree.Parse(SourceText.From("""
+            package Oahu.Cli.Tui.Widgets
+            Console.WriteLine(Tokens.Tokens.Hello())
+            """));
+
+        Assert.Empty(BindDiagnostics(tree1, tree2));
+    }
+
+    [Fact]
+    public void TypeNameEqualsPackageTail_DoubleQualifiedStaticFieldAccess_Resolves()
+    {
+        var tree1 = SyntaxTree.Parse(SourceText.From("""
+            package Oahu.Cli.Tui.Tokens
+            open class Tokens {
+                shared {
+                    var TextPrimary string = "primary"
+                }
+            }
+            """));
+        var tree2 = SyntaxTree.Parse(SourceText.From("""
+            package Oahu.Cli.Tui.Widgets
+            Console.WriteLine(Tokens.Tokens.TextPrimary)
+            """));
+
+        Assert.Empty(BindDiagnostics(tree1, tree2));
+    }
+
+    [Fact]
+    public void TypeNameDoesNotEqualPackageTail_DoubleQualifiedCall_StillReportsUnresolvedMember()
+    {
+        // Regression guard: the fix must not blanket-accept every "X.X.Member"
+        // shape — it only peels the qualifier when the type's own package tail
+        // actually matches the qualifier. Here "Widgets" (the package tail) does
+        // not match "Tokens" (the leading qualifier), so the erroneous double
+        // qualification should still surface as an unresolved-member error.
+        var tree1 = SyntaxTree.Parse(SourceText.From("""
+            package Oahu.Cli.Tui.Widgets
+            open class Tokens {
+                shared {
+                    func Hello() string { return "hi" }
+                }
+            }
+            """));
+        var tree2 = SyntaxTree.Parse(SourceText.From("""
+            package Oahu.Cli.Tui.Other
+            Console.WriteLine(Tokens.Tokens.Hello())
+            """));
+
+        Assert.Contains(BindDiagnostics(tree1, tree2), d => d.Id == "GS0158");
+    }
+
+    private static ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> BindDiagnostics(params SyntaxTree[] trees)
+    {
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(trees));
+        var program = Binder.BindProgram(globalScope);
+        return globalScope.Diagnostics.Concat(program.Diagnostics).ToImmutableArray();
+    }
+}


### PR DESCRIPTION
Fixes #2203

## Problem
A type whose simple name equals the last segment of its own containing package (e.g. `class Tokens` in `package Oahu.Cli.Tui.Tokens`) failed member resolution with `GS0158: Cannot find member Tokens` when referenced from a sibling package as `Tokens.Tokens.Member`.

This double-qualified form arises from cs2gs translating C# source that relies on C#'s sibling-namespace-visibility rule: a nested namespace (`Oahu.Cli.Tui.Tokens`) is visible unqualified from a sibling namespace (`Oahu.Cli.Tui.Widgets`) under a shared ancestor (`Oahu.Cli.Tui`), so the original C# only needed `Tokens.TextPrimary`, not `Oahu.Cli.Tui.Tokens.TextPrimary`. cs2gs translates it literally to G# as `Tokens.Tokens.TextPrimary`.

G# has no equivalent namespace-visibility concept — types are resolved by simple name from a flat, cross-package scope — so the leading `Tokens` qualifier is actually redundant. But the binder previously tried to resolve the second `Tokens` as a static *member* of the already-resolved `Tokens` type, which failed since no such member exists.

## Fix
Extends the existing issue #1069 nested-type-qualifier-peeling logic in `BindAccessorExpression` (`ExpressionBinder.Access.cs`): when the qualifier's simple name resolves to a user aggregate type whose own package name ends with that same qualifier segment, treat the qualifier as redundant and bind the remainder directly — mirroring how the nested-type case already peels a redundant enclosing-type qualifier.

## Testing
- Added `Issue2203PackageNameTypeCollisionTests.cs` covering: double-qualified static method call, double-qualified static field access, and a regression guard ensuring the fix doesn't fire when the package tail doesn't actually match the qualifier (still reports GS0158).
- Verified against the real Oahu.Cli.Tui corpus via `cs2gs migrate --corpus ... --app corpus/Oahu.Cli.Tui`: all previously-failing "Cannot find member Tokens" GS0158 errors are gone (remaining compile failures are unrelated, pre-existing issues).
- Full test suites pass: `dotnet test test/Core.Tests/Core.Tests.csproj` (5742 passed) and `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj` (1169 passed).
- `dotnet build GSharp.sln` succeeds with 0 warnings/errors.