### PR TITLE
Fix Core_Targets_Declares_BuildTask_And_CoreCompile_Override test after ADR-0145

### DIFF
--- a/test/Sdk.Tests/SdkLayoutTests.cs
+++ b/test/Sdk.Tests/SdkLayoutTests.cs
@@ -79,8 +79,11 @@ public class SdkLayoutTests
 
         var doc = XDocument.Load(path);
 
-        var usingTask = doc.Descendants(MsbuildNs + "UsingTask").Single();
-        Assert.Equal("Gsharp.NET.Sdk.Tools.BuildTask", (string)usingTask.Attribute("TaskName"));
+        // ADR-0145 added a second UsingTask (GsgenTask) alongside BuildTask,
+        // so select the one this test cares about by TaskName rather than
+        // assuming BuildTask is the only <UsingTask> declared.
+        var usingTask = doc.Descendants(MsbuildNs + "UsingTask")
+            .Single(t => (string)t.Attribute("TaskName") == "Gsharp.NET.Sdk.Tools.BuildTask");
         Assert.Equal("$(GsharpToolFullPath)", (string)usingTask.Attribute("AssemblyFile"));
 
         var coreCompile = doc.Descendants(MsbuildNs + "Target")


### PR DESCRIPTION
## Root cause

ADR-0145 (#2208, merged as `9c4a55a0`) added a second `<UsingTask>` element
(`GsgenTask`, the source-generator host task) to
`src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets`, alongside the
pre-existing `BuildTask` UsingTask.

`SdkLayoutTests.Core_Targets_Declares_BuildTask_And_CoreCompile_Override`
called `doc.Descendants(MsbuildNs + "UsingTask").Single()` with no
predicate, assuming there was exactly one `UsingTask` in the file. With two
present, `.Single()` throws `InvalidOperationException: Sequence contains
more than one element`.

The targets file change is intentional and correct — it is the wiring for
the gsgen source-generator host described in ADR-0145. The bug is in the
test's outdated assumption, not the targets file.

## Fix

Updated the test to select the `UsingTask` by `TaskName` (`Gsharp.NET.Sdk.Tools.BuildTask`)
so it targets the element it actually cares about instead of assuming it's
the only one in the document.

## Verification

- `dotnet test test/Sdk.Tests/Sdk.Tests.csproj --filter Core_Targets_Declares_BuildTask_And_CoreCompile_Override` reproduced the failure before the fix, passes after.
- `dotnet test test/Sdk.Tests/Sdk.Tests.csproj` — all 38 tests pass.
- `dotnet build GSharp.sln` — builds clean, 0 warnings/errors.
- Grepped `test/` for other references to `Gsharp.NET.Core.Sdk.targets` — none found, so no other tests were affected.

Fixes #2212