### PR TITLE
cs2gs: qualify colliding top-level type names across imported namespaces

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2222TopLevelTypeQualificationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2222TopLevelTypeQualificationTranslationTests.cs
@@ -1,0 +1,196 @@
+// <copyright file="Issue2222TopLevelTypeQualificationTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2222: two TOP-LEVEL types sharing a simple name in different
+/// namespaces, both imported into the same file, must be emitted qualified
+/// (<c>Namespace.Type</c>) so gsc's flat import scope binds each reference to
+/// the right type instead of silently picking whichever homonym resolves
+/// first (the reported GS0155/GS0158 cascade). Generalizes the #1174
+/// nested-type homonym check — which only covered SOURCE-declared nested
+/// types — to <c>QualifiedTypeName</c>'s top-level branch, and additionally
+/// covers a homonym declared in a REFERENCED ASSEMBLY (a translated sibling
+/// project surfaced as a metadata reference), not just one declared in this
+/// compilation's own source.
+/// </summary>
+public class Issue2222TopLevelTypeQualificationTranslationTests
+{
+    /// <summary>
+    /// Two source-declared top-level types sharing the simple name
+    /// `ChapterInfo`, both imported into one file: the materialized `var`
+    /// local's inferred type AND an explicitly-qualified constructor call must
+    /// both round-trip fully qualified.
+    /// </summary>
+    [Fact]
+    public void SourceHomonym_AcrossImportedNamespaces_IsEmittedQualified()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("First.cs", @"
+namespace First
+{
+    public class ChapterInfo
+    {
+        public int RuntimeLengthSec;
+    }
+}
+"),
+            ("Second.cs", @"
+namespace Second
+{
+    public class ChapterInfo
+    {
+        public string Asin;
+    }
+}
+"),
+            ("Caller.cs", @"
+using First;
+using Second;
+
+namespace Consumer
+{
+    public class Book
+    {
+        public First.ChapterInfo ChapterInfo;
+    }
+
+    public class Caller
+    {
+        public void Use(Book book)
+        {
+            var chapterInfo = book.ChapterInfo;
+            var ci = new Second.ChapterInfo();
+            System.Console.WriteLine(chapterInfo.RuntimeLengthSec);
+            System.Console.WriteLine(ci.Asin);
+        }
+    }
+}
+"),
+        });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Inline C# source should bind with no errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = project.Documents.Single(d => d.FilePath.EndsWith("Caller.cs", StringComparison.Ordinal));
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+
+        // The `var` local's materialized type annotation is qualified...
+        Assert.Contains("First.ChapterInfo", printed);
+
+        // ...and the explicit constructor call keeps its qualification instead
+        // of collapsing to the bare (ambiguous) `ChapterInfo()`.
+        Assert.Contains("Second.ChapterInfo()", printed);
+
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
+    }
+
+    /// <summary>
+    /// Same simple-name collision, but the second `ChapterInfo` lives in a
+    /// REFERENCED ASSEMBLY (compiled to metadata, simulating a translated
+    /// sibling project) rather than in this compilation's own source. The
+    /// #1174 census only ever counted source-declared types, so this is the
+    /// case that needs the cross-assembly homonym check.
+    /// </summary>
+    [Fact]
+    public void MetadataHomonym_AcrossImportedNamespaces_IsEmittedQualified()
+    {
+        MetadataReference libRef = CompileLibrary(
+            @"
+namespace Second
+{
+    public class ChapterInfo
+    {
+        public string Asin;
+    }
+}
+",
+            "Issue2222SecondLib");
+
+        const string Source = @"
+using First;
+using Second;
+
+namespace First
+{
+    public class ChapterInfo
+    {
+        public int RuntimeLengthSec;
+    }
+}
+
+namespace Consumer
+{
+    public class Caller
+    {
+        public First.ChapterInfo Make()
+        {
+            return new First.ChapterInfo();
+        }
+    }
+}
+";
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(Source, parseOptions, path: "Caller.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue2222.MetadataHomonymInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Append(libRef).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Caller.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+
+        // `First.ChapterInfo` is ambiguous with the metadata `Second.ChapterInfo`
+        // reachable through the file's own `using Second;` — both the return
+        // type and the constructor call must be qualified.
+        Assert.Contains("First.ChapterInfo", printed);
+
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
+    }
+
+    private static MetadataReference CompileLibrary(string libSource, string assemblyName)
+    {
+        var libTree = CSharpSyntaxTree.ParseText(libSource, new CSharpParseOptions(LanguageVersion.Latest));
+        var libCompilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { libTree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var peStream = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult emit = libCompilation.Emit(peStream);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        peStream.Position = 0;
+        return MetadataReference.CreateFromStream(peStream);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2222TopLevelTypeQualificationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2222TopLevelTypeQualificationTranslationTests.cs
@@ -172,11 +172,170 @@ namespace Consumer
 
         // `First.ChapterInfo` is ambiguous with the metadata `Second.ChapterInfo`
         // reachable through the file's own `using Second;` — both the return
-        // type and the constructor call must be qualified.
-        Assert.Contains("First.ChapterInfo", printed);
+        // type (`func Make(): First.ChapterInfo`) and the constructor call
+        // (`new First.ChapterInfo()`) must be qualified. A single occurrence
+        // wouldn't prove that; assert both usages so this doesn't quietly
+        // regress to only qualifying one of them.
+        Assert.Equal(2, CountOccurrences(printed, "First.ChapterInfo"));
+        Assert.DoesNotContain(" ChapterInfo(", printed);
 
         RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
         Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
+    }
+
+    /// <summary>
+    /// Issue #2222 ordering blindspot: namespace <c>First</c> is reached via
+    /// an explicit <c>using</c>, but the colliding namespace <c>Second</c> is
+    /// reached ONLY via full qualification (<c>new Second.ChapterInfo()</c>),
+    /// with NO <c>using Second;</c> anywhere in the file. Because
+    /// <c>Second</c>'s namespace only enters scope as a synthesized `import`
+    /// (added after the whole file is visited), an EARLIER bare reference to
+    /// `ChapterInfo` from `First` must still be qualified — it cannot rely on
+    /// the `using Second;` that doesn't exist to detect the collision.
+    /// </summary>
+    [Fact]
+    public void SourceHomonym_ReachedOnlyViaFullQualification_StillQualifiesEarlierBareReference()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("First.cs", @"
+namespace First
+{
+    public class ChapterInfo
+    {
+        public int RuntimeLengthSec;
+    }
+}
+"),
+            ("Second.cs", @"
+namespace Second
+{
+    public class ChapterInfo
+    {
+        public string Asin;
+    }
+}
+"),
+            ("Caller.cs", @"
+using First;
+
+namespace Consumer
+{
+    public class Caller
+    {
+        public void Use()
+        {
+            // Bare reference to First.ChapterInfo, processed BEFORE the
+            // Second.ChapterInfo reference below. No `using Second;` exists
+            // anywhere in this file — Second is reached only by full
+            // qualification.
+            var chapterInfo = new First.ChapterInfo();
+            var other = new Second.ChapterInfo();
+            System.Console.WriteLine(chapterInfo.RuntimeLengthSec);
+            System.Console.WriteLine(other.Asin);
+        }
+    }
+}
+"),
+        });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Inline C# source should bind with no errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = project.Documents.Single(d => d.FilePath.EndsWith("Caller.cs", StringComparison.Ordinal));
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+
+        // The EARLIER reference (First.ChapterInfo) must be qualified even
+        // though, at the point it's processed, no explicit `using Second;`
+        // exists yet to reveal the collision.
+        Assert.Contains("First.ChapterInfo()", printed);
+        Assert.Contains("Second.ChapterInfo()", printed);
+        Assert.DoesNotContain(" ChapterInfo(", printed);
+
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
+    }
+
+    /// <summary>
+    /// Issue #2222 low-severity fix: a `using global::Foo.Bar;` directive
+    /// must be recognized the same as `using Foo.Bar;` — the `global::`
+    /// alias-qualifier prefix must be stripped before the namespace name is
+    /// parsed/split, or the homonym scan silently fails to match.
+    /// </summary>
+    [Fact]
+    public void SourceHomonym_ViaGlobalQualifiedUsing_IsEmittedQualified()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("First.cs", @"
+namespace First
+{
+    public class ChapterInfo
+    {
+        public int RuntimeLengthSec;
+    }
+}
+"),
+            ("Second.cs", @"
+namespace Second
+{
+    public class ChapterInfo
+    {
+        public string Asin;
+    }
+}
+"),
+            ("Caller.cs", @"
+using global::First;
+using global::Second;
+
+namespace Consumer
+{
+    public class Caller
+    {
+        public void Use()
+        {
+            var chapterInfo = new First.ChapterInfo();
+            var other = new Second.ChapterInfo();
+            System.Console.WriteLine(chapterInfo.RuntimeLengthSec);
+            System.Console.WriteLine(other.Asin);
+        }
+    }
+}
+"),
+        });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Inline C# source should bind with no errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = project.Documents.Single(d => d.FilePath.EndsWith("Caller.cs", StringComparison.Ordinal));
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+
+        Assert.Contains("First.ChapterInfo()", printed);
+        Assert.Contains("Second.ChapterInfo()", printed);
+        Assert.DoesNotContain(" ChapterInfo(", printed);
+
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        for (int index = haystack.IndexOf(needle, StringComparison.Ordinal); index >= 0; index = haystack.IndexOf(needle, index + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
     }
 
     private static MetadataReference CompileLibrary(string libSource, string assemblyName)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -529,7 +529,12 @@ public sealed class CSharpToGSharpTranslator
                 continue;
             }
 
-            string name = namespaceOrType.ToString();
+            // Issue #2222: strip a `global::` alias-qualifier prefix before
+            // recording the import name — `using global::Foo.Bar;` must
+            // become `import Foo.Bar`, not the unparseable `import
+            // global::Foo.Bar` (G#'s import syntax has no alias-qualifier
+            // form).
+            string name = CSharpTypeMapper.StripGlobalPrefix(namespaceOrType.ToString());
 
             if (!directive.StaticKeyword.IsKind(SyntaxKind.None))
             {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -222,6 +222,21 @@ public sealed class CSharpTypeMapper
             && (named.Name == "Index" || named.Name == "Range");
 
     /// <summary>
+    /// Issue #2222: strips a leading `global::` alias-qualifier from a
+    /// dotted namespace/type name (e.g. <c>using global::Foo.Bar;</c> yields
+    /// <c>directive.Name.ToString()</c> == <c>"global::Foo.Bar"</c>).
+    /// Splitting that text by <c>.</c> without stripping the prefix first
+    /// silently fails to match any real namespace segment. Shared with
+    /// <see cref="CSharpToGSharpTranslator.TranslateImports"/> so the
+    /// synthesized `import` list and the homonym scan agree on the same
+    /// name.
+    /// </summary>
+    /// <param name="name">The dotted namespace/type name text, possibly `global::`-prefixed.</param>
+    /// <returns><paramref name="name"/> with any leading `global::` removed.</returns>
+    internal static string StripGlobalPrefix(string name) =>
+        name.StartsWith("global::", System.StringComparison.Ordinal) ? name.Substring("global::".Length) : name;
+
+    /// <summary>
     /// Issue #1906: maps a C# function-pointer type (<c>delegate*&lt;...&gt;</c>)
     /// to a G# function-pointer type. A plain <c>delegate*&lt;T, R&gt;</c> or an
     /// explicit <c>delegate* managed&lt;T, R&gt;</c> is the <b>default</b>
@@ -605,9 +620,29 @@ public sealed class CSharpTypeMapper
     /// Issue #2222: the namespace names in scope for the file backing <see
     /// cref="TranslationContext.SemanticModel"/> — every `using` directive
     /// (skipping aliased/`using static` ones, which do not bring a type's bare
-    /// simple name into scope the same way) plus the file's own declared
-    /// namespace. Cached per mapper instance: one mapper translates one file,
-    /// so the import set never changes across calls.
+    /// simple name into scope the same way), the file's own declared
+    /// namespace, AND the namespace of every top-level type referenced
+    /// anywhere in the file, even one reached only via full qualification
+    /// with no matching `using`.
+    /// <para>
+    /// That last part fixes an ordering blindspot: <see
+    /// cref="TrackShortenedNamespace"/> records EVERY top-level-type
+    /// reference's namespace (not just qualified ones), and
+    /// <c>CSharpToGSharpTranslator.Translate</c> synthesizes a matching
+    /// `import` for any such namespace not already covered by an explicit
+    /// `using`, once the WHOLE file has been visited. So a namespace reached
+    /// only via full qualification (e.g. `new Oahu.Audible.Json.ChapterInfo()`
+    /// with no `using Oahu.Audible.Json;`) still ends up in scope in the final
+    /// G# output. But references are qualified in a single forward pass — an
+    /// EARLIER reference (e.g. bare `book.ChapterInfo`) cannot see that a
+    /// LATER reference's namespace will land in scope this way, so it would
+    /// wrongly stay bare and become ambiguous. Pre-scanning the whole file's
+    /// type references up front (this method) makes the ambiguity check see
+    /// the same namespace set the file will actually end up importing,
+    /// regardless of visit order.
+    /// </para>
+    /// Cached per mapper instance: one mapper translates one file, so the
+    /// import set never changes across calls.
     /// </summary>
     private HashSet<string> GetImportedNamespaceNames(TranslationContext context)
     {
@@ -628,12 +663,41 @@ public sealed class CSharpTypeMapper
                     continue;
                 }
 
-                names.Add(directive.Name.ToString());
+                names.Add(StripGlobalPrefix(directive.Name.ToString()));
             }
 
             foreach (BaseNamespaceDeclarationSyntax nsDecl in root.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>())
             {
-                names.Add(nsDecl.Name.ToString());
+                names.Add(StripGlobalPrefix(nsDecl.Name.ToString()));
+            }
+
+            // Pre-scan every name/member-access node for a bound top-level-type
+            // symbol, so a namespace reached only via full qualification (no
+            // `using`) is already visible to the FIRST reference processed,
+            // not just references processed after the synth-import-triggering
+            // one (see the ordering note above).
+            foreach (SyntaxNode node in root.DescendantNodes())
+            {
+                if (node is not (NameSyntax or MemberAccessExpressionSyntax))
+                {
+                    continue;
+                }
+
+                if (context.SemanticModel.GetSymbolInfo(node).Symbol is not INamedTypeSymbol candidate)
+                {
+                    continue;
+                }
+
+                INamedTypeSymbol outermost = candidate;
+                while (outermost.ContainingType != null)
+                {
+                    outermost = outermost.ContainingType;
+                }
+
+                if (outermost.ContainingNamespace is { IsGlobalNamespace: false } ns)
+                {
+                    names.Add(ns.ToDisplayString());
+                }
             }
         }
 
@@ -644,7 +708,7 @@ public sealed class CSharpTypeMapper
     private static INamespaceSymbol ResolveNamespace(Compilation compilation, string dottedName)
     {
         INamespaceSymbol current = compilation.GlobalNamespace;
-        foreach (string part in dottedName.Split('.'))
+        foreach (string part in StripGlobalPrefix(dottedName).Split('.'))
         {
             current = current.GetNamespaceMembers().FirstOrDefault(n => n.Name == part);
             if (current is null)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -604,9 +604,14 @@ public sealed class CSharpTypeMapper
                 continue;
             }
 
+            // `named` may be a CONSTRUCTED generic (e.g. `Box<Label>`), while
+            // `GetTypeMembers` always yields the unbound generic definition
+            // (`Box<T>`). Comparing them directly makes every reference to a
+            // constructed generic type look like a homonym of itself — compare
+            // original definitions so `Box<Label>` correctly matches `Box<T>`.
             foreach (INamedTypeSymbol candidate in candidateNamespace.GetTypeMembers(named.Name))
             {
-                if (!SymbolEqualityComparer.Default.Equals(candidate, named))
+                if (!SymbolEqualityComparer.Default.Equals(candidate.OriginalDefinition, named.OriginalDefinition))
                 {
                     return true;
                 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -10,6 +10,8 @@ using System.Runtime.InteropServices;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.Translator.Coverage;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Cs2Gs.Translator;
 
@@ -58,6 +60,16 @@ public sealed class CSharpTypeMapper
     /// type's simple name is ambiguous and must be emitted in qualified form.
     /// </summary>
     private Dictionary<string, int> sourceSimpleNameCounts;
+
+    /// <summary>
+    /// Issue #2222: the current file's imported namespace names (`using`
+    /// directives plus its own declared namespace), cached lazily since every
+    /// top-level-type reference in a file shares the same import set. Used to
+    /// detect a same-simple-name collision reachable via THIS file's imports,
+    /// including one that lives in a referenced assembly (a translated sibling
+    /// project) rather than in source.
+    /// </summary>
+    private HashSet<string> importedNamespaceNames;
 
     /// <summary>
     /// Gets every namespace shortened into a bare/qualified-nested type name by
@@ -478,7 +490,36 @@ public sealed class CSharpTypeMapper
         if (named.ContainingType == null)
         {
             this.TrackShortenedNamespace(named);
-            return CSharpToGSharpTranslator.SanitizeIdentifier(named.Name);
+            string simpleName = CSharpToGSharpTranslator.SanitizeIdentifier(named.Name);
+
+            // Issue #2222: a bare top-level type name is ambiguous in G#'s flat
+            // import scope when another top-level type of the SAME simple name
+            // is reachable through this file's imports (a source homonym
+            // anywhere in the compilation, per #1174's conservative census, OR a
+            // distinct type of the same name sitting in one of the file's
+            // actually-imported namespaces — including a referenced assembly,
+            // i.e. a translated sibling project surfaced as a metadata
+            // reference). Qualify with the namespace in that case so gsc binds
+            // the reference to the right type instead of whichever homonym
+            // happens to resolve first.
+            //
+            // The imported-namespace scan is gated on `named` itself being
+            // SOURCE-declared: a pure-BCL/metadata reference (e.g. `List<T>`)
+            // must never trip it — the runtime ships the same forwarded type
+            // across several referenced assemblies (facade + implementation),
+            // which otherwise looks like a spurious homonym and would qualify
+            // every common framework type. Only a type this project actually
+            // AUTHORS can be the accidental collision the issue describes.
+            bool ambiguous = this.HasSourceHomonym(named, context)
+                || (named.Locations.Any(l => l.IsInSource) && this.HasImportedNamespaceHomonym(named, context));
+            if (!ambiguous)
+            {
+                return simpleName;
+            }
+
+            return named.ContainingNamespace is { IsGlobalNamespace: false } containingNs
+                ? $"{containingNs.ToDisplayString()}.{simpleName}"
+                : simpleName;
         }
 
         // A source nested type only needs qualifying when its simple name is
@@ -526,6 +567,93 @@ public sealed class CSharpTypeMapper
     {
         this.sourceSimpleNameCounts ??= BuildSourceSimpleNameCounts(context.Compilation);
         return this.sourceSimpleNameCounts.TryGetValue(named.Name, out var count) && count > 1;
+    }
+
+    /// <summary>
+    /// Issue #2222: whether a DIFFERENT top-level type sharing <paramref
+    /// name="named"/>'s simple name is reachable through one of the current
+    /// file's imported namespaces (its `using` directives plus its own
+    /// declared namespace). Unlike <see cref="HasSourceHomonym"/>'s
+    /// compilation-wide source-only census, this walks only the namespaces
+    /// this file actually imports — cheap even when a referenced assembly
+    /// (e.g. a translated sibling project) is huge — and covers a homonym
+    /// declared in metadata rather than source.
+    /// </summary>
+    private bool HasImportedNamespaceHomonym(INamedTypeSymbol named, TranslationContext context)
+    {
+        foreach (string namespaceName in this.GetImportedNamespaceNames(context))
+        {
+            INamespaceSymbol candidateNamespace = ResolveNamespace(context.Compilation, namespaceName);
+            if (candidateNamespace is null)
+            {
+                continue;
+            }
+
+            foreach (INamedTypeSymbol candidate in candidateNamespace.GetTypeMembers(named.Name))
+            {
+                if (!SymbolEqualityComparer.Default.Equals(candidate, named))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #2222: the namespace names in scope for the file backing <see
+    /// cref="TranslationContext.SemanticModel"/> — every `using` directive
+    /// (skipping aliased/`using static` ones, which do not bring a type's bare
+    /// simple name into scope the same way) plus the file's own declared
+    /// namespace. Cached per mapper instance: one mapper translates one file,
+    /// so the import set never changes across calls.
+    /// </summary>
+    private HashSet<string> GetImportedNamespaceNames(TranslationContext context)
+    {
+        if (this.importedNamespaceNames != null)
+        {
+            return this.importedNamespaceNames;
+        }
+
+        var names = new HashSet<string>();
+        if (context.SemanticModel.SyntaxTree.GetRoot() is CompilationUnitSyntax root)
+        {
+            IEnumerable<UsingDirectiveSyntax> usings = root.Usings
+                .Concat(root.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>().SelectMany(n => n.Usings));
+            foreach (UsingDirectiveSyntax directive in usings)
+            {
+                if (directive.Alias != null || !directive.StaticKeyword.IsKind(SyntaxKind.None) || directive.Name is null)
+                {
+                    continue;
+                }
+
+                names.Add(directive.Name.ToString());
+            }
+
+            foreach (BaseNamespaceDeclarationSyntax nsDecl in root.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>())
+            {
+                names.Add(nsDecl.Name.ToString());
+            }
+        }
+
+        this.importedNamespaceNames = names;
+        return names;
+    }
+
+    private static INamespaceSymbol ResolveNamespace(Compilation compilation, string dottedName)
+    {
+        INamespaceSymbol current = compilation.GlobalNamespace;
+        foreach (string part in dottedName.Split('.'))
+        {
+            current = current.GetNamespaceMembers().FirstOrDefault(n => n.Name == part);
+            if (current is null)
+            {
+                return null;
+            }
+        }
+
+        return current;
     }
 
     private static Dictionary<string, int> BuildSourceSimpleNameCounts(Compilation compilation)


### PR DESCRIPTION
Fixes #2222

## Problem
`CSharpTypeMapper.QualifiedTypeName`'s top-level branch (`named.ContainingType == null`) always emitted a bare simple name with no ambiguity check, unlike the nested-type branch (#1174). When two top-level types in different namespaces share a simple name and both namespaces are imported into one G# file, cs2gs emitted the bare name for both — gsc's flat import scope then binds it to the wrong type, cascading into GS0155/GS0158 errors.

## Fix
- Top-level branch now reuses the existing compilation-wide source homonym census (generalizes #1174 to top-level types, not just nested).
- Added a per-file imported-namespace scan (`using` directives + the file's own namespace) that additionally detects a homonym declared in a **referenced assembly** (a translated sibling project surfaced as metadata) — not just one declared in this compilation's own source. Gated on the type itself being source-declared so BCL types reachable through multiple forwarded runtime reference assemblies are never mistaken for a collision.
- Because the check operates on the resolved symbol (not the C# syntax), an explicitly-qualified constructor call like `new Fully.Qualified.Type()` now keeps its qualification instead of collapsing to the ambiguous bare name — no separate special-casing needed.

## Tests
Added `Issue2222TopLevelTypeQualificationTranslationTests`:
- `SourceHomonym_AcrossImportedNamespaces_IsEmittedQualified`: two source-declared top-level `ChapterInfo` types in different namespaces, both imported into one file — verifies both the materialized `var` local and the explicit constructor call round-trip fully qualified.
- `MetadataHomonym_AcrossImportedNamespaces_IsEmittedQualified`: same collision but the second `ChapterInfo` lives in a referenced assembly (metadata), simulating a translated sibling project.

Full `Cs2Gs.Tests` suite (1194 tests) passes, including all existing homonym/qualification tests (#1174, #2211).