### PR TITLE
Fix #2227: char bitwise/shift operators promote to int32

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -382,6 +382,7 @@ YieldStatement
 
 [BoundBinaryOperator]
 AmpersandAmpersandToken LogicalAnd (bool,bool) -> bool
+AmpersandHatToken BitClear (char,char) -> int32
 AmpersandHatToken BitClear (int16,int16) -> int16
 AmpersandHatToken BitClear (int32,int32) -> int32
 AmpersandHatToken BitClear (int64,int64) -> int64
@@ -393,6 +394,7 @@ AmpersandHatToken BitClear (uint32,uint32) -> uint32
 AmpersandHatToken BitClear (uint64,uint64) -> uint64
 AmpersandHatToken BitClear (uint8,uint8) -> uint8
 AmpersandToken BitwiseAnd (bool,bool) -> bool
+AmpersandToken BitwiseAnd (char,char) -> int32
 AmpersandToken BitwiseAnd (int16,int16) -> int16
 AmpersandToken BitwiseAnd (int32,int32) -> int32
 AmpersandToken BitwiseAnd (int64,int64) -> int64
@@ -466,6 +468,7 @@ GreaterToken Greater (uint32,uint32) -> bool
 GreaterToken Greater (uint64,uint64) -> bool
 GreaterToken Greater (uint8,uint8) -> bool
 HatToken BitwiseXor (bool,bool) -> bool
+HatToken BitwiseXor (char,char) -> int32
 HatToken BitwiseXor (int16,int16) -> int16
 HatToken BitwiseXor (int32,int32) -> int32
 HatToken BitwiseXor (int64,int64) -> int64
@@ -532,6 +535,7 @@ PercentToken Remainder (uint64,uint64) -> uint64
 PercentToken Remainder (uint8,uint8) -> uint8
 PipePipeToken LogicalOr (bool,bool) -> bool
 PipeToken BitwiseOr (bool,bool) -> bool
+PipeToken BitwiseOr (char,char) -> int32
 PipeToken BitwiseOr (int16,int16) -> int16
 PipeToken BitwiseOr (int32,int32) -> int32
 PipeToken BitwiseOr (int64,int64) -> int64
@@ -556,6 +560,7 @@ PlusToken Sum (uint16,uint16) -> uint16
 PlusToken Sum (uint32,uint32) -> uint32
 PlusToken Sum (uint64,uint64) -> uint64
 PlusToken Sum (uint8,uint8) -> uint8
+ShiftLeftToken ShiftLeft (char,int32) -> int32
 ShiftLeftToken ShiftLeft (int16,int32) -> int16
 ShiftLeftToken ShiftLeft (int32,int32) -> int32
 ShiftLeftToken ShiftLeft (int64,int32) -> int64
@@ -566,6 +571,7 @@ ShiftLeftToken ShiftLeft (uint16,int32) -> uint16
 ShiftLeftToken ShiftLeft (uint32,int32) -> uint32
 ShiftLeftToken ShiftLeft (uint64,int32) -> uint64
 ShiftLeftToken ShiftLeft (uint8,int32) -> uint8
+ShiftRightToken ShiftRight (char,int32) -> int32
 ShiftRightToken ShiftRight (int16,int32) -> int16
 ShiftRightToken ShiftRight (int32,int32) -> int32
 ShiftRightToken ShiftRight (int64,int32) -> int64
@@ -602,6 +608,7 @@ StarToken Product (uint16,uint16) -> uint16
 StarToken Product (uint32,uint32) -> uint32
 StarToken Product (uint64,uint64) -> uint64
 StarToken Product (uint8,uint8) -> uint8
+UnsignedShiftRightToken UnsignedShiftRight (char,int32) -> int32
 UnsignedShiftRightToken UnsignedShiftRight (int16,int32) -> int16
 UnsignedShiftRightToken UnsignedShiftRight (int32,int32) -> int32
 UnsignedShiftRightToken UnsignedShiftRight (int64,int32) -> int64

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -539,6 +539,17 @@ public sealed record BoundBinaryOperator
         // across types here. Users can write `int(c1) + int(c2)` explicitly.
         AddComparisonOperators(list, TypeSymbol.Char);
 
+        // Issue #2227: unlike the other integral primitives above (which are
+        // closed under their own type per ADR-0044, e.g. `uint8 & uint8 ->
+        // uint8`), `char` has no arithmetic support at all — so a `char &
+        // char -> char` result would be a novel shape rather than an
+        // extension of an existing one. Instead follow C# §12.4.7 binary
+        // numeric promotion exactly: `char`-typed operands of the bitwise
+        // and shift operators promote to `int32`, and the result is
+        // `int32`. The shift count (right operand of `<<`/`>>`/`>>>`) is
+        // always `int32`, matching every other shift operator in this file.
+        AddCharBitwiseAndShiftOperators(list);
+
         // Bool operators (unchanged behaviour, kept here for one source of truth).
         list.Add(new BoundBinaryOperator(SyntaxKind.AmpersandToken, BoundBinaryOperatorKind.BitwiseAnd, TypeSymbol.Bool));
         list.Add(new BoundBinaryOperator(SyntaxKind.AmpersandAmpersandToken, BoundBinaryOperatorKind.LogicalAnd, TypeSymbol.Bool));
@@ -580,6 +591,23 @@ public sealed record BoundBinaryOperator
         list.Add(new BoundBinaryOperator(SyntaxKind.ShiftLeftToken, BoundBinaryOperatorKind.ShiftLeft, t, TypeSymbol.Int32, t));
         list.Add(new BoundBinaryOperator(SyntaxKind.ShiftRightToken, BoundBinaryOperatorKind.ShiftRight, t, TypeSymbol.Int32, t));
         list.Add(new BoundBinaryOperator(SyntaxKind.UnsignedShiftRightToken, BoundBinaryOperatorKind.UnsignedShiftRight, t, TypeSymbol.Int32, t));
+    }
+
+    /// <summary>
+    /// Issue #2227: <c>char &amp; char</c>, <c>char | char</c>, <c>char ^ char</c>,
+    /// <c>char &amp;^ char</c>, <c>char &lt;&lt; int32</c>, <c>char &gt;&gt; int32</c>,
+    /// and <c>char &gt;&gt;&gt; int32</c> all promote to <c>int32</c> per C# §12.4.7
+    /// binary numeric promotion.
+    /// </summary>
+    private static void AddCharBitwiseAndShiftOperators(System.Collections.Generic.List<BoundBinaryOperator> list)
+    {
+        list.Add(new BoundBinaryOperator(SyntaxKind.AmpersandToken, BoundBinaryOperatorKind.BitwiseAnd, TypeSymbol.Char, TypeSymbol.Int32));
+        list.Add(new BoundBinaryOperator(SyntaxKind.PipeToken, BoundBinaryOperatorKind.BitwiseOr, TypeSymbol.Char, TypeSymbol.Int32));
+        list.Add(new BoundBinaryOperator(SyntaxKind.HatToken, BoundBinaryOperatorKind.BitwiseXor, TypeSymbol.Char, TypeSymbol.Int32));
+        list.Add(new BoundBinaryOperator(SyntaxKind.AmpersandHatToken, BoundBinaryOperatorKind.BitClear, TypeSymbol.Char, TypeSymbol.Int32));
+        list.Add(new BoundBinaryOperator(SyntaxKind.ShiftLeftToken, BoundBinaryOperatorKind.ShiftLeft, TypeSymbol.Char, TypeSymbol.Int32, TypeSymbol.Int32));
+        list.Add(new BoundBinaryOperator(SyntaxKind.ShiftRightToken, BoundBinaryOperatorKind.ShiftRight, TypeSymbol.Char, TypeSymbol.Int32, TypeSymbol.Int32));
+        list.Add(new BoundBinaryOperator(SyntaxKind.UnsignedShiftRightToken, BoundBinaryOperatorKind.UnsignedShiftRight, TypeSymbol.Char, TypeSymbol.Int32, TypeSymbol.Int32));
     }
 
     private static void AddComparisonOperators(System.Collections.Generic.List<BoundBinaryOperator> list, TypeSymbol t)

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -2744,6 +2744,11 @@ public sealed class Evaluator
         ulong ul => ~ul,
         nint ni => ~ni,
         nuint nu => ~nu,
+
+        // Issue #2227: BitClear (&^) on char operands — complement the RHS
+        // before ANDing; kept as char here so NumericAnd's char/char arm
+        // (promoting the final AND to int32) fires.
+        char ch => (char)~ch,
         _ => throw new InvalidOperationException($"Unsupported ~ operand type {v?.GetType()}"),
     };
 
@@ -3066,6 +3071,9 @@ public sealed class Evaluator
         ushort li when r is ushort ri => li & ri,
         nint li when r is nint ri => li & ri,
         nuint li when r is nuint ri => li & ri,
+
+        // Issue #2227: char operands of `&` promote to int32 (C# §12.4.7).
+        char li when r is char ri => (int)li & (int)ri,
         _ => throw new InvalidOperationException($"Unsupported & on {l?.GetType()} and {r?.GetType()}"),
     };
 
@@ -3081,6 +3089,9 @@ public sealed class Evaluator
         ushort li when r is ushort ri => li | ri,
         nint li when r is nint ri => li | ri,
         nuint li when r is nuint ri => li | ri,
+
+        // Issue #2227: char operands of `|` promote to int32 (C# §12.4.7).
+        char li when r is char ri => (int)li | (int)ri,
         _ => throw new InvalidOperationException($"Unsupported | on {l?.GetType()} and {r?.GetType()}"),
     };
 
@@ -3096,6 +3107,9 @@ public sealed class Evaluator
         ushort li when r is ushort ri => li ^ ri,
         nint li when r is nint ri => li ^ ri,
         nuint li when r is nuint ri => li ^ ri,
+
+        // Issue #2227: char operands of `^` promote to int32 (C# §12.4.7).
+        char li when r is char ri => (int)li ^ (int)ri,
         _ => throw new InvalidOperationException($"Unsupported ^ on {l?.GetType()} and {r?.GetType()}"),
     };
 
@@ -3120,6 +3134,9 @@ public sealed class Evaluator
         ushort li => li << r,
         nint li => li << r,
         nuint li => li << r,
+
+        // Issue #2227: char operands of `<<` promote to int32 (C# §12.4.7).
+        char li => (int)li << r,
         _ => throw new InvalidOperationException($"Unsupported << on {l?.GetType()}"),
     };
 
@@ -3135,6 +3152,11 @@ public sealed class Evaluator
         ushort li => li >> r,
         nint li => li >> r,
         nuint li => li >> r,
+
+        // Issue #2227: char operands of `>>` promote to int32 (C# §12.4.7).
+        // `char` is unsigned so there is no sign-extension distinction —
+        // the promoted int32 shift right matches C#'s `>>` on `char`.
+        char li => (int)li >> r,
         _ => throw new InvalidOperationException($"Unsupported >> on {l?.GetType()}"),
     };
 
@@ -3155,6 +3177,10 @@ public sealed class Evaluator
         ushort li => li >> r,
         nint li => unchecked((nint)((nuint)li >> r)),
         nuint li => li >> r,
+
+        // Issue #2227: char operands of `>>>` promote to int32 (C# §12.4.7);
+        // char is already unsigned so no reinterpretation is needed.
+        char li => (int)li >> r,
         _ => throw new InvalidOperationException($"Unsupported >>> on {l?.GetType()}"),
     };
 

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -3179,7 +3179,9 @@ public sealed class Evaluator
         nuint li => li >> r,
 
         // Issue #2227: char operands of `>>>` promote to int32 (C# §12.4.7);
-        // char is already unsigned so no reinterpretation is needed.
+        // char is already unsigned so no reinterpretation is needed. Signed
+        // `>>` and unsigned `>>>` coincide here because char's range (0-65535)
+        // never sets bit 31, so the promoted int32 is always non-negative.
         char li => (int)li >> r,
         _ => throw new InvalidOperationException($"Unsupported >>> on {l?.GetType()}"),
     };

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2227CharBitwisePromotionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2227CharBitwisePromotionTests.cs
@@ -66,6 +66,24 @@ var c = a | b
         Assert.Equal((int)'a' | (int)'b', vars["c"]);
     }
 
+    /// <summary>
+    /// Exercises <c>char &amp;^ char</c> (BitClear, lowered to <c>a &amp; ~b</c>),
+    /// the one path that makes the <c>char ch =&gt; (char)~ch</c> unary arm in
+    /// <c>Evaluator.OnesComplement</c> reachable.
+    /// </summary>
+    [Fact]
+    public void CharBitClearChar_PromotesToInt32()
+    {
+        var (eval, vars) = EvaluateWithVariables(@"
+var a char = 'a'
+var b char = 'b'
+var c = a &^ b
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.IsType<int>(vars["c"]);
+        Assert.Equal((int)'a' & ~(int)'b', vars["c"]);
+    }
+
     [Fact]
     public void CharShiftLeftInt32_PromotesToInt32()
     {
@@ -134,10 +152,14 @@ while i < 4 {{
     }
 
     /// <summary>
-    /// Compiles the exact repro from issue #2227 to IL, loads it, and runs
-    /// it — verifying the emitter (not just the tree-walking evaluator)
-    /// produces the correct `int32` XOR-accumulated result for `char`
-    /// operands sourced from string indexing.
+    /// Compiles the exact repro from issue #2227 to IL, loads it, and calls
+    /// the compiled <c>constantTimeCompare</c> function directly (no
+    /// top-level statements, no <see cref="Console"/> capture) — verifying
+    /// the emitter (not just the tree-walking evaluator) produces the
+    /// correct `int32` XOR-accumulated result for `char` operands sourced
+    /// from string indexing. Asserting on the returned value directly
+    /// avoids the process-global <c>Console.SetOut</c> state that would
+    /// otherwise race with other tests under xUnit's default parallelization.
     /// </summary>
     [Fact]
     public void CompiledAndExecuted_ConstantTimeCompareIdiom_MatchesRuntimeBehavior()
@@ -152,9 +174,6 @@ func constantTimeCompare(a string, b string) int32 {
     }
     return diff
 }
-
-Console.WriteLine(constantTimeCompare(""abcd"", ""abcd""))
-Console.WriteLine(constantTimeCompare(""abcd"", ""abcE""))
 ";
         using var peStream = new MemoryStream();
         var tree = SyntaxTree.Parse(SourceText.From(source));
@@ -170,25 +189,16 @@ Console.WriteLine(constantTimeCompare(""abcd"", ""abcE""))
         {
             var asm = loadContext.LoadFromStream(peStream);
             var programType = asm.GetTypes().First(t => t.Name == "<Program>");
-            var entry = programType.GetMethod(
-                "<Main>$",
+            var constantTimeCompare = programType.GetMethod(
+                "constantTimeCompare",
                 BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
-            Assert.NotNull(entry);
+            Assert.NotNull(constantTimeCompare);
 
-            var stdout = Console.Out;
-            var captured = new StringWriter();
-            Console.SetOut(captured);
-            try
-            {
-                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
-            }
-            finally
-            {
-                Console.SetOut(stdout);
-            }
+            var equal = constantTimeCompare!.Invoke(null, new object[] { "abcd", "abcd" });
+            var differing = constantTimeCompare.Invoke(null, new object[] { "abcd", "abcE" });
 
-            var lines = captured.ToString().Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
-            Assert.Equal(new[] { "0", ('d' ^ 'E').ToString() }, lines);
+            Assert.Equal(0, equal);
+            Assert.Equal('d' ^ 'E', differing);
         }
         finally
         {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2227CharBitwisePromotionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2227CharBitwisePromotionTests.cs
@@ -1,0 +1,198 @@
+// <copyright file="Issue2227CharBitwisePromotionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2227: the bitwise (<c>^</c>, <c>&amp;</c>, <c>|</c>) and shift
+/// (<c>&lt;&lt;</c>, <c>&gt;&gt;</c>) operators must be defined for
+/// <c>char</c> operands, matching C# §12.4.7 binary numeric promotion:
+/// both operands promote to <c>int32</c> and the result is <c>int32</c>.
+/// Discovered migrating a constant-time-comparison idiom
+/// (<c>diff |= a[i] ^ b[i]</c>, <c>a</c>/<c>b</c> strings) from C#.
+/// </summary>
+public class Issue2227CharBitwisePromotionTests
+{
+    [Fact]
+    public void CharXorChar_PromotesToInt32()
+    {
+        var (eval, vars) = EvaluateWithVariables(@"
+var a char = 'a'
+var b char = 'b'
+var c = a ^ b
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.IsType<int>(vars["c"]);
+        Assert.Equal((int)'a' ^ (int)'b', vars["c"]);
+    }
+
+    [Fact]
+    public void CharAndChar_PromotesToInt32()
+    {
+        var (eval, vars) = EvaluateWithVariables(@"
+var a char = 'a'
+var b char = 'b'
+var c = a & b
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.IsType<int>(vars["c"]);
+        Assert.Equal((int)'a' & (int)'b', vars["c"]);
+    }
+
+    [Fact]
+    public void CharOrChar_PromotesToInt32()
+    {
+        var (eval, vars) = EvaluateWithVariables(@"
+var a char = 'a'
+var b char = 'b'
+var c = a | b
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.IsType<int>(vars["c"]);
+        Assert.Equal((int)'a' | (int)'b', vars["c"]);
+    }
+
+    [Fact]
+    public void CharShiftLeftInt32_PromotesToInt32()
+    {
+        var (eval, vars) = EvaluateWithVariables(@"
+var a char = 'a'
+var c = a << 2
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.IsType<int>(vars["c"]);
+        Assert.Equal((int)'a' << 2, vars["c"]);
+    }
+
+    [Fact]
+    public void CharShiftRightInt32_PromotesToInt32()
+    {
+        var (eval, vars) = EvaluateWithVariables(@"
+var a char = 'a'
+var c = a >> 2
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.IsType<int>(vars["c"]);
+        Assert.Equal((int)'a' >> 2, vars["c"]);
+    }
+
+    /// <summary>
+    /// The exact idiom from the issue: <c>diff |= a[i] ^ b[i]</c> where
+    /// <c>a</c>/<c>b</c> are strings (so <c>a[i]</c>/<c>b[i]</c> are
+    /// <c>char</c>), accumulating a constant-time comparison across two
+    /// equal-length strings. Verifies both that it compiles and that the
+    /// runtime XOR/OR-accumulation value is correct: equal strings leave
+    /// <c>diff == 0</c>, a single differing character makes it non-zero.
+    /// </summary>
+    [Theory]
+    [InlineData("abcd", "abcd", 0)]
+    [InlineData("abcd", "abcE", ('d' ^ 'E'))]
+    public void ConstantTimeCompareIdiom_EvaluatesCorrectDiff(string left, string right, int expectedDiff)
+    {
+        var (eval, vars) = EvaluateWithVariables($@"
+var a string = ""{left}""
+var b string = ""{right}""
+var diff int32 = 0
+var i int32 = 0
+while i < 4 {{
+    diff |= a[i] ^ b[i]
+    i += 1
+}}
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.Equal(expectedDiff, vars["diff"]);
+    }
+
+    private static (EvaluationResult Result, Dictionary<string, object> Variables) EvaluateWithVariables(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var variables = new Dictionary<VariableSymbol, object>();
+        var result = compilation.Evaluate(variables);
+
+        var namedVars = new Dictionary<string, object>();
+        foreach (var kvp in variables)
+        {
+            namedVars[kvp.Key.Name] = kvp.Value;
+        }
+
+        return (result, namedVars);
+    }
+
+    /// <summary>
+    /// Compiles the exact repro from issue #2227 to IL, loads it, and runs
+    /// it — verifying the emitter (not just the tree-walking evaluator)
+    /// produces the correct `int32` XOR-accumulated result for `char`
+    /// operands sourced from string indexing.
+    /// </summary>
+    [Fact]
+    public void CompiledAndExecuted_ConstantTimeCompareIdiom_MatchesRuntimeBehavior()
+    {
+        var source = @"
+func constantTimeCompare(a string, b string) int32 {
+    var diff int32 = 0
+    var i int32 = 0
+    while i < 4 {
+        diff |= a[i] ^ b[i]
+        i += 1
+    }
+    return diff
+}
+
+Console.WriteLine(constantTimeCompare(""abcd"", ""abcd""))
+Console.WriteLine(constantTimeCompare(""abcd"", ""abcE""))
+";
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var emitResult = compilation.Emit(peStream);
+        Assert.True(
+            emitResult.Success,
+            "compilation should succeed: " + string.Join("; ", emitResult.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(nameof(CompiledAndExecuted_ConstantTimeCompareIdiom_MatchesRuntimeBehavior), isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().First(t => t.Name == "<Program>");
+            var entry = programType.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            var lines = captured.ToString().Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(new[] { "0", ('d' ^ 'E').ToString() }, lines);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -382,6 +382,7 @@ YieldStatement
 
 [BoundBinaryOperator]
 AmpersandAmpersandToken LogicalAnd (bool,bool) -> bool
+AmpersandHatToken BitClear (char,char) -> int32
 AmpersandHatToken BitClear (int16,int16) -> int16
 AmpersandHatToken BitClear (int32,int32) -> int32
 AmpersandHatToken BitClear (int64,int64) -> int64
@@ -393,6 +394,7 @@ AmpersandHatToken BitClear (uint32,uint32) -> uint32
 AmpersandHatToken BitClear (uint64,uint64) -> uint64
 AmpersandHatToken BitClear (uint8,uint8) -> uint8
 AmpersandToken BitwiseAnd (bool,bool) -> bool
+AmpersandToken BitwiseAnd (char,char) -> int32
 AmpersandToken BitwiseAnd (int16,int16) -> int16
 AmpersandToken BitwiseAnd (int32,int32) -> int32
 AmpersandToken BitwiseAnd (int64,int64) -> int64
@@ -466,6 +468,7 @@ GreaterToken Greater (uint32,uint32) -> bool
 GreaterToken Greater (uint64,uint64) -> bool
 GreaterToken Greater (uint8,uint8) -> bool
 HatToken BitwiseXor (bool,bool) -> bool
+HatToken BitwiseXor (char,char) -> int32
 HatToken BitwiseXor (int16,int16) -> int16
 HatToken BitwiseXor (int32,int32) -> int32
 HatToken BitwiseXor (int64,int64) -> int64
@@ -532,6 +535,7 @@ PercentToken Remainder (uint64,uint64) -> uint64
 PercentToken Remainder (uint8,uint8) -> uint8
 PipePipeToken LogicalOr (bool,bool) -> bool
 PipeToken BitwiseOr (bool,bool) -> bool
+PipeToken BitwiseOr (char,char) -> int32
 PipeToken BitwiseOr (int16,int16) -> int16
 PipeToken BitwiseOr (int32,int32) -> int32
 PipeToken BitwiseOr (int64,int64) -> int64
@@ -556,6 +560,7 @@ PlusToken Sum (uint16,uint16) -> uint16
 PlusToken Sum (uint32,uint32) -> uint32
 PlusToken Sum (uint64,uint64) -> uint64
 PlusToken Sum (uint8,uint8) -> uint8
+ShiftLeftToken ShiftLeft (char,int32) -> int32
 ShiftLeftToken ShiftLeft (int16,int32) -> int16
 ShiftLeftToken ShiftLeft (int32,int32) -> int32
 ShiftLeftToken ShiftLeft (int64,int32) -> int64
@@ -566,6 +571,7 @@ ShiftLeftToken ShiftLeft (uint16,int32) -> uint16
 ShiftLeftToken ShiftLeft (uint32,int32) -> uint32
 ShiftLeftToken ShiftLeft (uint64,int32) -> uint64
 ShiftLeftToken ShiftLeft (uint8,int32) -> uint8
+ShiftRightToken ShiftRight (char,int32) -> int32
 ShiftRightToken ShiftRight (int16,int32) -> int16
 ShiftRightToken ShiftRight (int32,int32) -> int32
 ShiftRightToken ShiftRight (int64,int32) -> int64
@@ -602,6 +608,7 @@ StarToken Product (uint16,uint16) -> uint16
 StarToken Product (uint32,uint32) -> uint32
 StarToken Product (uint64,uint64) -> uint64
 StarToken Product (uint8,uint8) -> uint8
+UnsignedShiftRightToken UnsignedShiftRight (char,int32) -> int32
 UnsignedShiftRightToken UnsignedShiftRight (int16,int32) -> int16
 UnsignedShiftRightToken UnsignedShiftRight (int32,int32) -> int32
 UnsignedShiftRightToken UnsignedShiftRight (int64,int32) -> int64


### PR DESCRIPTION
Fixes #2227

## Problem
`gsc` reported GS0129 for `char` operands of `^`, `&`, `|` (and `<<`, `>>`, `>>>`, `&^`):
```
error GS0129: Binary operator '^' is not defined for types 'char' and 'char'.
```
Repro from the issue (constant-time string comparison):
```csharp
diff |= a[i] ^ b[i];   // a[i], b[i] are char
```

## Root cause
Every other integral primitive (byte/sbyte/short/ushort/int32/...) is closed under its own type for the full arithmetic/comparison/bitwise/shift operator set, per ADR-0044 (uint8 & uint8 -> uint8, etc.) — confirmed those already work today. `char` was deliberately left comparison-only in `BoundBinaryOperator.BuildSupportedOperators`, with a comment noting it would need C#-style promotion to int that the binder didn't yet support.

## Fix
Added the missing operator-table entries for `char`, following C# §12.4.7 binary numeric promotion exactly: char-typed operands of `^`, `&`, `|`, `&^` (Go-style BitClear), `<<`, `>>`, and `>>>` promote to int32, and the result is int32 (matching that `char & char -> char` is never a thing in either language — C#'s `char & char` is `int`).

- `BoundBinaryOperator.cs`: new `AddCharBitwiseAndShiftOperators` table entries (char,char -> int32 for the non-shift ops; char,int32 -> int32 for the shifts, since the shift count operand is always int32, unchanged from every other integral type).
- `Evaluator.cs`: added char arms to `NumericAnd`/`NumericOr`/`NumericXor`/`NumericShl`/`NumericShr`/`NumericShrUnsigned`/`OnesComplement` so the tree-walking interpreter's runtime behavior matches the new operator table.
- No emitter change needed — IL's and/or/xor/shl/shr opcodes already operate on the int32-widened evaluation-stack value regardless of the operand's declared narrow width (char locals already push as int32), and `IsUnsignedOrChar` already treats char as unsigned for `Shr_un` selection.
- Regenerated `docs/coverage-matrix.md` / `test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt` for the 7 new operator-table rows.

### Scope note (byte/sbyte/short/ushort)
The issue's fix direction says to "generalize to all integer-promotable operand types." I verified byte/sbyte/short/ushort bitwise/shift operators are already defined today (uint8 ^ uint8 compiles and evaluates fine) — they just use G#'s own-type-closed semantics (ADR-0044) rather than C#'s int-promotion semantics. Changing that would be a breaking behavioral change to an existing, deliberate ADR-0044 design decision (every byte ^ byte call site in existing G# code would silently start returning int32), not a bug fix — GS0129 was never reported for those types. Only char had no operator defined at all, which is what this PR fixes.

## Tests
New file `test/Core.Tests/CodeAnalysis/Binding/Issue2227CharBitwisePromotionTests.cs`:
- Binder+evaluator promotion checks for `^`, `&`, `|`, `<<`, `>>` on char operands (asserts the boxed result is `int`, not `char`).
- `ConstantTimeCompareIdiom_EvaluatesCorrectDiff` — runs `diff |= a[i] ^ b[i]` over two strings via the tree-walking evaluator (equal strings -> 0, single differing char -> non-zero).
- `CompiledAndExecuted_ConstantTimeCompareIdiom_MatchesRuntimeBehavior` — compiles the same idiom to IL, loads it into a collectible `AssemblyLoadContext`, and executes it, verifying the emitted IL (not just the interpreter) produces the correct value.

## Verification
- `dotnet test test/Core.Tests --filter "FullyQualifiedName~Issue2227"` — 8/8 pass.
- `dotnet test test/Core.Tests --filter "FullyQualifiedName~Issue2226|FullyQualifiedName~EnumOperatorTableTests"` — 41/41 pass (enum bitwise operators unaffected — they route through `EnumOperatorTable`, a separate table).
- `dotnet test test/Core.Tests --filter "FullyQualifiedName~CodeAnalysis.Binding"` — 3649/3649 pass.
- `dotnet test test/Core.Tests` (full suite) — 5843 passed, 1 pre-existing skip, 0 failures.
