### PR TITLE
Fixes #2237: assembly attribute support has parity with C#

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -76,6 +76,13 @@ public sealed class Binder
     internal static readonly ImmutableHashSet<AttributeTargetKind> VariableDeclarationAllowedTargets =
         ImmutableHashSet.Create(AttributeTargetKind.Field);
 
+    /// <summary>
+    /// Targets permitted on a file-level <c>@assembly:</c> annotation lead-in
+    /// (ADR-0047 §2/§10, issue #2237): only <c>assembly</c>.
+    /// </summary>
+    internal static readonly ImmutableHashSet<AttributeTargetKind> AssemblyDeclarationAllowedTargets =
+        ImmutableHashSet.Create(AttributeTargetKind.Assembly);
+
     // PR-B-1: cross-cutting binder state lives on BinderContext so the
     // upcoming Binder-component extractions (MemberLookup, ConversionClassifier,
     // OverloadResolver, …) can consume it via constructor injection. The
@@ -994,6 +1001,25 @@ public sealed class Binder
             ?? ResolveEntryPointPackage(packageByTree, globalStatements, functions, packagesInOrder);
         var entryPoint = ResolveEntryPoint(binder, functions, structs, globalStatements, syntaxTrees, entryPointPackage, synthesizedEntryPoint);
 
+        // Issue #2237: bind every `@assembly:` annotation EXCEPT
+        // InternalsVisibleTo (which keeps its own early, syntactic
+        // fast path below via FriendAssemblyDeclarations.Collect) through
+        // the SAME general attribute binder used for every other
+        // declaration position, so any attribute type the compiler can
+        // resolve (AssemblyVersionAttribute, AssemblyMetadataAttribute, a
+        // same-compilation user attribute, ...) becomes a real
+        // assembly-level CustomAttribute row — full parity with C#'s
+        // `[assembly: ...]`. Must run before the diagnostics snapshot below
+        // so any reported diagnostics (e.g. "attribute type not found") are
+        // captured.
+        var otherAssemblyAnnotations = FriendAssemblyDeclarations.CollectOtherAnnotations(syntaxTrees);
+        var boundAssemblyAttributes = binder.declarations.BindAttributes(
+            otherAssemblyAnnotations,
+            AttributeTargetKind.Assembly,
+            AssemblyDeclarationAllowedTargets,
+            "assembly declaration",
+            System.AttributeTargets.Assembly);
+
         var diagnostics = binder.Diagnostics.ToImmutableArray();
 
         if (previous != null)
@@ -1005,6 +1031,9 @@ public sealed class Binder
 
         var result = new BoundGlobalScope(previous, entryPointPackage, packagesInOrder.ToImmutable(), diagnostics, imports, functions, variables, typeAliases, structs, interfaces, enums, delegates, entryPoint, statements.ToImmutable());
         result.PreprocessorSymbols = preprocessorSymbols ?? ImmutableHashSet<string>.Empty;
+        result.AssemblyAttributes = previous == null
+            ? boundAssemblyAttributes
+            : previous.AssemblyAttributes.AddRange(boundAssemblyAttributes);
 
         // Issue #1929/#1953: collect producer-declared friend assemblies
         // (`@assembly:InternalsVisibleTo("...")`) so the emitter can write
@@ -1022,6 +1051,7 @@ public sealed class Binder
             {
                 PreprocessorSymbols = result.PreprocessorSymbols,
                 FriendAssemblies = result.FriendAssemblies,
+                AssemblyAttributes = result.AssemblyAttributes,
             };
         }
 
@@ -1533,6 +1563,7 @@ public sealed class Binder
         {
             Imports = globalScope.GetCumulativeImports(),
             FriendAssemblies = globalScope.FriendAssemblies,
+            AssemblyAttributes = globalScope.AssemblyAttributes,
         };
     }
 

--- a/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
@@ -292,6 +292,16 @@ public sealed class BoundGlobalScope
     public ImmutableArray<string> FriendAssemblies { get; internal set; } = ImmutableArray<string>.Empty;
 
     /// <summary>
+    /// Gets every file-level <c>@assembly:</c> annotation (issue #2237)
+    /// EXCEPT <c>InternalsVisibleTo</c> (see <see cref="FriendAssemblies"/>),
+    /// bound through the general attribute binder so any C#-parity assembly
+    /// attribute (<c>AssemblyVersionAttribute</c>,
+    /// <c>AssemblyMetadataAttribute</c>, a same-compilation user attribute,
+    /// ...) becomes a real assembly-level <c>CustomAttribute</c> row.
+    /// </summary>
+    public ImmutableArray<BoundAttribute> AssemblyAttributes { get; internal set; } = ImmutableArray<BoundAttribute>.Empty;
+
+    /// <summary>
     /// Returns every import visible across the whole <see cref="Previous"/>
     /// chain, oldest submission first (issue #2101). This is the cumulative
     /// view that <see cref="Imports"/> itself used to provide directly —

--- a/src/Core/CodeAnalysis/Binding/BoundProgram.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundProgram.cs
@@ -269,4 +269,14 @@ public sealed class BoundProgram
     /// row per entry.
     /// </summary>
     public ImmutableArray<string> FriendAssemblies { get; internal set; } = ImmutableArray<string>.Empty;
+
+    /// <summary>
+    /// Gets every file-level <c>@assembly:</c> annotation (issue #2237)
+    /// EXCEPT <c>InternalsVisibleTo</c> (see <see cref="FriendAssemblies"/>).
+    /// Populated from <see cref="BoundGlobalScope.AssemblyAttributes"/>; the
+    /// emitter writes one real <c>CustomAttribute</c> row per entry via the
+    /// same generic <c>CustomAttributeEncoder.EmitBoundAttribute</c> path
+    /// used for every other declaration-level attribute.
+    /// </summary>
+    public ImmutableArray<BoundAttribute> AssemblyAttributes { get; internal set; } = ImmutableArray<BoundAttribute>.Empty;
 }

--- a/src/Core/CodeAnalysis/Binding/FriendAssemblyDeclarations.cs
+++ b/src/Core/CodeAnalysis/Binding/FriendAssemblyDeclarations.cs
@@ -21,16 +21,61 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// declared friendship).
 ///
 /// This intentionally does not go through the general <c>@Attribute</c>
-/// binder (<c>DeclarationBinder.BindAttributes</c>): assembly attributes are
-/// resolved before any type is bound, and the only shape gsc supports today
-/// is a single string-literal argument, so a syntactic read is sufficient
-/// and avoids a much larger "arbitrary assembly-level custom attribute"
-/// binding/emit feature that nothing here needs yet.
+/// binder (<c>DeclarationBinder.BindAttributes</c>): friend-assembly names
+/// must be known as plain strings very early (before internal-visibility
+/// checks against previously-compiled references), so a syntactic,
+/// string-literal-only read is sufficient and keeps that specific opt-in
+/// resolvable without a full expression bind.
+///
+/// Issue #2237: every OTHER <c>@assembly:</c> annotation (i.e. anything that
+/// isn't <c>InternalsVisibleTo</c>) is bound through the general attribute
+/// binder instead — see <see cref="CollectOtherAnnotations"/> and
+/// <c>Binder.BindGlobalScope</c>'s <c>AssemblyAttributes</c> handling — so
+/// arbitrary C#-parity assembly attributes (<c>AssemblyVersionAttribute</c>,
+/// <c>AssemblyMetadataAttribute</c>, a same-compilation user attribute, ...)
+/// become real assembly-level <c>CustomAttribute</c> rows.
 /// </summary>
 internal static class FriendAssemblyDeclarations
 {
     private const string AnnotationName = "InternalsVisibleTo";
     private const string AnnotationNameWithSuffix = "InternalsVisibleToAttribute";
+
+    /// <summary>
+    /// Collects every file-level <c>@assembly:</c> annotation across
+    /// <paramref name="syntaxTrees"/> EXCEPT <c>InternalsVisibleTo</c> (which
+    /// <see cref="Collect"/> already handles via its own syntactic,
+    /// string-literal-only fast path). Used by <c>Binder.BindGlobalScope</c>
+    /// to feed the remaining annotations through the general attribute
+    /// binder (issue #2237).
+    /// </summary>
+    /// <param name="syntaxTrees">The syntax trees making up the compilation.</param>
+    /// <returns>The non-<c>InternalsVisibleTo</c> assembly-level annotations, in source order.</returns>
+    public static ImmutableArray<AnnotationSyntax> CollectOtherAnnotations(ImmutableArray<SyntaxTree> syntaxTrees)
+    {
+        if (syntaxTrees.IsDefaultOrEmpty)
+        {
+            return ImmutableArray<AnnotationSyntax>.Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<AnnotationSyntax>();
+        foreach (var tree in syntaxTrees)
+        {
+            var annotations = tree.Root?.AssemblyAttributes ?? ImmutableArray<AnnotationSyntax>.Empty;
+            foreach (var annotation in annotations)
+            {
+                var name = annotation.GetNameText();
+                if (string.Equals(name, AnnotationName, StringComparison.Ordinal)
+                    || string.Equals(name, AnnotationNameWithSuffix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                builder.Add(annotation);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
 
     /// <summary>
     /// Collects the distinct friend-assembly names declared via
@@ -59,7 +104,9 @@ internal static class FriendAssemblyDeclarations
                 if (!string.Equals(name, AnnotationName, StringComparison.Ordinal)
                     && !string.Equals(name, AnnotationNameWithSuffix, StringComparison.Ordinal))
                 {
-                    diagnostics?.ReportUnsupportedAssemblyAnnotation(GetNameLocation(annotation), name);
+                    // Issue #2237: no longer unsupported — every other
+                    // `@assembly:` annotation is bound generically by
+                    // `Binder.BindGlobalScope` via `CollectOtherAnnotations`.
                     continue;
                 }
 

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -720,18 +720,6 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
-    /// Reports a file-level <c>@assembly:</c> annotation whose name is not
-    /// <c>InternalsVisibleTo</c> — the only assembly-scoped annotation gsc
-    /// currently understands (issue #1929/#1953 friend-assembly opt-in).
-    /// </summary>
-    /// <param name="location">The source location of the annotation name.</param>
-    /// <param name="name">The unsupported annotation name as written in source.</param>
-    public void ReportUnsupportedAssemblyAnnotation(TextLocation location, string name)
-    {
-        Report(location, "GS0464", $"'@assembly:{name}' is not supported. The only file-level assembly annotation gsc emits today is '@assembly:InternalsVisibleTo(\"OtherAssemblyName\")'.");
-    }
-
-    /// <summary>
     /// Reports an <c>@assembly:InternalsVisibleTo(...)</c> annotation whose
     /// single argument is not a string literal (the friend assembly name must
     /// be a compile-time constant known to gsc without full expression

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -3511,9 +3511,19 @@ internal sealed class ReflectionMetadataEmitter
     /// </summary>
     private void EmitAssemblyInteropAttributes(AssemblyDefinitionHandle assemblyHandle)
     {
+        // Issue #2237: emit every user-declared `@assembly:` attribute
+        // (everything except InternalsVisibleTo, which keeps its dedicated
+        // emission below) first, so the built-in synthesized attributes that
+        // follow can detect — and skip — a type the user already declared
+        // explicitly (e.g. an NBGV-style
+        // `@assembly:AssemblyInformationalVersionAttribute(...)`), avoiding a
+        // duplicate, non-repeatable CustomAttribute row.
+        var userDeclaredAttributeTypeNames = this.EmitUserAssemblyAttributes(assemblyHandle);
+
         // 1. AssemblyInformationalVersionAttribute — carries the full NuGet
         // version string including pre-release suffix.
-        if (!string.IsNullOrEmpty(this.emitCtx.AssemblyVersionOverride))
+        if (!string.IsNullOrEmpty(this.emitCtx.AssemblyVersionOverride)
+            && !userDeclaredAttributeTypeNames.Contains("System.Reflection.AssemblyInformationalVersionAttribute"))
         {
             this.customAttrEncoder.EmitStringAttribute(
                 assemblyHandle,
@@ -3535,6 +3545,41 @@ internal sealed class ReflectionMetadataEmitter
         // nullable context as "annotated" so C# consumers see non-null by
         // default for GSharp types (GSharp has no null references).
         this.EmitNullableContextAttribute(assemblyHandle);
+    }
+
+    /// <summary>
+    /// Issue #2237: emits a real <c>CustomAttribute</c> row for every
+    /// file-level <c>@assembly:</c> annotation the binder resolved
+    /// (<see cref="Binding.BoundProgram.AssemblyAttributes"/>) — every
+    /// annotation EXCEPT <c>InternalsVisibleTo</c>, which
+    /// <see cref="EmitFriendAssemblyAttributes"/> already covers. Reuses the
+    /// same generic <see cref="CustomAttributeEncoder.EmitBoundAttribute"/>
+    /// path used for type/method/field-level attributes, so any attribute
+    /// type the compiler can resolve — BCL (<c>AssemblyVersionAttribute</c>,
+    /// <c>AssemblyMetadataAttribute</c>, ...) or a same-compilation
+    /// user-declared attribute type — becomes real assembly metadata,
+    /// achieving parity with C#'s <c>[assembly: ...]</c>.
+    /// </summary>
+    /// <returns>
+    /// The distinct set of emitted attributes' CLR type full names, used by
+    /// <see cref="EmitAssemblyInteropAttributes"/> to avoid emitting a
+    /// duplicate built-in synthesized attribute of the same (non-repeatable)
+    /// type.
+    /// </returns>
+    private ImmutableHashSet<string> EmitUserAssemblyAttributes(AssemblyDefinitionHandle assemblyHandle)
+    {
+        var emitted = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
+        foreach (var attr in this.emitCtx.Program.AssemblyAttributes)
+        {
+            this.customAttrEncoder.EmitBoundAttribute(assemblyHandle, attr);
+            var clrTypeName = attr.AttributeType?.ClrType?.FullName;
+            if (clrTypeName != null)
+            {
+                emitted.Add(clrTypeName);
+            }
+        }
+
+        return emitted.ToImmutable();
     }
 
     private void EmitFriendAssemblyAttributes(AssemblyDefinitionHandle assemblyHandle)

--- a/src/Core/CodeAnalysis/Lowering/BaseCallForwarderRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/BaseCallForwarderRewriter.cs
@@ -131,6 +131,7 @@ public static class BaseCallForwarderRewriter
         {
             Imports = program.Imports,
             FriendAssemblies = program.FriendAssemblies,
+            AssemblyAttributes = program.AssemblyAttributes,
         };
     }
 

--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -152,6 +152,7 @@ internal static class CaptureBoxingRewriter
         {
             Imports = program.Imports,
             FriendAssemblies = program.FriendAssemblies,
+            AssemblyAttributes = program.AssemblyAttributes,
         };
 
         return result;

--- a/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
@@ -228,6 +228,7 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
         {
             Imports = program.Imports,
             FriendAssemblies = program.FriendAssemblies,
+            AssemblyAttributes = program.AssemblyAttributes,
         };
     }
 

--- a/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
@@ -113,6 +113,7 @@ internal sealed class InterpolatedStringHandlerLowerer : NestedFunctionBodyRewri
         {
             Imports = program.Imports,
             FriendAssemblies = program.FriendAssemblies,
+            AssemblyAttributes = program.AssemblyAttributes,
         };
 
         return result;

--- a/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
@@ -122,6 +122,7 @@ internal sealed class SideEffectSpiller : NestedFunctionBodyRewriter
         {
             Imports = program.Imports,
             FriendAssemblies = program.FriendAssemblies,
+            AssemblyAttributes = program.AssemblyAttributes,
         };
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2237AssemblyAttributeParityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2237AssemblyAttributeParityTests.cs
@@ -1,0 +1,204 @@
+// <copyright file="Issue2237AssemblyAttributeParityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2237: file-level <c>@assembly:</c> annotations must reach parity
+/// with C#'s <c>[assembly: ...]</c> — any attribute type the compiler can
+/// resolve (BCL or a same-compilation user-declared attribute), not just
+/// <c>InternalsVisibleTo</c>.
+/// </summary>
+public class Issue2237AssemblyAttributeParityTests
+{
+    [Fact]
+    public void Binds_NonInternalsVisibleTo_Assembly_Annotation_Into_AssemblyAttributes()
+    {
+        var globalScope = BindSource(
+            """
+            package MyApp
+            @assembly:System.Reflection.AssemblyMetadataAttribute("Key", "Value")
+
+            func Main() {
+            }
+            """);
+
+        Assert.Empty(GetBinderDiagnostics(globalScope));
+        var attr = Assert.Single(globalScope.AssemblyAttributes);
+        Assert.Equal("System.Reflection.AssemblyMetadataAttribute", attr.AttributeType.Name);
+        Assert.Equal(AttributeTargetKind.Assembly, attr.Target);
+        Assert.Equal(2, attr.PositionalArguments.Length);
+        Assert.Equal("Key", attr.PositionalArguments[0].Value);
+        Assert.Equal("Value", attr.PositionalArguments[1].Value);
+    }
+
+    [Fact]
+    public void InternalsVisibleTo_Annotation_Is_Excluded_From_AssemblyAttributes_But_Kept_In_FriendAssemblies()
+    {
+        // InternalsVisibleTo keeps its own early, syntactic fast path
+        // (FriendAssemblies) so it isn't double-bound/double-emitted via the
+        // general AssemblyAttributes list.
+        var globalScope = BindSource(
+            """
+            package MyApp
+            @assembly:InternalsVisibleTo("Some.Other.Assembly")
+            @assembly:System.Reflection.AssemblyMetadataAttribute("Key", "Value")
+
+            func Main() {
+            }
+            """);
+
+        Assert.Empty(GetBinderDiagnostics(globalScope));
+        Assert.Equal(new[] { "Some.Other.Assembly" }, globalScope.FriendAssemblies);
+        var attr = Assert.Single(globalScope.AssemblyAttributes);
+        Assert.Equal("System.Reflection.AssemblyMetadataAttribute", attr.AttributeType.Name);
+    }
+
+    [Fact]
+    public void Reports_AttributeTypeNotFound_Instead_Of_The_Old_Fixed_GS0464_For_Unknown_Assembly_Attribute()
+    {
+        var globalScope = BindSource(
+            """
+            package MyApp
+            @assembly:TotallyBogusAttribute("x")
+
+            func Main() {
+            }
+            """);
+
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0198");
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0464");
+        Assert.Empty(globalScope.AssemblyAttributes);
+    }
+
+    [Fact]
+    public void Emits_Multiple_Arbitrary_Assembly_Attributes_As_Real_CustomAttribute_Rows()
+    {
+        const string source = """
+            package MyApp
+            @assembly:InternalsVisibleTo("Friend.Assembly")
+            @assembly:System.Reflection.AssemblyFileVersionAttribute("1.3.1.0")
+            @assembly:System.CodeDom.Compiler.GeneratedCodeAttribute("Nerdbank.GitVersioning.Tasks", "1.0")
+
+            func Main() {
+            }
+            """;
+
+        using var pe = Compile(source);
+        var typeNames = GetAssemblyCustomAttributeTypeNames(pe);
+
+        Assert.Contains("System.Runtime.CompilerServices.InternalsVisibleToAttribute", typeNames);
+        Assert.Contains("System.Reflection.AssemblyFileVersionAttribute", typeNames);
+        Assert.Contains("System.CodeDom.Compiler.GeneratedCodeAttribute", typeNames);
+    }
+
+    [Fact]
+    public void Does_Not_Duplicate_AssemblyInformationalVersionAttribute_When_User_Declares_It_Explicitly()
+    {
+        // The emitter also synthesizes AssemblyInformationalVersionAttribute
+        // from the /version:-style override when present; an explicit
+        // user `@assembly:` declaration of the same (non-repeatable)
+        // attribute type must win instead of producing a duplicate row.
+        const string source = """
+            package MyApp
+            @assembly:System.Reflection.AssemblyInformationalVersionAttribute("1.3.0-explicit")
+
+            func Main() {
+            }
+            """;
+
+        var pe = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(pe, pdbStream: null, refStream: null, assemblyName: "Issue2237Dedup", assemblyVersion: "9.9.9-override");
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        pe.Position = 0;
+
+        using var peReader = new PEReader(pe, PEStreamOptions.LeaveOpen);
+        var md = peReader.GetMetadataReader();
+        var assembly = md.GetAssemblyDefinition();
+
+        var count = 0;
+        foreach (var cah in assembly.GetCustomAttributes())
+        {
+            if (GetAttributeTypeName(md, cah) == "System.Reflection.AssemblyInformationalVersionAttribute")
+            {
+                count++;
+            }
+        }
+
+        Assert.Equal(1, count);
+    }
+
+    private static BoundGlobalScope BindSource(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+
+    private static System.Collections.Generic.IEnumerable<GSharp.Core.CodeAnalysis.Diagnostic> GetBinderDiagnostics(BoundGlobalScope scope)
+    {
+        return scope.Diagnostics;
+    }
+
+    private static MemoryStream Compile(string source)
+    {
+        var pe = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(pe);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        pe.Position = 0;
+        return pe;
+    }
+
+    private static System.Collections.Generic.HashSet<string> GetAssemblyCustomAttributeTypeNames(MemoryStream pe)
+    {
+        using var peReader = new PEReader(pe, PEStreamOptions.LeaveOpen);
+        var md = peReader.GetMetadataReader();
+        var assembly = md.GetAssemblyDefinition();
+
+        var names = new System.Collections.Generic.HashSet<string>();
+        foreach (var cah in assembly.GetCustomAttributes())
+        {
+            var name = GetAttributeTypeName(md, cah);
+            if (name != null)
+            {
+                names.Add(name);
+            }
+        }
+
+        return names;
+    }
+
+    private static string GetAttributeTypeName(MetadataReader md, CustomAttributeHandle cah)
+    {
+        var ca = md.GetCustomAttribute(cah);
+        var ctor = ca.Constructor;
+        if (ctor.Kind == HandleKind.MemberReference)
+        {
+            var mr = md.GetMemberReference((MemberReferenceHandle)ctor);
+            if (mr.Parent.Kind == HandleKind.TypeReference)
+            {
+                var tr = md.GetTypeReference((TypeReferenceHandle)mr.Parent);
+                return md.GetString(tr.Namespace) + "." + md.GetString(tr.Name);
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2237.

`@assembly:` annotations were previously restricted to a single hard-coded case: `@assembly:InternalsVisibleTo("...")`. Every other assembly-level annotation (e.g. `@assembly:System.Reflection.AssemblyVersionAttribute("1.3.0.0")`) reported the fixed diagnostic GS0464, even though ADR-0047 already specifies that `@assembly:`/`@module:` annotations should route generically to assembly/module metadata like any other attribute.

## Changes

- Every `@assembly:` annotation (except `InternalsVisibleTo`, which keeps its early syntactic fast path used for friend-assembly resolution) is now bound through the same general attribute binder (`DeclarationBinder.BindAttributes`) used for every other declaration position (types, methods, fields, ...), with `AttributeTargetKind.Assembly` / `System.AttributeTargets.Assembly`.
- This means arbitrary attribute types now work at assembly scope: BCL attributes (`AssemblyVersionAttribute`, `AssemblyFileVersionAttribute`, `AssemblyMetadataAttribute`, `GeneratedCodeAttribute`, `ExcludeFromCodeCoverageAttribute`, ...) as well as same-compilation user-declared attribute types.
- `BoundGlobalScope`/`BoundProgram` gain an `AssemblyAttributes` list (threaded through every lowering pass alongside the existing `FriendAssemblies`).
- `ReflectionMetadataEmitter` emits each bound assembly attribute via the existing generic `CustomAttributeEncoder.EmitBoundAttribute` path (the same one already used for type/method/field-level attributes), and skips synthesizing its own `AssemblyInformationalVersionAttribute` when the user already declared one explicitly, avoiding a duplicate non-repeatable `CustomAttribute` row.
- Unknown/invalid assembly attribute names now get the normal `GS0198`/`GS0200`/etc. diagnostics instead of the old fixed GS0464 message, which has been removed as dead code.
- `FriendAssemblyDeclarations` (the `InternalsVisibleTo`-only syntactic fast path) is unchanged in behavior, aside from no longer reporting GS0464 for names it doesn't recognize — those now flow through the general binder instead.

## Testing

- `dotnet build GSharp.sln` — success.
- `dotnet test test/Core.Tests/Core.Tests.csproj` — 5810 passed (5805 pre-existing + 5 new), 1 skipped (pre-existing, unrelated `RegenerateBaseline`).
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj` — 1192 passed.
- Manual repro of the issue's NBGV-style example (`@assembly:AssemblyVersionAttribute`, `AssemblyFileVersionAttribute`, `AssemblyInformationalVersionAttribute`) compiles and the emitted assembly was verified via reflection to carry all three real `CustomAttribute` rows.
- Added `test/Core.Tests/CodeAnalysis/Binding/Issue2237AssemblyAttributeParityTests.cs` covering: binder-level resolution into `AssemblyAttributes`, `InternalsVisibleTo` exclusion/no-double-emission, the new attribute-not-found diagnostic (replacing GS0464), a full emit round-trip verifying real metadata rows, and the AssemblyInformationalVersionAttribute dedup guard.