### PR TITLE
cs2gs: synthesize imports for shortened fully-qualified type/enum refs

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2211FullyQualifiedNoUsingImportSynthesisTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2211FullyQualifiedNoUsingImportSynthesisTests.cs
@@ -1,0 +1,270 @@
+// <copyright file="Issue2211FullyQualifiedNoUsingImportSynthesisTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2211: back-translating C# that fully-qualifies every type/enum
+/// reference with NO <c>using</c> directives (the shape a Roslyn source
+/// generator emits — see ADR-0145) shortened some of those references to a
+/// bare name without synthesizing the matching <c>import</c>, producing G#
+/// gsc rejects (GS0113/GS0157/GS0202). Root cause: <see cref="CSharpTypeMapper"/>
+/// always shortens a non-nested named type to its simple name
+/// (<c>QualifiedTypeName</c>), relying on the file's own <c>using</c>
+/// directives to supply a matching <c>import</c> — but a generator-shaped
+/// file with no <c>using</c>s at all has none. This affected EVERY call site
+/// funneled through <c>CSharpTypeMapper.Map</c> (enum-constant attribute
+/// arguments, field/local type annotations, generic type arguments, ...),
+/// while a C# attribute's own type name (taken verbatim from syntax, not
+/// through the type mapper) stayed fully qualified — the inconsistency the
+/// issue observed within one file.
+/// <para>
+/// The fix collects every namespace the type mapper shortens a reference into
+/// (<see cref="CSharpTypeMapper.ShortenedNamespaces"/>) and, once the whole
+/// file is translated, synthesizes a matching <c>import</c> for any such
+/// namespace not already covered by the file's own package or an explicit
+/// <c>using</c> (<see cref="CSharpToGSharpTranslator.TranslateDocument"/>).
+/// </para>
+/// </summary>
+public class Issue2211FullyQualifiedNoUsingImportSynthesisTests
+{
+    [Fact]
+    public void EnumArgumentAndFieldType_FullyQualifiedNoUsing_SynthesizesImportAndRoundTrips()
+    {
+        // Mirrors the exact shape from the issue: a generator-emitted file with
+        // NO `using` directives, an attribute whose enum argument is fully
+        // qualified, and a field of a fully-qualified BCL type.
+        string printed = TranslateUnit(@"
+namespace CommunityToolkit.Mvvm.ComponentModel.__Internals
+{
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static class __KnownINotifyPropertyChangedArgs
+    {
+        public static readonly global::System.ComponentModel.PropertyChangedEventArgs Message =
+            new global::System.ComponentModel.PropertyChangedEventArgs(""Message"");
+    }
+}");
+
+        Assert.Contains("import System.ComponentModel", printed);
+        Assert.Contains("EditorBrowsableState.Never", printed);
+        Assert.Contains("PropertyChangedEventArgs", printed);
+
+        // Every shortened reference must actually resolve: compile the printed
+        // G# with the real gsc. gsc's default (no `/r:`) resolver only probes
+        // its own host process's already-loaded assemblies plus a small
+        // well-known BCL set (System.Runtime, System.Private.CoreLib, ...) —
+        // `PropertyChangedEventArgs` lives in System.ObjectModel.dll, which
+        // that process never otherwise loads, so it must be passed explicitly
+        // (an infra fact unrelated to this translator fix).
+        AssertCompiles(
+            printed,
+            typeof(System.ComponentModel.PropertyChangedEventArgs).Assembly.Location,
+            typeof(object).Assembly.Location);
+    }
+
+    [Fact]
+    public void NestedEnumAccessInAttributeArgument_FullyQualifiedNoUsing_SynthesizesImport()
+    {
+        // A NESTED BCL enum (`System.Environment.SpecialFolder`) referenced
+        // fully-qualified as an attribute argument, with no `using` for its
+        // namespace. Exercises the nested-type branch of
+        // `CSharpTypeMapper.QualifiedTypeName` (distinct from the top-level
+        // `EditorBrowsableState` in the first test).
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class TagAttribute : global::System.Attribute
+    {
+        public TagAttribute(global::System.Environment.SpecialFolder folder) { }
+    }
+
+    [Tag(global::System.Environment.SpecialFolder.ApplicationData)]
+    public class Marker
+    {
+    }
+}");
+
+        Assert.Contains("SpecialFolder.ApplicationData", printed);
+        Assert.Contains(printed.Split('\n').Select(l => l.Trim()), l => l == "import System");
+
+        // ponytail: skip a second real-gsc compile here — the first test
+        // already proves the mechanism compiles end-to-end; running gsc as a
+        // subprocess for every generality case here multiplies process load
+        // for no extra coverage (GSharpRoundTrip.Validate inside TranslateUnit
+        // already proves the printed text re-parses).
+    }
+
+    [Fact]
+    public void LocalVariableType_FullyQualifiedNoUsing_SynthesizesImport()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int Length()
+        {
+            global::System.Text.StringBuilder builder = new global::System.Text.StringBuilder(""hi"");
+            return builder.Length;
+        }
+    }
+}");
+
+        Assert.Contains("import System.Text", printed);
+        Assert.Contains("StringBuilder", printed);
+    }
+
+    [Fact]
+    public void GenericTypeArgument_FullyQualifiedNoUsing_SynthesizesImport()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public global::System.Collections.Generic.List<global::System.Text.StringBuilder> Items()
+        {
+            return new global::System.Collections.Generic.List<global::System.Text.StringBuilder>();
+        }
+    }
+}");
+
+        Assert.Contains("import System.Collections.Generic", printed);
+        Assert.Contains("import System.Text", printed);
+    }
+
+    [Fact]
+    public void NamespaceAlreadyCoveredByUsing_NoDuplicateImportSynthesized()
+    {
+        // Control: when a `using` already exists for the shortened
+        // namespace, no synthesized duplicate is added.
+        string printed = TranslateUnit(@"
+using System.ComponentModel;
+
+namespace Demo
+{
+    public class C
+    {
+        public PropertyChangedEventArgs Field = new PropertyChangedEventArgs(""X"");
+    }
+}");
+
+        Assert.Equal(1, CountOccurrences(printed, "import System.ComponentModel"));
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="printed"/> with the real <c>gsc</c> and asserts
+    /// zero errors — proving every shortened reference actually resolves, not
+    /// just that the text happens to look right.
+    /// </summary>
+    private static void AssertCompiles(string printed, params string[] extraReferences)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-2211-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(gsPath, printed);
+
+        string refArgs = string.Concat(extraReferences.Select(r => $" /r:\"{r}\""));
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:library{refArgs} /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated snippet with zero errors. Output:\n" + compileOut +
+                "\n\nTranslated G#:\n" + printed);
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+
+        // Read stdout/stderr concurrently to avoid a classic pipe deadlock:
+        // reading one stream fully before starting the other can hang forever
+        // if the child fills the OS pipe buffer on the stream not yet read.
+        Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+        Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+        Task.WaitAll(stdoutTask, stderrTask);
+        process.WaitForExit();
+        return (process.ExitCode, stdoutTask.Result + stderrTask.Result);
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -151,7 +151,8 @@ public sealed class CSharpToGSharpTranslator
         IMethodSymbol entryPoint = context.Compilation.GetEntryPoint(default);
         INamedTypeSymbol entryType = entryPoint?.ContainingType;
 
-        var visitor = new DeclarationVisitor(context, new CSharpTypeMapper(), openBases, staticUsingTargets, entryPoint, partialTypeParts, this.preservePartialParts);
+        var typeMapper = new CSharpTypeMapper();
+        var visitor = new DeclarationVisitor(context, typeMapper, openBases, staticUsingTargets, entryPoint, partialTypeParts, this.preservePartialParts);
 
         var members = new List<GNode>();
         var trailingStatements = new List<GNode>();
@@ -184,7 +185,27 @@ public sealed class CSharpToGSharpTranslator
         // entry runs with all package types and funcs already in scope.
         members.AddRange(trailingStatements);
 
-        return new CompilationUnit(package, imports, members);
+        // Issue #2211: a Roslyn source generator (and other fully-qualified,
+        // no-`using` C# input) can reference a BCL/external type by its
+        // fully-qualified name with no matching `using` directive. The type
+        // mapper still shortens such a reference to its bare name (§B.7/§B.12
+        // qualification rules), so without a corresponding `import` the
+        // shortened name is unresolvable in the emitted G# (GS0113/GS0157).
+        // Synthesize the missing imports here, once every member is
+        // translated (so every shortened reference has been recorded) —
+        // skipping the file's own package (needs no import) and any namespace
+        // an explicit `using` already covers.
+        var allImports = imports is List<ImportDirective> list ? list : imports.ToList();
+        var alreadyImported = new HashSet<string>(allImports.Select(i => i.Name));
+        foreach (string ns in typeMapper.ShortenedNamespaces.OrderBy(n => n, System.StringComparer.Ordinal))
+        {
+            if (ns != package && alreadyImported.Add(ns))
+            {
+                allImports.Add(new ImportDirective(ns));
+            }
+        }
+
+        return new CompilationUnit(package, allImports, members);
     }
 
     // Forwards to the canonical identifier sanitizer implemented on the nested

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -39,11 +39,31 @@ public sealed class CSharpTypeMapper
     public const string UnsupportedPlaceholderType = "object";
 
     /// <summary>
+    /// Issue #2211: every namespace this mapper has shortened a type reference
+    /// into (via <see cref="QualifiedTypeName"/>), collected so the translator
+    /// can synthesize a matching <c>import</c> for a namespace with no
+    /// corresponding <c>using</c> directive in the source file — the shape
+    /// Roslyn source generators emit (fully-qualified references, no
+    /// <c>using</c>s at all). Without this, a short-named reference to a type
+    /// whose namespace has no <c>using</c> directive round-trips to unresolvable
+    /// G# (GS0113/GS0157). The translator filters out the file's own package
+    /// and any namespace already covered by an explicit <c>using</c> before
+    /// emitting the rest as synthesized imports.
+    /// </summary>
+    private readonly HashSet<string> shortenedNamespaces = new();
+
+    /// <summary>
     /// Issue #1174: cached per-compilation census of source-declared type simple
     /// names (built lazily on first use), used to decide whether a source nested
     /// type's simple name is ambiguous and must be emitted in qualified form.
     /// </summary>
     private Dictionary<string, int> sourceSimpleNameCounts;
+
+    /// <summary>
+    /// Gets every namespace shortened into a bare/qualified-nested type name by
+    /// this mapper so far (see <see cref="shortenedNamespaces"/>).
+    /// </summary>
+    public IReadOnlyCollection<string> ShortenedNamespaces => this.shortenedNamespaces;
 
     /// <summary>
     /// Maps a Roslyn type symbol to its canonical G# type reference, recording
@@ -457,6 +477,7 @@ public sealed class CSharpTypeMapper
     {
         if (named.ContainingType == null)
         {
+            this.TrackShortenedNamespace(named);
             return CSharpToGSharpTranslator.SanitizeIdentifier(named.Name);
         }
 
@@ -468,12 +489,31 @@ public sealed class CSharpTypeMapper
         }
 
         var parts = new List<string>();
+        INamedTypeSymbol outermost = named;
         for (INamedTypeSymbol current = named; current != null; current = current.ContainingType)
         {
             parts.Insert(0, CSharpToGSharpTranslator.SanitizeIdentifier(current.Name));
+            outermost = current;
         }
 
+        this.TrackShortenedNamespace(outermost);
         return string.Join(".", parts);
+    }
+
+    /// <summary>
+    /// Issue #2211: records <paramref name="outermostType"/>'s namespace as one
+    /// this mapper shortened a reference into, so the translator can synthesize
+    /// a matching <c>import</c> when no <c>using</c> directive already covers it
+    /// (see <see cref="shortenedNamespaces"/>). The global namespace (no
+    /// namespace at all) needs no import and is skipped.
+    /// </summary>
+    /// <param name="outermostType">The outermost containing type of the reference (itself, if not nested).</param>
+    private void TrackShortenedNamespace(INamedTypeSymbol outermostType)
+    {
+        if (outermostType.ContainingNamespace is { IsGlobalNamespace: false } ns)
+        {
+            this.shortenedNamespaces.Add(ns.ToDisplayString());
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #2211.

## Problem

When back-translating C# that fully-qualifies every type/enum reference with no `using` directives (the shape a Roslyn source generator emits, e.g. ADR-0145's gsgen host), `cs2gs` sometimes shortened a reference to a bare name without emitting a matching `import`, producing G# that `gsc` rejects with GS0113/GS0157/GS0202. Qualification was applied inconsistently within one file: an attribute's own type name stayed fully qualified while an enum-argument value or field type on the same line got shortened with no import.

## Root cause

`CSharpTypeMapper.QualifiedTypeName` (the single choke point used for field/local type annotations, generic type arguments, and enum-constant values) always shortens a type reference to its bare name, trusting that a `using` directive already covers it. `CSharpToGSharpTranslator.TranslateDocument` computed the G# import list once, up front, purely from the C# file's own `using` directives - it never reconciled that list against what the type mapper actually shortened afterward. Ordinary hand-written C# always has a `using` for anything it references by short name, so this never showed up until generator-emitted code (fully qualified, zero `using`s) hit the same path.

Separately, `TranslateAttributeName` takes an attribute's type name verbatim from C# syntax (only stripping `global::`) and never goes through `CSharpTypeMapper` at all - that's why the attribute type in the issue's repro stayed fully qualified while the enum argument right next to it didn't: two different code paths with different rules.

## Fix

`CSharpTypeMapper` now tracks every namespace it shortens a reference into (`ShortenedNamespaces`). Once a document's members are fully translated, `TranslateDocument` merges that set into the emitted import list, skipping the file's own package and any namespace already covered by an explicit `using`. This fixes the general mechanism - not just the two types named in the issue - so any fully-qualified type or enum-value reference the mapper shortens now gets a matching `import` synthesized for it.

Import synthesis was chosen over full-qualification-preservation per the issue's own recommendation, since it matches idiomatic hand-written G# (short names + imports).

## Tests

Added `tools/cs2gs/Cs2Gs.Tests/Issue2211FullyQualifiedNoUsingImportSynthesisTests.cs`:
- Exact issue repro: `EditorBrowsable` attribute with an enum argument + a fully-qualified field type, no `using`s. Asserts the import is synthesized and also compiles the emitted G# with the real `gsc` end-to-end to prove the reference actually resolves (not just that the text looks right).
- Nested enum access in an attribute argument (distinct branch of `QualifiedTypeName`).
- A local variable type reference.
- A generic type argument reference.
- A control case proving no duplicate import is synthesized when a `using` already covers the namespace.

## Validation

- `dotnet build GSharp.sln` - succeeds, 0 errors/warnings.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj` - targeted new tests pass consistently; full suite (~1191 tests) passes with 0 failures on clean runs. Note: this sandbox occasionally aborts the full suite with "Test host process crashed" under heavy parallel load, independent of this change's content (confirmed pre-existing/environmental - reproduced identically on unmodified `main` and shown to be non-deterministic by re-running an unchanged test-file state and getting a different pass/crash outcome each time). Not something this PR can or should fix.

There is no `samples/SourceGen` sample in this repo to regenerate (checked, not present).
