### PR TITLE
cs2gs: deconstruction-assignment into indexer/member targets (#2234)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1895DeconstructAssignTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1895DeconstructAssignTranslationTests.cs
@@ -253,14 +253,13 @@ namespace Corpus.Issue1895
     }
 
     [Fact]
-    public void ElementAccessTarget_StaysLoudGap()
+    public void ElementAccessTarget_NowLowersWithoutGap()
     {
-        // `(arr[i], y) = rhs`: C# evaluates `arr`/`i` before `rhs`, but the
-        // lowering must spill `rhs` first, reversing that order. If `rhs`
-        // mutates `arr`/`i` this would silently miscompile, so gap loudly
-        // instead (issue #1895).
-        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
-            new[] { ("Source.cs", @"
+        // `(arr[i], y) = rhs`: issue #2234 generalizes the #1895 lowering to
+        // capture `arr`/`i` into temps BEFORE the RHS is spilled (via
+        // `MakeDuplicationSafeTarget`), preserving C#'s evaluation order —
+        // no more loud gap.
+        string rendered = Render(@"
 namespace Corpus.Issue1895
 {
     public class Holder
@@ -275,24 +274,17 @@ namespace Corpus.Issue1895
         }
     }
 }
-") });
-
-        Assert.True(project.BoundWithoutErrors);
-        LoadedDocument document = Assert.Single(project.Documents);
-        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
-        new CSharpToGSharpTranslator().TranslateDocument(document, context);
-        Assert.Contains(
-            context.Diagnostics,
-            d => d.Message.Contains("non-identifier target", StringComparison.Ordinal));
+");
+        AssertRoundTripParses(rendered);
+        Assert.Contains("let (__decon", rendered);
+        Assert.Contains("arr[i]", rendered);
     }
 
     [Fact]
-    public void MemberAccessTarget_StaysLoudGap()
+    public void MemberAccessTarget_NowLowersWithoutGap()
     {
-        // `(obj.F, y) = rhs`: same reversed-evaluation-order hazard as an
-        // element-access target.
-        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
-            new[] { ("Source.cs", @"
+        // `(obj.F, y) = rhs`: same generalization as the element-access case.
+        string rendered = Render(@"
 namespace Corpus.Issue1895
 {
     public class Box
@@ -311,15 +303,10 @@ namespace Corpus.Issue1895
         }
     }
 }
-") });
-
-        Assert.True(project.BoundWithoutErrors);
-        LoadedDocument document = Assert.Single(project.Documents);
-        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
-        new CSharpToGSharpTranslator().TranslateDocument(document, context);
-        Assert.Contains(
-            context.Diagnostics,
-            d => d.Message.Contains("non-identifier target", StringComparison.Ordinal));
+");
+        AssertRoundTripParses(rendered);
+        Assert.Contains("let (__decon", rendered);
+        Assert.Contains("obj.F", rendered);
     }
 
     private static void AssertRoundTripParses(string rendered)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1974ExpressionPositionDeconstructAssignTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1974ExpressionPositionDeconstructAssignTranslationTests.cs
@@ -184,12 +184,12 @@ namespace Corpus.Issue1974
     }
 
     [Fact]
-    public void NonIdentifierTarget_InExpressionPosition_StaysLoudGap()
+    public void NonIdentifierTarget_InExpressionPosition_NowLowersWithoutGap()
     {
-        // Same evaluation-order hazard as the statement form (issue #1895),
-        // reached here via the value-position hoisting seam instead.
-        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
-            new[] { ("Source.cs", @"
+        // Issue #2234 generalizes the #1895/#1974 lowering to element/member-
+        // access targets reached via the value-position hoisting seam too:
+        // `arr`/`i` are captured into temps before the RHS is spilled.
+        string rendered = Render(@"
 namespace Corpus.Issue1974
 {
     public class Holder
@@ -204,15 +204,9 @@ namespace Corpus.Issue1974
         }
     }
 }
-") });
-
-        Assert.True(project.BoundWithoutErrors);
-        LoadedDocument document = Assert.Single(project.Documents);
-        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
-        new CSharpToGSharpTranslator().TranslateDocument(document, context);
-        Assert.Contains(
-            context.Diagnostics,
-            d => d.Message.Contains("non-identifier target", StringComparison.Ordinal));
+");
+        AssertRoundTripParses(rendered);
+        Assert.Contains("arr[i]", rendered);
     }
 
     private static void AssertRoundTripParses(string rendered)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2234IndexerMemberDeconstructAssignTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2234IndexerMemberDeconstructAssignTranslationTests.cs
@@ -1,0 +1,325 @@
+// <copyright file="Issue2234IndexerMemberDeconstructAssignTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2234: a deconstruction-ASSIGNMENT whose targets are indexer
+/// (<c>arr[i]</c>) or member-access (<c>obj.F</c>) expressions — e.g. the
+/// classic tuple-swap-via-indexers <c>(entries[idx], entries[target]) =
+/// (entries[target], entries[idx]);</c> — was gapped loudly (CS2GS-GAP) by
+/// issue #1895's lowering: that lowering spills the whole right-hand side
+/// FIRST into a native <c>let (t0, t1, ...) = rhs</c> binding and only then
+/// writes each target, which reverses C#'s left-to-right, targets-then-value
+/// evaluation order for any target with a pre-existing storage location to
+/// evaluate (an indexer's receiver/index, a member access's receiver).
+///
+/// The fix generalizes #1895/#1974: before the RHS is spilled, every
+/// indexer/member-access target's receiver (and index, for an indexer) is
+/// captured into its own temp via <c>MakeDuplicationSafeTarget</c> — the SAME
+/// machinery chained assignment (<c>a[F()] = b[G()] = c</c>, issue #1731)
+/// already uses to make a target safe to write to without re-evaluating its
+/// receiver/index. Only after every target is captured does the RHS get
+/// spilled, and only then are the (now single-evaluation-safe) targets
+/// written to, in left-to-right order — matching C#'s own evaluation order
+/// exactly, including for a self-referential swap.
+///
+/// No gsc language change was needed for this: cs2gs already fully lowers a
+/// deconstruction assignment to a flat sequence of gsc's EXISTING primitives
+/// — a native <c>let (...) = rhs</c> tuple-deconstruction-declaration and
+/// ordinary <c>target = value</c> assignment statements, which gsc already
+/// accepts for any assignable target shape (identifier, indexer, member
+/// access) outside of tuple deconstruction. The gap was purely in cs2gs's
+/// translation-time evaluation-order handling, not in gsc's grammar.
+/// </summary>
+public class Issue2234IndexerMemberDeconstructAssignTranslationTests
+{
+    [Fact]
+    public void ElementAccessTargets_MixedWithIdentifier_LowersWithoutGap()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue2234
+{
+    public class Holder
+    {
+        public void M()
+        {
+            int[] arr = new int[3];
+            int i = 0;
+            int j = 1;
+            int y = 5;
+            (arr[i], arr[j], y) = (10, 20, 30);
+            System.Console.WriteLine(arr[0] + arr[1] + y);
+        }
+    }
+}
+");
+        AssertRoundTripParses(rendered);
+        Assert.Contains("arr[i]", rendered);
+        Assert.Contains("arr[j]", rendered);
+    }
+
+    [Fact]
+    public void MemberAndElementAccessTargets_Mixed_LowersWithoutGap()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue2234
+{
+    public class Box
+    {
+        public int F;
+    }
+
+    public class Holder
+    {
+        public void M()
+        {
+            var obj = new Box();
+            int[] arr = new int[2];
+            int i = 0;
+            int a = 1;
+            int b = 2;
+            (obj.F, arr[i], a) = (b, obj.F, 7);
+            System.Console.WriteLine(obj.F + arr[0] + a);
+        }
+    }
+}
+");
+        AssertRoundTripParses(rendered);
+        Assert.Contains("obj.F", rendered);
+        Assert.Contains("arr[i]", rendered);
+    }
+
+    [Fact]
+    public void NestedTupleTarget_WithElementAccessLeaf_LowersWithoutGap()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue2234
+{
+    public class Holder
+    {
+        public void M()
+        {
+            int[] arr = new int[2];
+            int i = 0;
+            int c = 0;
+            ((arr[i], c), c) = ((1, 2), 3);
+            System.Console.WriteLine(arr[0] + c);
+        }
+    }
+}
+");
+        AssertRoundTripParses(rendered);
+        Assert.Contains("arr[i]", rendered);
+    }
+
+    /// <summary>
+    /// The issue's exact repro: a tuple-swap performed entirely through
+    /// indexer targets. Proves — by actually running the translated G#
+    /// through the real <c>gsc</c> compiler — that the swap produces the
+    /// CORRECT swapped values, not just that it compiles.
+    /// </summary>
+    [Fact]
+    public void SwapViaIndexers_CompilesAndRunsWithCorrectResult()
+    {
+        string printed = TranslateUnit(@"
+using System.Collections.Generic;
+namespace Corpus.Issue2234
+{
+    public class Holder
+    {
+        public void Swap(List<int> entries, int idx, int target)
+        {
+            (entries[idx], entries[target]) = (entries[target], entries[idx]);
+        }
+    }
+}");
+
+        Assert.DoesNotContain("(entries[idx], entries[target]) =", printed);
+
+        string output = CompileAndRunCapturingOutput(
+            printed,
+            "var e = List[int32]{ 1, 2, 3, 4, 5 }\n" +
+            "Holder().Swap(e, 1, 3)\n" +
+            "Console.WriteLine(e[0])\n" +
+            "Console.WriteLine(e[1])\n" +
+            "Console.WriteLine(e[3])\n" +
+            "Console.WriteLine(e[4])");
+
+        Assert.Equal("1" + Environment.NewLine + "4" + Environment.NewLine + "2" + Environment.NewLine + "5", output.Trim());
+    }
+
+    /// <summary>
+    /// Proves left-to-right evaluation order is preserved for a target whose
+    /// index expression has an observable side effect: C# evaluates every
+    /// target's storage location (left to right) BEFORE the right-hand side
+    /// (also left to right), then performs the assignments. An ordered log
+    /// records the actual order the translated-and-compiled G# runs in.
+    /// </summary>
+    [Fact]
+    public void ElementAccessTargets_SideEffectingIndices_PreserveLeftToRightEvaluationOrder()
+    {
+        string printed = TranslateUnit(@"
+using System.Collections.Generic;
+namespace Corpus.Issue2234
+{
+    public class Holder
+    {
+        public static List<string> Log = new List<string>();
+
+        public static int Idx(string tag, int i)
+        {
+            Log.Add(tag);
+            return i;
+        }
+
+        public static int Val(string tag, int v)
+        {
+            Log.Add(tag);
+            return v;
+        }
+
+        public void Run(int[] arr)
+        {
+            (arr[Idx(""L0"", 0)], arr[Idx(""L1"", 1)]) = (Val(""R0"", 10), Val(""R1"", 20));
+        }
+    }
+}");
+
+        string output = CompileAndRunCapturingOutput(
+            printed,
+            "var arr = []int32{0, 0}\n" +
+            "Holder().Run(arr)\n" +
+            "Console.WriteLine(arr[0])\n" +
+            "Console.WriteLine(arr[1])\n" +
+            "Console.WriteLine(String.Join(\",\", Holder.Log))");
+
+        string[] lines = output.Trim().Split(Environment.NewLine);
+        Assert.Equal("10", lines[0]);
+        Assert.Equal("20", lines[1]);
+        Assert.Equal("L0,L1,R0,R1", lines[2]);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+
+        string printed = GSharpPrinter.Print(unit);
+        AssertRoundTripParses(printed);
+        return printed;
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="printed"/> (with <paramref name="topLevelCode"/>
+    /// appended as top-level entry statements) with the real <c>gsc</c> and
+    /// runs it, returning captured stdout — proving the translated snippet
+    /// not only compiles but produces the correct runtime values.
+    /// </summary>
+    private static string CompileAndRunCapturingOutput(string printed, string topLevelCode)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-2234-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(gsPath, printed + Environment.NewLine + topLevelCode + Environment.NewLine);
+
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated snippet with zero errors. Output:\n" + compileOut +
+                "\n\nTranslated G#:\n" + printed);
+
+        (int runExit, string runOut) = RunDotnet($"\"{dllPath}\"");
+        Assert.True(runExit == 0, "Translated snippet must run successfully. Output:\n" + runOut);
+        return runOut;
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -7381,32 +7381,17 @@ public sealed class CSharpToGSharpTranslator
                 // recursing: the nested arm gets its own temp, which is then
                 // deconstructed by a SECOND `let (...) = temp` statement
                 // (issue #1974) — G#'s grammar only needs a flat name list per
-                // statement, and nothing stops chaining several of them.
+                // statement, and nothing stops chaining several of them. A
+                // non-identifier target (`arr[i]`, `obj.F`, ...) anywhere in the
+                // (possibly nested) target shape is handled by
+                // `LowerTupleAssignment` capturing its receiver/index FIRST
+                // (via `MakeDuplicationSafeTarget`, the same machinery chained
+                // assignment already uses), before the RHS is spilled —
+                // preserving C#'s left-to-right, targets-then-value evaluation
+                // order (issue #2234, generalizing #1895).
                 if (assignment.Left is TupleExpressionSyntax leftTuple)
                 {
-                    if (HasNonIdentifierDeconstructionTarget(leftTuple))
-                    {
-                        // A non-identifier target (`arr[i]`, `obj.F`, ...) anywhere
-                        // in the (possibly nested) target shape. C# evaluates all
-                        // LHS storage references BEFORE the RHS; `LowerTuplePattern`
-                        // spills the RHS first and writes targets afterward,
-                        // reversing that order. For a plain identifier (or a new
-                        // `var`/nested-`var` binding) there is nothing to evaluate
-                        // (no side effect), so the reorder is safe; for anything
-                        // else (element/member access, deref, ...) it can silently
-                        // miscompile if the RHS mutates state the target expression
-                        // reads (issue #1895). Gap loudly instead.
-                        string message = "a non-identifier target ('arr[i]', 'obj.F', ...) in a " +
-                            "deconstruction-assignment has no safe G# lowering yet (issue #1895): " +
-                            "C# evaluates LHS storage references before the right-hand side, but " +
-                            "G#'s lowering must spill the right-hand side first, which would " +
-                            "silently reverse evaluation order for a side-effecting target.";
-                        this.context.ReportUnsupported(assignment, message);
-                    }
-                    else
-                    {
-                        return this.LowerTupleAssignment(leftTuple, assignment.Right);
-                    }
+                    return this.LowerTupleAssignment(leftTuple, assignment.Right);
                 }
             }
 
@@ -7793,26 +7778,15 @@ public sealed class CSharpToGSharpTranslator
             GExpression value;
             if (tupleLink != null)
             {
-                if (HasNonIdentifierDeconstructionTarget(tupleLink))
-                {
-                    // Same evaluation-order hazard as the statement-position gap
-                    // above (issue #1895), reached here via the value-position
-                    // path instead (issue #1974).
-                    string message = "a non-identifier target ('arr[i]', 'obj.F', ...) in a " +
-                        "deconstruction-assignment has no safe G# lowering yet (issue #1895): " +
-                        "C# evaluates LHS storage references before the right-hand side, but " +
-                        "G#'s lowering must spill the right-hand side first, which would " +
-                        "silently reverse evaluation order for a side-effecting target.";
-                    this.context.ReportUnsupported(tupleLink, message);
-                    value = new IdentifierExpression("nil");
-                }
-                else
-                {
-                    (List<GStatement> tupleStatements, GExpression tupleValue) =
-                        this.LowerTupleAssignmentForValue(tupleLink, tupleLinkRight);
-                    statements.AddRange(tupleStatements);
-                    value = tupleValue;
-                }
+                // A non-identifier target (`arr[i]`, `obj.F`, ...) anywhere in the
+                // (possibly nested) target shape is handled by
+                // `LowerTupleAssignmentForValue` capturing its receiver/index
+                // FIRST, before the RHS is spilled (issue #2234, generalizing
+                // #1895/#1974).
+                (List<GStatement> tupleStatements, GExpression tupleValue) =
+                    this.LowerTupleAssignmentForValue(tupleLink, tupleLinkRight);
+                statements.AddRange(tupleStatements);
+                value = tupleValue;
             }
             else
             {
@@ -7948,21 +7922,6 @@ public sealed class CSharpToGSharpTranslator
             return true;
         }
 
-        // Recursively checks every leaf of a (possibly nested) deconstruction
-        // *assignment* target for a non-identifier storage reference (`arr[i]`,
-        // `obj.F`, ...). A nested tuple target or a new `var`/nested-`var`
-        // binding is always safe (no pre-existing storage to evaluate before
-        // the RHS); only an existing-variable write needs to be a bare
-        // identifier (issue #1895/#1974).
-        private static bool HasNonIdentifierDeconstructionTarget(TupleExpressionSyntax tuple) =>
-            tuple.Arguments.Any(a => a.Expression switch
-            {
-                TupleExpressionSyntax nested => HasNonIdentifierDeconstructionTarget(nested),
-                DeclarationExpressionSyntax => false,
-                IdentifierNameSyntax => false,
-                _ => true,
-            });
-
         // Statement-position deconstruction assignment (`(a, b) = (x, y);`):
         // the resulting per-element values are never read back, so discards
         // stay true discards (no temp allocated for them).
@@ -7971,7 +7930,8 @@ public sealed class CSharpToGSharpTranslator
             ExpressionSyntax right)
         {
             var statements = new List<GStatement>();
-            this.LowerTuplePattern(leftTuple, this.TranslateExpression(right), forceRealTemps: false, statements);
+            Dictionary<ExpressionSyntax, GExpression> captured = this.CaptureDeconstructionStorageTargets(leftTuple, statements);
+            this.LowerTuplePattern(leftTuple, this.TranslateExpression(right), forceRealTemps: false, statements, captured);
             return statements;
         }
 
@@ -7986,10 +7946,65 @@ public sealed class CSharpToGSharpTranslator
             ExpressionSyntax right)
         {
             var statements = new List<GStatement>();
-            List<GExpression> values = this.LowerTuplePattern(leftTuple, this.TranslateExpression(right), forceRealTemps: true, statements);
+            Dictionary<ExpressionSyntax, GExpression> captured = this.CaptureDeconstructionStorageTargets(leftTuple, statements);
+            List<GExpression> values = this.LowerTuplePattern(leftTuple, this.TranslateExpression(right), forceRealTemps: true, statements, captured);
             GExpression value = new TupleLiteralExpression(values);
             this.tupleAssignmentValues[leftTuple] = value;
             return (statements, value);
+        }
+
+        // Walks a (possibly nested) deconstruction-assignment target shape
+        // and, for every indexer/member-access (or other existing storage-
+        // location) leaf, spills its receiver/index sub-expression into a
+        // temp via `MakeDuplicationSafeTarget` — the SAME machinery chained
+        // assignment (`a[F()] = b[G()] = c`, issue #1731) already uses —
+        // emitted into `statements` BEFORE anything about the right-hand
+        // side. This preserves C#'s left-to-right, targets-then-value
+        // evaluation order (issue #2234, generalizing #1895/#1974: a plain
+        // identifier or a new `var`/nested-`var` binding has nothing
+        // pre-existing to evaluate, so needs no capture; a nested tuple
+        // target is walked recursively, since its own leaves are storage
+        // locations too). Returns a map from each captured leaf's original
+        // syntax to its now-single-evaluation-safe G# replacement, consulted
+        // by `LowerTuplePattern` when it emits the final per-target
+        // assignment.
+        private Dictionary<ExpressionSyntax, GExpression> CaptureDeconstructionStorageTargets(
+            TupleExpressionSyntax pattern,
+            List<GStatement> statements)
+        {
+            var captured = new Dictionary<ExpressionSyntax, GExpression>();
+            this.CaptureDeconstructionStorageTargets(pattern, statements, captured);
+            return captured;
+        }
+
+        private void CaptureDeconstructionStorageTargets(
+            TupleExpressionSyntax pattern,
+            List<GStatement> statements,
+            Dictionary<ExpressionSyntax, GExpression> captured)
+        {
+            foreach (ArgumentSyntax argument in pattern.Arguments)
+            {
+                ExpressionSyntax targetExpr = argument.Expression;
+                switch (targetExpr)
+                {
+                    case TupleExpressionSyntax nested:
+                        this.CaptureDeconstructionStorageTargets(nested, statements, captured);
+                        break;
+
+                    case IdentifierNameSyntax:
+                    case DeclarationExpressionSyntax:
+                        // No pre-existing storage to evaluate: an identifier is
+                        // already a stable reference, and a declaration
+                        // (`var y`) is a brand-new local.
+                        break;
+
+                    default:
+                        // An existing storage location (`arr[i]`, `obj.F`, ...):
+                        // spill its receiver/index once, now, before the RHS.
+                        captured[targetExpr] = this.MakeDuplicationSafeTarget(this.TranslateExpression(targetExpr), statements);
+                        break;
+                }
+            }
         }
 
         // Core recursive lowering shared by the statement- and
@@ -8004,7 +8019,8 @@ public sealed class CSharpToGSharpTranslator
             TupleExpressionSyntax pattern,
             GExpression rhsValue,
             bool forceRealTemps,
-            List<GStatement> statements)
+            List<GStatement> statements,
+            Dictionary<ExpressionSyntax, GExpression> captured)
         {
             int count = pattern.Arguments.Count;
             var temps = new List<string>(count);
@@ -8053,7 +8069,7 @@ public sealed class CSharpToGSharpTranslator
                     // to flatten every depth into one `let (...)` (issue
                     // #1974). The recursive rhsValue is already a bare temp
                     // read, so no further spill is needed before recursing.
-                    List<GExpression> nestedValues = this.LowerTuplePattern(nestedTuple, tempRead, forceRealTemps, statements);
+                    List<GExpression> nestedValues = this.LowerTuplePattern(nestedTuple, tempRead, forceRealTemps, statements, captured);
                     values.Add(forceRealTemps ? new TupleLiteralExpression(nestedValues) : null);
                     continue;
                 }
@@ -8108,9 +8124,14 @@ public sealed class CSharpToGSharpTranslator
                 // `_ = __decon1;` statement (issue #2099).
                 if (!this.IsDeconstructionDiscard(targetExpr))
                 {
-                    statements.Add(new AssignmentStatement(
-                        this.TranslateExpression(targetExpr),
-                        tempRead));
+                    // A member/element-access target was already captured
+                    // into a duplication-safe replacement BEFORE the RHS was
+                    // spilled above (issue #2234); a plain identifier has no
+                    // entry and translates as-is.
+                    GExpression assignTarget = captured.TryGetValue(targetExpr, out GExpression safeTarget)
+                        ? safeTarget
+                        : this.TranslateExpression(targetExpr);
+                    statements.Add(new AssignmentStatement(assignTarget, tempRead));
                 }
 
                 values.Add(tempRead);


### PR DESCRIPTION
Fixes #2234

## What
Swap-via-indexers repro from issue (`(entries[idx], entries[target]) = (entries[target], entries[idx]);`) was CS2GS-GAP + CS2GS-ROUNDTRIP. Fix: no new gsc feature needed. cs2gs already lowers deconstruction-assignment to plain gsc primitives (native `let (...) = rhs` decon-binding + ordinary `target = value` assignments, which gsc already accepts for indexer/member targets outside tuples). Bug was purely eval-order in cs2gs's lowering.

## Root cause
#1895's lowering spills the WHOLE rhs first into `let (t0,t1,...) = rhs`, then writes each target from its temp. Safe for identifiers (nothing to eval). Unsafe for `arr[i]`/`obj.F`: C# evaluates receiver/index BEFORE rhs; spilling rhs first reverses that for side-effecting targets. #1895 gapped it loudly instead of risking miscompile; gap's fallback then emitted invalid G# text (round-trip GS0005).

## Fix
Before rhs is spilled, capture every indexer/member target's storage-location ingredients (receiver+index / receiver) into temps via `MakeDuplicationSafeTarget` — same machinery chained-assignment (#1731) already uses. THEN spill rhs (reusing #1895's exact mechanism unchanged). THEN assign into captured, now-safe targets, left to right. Matches C#'s eval-targets-then-value-then-assign order exactly, incl. self-referential swap.

No new SyntaxKind/BoundNodeKind — no coverage-matrix golden update needed.

## Files touched
- `tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs`: removed `HasNonIdentifierDeconstructionTarget` gap gate; added `CaptureDeconstructionStorageTargets` (recursive capture walk, incl. nested tuples); threaded capture map through `LowerTuplePattern`.
- `tools/cs2gs/Cs2Gs.Tests/Issue1895DeconstructAssignTranslationTests.cs`, `Issue1974ExpressionPositionDeconstructAssignTranslationTests.cs`: updated 3 tests that asserted the old gap to now assert successful lowering.
- `tools/cs2gs/Cs2Gs.Tests/Issue2234IndexerMemberDeconstructAssignTranslationTests.cs` (new): mixed identifier+indexer+member targets, nested tuple w/ indexer leaf, real gsc compile+run proving the exact swap-via-indexers repro produces CORRECT values, real gsc compile+run proving left-to-right eval order preserved for side-effecting indices (ordered log).

## Test evidence
- `test/Core.Tests`: 5860 passed, 0 failed (untouched, no gsc/Core change).
- `test/Compiler.Tests`: 2772 passed, 0 failed.
- `tools/cs2gs/Cs2Gs.Tests`: 1216 passed, 0 failed (run as 1193 + 23 ReportTests split — full-run test host crash reproduced identically on `main` before this change, pre-existing/unrelated).
