### PR TITLE
Fix static member access through a fully-qualified generic type name (GS0157)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1592,6 +1592,36 @@ internal sealed partial class ExpressionBinder
 
         while (true)
         {
+            // Issue #2209: `Ns.Sub.Generic[Args].StaticMember` places a generic
+            // instantiation (`Comparer[int32]`, parsed as an `IndexExpressionSyntax`
+            // for a single type argument or a `GenericNameExpressionSyntax` for
+            // multiple/type-shaped arguments) in the middle of the dotted chain,
+            // immediately followed by the static member access. Neither shape is
+            // a plain `NameExpressionSyntax` segment, so without this case the
+            // walk below falls through to `default: return false` at the FIRST
+            // segment, and the caller re-reports the whole chain as an undefined
+            // type starting from its leftmost name. Close the generic type here
+            // (mirroring the non-generic branch just below) and hand the
+            // remaining chain back as the static-member access on the closed type.
+            if (currentRight is AccessorExpressionSyntax genericSegment
+                && TryGetGenericSegmentNameAndArity(genericSegment.LeftPart, out var genericSegmentName, out var genericArity))
+            {
+                var mangledName = currentPath + "." + genericSegmentName + "`" + genericArity;
+                if (scope.References.TryResolveType(mangledName, out var openGenericType)
+                    && TryBindGenericImportSegmentTypeArguments(genericSegment.LeftPart, genericArity, out var segmentTypeArgs)
+                    && TryCloseImportedGenericTypeReceiver(openGenericType, segmentTypeArgs, genericSegment.LeftPart, out var closedGenericImported))
+                {
+                    importedClass = closedGenericImported;
+                    rightPart = genericSegment.RightPart;
+                    return true;
+                }
+
+                // A generic instantiation can never be a further namespace
+                // level, so a failed resolution here ends the walk instead of
+                // falling through to the plain-segment cases below.
+                return false;
+            }
+
             NameExpressionSyntax typeNameSyntax;
             ExpressionSyntax remainder;
             bool hasMoreChain;
@@ -1631,6 +1661,58 @@ internal sealed partial class ExpressionBinder
 
             currentPath = fullTypeName;
             currentRight = remainder;
+        }
+    }
+
+    /// <summary>
+    /// Issue #2209: recognises a generic-instantiation segment
+    /// (<c>Comparer[int32]</c>) in the middle of a fully-qualified dotted
+    /// namespace/type chain and returns its simple type name and arity. The
+    /// parser shapes a single type argument as an <see cref="IndexExpressionSyntax"/>
+    /// (target is the bare type name, e.g. <c>Comparer[int32]</c>) and multiple
+    /// or type-shaped arguments as a <see cref="GenericNameExpressionSyntax"/>
+    /// (e.g. <c>Pair[int32, string]</c>, <c>Box[int32?]</c>).
+    /// </summary>
+    private static bool TryGetGenericSegmentNameAndArity(ExpressionSyntax segment, out string name, out int arity)
+    {
+        switch (segment)
+        {
+            case IndexExpressionSyntax index when !index.IsNullConditional && index.Target is NameExpressionSyntax indexName:
+                name = indexName.IdentifierToken.Text;
+                arity = 1;
+                return true;
+
+            case GenericNameExpressionSyntax generic:
+                name = generic.Identifier.Text;
+                arity = generic.TypeArgumentList.Arguments.Count;
+                return true;
+
+            default:
+                name = null;
+                arity = 0;
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #2209: binds the type-argument(s) of a generic-instantiation
+    /// segment recognised by <see cref="TryGetGenericSegmentNameAndArity"/>,
+    /// dispatching to the matching argument shape (index-expression argument or
+    /// generic-name type-argument list).
+    /// </summary>
+    private bool TryBindGenericImportSegmentTypeArguments(ExpressionSyntax segment, int arity, out ImmutableArray<TypeSymbol> typeArgs)
+    {
+        switch (segment)
+        {
+            case IndexExpressionSyntax index:
+                return TryBindTypeArgumentExpressions(index.Index, out typeArgs) && typeArgs.Length == arity;
+
+            case GenericNameExpressionSyntax generic:
+                return TryBindGenericSegmentArguments(generic, out typeArgs) && typeArgs.Length == arity;
+
+            default:
+                typeArgs = default;
+                return false;
         }
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2209GenericFqnStaticAccessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2209GenericFqnStaticAccessTests.cs
@@ -1,0 +1,96 @@
+// <copyright file="Issue2209GenericFqnStaticAccessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #2209: static member access through a
+/// fully-qualified GENERIC type name (<c>Ns.Sub.Generic[Args].StaticMember</c>)
+/// failed with GS0157 ("Cannot find type System") because
+/// <c>TryBindImportAccessor</c>'s dotted-namespace walk only recognised a
+/// plain <see cref="NameExpressionSyntax"/> segment; a generic-instantiation
+/// segment (<c>Comparer[int32]</c>, parsed as an <see cref="IndexExpressionSyntax"/>
+/// or a <see cref="GenericNameExpressionSyntax"/>) fell through to the
+/// default case and aborted the whole walk at the FIRST segment
+/// (<c>System</c>). The non-generic FQN static-access form
+/// (<c>System.Text.Encoding.UTF8</c>) and the FQN generic CONSTRUCTION form
+/// (<c>System.Collections.Generic.List[int32]()</c>) already worked; this bug
+/// was isolated to the generic-instantiation + static-member combination.
+/// </summary>
+public class Issue2209GenericFqnStaticAccessTests
+{
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+
+    [Fact]
+    public void QualifiedGenericComparerDefault_Compare_Binds()
+    {
+        // The exact repro from the issue.
+        var source = """
+            package T
+            func F() int32 { return System.Collections.Generic.Comparer[int32].Default.Compare(1, 2) }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void UnqualifiedGenericComparerDefault_Compare_StillBinds_Control()
+    {
+        // Control: the same code with an import already worked before the fix
+        // and must keep working after it.
+        var source = """
+            package T
+            import System.Collections.Generic
+            func F() int32 { return Comparer[int32].Default.Compare(1, 2) }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void QualifiedGenericEqualityComparerDefault_Equals_Binds()
+    {
+        // Variation: a different imported generic type, and a further member
+        // access (`.Equals`) chained after the static member (`.Default`) —
+        // mirrors the real-world CommunityToolkit.Mvvm-generated shape from
+        // the issue (`EqualityComparer<T>.Default.Equals(...)`).
+        var source = """
+            package T
+            func F(message string, value string) bool {
+                return System.Collections.Generic.EqualityComparer[string].Default.Equals(message, value)
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void QualifiedGenericImmutableDictionaryEmpty_Count_Binds()
+    {
+        // Variation: a two-type-argument generic (different arity than the
+        // repro's single-argument `Comparer[int32]`), plus a further member
+        // access chained after the static member.
+        var source = """
+            package T
+            func F() int32 { return System.Collections.Immutable.ImmutableDictionary[string, int32].Empty.Count }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2209.

`gsc` failed to resolve a static member access through a fully-qualified **generic** type name — `Ns.Sub.Generic[Args].StaticMember` — while the non-generic FQN static-access form (`System.Text.Encoding.UTF8`) and the FQN generic *construction* form (`System.Collections.Generic.List[int32]()`) already worked.

```gsharp
package T
func F() int32 { return System.Collections.Generic.Comparer[int32].Default.Compare(1, 2) }
```
```
error GS0157: Cannot find type System. Are you missing an import?
```

## Root cause

`TryBindImportAccessor` (`ExpressionBinder.Access.cs`) walks a dotted import-relative accessor chain (`Ns.Sub.Type.Member`) segment by segment, accumulating the namespace prefix until a segment resolves as a CLR type. Its `switch` over the current chain segment only recognized a plain `NameExpressionSyntax` segment (`.Sub`, `.Type`).

A generic instantiation placed in the middle of the chain — `Comparer[int32]` — parses as an `IndexExpressionSyntax` (single type argument) or a `GenericNameExpressionSyntax` (multiple/type-shaped arguments), neither of which is a `NameExpressionSyntax`. Neither shape matched any switch arm, so the walk fell through to `default: return false` at the very **first** segment (`System`), and the caller re-reported the whole chain as an undefined type starting from its leftmost name — hence the misleading "Cannot find type System" diagnostic.

## Fix

Added a case to the segment walk that recognizes a generic-instantiation segment (either shape), resolves the arity-mangled type name (`Prefix.Name\`N`) against the namespace prefix accumulated so far, binds its type argument(s), and closes the generic type via the existing `TryCloseImportedGenericTypeReceiver` helper — mirroring how the adjacent non-generic branch already resolves a plain qualified type name. The rest of the chain (`.Default.Compare(...)`) is then handed back to the caller as an ordinary static-member access on the closed generic type, reusing the same `BindAccessorStep` path already exercised by the non-generic and import-relative-simple-name forms.

This is a general fix — it does not special-case `Comparer`/`EqualityComparer`, and it works for any namespace depth and any generic arity (both the single-argument index-expression shape and the multi-argument/type-shaped generic-name-expression shape).

## Tests

Added `test/Core.Tests/CodeAnalysis/Binding/Issue2209GenericFqnStaticAccessTests.cs`:
- The exact repro from the issue (`System.Collections.Generic.Comparer[int32].Default.Compare(1, 2)`).
- The import-qualified control case (must keep working unchanged).
- A different generic type with a member access chained after the static member (`System.Collections.Generic.EqualityComparer[string].Default.Equals(...)`) — mirrors the real-world CommunityToolkit.Mvvm-generated shape from the issue.
- A different generic arity (two type arguments) with a further member access after the static member (`System.Collections.Immutable.ImmutableDictionary[string, int32].Empty.Count`).

Verified each of the three previously-failing tests fails with GS0157 on the pre-fix code and passes after the fix.

## Validation

- `dotnet test test/Core.Tests/Core.Tests.csproj` — 5797 passed, 1 skipped, 0 failed.
- `dotnet build GSharp.sln` — builds clean, 0 warnings/errors.
- No `SyntaxKind`/`BoundNodeKind` additions, so `docs/coverage-matrix.md` and the coverage-matrix golden test needed no changes (verified unaffected).