### PR TITLE
Fixes #2232: async func returning a tuple with a user-defined element drops its Task wrapper (GS0133)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -958,8 +958,17 @@ internal sealed class LambdaBinder
             // constructed generic like `Box[U]`) through the same symbolic
             // Task<T> construction so the call-site observable return type
             // stays `Task[U]` instead of silently dropping the Task wrapper.
-            if ((element is StructSymbol or InterfaceSymbol or EnumSymbol
-                || (element is NullableTypeSymbol nullableUserVt && nullableUserVt.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol)
+            // Issue #2232: a tuple type `(..., UserType, ...)` whose CLR backing
+            // is null because at least one element is a still-in-flight user
+            // type (`TupleTypeSymbol.BuildClrType` returns null unless every
+            // element resolves to a CLR type) must likewise route through the
+            // symbolic Task<T> construction. Otherwise an `async func F() (bool,
+            // UserType)` silently drops its Task wrapper here, so `await F()`
+            // sees the bare tuple and fails with GS0133 "cannot be awaited"
+            // (cascading GS0125 on any deconstructed bindings). A nullable
+            // tuple (`(bool, UserType)?`) is handled the same way.
+            if ((element is StructSymbol or InterfaceSymbol or EnumSymbol or TupleTypeSymbol
+                || (element is NullableTypeSymbol nullableUserVt && nullableUserVt.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol or TupleTypeSymbol)
                 || TypeSymbol.ContainsTypeParameter(element))
                 && Scope.References.TryResolveType(wrapperOpenName, out var symbolicTaskOpen))
             {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2232AsyncTupleTaskWrapTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2232AsyncTupleTaskWrapTests.cs
@@ -1,0 +1,172 @@
+// <copyright file="Issue2232AsyncTupleTaskWrapTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2232: an <c>async func</c> whose declared (implicit-wrap) return type
+/// is a tuple containing a still-in-flight user-defined element — e.g.
+/// <c>(bool, UserClass)</c> or <c>(bool, IUserInterface)</c> — must observe its
+/// call-site result as <c>Task[(bool, UserType)]</c>, so <c>await F()</c>
+/// yields the bare tuple. <see cref="TupleTypeSymbol"/> reports a <c>null</c>
+/// <see cref="TypeSymbol.ClrType"/> when any element lacks a CLR backing type,
+/// which previously fell through <see cref="LambdaBinder.WrapAsTask"/>'s
+/// symbolic branch (that only special-cased <c>struct</c>/<c>interface</c>/
+/// <c>enum</c>/type-parameter elements), silently dropping the <c>Task</c>
+/// wrapper. The bare tuple then failed <c>await</c> with GS0133 ("cannot be
+/// awaited"), cascading GS0125 onto any deconstructed bindings. A tuple whose
+/// elements are all BCL types (e.g. <c>(bool, string)</c>) was unaffected
+/// because its <c>ValueTuple&lt;...&gt;</c> ClrType resolves.
+/// </summary>
+public class Issue2232AsyncTupleTaskWrapTests
+{
+    [Fact]
+    public void AsyncFunc_ReturningTupleWithUserClassElement_Awaited_ObservedAsTaskOfTuple()
+    {
+        const string source = @"
+package p
+class Box { }
+async func Producer() (bool, Box) {
+    return (true, Box())
+}
+async func Consume() bool {
+    let t = await Producer()
+    return t.Item1
+}
+";
+        var compilation = Compile(source);
+        AssertNoAwaitOrScopeErrors(compilation);
+
+        var call = FindCall(compilation, "Consume", "Producer");
+        Assert.NotNull(call);
+        AssertIsTaskOfTuple(call.Type);
+    }
+
+    [Fact]
+    public void AsyncFunc_ReturningTupleWithUserClassElement_AwaitedAndDeconstructed_NoGS0125()
+    {
+        const string source = @"
+package p
+class Box { }
+async func Producer() (bool, Box) {
+    return (true, Box())
+}
+async func Consume() bool {
+    let (ok, x) = await Producer()
+    return ok
+}
+";
+        var compilation = Compile(source);
+        AssertNoAwaitOrScopeErrors(compilation);
+    }
+
+    [Fact]
+    public void AsyncFunc_ReturningTupleWithUserInterfaceElement_Awaited_NoGS0133()
+    {
+        const string source = @"
+package p
+interface IProfile { func Name() string; }
+async func Producer(p IProfile) (bool, IProfile) {
+    return (true, p)
+}
+async func Consume(p IProfile) bool {
+    let (ok, prof) = await Producer(p)
+    return ok
+}
+";
+        var compilation = Compile(source);
+        AssertNoAwaitOrScopeErrors(compilation);
+
+        var call = FindCall(compilation, "Consume", "Producer");
+        Assert.NotNull(call);
+        AssertIsTaskOfTuple(call.Type);
+    }
+
+    [Fact]
+    public void AsyncFunc_ReturningTupleWithAllBclElements_StillWrapsAsTask_Regression()
+    {
+        // A tuple whose elements are all BCL types keeps a resolvable
+        // ValueTuple ClrType and never depended on the fix; pin it stays green.
+        const string source = @"
+package p
+async func Producer() (bool, string) {
+    return (true, ""s"")
+}
+async func Consume() bool {
+    let (ok, s) = await Producer()
+    return ok
+}
+";
+        var compilation = Compile(source);
+        AssertNoAwaitOrScopeErrors(compilation);
+
+        var call = FindCall(compilation, "Consume", "Producer");
+        Assert.NotNull(call);
+        Assert.True(call.Type is ImportedTypeSymbol imported
+            && imported.ClrType.IsGenericType
+            && imported.ClrType.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.Task<>),
+            $"Expected Task[...], got '{call.Type}'.");
+    }
+
+    private static void AssertNoAwaitOrScopeErrors(Compilation compilation)
+    {
+        Assert.DoesNotContain(compilation.BoundProgram.Diagnostics, d => d.Id == "GS0133");
+        Assert.DoesNotContain(compilation.BoundProgram.Diagnostics, d => d.Id == "GS0125");
+    }
+
+    private static void AssertIsTaskOfTuple(TypeSymbol type)
+    {
+        Assert.True(type is ImportedTypeSymbol imported
+            && imported.ClrType.IsGenericType
+            && imported.ClrType.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.Task<>)
+            && imported.TypeArguments.Length == 1
+            && imported.TypeArguments[0] is TupleTypeSymbol,
+            $"Expected Task[(...)] over a tuple, got '{type}'.");
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree) { IsLibrary = true };
+    }
+
+    private static BoundCallExpression FindCall(Compilation compilation, string functionName, string callName)
+    {
+        var fn = compilation.BoundProgram.Functions.Keys.Single(f => f.Name == functionName);
+        var body = compilation.BoundProgram.Functions[fn];
+        var collector = new CallCollector(callName);
+        collector.Visit(body);
+        return collector.Collected.FirstOrDefault();
+    }
+
+    private sealed class CallCollector : BoundTreeWalker
+    {
+        private readonly string callName;
+
+        public CallCollector(string callName)
+        {
+            this.callName = callName;
+        }
+
+        public System.Collections.Generic.List<BoundCallExpression> Collected { get; } = new();
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node is BoundCallExpression call && call.Function.Name == callName)
+            {
+                Collected.Add(call);
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Discovered migrating the Oahu corpus. An `async func` whose declared (implicit-wrap) return type is a **tuple containing a user-defined element** — e.g. `(bool, IProfile)` / `(bool, UserClass)` — silently drops its `Task` wrapper at the call site, so `await F()` fails with **GS0133** ("cannot be awaited"), cascading GS0125 onto any deconstructed bindings.

```
// Authorize.gs — faithful cs2gs output of async Task<(bool, IProfile)> RegisterAsync(...)
async func RegisterAsync(profile Profile?) (bool, IProfile) { ... }
// AudibleClient.gs:122
let (succ, prevProfile) = await Authorize!!.RegisterAsync(profile)   // GS0133 + cascade GS0125
```

Minimal pure-G# repro:
```
class Box { }
async func Producer() (bool, Box) { return (true, Box()) }
async func Consume() bool {
    let t = await Producer()   // GS0133: '(bool, Box)' cannot be awaited
    return t.Item1
}
```
`(bool, string)` (all-BCL) worked — only tuples with a user-defined element fail.

## Root cause

`LambdaBinder.WrapAsTask` computes an async func's observable return type `Task[T]` from its awaited result `T`. When `T.ClrType == null` it uses a symbolic `Task<object>` + symbolic-result construction, but that branch only special-cased `StructSymbol`/`InterfaceSymbol`/`EnumSymbol`/nullable-of-those/type-parameter elements. `TupleTypeSymbol.BuildClrType` returns **null** whenever any element lacks a CLR backing type, so `(bool, Box)` matched none of the shapes and fell through to `return element` — dropping the `Task` wrapper. All-BCL tuples keep a resolvable `ValueTuple<...>` ClrType and take the normal path.

## Fix

Route null-`ClrType` tuples (and nullable-of-tuple) through the same symbolic `Task<T>` construction already used for user struct/interface/enum and open type-parameter elements. Sibling of #1785 / #2026 / #502.

## Tests

New `Issue2232AsyncTupleTaskWrapTests` (4 cases: user class element awaited + type assertion, user class deconstructed, user interface element, all-BCL regression). Existing 408 async/await/tuple tests still pass.

Fixes #2232.
