### PR TITLE
cs2gs: merge filtered catch w/ overlapping later sibling into one dispatching catch (fixes #2235)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
@@ -260,41 +260,39 @@ public class BodyTranslationTests
 
     /// <summary>A filtered catch whose later sibling could still receive the
     /// same exception (here, a plain <c>Exception</c> catch-all after a filtered
-    /// <c>InvalidOperationException</c>) is NOT rethrow-lowered: in C#, a false
-    /// filter falls through to the later sibling instead of leaving the
-    /// <c>try</c>, and the per-catch <c>throw ex</c> prologue cannot reproduce
-    /// that fall-through (it would make the exception escape the whole
-    /// <c>try</c>, silently skipping the sibling — the exact bug class issue
-    /// #1724 exists to kill). The translator reports it as unsupported instead
-    /// of emitting the wrong control flow.</summary>
+    /// <c>InvalidOperationException</c>) is no longer reported unsupported
+    /// (issue #2235, follow-up to #1724): it merges with its later sibling(s)
+    /// into ONE catch that dispatches on type-then-filter in source order, so
+    /// a false filter falls through to the sibling instead of escaping the
+    /// whole <c>try</c>.</summary>
     [Fact]
-    public void FilteredCatch_WithOverlappingLaterSibling_ReportsUnsupportedInsteadOfRethrowLowering()
+    public void FilteredCatch_WithOverlappingLaterSibling_MergesIntoSingleDispatchingCatch()
     {
         (string body, TranslationContext context) = GetMethodBodyAndContext(@"
             try { n = 1; }
             catch (InvalidOperationException ex) when (ex.Message.Length > 0) { n = 2; }
             catch (Exception ex2) { n = 3; }");
 
-        Assert.Contains(
-            context.Diagnostics,
-            d => d.Severity == TranslationSeverity.Unsupported
-                && d.Message.Contains("later sibling", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
 
-        // No rethrow prologue was fabricated for the unsafe shape: the filter
-        // condition text must not appear as a synthesized "if !(...)" guard.
-        Assert.DoesNotContain("if !(ex.Message.Length > 0)", body);
+        // A single merged catch, typed at the common supertype `Exception`.
+        Assert.Contains("} catch (ex Exception) {", body);
+        Assert.DoesNotContain("catch (ex2", body);
 
-        int firstCatch = body.IndexOf("} catch (ex InvalidOperationException) {", StringComparison.Ordinal);
-        int secondCatch = body.IndexOf("} catch (ex2 Exception) {", StringComparison.Ordinal);
-        Assert.True(firstCatch >= 0 && secondCatch > firstCatch);
+        // Dispatches on type then filter, in source order, with both bodies present.
+        Assert.Contains("ex is InvalidOperationException", body);
+        Assert.Contains("ex.Message.Length > 0", body);
+        Assert.Contains("ex is Exception", body);
+        Assert.Contains("let ex2 = ex", body);
+        Assert.Contains("n = 2", body);
+        Assert.Contains("n = 3", body);
     }
 
     /// <summary>Same divergent shape as above, framed around the actual runtime
     /// behavior it protects: with the filter false, C# falls through to the
     /// <c>Exception</c> sibling and runs its body — the sibling catch is never
-    /// dead code, so the translator must not treat it as unreachable via a
-    /// silent rethrow-escape. This is captured as the unsupported diagnostic
-    /// (issue #1724 follow-up); no G# "faithful" lowering exists yet.</summary>
+    /// dead code, so the merged dispatch must still reach it instead of
+    /// rethrowing past it (issue #2235).</summary>
     [Fact]
     public void FilteredCatch_WithOverlappingLaterSibling_SiblingRemainsReachableNotDeadCode()
     {
@@ -303,14 +301,12 @@ public class BodyTranslationTests
             catch (InvalidOperationException ex) when (false) { n = 2; }
             catch (Exception ex2) { n = 3; }");
 
-        Assert.Contains(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
 
-        // The sibling's body is preserved verbatim in the output — it is never
-        // silently made unreachable by a fabricated "throw ex" escape.
+        // The sibling's body is preserved and reachable in the merged dispatch
+        // (not made dead code by an escaping rethrow).
         Assert.Contains("n = 3", body);
-        int secondCatch = body.IndexOf("} catch (ex2 Exception) {", StringComparison.Ordinal);
-        Assert.True(secondCatch >= 0);
-        Assert.DoesNotContain("throw ex", body.Substring(0, secondCatch));
+        Assert.Contains("let ex2 = ex", body);
     }
 
     /// <summary>A filtered catch that is the LAST clause in the try is a SAFE

--- a/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
@@ -275,15 +275,20 @@ public class BodyTranslationTests
 
         Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
 
-        // A single merged catch, typed at the common supertype `Exception`.
-        Assert.Contains("} catch (ex Exception) {", body);
+        // A single merged catch, typed at the common supertype `Exception`,
+        // bound to a compiler-generated name that can never collide with a
+        // source catch-variable name (so the per-clause rebind below always
+        // fires, even for a clause whose original name is also "ex").
+        Assert.Contains("} catch (__caught Exception) {", body);
+        Assert.DoesNotContain("catch (ex", body);
         Assert.DoesNotContain("catch (ex2", body);
 
         // Dispatches on type then filter, in source order, with both bodies present.
-        Assert.Contains("ex is InvalidOperationException", body);
+        Assert.Contains("__caught is InvalidOperationException", body);
+        Assert.Contains("let ex = __caught", body);
         Assert.Contains("ex.Message.Length > 0", body);
-        Assert.Contains("ex is Exception", body);
-        Assert.Contains("let ex2 = ex", body);
+        Assert.Contains("__caught is Exception", body);
+        Assert.Contains("let ex2 = __caught", body);
         Assert.Contains("n = 2", body);
         Assert.Contains("n = 3", body);
     }
@@ -306,7 +311,7 @@ public class BodyTranslationTests
         // The sibling's body is preserved and reachable in the merged dispatch
         // (not made dead code by an escaping rethrow).
         Assert.Contains("n = 3", body);
-        Assert.Contains("let ex2 = ex", body);
+        Assert.Contains("let ex2 = __caught", body);
     }
 
     /// <summary>A filtered catch that is the LAST clause in the try is a SAFE

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2235FilteredCatchFallthroughTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2235FilteredCatchFallthroughTranslationTests.cs
@@ -69,8 +69,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("catch (ex Exception)", printed);
-        Assert.Contains("ex is OperationCanceledException", printed);
+        Assert.Contains("catch (__caught Exception)", printed);
+        Assert.Contains("__caught is OperationCanceledException", printed);
         Assert.Contains("ct.IsCancellationRequested", printed);
         Assert.Contains("return 1", printed);
         Assert.Contains("return 2", printed);
@@ -117,8 +117,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("catch (ex Exception)", printed);
-        Assert.Contains("ex is InvalidOperationException", printed);
+        Assert.Contains("catch (__caught Exception)", printed);
+        Assert.Contains("__caught is InvalidOperationException", printed);
 
         CompileAndRun(printed, "System.Console.WriteLine(C().Run(true))", "1");
         CompileAndRun(printed, "System.Console.WriteLine(C().Run(false))", "2");
@@ -163,6 +163,102 @@ namespace Demo
         Assert.DoesNotContain("is InvalidOperationException", printed);
 
         CompileAndRun(printed, "System.Console.WriteLine(C().Run(true))", "1");
+    }
+
+    /// <summary>
+    /// M2 regression guard: the merged branch must expose the SUBTYPE-only
+    /// member on the narrowed catch variable (not just the merged/base
+    /// type), proving the `ex is OriginalType` smart-cast narrowing (ADR-0069)
+    /// this merge relies on actually takes effect at runtime, not just that
+    /// the printed G# contains the `is` test.
+    /// </summary>
+    [Fact]
+    public void MergedBranch_AccessesSubtypeOnlyMember_OnNarrowedCatchVariable()
+    {
+        string printed = TranslateUnit(@"
+using System;
+namespace Demo
+{
+    public class MyCustomException : Exception
+    {
+        public int CustomProp { get; }
+        public MyCustomException(int customProp) { CustomProp = customProp; }
+    }
+
+    public class C
+    {
+        public int Run(bool retryable)
+        {
+            try
+            {
+                throw new MyCustomException(42);
+            }
+            catch (MyCustomException ex) when (retryable)
+            {
+                return ex.CustomProp;
+            }
+            catch (Exception)
+            {
+                return -1;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("__caught is MyCustomException", printed);
+
+        CompileAndRun(printed, "System.Console.WriteLine(C().Run(true))", "42");
+        CompileAndRun(printed, "System.Console.WriteLine(C().Run(false))", "-1");
+    }
+
+    /// <summary>
+    /// M1 regression guard: the ORIGINAL C# catch variable is named "ex" —
+    /// the exact case where the merge's shared binder used to ALSO be named
+    /// "ex", so the per-clause rebind was (bug) skipped and the closure below
+    /// would have captured the merged catch's declared (unnarrowed) type
+    /// instead of the smart-cast-narrowed subtype. Capturing the catch
+    /// variable in a closure and reading a subtype-only member from inside it
+    /// proves the compiler-generated shared-binder fix makes the narrowed
+    /// rebind unconditional and survive closure capture.
+    /// </summary>
+    [Fact]
+    public void MergedBranch_ClosureCapturesNarrowedCatchVariable_NamedExSameAsSharedBinder()
+    {
+        string printed = TranslateUnit(@"
+using System;
+namespace Demo
+{
+    public class MyCustomException : Exception
+    {
+        public int CustomProp { get; }
+        public MyCustomException(int customProp) { CustomProp = customProp; }
+    }
+
+    public class C
+    {
+        public int Run(bool retryable)
+        {
+            try
+            {
+                throw new MyCustomException(99);
+            }
+            catch (MyCustomException ex) when (retryable)
+            {
+                Func<int> get = () => ex.CustomProp;
+                return get();
+            }
+            catch (Exception)
+            {
+                return -1;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("__caught is MyCustomException", printed);
+
+        CompileAndRun(printed, "System.Console.WriteLine(C().Run(true))", "99");
+        CompileAndRun(printed, "System.Console.WriteLine(C().Run(false))", "-1");
     }
 
     private static string TranslateUnit(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2235FilteredCatchFallthroughTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2235FilteredCatchFallthroughTranslationTests.cs
@@ -1,0 +1,256 @@
+// <copyright file="Issue2235FilteredCatchFallthroughTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translation tests for issue #2235 (follow-up to #1724, ADR-0115 §B): a
+/// <c>catch ... when (filter)</c> clause with a later sibling catch whose
+/// type could also receive the exception used to block translation entirely
+/// (reported unsupported) because the per-clause rethrow-on-false-filter
+/// lowering would make the exception escape the whole <c>try</c> instead of
+/// falling through to that sibling, as C# requires.
+///
+/// The fix merges the offending filtered clause and every clause after it
+/// into ONE G# catch, typed at a provably-safe common type, whose body
+/// manually replays C#'s top-to-bottom type-then-filter matching using
+/// ordinary <c>is</c> type tests (G#'s Kotlin-style smart cast narrows the
+/// shared binder inside each branch, ADR-0069) plus each clause's own filter.
+/// </summary>
+public class Issue2235FilteredCatchFallthroughTranslationTests
+{
+    /// <summary>
+    /// The issue's exact repro: two back-to-back filtered
+    /// <c>OperationCanceledException when (...)</c> clauses, both of which
+    /// must fall through to a later <c>catch (Exception)</c> when their own
+    /// filter is false. Proves the merge handles 2+ filtered clauses in a row.
+    /// </summary>
+    [Fact]
+    public void TwoBackToBackFilteredClauses_FallThroughToLaterExceptionCatch()
+    {
+        string printed = TranslateUnit(@"
+using System;
+using System.Threading;
+namespace Demo
+{
+    public class C
+    {
+        public int Run(CancellationToken ct)
+        {
+            try
+            {
+                throw new OperationCanceledException();
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                return 1;
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                return 2;
+            }
+            catch (Exception)
+            {
+                return 3;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("catch (ex Exception)", printed);
+        Assert.Contains("ex is OperationCanceledException", printed);
+        Assert.Contains("ct.IsCancellationRequested", printed);
+        Assert.Contains("return 1", printed);
+        Assert.Contains("return 2", printed);
+        Assert.Contains("return 3", printed);
+
+        // A CancellationToken defaults to not-requested, so `ct.IsCancellationRequested`
+        // is false for the first filtered clause and its negation is true for the
+        // second: the exception must fall through the first filter and be caught
+        // by the second clause's body (return 2), not the first or the final
+        // `catch (Exception)`.
+        CompileAndRun(printed, "System.Console.WriteLine(C().Run(System.Threading.CancellationToken()))", "2");
+    }
+
+    /// <summary>
+    /// Simpler shape: a single filtered clause with one overlapping later
+    /// sibling. Runtime proof both branches of the merged dispatch are live:
+    /// a filter-true exception is caught by the first clause, a filter-false
+    /// one falls through to the sibling.
+    /// </summary>
+    [Fact]
+    public void SingleFilteredClause_WithOverlappingSibling_FallsThroughWhenFilterFalse()
+    {
+        string printed = TranslateUnit(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+        public int Run(bool retryable)
+        {
+            try
+            {
+                throw new InvalidOperationException(""boom"");
+            }
+            catch (InvalidOperationException ex) when (retryable)
+            {
+                return 1;
+            }
+            catch (Exception)
+            {
+                return 2;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("catch (ex Exception)", printed);
+        Assert.Contains("ex is InvalidOperationException", printed);
+
+        CompileAndRun(printed, "System.Console.WriteLine(C().Run(true))", "1");
+        CompileAndRun(printed, "System.Console.WriteLine(C().Run(false))", "2");
+    }
+
+    /// <summary>
+    /// Regression guard for the EXISTING #1724 safe shape: a filtered clause
+    /// with no overlapping later sibling (disjoint types) must still use the
+    /// simple rethrow-if-false lowering, not the merge — no diagnostic, no
+    /// merged catch.
+    /// </summary>
+    [Fact]
+    public void FilteredClause_WithDisjointSibling_StillUsesSimpleRethrowLowering()
+    {
+        string printed = TranslateUnit(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+        public int Run(bool retryable)
+        {
+            try
+            {
+                throw new InvalidOperationException(""boom"");
+            }
+            catch (InvalidOperationException ex) when (retryable)
+            {
+                return 1;
+            }
+            catch (FormatException)
+            {
+                return 2;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("catch (ex InvalidOperationException)", printed);
+        Assert.Contains("if !retryable", printed);
+        Assert.Contains("throw ex", printed);
+        Assert.DoesNotContain("is InvalidOperationException", printed);
+
+        CompileAndRun(printed, "System.Console.WriteLine(C().Run(true))", "1");
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="printed"/> (with <paramref name="callExpression"/>
+    /// appended as a top-level entry statement) with the real <c>gsc</c> and runs
+    /// it, asserting its stdout equals <paramref name="expectedOutput"/> — proving
+    /// the merged dispatch's runtime control flow (not just its shape) is correct.
+    /// </summary>
+    private static void CompileAndRun(string printed, string callExpression, string expectedOutput)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-2235-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(gsPath, printed + Environment.NewLine + callExpression + Environment.NewLine);
+
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated snippet with zero errors. Output:\n" + compileOut +
+                "\n\nTranslated G#:\n" + printed);
+
+        (int runExit, string runOut) = RunDotnet($"\"{dllPath}\"");
+        Assert.True(runExit == 0, "Translated snippet must run successfully. Output:\n" + runOut);
+        Assert.Equal(expectedOutput, runOut.Trim());
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -6955,8 +6955,26 @@ public sealed class CSharpToGSharpTranslator
                     : this.context.Compilation.GetTypeByMetadataName("System.Exception");
             }
 
+            // Issue #2235 (follow-up to #1724): the first filtered clause whose
+            // later sibling could overlap is where top-to-bottom fall-through
+            // becomes unrepresentable as a per-clause rethrow. Instead of
+            // reporting it as unsupported, merge that clause and every clause
+            // after it (lazy but always-correct boundary — a tighter boundary
+            // would need the same disjointness proof again) into ONE catch that
+            // manually replays C#'s type-then-filter matching in its body.
+            int mergeStartIndex = -1;
+            for (int i = 0; i < node.Catches.Count; i++)
+            {
+                if (node.Catches[i].Filter != null && this.HasOverlappingLaterSibling(catchTypeSymbols, i))
+                {
+                    mergeStartIndex = i;
+                    break;
+                }
+            }
+
+            int loopEnd = mergeStartIndex == -1 ? node.Catches.Count : mergeStartIndex;
             var catches = new List<CatchClause>();
-            for (int catchIndex = 0; catchIndex < node.Catches.Count; catchIndex++)
+            for (int catchIndex = 0; catchIndex < loopEnd; catchIndex++)
             {
                 CatchClauseSyntax catchClause = node.Catches[catchIndex];
                 string variableName = null;
@@ -6992,41 +7010,25 @@ public sealed class CSharpToGSharpTranslator
                     BlockStatement body = this.TranslateBlock(catchClause.Block);
                     if (catchClause.Filter != null)
                     {
-                        if (this.HasOverlappingLaterSibling(catchTypeSymbols, catchIndex))
-                        {
-                            // A later sibling catch could still receive this
-                            // exception when the filter is false (e.g. it is, or
-                            // is a supertype of, this clause's type, or the
-                            // relationship can't be proven disjoint). Rethrow-
-                            // lowering would make the false-filter case escape the
-                            // whole try instead of falling through to that
-                            // sibling, silently diverging from C#. Report instead
-                            // of emitting the wrong control flow (ADR-0115 §B).
-                            string message = "a 'when' filter on a catch clause that has a later sibling catch whose type could "
-                                + "also receive the exception (e.g. a supertype such as 'Exception', or a type not "
-                                + "provably disjoint) has no faithful G# lowering: a false filter must fall through "
-                                + "to that sibling in C#, but G#'s rethrow-lowering would make it escape the whole "
-                                + "try instead (ADR-0115 §B / issue #1724).";
-                            this.context.ReportUnsupported(catchClause, message);
-                        }
-                        else
-                        {
-                            // G# has no native `catch ... when (filter)` (no Filter on
-                            // CatchClauseSyntax/TryStatementSyntax; grammar has no `when`
-                            // on catch). Lower it faithfully: evaluate the filter first and
-                            // rethrow the caught exception when it is false, so the
-                            // exception propagates exactly as it would in C# instead of
-                            // being silently swallowed (issue #1724). Note: unlike a real
-                            // CLR exception filter, this runs after the stack has already
-                            // unwound into the handler.
-                            GExpression filter = this.TranslateExpression(catchClause.Filter.FilterExpression);
-                            var rethrowIfFalse = new IfStatement(
-                                new UnaryExpression("!", filter),
-                                new BlockStatement(new List<GStatement> { new ThrowStatement(new IdentifierExpression(variableName)) }));
-                            var statements = new List<GStatement> { rethrowIfFalse };
-                            statements.AddRange(body.Statements);
-                            body = new BlockStatement(statements, body.IsUnsafe);
-                        }
+                        // No overlapping later sibling here by construction
+                        // (loopEnd stops before mergeStartIndex, the first index
+                        // for which HasOverlappingLaterSibling is true), so
+                        // rethrow-lowering is safe: G# has no native `catch ...
+                        // when (filter)` (no Filter on CatchClauseSyntax/
+                        // TryStatementSyntax; grammar has no `when` on catch).
+                        // Evaluate the filter first and rethrow the caught
+                        // exception when it is false, so the exception
+                        // propagates exactly as it would in C# instead of being
+                        // silently swallowed (issue #1724). Note: unlike a real
+                        // CLR exception filter, this runs after the stack has
+                        // already unwound into the handler.
+                        GExpression filter = this.TranslateExpression(catchClause.Filter.FilterExpression);
+                        var rethrowIfFalse = new IfStatement(
+                            new UnaryExpression("!", filter),
+                            new BlockStatement(new List<GStatement> { new ThrowStatement(new IdentifierExpression(variableName)) }));
+                        var statements = new List<GStatement> { rethrowIfFalse };
+                        statements.AddRange(body.Statements);
+                        body = new BlockStatement(statements, body.IsUnsafe);
                     }
 
                     catches.Add(new CatchClause(variableName, exceptionType, body));
@@ -7037,11 +7039,125 @@ public sealed class CSharpToGSharpTranslator
                 }
             }
 
+            if (mergeStartIndex != -1)
+            {
+                // Issue #2235: `mergeStartIndex..end` all get merged into one
+                // catch that manually replays C#'s top-to-bottom type-then-
+                // filter matching, since no per-clause rethrow lowering can be
+                // faithful once a later sibling could overlap.
+                catches.Add(this.BuildMergedFilteredCatch(node, catchTypeSymbols, mergeStartIndex));
+            }
+
             BlockStatement finallyBlock = node.Finally != null
                 ? this.TranslateBlock(node.Finally.Block)
                 : null;
 
             return new TryStatement(tryBlock, catches, finallyBlock);
+        }
+
+        /// <summary>
+        /// Merges catch clauses <c>[mergeStartIndex, node.Catches.Count)</c> into
+        /// a single G# catch clause that reproduces C#'s top-to-bottom, type-
+        /// then-filter catch matching in its body (issue #2235, follow-up to
+        /// #1724). Needed because a filtered clause with an overlapping later
+        /// sibling has no faithful per-clause rethrow lowering: a false filter
+        /// must fall through to that sibling in C#, not escape the whole
+        /// <c>try</c>. The merged catch is typed at the narrowest type provably
+        /// safe for every merged clause (the last clause's type, when it is a
+        /// supertype of all the others; <c>System.Exception</c> otherwise), and
+        /// its body dispatches on <c>ex is OriginalType</c> (G#'s Kotlin-style
+        /// smart cast narrows <c>ex</c> inside each branch, ADR-0069) plus each
+        /// clause's own filter, in source order, falling through to the next
+        /// clause when a type test or filter fails and rethrowing if none of
+        /// the merged clauses match (should not happen if the merge boundary is
+        /// correct, but is a safe fallback).
+        /// </summary>
+        private CatchClause BuildMergedFilteredCatch(TryStatementSyntax node, ITypeSymbol[] catchTypeSymbols, int mergeStartIndex)
+        {
+            const string sharedBinder = "ex";
+            var sharedBinderExpr = new IdentifierExpression(sharedBinder);
+
+            // Safety-net fallback: unreachable if the merged catch's declared
+            // type is a supertype of every merged clause's type, since then the
+            // last clause's `is` test always succeeds.
+            GStatement dispatch = new ThrowStatement(sharedBinderExpr);
+
+            for (int i = node.Catches.Count - 1; i >= mergeStartIndex; i--)
+            {
+                CatchClauseSyntax clause = node.Catches[i];
+                ITypeSymbol typeSymbol = catchTypeSymbols[i];
+                GTypeReference clauseType = typeSymbol != null
+                    ? this.typeMapper.Map(typeSymbol, this.context, clause.GetLocation())
+                    : new NamedTypeReference("Exception");
+                string originalName = clause.Declaration != null && !string.IsNullOrEmpty(clause.Declaration.Identifier.Text)
+                    ? SanitizeIdentifier(clause.Declaration.Identifier.Text)
+                    : sharedBinder;
+
+                string previousCatch = this.currentCatchVariable;
+                this.currentCatchVariable = originalName;
+                BlockStatement body;
+                GExpression filter = null;
+                try
+                {
+                    body = this.TranslateBlock(clause.Block);
+                    if (clause.Filter != null)
+                    {
+                        filter = this.TranslateExpression(clause.Filter.FilterExpression);
+                    }
+                }
+                finally
+                {
+                    this.currentCatchVariable = previousCatch;
+                }
+
+                // Re-bind this clause's own catch-variable name to the shared
+                // binder (narrowed to this clause's type by the `is` test below)
+                // so the body's references to its original name still resolve.
+                var branchStatements = new List<GStatement>();
+                if (originalName != sharedBinder)
+                {
+                    branchStatements.Add(new LocalDeclarationStatement(BindingKind.Let, originalName, initializer: sharedBinderExpr));
+                }
+
+                GStatement matched = filter != null
+                    ? new IfStatement(filter, body, new BlockStatement(new List<GStatement> { dispatch }))
+                    : (GStatement)body;
+                branchStatements.Add(matched);
+
+                GExpression typeTest = new BinaryExpression(sharedBinderExpr, "is", new TypeExpression(clauseType));
+                dispatch = new IfStatement(typeTest, new BlockStatement(branchStatements), new BlockStatement(new List<GStatement> { dispatch }));
+            }
+
+            GTypeReference mergedType = this.ComputeMergedCatchType(catchTypeSymbols, mergeStartIndex);
+            return new CatchClause(sharedBinder, mergedType, new BlockStatement(new List<GStatement> { dispatch }));
+        }
+
+        /// <summary>
+        /// Picks the merged catch's declared type (issue #2235): the last
+        /// merged clause's type when it is a supertype-or-equal of every
+        /// earlier merged clause's type (so it can safely catch all of them
+        /// without the outer G# catch itself narrowing anything away);
+        /// <c>System.Exception</c> otherwise (always safe, if less precise).
+        /// </summary>
+        private GTypeReference ComputeMergedCatchType(ITypeSymbol[] catchTypeSymbols, int mergeStartIndex)
+        {
+            int lastIndex = catchTypeSymbols.Length - 1;
+            ITypeSymbol lastType = catchTypeSymbols[lastIndex];
+            bool lastIsCommonSupertype = lastType != null;
+            for (int i = mergeStartIndex; lastIsCommonSupertype && i < lastIndex; i++)
+            {
+                if (!DerivesFromOrEquals(catchTypeSymbols[i], lastType))
+                {
+                    lastIsCommonSupertype = false;
+                }
+            }
+
+            if (lastIsCommonSupertype)
+            {
+                return this.typeMapper.Map(lastType, this.context, Location.None);
+            }
+
+            return new NamedTypeReference("Exception");
         }
 
         /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -7074,7 +7074,13 @@ public sealed class CSharpToGSharpTranslator
         /// </summary>
         private CatchClause BuildMergedFilteredCatch(TryStatementSyntax node, ITypeSymbol[] catchTypeSymbols, int mergeStartIndex)
         {
-            const string sharedBinder = "ex";
+            // Compiler-generated name (never a valid C# identifier a source
+            // catch variable could use) so the per-clause rebind below always
+            // fires, even when the original catch variable is itself named
+            // "ex" — otherwise that clause's body would see the merged
+            // binder's declared (unnarrowed) type instead of the smart-cast
+            // narrowed subtype.
+            const string sharedBinder = "__caught";
             var sharedBinderExpr = new IdentifierExpression(sharedBinder);
 
             // Safety-net fallback: unreachable if the merged catch's declared
@@ -7113,11 +7119,13 @@ public sealed class CSharpToGSharpTranslator
                 // Re-bind this clause's own catch-variable name to the shared
                 // binder (narrowed to this clause's type by the `is` test below)
                 // so the body's references to its original name still resolve.
-                var branchStatements = new List<GStatement>();
-                if (originalName != sharedBinder)
+                // Always emitted (sharedBinder can never collide with a
+                // source name), so this also carries the narrowed type into
+                // closures capturing the rebind, unlike the shared binder.
+                var branchStatements = new List<GStatement>
                 {
-                    branchStatements.Add(new LocalDeclarationStatement(BindingKind.Let, originalName, initializer: sharedBinderExpr));
-                }
+                    new LocalDeclarationStatement(BindingKind.Let, originalName, initializer: sharedBinderExpr),
+                };
 
                 GStatement matched = filter != null
                     ? new IfStatement(filter, body, new BlockStatement(new List<GStatement> { dispatch }))


### PR DESCRIPTION
Fixes #2235. Follow-up to #1724, ADR-0115 §B.

## Bug

`catch (T) when (filter)` with later sibling catch whose type could also
receive the exception blocked translate — cs2gs `ReportUnsupported`'d it
instead of lowering, since per-clause rethrow-on-false-filter escapes the
whole `try`, but C# falls through to the sibling instead.

## Fix

`TranslateTry`: find first filtered clause with overlapping later
sibling (via existing `HasOverlappingLaterSibling`). Merge it and every
clause after into ONE G# catch:

- Typed at last merged clause's type if it's a supertype of all
  earlier merged clauses (via existing `DerivesFromOrEquals`), else
  `System.Exception`.
- Body replays C#'s top-to-bottom type-then-filter matching as chained
  `if (ex is T) { ... } else if (ex is T2) { ... } else { throw ex }`.
  G#'s Kotlin-style smart cast (ADR-0069) narrows `ex` per branch, no
  need for a real pattern-binder AST.
- Each clause's own catch-var name rebound via `let name = ex` inside
  its branch when it differs from the shared binder, so its body's
  references still resolve.
- Filter false falls through to the next clause in the chain, not escape.
- No match at all (shouldn't happen given the merge boundary) rethrows
  as a safety net.

Merge boundary is simple by design (per the issue's stated tradeoff):
first offending clause through end of catch list — always correct, not
the tightest possible boundary. No new gsc syntax; pure cs2gs using
existing G# `if`/`is`/`catch`.

## Tests

New `Issue2235FilteredCatchFallthroughTranslationTests.cs`:
- issue's exact repro (2 back-to-back filtered `OperationCanceledException`
  clauses falling through to `catch (Exception)`)
- simpler 1-filtered + 1-sibling case
- regression guard: #1724's disjoint-sibling case still uses simple
  rethrow lowering (no merge)

All 3 include real `gsc` compile+run proving runtime fall-through
(not just shape). Updated 2 `BodyTranslationTests.cs` tests that
asserted the old unsupported-diagnostic behavior for the now-fixed
shape.

## Validation

- `dotnet test tools/cs2gs/Cs2Gs.Tests`: 1219/1219 pass, 0 regressions.
- `dotnet test test/Core.Tests`: 5860/5860 pass — confirms zero gsc
  changes needed (pure cs2gs fix).
