### PR TITLE
gsc: fix generic interface-method matching for imported interfaces

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1460,6 +1460,19 @@ internal sealed class MemberLookup
     public static bool HasMatchingMethodForClrSignature(StructSymbol structSymbol, MethodInfo clrMethod)
     {
         var clrParams = clrMethod.GetParameters();
+
+        // Issue #2230: an imported (metadata) interface method may itself be
+        // generic (e.g. `ILogger.BeginScope<TState>(TState state)`). Those
+        // method-own generic parameters need to be matched positionally
+        // against the implementer's method type parameters — the same way
+        // `TryBuildMethodTypeParameterMap` already does for source-declared
+        // interfaces (issue #1007) — because an unbound G# type parameter
+        // carries no `ClrType` and the plain `ClrTypeUtilities.AreSame`
+        // comparison below can never succeed for it.
+        var methodGenericParams = clrMethod.IsGenericMethodDefinition
+            ? clrMethod.GetGenericArguments()
+            : System.Array.Empty<Type>();
+
         foreach (var candidate in structSymbol.GetMethodsIncludingInherited(clrMethod.Name))
         {
             var callable = GetCallableParameters(candidate);
@@ -1468,20 +1481,29 @@ internal sealed class MemberLookup
                 continue;
             }
 
+            var candidateTypeParams = candidate.TypeParameters.IsDefaultOrEmpty
+                ? ImmutableArray<TypeParameterSymbol>.Empty
+                : candidate.TypeParameters;
+            if (methodGenericParams.Length != candidateTypeParams.Length)
+            {
+                // Generic-arity mismatch: not a viable implementor of this
+                // interface method overload (mirrors issue #1007).
+                continue;
+            }
+
             // Issue #1071: an `async func` implementing a CLR interface method
             // declared with an explicit `Task` / `Task[T]` return type has a
             // declared (awaited) return of void / T. Compare the contract's
             // unwrapped awaited result against the candidate's declared type.
-            var candidateReturnClr = NullableLifting.GetEffectiveClrType(candidate.Type);
             if (candidate.IsAsync
                 && AsyncReturnTypeNormalizer.TryUnwrapTaskClrType(clrMethod.ReturnType, out var awaitedReturnClr))
             {
-                if (!ClrTypeUtilities.AreSame(candidateReturnClr, awaitedReturnClr))
+                if (!ClrParamTypeMatchesGenericMethodParam(candidate.Type, awaitedReturnClr, methodGenericParams, candidateTypeParams))
                 {
                     continue;
                 }
             }
-            else if (!ClrTypeUtilities.AreSame(candidateReturnClr, clrMethod.ReturnType))
+            else if (!ClrParamTypeMatchesGenericMethodParam(candidate.Type, clrMethod.ReturnType, methodGenericParams, candidateTypeParams))
             {
                 continue;
             }
@@ -1504,7 +1526,7 @@ internal sealed class MemberLookup
                     }
 
                     var elementType = clrParamType.GetElementType();
-                    if (!ClrTypeUtilities.AreSame(NullableLifting.GetEffectiveClrType(gsParam.Type), elementType))
+                    if (!ClrParamTypeMatchesGenericMethodParam(gsParam.Type, elementType, methodGenericParams, candidateTypeParams))
                     {
                         allMatch = false;
                         break;
@@ -1519,7 +1541,7 @@ internal sealed class MemberLookup
                         break;
                     }
 
-                    if (!ClrTypeUtilities.AreSame(NullableLifting.GetEffectiveClrType(gsParam.Type), clrParamType))
+                    if (!ClrParamTypeMatchesGenericMethodParam(gsParam.Type, clrParamType, methodGenericParams, candidateTypeParams))
                     {
                         allMatch = false;
                         break;
@@ -2948,6 +2970,95 @@ internal sealed class MemberLookup
             8 => typeof(Func<,,,,,,,,>).MakeGenericType(args),
             _ => null,
         };
+    }
+
+    /// <summary>
+    /// Issue #2230: compares a candidate implementer's parameter/return
+    /// <see cref="TypeSymbol"/> against a CLR contract position that may
+    /// reference an imported (metadata) interface METHOD's own generic
+    /// parameter (e.g. the <c>TState</c> in <c>ILogger.BeginScope&lt;TState&gt;</c>
+    /// / <c>ILogger.Log&lt;TState&gt;</c>), either directly or nested inside a
+    /// constructed delegate type (e.g. <c>Func&lt;TState, Exception, string&gt;</c>).
+    /// Falls back to the existing erased-<c>ClrType</c> comparison
+    /// (<see cref="HasMatchingMethodForClrSignature"/>'s prior behavior) for
+    /// every other position, so ordinary non-generic contract members are
+    /// unaffected.
+    /// </summary>
+    /// <param name="candidate">The implementer's parameter or return type.</param>
+    /// <param name="openType">The corresponding CLR contract type (from the open generic method definition).</param>
+    /// <param name="methodGenericParams">The interface method's own generic-parameter <see cref="Type"/>s, positionally.</param>
+    /// <param name="candidateTypeParams">The implementer method's own type parameters, positionally.</param>
+    /// <returns><see langword="true"/> when the positions match.</returns>
+    private static bool ClrParamTypeMatchesGenericMethodParam(
+        TypeSymbol candidate,
+        Type openType,
+        Type[] methodGenericParams,
+        ImmutableArray<TypeParameterSymbol> candidateTypeParams)
+    {
+        if (candidate == null || openType == null)
+        {
+            return false;
+        }
+
+        // Direct method-type-parameter position (e.g. `TState state`):
+        // match by position against the implementer's own method type
+        // parameter — an unbound G# type parameter has no ClrType, so the
+        // erased comparison below can never succeed for it.
+        if (openType.IsGenericMethodParameter)
+        {
+            var position = Array.IndexOf(methodGenericParams, openType);
+            return position >= 0
+                && position < candidateTypeParams.Length
+                && ReferenceEquals(candidate, candidateTypeParams[position]);
+        }
+
+        // Fast path: no method type parameter involved at or below this
+        // position — the pre-existing erased-ClrType comparison works
+        // (covers the overwhelming majority of contract positions,
+        // including non-generic methods entirely).
+        var effectiveClr = NullableLifting.GetEffectiveClrType(candidate);
+        if (effectiveClr != null && ClrTypeUtilities.AreSame(effectiveClr, openType))
+        {
+            return true;
+        }
+
+        // Slow path: a constructed generic contract position nests the
+        // method's own type parameter (e.g. `Func<TState, Exception, string>`
+        // in `Log<TState>(..., Func<TState, Exception, string> formatter)`),
+        // which erases to a null ClrType (FunctionTypeSymbol.BuildClrType
+        // bails when any parameter has no ClrType). Recurse structurally
+        // through the delegate's `Invoke` shape instead.
+        if (candidate is FunctionTypeSymbol fn && openType.IsConstructedGenericType)
+        {
+            var invoke = openType.GetMethodSafe("Invoke");
+            if (invoke == null)
+            {
+                return false;
+            }
+
+            var invokeParams = invoke.GetParameters();
+            if (invokeParams.Length != fn.ParameterTypes.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < invokeParams.Length; i++)
+            {
+                if (!ClrParamTypeMatchesGenericMethodParam(fn.ParameterTypes[i], invokeParams[i].ParameterType, methodGenericParams, candidateTypeParams))
+                {
+                    return false;
+                }
+            }
+
+            if (invoke.ReturnType.IsSameAs(typeof(void)))
+            {
+                return FunctionTypeSymbol.IsVoidReturn(fn.ReturnType);
+            }
+
+            return ClrParamTypeMatchesGenericMethodParam(fn.ReturnType, invoke.ReturnType, methodGenericParams, candidateTypeParams);
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2977,8 +2977,13 @@ internal sealed class MemberLookup
     /// <see cref="TypeSymbol"/> against a CLR contract position that may
     /// reference an imported (metadata) interface METHOD's own generic
     /// parameter (e.g. the <c>TState</c> in <c>ILogger.BeginScope&lt;TState&gt;</c>
-    /// / <c>ILogger.Log&lt;TState&gt;</c>), either directly or nested inside a
-    /// constructed delegate type (e.g. <c>Func&lt;TState, Exception, string&gt;</c>).
+    /// / <c>ILogger.Log&lt;TState&gt;</c>), either directly or nested inside ANY
+    /// constructed generic shape — a delegate (e.g.
+    /// <c>Func&lt;TState, Exception, string&gt;</c>), an array (<c>TState[]</c>),
+    /// or any other constructed generic type (<c>IEnumerable&lt;TState&gt;</c>,
+    /// <c>IComparer&lt;TState&gt;</c>, <c>Nullable&lt;TState&gt;</c>, a custom
+    /// generic, etc.), at any nesting depth (e.g.
+    /// <c>IEnumerable&lt;IEnumerable&lt;TState&gt;&gt;</c>).
     /// Falls back to the existing erased-<c>ClrType</c> comparison
     /// (<see cref="HasMatchingMethodForClrSignature"/>'s prior behavior) for
     /// every other position, so ordinary non-generic contract members are
@@ -3056,6 +3061,56 @@ internal sealed class MemberLookup
             }
 
             return ClrParamTypeMatchesGenericMethodParam(fn.ReturnType, invoke.ReturnType, methodGenericParams, candidateTypeParams);
+        }
+
+        // Slow path: an array contract position nests the method's own type
+        // parameter (e.g. `TState[]` in `CopyTo<TState>(TState[] items)`).
+        // C#/CLR arrays aren't "generic types" in the reflection sense
+        // (`IsConstructedGenericType` is false), so they need their own
+        // element-wise recursion against the G# array-of-T shapes.
+        if (openType.IsArray)
+        {
+            var openElementType = openType.GetElementType();
+            var candidateElementType = candidate switch
+            {
+                ArrayTypeSymbol arr => arr.ElementType,
+                SliceTypeSymbol slice => slice.ElementType,
+                _ => null,
+            };
+
+            return candidateElementType != null
+                && ClrParamTypeMatchesGenericMethodParam(candidateElementType, openElementType, methodGenericParams, candidateTypeParams);
+        }
+
+        // Slow path: any other constructed generic contract position nests
+        // the method's own type parameter (e.g. `IEnumerable<TState>`,
+        // `IComparer<TState>`, `Nullable<TState>`, or a custom imported/
+        // source generic, at any nesting depth). Recurse positionally
+        // through the CLR open type's generic arguments against the G#
+        // symbol's own symbolic type arguments — the same pattern as the
+        // delegate-Invoke-shape branch above, generalized to any generic
+        // type rather than just delegates.
+        if (openType.IsConstructedGenericType
+            && candidate is ImportedTypeSymbol named
+            && named.OpenDefinition != null
+            && !named.TypeArguments.IsDefaultOrEmpty
+            && ClrTypeUtilities.AreSame(openType.GetGenericTypeDefinition(), named.OpenDefinition))
+        {
+            var openArgs = openType.GetGenericArguments();
+            if (openArgs.Length != named.TypeArguments.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < openArgs.Length; i++)
+            {
+                if (!ClrParamTypeMatchesGenericMethodParam(named.TypeArguments[i], openArgs[i], methodGenericParams, candidateTypeParams))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         return false;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2230ImportedGenericInterfaceMethodTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2230ImportedGenericInterfaceMethodTests.cs
@@ -1,0 +1,192 @@
+// <copyright file="Issue2230ImportedGenericInterfaceMethodTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2230: gsc supported matching generic interface-method
+/// implementations for SOURCE-declared interfaces (issue #1007,
+/// <c>TryBuildMethodTypeParameterMap</c>) but rejected the identical shape
+/// when the interface came from an IMPORTED (metadata) assembly — the
+/// separate CLR-interface verification path
+/// (<c>DeclarationBinder.VerifyClrInterfaceImplementations</c> /
+/// <c>MemberLookup.HasMatchingMethodForClrSignature</c>) never unified the
+/// interface method's own generic parameters against the implementer's,
+/// spuriously reporting GS0187 (e.g. <c>ILogger.BeginScope&lt;TState&gt;</c> /
+/// <c>ILogger.Log&lt;TState&gt;</c>).
+/// </summary>
+public class Issue2230ImportedGenericInterfaceMethodTests
+{
+    /// <summary>
+    /// Baseline (kept passing before and after the fix): a generic method
+    /// implementing a SOURCE-declared interface in the same compilation
+    /// already worked via issue #1007's <c>TryBuildMethodTypeParameterMap</c>.
+    /// </summary>
+    [Fact]
+    public void SourceInterface_GenericMethodImplementation_BindsCleanly()
+    {
+        const string source = """
+            package t
+            interface IStore { func Put[T](item T) bool; func Name() string; }
+            class MyStore : IStore { func Put[T](item T) bool { return true } func Name() string { return "my" } }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    /// <summary>
+    /// Exact minimal repro from issue #2230: <c>IStore.Put[T]</c> comes from a
+    /// SEPARATELY compiled (imported/metadata) assembly. Before the fix, this
+    /// spuriously reported GS0187 even though the implicit implementation is
+    /// correct.
+    /// </summary>
+    [Fact]
+    public void ImportedInterface_GenericMethodImplementation_BindsCleanly()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2230");
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Issue2230.Lib.dll");
+
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Lib
+                interface IStore { func Put[T](item T) bool; func Name() string; }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var libResult = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2230.Lib");
+            Assert.True(libResult.Success, string.Join(Environment.NewLine, libResult.Diagnostics));
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Issue2230.Lib.Tests";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package App
+                import Lib
+                class MyStore : IStore { func Put[T](item T) bool { return true } func Name() string { return "my" } }
+                """)));
+
+        Assert.Empty(consumer.GlobalScope.Diagnostics.Where(d => d.IsError));
+    }
+
+    /// <summary>
+    /// ILogger-shaped multi-param generic method: the interface method carries
+    /// an interface-irrelevant method type parameter (<c>TState</c>) plus an
+    /// ordinary parameter that nests it inside a constructed generic delegate
+    /// (<c>Func&lt;TState, Exception, string&gt;</c>), pinning the
+    /// nested-generic-arg substitution described in the issue. Uses a real BCL
+    /// <c>Func&lt;,,&gt;</c> delegate over a <see cref="MetadataLoadContext"/>-backed
+    /// reference set (mirrors cs2gs / the MSBuild task compile mode), the same
+    /// harness pattern as issue #1958.
+    /// </summary>
+    [Fact]
+    public void ImportedInterface_GenericMethodWithNestedFuncParameter_BindsCleanly()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2230Logger");
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Issue2230.LoggerLib.dll");
+
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package LoggerLib
+                interface ILoggerLike {
+                    func Log[TState](state TState, formatter (TState, string) -> string) string;
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var libResult = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2230.LoggerLib");
+            Assert.True(libResult.Success, string.Join(Environment.NewLine, libResult.Diagnostics));
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Issue2230.LoggerLib.Tests";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package App
+                import LoggerLib
+                class MyLogger : ILoggerLike {
+                    func Log[TState](state TState, formatter (TState, string) -> string) string { return formatter(state, "x") }
+                }
+                """)));
+
+        Assert.Empty(consumer.GlobalScope.Diagnostics.Where(d => d.IsError));
+    }
+
+    /// <summary>
+    /// A generic-arity mismatch against an IMPORTED interface method must
+    /// still be rejected with GS0187 — the fix must not accept every
+    /// same-name candidate regardless of arity.
+    /// </summary>
+    [Fact]
+    public void ImportedInterface_NonGenericMethod_DoesNotSatisfyGenericInterfaceMethod_ReportsGS0187()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2230Arity");
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Issue2230.ArityLib.dll");
+
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package ArityLib
+                interface IStore { func Put[T](item T) bool; }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var libResult = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2230.ArityLib");
+            Assert.True(libResult.Success, string.Join(Environment.NewLine, libResult.Diagnostics));
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Issue2230.ArityLib.Tests";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package App
+                import ArityLib
+                class MyStore : IStore { func Put(item int32) bool { return true } }
+                """)));
+
+        Assert.Contains(consumer.GlobalScope.Diagnostics, d => d.Id == "GS0187");
+    }
+
+    private static System.Collections.Generic.IReadOnlyList<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.GlobalScope.Diagnostics.ToList();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2230ImportedGenericInterfaceMethodTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2230ImportedGenericInterfaceMethodTests.cs
@@ -183,6 +183,192 @@ public class Issue2230ImportedGenericInterfaceMethodTests
         Assert.Contains(consumer.GlobalScope.Diagnostics, d => d.Id == "GS0187");
     }
 
+    /// <summary>
+    /// Follow-up to the Opus rubber-duck review of #2249: an imported
+    /// generic method parameter nested inside a CLR ARRAY of the method's
+    /// own type parameter (e.g. <c>TState[]</c> in
+    /// <c>IReadOnlyCollection&lt;T&gt;.CopyTo(T[], int)</c>) must also match —
+    /// arrays aren't <c>IsConstructedGenericType</c> in the reflection sense,
+    /// so they need their own element-wise recursion, distinct from the
+    /// constructed-delegate/generic-type branches.
+    /// </summary>
+    [Fact]
+    public void ImportedInterface_GenericMethodWithArrayOfTypeParameterParameter_BindsCleanly()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2230Array");
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Issue2230.ArrayLib.dll");
+
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package ArrayLib
+                interface ICopier { func CopyTo[T](items []T, index int32) void; }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var libResult = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2230.ArrayLib");
+            Assert.True(libResult.Success, string.Join(Environment.NewLine, libResult.Diagnostics));
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Issue2230.ArrayLib.Tests";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package App
+                import ArrayLib
+                class MyCopier : ICopier { func CopyTo[T](items []T, index int32) void {  } }
+                """)));
+
+        Assert.Empty(consumer.GlobalScope.Diagnostics.Where(d => d.IsError));
+    }
+
+    /// <summary>
+    /// Follow-up to the Opus rubber-duck review of #2249: an imported
+    /// generic method's RETURN type nested inside a non-delegate constructed
+    /// generic (<c>IEnumerable&lt;TState&gt;</c>) of the method's own type
+    /// parameter must also match, generalizing beyond the delegate-only
+    /// slow path.
+    /// </summary>
+    [Fact]
+    public void ImportedInterface_GenericMethodWithEnumerableOfTypeParameterReturn_BindsCleanly()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2230Enumerable");
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Issue2230.EnumerableLib.dll");
+
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package EnumerableLib
+                import System.Collections.Generic
+                interface IWrapper { func Wrap[T](item T) IEnumerable[T]; }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var libResult = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2230.EnumerableLib");
+            Assert.True(libResult.Success, string.Join(Environment.NewLine, libResult.Diagnostics));
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Issue2230.EnumerableLib.Tests";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package App
+                import EnumerableLib
+                import System.Collections.Generic
+                class MyWrapper : IWrapper { func Wrap[T](item T) IEnumerable[T] { return []T{item} } }
+                """)));
+
+        Assert.Empty(consumer.GlobalScope.Diagnostics.Where(d => d.IsError));
+    }
+
+    /// <summary>
+    /// Follow-up to the Opus rubber-duck review of #2249: proves the
+    /// generalized recursion isn't arity/depth-limited to a single nesting
+    /// level — a doubly-nested constructed generic
+    /// (<c>IEnumerable&lt;IEnumerable&lt;TState&gt;&gt;</c>) must also match.
+    /// </summary>
+    [Fact]
+    public void ImportedInterface_GenericMethodWithDoublyNestedEnumerableReturn_BindsCleanly()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2230NestedEnumerable");
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Issue2230.NestedEnumerableLib.dll");
+
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package NestedEnumerableLib
+                import System.Collections.Generic
+                interface IWrapper { func WrapNested[T](item T) IEnumerable[IEnumerable[T]]; }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var libResult = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2230.NestedEnumerableLib");
+            Assert.True(libResult.Success, string.Join(Environment.NewLine, libResult.Diagnostics));
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Issue2230.NestedEnumerableLib.Tests";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package App
+                import NestedEnumerableLib
+                import System.Collections.Generic
+                class MyWrapper : IWrapper { func WrapNested[T](item T) IEnumerable[IEnumerable[T]] { return []IEnumerable[T]{[]T{item}} } }
+                """)));
+
+        Assert.Empty(consumer.GlobalScope.Diagnostics.Where(d => d.IsError));
+    }
+
+    /// <summary>
+    /// Review point #2 (LOW priority, cheap to pin): a candidate method with
+    /// matching PARAMETER shape but a WRONG return type — the interface
+    /// requires <c>func Put[T](item T) T</c> but the candidate implements
+    /// <c>func Put[T](item T) bool</c> — must still correctly fail with
+    /// GS0187. Proves the generalized recursion doesn't accidentally bypass
+    /// return-type checking.
+    /// </summary>
+    [Fact]
+    public void ImportedInterface_GenericMethodWithWrongReturnType_ReportsGS0187()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2230WrongReturn");
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Issue2230.WrongReturnLib.dll");
+
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package WrongReturnLib
+                interface IStore { func Put[T](item T) T; }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var libResult = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2230.WrongReturnLib");
+            Assert.True(libResult.Success, string.Join(Environment.NewLine, libResult.Diagnostics));
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Issue2230.WrongReturnLib.Tests";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package App
+                import WrongReturnLib
+                class MyStore : IStore { func Put[T](item T) bool { return true } }
+                """)));
+
+        Assert.Contains(consumer.GlobalScope.Diagnostics, d => d.Id == "GS0187");
+    }
+
     private static System.Collections.Generic.IReadOnlyList<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
Fixes #2230.

## Root cause
Source interfaces match generic methods via `TryBuildMethodTypeParameterMap` (#1007), positional symbol map, works fine. Imported (metadata) interfaces route through a DIFFERENT path: `VerifyClrInterfaceImplementations` -> `MemberLookup.HasMatchingMethodForClrSignature`. That fn compared params/return by erased `ClrType` only. G# type param (`TState`) has no `ClrType`; CLR generic-method type param erases too -> comparison always fails -> spurious GS0187. Bug hits ANY imported interface w/ generic method (min repro: `IStore.Put[T]` from `/r:lib.dll`; real-world: `ILogger.BeginScope<TState>`/`Log<TState>`).

## Fix
`src/Core/CodeAnalysis/Binding/MemberLookup.cs`:
- `HasMatchingMethodForClrSignature`: added generic-arity check (interface method type-param count vs candidate's), skip candidate if mismatch.
- New `ClrParamTypeMatchesGenericMethodParam` helper: matches CLR generic-method type param positionally against candidate's own type param (mirror of #1007's map). Fast path keeps old erased-ClrType compare for non-generic positions. Slow path recurses through delegate's `Invoke` shape for nested cases (`Func<TState, Exception, string>`), so `ILogger.Log<TState>`'s formatter param works too.

No new deps, no SyntaxKind/BoundNodeKind changes, coverage-matrix untouched.

## Tests
New file `test/Core.Tests/CodeAnalysis/Binding/Issue2230ImportedGenericInterfaceMethodTests.cs`, 4 tests (uses same cross-assembly PE-emit harness as #1929/#1958):
1. Source-interface baseline (kept passing, unchanged).
2. Exact repro: imported `IStore.Put[T]` via separately-compiled lib -> was GS0187, now clean.
3. ILogger-shaped: generic method w/ `Func<TState, string>` param -> pins nested-generic-arg substitution.
4. Arity mismatch (non-generic candidate vs generic interface method) still rejected w/ GS0187.

## Validation
- New tests: 4/4 pass.
- `dotnet test test/Core.Tests --filter "FullyQualifiedName~Interface"`: 366/366 pass.
- Full `dotnet test test/Core.Tests`: 5856 passed, 0 failed, 1 skipped (pre-existing baseline skip). Zero regressions.
- `dotnet test tools/cs2gs/Cs2Gs.Tests`: 1025/1025 pass (no cs2gs-side regression, as expected — pure gsc/binder fix).


## Follow-up (Opus rubber-duck review)
Review flagged that `ClrParamTypeMatchesGenericMethodParam`'s slow path only
recursed through constructed-delegate shapes (`Func<TState, ...>`), so a
non-delegate constructed generic nesting the method's type param — arrays
(`TState[]`), `IEnumerable<TState>`, `List<TState>`, `IComparer<TState>`,
`Nullable<TState>`, custom generics — would fall through and spuriously
re-trigger GS0187.

Generalized `MemberLookup.cs`:
- New array branch: recurses element-wise (`openType.GetElementType()`) against
  G#'s `ArrayTypeSymbol`/`SliceTypeSymbol` — CLR arrays aren't
  `IsConstructedGenericType`, so they need their own branch.
- New general constructed-generic branch: recurses positionally through
  `openType.GetGenericArguments()` against the G# `ImportedTypeSymbol`'s own
  symbolic `TypeArguments` — same pattern as the delegate branch, generalized
  to ANY generic type/arity/nesting depth (verified with a doubly-nested
  `IEnumerable<IEnumerable<T>>` test).

New tests (4) in the same PE-emit harness: array-of-T param, `IEnumerable[T]`
return, doubly-nested `IEnumerable[IEnumerable[T]]` return, and a negative test
pinning that a wrong-return-type candidate (`T` vs `bool`) still correctly
reports GS0187.

Validation: 8/8 new+updated tests pass; full `dotnet test test/Core.Tests`:
5860 passed, 0 failed, 1 skipped (pre-existing); `dotnet test
tools/cs2gs/Cs2Gs.Tests`: all pass (the "test host crashed" message after the
final result line is a pre-existing teardown flake reproducible on `main`,
unrelated to this change).
