### PR TITLE
Implement partial types (ADR-0144)

### DIFF
--- a/docs/adr/0144-partial-types.md
+++ b/docs/adr/0144-partial-types.md
@@ -1,6 +1,6 @@
 # ADR-0144: partial types (`partial` on class / struct / interface)
 
-- **Status**: Proposed
+- **Status**: Accepted (implemented)
 - **Date**: 2026-07-06
 - **Phase**: Phase 9 — language surface completeness
 - **Related**: ADR-0078 (aggregate declaration heads), ADR-0053 (`shared { }` static members), ADR-0140 (`shared { init { … } }`), ADR-0066 (deterministic top-level ordering), ADR-0105 (incremental rebind), ADR-0027 (bespoke compiler), ADR-0143 (cs2gs generator handling — companion), ADR-0145 (native generator host — companion), issue [#2201](https://github.com/DavidObando/gsharp/issues/2201)
@@ -149,20 +149,55 @@ order within each part — so metadata is byte-stable regardless of how MSBuild
 orders `@(Compile)` (which matters when generated `.g.gs` files under `obj/` join
 the compilation).
 
-### E. Binder mechanics
+### E. Binder mechanics — syntax-level merge (as built)
 
-A pre-pass in `BindGlobalScope`, before shell declaration (and recursively for
-nested types), groups declarations and validates heads (§B/§C via a new
-`PartialTypeGrouper`), then declares **one** shell from the primary part.
-Phase-2 body binding runs **once per part** against the shared symbol, with
-installers gaining accumulate semantics on the second-and-later parts (append
-rather than replace) and cross-part duplicate detection seeded from the members
-already installed on the symbol. `StructSymbol`/`InterfaceSymbol` gain a
-primary-first `Declarations` array; merged flags (effective openness, unioned
-interfaces) are computed at shell creation. The base clause is bound from the
-part that carries it; the primary-constructor part is the only one whose
-parameters bind; `shared init` statements concatenate across parts in part order
-(extending ADR-0140's same-part rule).
+A pre-pass in `BindGlobalScope`, before shell declaration, merges each group of
+`partial` parts into **one synthetic declaration node** and hands that single
+node to the existing two-phase pipeline. `PartialTypeMerger.MergeStructs` /
+`MergeInterfaces` (`src/Core/CodeAnalysis/Binding/PartialTypeMerger.cs`) group
+the raw declarations by `(package, name)`, order the parts deterministically
+(§D), validate head consistency (§B/§C, emitting `GS0475`–`GS0483`), and build a
+single `StructDeclarationSyntax`/`InterfaceDeclarationSyntax` whose:
+
+- members (`Fields`, `Properties`, `Events`, `Methods`, `Constructors`,
+  `NestedTypes`, interface `StaticFields`) are **concatenated** across parts in
+  part order;
+- base classes / implemented interfaces are **unioned** (de-duplicated by dotted
+  name), the base-constructor-argument part and primary-constructor part are the
+  single part that supplies them, `deinit` is the single part that declares one;
+- modifiers are composed per the §C rules (`open`/`sealed` unioned,
+  accessibility/`data`/`inline`/`ref` validated, annotations unioned);
+- `shared { }` blocks from every part are merged into one `SharedBlockSyntax`
+  (static members concatenated, `init` blocks concatenated in part order,
+  preserving ADR-0140 ordering);
+- `SyntaxTree`, identifier, and brace tokens are the **primary part's** (so the
+  type's own location and `packageByTree` lookup resolve to a real tree, and the
+  emitter's sequence-point/`.cctor` anchor is the primary part).
+
+`Binder.BindGlobalScope` then runs `DeclareStructShell` → `BindStructDeclarationBody`
+(and the interface equivalents) **once** on the merged node, exactly as for a
+lone declaration. The wiring is two one-line substitutions — the raw
+`structDeclarations`/`interfaceDeclarations` enumerables are replaced by the
+merged lists. **Nothing else changes**: the ~2 000-line body binder, every
+`Set*` installer, `StructSymbol`/`InterfaceSymbol`, and the emitter are
+untouched, because one merged node yields one shell, one symbol, and one TypeDef.
+Cross-part member collisions (e.g. a field name declared in two parts) surface
+through the body binder's existing duplicate detection (`GS0102`), since all
+parts' members now live in one node.
+
+This merge-the-syntax design was chosen over binding each part into a shared
+symbol with accumulating installers (the higher-blast-radius alternative) because
+two invariants make it sound: G# **imports are compilation-global** (`BindGlobalScope`
+binds every tree's `ImportSyntax` into one shared scope), so a member body merged
+from another file still resolves its type names; and G# **syntax nodes carry no
+`Parent` reference**, so composing child nodes drawn from different parts/files
+under one synthetic parent is safe — each child keeps its own `SyntaxTree`, so
+diagnostics still point at the correct file and span.
+
+**Nested partial types** are handled by the same merger recursively: when it
+builds (or passes through) a type node, it merges the partial nested types in
+that node's `NestedTypes` list, to any depth — so `partial class Outer`
+contributing `partial class Inner` from two files yields a single merged `Inner`.
 
 ### F. Partial methods and properties are out of scope
 
@@ -174,14 +209,18 @@ add source-level partial members if a native scenario demands them.
 
 ### G. Tooling
 
-- **Go-to-definition** on a partial type returns **all** part locations
-  (`textDocument/definition` widens to `Location[]`, which LSP permits).
+- **Go-to-definition** on a partial type returns **all** part locations. The
+  merged node retains its source parts (`StructDeclarationSyntax.PartialParts` /
+  `InterfaceDeclarationSyntax.PartialParts`, empty for a non-merged declaration),
+  the definition computer maps each to its identifier location, and
+  `textDocument/definition` returns an array (LSP permits `Location | Location[]`).
 - **Document symbols** stay per-file — each file shows its own part; already
-  computed from syntax, so no change.
-- **Incremental rebind** (ADR-0105): a body-only edit in one part repoints only
-  that part's syntax on the shared symbol (`IncrementalGlobalScopeReuse` +
-  `StructSymbol.RepointDeclaration` learn to match by `SyntaxTree`); any head
-  edit falls back to full rebind, as signature edits already do.
+  computed from raw per-file syntax, so no change.
+- **Incremental rebind** (ADR-0105): the body-only fast path cannot re-point a
+  synthetic merged node from a single edited file, so any file containing a
+  `partial` part **falls back to a full rebuild** (guarded in
+  `IncrementalGlobalScopeReuse.ContainsUnsupportedConstruct`). Correct, and the
+  full bind is already fast; a future optimization could re-point per-part.
 - **cs2gs code model**: `Cs2Gs.CodeModel.TypeDeclaration` gains `IsPartial` and
   `GSharpPrinter` renders `partial` before the kind keyword — required so
   ADR-0145 can *emit* partial parts and so cs2gs can later emit parts directly.
@@ -204,10 +243,14 @@ single `.cctor`.
   preserving file structure round-trip; ADR-0143 notes this.
 - Neutral: no new reserved word — `partial` stays a valid identifier everywhere
   outside an aggregate head.
-- Negative: the body-binding path (`BindStructDeclarationBodyCore`) must become
-  accumulation-safe; several installers assume replace semantics and are the main
-  regression surface. The single-`Location` definition response becomes
-  `Location[]`, a small protocol-visible change clients must tolerate.
+- Neutral: the syntax-level merge keeps the body binder, installers, symbols, and
+  emitter untouched, so the regression surface is confined to the merger pre-pass
+  and the diagnostics — the full Core and LanguageServer test suites pass
+  unchanged. The single-`Location` definition response becomes `Location[]`, a
+  small protocol-visible change clients must tolerate.
+- Negative: the merger rebuilds a synthetic declaration node per partial group;
+  the body-only incremental fast path is forgone for files containing partial
+  parts (full rebuild instead — always correct).
 - Constraint: stricter than C# on `data`/`inline`/`ref` (must-repeat),
   deliberately relaxable later.
 
@@ -223,3 +266,12 @@ single `.cctor`.
   back into the user's `.gs` files or a shadow copy). Rejected: mutating user
   files breaks diffs and incrementality, and shadow-compiling whole files
   reintroduces the #1910 merge complexity inside every build.
+- **Bind each part into a shared symbol with accumulating installers** (the
+  originally-sketched §E). Rejected during implementation in favor of the
+  syntax-level merge: it would require converting every replace-style `Set*`
+  installer in the ~2 000-line body binder to accumulate, seeding cross-part
+  duplicate detection, and making base-class / primary-constructor / type-param
+  binding "set once" across parts — a large, error-prone surface. The syntax
+  merge confines all partial logic to one pre-pass and leaves the binder,
+  installers, symbols, and emitter untouched. It is sound only because imports
+  are compilation-global and syntax nodes have no `Parent` (see §E).

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -743,8 +743,10 @@ public sealed class Binder
             binder.declarations.BindDelegateDeclaration(delegateSyntax, owningPackage);
         }
 
-        var interfaceDeclarations = syntaxTrees.SelectMany(st => st.Root.Members)
-                                               .OfType<InterfaceDeclarationSyntax>();
+        var interfaceDeclarations = PartialTypeMerger.MergeInterfaces(
+            syntaxTrees.SelectMany(st => st.Root.Members).OfType<InterfaceDeclarationSyntax>(),
+            packageByTree,
+            binder.Diagnostics);
 
         // Phase 3 exit: register interface type aliases up front so structs
         // declared in subsequent passes can implement them, *and* defer the
@@ -778,8 +780,10 @@ public sealed class Binder
         // user struct or class declared later in the same compilation —
         // e.g. a `class` whose field type is a `struct` declared below it —
         // mirroring the two-phase scheme already used for interfaces above.
-        var structDeclarations = syntaxTrees.SelectMany(st => st.Root.Members)
-                                            .OfType<StructDeclarationSyntax>();
+        var structDeclarations = PartialTypeMerger.MergeStructs(
+            syntaxTrees.SelectMany(st => st.Root.Members).OfType<StructDeclarationSyntax>(),
+            packageByTree,
+            binder.Diagnostics);
         var declaredStructs = new List<(StructDeclarationSyntax Syntax, StructSymbol Symbol)>();
         foreach (var structSyntax in structDeclarations)
         {

--- a/src/Core/CodeAnalysis/Binding/IncrementalGlobalScopeReuse.cs
+++ b/src/Core/CodeAnalysis/Binding/IncrementalGlobalScopeReuse.cs
@@ -491,6 +491,19 @@ public static class IncrementalGlobalScopeReuse
             {
                 return true;
             }
+
+            // ADR-0144: a `partial` type's symbol is bound from ONE synthetic
+            // declaration that PartialTypeMerger builds by merging every part
+            // (across files) during the full bind. The body-only positional
+            // re-point maps this file's raw declarations onto reused symbols, so
+            // a raw partial part cannot be re-pointed onto the merged symbol
+            // soundly (and the sibling parts in other files are not represented
+            // here). Fall back to a full rebuild for any file containing a
+            // partial part.
+            if (node is StructDeclarationSyntax { IsPartial: true } or InterfaceDeclarationSyntax { IsPartial: true })
+            {
+                return true;
+            }
         }
 
         return false;

--- a/src/Core/CodeAnalysis/Binding/PartialTypeMerger.cs
+++ b/src/Core/CodeAnalysis/Binding/PartialTypeMerger.cs
@@ -1,0 +1,769 @@
+// <copyright file="PartialTypeMerger.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#pragma warning disable SA1201 // Elements should appear in the correct order
+#pragma warning disable SA1512 // Single-line comments should not be followed by blank line
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0144 / issue #2201: pre-pass that merges multiple <c>partial</c>
+/// declarations of the same type (same package + name) into ONE synthetic
+/// declaration node before the two-phase shell/body binder runs. Grouping,
+/// deterministic part ordering (ADR-0066), and head-consistency validation
+/// (GS0475-GS0483) all happen here; the existing
+/// <c>DeclareStructShell</c>/<c>BindStructDeclarationBody</c> (and interface
+/// equivalents) then run once per merged node, exactly as they do for a lone
+/// declaration. This keeps the body binder, installers, symbols, and emitter
+/// untouched: one merged node yields one shell, one symbol, and one TypeDef.
+/// </summary>
+internal static class PartialTypeMerger
+{
+    /// <summary>
+    /// Merges the <c>partial</c> struct/class declarations of
+    /// <paramref name="declarations"/> that share a <c>(package, name)</c> key,
+    /// leaving lone declarations (and non-partial duplicate groups) untouched.
+    /// </summary>
+    /// <param name="declarations">The top-level struct/class declarations across every tree.</param>
+    /// <param name="packageByTree">Maps each syntax tree to its owning package (for the grouping key).</param>
+    /// <param name="diagnostics">The bag that receives GS0475-GS0483.</param>
+    /// <returns>One declaration per group: the merged node for multi-part partial groups, otherwise the original declarations.</returns>
+    public static IReadOnlyList<StructDeclarationSyntax> MergeStructs(
+        IEnumerable<StructDeclarationSyntax> declarations,
+        IReadOnlyDictionary<SyntaxTree, PackageSymbol> packageByTree,
+        DiagnosticBag diagnostics)
+    {
+        var result = new List<StructDeclarationSyntax>();
+        foreach (var group in GroupByKey(declarations, packageByTree))
+        {
+            if (group.Count == 1)
+            {
+                // A lone declaration is not merged, but it may still contain
+                // `partial` NESTED types that must be merged among themselves.
+                result.Add(NormalizeNestedTypes(group[0], diagnostics));
+                continue;
+            }
+
+            var anyPartial = group.Any(d => d.IsPartial);
+            if (!anyPartial)
+            {
+                // No part carries `partial` → today's duplicate-name GS0102 in
+                // DeclareStructShell fires for the second and later parts. Do
+                // not merge or suppress it (but still normalize each one's
+                // nested types).
+                result.AddRange(group.Select(g => NormalizeNestedTypes(g, diagnostics)));
+                continue;
+            }
+
+            result.Add(MergeStructGroup(group, diagnostics));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Merges the <c>partial</c> interface declarations of
+    /// <paramref name="declarations"/> that share a <c>(package, name)</c> key,
+    /// leaving lone declarations (and non-partial duplicate groups) untouched.
+    /// </summary>
+    /// <param name="declarations">The top-level interface declarations across every tree.</param>
+    /// <param name="packageByTree">Maps each syntax tree to its owning package (for the grouping key).</param>
+    /// <param name="diagnostics">The bag that receives GS0475-GS0483.</param>
+    /// <returns>One declaration per group: the merged node for multi-part partial groups, otherwise the original declarations.</returns>
+    public static IReadOnlyList<InterfaceDeclarationSyntax> MergeInterfaces(
+        IEnumerable<InterfaceDeclarationSyntax> declarations,
+        IReadOnlyDictionary<SyntaxTree, PackageSymbol> packageByTree,
+        DiagnosticBag diagnostics)
+    {
+        var result = new List<InterfaceDeclarationSyntax>();
+        foreach (var group in GroupByKey(declarations, packageByTree))
+        {
+            if (group.Count == 1)
+            {
+                result.Add(group[0]);
+                continue;
+            }
+
+            var anyPartial = group.Any(d => d.IsPartial);
+            if (!anyPartial)
+            {
+                result.AddRange(group);
+                continue;
+            }
+
+            result.Add(MergeInterfaceGroup(group, diagnostics));
+        }
+
+        return result;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Grouping / ordering
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static List<List<T>> GroupByKey<T>(
+        IEnumerable<T> declarations,
+        IReadOnlyDictionary<SyntaxTree, PackageSymbol> packageByTree)
+        where T : MemberSyntax
+    {
+        // Preserve first-appearance order of the groups for determinism of the
+        // returned list.
+        var order = new List<(string Package, string Name)>();
+        var groups = new Dictionary<(string Package, string Name), List<T>>();
+
+        foreach (var decl in declarations)
+        {
+            var packageName = packageByTree.TryGetValue(decl.SyntaxTree, out var pkg) ? pkg.Name : string.Empty;
+            var name = GetIdentifier(decl)?.Text ?? string.Empty;
+            var key = (packageName, name);
+            if (!groups.TryGetValue(key, out var list))
+            {
+                list = new List<T>();
+                groups[key] = list;
+                order.Add(key);
+            }
+
+            list.Add(decl);
+        }
+
+        var ordered = new List<List<T>>();
+        foreach (var key in order)
+        {
+            var parts = groups[key];
+
+            // Deterministic part order (ADR-0066): (file path, span start).
+            parts.Sort((a, b) =>
+            {
+                var fileA = a.SyntaxTree.Text?.FileName ?? string.Empty;
+                var fileB = b.SyntaxTree.Text?.FileName ?? string.Empty;
+                var byFile = string.CompareOrdinal(fileA, fileB);
+                if (byFile != 0)
+                {
+                    return byFile;
+                }
+
+                return a.Span.Start.CompareTo(b.Span.Start);
+            });
+
+            ordered.Add(parts);
+        }
+
+        return ordered;
+    }
+
+    private static SyntaxToken GetIdentifier(MemberSyntax decl) => decl switch
+    {
+        StructDeclarationSyntax s => s.Identifier,
+        InterfaceDeclarationSyntax i => i.Identifier,
+        _ => null,
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Struct/class merge
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static StructDeclarationSyntax MergeStructGroup(List<StructDeclarationSyntax> parts, DiagnosticBag diagnostics)
+    {
+        var primary = parts[0];
+        var name = primary.Identifier?.Text ?? string.Empty;
+
+        // GS0475: some — but not all — parts carry `partial`. Report each
+        // non-partial part, then merge everything (best effort — avoids a
+        // GS0102 cascade on the parts that ARE partial).
+        if (!parts.All(p => p.IsPartial))
+        {
+            foreach (var part in parts.Where(p => !p.IsPartial))
+            {
+                diagnostics.ReportPartialModifierMissing(part.Identifier.Location, name);
+            }
+        }
+
+        // GS0476: aggregate kind (class vs struct) must agree.
+        foreach (var part in parts.Skip(1).Where(p => p.IsClass != primary.IsClass))
+        {
+            diagnostics.ReportPartialKindMismatch(part.Identifier.Location, name);
+        }
+
+        var accessibilityModifier = ResolveAccessibility(parts, name, diagnostics);
+        ValidateOpenSealed(parts, name, diagnostics);
+        var openModifier = parts.Select(p => p.OpenModifier).FirstOrDefault(t => t != null);
+        var sealedKeyword = parts.Select(p => p.SealedKeyword).FirstOrDefault(t => t != null);
+
+        // GS0479: data / inline / ref must appear on every part or none.
+        RequireOnEveryPart(parts, p => p.DataKeyword != null, "data", name, diagnostics);
+        RequireOnEveryPart(parts, p => p.InlineKeyword != null, "inline", name, diagnostics);
+        RequireOnEveryPart(parts, p => p.RefModifier != null, "ref", name, diagnostics);
+
+        // GS0480: identical type-parameter lists (names + arity + constraints).
+        var primaryTypeParams = NormalizeNodeText(primary.TypeParameterList);
+        foreach (var part in parts.Skip(1).Where(p => NormalizeNodeText(p.TypeParameterList) != primaryTypeParams))
+        {
+            diagnostics.ReportPartialTypeParameterMismatch(part.Identifier.Location, name);
+        }
+
+        // Primary constructor: at most one part may declare one (GS0482).
+        StructDeclarationSyntax primaryCtorPart = null;
+        foreach (var part in parts.Where(p => p.HasPrimaryConstructor || p.PrimaryConstructorParameters.Count > 0))
+        {
+            if (primaryCtorPart == null)
+            {
+                primaryCtorPart = part;
+            }
+            else
+            {
+                diagnostics.ReportPartialMultiplePrimaryConstructors(part.Identifier.Location, name);
+            }
+        }
+
+        // deinit: at most one across all parts (GS0483).
+        DeinitDeclarationSyntax deinit = null;
+        foreach (var part in parts.Where(p => p.Deinitializer != null))
+        {
+            if (deinit == null)
+            {
+                deinit = part.Deinitializer;
+            }
+            else
+            {
+                diagnostics.ReportPartialMultipleDeinit(part.Deinitializer.Location, name);
+            }
+        }
+
+        // Base clause (GS0481) + union.
+        var baseInfo = ResolveStructBaseClause(parts, primary, name, diagnostics);
+
+        var mergedShared = MergeSharedBlocks(primary.SyntaxTree, parts.Select(p => p.SharedBlock));
+
+        var merged = new StructDeclarationSyntax(
+            primary.SyntaxTree,
+            accessibilityModifier,
+            primary.TypeKeyword,
+            primary.Identifier,
+            primary.DataKeyword,
+            primary.InlineKeyword,
+            openModifier,
+            primary.StructKeyword,
+            primaryCtorPart?.PrimaryConstructorOpenParenthesisToken,
+            primaryCtorPart?.PrimaryConstructorParameters ?? new SeparatedSyntaxList<ParameterSyntax>(ImmutableArray<SyntaxNode>.Empty),
+            primaryCtorPart?.PrimaryConstructorCloseParenthesisToken,
+            baseInfo.BaseColonToken,
+            baseInfo.BaseTypeIdentifier,
+            baseInfo.AdditionalBaseTypeIdentifiers,
+            primary.OpenBraceToken,
+            Concat(parts, p => p.Fields),
+            Concat(parts, p => p.Properties),
+            Concat(parts, p => p.Events),
+            Concat(parts, p => p.Methods),
+            primary.CloseBraceToken)
+        {
+            BaseTypeClauses = baseInfo.BaseTypeClauses,
+            SharedBlock = mergedShared,
+            BaseConstructorOpenParenthesisToken = baseInfo.BaseConstructorOpenParenthesisToken,
+            BaseConstructorArguments = baseInfo.BaseConstructorArguments,
+            BaseConstructorCloseParenthesisToken = baseInfo.BaseConstructorCloseParenthesisToken,
+            Constructors = Concat(parts, p => p.Constructors),
+            Deinitializer = deinit,
+            NestedTypes = MergePartialNestedTypes(Concat(parts, p => p.NestedTypes), diagnostics),
+            TypeParameterList = primary.TypeParameterList,
+            RefModifier = parts.Select(p => p.RefModifier).FirstOrDefault(t => t != null),
+            UnsafeModifier = parts.Select(p => p.UnsafeModifier).FirstOrDefault(t => t != null),
+            PartialModifier = parts.Select(p => p.PartialModifier).FirstOrDefault(t => t != null),
+            SealedKeyword = sealedKeyword,
+            PartialPartLocations = parts.Select(p => p.Identifier.Location).ToImmutableArray(),
+        };
+
+        merged.WithAnnotations(UnionAnnotations(parts));
+        return merged;
+    }
+
+    private readonly struct BaseClauseInfo
+    {
+        public BaseClauseInfo(
+            SyntaxToken baseColonToken,
+            SyntaxToken baseTypeIdentifier,
+            ImmutableArray<SyntaxToken> additionalBaseTypeIdentifiers,
+            SeparatedSyntaxList<TypeClauseSyntax> baseTypeClauses,
+            SyntaxToken baseConstructorOpenParenthesisToken,
+            SeparatedSyntaxList<ExpressionSyntax> baseConstructorArguments,
+            SyntaxToken baseConstructorCloseParenthesisToken)
+        {
+            BaseColonToken = baseColonToken;
+            BaseTypeIdentifier = baseTypeIdentifier;
+            AdditionalBaseTypeIdentifiers = additionalBaseTypeIdentifiers;
+            BaseTypeClauses = baseTypeClauses;
+            BaseConstructorOpenParenthesisToken = baseConstructorOpenParenthesisToken;
+            BaseConstructorArguments = baseConstructorArguments;
+            BaseConstructorCloseParenthesisToken = baseConstructorCloseParenthesisToken;
+        }
+
+        public SyntaxToken BaseColonToken { get; }
+
+        public SyntaxToken BaseTypeIdentifier { get; }
+
+        public ImmutableArray<SyntaxToken> AdditionalBaseTypeIdentifiers { get; }
+
+        public SeparatedSyntaxList<TypeClauseSyntax> BaseTypeClauses { get; }
+
+        public SyntaxToken BaseConstructorOpenParenthesisToken { get; }
+
+        public SeparatedSyntaxList<ExpressionSyntax> BaseConstructorArguments { get; }
+
+        public SyntaxToken BaseConstructorCloseParenthesisToken { get; }
+    }
+
+    private static BaseClauseInfo ResolveStructBaseClause(
+        List<StructDeclarationSyntax> parts,
+        StructDeclarationSyntax primary,
+        string name,
+        DiagnosticBag diagnostics)
+    {
+        var basedParts = parts.Where(p => p.HasBaseType).ToList();
+
+        // Common case: at most one part supplies a base clause — copy it
+        // verbatim so binding is byte-for-byte identical to the un-merged part.
+        if (basedParts.Count <= 1)
+        {
+            var bp = basedParts.FirstOrDefault();
+            return new BaseClauseInfo(
+                bp?.BaseColonToken,
+                bp?.BaseTypeIdentifier,
+                bp?.AdditionalBaseTypeIdentifiers ?? ImmutableArray<SyntaxToken>.Empty,
+                bp?.BaseTypeClauses ?? new SeparatedSyntaxList<TypeClauseSyntax>(ImmutableArray<SyntaxNode>.Empty),
+                bp?.BaseConstructorOpenParenthesisToken,
+                bp?.BaseConstructorArguments ?? new SeparatedSyntaxList<ExpressionSyntax>(ImmutableArray<SyntaxNode>.Empty),
+                bp?.BaseConstructorCloseParenthesisToken);
+        }
+
+        // GS0481: base-constructor arguments may appear on at most one part.
+        StructDeclarationSyntax ctorArgPart = null;
+        foreach (var part in basedParts.Where(p => p.HasBaseConstructorArguments))
+        {
+            if (ctorArgPart == null)
+            {
+                ctorArgPart = part;
+            }
+            else
+            {
+                diagnostics.ReportPartialBaseClauseConflict(part.Identifier.Location, name);
+            }
+        }
+
+        // GS0481: for classes, a differing FIRST base entry names a different
+        // base class. (Structs cannot have a base class, so their first entry is
+        // always an interface — union handles those with no conflict.)
+        if (primary.IsClass)
+        {
+            string firstBase = null;
+            foreach (var part in basedParts.Where(p => p.BaseTypeClauses.Count > 0))
+            {
+                var entry = part.BaseTypeClauses[0].DottedName;
+                if (firstBase == null)
+                {
+                    firstBase = entry;
+                }
+                else if (!string.Equals(firstBase, entry, System.StringComparison.Ordinal))
+                {
+                    diagnostics.ReportPartialBaseClauseConflict(part.Identifier.Location, name);
+                }
+            }
+        }
+
+        // Union the base type clauses, de-duplicating by textual (dotted) name.
+        var seen = new HashSet<string>(System.StringComparer.Ordinal);
+        var uniqueClauses = new List<TypeClauseSyntax>();
+        foreach (var part in basedParts)
+        {
+            foreach (var clause in part.BaseTypeClauses)
+            {
+                if (seen.Add(clause.DottedName))
+                {
+                    uniqueClauses.Add(clause);
+                }
+            }
+        }
+
+        var mergedClauses = BuildSeparatedList(primary.SyntaxTree, uniqueClauses);
+
+        return new BaseClauseInfo(
+            basedParts[0].BaseColonToken,
+            baseTypeIdentifier: null,
+            ImmutableArray<SyntaxToken>.Empty,
+            mergedClauses,
+            ctorArgPart?.BaseConstructorOpenParenthesisToken,
+            ctorArgPart?.BaseConstructorArguments ?? new SeparatedSyntaxList<ExpressionSyntax>(ImmutableArray<SyntaxNode>.Empty),
+            ctorArgPart?.BaseConstructorCloseParenthesisToken);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Interface merge
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static InterfaceDeclarationSyntax MergeInterfaceGroup(List<InterfaceDeclarationSyntax> parts, DiagnosticBag diagnostics)
+    {
+        var primary = parts[0];
+        var name = primary.Identifier?.Text ?? string.Empty;
+
+        if (!parts.All(p => p.IsPartial))
+        {
+            foreach (var part in parts.Where(p => !p.IsPartial))
+            {
+                diagnostics.ReportPartialModifierMissing(part.Identifier.Location, name);
+            }
+        }
+
+        var accessibilityModifier = ResolveInterfaceAccessibility(parts, name, diagnostics);
+        var sealedKeyword = parts.Select(p => p.SealedKeyword).FirstOrDefault(t => t != null);
+
+        // GS0480: identical type-parameter lists.
+        var primaryTypeParams = NormalizeNodeText(primary.TypeParameterList);
+        foreach (var part in parts.Skip(1).Where(p => NormalizeNodeText(p.TypeParameterList) != primaryTypeParams))
+        {
+            diagnostics.ReportPartialTypeParameterMismatch(part.Identifier.Location, name);
+        }
+
+        // Base interfaces: union across parts, de-duplicating by textual name.
+        var basedParts = parts.Where(p => p.HasBaseInterfaces).ToList();
+        SyntaxToken baseColon = basedParts.FirstOrDefault()?.BaseColonToken;
+        SeparatedSyntaxList<TypeClauseSyntax> mergedBaseInterfaces;
+        if (basedParts.Count <= 1)
+        {
+            mergedBaseInterfaces = basedParts.FirstOrDefault()?.BaseTypeClauses
+                ?? new SeparatedSyntaxList<TypeClauseSyntax>(ImmutableArray<SyntaxNode>.Empty);
+        }
+        else
+        {
+            var seen = new HashSet<string>(System.StringComparer.Ordinal);
+            var unique = new List<TypeClauseSyntax>();
+            foreach (var part in basedParts)
+            {
+                foreach (var clause in part.BaseTypeClauses)
+                {
+                    if (seen.Add(clause.DottedName))
+                    {
+                        unique.Add(clause);
+                    }
+                }
+            }
+
+            mergedBaseInterfaces = BuildSeparatedList(primary.SyntaxTree, unique);
+        }
+
+        var merged = new InterfaceDeclarationSyntax(
+            primary.SyntaxTree,
+            accessibilityModifier,
+            primary.TypeKeyword,
+            primary.Identifier,
+            primary.TypeParameterList,
+            sealedKeyword,
+            primary.InterfaceKeyword,
+            primary.OpenBraceToken,
+            Concat(parts, p => p.Properties),
+            Concat(parts, p => p.Events),
+            Concat(parts, p => p.Methods),
+            primary.CloseBraceToken)
+        {
+            BaseColonToken = baseColon,
+            BaseTypeClauses = mergedBaseInterfaces,
+            StaticFields = Concat(parts, p => p.StaticFields),
+            PartialModifier = parts.Select(p => p.PartialModifier).FirstOrDefault(t => t != null),
+            PartialPartLocations = parts.Select(p => p.Identifier.Location).ToImmutableArray(),
+        };
+
+        merged.WithAnnotations(UnionAnnotations(parts));
+        return merged;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Shared helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static SyntaxToken ResolveAccessibility(List<StructDeclarationSyntax> parts, string name, DiagnosticBag diagnostics)
+    {
+        SyntaxToken stated = null;
+        foreach (var part in parts.Where(p => p.AccessibilityModifier != null))
+        {
+            if (stated == null)
+            {
+                stated = part.AccessibilityModifier;
+            }
+            else if (!string.Equals(stated.Text, part.AccessibilityModifier.Text, System.StringComparison.Ordinal))
+            {
+                diagnostics.ReportPartialAccessibilityConflict(part.AccessibilityModifier.Location, name);
+            }
+        }
+
+        return stated;
+    }
+
+    private static SyntaxToken ResolveInterfaceAccessibility(List<InterfaceDeclarationSyntax> parts, string name, DiagnosticBag diagnostics)
+    {
+        SyntaxToken stated = null;
+        foreach (var part in parts.Where(p => p.AccessibilityModifier != null))
+        {
+            if (stated == null)
+            {
+                stated = part.AccessibilityModifier;
+            }
+            else if (!string.Equals(stated.Text, part.AccessibilityModifier.Text, System.StringComparison.Ordinal))
+            {
+                diagnostics.ReportPartialAccessibilityConflict(part.AccessibilityModifier.Location, name);
+            }
+        }
+
+        return stated;
+    }
+
+    private static void ValidateOpenSealed(List<StructDeclarationSyntax> parts, string name, DiagnosticBag diagnostics)
+    {
+        var openPart = parts.FirstOrDefault(p => p.OpenModifier != null);
+        var sealedPart = parts.FirstOrDefault(p => p.SealedKeyword != null);
+        if (openPart != null && sealedPart != null)
+        {
+            // Report on the second-appearing offender in part order.
+            var offender = parts.IndexOf(openPart) > parts.IndexOf(sealedPart) ? openPart : sealedPart;
+            diagnostics.ReportPartialOpenSealedConflict(offender.Identifier.Location, name);
+        }
+    }
+
+    private static void RequireOnEveryPart(
+        List<StructDeclarationSyntax> parts,
+        System.Func<StructDeclarationSyntax, bool> hasModifier,
+        string modifier,
+        string name,
+        DiagnosticBag diagnostics)
+    {
+        var withCount = parts.Count(hasModifier);
+        if (withCount == 0 || withCount == parts.Count)
+        {
+            return;
+        }
+
+        // Inconsistent: report each part that lacks the modifier.
+        foreach (var part in parts.Where(p => !hasModifier(p)))
+        {
+            diagnostics.ReportPartialModifierMustMatchAllParts(part.Identifier.Location, modifier, name);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Nested partial types
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns <paramref name="node"/> with its nested types normalized so that
+    /// any <c>partial</c> nested struct/interface split into several parts is
+    /// merged into one. The same node instance is returned when nothing changed
+    /// (the common case), so a lone declaration without nested partials is passed
+    /// through untouched.
+    /// </summary>
+    private static StructDeclarationSyntax NormalizeNestedTypes(StructDeclarationSyntax node, DiagnosticBag diagnostics)
+    {
+        if (node.NestedTypes.IsDefaultOrEmpty)
+        {
+            return node;
+        }
+
+        var merged = MergePartialNestedTypes(node.NestedTypes, diagnostics);
+
+        // ImmutableArray<T>.Equals compares the backing-array reference, so this
+        // is true only when MergePartialNestedTypes returned the same instance
+        // (nothing merged) — assign (and invalidate the cached span) only on a
+        // real change.
+        if (!merged.Equals(node.NestedTypes))
+        {
+            node.NestedTypes = merged;
+        }
+
+        return node;
+    }
+
+    /// <summary>
+    /// Merges the <c>partial</c> nested struct/interface declarations within a
+    /// container's <c>NestedTypes</c> list, recursively (nested-in-nested).
+    /// Non-partial members, enums, and singleton types are preserved in place and
+    /// in first-appearance order; when no nested partial group exists the input
+    /// array is returned unchanged (reference-equal) so callers can skip mutation.
+    /// </summary>
+    private static ImmutableArray<MemberSyntax> MergePartialNestedTypes(
+        ImmutableArray<MemberSyntax> nested,
+        DiagnosticBag diagnostics)
+    {
+        if (nested.IsDefaultOrEmpty)
+        {
+            return nested;
+        }
+
+        // Group the nested structs and interfaces by name (order-preserving).
+        var structGroups = GroupByKey(nested.OfType<StructDeclarationSyntax>(), EmptyPackages);
+        var interfaceGroups = GroupByKey(nested.OfType<InterfaceDeclarationSyntax>(), EmptyPackages);
+
+        var mergedStructByName = new Dictionary<string, StructDeclarationSyntax>(System.StringComparer.Ordinal);
+        var mergedInterfaceByName = new Dictionary<string, InterfaceDeclarationSyntax>(System.StringComparer.Ordinal);
+        foreach (var g in structGroups.Where(g => g.Count > 1 && g.Any(d => d.IsPartial)))
+        {
+            mergedStructByName[g[0].Identifier?.Text ?? string.Empty] = MergeStructGroup(g, diagnostics);
+        }
+
+        foreach (var g in interfaceGroups.Where(g => g.Count > 1 && g.Any(d => d.IsPartial)))
+        {
+            mergedInterfaceByName[g[0].Identifier?.Text ?? string.Empty] = MergeInterfaceGroup(g, diagnostics);
+        }
+
+        // No nested partial group to merge at this level — but a lone nested
+        // struct may still contain its OWN nested partials, so recurse into every
+        // nested struct (NormalizeNestedTypes mutates it in place) and return the
+        // same array instance so the caller skips rebuilding.
+        if (mergedStructByName.Count == 0 && mergedInterfaceByName.Count == 0)
+        {
+            foreach (var s in nested.OfType<StructDeclarationSyntax>())
+            {
+                NormalizeNestedTypes(s, diagnostics);
+            }
+
+            return nested;
+        }
+
+        var emittedStruct = new HashSet<string>(System.StringComparer.Ordinal);
+        var emittedInterface = new HashSet<string>(System.StringComparer.Ordinal);
+        var result = ImmutableArray.CreateBuilder<MemberSyntax>();
+        foreach (var member in nested)
+        {
+            switch (member)
+            {
+                case StructDeclarationSyntax s:
+                    var sName = s.Identifier?.Text ?? string.Empty;
+                    if (mergedStructByName.TryGetValue(sName, out var mergedStruct))
+                    {
+                        if (emittedStruct.Add(sName))
+                        {
+                            result.Add(mergedStruct);
+                        }
+
+                        // Later parts of the same group are dropped (already merged).
+                    }
+                    else
+                    {
+                        result.Add(NormalizeNestedTypes(s, diagnostics));
+                    }
+
+                    break;
+
+                case InterfaceDeclarationSyntax iface:
+                    var iName = iface.Identifier?.Text ?? string.Empty;
+                    if (mergedInterfaceByName.TryGetValue(iName, out var mergedIface))
+                    {
+                        if (emittedInterface.Add(iName))
+                        {
+                            result.Add(mergedIface);
+                        }
+                    }
+                    else
+                    {
+                        result.Add(iface);
+                    }
+
+                    break;
+
+                default:
+                    result.Add(member);
+                    break;
+            }
+        }
+
+        return result.ToImmutable();
+    }
+
+    private static readonly IReadOnlyDictionary<SyntaxTree, PackageSymbol> EmptyPackages =
+        new Dictionary<SyntaxTree, PackageSymbol>();
+
+    private static SharedBlockSyntax MergeSharedBlocks(SyntaxTree tree, IEnumerable<SharedBlockSyntax> blocks)
+    {
+        var present = blocks.Where(b => b != null).ToList();
+        if (present.Count == 0)
+        {
+            return null;
+        }
+
+        if (present.Count == 1)
+        {
+            return present[0];
+        }
+
+        var first = present[0];
+        return new SharedBlockSyntax(
+            tree,
+            first.SharedKeyword,
+            first.OpenBraceToken,
+            Concat(present, b => b.Fields),
+            Concat(present, b => b.Properties),
+            Concat(present, b => b.Events),
+            Concat(present, b => b.Methods),
+            Concat(present, b => b.InitBlocks),
+            first.CloseBraceToken);
+    }
+
+    private static ImmutableArray<AnnotationSyntax> UnionAnnotations<T>(List<T> parts)
+        where T : MemberSyntax
+    {
+        var builder = ImmutableArray.CreateBuilder<AnnotationSyntax>();
+        foreach (var part in parts)
+        {
+            if (!part.Annotations.IsDefaultOrEmpty)
+            {
+                builder.AddRange(part.Annotations);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static ImmutableArray<TItem> Concat<TPart, TItem>(
+        IEnumerable<TPart> parts,
+        System.Func<TPart, ImmutableArray<TItem>> selector)
+    {
+        var builder = ImmutableArray.CreateBuilder<TItem>();
+        foreach (var part in parts)
+        {
+            var items = selector(part);
+            if (!items.IsDefaultOrEmpty)
+            {
+                builder.AddRange(items);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static SeparatedSyntaxList<TypeClauseSyntax> BuildSeparatedList(SyntaxTree tree, List<TypeClauseSyntax> nodes)
+    {
+        var withSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            withSeparators.Add(nodes[i]);
+            if (i < nodes.Count - 1)
+            {
+                withSeparators.Add(new SyntaxToken(tree, SyntaxKind.CommaToken, 0, ",", null));
+            }
+        }
+
+        return new SeparatedSyntaxList<TypeClauseSyntax>(withSeparators.ToImmutable());
+    }
+
+    private static string NormalizeNodeText(SyntaxNode node)
+    {
+        if (node?.SyntaxTree?.Text == null)
+        {
+            return string.Empty;
+        }
+
+        var text = node.SyntaxTree.Text.ToString(node.Span);
+        return new string(text.Where(c => !char.IsWhiteSpace(c)).ToArray());
+    }
+}

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -4506,6 +4506,162 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// ADR-0144 / issue #2201: GS0484 — the <c>partial</c> contextual modifier
+    /// was applied to an aggregate kind that cannot be partial. Only
+    /// <c>class</c>, <c>struct</c>, and <c>interface</c> declarations may be
+    /// partial; <c>enum</c> is rejected at parse time.
+    /// </summary>
+    /// <param name="location">The source location of the offending <c>partial</c> modifier.</param>
+    /// <param name="kind">The rejected aggregate kind spelling (e.g. <c>enum</c>).</param>
+    public void ReportPartialNotValidOnKind(TextLocation location, string kind)
+    {
+        Report(
+            location,
+            "GS0484",
+            $"'partial' is not valid on '{kind}'; only 'class', 'struct', and 'interface' declarations can be partial.",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// ADR-0144 / issue #2201: GS0475 — a declaration in a partial-type group
+    /// lacks the <c>partial</c> modifier while another declaration of the same
+    /// type carries it (the analog of C# CS0260).
+    /// </summary>
+    /// <param name="location">The source location of the non-partial declaration's identifier.</param>
+    /// <param name="name">The type name.</param>
+    public void ReportPartialModifierMissing(TextLocation location, string name)
+    {
+        Report(
+            location,
+            "GS0475",
+            $"Missing 'partial' modifier on declaration of type '{name}'; another partial declaration of this type exists.",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// ADR-0144 / issue #2201: GS0476 — the parts of a partial type disagree on
+    /// aggregate kind (<c>class</c> vs <c>struct</c> vs <c>interface</c>).
+    /// </summary>
+    /// <param name="location">The source location of the mismatched declaration's identifier.</param>
+    /// <param name="name">The type name.</param>
+    public void ReportPartialKindMismatch(TextLocation location, string name)
+    {
+        Report(
+            location,
+            "GS0476",
+            $"Partial declarations of '{name}' must all be the same aggregate kind ('class', 'struct', or 'interface').",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// ADR-0144 / issue #2201: GS0477 — two parts of a partial type state
+    /// different accessibility modifiers.
+    /// </summary>
+    /// <param name="location">The source location of the conflicting accessibility modifier.</param>
+    /// <param name="name">The type name.</param>
+    public void ReportPartialAccessibilityConflict(TextLocation location, string name)
+    {
+        Report(
+            location,
+            "GS0477",
+            $"Partial declarations of '{name}' have conflicting accessibility modifiers.",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// ADR-0144 / issue #2201: GS0478 — one part of a partial type is <c>open</c>
+    /// and another is <c>sealed</c>.
+    /// </summary>
+    /// <param name="location">The source location of the conflicting declaration's identifier.</param>
+    /// <param name="name">The type name.</param>
+    public void ReportPartialOpenSealedConflict(TextLocation location, string name)
+    {
+        Report(
+            location,
+            "GS0478",
+            $"Partial declarations of '{name}' have conflicting 'open'/'sealed' modifiers.",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// ADR-0144 / issue #2201: GS0479 — a <c>data</c>/<c>inline</c>/<c>ref</c>
+    /// modifier that changes how each part's body binds appears on some but not
+    /// all parts of a partial type.
+    /// </summary>
+    /// <param name="location">The source location of the part missing the modifier.</param>
+    /// <param name="modifier">The modifier spelling (<c>data</c>, <c>inline</c>, or <c>ref</c>).</param>
+    /// <param name="name">The type name.</param>
+    public void ReportPartialModifierMustMatchAllParts(TextLocation location, string modifier, string name)
+    {
+        Report(
+            location,
+            "GS0479",
+            $"The '{modifier}' modifier must appear on every partial declaration of '{name}'.",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// ADR-0144 / issue #2201: GS0480 — the parts of a partial type declare
+    /// differing type-parameter lists (names, arity, order, or constraints).
+    /// </summary>
+    /// <param name="location">The source location of the mismatched declaration's identifier.</param>
+    /// <param name="name">The type name.</param>
+    public void ReportPartialTypeParameterMismatch(TextLocation location, string name)
+    {
+        Report(
+            location,
+            "GS0480",
+            $"Partial declarations of '{name}' must have identical type parameter lists (including names and constraints).",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// ADR-0144 / issue #2201: GS0481 — the parts of a partial type have
+    /// conflicting base clauses (differing base class, or base-constructor
+    /// arguments on more than one part).
+    /// </summary>
+    /// <param name="location">The source location of the conflicting declaration's identifier.</param>
+    /// <param name="name">The type name.</param>
+    public void ReportPartialBaseClauseConflict(TextLocation location, string name)
+    {
+        Report(
+            location,
+            "GS0481",
+            $"Partial declarations of '{name}' have conflicting base clauses; only one part may supply base-constructor arguments and any repeated base class must match.",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// ADR-0144 / issue #2201: GS0482 — more than one part of a partial type
+    /// declares a primary constructor.
+    /// </summary>
+    /// <param name="location">The source location of the offending declaration's identifier.</param>
+    /// <param name="name">The type name.</param>
+    public void ReportPartialMultiplePrimaryConstructors(TextLocation location, string name)
+    {
+        Report(
+            location,
+            "GS0482",
+            $"Only one partial declaration of '{name}' may declare a primary constructor.",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
+    /// ADR-0144 / issue #2201: GS0483 — more than one part of a partial type
+    /// declares a <c>deinit</c>.
+    /// </summary>
+    /// <param name="location">The source location of the offending <c>deinit</c>.</param>
+    /// <param name="name">The type name.</param>
+    public void ReportPartialMultipleDeinit(TextLocation location, string name)
+    {
+        Report(
+            location,
+            "GS0483",
+            $"Partial declarations of '{name}' declare more than one 'deinit'.",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
     /// Issue #1336: GS0415 — a <c>sizeof(T)</c> expression names a type that is
     /// not an unmanaged type. <c>sizeof</c> measures the unmanaged byte size of
     /// its operand, so the operand must be a blittable primitive, an enum, a

--- a/src/Core/CodeAnalysis/Syntax/InterfaceDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/InterfaceDeclarationSyntax.cs
@@ -18,6 +18,7 @@ public sealed class InterfaceDeclarationSyntax : MemberSyntax
     private SyntaxToken baseColonToken;
     private SeparatedSyntaxList<TypeClauseSyntax> baseTypeClauses = new SeparatedSyntaxList<TypeClauseSyntax>(ImmutableArray<SyntaxNode>.Empty);
     private ImmutableArray<FieldDeclarationSyntax> staticFields = ImmutableArray<FieldDeclarationSyntax>.Empty;
+    private SyntaxToken partialModifier;
 
     /// <summary>Initializes a new instance of the <see cref="InterfaceDeclarationSyntax"/> class.</summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
@@ -231,6 +232,36 @@ public sealed class InterfaceDeclarationSyntax : MemberSyntax
 
     /// <summary>Gets a value indicating whether this interface declares one or more base interfaces (issue #1006).</summary>
     public bool HasBaseInterfaces => BaseColonToken != null;
+
+    /// <summary>
+    /// Gets or sets the optional <c>partial</c> contextual modifier (ADR-0144 /
+    /// issue #2201) on the interface declaration (<c>partial interface</c>).
+    /// When non-null this declaration is one part of an interface that may be
+    /// split across multiple declarations in the same package. Assigned by the
+    /// parser; <c>null</c> otherwise.
+    /// </summary>
+    public SyntaxToken PartialModifier
+    {
+        get => partialModifier;
+        set
+        {
+            partialModifier = value;
+            InvalidateCachedSpan();
+        }
+    }
+
+    /// <summary>Gets a value indicating whether this interface was declared <c>partial</c> (ADR-0144 / issue #2201).</summary>
+    public bool IsPartial => PartialModifier != null;
+
+    /// <summary>
+    /// Gets or sets the identifier locations of every part of a merged
+    /// <c>partial</c> interface (ADR-0144). Populated only on the synthetic node
+    /// <c>PartialTypeMerger</c> produces; empty on an ordinary declaration. Drives
+    /// go-to-definition returning all part locations. Its element type
+    /// (<see cref="Text.TextLocation"/>) is not a syntax node, so it is invisible
+    /// to <see cref="SyntaxNode.GetChildren"/> and does not affect this node's span.
+    /// </summary>
+    public ImmutableArray<Text.TextLocation> PartialPartLocations { get; set; } = ImmutableArray<Text.TextLocation>.Empty;
 
     /// <summary>
     /// Gets or sets the static field declarations (<c>var</c> / <c>let</c> /

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -681,7 +681,7 @@ public class Parser
             // ADR-0122 / issue #1202: `unsafe` composes with the other class
             // modifiers (in any order), establishing an unsafe context for the
             // whole aggregate. Treat it like the other contextual modifiers.
-            if (k.Kind == SyntaxKind.IdentifierToken && (k.Text == "data" || k.Text == "inline" || k.Text == "ref" || k.Text == "unsafe"))
+            if (k.Kind == SyntaxKind.IdentifierToken && (k.Text == "data" || k.Text == "inline" || k.Text == "ref" || k.Text == "unsafe" || k.Text == "partial"))
             {
                 // Bail out if the same contextual modifier appears twice — we are
                 // not in a declaration head; let the legacy / statement parser
@@ -728,6 +728,7 @@ public class Parser
         SyntaxToken inlineKeyword = null;
         SyntaxToken refModifier = null;
         SyntaxToken unsafeModifier = null;
+        SyntaxToken partialModifier = null;
 
         // Collect modifiers in any order. Re-issuing of a modifier is reported
         // as an unexpected token but parsing continues for recovery.
@@ -799,6 +800,20 @@ public class Parser
                 }
 
                 refModifier = NextToken();
+                continue;
+            }
+
+            // ADR-0144 / issue #2201: `partial` is a contextual modifier that
+            // composes with the other aggregate modifiers in any order. It is
+            // valid on class/struct/interface (rejected on enum below).
+            if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "partial")
+            {
+                if (partialModifier != null)
+                {
+                    Diagnostics.ReportUnexpectedToken(Current.Location, Current.Kind, SyntaxKind.ClassKeyword);
+                }
+
+                partialModifier = NextToken();
                 continue;
             }
 
@@ -896,6 +911,11 @@ public class Parser
                     Diagnostics.ReportUnexpectedToken(unsafeModifier.Location, SyntaxKind.IdentifierToken, SyntaxKind.EnumKeyword);
                 }
 
+                if (partialModifier != null)
+                {
+                    Diagnostics.ReportPartialNotValidOnKind(partialModifier.Location, "enum");
+                }
+
                 break;
 
             case SyntaxKind.InterfaceKeyword:
@@ -948,7 +968,9 @@ public class Parser
 
         if (aggregateKind == SyntaxKind.InterfaceKeyword)
         {
-            return ParseInterfaceDeclarationNew(accessibilityModifier, sealedModifier, aggregateKeyword, identifier, typeParameterList);
+            var interfaceDecl = ParseInterfaceDeclarationNew(accessibilityModifier, sealedModifier, aggregateKeyword, identifier, typeParameterList);
+            interfaceDecl.PartialModifier = partialModifier;
+            return interfaceDecl;
         }
 
         // class / struct path.
@@ -963,6 +985,7 @@ public class Parser
             structDecl.TypeParameterList = typeParameterList;
             structDecl.RefModifier = refModifier;
             structDecl.UnsafeModifier = unsafeModifier;
+            structDecl.PartialModifier = partialModifier;
             return structDecl;
         }
         finally

--- a/src/Core/CodeAnalysis/Syntax/StructDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/StructDeclarationSyntax.cs
@@ -16,6 +16,7 @@ public sealed class StructDeclarationSyntax : MemberSyntax
     // never served afterwards.
     private SeparatedSyntaxList<TypeClauseSyntax> baseTypeClauses = new SeparatedSyntaxList<TypeClauseSyntax>(ImmutableArray<SyntaxNode>.Empty);
     private SyntaxToken unsafeModifier;
+    private SyntaxToken partialModifier;
     private TypeParameterListSyntax typeParameterList;
     private SyntaxToken refModifier;
     private SharedBlockSyntax sharedBlock;
@@ -458,6 +459,38 @@ public sealed class StructDeclarationSyntax : MemberSyntax
 
     /// <summary>Gets a value indicating whether this aggregate was declared <c>unsafe</c> (ADR-0122 / issue #1014).</summary>
     public bool IsUnsafe => UnsafeModifier != null;
+
+    /// <summary>
+    /// Gets or sets the optional <c>partial</c> contextual modifier (ADR-0144 /
+    /// issue #2201) on the aggregate declaration (<c>partial class</c> /
+    /// <c>partial struct</c>). When non-null this declaration is one part of a
+    /// type that may be split across multiple declarations in the same package.
+    /// Assigned by the parser; <c>null</c> otherwise. Rejected on <c>enum</c>
+    /// (GS0484).
+    /// </summary>
+    public SyntaxToken PartialModifier
+    {
+        get => partialModifier;
+        set
+        {
+            partialModifier = value;
+            InvalidateCachedSpan();
+        }
+    }
+
+    /// <summary>Gets a value indicating whether this aggregate was declared <c>partial</c> (ADR-0144 / issue #2201).</summary>
+    public bool IsPartial => PartialModifier != null;
+
+    /// <summary>
+    /// Gets or sets the identifier locations of every part of a merged
+    /// <c>partial</c> type (ADR-0144). Populated only on the synthetic node
+    /// <c>PartialTypeMerger</c> produces; empty on an ordinary (un-merged)
+    /// declaration. Used by the language server so go-to-definition on a partial
+    /// type returns all part locations. Its element type (<see cref="Text.TextLocation"/>)
+    /// is not a syntax node, so it is intentionally invisible to
+    /// <see cref="SyntaxNode.GetChildren"/> and does not affect this node's span.
+    /// </summary>
+    public ImmutableArray<Text.TextLocation> PartialPartLocations { get; set; } = ImmutableArray<Text.TextLocation>.Empty;
 
     /// <summary>Gets a value indicating whether this aggregate was declared with the <c>class</c> keyword (Phase 3.B.3) rather than <c>struct</c>.</summary>
     public bool IsClass => StructKeyword?.Kind == SyntaxKind.ClassKeyword;

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -1119,6 +1119,23 @@ public static class DefinitionComputer
 {
     public static Location ComputeDefinition(DocumentUri uri, DocumentContent content, Position position, CancellationToken ct = default)
     {
+        var all = ComputeDefinitions(uri, content, position, ct);
+        return all.Count > 0 ? all[0] : null;
+    }
+
+    /// <summary>
+    /// Like <see cref="ComputeDefinition"/> but returns <em>every</em> declaration
+    /// location. For a <c>partial</c> type (ADR-0144) this is one location per
+    /// part (across files); for every other symbol it is a single-element list
+    /// (or empty). The <c>textDocument/definition</c> handler returns this array.
+    /// </summary>
+    /// <param name="uri">The URI of the document the request originated from (fallback when a target has no file path).</param>
+    /// <param name="content">The document content and its owning project/workspace.</param>
+    /// <param name="position">The cursor position whose symbol is being resolved.</param>
+    /// <param name="ct">A cancellation token.</param>
+    /// <returns>Every declaration location for the resolved symbol; empty when none resolves.</returns>
+    public static IReadOnlyList<Location> ComputeDefinitions(DocumentUri uri, DocumentContent content, Position position, CancellationToken ct = default)
+    {
         var compilation = content.Project?.GetCompilation() ?? new Compilation(content.SyntaxTree);
         var offset = SemanticLookup.ToOffset(content, position);
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
@@ -1129,16 +1146,24 @@ public static class DefinitionComputer
         // first, then portable-PDB navigation. See CrossAssemblyDefinitionResolver.
         if (TryResolveImportedSymbol(symbol, workspace, out var crossLocation))
         {
-            return crossLocation;
+            return new[] { crossLocation };
         }
 
         if (symbol != null)
         {
+            // ADR-0144: a partial type resolves to a synthetic merged declaration
+            // that records every part's identifier location. Return them all.
+            var partLocations = GetPartialTypeLocations(symbol, uri);
+            if (partLocations != null)
+            {
+                return partLocations;
+            }
+
             var declarationToken = FindDeclarationToken(compilation, symbol, ct);
             if (declarationToken != null)
             {
                 var targetUri = GetDocumentUri(declarationToken, uri);
-                return new Location { Uri = targetUri, Range = SemanticLookup.ToRange(declarationToken) };
+                return new[] { new Location { Uri = targetUri, Range = SemanticLookup.ToRange(declarationToken) } };
             }
         }
 
@@ -1152,17 +1177,46 @@ public static class DefinitionComputer
             if (ImportedClrMemberResolver.TryResolveClrType(content.SyntaxTree, compilation, token, out var clrType)
                 && CrossAssemblyDefinitionResolver.TryResolveType(workspace, clrType, out var typeLocation))
             {
-                return typeLocation;
+                return new[] { typeLocation };
             }
 
             if (ImportedClrMemberResolver.TryResolveClrMember(content.SyntaxTree, compilation, token, out var clrMember)
                 && TryResolveClrMember(workspace, clrMember, out var memberLocation))
             {
-                return memberLocation;
+                return new[] { memberLocation };
             }
         }
 
-        return null;
+        return Array.Empty<Location>();
+    }
+
+    /// <summary>
+    /// Returns one <see cref="Location"/> per part of a merged <c>partial</c> type
+    /// (ADR-0144), or <see langword="null"/> when <paramref name="symbol"/> is not
+    /// a multi-part partial struct/interface (so the caller falls through to the
+    /// ordinary single-declaration path).
+    /// </summary>
+    private static IReadOnlyList<Location> GetPartialTypeLocations(Symbol symbol, DocumentUri fallback)
+    {
+        var partLocations = symbol switch
+        {
+            StructSymbol s => s.Declaration?.PartialPartLocations ?? ImmutableArray<TextLocation>.Empty,
+            InterfaceSymbol i => i.Declaration?.PartialPartLocations ?? ImmutableArray<TextLocation>.Empty,
+            _ => ImmutableArray<TextLocation>.Empty,
+        };
+
+        if (partLocations.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        return partLocations
+            .Select(loc => new Location
+            {
+                Uri = !string.IsNullOrEmpty(loc.FileName) ? DocumentUri.FromFileSystemPath(loc.FileName) : fallback,
+                Range = SemanticLookup.ToRange(loc.Text, loc.Span),
+            })
+            .ToArray();
     }
 
     private static bool TryResolveImportedSymbol(Symbol symbol, WorkspaceState workspace, out Location location)

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -379,11 +379,11 @@ public sealed class LspServer
             cancellationToken);
 
     [JsonRpcMethod("textDocument/definition", UseSingleObjectParameterDeserialization = true)]
-    public Task<Location> DefinitionAsync(DefinitionParams request, CancellationToken cancellationToken = default)
+    public Task<Location[]> DefinitionAsync(DefinitionParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => DefinitionComputer.ComputeDefinition(request.TextDocument.Uri, content, request.Position, ct),
-            null,
+            (content, ct) => DefinitionComputer.ComputeDefinitions(request.TextDocument.Uri, content, request.Position, ct).ToArray(),
+            Array.Empty<Location>(),
             cancellationToken);
 
     [JsonRpcMethod("textDocument/references", UseSingleObjectParameterDeserialization = true)]

--- a/test/Core.Tests/CodeAnalysis/Adr0144PartialTypesBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0144PartialTypesBinderTests.cs
@@ -1,0 +1,492 @@
+// <copyright file="Adr0144PartialTypesBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// ADR-0144 / issue #2201: binder-layer tests for <c>partial</c> types. These
+/// exercise the <c>PartialTypeMerger</c> pre-pass that merges multiple
+/// <c>partial</c> parts of the same type into one synthetic declaration node
+/// before the two-phase shell/body binder runs — covering successful merges
+/// (single-file and cross-file), <c>shared { }</c>/init merging, and each new
+/// consistency diagnostic (GS0475-GS0483).
+/// </summary>
+public class Adr0144PartialTypesBinderTests
+{
+    // ─────────────────────────────────────────────────────────────────────────
+    // 1. Successful merges (emit + run)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TwoPartialClassParts_FieldAndMethod_MergeAndRun()
+    {
+        var source = @"package App
+import System
+
+partial class Foo {
+    var value int32 = 40
+}
+
+partial class Foo {
+    func Sum() int32 {
+        return value + 2
+    }
+}
+
+let f = Foo()
+Console.WriteLine(f.Sum())
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "Adr0144-TwoParts");
+        Assert.Contains("42", output);
+    }
+
+    [Fact]
+    public void TwoPartialClassParts_EmitExactlyOneTypeDef_WithMembersFromBothParts()
+    {
+        // The merge must yield ONE TypeDef (not one per part), carrying the field
+        // from the first part and the method from the second.
+        var source = @"package App
+import System
+
+partial class Foo {
+    var value int32 = 40
+}
+
+partial class Foo {
+    func Sum() int32 {
+        return value + 2
+    }
+}
+
+Console.WriteLine(Foo().Sum())
+";
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var result = new Compilation(tree).Emit(peStream);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        using var peReader = new PEReader(peStream);
+        var md = peReader.GetMetadataReader();
+
+        var fooDefs = md.TypeDefinitions
+            .Select(md.GetTypeDefinition)
+            .Where(t => md.GetString(t.Name) == "Foo")
+            .ToList();
+        Assert.Single(fooDefs);
+
+        var foo = fooDefs[0];
+        var fieldNames = foo.GetFields().Select(h => md.GetString(md.GetFieldDefinition(h).Name)).ToList();
+        var methodNames = foo.GetMethods().Select(h => md.GetString(md.GetMethodDefinition(h).Name)).ToList();
+        Assert.Contains("value", fieldNames);
+        Assert.Contains("Sum", methodNames);
+    }
+
+    [Fact]
+    public void CrossFile_PartsMergeAndGlobalImportsResolve()
+    {
+        // Part A declares a field; part B (a separate tree, with its OWN
+        // `import System`) declares a method that references a System type.
+        // Compiling both trees together must merge the parts AND let part B's
+        // body resolve `System.Math` — proving imports are compilation-global.
+        var treeA = SyntaxTree.Parse(SourceText.From(
+            @"package App
+
+partial class Calc {
+    var seed int32 = 9
+}
+",
+            "A.gs"));
+
+        var treeB = SyntaxTree.Parse(SourceText.From(
+            @"package App
+import System
+
+partial class Calc {
+    func Abs() int32 {
+        return Math.Abs(seed - 20)
+    }
+}
+
+let c = Calc()
+Console.WriteLine(c.Abs())
+",
+            "B.gs"));
+
+        var output = CompileLoadInvokeCaptureStdout(new[] { treeA, treeB }, "Adr0144-CrossFile");
+        Assert.Contains("11", output);
+    }
+
+    [Fact]
+    public void TwoPartialStructParts_Merge()
+    {
+        var source = @"package App
+import System
+
+partial struct Point {
+    var x int32
+}
+
+partial struct Point {
+    var y int32
+    func Sum() int32 {
+        return x + y
+    }
+}
+
+var p Point
+p.x = 3
+p.y = 4
+Console.WriteLine(p.Sum())
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "Adr0144-StructMerge");
+        Assert.Contains("7", output);
+    }
+
+    [Fact]
+    public void TwoPartialInterfaceParts_UnionMustBeSatisfiedByImplementer()
+    {
+        var source = @"package App
+import System
+
+partial interface IShape {
+    func Area() int32;
+}
+
+partial interface IShape {
+    func Perimeter() int32;
+}
+
+class Square : IShape {
+    var side int32 = 5
+    func Area() int32 {
+        return side * side
+    }
+    func Perimeter() int32 {
+        return side * 4
+    }
+}
+
+let s = Square()
+Console.WriteLine(s.Area() + s.Perimeter())
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "Adr0144-IfaceMerge");
+        Assert.Contains("45", output);
+    }
+
+    [Fact]
+    public void MergedSharedBlocks_BothContributeStaticMembersAndInitBlocks()
+    {
+        // Each part contributes a `shared { }` block with a static field and an
+        // init block. The merge must concatenate init blocks in part order
+        // (ADR-0140), so BOTH run.
+        var source = @"package App
+import System
+
+partial class Config {
+    shared {
+        var A int32 = 0
+        init {
+            A = 10
+        }
+    }
+}
+
+partial class Config {
+    shared {
+        var B int32 = 0
+        init {
+            B = A + 5
+        }
+    }
+}
+
+Console.WriteLine(Config.A + Config.B)
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "Adr0144-SharedMerge");
+
+        // A = 10 (part 1 init), B = A + 5 = 15 (part 2 init runs after) => 25.
+        Assert.Contains("25", output);
+    }
+
+    [Fact]
+    public void LonePartialClass_CompilesFine()
+    {
+        var source = @"package App
+import System
+
+partial class Solo {
+    var n int32 = 3
+    func Get() int32 {
+        return n
+    }
+}
+
+let x = Solo()
+Console.WriteLine(x.Get())
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "Adr0144-Lone");
+        Assert.Contains("3", output);
+    }
+
+    [Fact]
+    public void NestedPartialType_SplitAcrossOuterParts_Merges()
+    {
+        // The outer `Box` is split across two parts; each contributes a part of a
+        // nested `partial class Slot`. The recursive nested merge must fold the two
+        // Slot parts into one type (no GS0102), with members from both.
+        var fileA = SyntaxTree.Parse(SourceText.From(@"package App
+import System
+
+partial class Box {
+    partial class Slot {
+        var value int32 = 7
+    }
+}", "A.gs"));
+        var fileB = SyntaxTree.Parse(SourceText.From(@"package App
+import System
+
+partial class Box {
+    partial class Slot {
+        func Read() int32 {
+            return value
+        }
+    }
+}
+
+let s = Box.Slot()
+Console.WriteLine(s.Read())", "B.gs"));
+
+        var output = CompileLoadInvokeCaptureStdout(new[] { fileA, fileB }, "Adr0144-NestedSplit");
+        Assert.Contains("7", output);
+    }
+
+    [Fact]
+    public void NestedPartialType_WithinSingleOuter_Merges()
+    {
+        // A non-split (lone) outer `Holder` contains two `partial class Item` parts
+        // in the same file. NormalizeNestedTypes must merge them even though the
+        // outer itself was never merged.
+        var source = @"package App
+import System
+
+class Holder {
+    partial class Item {
+        var a int32 = 20
+    }
+    partial class Item {
+        func Sum() int32 {
+            return a + 1
+        }
+    }
+}
+
+let i = Holder.Item()
+Console.WriteLine(i.Sum())
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "Adr0144-NestedSingle");
+        Assert.Contains("21", output);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 2. Consistency diagnostics (GS0475-GS0483)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void MixedPartialAndNonPartial_ReportsGS0475()
+    {
+        var source = @"package App
+
+partial class Foo {
+    var a int32
+}
+
+class Foo {
+    var b int32
+}
+";
+        AssertHasDiagnostic(source, "GS0475");
+    }
+
+    [Fact]
+    public void DifferentBaseClass_ReportsGS0481()
+    {
+        var source = @"package App
+
+open class BaseA {
+}
+
+open class BaseB {
+}
+
+partial class Foo : BaseA {
+    var a int32
+}
+
+partial class Foo : BaseB {
+    var b int32
+}
+";
+        AssertHasDiagnostic(source, "GS0481");
+    }
+
+    [Fact]
+    public void PrimaryConstructorOnTwoParts_ReportsGS0482()
+    {
+        var source = @"package App
+
+partial class Foo(a int32) {
+    var x int32
+}
+
+partial class Foo(b int32) {
+    var y int32
+}
+";
+        AssertHasDiagnostic(source, "GS0482");
+    }
+
+    [Fact]
+    public void DataOnOnePartOnly_ReportsGS0479()
+    {
+        var source = @"package App
+
+partial data struct Foo {
+    var a int32
+}
+
+partial struct Foo {
+    var b int32
+}
+";
+        AssertHasDiagnostic(source, "GS0479");
+    }
+
+    [Fact]
+    public void ConflictingAccessibility_ReportsGS0477()
+    {
+        var source = @"package App
+
+public partial class Foo {
+    var a int32
+}
+
+private partial class Foo {
+    var b int32
+}
+";
+        AssertHasDiagnostic(source, "GS0477");
+    }
+
+    [Fact]
+    public void TwoDeinits_ReportsGS0483()
+    {
+        var source = @"package App
+
+partial class Foo {
+    deinit {
+    }
+}
+
+partial class Foo {
+    deinit {
+    }
+}
+";
+        AssertHasDiagnostic(source, "GS0483");
+    }
+
+    [Fact]
+    public void DuplicateMemberAcrossParts_SurfacesGS0102()
+    {
+        // The merged node's Fields contains both `dup` fields, so the body
+        // binder's duplicate detection catches the collision across parts.
+        var source = @"package App
+
+partial class Foo {
+    var dup int32
+}
+
+partial class Foo {
+    var dup int32
+}
+";
+        AssertHasDiagnostic(source, "GS0102");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static void AssertHasDiagnostic(string source, string expectedId)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Id == expectedId);
+    }
+
+    private static string CompileLoadInvokeCaptureStdout(string source, string contextName)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return CompileLoadInvokeCaptureStdout(new[] { tree }, contextName);
+    }
+
+    private static string CompileLoadInvokeCaptureStdout(SyntaxTree[] trees, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var compilation = new Compilation(trees);
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/IncrementalGlobalScopeReuseTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/IncrementalGlobalScopeReuseTests.cs
@@ -83,6 +83,49 @@ public class IncrementalGlobalScopeReuseTests
     }
 
     /// <summary>
+    /// ADR-0144: a file containing a <c>partial</c> type is never eligible for
+    /// the body-only fast path, even for an otherwise body-only edit — the
+    /// type's symbol is bound from a synthetic merged declaration spanning every
+    /// part, which a single-file positional re-point cannot reproduce. The edit
+    /// must fall back to a full rebuild (<see cref="IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit"/>
+    /// returns <see langword="false"/>).
+    /// </summary>
+    [Fact]
+    public void PartialType_BodyOnlyEdit_FallsBackToFullRebuild()
+    {
+        var fileA = Parse("A.gs", """
+            package P
+            partial class Widget {
+                func Value() int {
+                    return 1
+                }
+            }
+            """);
+        var fileB = Parse("B.gs", """
+            package P
+            partial class Widget {
+                func Other() int {
+                    return 2
+                }
+            }
+            """);
+
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA, fileB));
+
+        // Body-only edit to A.gs: only the returned literal changes.
+        var editedA = Parse("A.gs", """
+            package P
+            partial class Widget {
+                func Value() int {
+                    return 100
+                }
+            }
+            """);
+
+        Assert.False(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+    }
+
+    /// <summary>
     /// The fast path is bit-for-bit identical to a full rebuild on the edited
     /// trees: same emitted IL and same diagnostics. This is the load-bearing
     /// determinism guarantee — the cache/reuse must never change output. The

--- a/test/Core.Tests/CodeAnalysis/Syntax/Adr0144PartialTypeParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Adr0144PartialTypeParserTests.cs
@@ -1,0 +1,134 @@
+// <copyright file="Adr0144PartialTypeParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// ADR-0144 / issue #2201: the <c>partial</c> contextual modifier joins the
+/// existing contextual-identifier modifier family (<c>data</c>/<c>inline</c>/
+/// <c>ref</c>/<c>unsafe</c>). It requires no lexer change and no new SyntaxKind,
+/// and is only special inside an aggregate declaration head. It is valid on
+/// <c>class</c>, <c>struct</c>, and <c>interface</c>, and rejected on
+/// <c>enum</c> (GS0484). These tests pin the SYNTAX layer only.
+/// </summary>
+public class Adr0144PartialTypeParserTests
+{
+    [Fact]
+    public void PartialClass_Parses_WithIsPartialSet()
+    {
+        const string source = "package p\npartial class C { }\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var root = (CompilationUnitSyntax)tree.Root;
+        var classDecl = root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.True(classDecl.IsPartial);
+    }
+
+    [Fact]
+    public void PartialStruct_Parses_WithIsPartialSet()
+    {
+        const string source = "package p\npartial struct S { }\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var root = (CompilationUnitSyntax)tree.Root;
+        var structDecl = root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.True(structDecl.IsPartial);
+    }
+
+    [Fact]
+    public void PartialInterface_Parses_WithIsPartialSet()
+    {
+        const string source = "package p\npartial interface I { }\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var root = (CompilationUnitSyntax)tree.Root;
+        var interfaceDecl = root.Members.OfType<InterfaceDeclarationSyntax>().Single();
+        Assert.True(interfaceDecl.IsPartial);
+    }
+
+    [Theory]
+    [InlineData("package p\npublic open partial class C { }\n")]
+    [InlineData("package p\npartial open class C { }\n")]
+    [InlineData("package p\nopen partial class C { }\n")]
+    public void PartialComposesWithClassModifiers_InAnyOrder(string source)
+    {
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var root = (CompilationUnitSyntax)tree.Root;
+        var classDecl = root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.True(classDecl.IsPartial);
+        Assert.True(classDecl.IsOpen);
+    }
+
+    [Fact]
+    public void PartialComposesWithData_OnStruct()
+    {
+        const string source = "package p\npublic partial data struct S { }\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var root = (CompilationUnitSyntax)tree.Root;
+        var structDecl = root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.True(structDecl.IsPartial);
+        Assert.True(structDecl.IsData);
+    }
+
+    [Fact]
+    public void NonPartialClass_HasIsPartialFalse()
+    {
+        const string source = "package p\nclass C { }\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var root = (CompilationUnitSyntax)tree.Root;
+        var classDecl = root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.False(classDecl.IsPartial);
+    }
+
+    [Fact]
+    public void PartialEnum_ReportsGS0484()
+    {
+        const string source = "package p\npartial enum E { A }\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Contains(tree.Diagnostics, d => d.Id == "GS0484");
+    }
+
+    [Fact]
+    public void DuplicatePartial_RecoversLikeSiblingContextualModifiers()
+    {
+        // `partial` is a contextual identifier modifier, so it behaves exactly
+        // like the sibling `data`/`inline`/`ref`/`unsafe` modifiers on a
+        // duplicate. TryDetectAggregateDeclarationHead's `saw` HashSet bails on
+        // the second occurrence, so the leading `partial` is swallowed as an
+        // expression statement and the trailing `partial class C { }` still
+        // parses as a valid partial class — no crash, no cascade. (Cf.
+        // `data data struct S { }`, which recovers identically.)
+        const string source = "package p\npartial partial class C { }\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var root = (CompilationUnitSyntax)tree.Root;
+        var classDecl = root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.True(classDecl.IsPartial);
+    }
+
+    [Fact]
+    public void Partial_RemainsUsableAsAnOrdinaryIdentifier()
+    {
+        // `partial` is contextual: it is only special inside an aggregate
+        // declaration head where a trailing kind keyword disambiguates. A local
+        // named `partial` must still parse cleanly.
+        const string source = "package p\nimport System\nvar partial = 3\nConsole.WriteLine(partial)\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+}

--- a/test/LanguageServer.Tests/DefinitionHandlerTests.cs
+++ b/test/LanguageServer.Tests/DefinitionHandlerTests.cs
@@ -54,6 +54,29 @@ public class DefinitionHandlerTests
     }
 
     [Fact]
+    public void ComputeDefinitions_PartialType_ReturnsAllPartLocations()
+    {
+        // ADR-0144: go-to-definition on a partial type returns every part's
+        // location. Two `partial class Point` parts on lines 0 and 3.
+        const string source =
+            "partial class Point {\n    var x int32 = 0\n}\npartial class Point {\n    func Get() int32 { return x }\n}\nlet p = Point()\n";
+        var content = LanguageServerTestHelpers.Content(source);
+        var uri = DocumentUri.From("file:///def.gs");
+
+        // Cursor on the `Point` type name in the `Point()` construction.
+        var locations = DefinitionComputer.ComputeDefinitions(uri, content, LanguageServerTestHelpers.PositionOf(source, "Point", 2));
+
+        Assert.Equal(2, locations.Count);
+        Assert.Contains(locations, l => l.Range.Start.Line == 0);
+        Assert.Contains(locations, l => l.Range.Start.Line == 3);
+
+        // The single-Location convenience overload returns the first part.
+        var single = DefinitionComputer.ComputeDefinition(uri, content, LanguageServerTestHelpers.PositionOf(source, "Point", 2));
+        Assert.NotNull(single);
+        Assert.Equal(0, single.Range.Start.Line);
+    }
+
+    [Fact]
     public void ComputeDefinition_ReturnsNullForUnknownToken()
     {
         const string source = "let x = 42\n";

--- a/test/LanguageServer.Tests/LspServerMemberFeatureTests.cs
+++ b/test/LanguageServer.Tests/LspServerMemberFeatureTests.cs
@@ -56,7 +56,8 @@ public class LspServerMemberFeatureTests
             // 1) go-to-definition on the implicit-this property usage `Width`.
             var def = await server.DefinitionAsync(new DefinitionParams { TextDocument = id, Position = LanguageServerTestHelpers.PositionOf(v2, "Width", 1) });
             Assert.NotNull(def);
-            Assert.Equal(3, def.Range.Start.Line); // `prop Width` declaration
+            var defLocation = Assert.Single(def);
+            Assert.Equal(3, defLocation.Range.Start.Line); // `prop Width` declaration
 
             // 2) reference code lens is produced for the file.
             var lenses = await server.CodeLensAsync(new CodeLensParams { TextDocument = id });

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/TypeDeclaration.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/TypeDeclaration.cs
@@ -32,6 +32,7 @@ public sealed class TypeDeclaration : GMember
     /// <param name="isOpen">Whether the type is <c>open</c> for subclassing.</param>
     /// <param name="isSealed">Whether the type is a <c>sealed</c> closed hierarchy.</param>
     /// <param name="isAbstract">Whether the type is <c>abstract</c>.</param>
+    /// <param name="isPartial">Whether the type is <c>partial</c> (ADR-0144 §G).</param>
     /// <param name="hasBody">Whether to render a body block (false emits the bodyless primary-ctor form).</param>
     /// <param name="attributes">The type attributes.</param>
     /// <param name="isUnsafe">Whether the type is <c>unsafe</c> (its body is an unsafe context).</param>
@@ -48,6 +49,7 @@ public sealed class TypeDeclaration : GMember
         bool isOpen = false,
         bool isSealed = false,
         bool isAbstract = false,
+        bool isPartial = false,
         bool hasBody = true,
         IReadOnlyList<AttributeUse> attributes = null,
         bool isUnsafe = false)
@@ -64,6 +66,7 @@ public sealed class TypeDeclaration : GMember
         IsOpen = isOpen;
         IsSealed = isSealed;
         IsAbstract = isAbstract;
+        IsPartial = isPartial;
         HasBody = hasBody;
         Attributes = attributes ?? new List<AttributeUse>();
         IsUnsafe = isUnsafe;
@@ -108,6 +111,9 @@ public sealed class TypeDeclaration : GMember
 
     /// <summary>Gets a value indicating whether the type is <c>abstract</c>.</summary>
     public bool IsAbstract { get; }
+
+    /// <summary>Gets a value indicating whether the type is <c>partial</c> (ADR-0144 §G).</summary>
+    public bool IsPartial { get; }
 
     /// <summary>Gets a value indicating whether to render a body block.</summary>
     public bool HasBody { get; }

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1310,6 +1310,14 @@ public static class GSharpPrinter
             sb.Append("abstract ");
         }
 
+        if (declaration.IsPartial)
+        {
+            // ADR-0144 §G: the `partial` modifier is placed after
+            // `open`/`sealed`, immediately before the aggregate keyword
+            // (e.g. `public open partial class Foo`).
+            sb.Append("partial ");
+        }
+
         sb.Append(RenderKindKeyword(declaration.Kind));
         sb.Append(' ');
         sb.Append(declaration.Name);

--- a/tools/cs2gs/Cs2Gs.Tests/GoldenTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/GoldenTests.cs
@@ -913,6 +913,66 @@ public class GoldenTests
         Assert.True(result.Success, "Round-trip errors:\n" + string.Join("\n", result.Errors));
     }
 
+    /// <summary>ADR-0144 §G: a <c>partial</c> class/struct/interface renders the
+    /// <c>partial</c> modifier immediately before the aggregate keyword.</summary>
+    [Theory]
+    [InlineData(TypeDeclarationKind.Class, "partial class Foo {")]
+    [InlineData(TypeDeclarationKind.Struct, "partial struct Foo {")]
+    [InlineData(TypeDeclarationKind.Interface, "partial interface Foo {")]
+    public void GTooling_PartialRendersBeforeKindKeyword(TypeDeclarationKind kind, string expected)
+    {
+        var cls = new TypeDeclaration(kind, "Foo", isPartial: true);
+        var unit = new CompilationUnit("Demo", members: Nodes(cls));
+
+        var printed = GSharpPrinter.Print(unit);
+
+        Assert.Contains(expected, printed);
+    }
+
+    /// <summary>ADR-0144 §G: <c>partial</c> follows <c>open</c> in canonical
+    /// order (<c>open partial class</c>).</summary>
+    [Fact]
+    public void GTooling_OpenPartialClassOrder()
+    {
+        var cls = new TypeDeclaration(TypeDeclarationKind.Class, "Foo", isOpen: true, isPartial: true);
+        var unit = new CompilationUnit("Demo", members: Nodes(cls));
+
+        var printed = GSharpPrinter.Print(unit);
+
+        Assert.Contains("open partial class Foo {", printed);
+    }
+
+    /// <summary>ADR-0144 §G: accessibility, <c>open</c> and <c>partial</c> render
+    /// in canonical order (<c>public open partial class</c>).</summary>
+    [Fact]
+    public void GTooling_PublicOpenPartialClassOrder()
+    {
+        var cls = new TypeDeclaration(
+            TypeDeclarationKind.Class,
+            "Foo",
+            visibility: Visibility.Public,
+            isOpen: true,
+            isPartial: true);
+        var unit = new CompilationUnit("Demo", members: Nodes(cls));
+
+        var printed = GSharpPrinter.Print(unit);
+
+        Assert.Contains("public open partial class Foo {", printed);
+    }
+
+    /// <summary>ADR-0144 §G: <c>partial</c> follows <c>sealed</c> and precedes the
+    /// kind keyword (<c>sealed partial class</c>).</summary>
+    [Fact]
+    public void GTooling_SealedPartialClassOrder()
+    {
+        var cls = new TypeDeclaration(TypeDeclarationKind.Class, "Foo", isSealed: true, isPartial: true);
+        var unit = new CompilationUnit("Demo", members: Nodes(cls));
+
+        var printed = GSharpPrinter.Print(unit);
+
+        Assert.Contains("sealed partial class Foo {", printed);
+    }
+
     private static void AssertGolden(string expected, CompilationUnit unit)
     {
         var printed = GSharpPrinter.Print(unit);


### PR DESCRIPTION
## Summary

Implements **partial types** in G# (ADR-0144) — a `partial` modifier on `class`/`struct`/`interface` that merges same-named declarations (across files, and nested) into one type. This is the language prerequisite for Roslyn source-generator support; the companion design docs (ADR-0143 cs2gs migration, ADR-0145 native generator host) are already on `main` and are not part of this PR.

This PR updates ADR-0144 to the as-built design and adds its implementation. Addresses the partial-types portion of #2201.

## What's implemented (ADR-0144)

- **Syntax** — `partial` as a contextual modifier (no lexer/`SyntaxKind` change), rejected on `enum` (`GS0484`).
- **Binder** — a `PartialTypeMerger` pre-pass in `BindGlobalScope` combines each group of parts into **one synthetic declaration**, so the ~2 000-line body binder, every installer, the symbols, and the emitter stay untouched (one merged node → one symbol → one TypeDef). New head-consistency diagnostics `GS0475`–`GS0483`.
- **Nested partial types** — merged recursively (split across a split outer, and partials nested in a single outer).
- **Emit** — no code change needed; a metadata test asserts exactly one TypeDef with members from all parts.
- **Language server** — go-to-definition returns **all** part locations (`textDocument/definition` now returns `Location[]`); the incremental-rebind fast path falls back to full rebuild for any file containing a partial part.
- **cs2gs** — `TypeDeclaration.IsPartial` + printer rendering, so generated partial parts can be emitted (needed by ADR-0145).

### Design note

The implementation uses a **syntax-level merge** rather than the accumulate-into-a-shared-symbol approach originally sketched in ADR-0144 §E (the ADR has been updated to match). This is far lower blast-radius and is sound because G# imports are compilation-global and syntax nodes carry no `Parent`, so composing child nodes from different files under one synthetic parent preserves both name resolution and diagnostic locations.

## Testing

- `Core.Tests`: **5793 passed / 1 skipped / 0 failed** (25 new Adr0144 parser+binder tests incl. cross-file, nested, shared-block merge, one-TypeDef metadata, and each diagnostic).
- `LanguageServer.Tests`: **414 passed** (partial go-to-def, incremental-rebind guard).
- Full solution builds clean; a two-file `partial class` program compiles and runs via the real `gsc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
