### PR TITLE
cs2gs: fix decimal parameter default gap for named-arg positional lowering (#2236)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
@@ -322,14 +322,19 @@ namespace Corpus.Issue1901
     }
 
     /// <summary>
-    /// A lambda default that is not a primitive/enum/null constant (here
-    /// <c>decimal</c>) has no gsc literal form; the translator must gap loudly
-    /// rather than substitute the wrong value AND type via <c>nil</c>.
+    /// Issue #2236: a lambda default of a <c>decimal</c> constant used to gap
+    /// ("not a simple literal") because <c>MapConstantValue</c>'s
+    /// constant-mapping switch had no <c>decimal</c> arm — even though
+    /// <c>decimal</c> is exactly as much a compile-time constant as
+    /// <c>double</c>/<c>float</c>, both of which it already handled. Now that
+    /// the missing arm is filled in, the default is preserved on the lambda
+    /// parameter and materialized at the omitted call site, with NO Unsupported
+    /// diagnostic.
     /// </summary>
     [Fact]
-    public void LambdaDefaultParameter_DecimalConstant_ReportsUnsupported()
+    public void LambdaDefaultParameter_DecimalConstant_TranslatesWithoutGap()
     {
-        (_, TranslationContext context) = Translate(@"
+        string rendered = Render(@"
 using System;
 namespace Corpus.Issue1901
 {
@@ -344,8 +349,9 @@ namespace Corpus.Issue1901
 }
 ");
 
-        Assert.Contains(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported
-            && d.Message.Contains("default value", StringComparison.Ordinal));
+        Assert.Contains("x decimal = 1.5", rendered, StringComparison.Ordinal);
+        Assert.Contains("Console.WriteLine(f(1.5))", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
     }
 
     private static (Cs2Gs.CodeModel.Ast.CompilationUnit Unit, TranslationContext Context) Translate(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2236NamedArgumentSkipNonLiteralDefaultTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2236NamedArgumentSkipNonLiteralDefaultTests.cs
@@ -1,0 +1,184 @@
+// <copyright file="Issue2236NamedArgumentSkipNonLiteralDefaultTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2236: a named-argument call that SKIPS an optional parameter reports
+/// "no faithful G# positional form yet (issue #1727)" whenever
+/// <c>BuildOptionalParameterDefault</c> cannot express the skipped parameter's
+/// own default. Investigation found that <c>default</c>/<c>default(T)</c>,
+/// <c>new T()</c> (value type), and a referenced <c>const</c> field were ALL
+/// already handled correctly — Roslyn's <c>IParameterSymbol.ExplicitDefaultValue</c>
+/// resolves each of those to a plain constant (or <c>null</c> for the zero
+/// value), which <see cref="M:Cs2Gs.Translator.CSharpToGSharpTranslator"/>'s
+/// existing constant-mapping switch already covered for every numeric kind
+/// EXCEPT <c>decimal</c> — a <c>decimal</c> default fell through to the
+/// "not a simple literal" diagnostic and was dropped, which (since the
+/// dropped default also makes the DECLARATION itself wrongly require the
+/// argument) breaks both the named-argument-skip path AND a plain declaration
+/// with a <c>decimal</c> default. The fix adds the missing <c>decimal</c> arm
+/// to the shared constant-mapping switch (<c>MapConstantValue</c>) rather than
+/// add native named-argument call syntax to gsc (see the PR description for
+/// the full engineering-judgment reasoning): every other "non-literal" shape
+/// the issue calls out was already a faithful reconstruction via the existing
+/// call path, so only the one missing numeric kind needed a fix, and doing so
+/// in the single shared method used by both call sites (declaration defaults
+/// and named-argument-skip filler defaults) fixes both root causes at once.
+/// </summary>
+public class Issue2236NamedArgumentSkipNonLiteralDefaultTests
+{
+    [Fact]
+    public void NamedArgument_SkipsParameterWithDecimalDefault_FillsDefaultPositionally()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Foo(int a, decimal price = 1.5m, int flag = 0) { }
+
+        public void Caller()
+        {
+            Foo(a: 1, flag: 2);
+        }
+    }
+}");
+        Assert.Contains("Foo(1, 1.5, 2)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DecimalDefault_WithoutNamedArguments_KeepsParameterOptional()
+    {
+        // Regression for the same root cause on the DECLARATION side (not just
+        // the named-argument-skip path): a plain `decimal` default must not be
+        // silently dropped, or the parameter becomes wrongly required.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Foo(int a, decimal price = 1.5m) { }
+
+        public void Caller()
+        {
+            Foo(1);
+        }
+    }
+}");
+        Assert.Contains("price decimal = 1.5", printed, StringComparison.Ordinal);
+        Assert.Contains("Foo(1)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NamedArgument_SkipsParameterWithDefaultKeyword_FillsDefaultPositionally()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public struct Options { public int X; }
+
+    public class C
+    {
+        public void Foo(int a, Options table = default, int flag = 0) { }
+
+        public void Caller()
+        {
+            Foo(a: 1, flag: 2);
+        }
+    }
+}");
+        Assert.Contains("Foo(1, default(Options), 2)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NamedArgument_SkipsParameterWithNewValueTypeDefault_FillsDefaultPositionally()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public struct Options { public int X; }
+
+    public class C
+    {
+        public void Foo(int a, Options table = new Options(), int flag = 0) { }
+
+        public void Caller()
+        {
+            Foo(a: 1, flag: 2);
+        }
+    }
+}");
+        Assert.Contains("Foo(1, default(Options), 2)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NamedArgument_SkipsParameterWithReferencedConstantDefault_FillsDefaultPositionally()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public const string TableName = ""users"";
+
+        public void Foo(int a, string table = TableName, int flag = 0) { }
+
+        public void Caller()
+        {
+            Foo(a: 1, flag: 2);
+        }
+    }
+}");
+        Assert.Contains("Foo(1, \"users\", 2)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NamedArgument_SkipsParameterWithSimpleLiteralDefault_StillWorks()
+    {
+        // Baseline from issue #1727: must still work unchanged.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Foo(int a, int b = 42, int flag = 0) { }
+
+        public void Caller()
+        {
+            Foo(a: 1, flag: 2);
+        }
+    }
+}");
+        Assert.Contains("Foo(1, 42, 2)", printed, StringComparison.Ordinal);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1514,6 +1514,16 @@ public sealed class CSharpToGSharpTranslator
                 case float f:
                     return MapSpecialFloatConstant(f, isDouble: false) ??
                         LiteralExpression.Float(f.ToString(CultureInfo.InvariantCulture));
+
+                // Issue #2236: a `decimal` default (e.g. `decimal price = 1.5m`) is
+                // just as much a compile-time constant as `double`/`float` — Roslyn
+                // resolves it via `ExplicitDefaultValue` like any other numeric
+                // default — but this switch had no `decimal` arm, so it fell to the
+                // `default:` branch below, failed `IsIntegral`, and was reported as
+                // "not a simple literal" even though `decimal.ToString` never uses
+                // scientific notation and round-trips cleanly as a float literal.
+                case decimal m:
+                    return LiteralExpression.Float(m.ToString(CultureInfo.InvariantCulture));
                 default:
                     return IsIntegral(value)
                         ? LiteralExpression.Int(System.Convert.ToString(value, CultureInfo.InvariantCulture))


### PR DESCRIPTION
Fixes #2236.

## Root cause
`MapConstantValue` (shared by `BuildOptionalParameterDefault`, used both for a plain optional-parameter default AND the filler value `TranslateNamedArguments`/`BuildSkippedNamedArgumentDefault` inject when a named-argument call skips an optional parameter) had a constant-mapping switch for `bool`/`string`/`char`/`double`/`float`/integrals — but no `decimal` arm. A `decimal` default fell through to the integral-only `default:` branch, failed `IsIntegral`, and got reported as "not a simple literal" — the exact `CS2GS-GAP` this issue names, blocking `cs2gs migrate` whenever a named-argument call skipped a `decimal`-defaulted parameter. As a side effect, ANY `decimal`-defaulted parameter (independent of named args) was also silently made required.

## Investigation (per issue's own instruction)
Checked whether gsc has native named-argument call syntax: it does not (grepped the parser/binder — no scaffolding). Then checked each "non-literal default" shape the issue calls out:
- `default` / `default(T)` for a value type → already correct (`ExplicitDefaultValue == null` → `default(T)`)
- `new T()` for a value type → already correct (same path, Roslyn treats it identically to `default`)
- a referenced `const` field → already correct (`ExplicitDefaultValue` resolves the referenced constant's actual value already)
- `decimal` → **broken**, the one missing arm

Verified all four with throwaway probe tests before touching any code. Since three of the four "preferred fix direction" scenarios already worked, and the fourth needed only one missing `case` in an existing switch, adding native named-argument call syntax to gsc (a new parser/binder/printer feature, new `SyntaxKind`s, and a matching golden-file update) would have been a much larger and riskier change to fix a one-line gap. Went with the smaller, equally-faithful fix.

## Fix
Added a `decimal` case to `MapConstantValue`, formatting via `decimal.ToString(CultureInfo.InvariantCulture)` (decimal never uses scientific notation, so it round-trips cleanly as a G# float literal) — mirrors the existing `double`/`float` handling exactly.

No new gsc `SyntaxKind`/`BoundNodeKind` was introduced (pure reuse of the existing C#-constant-to-G#-literal translation path), so `coverage-matrix.golden.txt` needed no update — confirmed `CoverageMatrixGoldenTests` still passes unchanged.

## Tests
- Added `Issue2236NamedArgumentSkipNonLiteralDefaultTests.cs`: named-arg skip of a `decimal` default (the bug), `default`/`default(T)`, `new T()` (value type), a referenced `const`, and the pre-existing simple-literal case (no regression) — 6 tests, all pass.
- Updated `Issue1901LambdaDefaultsTranslationTests.LambdaDefaultParameter_DecimalConstant_ReportsUnsupported`: its premise ("decimal lambda defaults always gap") is no longer true after this fix, since lambda default parameters route through the same `BuildOptionalParameterDefault`/`MapConstantValue` path. Renamed to `_TranslatesWithoutGap` and now asserts the decimal default is faithfully materialized at the omitted call site instead of gapping.

## Before / after
- `tools/cs2gs/Cs2Gs.Tests`: before 1221 tests (all passing on `main`), after **1227 total, 1227 passed, 0 failed** (+6 new tests, 0 regressions).
- `test/Core.Tests`: **5861 total, 5860 passed, 1 skipped, 0 failed** (unchanged — this fix doesn't touch gsc itself).
