### PR TITLE
Fix #2223: materialize Avalonia InitializeComponent via AdditionalText/options forwarding

### DIFF
--- a/docs/adr/0143-source-generators-in-cs2gs-migration.md
+++ b/docs/adr/0143-source-generators-in-cs2gs-migration.md
@@ -78,6 +78,23 @@ largely does:
   reproduce the members. (This is exactly the loop ADR-0145's end-to-end test
   proves for `@ObservableProperty`.)
 
+**File/options-driven generators (Avalonia `.axaml`, issue #2223).** Some
+generators consume non-source inputs rather than attributes — Avalonia's XAML
+name generator reads each `.axaml` (a Roslyn `AdditionalText`) and, guided by
+`build_property.AvaloniaNameGeneratorBehavior` +
+`build_metadata.AdditionalFiles.SourceItemGroup=AvaloniaXaml`, generates the
+partial `InitializeComponent()` and named-control fields into the `.axaml.cs`
+code-behind. These reproduce through the same gsgen path once gsgen forwards
+`AdditionalText` + `AnalyzerConfigOptions` (ADR-0145 §C, issue #2223). cs2gs
+keeps the trigger intact by (a) discovering the project's `@(AdditionalFiles)` +
+`.axaml` (`CSharpProjectLoader`), (b) forwarding them — tagged
+`SourceItemGroup=AvaloniaXaml` — plus `RootNamespace`/`ProjectDir` options to the
+Compile stage's gsc invocation, and (c) marking the code-behind `partial` (the
+project's analyzer references already trigger `markMergedTypePartial`). The
+runtime side (Avalonia's `CompileAvaloniaXaml` IL-rewrite) is a language-agnostic
+post-compile MSBuild task that hooks the standard `AfterCompile` chain and needs
+no G# changes.
+
 **Pipeline requirement.** The cs2gs Compile stage shells out to gsc directly
 (`GscInvoker`, not the SDK), so gsgen does not run there today and the stage
 would still see missing symbols. The Compile stage must run gsgen before gsc —

--- a/docs/adr/0145-source-generator-host-native-gsharp.md
+++ b/docs/adr/0145-source-generator-host-native-gsharp.md
@@ -341,6 +341,33 @@ gsc consumes the emitted `.g.gs`):
   `retainedFilePaths` and `markMergedTypePartial` — needed to avoid duplicating
   a generator's output), verified via `test/Compiler.Tests/Issue2215AnalyzerFlagTests.cs`
   and `tools/cs2gs/Cs2Gs.Tests/Issue2215AnalyzerReferenceTests.cs`.
+- **`AdditionalText` + `AnalyzerConfigOptions` forwarding** (§C, issue #2223) —
+  file/options-driven generators (Avalonia's XAML name generator that
+  materializes `InitializeComponent` from `.axaml`, the archetype) now receive
+  their non-source inputs and MSBuild options. `GeneratorRunner`/
+  `GeneratorHostRunner` pass an `AdditionalText` set and an
+  `AnalyzerConfigOptionsProvider` (`HostAdditionalText` +
+  `HostAnalyzerConfigOptionsProvider`, surfacing per-file
+  `build_metadata.AdditionalFiles.*` — e.g. `SourceItemGroup=AvaloniaXaml` — and
+  project-wide `build_property.*`) to `CSharpGeneratorDriver.Create`. Plumbed
+  through the `gsgen` CLI (`/additionalfile:<path[;key=value]>`,
+  `/globaloption:<key>=<value>`), gsc's forwarding of the same flags into its
+  `SpawnGsgen` response file, the SDK's `GsgenTask`/targets (forwarding
+  `@(AdditionalFiles)` + a `build_property.*` global-option set), and the cs2gs
+  migrate path (`CSharpProjectLoader` discovers `@(AdditionalFiles)` + `.axaml`;
+  `TranslateStage`/`CompileStage`/`GscInvoker` forward them). Generator-agnostic:
+  Avalonia is merely the first consumer. Verified via
+  `tools/gsgen/GSharp.GeneratorHost.Tests/AdditionalTextGeneratorTests.cs` and
+  `GsgenArgsAdditionalFilesTests.cs`.
+- **Avalonia runtime XAML (`CompileAvaloniaXaml`)** — the post-compile IL-rewrite
+  task that makes compiled XAML load at runtime needs *no* new host/SDK code: the
+  G# SDK imports `Microsoft.NET.Sdk` and its `CoreCompile` emits the assembly at
+  the standard `$(IntermediateOutputPath)$(TargetName)$(TargetExt)`
+  (`@(IntermediateAssembly)`) path, so Avalonia's package targets — which hook the
+  standard `AfterCompile`/`AfterTargets="CoreCompile"` chain and operate on the
+  emitted PE + `@(AvaloniaResource)` items via Mono.Cecil — run against gsc's
+  output exactly as they would against csc's. Requires validation against the
+  real Oahu Avalonia corpus.
 
 Follow-ups (not in the initial delivery):
 

--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -562,6 +562,18 @@ public class Program
             rspLines.Add($"/analyzer:\"{a}\"");
         }
 
+        // Issue #2223: forward non-source generator inputs (.axaml) and project
+        // options (build_property.*) so file/options-driven generators run.
+        foreach (var af in parsed.AdditionalFiles)
+        {
+            rspLines.Add($"/additionalfile:\"{af}\"");
+        }
+
+        foreach (var go in parsed.GlobalOptions)
+        {
+            rspLines.Add($"/globaloption:\"{go}\"");
+        }
+
         rspLines.Add($"/out:\"{outDir}\"");
         rspLines.Add($"/manifest:\"{manifestPath}\"");
         File.WriteAllLines(rspPath, rspLines, Encoding.UTF8);
@@ -706,6 +718,8 @@ public class Program
           /sourcelink:<file>            Source Link JSON file.
           /deterministic[+|-]           Enable/disable deterministic emit.
           /embed[+|-]                   Embed all primary sources in the PDB.
+          /additionalfile:<file>        Non-source generator input (e.g. Avalonia .axaml); forwarded to gsgen (repeatable).
+          /globaloption:<key>=<value>   Project-wide generator option (build_property.*); forwarded to gsgen (repeatable).
           /log:<file>                   Write compiler diagnostic log to file.
           /?, /help                     Show this help message.
         """);
@@ -785,6 +799,29 @@ public class Program
                         }
 
                         result.AnalyzerPaths.Add(value);
+                        break;
+
+                    case "additionalfile":
+                        // Issue #2223: a non-source input (e.g. Avalonia .axaml)
+                        // forwarded verbatim to gsgen as a Roslyn AdditionalText.
+                        // Repeatable. Value may carry `;key=value` metadata pairs.
+                        if (string.IsNullOrWhiteSpace(value))
+                        {
+                            throw new CommandLineException("/additionalfile requires a path: /additionalfile:<file>.");
+                        }
+
+                        result.AdditionalFiles.Add(value);
+                        break;
+
+                    case "globaloption":
+                        // Issue #2223: a project-wide generator option (build_property.*)
+                        // forwarded verbatim to gsgen. Repeatable. Value is `key=value`.
+                        if (string.IsNullOrWhiteSpace(value))
+                        {
+                            throw new CommandLineException("/globaloption requires a key=value: /globaloption:<key>=<value>.");
+                        }
+
+                        result.GlobalOptions.Add(value);
                         break;
 
                     case "gsgentool":
@@ -1121,6 +1158,12 @@ public class Program
 
         /// <summary>Gets the analyzer/generator assembly paths (from /analyzer:&lt;path&gt;). Non-empty triggers a gsgen run (issue #2215).</summary>
         public List<string> AnalyzerPaths { get; } = new();
+
+        /// <summary>Gets the raw additional-file specs (from /additionalfile:&lt;path[;key=value]&gt;) forwarded to gsgen (issue #2223).</summary>
+        public List<string> AdditionalFiles { get; } = new();
+
+        /// <summary>Gets the raw generator global options (from /globaloption:&lt;key=value&gt;) forwarded to gsgen (issue #2223).</summary>
+        public List<string> GlobalOptions { get; } = new();
 
         /// <summary>Gets or sets an explicit override for the resolved gsgen.dll path (from /gsgentool:&lt;path&gt;).</summary>
         public string GsgenToolPath { get; set; }

--- a/src/Sdk/Gsharp.NET.Sdk/GsgenTask.cs
+++ b/src/Sdk/Gsharp.NET.Sdk/GsgenTask.cs
@@ -67,6 +67,22 @@ public class GsgenTask : Microsoft.Build.Utilities.Task, ICancelableTask
     /// <summary>Gets or sets the analyzer/generator assembly paths (forwarded via /analyzer:).</summary>
     public ITaskItem[] Analyzers { get; set; } = Array.Empty<ITaskItem>();
 
+    /// <summary>
+    /// Gets or sets the additional (non-source) files (issue #2223) forwarded to
+    /// generators via /additionalfile:. Each item's <c>SourceItemGroup</c>,
+    /// <c>TargetPath</c> and <c>ManifestResourceName</c> metadata (when present)
+    /// are appended as <c>;key=value</c> pairs so a file/options-driven generator
+    /// (e.g. Avalonia's XAML name generator) recognizes them.
+    /// </summary>
+    public ITaskItem[] AdditionalFiles { get; set; } = Array.Empty<ITaskItem>();
+
+    /// <summary>
+    /// Gets or sets the project-wide generator options (issue #2223) forwarded
+    /// via /globaloption: as <c>build_property.*</c>. Each item's ItemSpec is the
+    /// option name and its <c>Value</c> metadata the option value.
+    /// </summary>
+    public ITaskItem[] GlobalOptions { get; set; } = Array.Empty<ITaskItem>();
+
     /// <summary>Gets or sets the output directory for the generated .g.gs files (/out:).</summary>
     [Required]
     public string OutputDir { get; set; }
@@ -118,6 +134,26 @@ public class GsgenTask : Microsoft.Build.Utilities.Task, ICancelableTask
         foreach (var c in this.ForeignCompile)
         {
             args.Add(BuildTask.QuoteIfNeeded($"/csfile:{c.ItemSpec}"));
+        }
+
+        foreach (var af in this.AdditionalFiles)
+        {
+            var spec = af.ItemSpec;
+            foreach (var name in new[] { "SourceItemGroup", "TargetPath", "ManifestResourceName" })
+            {
+                var meta = af.GetMetadata(name);
+                if (!string.IsNullOrEmpty(meta))
+                {
+                    spec += $";{name}={meta}";
+                }
+            }
+
+            args.Add(BuildTask.QuoteIfNeeded($"/additionalfile:{spec}"));
+        }
+
+        foreach (var go in this.GlobalOptions)
+        {
+            args.Add(BuildTask.QuoteIfNeeded($"/globaloption:{go.ItemSpec}={go.GetMetadata("Value")}"));
         }
 
         args.Add(BuildTask.QuoteIfNeeded($"/out:{this.OutputDir}"));

--- a/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
+++ b/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
@@ -153,15 +153,37 @@
     <Message Condition=" '@(_GsharpForeignCompile)' != '' " Importance="Low" Text="gsgen: found stray C# Compile item(s) to translate: @(_GsharpForeignCompile)" />
   </Target>
 
+  <!-- Issue #2223: project-wide generator options forwarded to gsgen as
+       build_property.* AnalyzerConfigOptions. A file/options-driven generator
+       (e.g. Avalonia's XAML name generator) reads these. Only the concrete
+       properties known to matter are forwarded; a generator's own default
+       applies for any it does not find. -->
+  <Target Name="_GsharpCollectGeneratorOptions">
+    <ItemGroup>
+      <_GsharpGeneratorGlobalOption Include="RootNamespace" Condition=" '$(RootNamespace)' != '' ">
+        <Value>$(RootNamespace)</Value>
+      </_GsharpGeneratorGlobalOption>
+      <_GsharpGeneratorGlobalOption Include="ProjectDir">
+        <Value>$(MSBuildProjectDirectory)</Value>
+      </_GsharpGeneratorGlobalOption>
+      <_GsharpGeneratorGlobalOption Include="AvaloniaNameGeneratorBehavior" Condition=" '$(AvaloniaNameGeneratorBehavior)' != '' ">
+        <Value>$(AvaloniaNameGeneratorBehavior)</Value>
+      </_GsharpGeneratorGlobalOption>
+      <_GsharpGeneratorGlobalOption Include="AvaloniaNameGeneratorViewFileNamingStrategy" Condition=" '$(AvaloniaNameGeneratorViewFileNamingStrategy)' != '' ">
+        <Value>$(AvaloniaNameGeneratorViewFileNamingStrategy)</Value>
+      </_GsharpGeneratorGlobalOption>
+    </ItemGroup>
+  </Target>
+
   <!-- (2) Run gsgen over the user's .gs (BEFORE generated files are added to
        @(Compile)), the resolved reference closure, and the resolved analyzers.
        Incremental: re-runs only when a source/analyzer/reference/project file is
        newer than the manifest. -->
   <Target Name="_GsharpRunSourceGenerators"
           BeforeTargets="CoreCompile"
-          DependsOnTargets="_GsharpPartitionForeignCompile;_GsharpResolveAnalyzers;ResolveReferences"
+          DependsOnTargets="_GsharpPartitionForeignCompile;_GsharpResolveAnalyzers;_GsharpCollectGeneratorOptions;ResolveReferences"
           Condition=" '$(GsharpRunSourceGenerators)' != 'false' "
-          Inputs="@(Compile);@(_GsharpForeignCompile);@(GsharpAnalyzer);@(ReferencePathWithRefAssemblies);$(MSBuildAllProjects)"
+          Inputs="@(Compile);@(_GsharpForeignCompile);@(AdditionalFiles);@(GsharpAnalyzer);@(ReferencePathWithRefAssemblies);$(MSBuildAllProjects)"
           Outputs="$(IntermediateOutputPath)gsgen\gsgen.manifest">
     <!-- The analyzer-empty fast path is gated on the TASK, not the target's
          Condition: a target whose Condition is false never runs its
@@ -177,12 +199,15 @@
         ForeignCompile="@(_GsharpForeignCompile)"
         References="@(ReferencePathWithRefAssemblies)"
         Analyzers="@(GsharpAnalyzer)"
+        AdditionalFiles="@(AdditionalFiles)"
+        GlobalOptions="@(_GsharpGeneratorGlobalOption)"
         OutputDir="$(IntermediateOutputPath)gsgen\"
         ManifestPath="$(IntermediateOutputPath)gsgen\gsgen.manifest"
         ResponseFilePath="$(IntermediateOutputPath)$(TargetName).gsgen.rsp"
         RootNamespace="$(RootNamespace)"
         BasePath="$(MSBuildProjectDirectory)" />
   </Target>
+
 
   <!-- (3) Fold the generated parts into @(Compile). This target has NO
        Inputs/Outputs so it ALWAYS runs before CoreCompile — even when (2) was

--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -48,7 +48,9 @@ public sealed class CompileStage : IMigrationStage
             outputPath,
             context.App.TargetKind,
             BuildReferenceSet(context.App.ReferencedAssemblies, context.ExternalReferencePaths),
-            context.AnalyzerReferencePaths);
+            context.AnalyzerReferencePaths,
+            context.AdditionalGeneratorFiles,
+            context.GeneratorGlobalOptions);
 
         File.WriteAllText(
             Path.Combine(context.AppRunDir, "gsc.compile.log"),

--- a/tools/cs2gs/Cs2Gs.Pipeline/GscInvoker.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GscInvoker.cs
@@ -122,13 +122,25 @@ public sealed class GscInvoker
     /// <c>.gs</c> into this same compile, so the pipeline's compiled assembly
     /// carries generator output the way a real MSBuild build would.
     /// </param>
+    /// <param name="additionalFiles">
+    /// Issue #2223: non-source generator inputs (e.g. Avalonia <c>.axaml</c>),
+    /// each optionally suffixed with <c>;key=value</c> metadata, passed via gsc's
+    /// <c>/additionalfile:</c> and forwarded to gsgen as <c>AdditionalText</c>.
+    /// </param>
+    /// <param name="globalOptions">
+    /// Issue #2223: project-wide generator options (<c>key=value</c>) passed via
+    /// gsc's <c>/globaloption:</c> and forwarded to gsgen as
+    /// <c>build_property.*</c>.
+    /// </param>
     /// <returns>The exit code, combined output, and parsed diagnostics.</returns>
     public GscResult Compile(
         IReadOnlyList<string> gsFiles,
         string outputPath,
         TargetKind target,
         IReadOnlyList<string> references,
-        IReadOnlyList<string> analyzerPaths = null)
+        IReadOnlyList<string> analyzerPaths = null,
+        IReadOnlyList<string> additionalFiles = null,
+        IReadOnlyList<string> globalOptions = null)
     {
         var args = new List<string>
         {
@@ -155,6 +167,22 @@ public sealed class GscInvoker
             if (!string.IsNullOrEmpty(this.GsgenPath))
             {
                 args.Add("/gsgentool:" + this.GsgenPath);
+            }
+        }
+
+        if (additionalFiles is not null)
+        {
+            foreach (string additionalFile in additionalFiles)
+            {
+                args.Add("/additionalfile:" + additionalFile);
+            }
+        }
+
+        if (globalOptions is not null)
+        {
+            foreach (string globalOption in globalOptions)
+            {
+                args.Add("/globaloption:" + globalOption);
             }
         }
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -99,6 +99,24 @@ public sealed class StageExecutionContext
     public List<string> AnalyzerReferencePaths { get; } = new List<string>();
 
     /// <summary>
+    /// Gets the non-source generator inputs (issue #2223) to forward to gsc's
+    /// <c>/additionalfile:</c> flag — the project's <c>@(AdditionalFiles)</c>
+    /// plus discovered <c>.axaml</c>, each optionally suffixed with
+    /// <c>;key=value</c> metadata (e.g. <c>;SourceItemGroup=AvaloniaXaml</c>) so
+    /// a file/options-driven generator (Avalonia's XAML name generator)
+    /// recognizes them. Populated by the Translate stage from the loaded
+    /// project's additional files.
+    /// </summary>
+    public List<string> AdditionalGeneratorFiles { get; } = new List<string>();
+
+    /// <summary>
+    /// Gets the project-wide generator options (issue #2223) to forward to gsc's
+    /// <c>/globaloption:</c> flag as <c>key=value</c> pairs (surfaced to
+    /// generators as <c>build_property.*</c>). Populated by the Translate stage.
+    /// </summary>
+    public List<string> GeneratorGlobalOptions { get; } = new List<string>();
+
+    /// <summary>
     /// Gets or sets the absolute path of the assembly emitted by the Compile
     /// stage, published for the IL-verify stage to read (ADR-0115 §C). It is
     /// <see langword="null"/> until a green stage-2 compile has run.

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -104,6 +104,36 @@ public sealed class TranslateStage : IMigrationStage
                 {
                     context.AnalyzerReferencePaths.Add(analyzerPath);
                 }
+
+                // Issue #2223: forward the app's non-source generator inputs
+                // (.axaml) and project options so gsc's gsgen run materializes
+                // file-driven generator output (e.g. Avalonia's InitializeComponent).
+                foreach (string additionalFile in currentProject.AdditionalFiles)
+                {
+                    string spec = additionalFile;
+                    string ext = Path.GetExtension(additionalFile);
+                    if (ext.Equals(".axaml", StringComparison.OrdinalIgnoreCase) ||
+                        ext.Equals(".xaml", StringComparison.OrdinalIgnoreCase) ||
+                        ext.Equals(".paml", StringComparison.OrdinalIgnoreCase))
+                    {
+                        spec += ";SourceItemGroup=AvaloniaXaml";
+                    }
+
+                    context.AdditionalGeneratorFiles.Add(spec);
+                }
+
+                if (context.AdditionalGeneratorFiles.Count > 0)
+                {
+                    if (!string.IsNullOrEmpty(currentProject.RootNamespace))
+                    {
+                        context.GeneratorGlobalOptions.Add("RootNamespace=" + currentProject.RootNamespace);
+                    }
+
+                    if (!string.IsNullOrEmpty(currentProject.ProjectDirectory))
+                    {
+                        context.GeneratorGlobalOptions.Add("ProjectDir=" + currentProject.ProjectDirectory);
+                    }
+                }
             }
 
             // Issue #2215: a project with analyzer references may have had a

--- a/tools/cs2gs/Cs2Gs.ProjectLoading/CSharpProjectLoader.cs
+++ b/tools/cs2gs/Cs2Gs.ProjectLoading/CSharpProjectLoader.cs
@@ -324,9 +324,73 @@ public static class CSharpProjectLoader
 
         string rootNamespace = ResolveRootNamespace(project);
         IReadOnlyList<string> resxFiles = DiscoverResxFiles(projectDirectory);
+        IReadOnlyList<string> additionalFiles = DiscoverAdditionalFiles(project, projectDirectory);
         IReadOnlyList<string> analyzerReferencePaths = ResolveAnalyzerReferencePaths(project);
 
-        return new LoadedCSharpProject(csharpCompilation, documents, seedDiagnostics, projectDirectory, rootNamespace, resxFiles, analyzerReferencePaths);
+        return new LoadedCSharpProject(csharpCompilation, documents, seedDiagnostics, projectDirectory, rootNamespace, resxFiles, analyzerReferencePaths, additionalFiles);
+    }
+
+    /// <summary>
+    /// Issue #2223: the non-source generator inputs the project exposes to
+    /// Roslyn analyzers/generators — the MSBuild <c>@(AdditionalFiles)</c> set
+    /// (Roslyn <see cref="Project.AdditionalDocuments"/>, which Avalonia's
+    /// targets populate with each <c>.axaml</c>), unioned with an explicit
+    /// <c>*.axaml</c> glob under the project directory as a fallback for a
+    /// workspace load that did not surface them. Files under the project's own
+    /// <c>obj</c>/<c>bin</c> are excluded (generated/copied artifacts).
+    /// </summary>
+    private static IReadOnlyList<string> DiscoverAdditionalFiles(Project project, string projectDirectory)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<string>();
+
+        void Add(string path)
+        {
+            if (string.IsNullOrEmpty(path) || !File.Exists(path))
+            {
+                return;
+            }
+
+            string full = Path.GetFullPath(path);
+            if (IsUnderObjOrBin(full, projectDirectory))
+            {
+                return;
+            }
+
+            if (seen.Add(full))
+            {
+                result.Add(full);
+            }
+        }
+
+        foreach (TextDocument additional in project.AdditionalDocuments)
+        {
+            Add(additional.FilePath);
+        }
+
+        if (!string.IsNullOrEmpty(projectDirectory) && Directory.Exists(projectDirectory))
+        {
+            foreach (string axaml in Directory.EnumerateFiles(projectDirectory, "*.axaml", SearchOption.AllDirectories))
+            {
+                Add(axaml);
+            }
+        }
+
+        return result.OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    private static bool IsUnderObjOrBin(string fullPath, string projectDirectory)
+    {
+        if (string.IsNullOrEmpty(projectDirectory))
+        {
+            return false;
+        }
+
+        string objPrefix = Path.Combine(projectDirectory, "obj").Replace('\\', '/').TrimEnd('/') + "/";
+        string binPrefix = Path.Combine(projectDirectory, "bin").Replace('\\', '/').TrimEnd('/') + "/";
+        string normalized = fullPath.Replace('\\', '/');
+        return normalized.StartsWith(objPrefix, StringComparison.OrdinalIgnoreCase) ||
+            normalized.StartsWith(binPrefix, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.ProjectLoading/LoadedCSharpProject.cs
+++ b/tools/cs2gs/Cs2Gs.ProjectLoading/LoadedCSharpProject.cs
@@ -45,6 +45,12 @@ public sealed class LoadedCSharpProject
     /// flag so generator output reaches the cs2gs-compiled assembly the same
     /// way a real build would produce it.
     /// </param>
+    /// <param name="additionalFiles">
+    /// The non-source generator inputs (issue #2223) — the project's
+    /// <c>@(AdditionalFiles)</c> plus discovered <c>.axaml</c> — forwarded to
+    /// gsc/gsgen as Roslyn <c>AdditionalText</c> so file-driven generators (e.g.
+    /// Avalonia's XAML name generator) can materialize their output.
+    /// </param>
     public LoadedCSharpProject(
         CSharpCompilation compilation,
         IReadOnlyList<LoadedDocument> documents,
@@ -52,7 +58,8 @@ public sealed class LoadedCSharpProject
         string projectDirectory = null,
         string rootNamespace = null,
         IReadOnlyList<string> resxFiles = null,
-        IReadOnlyList<string> analyzerReferencePaths = null)
+        IReadOnlyList<string> analyzerReferencePaths = null,
+        IReadOnlyList<string> additionalFiles = null)
     {
         this.Compilation = compilation;
         this.Documents = documents;
@@ -61,6 +68,7 @@ public sealed class LoadedCSharpProject
         this.RootNamespace = rootNamespace ?? string.Empty;
         this.ResxFiles = resxFiles ?? ImmutableArray<string>.Empty;
         this.AnalyzerReferencePaths = analyzerReferencePaths ?? ImmutableArray<string>.Empty;
+        this.AdditionalFiles = additionalFiles ?? ImmutableArray<string>.Empty;
     }
 
     /// <summary>Gets the bound C# compilation.</summary>
@@ -102,6 +110,14 @@ public sealed class LoadedCSharpProject
     /// references (issue #2215) — empty for an in-memory-loaded project.
     /// </summary>
     public IReadOnlyList<string> AnalyzerReferencePaths { get; }
+
+    /// <summary>
+    /// Gets the non-source generator inputs (issue #2223) — the project's
+    /// <c>@(AdditionalFiles)</c> plus discovered <c>.axaml</c> — forwarded to
+    /// gsc/gsgen as Roslyn <c>AdditionalText</c>. Empty for an in-memory-loaded
+    /// project.
+    /// </summary>
+    public IReadOnlyList<string> AdditionalFiles { get; }
 
     /// <summary>
     /// Gets the subset of <see cref="LoadDiagnostics"/> with

--- a/tools/gsgen/GSharp.GeneratorHost.Tests/AdditionalTextGeneratorTests.cs
+++ b/tools/gsgen/GSharp.GeneratorHost.Tests/AdditionalTextGeneratorTests.cs
@@ -1,0 +1,118 @@
+// <copyright file="AdditionalTextGeneratorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Cs2Gs.Translator.Loading;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Xunit;
+using Compilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+
+namespace GSharp.GeneratorHost.Tests;
+
+/// <summary>
+/// Issue #2223: verifies the host forwards Roslyn <c>AdditionalText</c> and
+/// <c>AnalyzerConfigOptions</c> to generators — the plumbing an Avalonia-style
+/// XAML generator needs to materialize <c>InitializeComponent</c> from an
+/// <c>.axaml</c> file. Uses a fake generator that mimics Avalonia's behavior
+/// (read each <c>SourceItemGroup=AvaloniaXaml</c> additional file and emit a
+/// partial <c>InitializeComponent</c> into the matching code-behind).
+/// </summary>
+public class AdditionalTextGeneratorTests
+{
+    private static IReadOnlyList<MetadataReference> References => CSharpProjectLoader.RuntimeReferences();
+
+    [Fact]
+    public void AdditionalText_And_Options_ReachGenerator_AndMaterializePartial()
+    {
+        string dir = Directory.CreateTempSubdirectory("gsgen-axaml-").FullName;
+        try
+        {
+            string axaml = Path.Combine(dir, "MainWindow.axaml");
+            File.WriteAllText(axaml, "<Window/>");
+            string txt = Path.Combine(dir, "readme.txt");
+            File.WriteAllText(txt, "hello");
+
+            Compilation gs = BuildGs(@"
+package App
+
+partial class MainWindow {
+    func New() -> InitializeComponent()
+}
+");
+
+            var additionalTexts = new List<AdditionalText>
+            {
+                new HostAdditionalText(
+                    axaml,
+                    new Dictionary<string, string> { ["SourceItemGroup"] = "AvaloniaXaml" }),
+
+                // A non-Avalonia additional file must be ignored by the generator.
+                new HostAdditionalText(txt),
+            };
+
+            var options = new HostAnalyzerConfigOptionsProvider(
+                new Dictionary<string, string> { ["build_property.RootNamespace"] = "App" });
+
+            GeneratorHostResult result = GeneratorHostRunner.Run(
+                gs,
+                References,
+                new IIncrementalGenerator[] { new FakeAvaloniaNameGenerator() },
+                additionalTexts,
+                options);
+
+            Assert.Empty(result.Failures);
+
+            (string HintName, string GSharpSource) file = Assert.Single(result.GeneratedGsFiles);
+            Assert.Contains("partial class MainWindow", file.GSharpSource);
+            Assert.Contains("InitializeComponent", file.GSharpSource);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    private static Compilation BuildGs(string gsSource)
+    {
+        return new Compilation(GsSyntaxTree.Parse(SourceText.From(gsSource)));
+    }
+
+    /// <summary>
+    /// A minimal stand-in for Avalonia's XAML name generator: for each
+    /// additional file whose <c>SourceItemGroup</c> option is <c>AvaloniaXaml</c>,
+    /// emits a partial <c>InitializeComponent()</c> into a code-behind class named
+    /// after the file (<c>MainWindow.axaml</c> → <c>MainWindow</c>).
+    /// </summary>
+    private sealed class FakeAvaloniaNameGenerator : IIncrementalGenerator
+    {
+        public void Initialize(IncrementalGeneratorInitializationContext context)
+        {
+            var xamlFiles = context.AdditionalTextsProvider
+                .Combine(context.AnalyzerConfigOptionsProvider)
+                .Where(static pair =>
+                {
+                    return pair.Right.GetOptions(pair.Left)
+                        .TryGetValue("build_metadata.AdditionalFiles.SourceItemGroup", out var group)
+                        && group == "AvaloniaXaml";
+                })
+                .Select(static (pair, _) => Path.GetFileNameWithoutExtension(pair.Left.Path));
+
+            context.RegisterSourceOutput(xamlFiles, static (spc, className) =>
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine("#nullable enable");
+                sb.Append("partial class ").AppendLine(className);
+                sb.AppendLine("{");
+                sb.AppendLine("    public void InitializeComponent() { }");
+                sb.AppendLine("}");
+                spc.AddSource(className + ".axaml.g.cs", sb.ToString());
+            });
+        }
+    }
+}

--- a/tools/gsgen/GSharp.GeneratorHost.Tests/GsgenArgsAdditionalFilesTests.cs
+++ b/tools/gsgen/GSharp.GeneratorHost.Tests/GsgenArgsAdditionalFilesTests.cs
@@ -1,0 +1,62 @@
+// <copyright file="GsgenArgsAdditionalFilesTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Gsgen.Cli;
+using Xunit;
+
+namespace GSharp.GeneratorHost.Tests;
+
+/// <summary>
+/// Issue #2223: parse tests for the <c>gsgen</c> CLI's new
+/// <c>/additionalfile:</c> and <c>/globaloption:</c> flags.
+/// </summary>
+public class GsgenArgsAdditionalFilesTests
+{
+    [Fact]
+    public void AdditionalFile_WithMetadata_ParsesPathAndMetadata()
+    {
+        var notes = new List<string>();
+        GsgenArgs parsed = GsgenArgs.Parse(
+            new[] { "/additionalfile:/proj/MainWindow.axaml;SourceItemGroup=AvaloniaXaml;TargetPath=MainWindow.axaml" },
+            notes);
+
+        AdditionalFileSpec spec = Assert.Single(parsed.AdditionalFiles);
+        Assert.Equal("/proj/MainWindow.axaml", spec.Path);
+        Assert.Equal("AvaloniaXaml", spec.Metadata["SourceItemGroup"]);
+        Assert.Equal("MainWindow.axaml", spec.Metadata["TargetPath"]);
+    }
+
+    [Fact]
+    public void AdditionalFile_WithoutMetadata_ParsesPathOnly()
+    {
+        GsgenArgs parsed = GsgenArgs.Parse(new[] { "/additionalfile:/proj/readme.txt" }, new List<string>());
+
+        AdditionalFileSpec spec = Assert.Single(parsed.AdditionalFiles);
+        Assert.Equal("/proj/readme.txt", spec.Path);
+        Assert.Empty(spec.Metadata);
+    }
+
+    [Fact]
+    public void GlobalOption_IsPrefixedWithBuildProperty()
+    {
+        GsgenArgs parsed = GsgenArgs.Parse(
+            new[] { "/globaloption:RootNamespace=App", "/globaloption:build_property.ProjectDir=/proj" },
+            new List<string>());
+
+        Assert.Equal("App", parsed.GlobalOptions["build_property.RootNamespace"]);
+        Assert.Equal("/proj", parsed.GlobalOptions["build_property.ProjectDir"]);
+    }
+
+    [Fact]
+    public void GlobalOption_Malformed_IsNoted_AndIgnored()
+    {
+        var notes = new List<string>();
+        GsgenArgs parsed = GsgenArgs.Parse(new[] { "/globaloption:NoEquals" }, notes);
+
+        Assert.Empty(parsed.GlobalOptions);
+        Assert.Contains(notes, n => n.Contains("globaloption"));
+    }
+}

--- a/tools/gsgen/GSharp.GeneratorHost/GeneratorHostRunner.cs
+++ b/tools/gsgen/GSharp.GeneratorHost/GeneratorHostRunner.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Compilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
 
 namespace GSharp.GeneratorHost;
@@ -24,15 +25,19 @@ public static class GeneratorHostRunner
     /// <param name="gsCompilation">The bound G# compilation to project and generate against.</param>
     /// <param name="references">The metadata references the C# stub/generated code binds against.</param>
     /// <param name="generators">The incremental generators to run.</param>
+    /// <param name="additionalTexts">Non-source inputs forwarded to generators as <see cref="AdditionalText"/> (issue #2223).</param>
+    /// <param name="optionsProvider">The MSBuild-derived generator options, or <see langword="null"/> for none.</param>
     /// <returns>The aggregate host result.</returns>
     public static GeneratorHostResult Run(
         Compilation gsCompilation,
         IReadOnlyList<MetadataReference> references,
-        IReadOnlyList<IIncrementalGenerator> generators)
+        IReadOnlyList<IIncrementalGenerator> generators,
+        IReadOnlyList<AdditionalText> additionalTexts = null,
+        AnalyzerConfigOptionsProvider optionsProvider = null)
     {
         ArgumentNullException.ThrowIfNull(generators);
         string stub = ProjectStub(gsCompilation, out IReadOnlyList<string> fallbacks);
-        GeneratorRunResult runResult = GeneratorRunner.Run(stub, references, generators);
+        GeneratorRunResult runResult = GeneratorRunner.Run(stub, references, generators, additionalTexts, optionsProvider);
         return Assemble(stub, runResult, references, fallbacks);
     }
 
@@ -43,15 +48,19 @@ public static class GeneratorHostRunner
     /// <param name="gsCompilation">The bound G# compilation to project and generate against.</param>
     /// <param name="references">The metadata references the C# stub/generated code binds against.</param>
     /// <param name="analyzerAssemblyPaths">The analyzer/generator assembly paths.</param>
+    /// <param name="additionalTexts">Non-source inputs forwarded to generators as <see cref="AdditionalText"/> (issue #2223).</param>
+    /// <param name="optionsProvider">The MSBuild-derived generator options, or <see langword="null"/> for none.</param>
     /// <returns>The aggregate host result.</returns>
     public static GeneratorHostResult RunFromAnalyzerPaths(
         Compilation gsCompilation,
         IReadOnlyList<MetadataReference> references,
-        IReadOnlyList<string> analyzerAssemblyPaths)
+        IReadOnlyList<string> analyzerAssemblyPaths,
+        IReadOnlyList<AdditionalText> additionalTexts = null,
+        AnalyzerConfigOptionsProvider optionsProvider = null)
     {
         ArgumentNullException.ThrowIfNull(analyzerAssemblyPaths);
         string stub = ProjectStub(gsCompilation, out IReadOnlyList<string> fallbacks);
-        GeneratorRunResult runResult = GeneratorRunner.RunFromAnalyzerPaths(stub, references, analyzerAssemblyPaths);
+        GeneratorRunResult runResult = GeneratorRunner.RunFromAnalyzerPaths(stub, references, analyzerAssemblyPaths, additionalTexts, optionsProvider);
         return Assemble(stub, runResult, references, fallbacks);
     }
 

--- a/tools/gsgen/GSharp.GeneratorHost/GeneratorRunner.cs
+++ b/tools/gsgen/GSharp.GeneratorHost/GeneratorRunner.cs
@@ -36,18 +36,24 @@ public static class GeneratorRunner
     /// <param name="stubCSharp">The declaration-only C# stub source.</param>
     /// <param name="references">The metadata references the stub compiles against.</param>
     /// <param name="generators">The incremental generators to run.</param>
+    /// <param name="additionalTexts">Non-source inputs forwarded to generators as <see cref="AdditionalText"/> (issue #2223).</param>
+    /// <param name="optionsProvider">The MSBuild-derived generator options, or <see langword="null"/> for none.</param>
     /// <returns>The aggregate generator run result.</returns>
     public static GeneratorRunResult Run(
         string stubCSharp,
         IReadOnlyList<MetadataReference> references,
-        IReadOnlyList<IIncrementalGenerator> generators)
+        IReadOnlyList<IIncrementalGenerator> generators,
+        IReadOnlyList<AdditionalText> additionalTexts = null,
+        AnalyzerConfigOptionsProvider optionsProvider = null)
     {
         ArgumentNullException.ThrowIfNull(generators);
         return RunCore(
             stubCSharp,
             references,
             generators.Select(g => g.AsSourceGenerator()).ToList(),
-            new List<GeneratorFailure>());
+            new List<GeneratorFailure>(),
+            additionalTexts,
+            optionsProvider);
     }
 
     /// <summary>
@@ -58,11 +64,15 @@ public static class GeneratorRunner
     /// <param name="stubCSharp">The declaration-only C# stub source.</param>
     /// <param name="references">The metadata references the stub compiles against.</param>
     /// <param name="analyzerAssemblyPaths">The analyzer/generator assembly paths.</param>
+    /// <param name="additionalTexts">Non-source inputs forwarded to generators as <see cref="AdditionalText"/> (issue #2223).</param>
+    /// <param name="optionsProvider">The MSBuild-derived generator options, or <see langword="null"/> for none.</param>
     /// <returns>The aggregate generator run result.</returns>
     public static GeneratorRunResult RunFromAnalyzerPaths(
         string stubCSharp,
         IReadOnlyList<MetadataReference> references,
-        IReadOnlyList<string> analyzerAssemblyPaths)
+        IReadOnlyList<string> analyzerAssemblyPaths,
+        IReadOnlyList<AdditionalText> additionalTexts = null,
+        AnalyzerConfigOptionsProvider optionsProvider = null)
     {
         ArgumentNullException.ThrowIfNull(analyzerAssemblyPaths);
 
@@ -82,17 +92,16 @@ public static class GeneratorRunner
             }
         }
 
-        // TODO(ADR-0145): forward AdditionalText / AnalyzerConfigOptionsProvider
-        // to the driver once the production host needs generators that consume
-        // them. The in-test / declaration-driven path does not require them.
-        return RunCore(stubCSharp, references, generators, failures);
+        return RunCore(stubCSharp, references, generators, failures, additionalTexts, optionsProvider);
     }
 
     private static GeneratorRunResult RunCore(
         string stubCSharp,
         IReadOnlyList<MetadataReference> references,
         IReadOnlyList<ISourceGenerator> generators,
-        List<GeneratorFailure> failures)
+        List<GeneratorFailure> failures,
+        IReadOnlyList<AdditionalText> additionalTexts = null,
+        AnalyzerConfigOptionsProvider optionsProvider = null)
     {
         ArgumentNullException.ThrowIfNull(stubCSharp);
         ArgumentNullException.ThrowIfNull(references);
@@ -118,7 +127,14 @@ public static class GeneratorRunner
                 failures);
         }
 
-        GeneratorDriver driver = CSharpGeneratorDriver.Create(generators);
+        // ADR-0145 §C / issue #2223: forward the project's non-source inputs
+        // (e.g. Avalonia .axaml) and their MSBuild options so file/options-driven
+        // generators can find and process them.
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators,
+            additionalTexts: additionalTexts?.ToImmutableArray() ?? ImmutableArray<AdditionalText>.Empty,
+            parseOptions: (CSharpParseOptions)stubTree.Options,
+            optionsProvider: optionsProvider);
 
         // RunGenerators never surfaces a generator's own exception; it is
         // captured on the per-generator GeneratorRunResult.Exception instead.

--- a/tools/gsgen/GSharp.GeneratorHost/HostAdditionalText.cs
+++ b/tools/gsgen/GSharp.GeneratorHost/HostAdditionalText.cs
@@ -1,0 +1,51 @@
+// <copyright file="HostAdditionalText.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace GSharp.GeneratorHost;
+
+/// <summary>
+/// ADR-0145 §C: a file-backed <see cref="AdditionalText"/> forwarded to the
+/// generator driver so generators that consume non-source inputs (e.g.
+/// Avalonia's <c>.axaml</c> XAML → <c>InitializeComponent</c> generator, issue
+/// #2223) can read them. Each instance also carries the MSBuild item metadata
+/// (<c>build_metadata.AdditionalFiles.*</c>) the generator's
+/// <see cref="Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptions"/> lookup
+/// needs — most importantly <c>SourceItemGroup</c> (e.g. <c>AvaloniaXaml</c>),
+/// which is how such a generator recognizes a file as its own input.
+/// </summary>
+public sealed class HostAdditionalText : AdditionalText
+{
+    private readonly string resolvedPath;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HostAdditionalText"/> class.
+    /// </summary>
+    /// <param name="path">The path to the additional file on disk.</param>
+    /// <param name="metadata">The <c>build_metadata.AdditionalFiles.*</c> pairs for this file (case-insensitive keys).</param>
+    public HostAdditionalText(string path, IReadOnlyDictionary<string, string> metadata = null)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        this.resolvedPath = System.IO.Path.GetFullPath(path);
+        this.Metadata = metadata ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc/>
+    public override string Path => this.resolvedPath;
+
+    /// <summary>Gets the <c>build_metadata.AdditionalFiles.*</c> pairs for this file.</summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; }
+
+    /// <inheritdoc/>
+    public override SourceText GetText(System.Threading.CancellationToken cancellationToken = default)
+    {
+        using var stream = File.OpenRead(this.resolvedPath);
+        return SourceText.From(stream);
+    }
+}

--- a/tools/gsgen/GSharp.GeneratorHost/HostAnalyzerConfigOptionsProvider.cs
+++ b/tools/gsgen/GSharp.GeneratorHost/HostAnalyzerConfigOptionsProvider.cs
@@ -1,0 +1,85 @@
+// <copyright file="HostAnalyzerConfigOptions.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace GSharp.GeneratorHost;
+
+/// <summary>
+/// ADR-0145 §C: an <see cref="AnalyzerConfigOptionsProvider"/> that surfaces the
+/// MSBuild-derived options a Roslyn generator reads — project-wide
+/// <c>build_property.*</c> globals (e.g. <c>RootNamespace</c>, <c>ProjectDir</c>,
+/// <c>AvaloniaNameGeneratorBehavior</c>) and per-<see cref="AdditionalText"/>
+/// <c>build_metadata.AdditionalFiles.*</c> pairs (e.g. <c>SourceItemGroup</c>).
+/// This is what lets a file/options-driven generator such as Avalonia's XAML
+/// name generator (issue #2223) recognize and process its inputs.
+/// </summary>
+public sealed class HostAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
+{
+    private readonly AnalyzerConfigOptions global;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HostAnalyzerConfigOptionsProvider"/> class.
+    /// </summary>
+    /// <param name="globalOptions">The project-wide <c>build_property.*</c> options (keys already prefixed).</param>
+    public HostAnalyzerConfigOptionsProvider(IReadOnlyDictionary<string, string> globalOptions)
+    {
+        this.global = new DictionaryOptions(globalOptions ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+    }
+
+    /// <inheritdoc/>
+    public override AnalyzerConfigOptions GlobalOptions => this.global;
+
+    /// <inheritdoc/>
+    public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => this.global;
+
+    /// <inheritdoc/>
+    public override AnalyzerConfigOptions GetOptions(AdditionalText textFile)
+    {
+        if (textFile is HostAdditionalText host && host.Metadata.Count > 0)
+        {
+            var merged = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kvp in host.Metadata)
+            {
+                merged["build_metadata.AdditionalFiles." + kvp.Key] = kvp.Value;
+            }
+
+            return new DictionaryOptions(merged, fallback: this.global);
+        }
+
+        return this.global;
+    }
+
+    private sealed class DictionaryOptions : AnalyzerConfigOptions
+    {
+        private readonly IReadOnlyDictionary<string, string> values;
+        private readonly AnalyzerConfigOptions fallback;
+
+        public DictionaryOptions(IReadOnlyDictionary<string, string> values, AnalyzerConfigOptions fallback = null)
+        {
+            this.values = values;
+            this.fallback = fallback;
+        }
+
+        public override bool TryGetValue(string key, [NotNullWhen(true)] out string value)
+        {
+            if (this.values.TryGetValue(key, out value) && value is not null)
+            {
+                return true;
+            }
+
+            if (this.fallback is not null)
+            {
+                return this.fallback.TryGetValue(key, out value);
+            }
+
+            value = null;
+            return false;
+        }
+    }
+}

--- a/tools/gsgen/Gsgen.Cli/GsgenArgs.cs
+++ b/tools/gsgen/Gsgen.Cli/GsgenArgs.cs
@@ -35,6 +35,25 @@ public sealed class GsgenArgs
     /// </summary>
     public List<string> CsFiles { get; } = new();
 
+    /// <summary>
+    /// Gets the additional (non-source) files (<c>/additionalfile:</c>) forwarded
+    /// to generators as Roslyn <c>AdditionalText</c> (issue #2223 — Avalonia
+    /// <c>.axaml</c>). Each entry is <c>path</c> optionally followed by
+    /// <c>;key=value</c> MSBuild-metadata pairs (e.g.
+    /// <c>;SourceItemGroup=AvaloniaXaml</c>) that become
+    /// <c>build_metadata.AdditionalFiles.*</c> options for that file.
+    /// </summary>
+    public List<AdditionalFileSpec> AdditionalFiles { get; } = new();
+
+    /// <summary>
+    /// Gets the project-wide generator options (<c>/globaloption:</c>) forwarded
+    /// as <c>build_property.*</c> global <c>AnalyzerConfigOptions</c> (e.g.
+    /// <c>RootNamespace</c>, <c>AvaloniaNameGeneratorBehavior</c>). Keys are
+    /// stored already prefixed with <c>build_property.</c>.
+    /// </summary>
+    public Dictionary<string, string> GlobalOptions { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>Gets or sets the output directory for generated <c>.g.gs</c> files (<c>/out:</c>). Required.</summary>
     public string OutDir { get; set; }
 
@@ -81,6 +100,34 @@ public sealed class GsgenArgs
             else if (TryMatch(arg, "/csfile:", out var csFile))
             {
                 parsed.CsFiles.Add(csFile);
+            }
+            else if (TryMatch(arg, "/additionalfile:", out var additionalFile))
+            {
+                var spec = AdditionalFileSpec.Parse(additionalFile);
+                if (spec is not null)
+                {
+                    parsed.AdditionalFiles.Add(spec);
+                }
+            }
+            else if (TryMatch(arg, "/globaloption:", out var globalOption))
+            {
+                int eq = globalOption.IndexOf('=');
+                if (eq > 0)
+                {
+                    var key = globalOption.Substring(0, eq).Trim();
+                    var value = globalOption.Substring(eq + 1);
+                    if (key.Length > 0)
+                    {
+                        var prefixed = key.StartsWith("build_property.", StringComparison.OrdinalIgnoreCase)
+                            ? key
+                            : "build_property." + key;
+                        parsed.GlobalOptions[prefixed] = value;
+                    }
+                }
+                else
+                {
+                    notes?.Add($"ignoring malformed '/globaloption:' (expected key=value): '{arg}'");
+                }
             }
             else if (TryMatch(arg, "/out:", out var outDir))
             {
@@ -151,6 +198,21 @@ public sealed class GsgenArgs
         }
     }
 
+    /// <summary>
+    /// Verifies each <c>/additionalfile:</c> file exists on disk, throwing a
+    /// <see cref="FileNotFoundException"/> (surfaced as <c>GS9200</c>) otherwise.
+    /// </summary>
+    public void ValidateAdditionalFilesExist()
+    {
+        foreach (var spec in AdditionalFiles)
+        {
+            if (!File.Exists(spec.Path))
+            {
+                throw new FileNotFoundException($"additional file not found: '{spec.Path}'.", spec.Path);
+            }
+        }
+    }
+
     private static bool TryMatch(string arg, string prefix, out string value)
     {
         if (arg.StartsWith(prefix, StringComparison.Ordinal))
@@ -161,5 +223,65 @@ public sealed class GsgenArgs
 
         value = null;
         return false;
+    }
+}
+
+/// <summary>
+/// A parsed <c>/additionalfile:</c> entry: a file path plus optional
+/// <c>;key=value</c> MSBuild-metadata pairs (e.g.
+/// <c>;SourceItemGroup=AvaloniaXaml</c>) that become
+/// <c>build_metadata.AdditionalFiles.*</c> options for that file.
+/// </summary>
+public sealed class AdditionalFileSpec
+{
+    private AdditionalFileSpec(string path, IReadOnlyDictionary<string, string> metadata)
+    {
+        Path = path;
+        Metadata = metadata;
+    }
+
+    /// <summary>Gets the additional file path.</summary>
+    public string Path { get; }
+
+    /// <summary>Gets the <c>build_metadata.AdditionalFiles.*</c> pairs (key without the prefix).</summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; }
+
+    /// <summary>
+    /// Parses a <c>path[;key=value[;key=value...]]</c> spec. Returns
+    /// <see langword="null"/> for a blank path.
+    /// </summary>
+    /// <param name="raw">The raw value following <c>/additionalfile:</c>.</param>
+    /// <returns>The parsed spec, or <see langword="null"/> when the path is blank.</returns>
+    public static AdditionalFileSpec Parse(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        var parts = raw.Split(';');
+        var path = parts[0].Trim();
+        if (path.Length == 0)
+        {
+            return null;
+        }
+
+        var metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 1; i < parts.Length; i++)
+        {
+            var part = parts[i];
+            int eq = part.IndexOf('=');
+            if (eq > 0)
+            {
+                var key = part.Substring(0, eq).Trim();
+                var value = part.Substring(eq + 1);
+                if (key.Length > 0)
+                {
+                    metadata[key] = value;
+                }
+            }
+        }
+
+        return new AdditionalFileSpec(path, metadata);
     }
 }

--- a/tools/gsgen/Gsgen.Cli/GsgenProgram.cs
+++ b/tools/gsgen/Gsgen.Cli/GsgenProgram.cs
@@ -80,6 +80,7 @@ public static class GsgenProgram
 
             parsed.ValidateGsFilesExist();
             parsed.ValidateCsFilesExist();
+            parsed.ValidateAdditionalFilesExist();
 
             var generatedGsFiles = new List<(string HintName, string GSharpSource)>();
             GeneratorHostResult result = null;
@@ -128,7 +129,16 @@ public static class GsgenProgram
 
         var compilation = new Compilation(resolver, syntaxTrees);
 
-        return GeneratorHostRunner.RunFromAnalyzerPaths(compilation, metadataRefs, parsed.AnalyzerPaths);
+        // Issue #2223: forward the project's non-source inputs (.axaml) and the
+        // MSBuild options file/options-driven generators (e.g. Avalonia) read.
+        IReadOnlyList<AdditionalText> additionalTexts = parsed.AdditionalFiles
+            .Select(spec => (AdditionalText)new HostAdditionalText(spec.Path, spec.Metadata))
+            .ToList();
+
+        var optionsProvider = new HostAnalyzerConfigOptionsProvider(parsed.GlobalOptions);
+
+        return GeneratorHostRunner.RunFromAnalyzerPaths(
+            compilation, metadataRefs, parsed.AnalyzerPaths, additionalTexts, optionsProvider);
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

Migrating the Oahu Avalonia projects with `cs2gs migrate` produces
`GS0130: Cannot find function InitializeComponent` (8× across the `.axaml`
code-behind files). Avalonia's `InitializeComponent` is emitted by a Roslyn
incremental source generator (`Avalonia.Generators`) that consumes each
`Foo.axaml` as an `AdditionalText` and reads `AnalyzerConfigOptions`
(e.g. `build_property.AvaloniaNameGeneratorBehavior`). gsgen never forwarded
`AdditionalText`/`AnalyzerConfigOptions` (an ADR-0145 TODO), so the generator
could not see the XAML.

## Approach (general, not Avalonia-specific)

Forward Roslyn `AdditionalText` + `AnalyzerConfigOptions` into gsgen so the
project's real generators run. Avalonia is just the first consumer; any
AdditionalFiles/options-driven generator now works.

### Layers wired
- **gsgen host**: `GeneratorRunner`/`GeneratorHostRunner` pass file-backed
  `HostAdditionalText` + a global/per-file `HostAnalyzerConfigOptionsProvider`
  into `CSharpGeneratorDriver.Create`; resolves the ADR-0145 TODO. New CLI
  args `/additionalfile:<path[;key=value]>` and `/globaloption:<key>=<value>`.
- **gsc**: relays the new flags into its `SpawnGsgen` rsp.
- **SDK**: `GsgenTask` emits the flags from `@(AdditionalFiles)`; a new
  `_GsharpCollectGeneratorOptions` target surfaces `RootNamespace`/`ProjectDir`/
  `AvaloniaNameGenerator*` as `build_property.*` options and adds
  `@(AdditionalFiles)` to the generator target's `Inputs`.
- **cs2gs migrate**: `CSharpProjectLoader` discovers `.axaml`/Roslyn
  `AdditionalDocuments`; `TranslateStage` tags XAML with
  `SourceItemGroup=AvaloniaXaml` and adds `RootNamespace`/`ProjectDir`;
  `GscInvoker`/`CompileStage` forward them so the migrate compile check
  materializes `InitializeComponent` and clears GS0130.

The runtime `CompileAvaloniaXaml` post-compile task needs no new code: the
G# SDK imports `Microsoft.NET.Sdk` and emits the assembly at the standard
`@(IntermediateAssembly)` path, so Avalonia's language-agnostic `AfterCompile`
IL rewrite hooks normally.

## Tests
- `AdditionalTextGeneratorTests` — a fake Avalonia-style generator reading
  `.axaml` AdditionalText + options materializes a partial `InitializeComponent`.
- `GsgenArgsAdditionalFilesTests` — `/additionalfile:`/`/globaloption:` parsing.
- Existing `Issue2215` gsc analyzer-flag tests still pass (spawn path intact).

## Docs
- ADR-0145 (AdditionalText/options implemented) and ADR-0143 (Avalonia added to
  the reproduced-generator set) updated.

## Follow-up
- End-to-end validation against the real Oahu Avalonia corpus (needs Avalonia
  packages) is recommended as the acceptance check.

Fixes #2223.