### PR TITLE
cs2gs: hoist local-function let bindings before first use (fix GS0125 forward-ref bug)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
@@ -3,6 +3,9 @@
 // </copyright>
 
 using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.CodeModel.RoundTrip;
@@ -16,10 +19,11 @@ namespace Cs2Gs.Tests;
 /// Translator-fidelity tests for C# local functions. C# local functions are
 /// hoisted (callable before their lexical declaration), but G# renders them as
 /// <c>let name = func(...)</c> bindings, which are not hoisted and cannot be
-/// forward-referenced (GS0130). When a local function is called before its
-/// declaration, the translator moves its declaration to the top of the block —
-/// unless it captures a sibling local declared in the same block (G# closures
-/// require captured locals to already be in scope at the binding point).
+/// forward-referenced (GS0130/GS0125, issue #2231). When a local function is
+/// referenced before its declaration, the translator moves its <c>let</c>
+/// binding to just before that first use — but no earlier than the last
+/// sibling local it captures by closure (G# closures require captured locals
+/// to already be in scope at the binding point).
 /// </summary>
 public class LocalFunctionHoistTranslationTests
 {
@@ -62,8 +66,15 @@ namespace Demo
     }
 
     [Fact]
-    public void LocalFunctionCapturingSiblingLocal_IsNotHoisted()
+    public void LocalFunctionCapturingSiblingLocal_IsHoistedAfterCaptureNotAboveIt()
     {
+        // Issue #2231, case (c): `Helper` is used before its textual
+        // declaration AND captures `seed`, a sibling local declared between
+        // the original declaration position and the use. The fix must hoist
+        // `let Helper` above the use but *below* `let seed` — not skip
+        // hoisting altogether (which would leave the forward-reference bug
+        // unfixed) and not hoist to the very top of the block (which would
+        // break the `seed` capture).
         string printed = TranslateUnit(@"
 namespace Demo
 {
@@ -84,14 +95,161 @@ namespace Demo
     }
 }");
 
-        // Hoisting would move `let Helper` above `let seed`, breaking the capture,
-        // so the declaration must stay after the sibling local it captures.
         int seedIndex = printed.IndexOf("let seed", StringComparison.Ordinal);
         int declIndex = printed.IndexOf("let Helper", StringComparison.Ordinal);
-        Assert.True(seedIndex >= 0 && declIndex >= 0, "Both bindings should be present.\n" + printed);
+        int useIndex = printed.IndexOf("Helper()", StringComparison.Ordinal);
+        Assert.True(seedIndex >= 0 && declIndex >= 0 && useIndex >= 0, "All three should be present.\n" + printed);
         Assert.True(
             seedIndex < declIndex,
             "Local function capturing a sibling local must not be hoisted above it.\n" + printed);
+        Assert.True(
+            declIndex < useIndex,
+            "Local function must still be hoisted above its first use.\n" + printed);
+
+        CompileAndRun(printed, "C().M()");
+    }
+
+    [Fact]
+    public void MinimalRepro_LetActionBeforeLetHandler_Issue2231()
+    {
+        // Issue #2231's exact minimal repro: a delegate-typed local function
+        // assigned to a plain local before its declaration.
+        string printed = TranslateUnit(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+        public void M()
+        {
+            Action<int> action = handler;
+
+            void handler(int x)
+            {
+            }
+        }
+    }
+}");
+
+        int declIndex = printed.IndexOf("let handler", StringComparison.Ordinal);
+        int actionIndex = printed.IndexOf("let action", StringComparison.Ordinal);
+        Assert.True(declIndex >= 0 && actionIndex >= 0, "Both bindings should be present.\n" + printed);
+        Assert.True(
+            declIndex < actionIndex,
+            "`let handler` must be hoisted above `let action = handler`.\n" + printed);
+
+        CompileAndRun(printed, "C().M()");
+    }
+
+    [Fact]
+    public void EventHandlerPlusEqualsForwardReference_IsHoisted()
+    {
+        // Issue #2231: mirrors the `AudibleApi.cs` shape — a local function
+        // subscribed to an event with `+=` before its textual declaration.
+        string printed = TranslateUnit(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+        public event EventHandler Progress;
+
+        public void M()
+        {
+            Progress += OnProgress;
+
+            void OnProgress(object sender, EventArgs e)
+            {
+            }
+        }
+    }
+}");
+
+        int declIndex = printed.IndexOf("let OnProgress", StringComparison.Ordinal);
+        int useIndex = printed.IndexOf("OnProgress", StringComparison.Ordinal);
+        Assert.True(declIndex >= 0, "Local function should be emitted as a let binding.\n" + printed);
+        Assert.True(
+            declIndex < useIndex,
+            "Local function subscribed via `+=` must be hoisted above the subscription.\n" + printed);
+    }
+
+    [Fact]
+    public void MutuallyRecursiveLocalFunctions_AreBothHoistedBeforeFirstExternalUse()
+    {
+        // Issue #2231, case (d): `A` and `B` call each other and are both used
+        // (via `A`) before either's textual declaration. Both `let` bindings
+        // must land before the external use, in their original relative
+        // order. (Whether the mutual recursion itself binds in gsc is a
+        // pre-existing, separate `let`-recursion limitation — see
+        // Issue2231MutualRecursionRemainsUnsupportedByGscLetBindings below —
+        // this test only checks the hoist ordering.)
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void M(int input)
+        {
+            if (input > 0)
+            {
+                A();
+            }
+
+            void A()
+            {
+                B();
+            }
+
+            void B()
+            {
+                A();
+            }
+        }
+    }
+}");
+
+        int aDeclIndex = printed.IndexOf("let A", StringComparison.Ordinal);
+        int bDeclIndex = printed.IndexOf("let B", StringComparison.Ordinal);
+        int ifIndex = printed.IndexOf("if ", StringComparison.Ordinal);
+        Assert.True(ifIndex >= 0, "The external `if` call site should be present.\n" + printed);
+        int useIndex = printed.IndexOf("A()", ifIndex, StringComparison.Ordinal);
+        Assert.True(aDeclIndex >= 0 && bDeclIndex >= 0, "Both bindings should be present.\n" + printed);
+        Assert.True(
+            aDeclIndex < useIndex && bDeclIndex < useIndex,
+            "Both mutually-recursive local functions must be hoisted above the first external use.\n" + printed);
+        Assert.True(
+            aDeclIndex < bDeclIndex,
+            "Original relative declaration order (A before B) must be preserved.\n" + printed);
+    }
+
+    [Fact]
+    public void Issue2231MutualRecursionRemainsUnsupportedByGscLetBindings()
+    {
+        // Documents a pre-existing, separate gsc limitation (not addressed by
+        // this fix, per the issue's own scoping guidance): `let` bindings are
+        // not letrec — a lambda cannot forward-reference a `let` name bound
+        // later in the same block, so two mutually-recursive `let`-lambdas
+        // can never both bind successfully, regardless of hoist order.
+        const string Source = @"
+package p
+class C {
+    func M() {
+        let a = func (n int32) { b(n) }
+        let b = func (n int32) { a(n) }
+    }
+}";
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-2231-mutrec", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(gsPath, Source);
+
+        (int exit, string output) = RunDotnet($"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(exit != 0, "Forward-referencing `let` recursion is expected to still fail today:\n" + output);
+        Assert.Contains("GS0130", output, StringComparison.Ordinal);
     }
 
     private static string TranslateUnit(string source)
@@ -113,5 +271,71 @@ namespace Demo
             "Translated G# must round-trip. Errors:\n" +
                 string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
         return printed;
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="printed"/> (with <paramref name="callExpression"/>
+    /// appended as a top-level entry statement) with the real <c>gsc</c> and runs
+    /// it — proving the translated snippet actually binds (issue #2231's GS0125
+    /// forward-reference bug is a binder-time error that a parse-only round-trip
+    /// cannot catch).
+    /// </summary>
+    private static void CompileAndRun(string printed, string callExpression)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-2231-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(gsPath, printed + Environment.NewLine + callExpression + Environment.NewLine);
+
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated snippet with zero errors. Output:\n" + compileOut +
+                "\n\nTranslated G#:\n" + printed);
+
+        (int runExit, string runOut) = RunDotnet($"\"{dllPath}\"");
+        Assert.True(runExit == 0, "Translated snippet must run successfully. Output:\n" + runOut);
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
     }
 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5323,11 +5323,12 @@ public sealed class CSharpToGSharpTranslator
         // C# local functions are hoisted (callable before their lexical
         // declaration), but G# renders them as `let name = func(...)` bindings,
         // which are NOT hoisted and cannot be forward-referenced (GS0130/GS0125).
-        // When a local function is called before its declaration within a block,
-        // move its declaration to the top of the block — but only when it is safe
-        // to do so (it must not capture a sibling local declared in the same
-        // block, since G# closures require captured locals to already be in scope
-        // at the binding point).
+        // When a local function is referenced (call, method-group, `+=`/`-=`
+        // subscription, argument, ...) before its declaration within a block,
+        // move its `let` binding to just before that first use — but no earlier
+        // than the last sibling local it captures by closure, since G# `let`
+        // bindings require captured locals to already be in scope at the
+        // binding point (issue #2231).
         private IReadOnlyList<StatementSyntax> HoistCallBeforeDeclLocalFunctions(BlockSyntax block)
         {
             SyntaxList<StatementSyntax> statements = block.Statements;
@@ -5337,7 +5338,8 @@ public sealed class CSharpToGSharpTranslator
                 return statements;
             }
 
-            var toHoist = new List<LocalFunctionStatementSyntax>();
+            // (function, anchor index to insert after; null = front of block)
+            var toHoist = new List<(LocalFunctionStatementSyntax Function, int DeclIndex, int? AnchorIndex)>();
             foreach (LocalFunctionStatementSyntax localFunction in localFunctions)
             {
                 int declIndex = statements.IndexOf(localFunction);
@@ -5346,28 +5348,39 @@ public sealed class CSharpToGSharpTranslator
                     continue;
                 }
 
-                bool usedBeforeDeclaration = false;
-                for (int i = 0; i < declIndex && !usedBeforeDeclaration; i++)
+                int firstUseIndex = -1;
+                for (int i = 0; i < declIndex; i++)
                 {
-                    usedBeforeDeclaration = statements[i]
+                    bool usedHere = statements[i]
                         .DescendantNodes()
                         .OfType<IdentifierNameSyntax>()
                         .Any(id => id.Identifier.Text == localFunction.Identifier.Text
                             && SymbolEqualityComparer.Default.Equals(
                                 this.context.GetSymbolInfo(id).Symbol, funcSymbol));
+                    if (usedHere)
+                    {
+                        firstUseIndex = i;
+                        break;
+                    }
                 }
 
-                if (!usedBeforeDeclaration)
+                if (firstUseIndex < 0)
                 {
+                    // Never referenced ahead of its declaration — leave in place.
                     continue;
                 }
 
-                if (this.CapturesSiblingBlockLocal(localFunction, block))
+                int? barrierIndex = this.SiblingCaptureBarrierIndex(localFunction, block, statements);
+                int anchorIndex = barrierIndex.HasValue ? barrierIndex.Value + 1 : 0;
+                if (anchorIndex > firstUseIndex)
                 {
+                    // The captured sibling local is declared after the first use,
+                    // so there is no valid position for the `let` binding — leave
+                    // it in place (pre-existing, unrelated ordering conflict).
                     continue;
                 }
 
-                toHoist.Add(localFunction);
+                toHoist.Add((localFunction, declIndex, barrierIndex));
             }
 
             if (toHoist.Count == 0)
@@ -5375,25 +5388,34 @@ public sealed class CSharpToGSharpTranslator
                 return statements;
             }
 
-            var reordered = new List<StatementSyntax>(toHoist);
-            foreach (StatementSyntax statement in statements)
+            var hoistSet = new HashSet<StatementSyntax>(toHoist.Select(t => (StatementSyntax)t.Function));
+            var reordered = statements.Where(s => !hoistSet.Contains(s)).ToList();
+
+            // Group by anchor statement (the sibling local's declaring statement,
+            // or the front of the block) and re-insert each group, preserving the
+            // original relative order of the local functions within the group.
+            foreach (var group in toHoist
+                .OrderBy(t => t.DeclIndex)
+                .GroupBy(t => t.AnchorIndex.HasValue ? statements[t.AnchorIndex.Value] : null))
             {
-                if (!toHoist.Contains(statement))
-                {
-                    reordered.Add(statement);
-                }
+                int insertAt = group.Key is null ? 0 : reordered.IndexOf(group.Key) + 1;
+                reordered.InsertRange(insertAt, group.Select(t => (StatementSyntax)t.Function));
             }
 
             return reordered;
         }
 
-        // Returns true when the local function references a local variable that is
-        // declared directly within the given block (a sibling), which would make
-        // hoisting the function to the top of that block unsafe. References to the
-        // enclosing method's parameters, outer-scope locals, or the function's own
-        // locals/parameters are fine — those remain in scope at the top.
-        private bool CapturesSiblingBlockLocal(LocalFunctionStatementSyntax localFunction, BlockSyntax block)
+        // Returns the index (within `statements`) of the last statement that
+        // declares a local variable captured by `localFunction` from the
+        // enclosing block — the `let` binding must not be hoisted above this
+        // point. Returns null when no sibling local is captured (references to
+        // the enclosing method's parameters, outer-scope locals, or the
+        // function's own locals/parameters don't count — those remain in scope
+        // at the front of the block).
+        private int? SiblingCaptureBarrierIndex(
+            LocalFunctionStatementSyntax localFunction, BlockSyntax block, SyntaxList<StatementSyntax> statements)
         {
+            int? barrier = null;
             foreach (IdentifierNameSyntax id in localFunction.DescendantNodes().OfType<IdentifierNameSyntax>())
             {
                 if (this.context.GetSymbolInfo(id).Symbol is not ILocalSymbol local)
@@ -5411,16 +5433,25 @@ public sealed class CSharpToGSharpTranslator
                         continue;
                     }
 
-                    // A local declared (directly or nested) within this block but
-                    // outside the function is a sibling capture — unsafe to hoist.
-                    if (block.Span.Contains(declaration.Span))
+                    // Not a sibling of this block (e.g. an outer-scope local) —
+                    // already in scope wherever the `let` binding lands.
+                    if (!block.Span.Contains(declaration.Span))
                     {
-                        return true;
+                        continue;
+                    }
+
+                    for (int i = 0; i < statements.Count; i++)
+                    {
+                        if (statements[i].Span.Contains(declaration.Span)
+                            && (barrier is null || i > barrier))
+                        {
+                            barrier = i;
+                        }
                     }
                 }
             }
 
-            return false;
+            return barrier;
         }
 
         private IEnumerable<GStatement> TranslateFixedStatement(FixedStatementSyntax node)


### PR DESCRIPTION
Fixes #2231

## Root cause
C# local funcs hoisted by lang (usable before decl). cs2gs emits them as G# `let name = func...` at ORIGINAL textual pos. G# `let` not hoisted -> forward ref -> GS0125.

A prior fix already hoisted funcs used-before-decl to block TOP, but bailed entirely (left broken) when the func captured a sibling local declared between decl and use — issue's case (c).

## Fix
`HoistCallBeforeDeclLocalFunctions` in `CSharpToGSharpTranslator.cs`:
- For each local func, find first-use index (any identifier ref bound to the func symbol — covers call, method-group, `+=`/`-=`, arg-pass, all via Roslyn symbol equality, no special-casing needed).
- New `SiblingCaptureBarrierIndex`: find last statement index declaring a sibling local the func captures (barrier). Skip captures of outer-scope locals/params/self — those are already in scope anywhere.
- Insert func right after barrier (or at block front if no capture), as long as barrier < first-use. If barrier is at/after first use, leave in place (unrepairable pre-existing conflict, doesn't occur in valid inputs from the issue).
- Multiple funcs group by anchor point, insert preserving original relative order (handles mutual recursion: both get hoisted before whichever is used first, in original order).

Self/mutual recursion between two `let`-lambdas: confirmed via real gsc compile this is a separate pre-existing limit (`let` isn't `letrec`, forward name ref inside another let's initializer fails GS0130) — untouched, out of scope per issue's own guidance.

## Files
- `tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs`
- `tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs` — 6 tests: minimal repro (exact issue example), event-handler `+=` forward-ref, sibling-capture-ordering (barrier case), mutual-recursion hoist-ordering, + doc test for the pre-existing letrec limit. Two of these actually run real `gsc` compile+run (not just parse round-trip) to prove GS0125 is gone, since parse-only checks can't catch a binder-time error.

## Test evidence
- `dotnet test tools/cs2gs/Cs2Gs.Tests`: **1206 passed, 0 failed** (0 regressions).
- `dotnet test test/Core.Tests` sanity pass: **5860 passed, 1 skipped, 0 failed**.
