### PR TITLE
gsc: fix lifted boxing for nullable value tuple elements (GS0154)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -365,6 +365,23 @@ public sealed class Conversion
                     }
                 }
 
+                // Issue #2229: lifted boxing — `T? → U?` where `T` is a value
+                // type and `U` is reference-like (e.g. `int32? → object?`) is
+                // implicit whenever the bare `T → U` boxing conversion is
+                // implicit. Unlike the reference-upcast arm above, this DOES
+                // change representation: a `HasValue == false` source becomes an
+                // actual `null` reference and a `HasValue == true` source boxes
+                // its underlying value. `BindConversion` materialises this as a
+                // `BoundConversionExpression` so emit inserts the box.
+                if (fromNullable.UnderlyingType?.ClrType is { IsValueType: true })
+                {
+                    var boxedConversion = Classify(fromNullable.UnderlyingType, toNullable.UnderlyingType);
+                    if (boxedConversion.Exists && boxedConversion.IsImplicit)
+                    {
+                        return Conversion.Implicit;
+                    }
+                }
+
                 return Conversion.None;
             }
 

--- a/test/Compiler.Tests/Emit/Issue2229TupleBoxingConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2229TupleBoxingConversionEmitTests.cs
@@ -1,0 +1,217 @@
+// <copyright file="Issue2229TupleBoxingConversionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2229: a tuple element conversion that boxes a nullable VALUE type to
+/// a nullable reference target (e.g. <c>int32? -> object?</c>) must not just
+/// bind — it must emit a real box so the runtime value observed through the
+/// target-typed tuple is the boxed value (or an actual null reference when the
+/// source has no value), exactly like the equivalent scalar
+/// <c>int32? -> object?</c> argument conversion. This proves the fix (a new
+/// arm in <c>Conversion.Classify</c>'s lifted-nullable-target branch) flows
+/// through <c>ConversionClassifier.BindTupleConversion</c>'s existing
+/// per-element lowering (issue #1256) to produce verifiable IL.
+/// </summary>
+public class Issue2229TupleBoxingConversionEmitTests
+{
+    [Fact]
+    public void NullableInt32Element_BoxedToObject_RoundTripsValue()
+    {
+        var source = """
+            package Test
+            import System
+
+            func Take(t (string, object?)) string {
+                return t.Item1 + ":" + t.Item2.ToString()
+            }
+
+            func F(n int32?) string { return Take(("count", n)) }
+
+            Console.WriteLine(F(42))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("count:42\n", output);
+    }
+
+    [Fact]
+    public void NullableBoolElement_BoxedToObject_RoundTripsValue()
+    {
+        var source = """
+            package Test
+            import System
+
+            func Take(t (string, object?)) string {
+                return t.Item1 + ":" + t.Item2.ToString()
+            }
+
+            func F(b bool?) string { return Take(("ok", b)) }
+
+            Console.WriteLine(F(true))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("ok:True\n", output);
+    }
+
+    [Fact]
+    public void NullValuedNullableElement_BoxedToObject_ProducesNullReference()
+    {
+        var source = """
+            package Test
+            import System
+
+            func Take(t (string, object?)) string {
+                if t.Item2 == nil {
+                    return t.Item1 + ":nil"
+                }
+                return t.Item1 + ":" + t.Item2.ToString()
+            }
+
+            func F(n int32?) string { return Take(("count", n)) }
+
+            Console.WriteLine(F(nil))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("count:nil\n", output);
+    }
+
+    [Fact]
+    public void ParamsTupleArray_MixedNullableValueElements_RoundTripsValues()
+    {
+        // The exact repro shape from issue #2229: a variadic `(string, object?)`
+        // slice packed from tuple literals whose second element is a different
+        // nullable value type per argument.
+        var source = """
+            package Test
+            import System
+
+            func Args(pairs ...(string, object?)) string {
+                var result string = ""
+                for p in pairs {
+                    result = result + p.Item1 + "=" + p.Item2.ToString() + ";"
+                }
+                return result
+            }
+
+            func F(n int32?, b bool?) string {
+                return Args(("count", n), ("ok", b))
+            }
+
+            Console.WriteLine(F(7, false))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("count=7;ok=False;\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"gsc failed (exit {exitCode}):\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2229_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add("/nowarn:GS9100");
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            if (compileExit != 0)
+            {
+                return (compileExit, compileOut.ToString(), compileErr.ToString());
+            }
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2229ElementWiseTupleBoxingConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2229ElementWiseTupleBoxingConversionTests.cs
@@ -1,0 +1,123 @@
+// <copyright file="Issue2229ElementWiseTupleBoxingConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2229: <see cref="Issue1256ElementWiseTupleConversionTests"/> taught
+/// <c>Conversion.Classify</c> to accept a tuple `(T1, …, Tn) -> (U1, …, Un)`
+/// whenever each element `Ti -> Ui` has an implicit conversion, but the lifted
+/// nullable-target arm (`T? -> U?`) only covered TWO cases: reference-typed
+/// underlyings sharing a CLR representation (#1255) and value-typed
+/// underlyings widening to another value type (#1236). A value-typed nullable
+/// source boxing to a reference-like nullable target — e.g. <c>int32? -> object?</c>,
+/// which is exactly what a <c>bool?</c>/<c>int32?</c> tuple element boxes to when
+/// passed as <c>(string, object?)</c> — fell through to <c>Conversion.None</c>
+/// even though the bare `int32 -> object` boxing conversion is implicit. This
+/// left every tuple containing such an element unable to convert, surfacing as
+/// GS0154 on the <c>params (string, object?)...</c> call in the reported repro.
+/// </summary>
+public class Issue2229ElementWiseTupleBoxingConversionTests
+{
+    [Fact]
+    public void NullableInt32Element_To_NullableObjectElement_AsArgument_Binds()
+    {
+        var source = @"
+func Take(t (string, object?)) {}
+
+func F(n int32?) { Take((""count"", n)) }
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NullableBoolElement_To_NullableObjectElement_AsArgument_Binds()
+    {
+        var source = @"
+func Take(t (string, object?)) {}
+
+func F(b bool?) { Take((""ok"", b)) }
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void ParamsTupleArray_MixedNullableValueElements_Binds()
+    {
+        // The exact repro from issue #2229: a `params (string, object?)[]`-style
+        // variadic call site with tuple literals whose second element is a
+        // different nullable value type per argument.
+        var source = @"
+func Args(pairs ...(string, object?)) {}
+
+func F(n int32?, b bool?) {
+    Args((""count"", n), (""ok"", b))
+}
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NonNullableInt32Element_To_NullableObjectElement_AsArgument_Binds()
+    {
+        var source = @"
+func Take(t (string, object?)) {}
+
+func F(n int32) { Take((""count"", n)) }
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NumericWideningElement_IntToLong_AsArgument_Binds()
+    {
+        var source = @"
+func Take(t (string, int64)) {}
+
+func F(n int32) { Take((""count"", n)) }
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NestedTupleElement_BoxingInnerElement_Binds()
+    {
+        var source = @"
+func Take(t (string, (string, object?))) {}
+
+func F(n int32?) { Take((""outer"", (""inner"", n))) }
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NoConversion_NullableIntToNullableString_StillReportsError()
+    {
+        var source = @"
+func Take(t (string, string?)) {}
+
+func F(n int32?) { Take((""count"", n)) }
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Message.Contains("Cannot convert") || d.Message.Contains("requires a value of type"));
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #2229

## Root cause
`Conversion.Classify`'s `T? -> U?` nullable-target arm had two rules only: ref-typed underlyings sharing CLR repr (#1255), value-typed underlyings widening to another value type (#1236). Missing: value-typed nullable boxing to reference-like nullable target (`int32? -> object?`, `bool? -> object?`). Fell thru to `None` even tho bare `int32 -> object` boxing implicit. Every tuple with such elem (`(string, object?)` fed `(string, int32?)`) failed elem-wise conversion (#1256), surfaced GS0154 exactly per issue repro (Oahu `Args(("count", n), ("ok", b))`).

## Fix
One new arm in `Conversion.cs`: box `T? -> U?` when `T` value type + bare `T -> U` implicit. Reuses existing `Classify` recursion + #1256 per-elem tuple lowering/emit (`BindTupleConversion`) — no emit-side changes needed, boxing insert already worked once classification said yes.

Files touched:
- `src/Core/CodeAnalysis/Binding/Conversion.cs` (fix, ~17 lines)
- `test/Core.Tests/CodeAnalysis/Binding/Issue2229ElementWiseTupleBoxingConversionTests.cs` (new, 7 tests)
- `test/Compiler.Tests/Emit/Issue2229TupleBoxingConversionEmitTests.cs` (new, 4 tests, real compile+run+ILverify)

## Tests
- 7 binding tests: exact repro (params tuple array), numeric widening elem, nested tuple elem, non-nullable->nullable-object elem, negative (no-conversion still errors).
- 4 emit tests: proves real `box` IL + null round-trip via actual dotnet exec, incl exact params-tuple-array repro shape.
- `dotnet test test/Core.Tests`: 5852 passed, 0 failed (1 skipped baseline-regen, pre-existing).
- `dotnet test test/Compiler.Tests`: 2772 passed, 0 failed.
- No Cs2Gs.Tests project exists in repo — n/a.
- No new SyntaxKind/BoundNodeKind added, coverage-matrix golden untouched (confirmed via git diff, only Conversion.cs + 2 new test files touched).
