### PR TITLE
Fix #2226: allow enum ==/!= against the integer literal 0

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -1626,6 +1626,38 @@ internal sealed partial class ExpressionBinder
             }
         }
 
+        // Issue #2226: C# §12.12 enum equality against the literal `0`. Per
+        // C# §10.2.4, the INTEGER LITERAL `0` (or any constant expression
+        // whose compile-time value is zero, e.g. a folded unary `-0`) is the
+        // one integer value that implicitly converts to ANY enum type
+        // without a cast — servicing the common flags idiom
+        // `(mode & X) != 0`, where the `&` of two same-typed flags produces
+        // an enum-typed result that must then compare against `0`. Any OTHER
+        // integer constant/expression against an enum is still rejected
+        // (GS0129), matching C#: this does not extend to `enum == 1` or
+        // `enum == someIntVariable`.
+        if (boundOperator == null && (operatorKind == SyntaxKind.EqualsEqualsToken || operatorKind == SyntaxKind.BangEqualsToken))
+        {
+            if (EnumOperatorTable.IsEnumType(boundLeft.Type)
+                && !EnumOperatorTable.IsEnumType(boundRight.Type)
+                && TryGetConstantIntegerValue(boundRight, out var rightZero)
+                && rightZero.IsZero
+                && TryAdaptIntegerLiteral(rightZero, EnumOperatorTable.GetUnderlyingType(boundLeft.Type), out var rightZeroValue))
+            {
+                boundRight = new BoundLiteralExpression(boundRight.Syntax, rightZeroValue, boundLeft.Type);
+                boundOperator = BoundBinaryOperator.Bind(operatorKind, boundLeft.Type, boundRight.Type);
+            }
+            else if (EnumOperatorTable.IsEnumType(boundRight.Type)
+                && !EnumOperatorTable.IsEnumType(boundLeft.Type)
+                && TryGetConstantIntegerValue(boundLeft, out var leftZero)
+                && leftZero.IsZero
+                && TryAdaptIntegerLiteral(leftZero, EnumOperatorTable.GetUnderlyingType(boundRight.Type), out var leftZeroValue))
+            {
+                boundLeft = new BoundLiteralExpression(boundLeft.Syntax, leftZeroValue, boundRight.Type);
+                boundOperator = BoundBinaryOperator.Bind(operatorKind, boundLeft.Type, boundRight.Type);
+            }
+        }
+
         // issue #1144: constant integer-literal adaptation (C#-style
         // constant-expression conversion). When exactly one operand is a
         // compile-time constant integer literal and the OTHER operand is a

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -3781,10 +3781,29 @@ public sealed class Evaluator
     // NaN == NaN is false (and != is true). Route float/double equality
     // through the native operators so NaN stays unordered/unequal
     // everywhere; every other type keeps its normal Equals semantics.
+    //
+    // Issue #2226: the binder's zero-literal enum adaptation boxes the
+    // literal `0` as the enum's raw underlying primitive (an `int32`, say),
+    // NOT an actual CLR enum instance — the emitter's `EmitLiteral` only
+    // knows how to load primitive constants (`ldc.i4` etc.), never a boxed
+    // `System.Enum`. That representation matches how a SOURCE-declared G#
+    // enum value already evaluates in this tree-walking interpreter (as its
+    // raw underlying primitive, see EvaluateNameExpression / enum-member
+    // access), but an IMPORTED CLR enum member (e.g. `ConsoleModifiers.None`)
+    // evaluates to a real boxed `System.Enum` instance. `object.Equals`
+    // between a boxed `System.Enum` and a boxed primitive of the SAME
+    // underlying value is `false` (CLR type mismatch), even though C#
+    // (and the emitter's `ceq`, which compares by underlying bit pattern)
+    // says they are equal. Unwrap either side's `Enum` to its underlying
+    // primitive before falling back to `Equals` so an enum value compares
+    // correctly against ITS OWN underlying-typed zero (or any other
+    // same-typed underlying primitive reaching this path).
     private static bool NumericEquals(object l, object r) => (l, r) switch
     {
         (float lf, float rf) => lf == rf,
         (double ld, double rd) => ld == rd,
+        (Enum le, not Enum) => Equals(Convert.ChangeType(le, Enum.GetUnderlyingType(le.GetType()), System.Globalization.CultureInfo.InvariantCulture), r),
+        (not Enum, Enum re) => Equals(l, Convert.ChangeType(re, Enum.GetUnderlyingType(re.GetType()), System.Globalization.CultureInfo.InvariantCulture)),
         _ => Equals(l, r),
     };
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2226EnumZeroLiteralComparisonTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2226EnumZeroLiteralComparisonTests.cs
@@ -1,0 +1,244 @@
+// <copyright file="Issue2226EnumZeroLiteralComparisonTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2226: `==` / `!=` between an enum type and the integer literal `0`
+/// previously reported GS0129 ("Binary operator '!=' is not defined for
+/// types 'System.IO.UnixFileMode' and 'int32'"), blocking the common
+/// bitwise-flag-test idiom `(flags &amp; Bit) != 0` — the `&amp;` of two
+/// same-typed flags enums already produced an enum-typed result (per the
+/// existing <see cref="GSharp.Core.CodeAnalysis.Binding.EnumOperatorTable"/>
+/// bitwise arm), but comparing that result against `0` had no adaptation.
+/// Per C# §10.2.4, the literal `0` (and only `0`) implicitly converts to any
+/// enum type without a cast, so `enum == 0` / `enum != 0` (either operand
+/// order) is now accepted for both source-declared G# enums and imported CLR
+/// (including `[Flags]`) enums; any other integer literal/constant against an
+/// enum is still rejected, matching C#.
+/// </summary>
+public class Issue2226EnumZeroLiteralComparisonTests
+{
+    // ── source-declared G# enum ────────────────────────────────────────
+
+    [Fact]
+    public void SourceEnum_NotEqualsZero_Binds()
+    {
+        var source = @"
+enum Color { Red, Green, Blue }
+let c = Color.Red
+c != 0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(false, result.Value); // Red == 0
+    }
+
+    [Fact]
+    public void SourceEnum_EqualsZero_Binds()
+    {
+        var source = @"
+enum Color { Red, Green, Blue }
+let c = Color.Green
+c == 0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(false, result.Value); // Green == 1
+    }
+
+    [Fact]
+    public void ZeroEqualsSourceEnum_ReversedOperandOrder_Binds()
+    {
+        var source = @"
+enum Color { Red, Green, Blue }
+let c = Color.Red
+0 == c
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void ZeroNotEqualsSourceEnum_ReversedOperandOrder_Binds()
+    {
+        var source = @"
+enum Color { Red, Green, Blue }
+let c = Color.Blue
+0 != c
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    // ── imported CLR [Flags] enum ───────────────────────────────────────
+
+    [Fact]
+    public void ImportedFlagsEnum_NotEqualsZero_Binds()
+    {
+        var source = @"
+import System
+
+let m = ConsoleModifiers.Alt
+m != 0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void ImportedFlagsEnum_EqualsZero_Binds()
+    {
+        var source = @"
+import System
+
+let m = ConsoleModifiers.None
+m == 0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void ImportedUnixFileMode_NotEqualsZero_Binds()
+    {
+        var source = @"
+import System.IO
+
+let mode = UnixFileMode.UserRead
+mode != 0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    // ── the actual flags-check idiom: `(flags & Bit) != 0` ──────────────
+
+    [Fact]
+    public void FlagsMaskIdiom_BitSet_EvaluatesTrue()
+    {
+        var source = @"
+import System
+
+let m = ConsoleModifiers.Alt | ConsoleModifiers.Shift
+let bit = m & ConsoleModifiers.Alt
+bit != 0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void FlagsMaskIdiom_BitNotSet_EvaluatesFalse()
+    {
+        var source = @"
+import System
+
+let m = ConsoleModifiers.Alt | ConsoleModifiers.Shift
+let bit = m & ConsoleModifiers.Control
+bit != 0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(false, result.Value);
+    }
+
+    // ── non-zero integer literals against an enum still error ──────────
+
+    [Fact]
+    public void SourceEnum_EqualsNonZeroLiteral_StillReportsGS0129()
+    {
+        var source = @"
+enum Color { Red, Green, Blue }
+let c = Color.Red
+c == 1
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("GS0129", System.StringComparison.Ordinal)
+            || d.Message.Contains("is not defined for types", System.StringComparison.Ordinal));
+    }
+
+    // ── compiled + executed idiom, using the natural `(flags & Bit) != 0`
+    //    shape as written inside a function body (parenthesized inline,
+    //    matching the exact idiom migrated from C#) ──────────────────────
+
+    [Fact]
+    public void CompiledAndExecuted_FlagsMaskIdiom_MatchesRuntimeBehavior()
+    {
+        var source = @"
+import System
+
+func hasAlt(m ConsoleModifiers) bool {
+    return (m & ConsoleModifiers.Alt) != 0
+}
+
+Console.WriteLine(hasAlt(ConsoleModifiers.Alt | ConsoleModifiers.Shift))
+Console.WriteLine(hasAlt(ConsoleModifiers.Shift | ConsoleModifiers.Control))
+";
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var emitResult = compilation.Emit(peStream);
+        Assert.True(
+            emitResult.Success,
+            "compilation should succeed: " + string.Join("; ", emitResult.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(nameof(CompiledAndExecuted_FlagsMaskIdiom_MatchesRuntimeBehavior), isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().First(t => t.Name == "<Program>");
+            var entry = programType.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { System.Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            var lines = captured.ToString().Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(new[] { "True", "False" }, lines);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #2226

## Problem
`gsc` rejected `==`/`!=` between an enum type and an `int32` literal, e.g.:
```
error GS0129: Binary operator '!=' is not defined for types 'System.IO.UnixFileMode' and 'int32'.
error GS0129: Binary operator '!=' is not defined for types 'System.ConsoleModifiers' and 'int32'.
```
This blocked the common flags-check idiom `(mode & X) != 0`, migrated ~25x from the Oahu corpus.

## Fix
Per C# section 10.2.4, the integer literal `0` (and only `0`) implicitly converts to any enum type without a cast — this is the special case C# permits, not arbitrary enum/int comparisons.

- `ExpressionBinder.Operators.cs`: in the shared numeric-adaptation path (already used for constant-integer-literal adaptation, boxed-constant equality, etc.), detect when one operand is enum-typed and the other is a constant integer expression evaluating to zero (bare literal or folded unary `+`/`-`), synthesize a same-typed enum zero literal, and rebind through the existing `EnumOperatorTable` `EnumEnum` comparison arm. Works uniformly for source-declared G# enums and imported CLR enums. Any non-zero literal/constant against an enum still reports GS0129, matching C#.
- `Evaluator.cs`: `NumericEquals` now unwraps a boxed `System.Enum` operand to its underlying primitive before falling back to `object.Equals`. The synthesized zero literal is boxed as the enum's raw underlying primitive (what the emitter's `EmitLiteral` can load as an IL constant), but an imported CLR enum member evaluates to a real boxed `System.Enum` instance in the tree-walking interpreter — so `object.Equals(int, EnumInstance)` was always `false` even when the underlying values matched. This is a general fix, not special-cased to any one enum.
- Verified `&`/`|`/`^` between two operands of the SAME flags-enum type was already supported (`EnumOperatorTable`, issues #534/#574) — the mask step of `(flags & Bit)` needed no change; only comparing its enum-typed result against `0` was missing.

## Tests
Added `test/Core.Tests/CodeAnalysis/Binding/Issue2226EnumZeroLiteralComparisonTests.cs`:
- `enum == 0` / `enum != 0` / `0 == enum` / `0 != enum` for a source-declared G# enum
- Same for an imported CLR `[Flags]` enum (`System.ConsoleModifiers`, `System.IO.UnixFileMode`)
- The `(flags & Bit) != 0` idiom evaluated via the tree-walking interpreter
- The same idiom compiled to IL and executed via `AssemblyLoadContext`, verifying runtime-correct behavior
- A regression check that a non-zero literal (`enum == 1`) still reports GS0129

No new `SyntaxKind`/`BoundNodeKind` was added, so `coverage-matrix.golden.txt` needed no update (verified `CoverageMatrixGoldenTests` still passes).

## Test results
- New tests: 11/11 passed
- Full `CodeAnalysis.Binding` folder: 3641/3641 passed
- Full `Core.Tests` suite: 5835 passed, 1 pre-existing unrelated skip
