### PR TITLE
Fix qualified/dotted type-name resolution for source types (#2256)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3315,7 +3315,13 @@ public sealed class Binder
         // by a single-name `Probe` that happens to exist somewhere.
         for (var outerLen = totalSegments; outerLen >= 1; outerLen--)
         {
-            var clrType = TryResolveOuterPrefix(segmentTexts, outerLen);
+            // When the whole dotted name IS the (generic) type — the trailing
+            // type-argument list belongs to the deepest prefix segment — the
+            // metadata name is arity-mangled (`Ns.IFoo`1`). Pass the target
+            // arity so a namespace-qualified generic user/CLR type resolves
+            // (issue: qualified generic type-name/constraint resolution).
+            var prefixArity = outerLen == totalSegments ? targetArity : 0;
+            var clrType = TryResolveOuterPrefix(segmentTexts, outerLen, prefixArity);
             if (clrType == null)
             {
                 continue;
@@ -3328,6 +3334,37 @@ public sealed class Binder
             if (walked != null)
             {
                 return ConstructIfGeneric(walked, syntax, targetArity);
+            }
+        }
+
+        // Same-compilation package-qualified source type: the qualifier segments
+        // form a package/namespace prefix and the final segment names a source
+        // type declared in this compilation (e.g. `Oahu.Decrypt.INewSplitCallback[T]`
+        // referenced from within package `Oahu.Decrypt`). Source types are visible
+        // by simple name across packages, but the reflection-based prefix walk
+        // above only sees types with a CLR representation, so a source type — which
+        // has none while binding — never resolves through it. Fall back to a
+        // simple-name lookup of the final segment, honoring the trailing arity.
+        // cs2gs fully-qualifies type references (including generic-math
+        // constraints), so this is the common shape for translated code.
+        var lastSegment = segmentTexts[totalSegments - 1];
+        var sourceType = LookupType(lastSegment, targetArity > 0 ? targetArity : -1);
+        if (sourceType != null && !ReferenceEquals(sourceType, TypeSymbol.Error))
+        {
+            if (targetArity == 0)
+            {
+                return sourceType;
+            }
+
+            var constructed = BindAndConstructUserGenericSegment(
+                syntax,
+                sourceType,
+                syntax.TypeArguments,
+                syntax.Identifier.Location,
+                syntax.DottedName);
+            if (constructed != null)
+            {
+                return constructed;
             }
         }
 
@@ -3394,15 +3431,37 @@ public sealed class Binder
     /// prefixes, and the active import set as a namespace prefix for
     /// multi-segment prefixes.
     /// </summary>
-    private Type TryResolveOuterPrefix(string[] segmentTexts, int outerLen)
+    private Type TryResolveOuterPrefix(string[] segmentTexts, int outerLen, int lastSegmentArity = 0)
     {
         if (outerLen == 1)
         {
-            var symbol = LookupType(segmentTexts[0]);
+            var symbol = LookupType(segmentTexts[0], lastSegmentArity > 0 ? lastSegmentArity : -1);
             return symbol?.ClrType;
         }
 
         var prefix = string.Join(".", segmentTexts, 0, outerLen);
+
+        // A generic type's metadata name is arity-mangled (`Ns.IFoo`1`); when
+        // the deepest prefix segment carries the trailing type-argument list,
+        // try the mangled name first so a namespace-qualified generic type
+        // resolves to its open definition (closed later by ConstructIfGeneric).
+        if (lastSegmentArity > 0)
+        {
+            var mangled = prefix + "`" + lastSegmentArity;
+            if (scope.References.TryResolveType(mangled, out var directGeneric))
+            {
+                return directGeneric;
+            }
+
+            foreach (var import in scope.GetDeclaredImports())
+            {
+                if (scope.References.TryResolveType(import.Target + "." + mangled, out var viaImportGeneric))
+                {
+                    return viaImportGeneric;
+                }
+            }
+        }
+
         if (scope.References.TryResolveType(prefix, out var direct))
         {
             return direct;

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -6708,7 +6708,11 @@ internal sealed class DeclarationBinder
     /// <param name="symbol">The bare type-parameter symbol to annotate.</param>
     private void ResolveInterfaceConstraint(TypeParameterSyntax p, TypeParameterSymbol symbol)
     {
-        var constraintClause = new TypeClauseSyntax(
+        // A qualified (dotted) constraint name is captured whole by the parser
+        // as a ready-made type clause; bind it directly. Otherwise reconstruct
+        // the clause from the single-identifier constraint token plus its
+        // optional generic-argument list (the `[T IAdd[T]]` shape).
+        var constraintClause = p.ConstraintType ?? new TypeClauseSyntax(
             p.SyntaxTree,
             openBracketToken: null,
             lengthToken: null,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -248,18 +248,9 @@ internal sealed partial class ExpressionBinder
         var peeledAny = false;
         while (current is AccessorExpressionSyntax accessor
                && !accessor.IsNullConditional
-               && accessor.LeftPart is NameExpressionSyntax leftName)
+               && accessor.LeftPart is NameExpressionSyntax leftName
+               && IsNamespacePrefixSegment(leftName.IdentifierToken.Text))
         {
-            var segment = leftName.IdentifierToken.Text;
-            var isNamespaceSegment = scope.TryLookupSymbol(segment) is not VariableSymbol
-                && !scope.TryLookupTypeAlias(segment, out _)
-                && !scope.TryLookupImport(segment, out _)
-                && !scope.TryLookupImportedClass(segment, declaration: null, out _);
-            if (!isNamespaceSegment)
-            {
-                break;
-            }
-
             current = accessor.RightPart;
             peeledAny = true;
         }
@@ -274,8 +265,13 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        // Peel the redundant namespace prefix and bind the remainder by simple name.
-        result = BindExpression(current);
+        // Peel the redundant namespace prefix and bind the remainder by simple
+        // name. Use BindExpressionpublic (not BindExpression) so a void terminal
+        // (a `Ns.Type[Args].VoidMethod(...)` call in an expression-bodied void
+        // member) is not prematurely rejected here — the caller's BindExpression
+        // wrapper applies the correct void-in-value-position check on the
+        // original syntax.
+        result = BindExpressionpublic(current);
         return true;
     }
 
@@ -2732,9 +2728,59 @@ internal sealed partial class ExpressionBinder
                 return TryResolveConstructedGenericTypeReceiver(index, out constructedStruct, out constructedInterface, out constructedImported);
             case GenericNameExpressionSyntax generic:
                 return TryResolveConstructedGenericTypeReceiver(generic, out constructedStruct, out constructedInterface, out constructedImported);
+            case AccessorExpressionSyntax accessorChain when !accessorChain.IsNullConditional:
+                // A package-qualified generic type receiver written by cs2gs,
+                // e.g. `Oahu.Aux.Diagnostics.TreeDecomposition[T].field = v`. The
+                // leading namespace segments are redundant for a source type; peel
+                // them and re-dispatch on the bare constructed-generic terminal.
+                var peeled = PeelNamespacePrefix(accessorChain);
+                if (!ReferenceEquals(peeled, accessorChain)
+                    && peeled is IndexExpressionSyntax or GenericNameExpressionSyntax)
+                {
+                    return TryResolveConstructedGenericTypeReceiver(peeled, out constructedStruct, out constructedInterface, out constructedImported);
+                }
+
+                return false;
             default:
                 return false;
         }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="segment"/> is a pure namespace/package prefix
+    /// component — it does not name an in-scope value, a known type/alias, an
+    /// import alias, or an imported class. cs2gs fully-qualifies type references,
+    /// so a leading run of such segments in front of a same-compilation source
+    /// type is redundant and must be peeled before binding by simple name.
+    /// </summary>
+    /// <param name="segment">The dotted-name segment to classify.</param>
+    /// <returns>Whether the segment is a pure namespace/package prefix.</returns>
+    private bool IsNamespacePrefixSegment(string segment) =>
+        scope.TryLookupSymbol(segment) is not VariableSymbol
+        && !scope.TryLookupTypeAlias(segment, out _)
+        && !scope.TryLookupImport(segment, out _)
+        && !scope.TryLookupImportedClass(segment, declaration: null, out _);
+
+    /// <summary>
+    /// Peels a leading run of pure namespace/package segments off a dotted
+    /// accessor chain, returning the first non-namespace remainder (unchanged
+    /// when the head is not a namespace segment). Used to strip a redundant
+    /// package prefix cs2gs emits in front of a same-compilation source type.
+    /// </summary>
+    /// <param name="expr">The dotted accessor chain to peel.</param>
+    /// <returns>The first non-namespace remainder of the chain.</returns>
+    private ExpressionSyntax PeelNamespacePrefix(ExpressionSyntax expr)
+    {
+        var current = expr;
+        while (current is AccessorExpressionSyntax accessor
+               && !accessor.IsNullConditional
+               && accessor.LeftPart is NameExpressionSyntax leftName
+               && IsNamespacePrefixSegment(leftName.IdentifierToken.Text))
+        {
+            current = accessor.RightPart;
+        }
+
+        return current;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -970,6 +970,18 @@ internal sealed partial class ExpressionBinder
                 // member access binds identically to the capitalized form.
                 classSymbol = predefinedClass;
             }
+            else if (rightPart is not NameExpressionSyntax
+                && TryBindFullyQualifiedClrStaticAccess(leftName, ref rightPart, out var fullyQualifiedClrClass))
+            {
+                // Issue #2258: a fully-qualified CLR type reference whose leading
+                // segment is not a registered import — e.g.
+                // `Microsoft.Extensions.Logging.LogLevel.Warning`. cs2gs emits the
+                // full namespace path; walk it to the referenced CLR type and bind
+                // the trailing member as a static access. Gated on the right part
+                // being a further chain (not a bare terminal name) so a genuine
+                // undefined single-segment name still reports GS0157 below.
+                classSymbol = fullyQualifiedClrClass;
+            }
             else
             {
                 Diagnostics.ReportUnableToFindType(leftName.Location, name);
@@ -1701,7 +1713,6 @@ internal sealed partial class ExpressionBinder
         importedClass = null;
 
         var currentPath = import.Target;
-        var currentRight = rightPart;
 
         // A type alias (`import R = System.Console`) names a type outright: the
         // import target itself resolves as a type, and the accessor's right part
@@ -1715,6 +1726,43 @@ internal sealed partial class ExpressionBinder
             importedClass = new ImportedClassSymbol(aliasTargetType, rightPart, references: scope.References);
             return true;
         }
+
+        return TryWalkQualifiedClrTypePath(currentPath, ref rightPart, out importedClass);
+    }
+
+    /// <summary>
+    /// Issue #2258: last-resort fallback for a fully-qualified CLR type reference
+    /// written in expression position whose leading segment is NOT a registered
+    /// import/alias — e.g. <c>Microsoft.Extensions.Logging.LogLevel.Warning</c>
+    /// (CLR enum member) or
+    /// <c>Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance</c>
+    /// (CLR static field). cs2gs fully-qualifies every type reference, so a
+    /// referenced-assembly type accessed by its full namespace path lands here
+    /// when the root namespace segment (<c>Microsoft</c>) matches no import.
+    /// Walks the dotted chain the same way <see cref="TryBindImportAccessor"/>
+    /// does, but starting from the bare leading name as the first namespace
+    /// segment, so any referenced CLR type — regardless of namespace depth —
+    /// resolves and its trailing member binds as a static access.
+    /// </summary>
+    private bool TryBindFullyQualifiedClrStaticAccess(NameExpressionSyntax leftName, ref ExpressionSyntax rightPart, out ImportedClassSymbol importedClass)
+        => TryWalkQualifiedClrTypePath(leftName.IdentifierToken.Text, ref rightPart, out importedClass);
+
+    /// <summary>
+    /// Walks a dotted accessor chain, extending a namespace prefix segment by
+    /// segment until a prefix resolves to a referenced CLR type. On success the
+    /// resolved type is returned as an <see cref="ImportedClassSymbol"/> and
+    /// <paramref name="rightPart"/> is advanced to the remaining (post-type)
+    /// member-access chain. Shared by <see cref="TryBindImportAccessor"/> (which
+    /// starts from a registered import target) and
+    /// <see cref="TryBindFullyQualifiedClrStaticAccess"/> (which starts from a
+    /// bare leading namespace name).
+    /// </summary>
+    private bool TryWalkQualifiedClrTypePath(string startPath, ref ExpressionSyntax rightPart, out ImportedClassSymbol importedClass)
+    {
+        importedClass = null;
+
+        var currentPath = startPath;
+        var currentRight = rightPart;
 
         while (true)
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -209,6 +209,121 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Binds a same-compilation SOURCE type constructed or referenced through a
+    /// package-qualified name — e.g. <c>Oahu.Decrypt.Mp4Operation(...)</c> or the
+    /// generic <c>Oahu.Decrypt.Mp4Operation[TResult](...)</c>. cs2gs
+    /// fully-qualifies type references, but a G# source type has no CLR type at
+    /// bind time, so <see cref="TryBindQualifiedClrConstructorCall"/> (which only
+    /// resolves reference-set types) cannot see it. G# resolves source types by
+    /// simple name from a flat, cross-package type scope, so a leading
+    /// namespace/package prefix is redundant.
+    /// <para>
+    /// This fires only when every leading segment is a pure namespace/package
+    /// component — none names an in-scope value, a known type, an import alias,
+    /// or an imported class (which would make the chain a static-member access or
+    /// nested-type reference handled elsewhere) — and the terminal is a call or
+    /// struct-literal whose simple name resolves to a user aggregate type. In that
+    /// case the redundant prefix is peeled off and the terminal is bound by simple
+    /// name, matching how the same construction binds when written unqualified.
+    /// </para>
+    /// </summary>
+    /// <param name="syntax">The accessor chain forming the qualified name.</param>
+    /// <param name="result">The bound terminal construction on success.</param>
+    /// <returns>Whether the qualified name bound to a source-type construction.</returns>
+    private bool TryBindQualifiedSourceTypeConstruction(AccessorExpressionSyntax syntax, out BoundExpression result)
+    {
+        result = null;
+
+        if (syntax.IsNullConditional)
+        {
+            return false;
+        }
+
+        // Peel the leading dotted-name segments while each is a bare identifier
+        // that does NOT resolve to a value, a type, an import alias, or an
+        // imported class — i.e. a pure namespace/package component. Stop at the
+        // first segment that is anything else (a generic-name type reference, a
+        // type name, or the terminal construction).
+        ExpressionSyntax current = syntax;
+        var peeledAny = false;
+        while (current is AccessorExpressionSyntax accessor
+               && !accessor.IsNullConditional
+               && accessor.LeftPart is NameExpressionSyntax leftName)
+        {
+            var segment = leftName.IdentifierToken.Text;
+            var isNamespaceSegment = scope.TryLookupSymbol(segment) is not VariableSymbol
+                && !scope.TryLookupTypeAlias(segment, out _)
+                && !scope.TryLookupImport(segment, out _)
+                && !scope.TryLookupImportedClass(segment, declaration: null, out _);
+            if (!isNamespaceSegment)
+            {
+                break;
+            }
+
+            current = accessor.RightPart;
+            peeledAny = true;
+        }
+
+        // Only fire when at least one namespace segment was peeled (so ordinary
+        // static-member access and simple-name construction are untouched) and
+        // the remainder's head names a same-compilation user aggregate source
+        // type — a constructor call `Type(...)`, a struct literal `Type{...}`, or
+        // a static-member access `Type.Member` / `Type[Args].Member`.
+        if (!peeledAny || !RemainderHeadIsSourceType(current))
+        {
+            return false;
+        }
+
+        // Peel the redundant namespace prefix and bind the remainder by simple name.
+        result = BindExpression(current);
+        return true;
+    }
+
+    /// <summary>
+    /// Whether the head of <paramref name="remainder"/> (after peeling a
+    /// namespace prefix) names a same-compilation user aggregate source type:
+    /// a constructor call <c>Type(...)</c>, a struct literal <c>Type{...}</c>,
+    /// or a static-member access rooted at a type name <c>Type.Member</c> /
+    /// generic type reference <c>Type[Args].Member</c>.
+    /// </summary>
+    private bool RemainderHeadIsSourceType(ExpressionSyntax remainder)
+    {
+        string simpleName;
+        int arity;
+        switch (remainder)
+        {
+            case CallExpressionSyntax call when !call.Identifier.IsMissing:
+                simpleName = call.Identifier.Text;
+                arity = call.TypeArgumentList?.Arguments.Count ?? 0;
+                break;
+            case StructLiteralExpressionSyntax literal when !literal.TypeIdentifier.IsMissing:
+                simpleName = literal.TypeIdentifier.Text;
+                arity = literal.TypeArgumentList?.Arguments.Count ?? 0;
+                break;
+            case AccessorExpressionSyntax { LeftPart: GenericNameExpressionSyntax genericHead }:
+                simpleName = genericHead.Identifier.Text;
+                arity = genericHead.TypeArgumentList?.Arguments.Count ?? 0;
+                break;
+            case AccessorExpressionSyntax { LeftPart: NameExpressionSyntax nameHead }:
+                simpleName = nameHead.IdentifierToken.Text;
+                arity = 0;
+                break;
+            case AccessorExpressionSyntax { LeftPart: IndexExpressionSyntax { Target: NameExpressionSyntax indexNameHead } }:
+                // `Type[Args].Member`: a generic type receiver parses as an index
+                // expression (`Mp4Operation[int32]`), not a GenericName, when it
+                // appears as the left part of a member access.
+                simpleName = indexNameHead.IdentifierToken.Text;
+                arity = 0;
+                break;
+            default:
+                return false;
+        }
+
+        return scope.TryLookupTypeAlias(simpleName, arity > 0 ? arity : -1, out var terminalType)
+            && IsUserAggregateType(terminalType);
+    }
+
+    /// <summary>
     /// Resolves a closed CLR type from a fully-qualified dotted name written in
     /// source. Tries the name as written, the name with the leading segment
     /// expanded from a matching import alias/path, and the name prefixed by each
@@ -539,6 +654,21 @@ internal sealed partial class ExpressionBinder
         if (TryBindQualifiedClrConstructorCall(syntax, out var qualifiedCtorCall))
         {
             return qualifiedCtorCall;
+        }
+
+        // A same-compilation SOURCE type constructed/referenced through a
+        // package-qualified name — `Oahu.Decrypt.Mp4Operation(...)`,
+        // `Oahu.Decrypt.Mp4Operation[TResult](...)`. Source types are visible by
+        // simple name across packages, but the qualified path above only resolves
+        // CLR-backed reference types (a source type has no CLR type at bind time).
+        // When the leading segments are a pure namespace/package prefix (none names
+        // a value, type, import, or imported class) and the terminal simple name
+        // is a user aggregate, peel the redundant prefix and bind the terminal by
+        // simple name. cs2gs fully-qualifies constructor calls, so this is the
+        // common translated shape.
+        if (TryBindQualifiedSourceTypeConstruction(syntax, out var qualifiedSourceCtor))
+        {
+            return qualifiedSourceCtor;
         }
 
         // Issue #1069: a nested user type referenced by a qualified name from

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -3485,7 +3485,7 @@ public class Parser
         while (true)
         {
             var k = Peek(ahead).Kind;
-            if (k == SyntaxKind.IdentifierToken || k == SyntaxKind.ClassKeyword || k == SyntaxKind.StructKeyword)
+            if (k == SyntaxKind.IdentifierToken || k == SyntaxKind.ClassKeyword || k == SyntaxKind.StructKeyword || k == SyntaxKind.DotToken)
             {
                 // `init` is lexed as an identifier; consume an optional `()` pair
                 // when this identifier is the contextual `init` constraint keyword.
@@ -3498,6 +3498,10 @@ public class Parser
                     continue;
                 }
 
+                // A `.` continues a qualified (dotted) constraint name
+                // (e.g. `[T Namespace.Sub.IFace[T]]`); skip it and the segment
+                // identifier that follows so the balanced `[ ... ]` and the
+                // list-terminating `,`/`]` are examined against the right token.
                 ahead++;
                 continue;
             }
@@ -3586,6 +3590,7 @@ public class Parser
         SyntaxToken openBracket = null;
         SeparatedSyntaxList<TypeClauseSyntax> constraintTypeArgs = default;
         SyntaxToken closeBracket = null;
+        TypeClauseSyntax constraintTypeClause = null;
 
         if (Current.Kind == SyntaxKind.IdentifierToken)
         {
@@ -3595,36 +3600,53 @@ public class Parser
             // any/comparable/interface-name slot.
             if (!IsAdditionalConstraintStart(Current))
             {
-                constraint = NextToken();
-
-                // ADR-0089 / issue #755: a constraint identifier may be followed by
-                // a generic type-argument list (the curiously-recurring pattern
-                // `[T IAdd[T]]` is the canonical generic-math shape required for
-                // static-virtual interface members). Parse `[ TypeClause (, TypeClause)* ]`
-                // when present; the binder constructs the closed interface from the
-                // resulting argument list.
-                if (Current.Kind == SyntaxKind.OpenSquareBracketToken)
+                // A qualified (dotted) constraint name — e.g.
+                // `Namespace.Sub.IFace[T]` — cannot be represented by the single
+                // `constraint` identifier token. Parse the whole thing through the
+                // regular type-clause machinery (which already handles dotted names
+                // and per-segment generic arguments, stopping at the `,`/`]` that
+                // closes the type-parameter list). The first-segment identifier is
+                // retained in `constraint` for `any`/`comparable` dispatch and
+                // error locations. cs2gs emits fully-qualified constraint names, so
+                // this is the common shape for translated generic-math interfaces.
+                if (Peek(1).Kind == SyntaxKind.DotToken)
                 {
-                    openBracket = MatchToken(SyntaxKind.OpenSquareBracketToken);
-                    var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
-                    var parseNext = true;
-                    while (parseNext &&
-                           Current.Kind != SyntaxKind.CloseSquareBracketToken &&
-                           Current.Kind != SyntaxKind.EndOfFileToken)
-                    {
-                        nodesAndSeparators.Add(ParseTypeClause());
-                        if (Current.Kind == SyntaxKind.CommaToken)
-                        {
-                            nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
-                        }
-                        else
-                        {
-                            parseNext = false;
-                        }
-                    }
+                    constraintTypeClause = ParseTypeClause();
+                    constraint = constraintTypeClause.Identifier;
+                }
+                else
+                {
+                    constraint = NextToken();
 
-                    closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
-                    constraintTypeArgs = new SeparatedSyntaxList<TypeClauseSyntax>(nodesAndSeparators.ToImmutable());
+                    // ADR-0089 / issue #755: a constraint identifier may be followed by
+                    // a generic type-argument list (the curiously-recurring pattern
+                    // `[T IAdd[T]]` is the canonical generic-math shape required for
+                    // static-virtual interface members). Parse `[ TypeClause (, TypeClause)* ]`
+                    // when present; the binder constructs the closed interface from the
+                    // resulting argument list.
+                    if (Current.Kind == SyntaxKind.OpenSquareBracketToken)
+                    {
+                        openBracket = MatchToken(SyntaxKind.OpenSquareBracketToken);
+                        var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+                        var parseNext = true;
+                        while (parseNext &&
+                               Current.Kind != SyntaxKind.CloseSquareBracketToken &&
+                               Current.Kind != SyntaxKind.EndOfFileToken)
+                        {
+                            nodesAndSeparators.Add(ParseTypeClause());
+                            if (Current.Kind == SyntaxKind.CommaToken)
+                            {
+                                nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
+                            }
+                            else
+                            {
+                                parseNext = false;
+                            }
+                        }
+
+                        closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
+                        constraintTypeArgs = new SeparatedSyntaxList<TypeClauseSyntax>(nodesAndSeparators.ToImmutable());
+                    }
                 }
             }
         }
@@ -3698,7 +3720,7 @@ public class Parser
             }
         }
 
-        return new TypeParameterSyntax(
+        var typeParameter = new TypeParameterSyntax(
             syntaxTree,
             variance,
             identifier,
@@ -3712,6 +3734,13 @@ public class Parser
             initOpenParen,
             initCloseParen,
             unmanagedKw);
+
+        if (constraintTypeClause != null)
+        {
+            typeParameter.ConstraintType = constraintTypeClause;
+        }
+
+        return typeParameter;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Syntax/TypeParameterSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeParameterSyntax.cs
@@ -12,6 +12,8 @@ namespace GSharp.Core.CodeAnalysis.Syntax;
 /// </summary>
 public sealed class TypeParameterSyntax : SyntaxNode
 {
+    private TypeClauseSyntax constraintType;
+
     /// <summary>Initializes a new instance of the <see cref="TypeParameterSyntax"/> class.</summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
     /// <param name="varianceModifier">Optional <c>in</c>/<c>out</c> variance contextual keyword (ADR-0021); only valid on interface type parameters.</param>
@@ -152,6 +154,25 @@ public sealed class TypeParameterSyntax : SyntaxNode
 
     /// <summary>Gets the optional constraint identifier token (e.g. <c>any</c>, <c>comparable</c>, or a sealed-interface name).</summary>
     public SyntaxToken Constraint { get; }
+
+    /// <summary>
+    /// Gets the optional fully-parsed constraint type clause used when the constraint names a
+    /// <em>qualified</em> (dotted) type — e.g. <c>Oahu.Decrypt.INewSplitCallback[TCallback]</c>.
+    /// When set, <see cref="Constraint"/> still holds the first-segment identifier (for
+    /// <c>any</c>/<c>comparable</c> dispatch and error locations), while this clause carries the
+    /// full dotted name and per-segment generic arguments so the binder resolves it directly
+    /// rather than reconstructing it from <see cref="Constraint"/> + <see cref="ConstraintTypeArguments"/>.
+    /// The parser assigns this after construction, so the setter invalidates any cached span.
+    /// </summary>
+    public TypeClauseSyntax ConstraintType
+    {
+        get => constraintType;
+        internal set
+        {
+            constraintType = value;
+            InvalidateCachedSpan();
+        }
+    }
 
     /// <summary>Gets the optional opening <c>[</c> of the constraint's generic type-argument list (ADR-0089).</summary>
     public SyntaxToken ConstraintTypeArgumentOpenBracketToken { get; }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2256QualifiedConstraintTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2256QualifiedConstraintTests.cs
@@ -142,6 +142,56 @@ public class Issue2256QualifiedConstraintTests
         Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
     }
 
+    [Fact]
+    public void QualifiedSourceType_StaticFieldWrite_OnGenericType_Binds()
+    {
+        // Assignment LHS (write path): `Ns.Type[T].field = value`. The qualified
+        // generic type receiver must be recognized as a static-type receiver
+        // after peeling the redundant package prefix.
+        const string source = """
+            package Oahu.Aux.Diagnostics
+            import System
+
+            class TreeDecomposition[T] {
+                shared {
+                    private var default_ Oahu.Aux.Diagnostics.TreeDecomposition[T]?
+                    prop Instance Oahu.Aux.Diagnostics.TreeDecomposition[T] {
+                        get {
+                            if Oahu.Aux.Diagnostics.TreeDecomposition[T].default_ == nil {
+                                Oahu.Aux.Diagnostics.TreeDecomposition[T].default_ = Oahu.Aux.Diagnostics.TreeDecomposition[T]()
+                            }
+                            return Oahu.Aux.Diagnostics.TreeDecomposition[T].default_!!
+                        }
+                    }
+                }
+            }
+            """;
+
+        var compilation = Compile(source);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void QualifiedSourceType_VoidStaticCall_AsExpressionBody_Binds()
+    {
+        // A `Ns.Type[T].VoidMethod(...)` call in an expression-bodied void member:
+        // peeling the prefix must not prematurely reject the void terminal.
+        const string source = """
+            package P
+            import System
+
+            class TD[T] {
+                shared {
+                    func Write(x int32) -> nil
+                }
+                func Use() -> P.TD[T].Write(3)
+            }
+            """;
+
+        var compilation = Compile(source);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
     private static Compilation Compile(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2256QualifiedConstraintTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2256QualifiedConstraintTests.cs
@@ -1,0 +1,176 @@
+// <copyright file="Issue2256QualifiedConstraintTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2256: cs2gs fully-qualifies type references, so a generic-math
+/// constraint <c>where TCallback : INewSplitCallback&lt;TCallback&gt;</c> is
+/// emitted as the G# constraint <c>[TCallback Oahu.Decrypt.INewSplitCallback[TCallback]]</c>.
+/// Three gsc bugs combined to block this: (1) the parser rejected a dotted
+/// type-parameter constraint (GS0005), (2) a reference-set qualified generic
+/// type name failed to resolve (GS0113), and (3) a same-compilation
+/// package-qualified source type failed to resolve (GS0113 / GS0157). These
+/// tests pin the fixes.
+/// </summary>
+public class Issue2256QualifiedConstraintTests
+{
+    [Fact]
+    public void DottedConstraint_Parses_WithoutDiagnostics()
+    {
+        const string source = """
+            package P
+            import System
+            func Max[T System.IComparable[T]](a T, b T) T {
+                if a.CompareTo(b) > 0 { return a }
+                return b
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var tp = FindFirstTypeParameter(tree);
+        Assert.Equal("T", tp.Identifier.Text);
+        Assert.NotNull(tp.ConstraintType);
+        Assert.Equal("System", tp.Constraint.Text);
+        Assert.Equal("System.IComparable", tp.ConstraintType.DottedName);
+    }
+
+    [Fact]
+    public void SamePackage_QualifiedGenericSourceType_AsAnnotation_Binds()
+    {
+        const string source = """
+            package A.B
+            import System
+
+            interface IFoo[T] {
+                func Baz(x T) T;
+            }
+
+            func UseGen(f A.B.IFoo[int32]) int32 -> f.Baz(3)
+            """;
+
+        var compilation = Compile(source);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void SamePackage_QualifiedNonGenericSourceType_Binds()
+    {
+        const string source = """
+            package A.B
+            import System
+
+            interface IPlain {
+                func Bar(x int32) int32;
+            }
+
+            func UsePlain(f A.B.IPlain) int32 -> f.Bar(3)
+            """;
+
+        var compilation = Compile(source);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void SelfReferentialQualifiedCrtpConstraint_InPackage_Binds()
+    {
+        const string source = """
+            package Oahu.Decrypt
+            import System
+
+            interface INewSplitCallback[TCallback] {
+                func OnSplit(x TCallback) TCallback;
+            }
+
+            func Register[TCallback Oahu.Decrypt.INewSplitCallback[TCallback]](c TCallback, v TCallback) TCallback -> c.OnSplit(v)
+            """;
+
+        var compilation = Compile(source);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void QualifiedSourceType_ConstructorCall_InExpression_Binds()
+    {
+        // cs2gs fully-qualifies constructor calls; the package prefix on a
+        // same-compilation source type is redundant and must be peeled.
+        const string source = """
+            package Oahu.Decrypt
+            import System
+
+            class Mp4Operation[T] {
+                func Hello() int32 -> 42
+            }
+
+            func Make() Oahu.Decrypt.Mp4Operation[int32] -> Oahu.Decrypt.Mp4Operation[int32]()
+            """;
+
+        var compilation = Compile(source);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void QualifiedSourceType_StaticCallOnGenericType_InExpression_Binds()
+    {
+        // `Ns.Type[Args].StaticMethod(...)`: the generic type receiver parses as
+        // an index expression, and the package prefix is redundant on a source
+        // type. Fix 4b peels the prefix and binds the static call by simple name.
+        const string source = """
+            package Oahu.Decrypt
+            import System
+
+            class Mp4Operation[T] {
+                shared {
+                    func FromCompleted(x int32, y T?) Oahu.Decrypt.Mp4Operation[T] -> Oahu.Decrypt.Mp4Operation[T]()
+                }
+                func Hello() int32 -> 42
+            }
+
+            func Make() Oahu.Decrypt.Mp4Operation[int32] -> Oahu.Decrypt.Mp4Operation[int32].FromCompleted(3, nil)
+            """;
+
+        var compilation = Compile(source);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree) { IsLibrary = true };
+    }
+
+    private static TypeParameterSyntax FindFirstTypeParameter(SyntaxTree tree)
+    {
+        TypeParameterSyntax found = null;
+        Walk(tree.Root);
+        return found;
+
+        void Walk(SyntaxNode node)
+        {
+            if (found != null)
+            {
+                return;
+            }
+
+            if (node is TypeParameterSyntax tp)
+            {
+                found = tp;
+                return;
+            }
+
+            foreach (var c in node.GetChildren())
+            {
+                Walk(c);
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2256QualifiedConstraintTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2256QualifiedConstraintTests.cs
@@ -192,6 +192,26 @@ public class Issue2256QualifiedConstraintTests
         Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
     }
 
+    [Fact]
+    public void QualifiedClrType_DeepNamespace_EnumMemberAccess_Binds()
+    {
+        // Issue #2258: cs2gs fully-qualifies CLR type references. A referenced-
+        // assembly enum accessed by its full namespace path whose ROOT segment is
+        // not the implicitly-imported `System` (here `Microsoft`) must resolve in
+        // expression position and bind the trailing enum member as a static field.
+        // Force-load the assembly so it is part of the host reference set.
+        _ = typeof(GSharp.Core.CodeAnalysis.Syntax.SyntaxKind);
+
+        const string source = """
+            package P
+
+            func Flag() GSharp.Core.CodeAnalysis.Syntax.SyntaxKind -> GSharp.Core.CodeAnalysis.Syntax.SyntaxKind.BadToken
+            """;
+
+        var compilation = Compile(source);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
     private static Compilation Compile(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -284,7 +284,99 @@ public sealed class TranslateStage : IMigrationStage
             }
         }
 
+        // Issue #2225: nbgv only generates the `ThisAssembly` source for the
+        // languages its MSBuild `<Language>` switch supports; G# first shipped in
+        // 3.11.13-beta. If the migrated project references an older nbgv it would
+        // silently drop `ThisAssembly`. Emit a bumped copy of whichever project /
+        // props file pins a below-floor nbgv literal (source is never mutated).
+        EmitNerdbankGitVersioningBumps(context);
+
         return artifacts.Count == 0 ? StageOutcome.Passed() : StageOutcome.Failed(artifacts);
+    }
+
+    /// <summary>
+    /// Scans the app's own <c>.csproj</c> plus every ancestor
+    /// <c>Directory.Packages.props</c>/<c>Directory.Build.props</c> for a literal
+    /// <c>Nerdbank.GitVersioning</c> version below
+    /// <see cref="NerdbankGitVersioningPolicy.MinimumGSharpVersion"/> and, when
+    /// found, writes a bumped copy into <c>&lt;AppRunDir&gt;/nbgv-bump/</c> alongside
+    /// a manifest recording the source path. The original files are never touched
+    /// (the corpus tree is read-only); the migrated project can adopt the bumped
+    /// file so nbgv produces the G# <c>ThisAssembly</c> source (issue #2225).
+    /// </summary>
+    private static void EmitNerdbankGitVersioningBumps(StageExecutionContext context)
+    {
+        var candidates = new List<string>();
+        string projectPath = context.App.ProjectPath;
+        if (!string.IsNullOrEmpty(projectPath) && File.Exists(projectPath))
+        {
+            candidates.Add(projectPath);
+        }
+
+        string dir = Path.GetDirectoryName(projectPath);
+        while (!string.IsNullOrEmpty(dir))
+        {
+            foreach (string name in new[] { "Directory.Packages.props", "Directory.Build.props" })
+            {
+                string candidate = Path.Combine(dir, name);
+                if (File.Exists(candidate))
+                {
+                    candidates.Add(candidate);
+                }
+            }
+
+            DirectoryInfo parent = Directory.GetParent(dir);
+            dir = parent?.FullName;
+        }
+
+        string outputDir = null;
+        var manifest = new List<string>();
+        var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string candidate in candidates)
+        {
+            string original;
+            try
+            {
+                original = File.ReadAllText(candidate);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                continue;
+            }
+
+            if (!NerdbankGitVersioningPolicy.TryBumpProjectXml(original, out string bumped))
+            {
+                continue;
+            }
+
+            if (outputDir is null)
+            {
+                outputDir = Path.Combine(context.AppRunDir, "nbgv-bump");
+                Directory.CreateDirectory(outputDir);
+            }
+
+            string baseName = Path.GetFileName(candidate);
+            string outName = baseName;
+            int suffix = 1;
+            while (!usedNames.Add(outName))
+            {
+                outName = Path.GetFileNameWithoutExtension(baseName) + "." + suffix + Path.GetExtension(baseName);
+                suffix++;
+            }
+
+            File.WriteAllText(Path.Combine(outputDir, outName), bumped);
+            manifest.Add(outName + " <- " + candidate);
+        }
+
+        if (outputDir is not null && manifest.Count > 0)
+        {
+            string manifestText =
+                "# Nerdbank.GitVersioning bumped to " + NerdbankGitVersioningPolicy.MinimumGSharpVersion
+                + " for G# ThisAssembly support (issue #2225)." + Environment.NewLine
+                + "# Each line: <emitted file> <- <original source file>." + Environment.NewLine
+                + string.Join(Environment.NewLine, manifest) + Environment.NewLine;
+            File.WriteAllText(Path.Combine(outputDir, "manifest.txt"), manifestText);
+        }
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.ProjectLoading/NerdbankGitVersioningPolicy.cs
+++ b/tools/cs2gs/Cs2Gs.ProjectLoading/NerdbankGitVersioningPolicy.cs
@@ -1,0 +1,309 @@
+// <copyright file="NerdbankGitVersioningPolicy.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Cs2Gs.Translator.Loading;
+
+/// <summary>
+/// Policy for the <c>Nerdbank.GitVersioning</c> (nbgv) package during migration
+/// (issue #2225). nbgv only generates the <c>ThisAssembly</c> source for the
+/// languages its MSBuild <c>&lt;Language&gt;</c> switch supports; G# support first
+/// shipped in <c>3.11.13-beta</c>. A C# project that references an older nbgv will,
+/// once migrated to G#, silently fail to produce <c>ThisAssembly</c>. cs2gs
+/// therefore bumps a below-floor nbgv reference up to the minimum G#-capable
+/// version when it can do so safely (a plain literal version — never an MSBuild
+/// property, floating range, or wildcard).
+/// </summary>
+public static class NerdbankGitVersioningPolicy
+{
+    /// <summary>The nbgv package id, matched case-insensitively.</summary>
+    public const string PackageId = "Nerdbank.GitVersioning";
+
+    /// <summary>
+    /// The lowest nbgv version that emits the G# <c>ThisAssembly</c> source.
+    /// A below-floor literal reference is bumped up to exactly this value.
+    /// </summary>
+    public const string MinimumGSharpVersion = "3.11.13-beta";
+
+    private static readonly SemVer Floor = SemVer.Parse(MinimumGSharpVersion);
+
+    // Element with an Include attribute referencing the nbgv package (either a
+    // <PackageReference> in the project / Directory.Build.props or a
+    // <PackageVersion> in a Central Package Management Directory.Packages.props).
+    private static readonly Regex NbgvElementPattern = new Regex(
+        "<(?<tag>PackageReference|PackageVersion)\\b(?<attrs>[^>]*?Include\\s*=\\s*\"Nerdbank\\.GitVersioning\"[^>]*?)(?<slash>/?)>",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex VersionAttrPattern = new Regex(
+        "(?<pre>Version\\s*=\\s*\")(?<value>[^\"]*)(?<post>\")",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Determines whether the supplied version string denotes an nbgv version
+    /// strictly below <see cref="MinimumGSharpVersion"/> that can be safely
+    /// bumped. A version is bumpable only when it is a plain semantic-version
+    /// literal; a version carrying an MSBuild property (<c>$(...)</c>), a
+    /// floating/wildcard (<c>*</c>), or a version range (<c>[..]</c>/<c>(..)</c>)
+    /// is left untouched ("if possible").
+    /// </summary>
+    /// <param name="version">The raw <c>Version</c> attribute value.</param>
+    /// <param name="bumpedVersion">
+    /// Receives <see cref="MinimumGSharpVersion"/> when a bump is warranted;
+    /// otherwise <see langword="null"/>.
+    /// </param>
+    /// <returns><see langword="true"/> when a bump should be applied.</returns>
+    public static bool TryGetRequiredBump(string version, out string bumpedVersion)
+    {
+        bumpedVersion = null;
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return false;
+        }
+
+        string trimmed = version.Trim();
+
+        // Not a plain literal — an MSBuild property, floating version, or range.
+        // We cannot know its resolved value, so leave it as-is.
+        if (trimmed.IndexOf("$(", StringComparison.Ordinal) >= 0 ||
+            trimmed.IndexOf('*') >= 0 ||
+            trimmed.IndexOf('[') >= 0 ||
+            trimmed.IndexOf('(') >= 0 ||
+            trimmed.IndexOf(',') >= 0)
+        {
+            return false;
+        }
+
+        if (!SemVer.TryParse(trimmed, out SemVer current))
+        {
+            return false;
+        }
+
+        if (SemVer.Compare(current, Floor) < 0)
+        {
+            bumpedVersion = MinimumGSharpVersion;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Rewrites an MSBuild file's XML so any below-floor literal nbgv version is
+    /// bumped to <see cref="MinimumGSharpVersion"/>. Only the version attribute
+    /// value is edited; the surrounding formatting, comments, and unrelated items
+    /// are preserved. A version-less nbgv reference (the CPM consumer side) is
+    /// left unchanged — the version lives in <c>Directory.Packages.props</c>.
+    /// </summary>
+    /// <param name="msbuildXml">The full text of a <c>.csproj</c>/<c>.props</c> file.</param>
+    /// <param name="rewrittenXml">Receives the bumped text when a change was made.</param>
+    /// <returns><see langword="true"/> when the text was changed.</returns>
+    public static bool TryBumpProjectXml(string msbuildXml, out string rewrittenXml)
+    {
+        rewrittenXml = null;
+        if (string.IsNullOrEmpty(msbuildXml))
+        {
+            return false;
+        }
+
+        bool changed = false;
+        string result = NbgvElementPattern.Replace(msbuildXml, element =>
+        {
+            string attrs = element.Groups["attrs"].Value;
+            Match versionMatch = VersionAttrPattern.Match(attrs);
+            if (!versionMatch.Success)
+            {
+                return element.Value;
+            }
+
+            string currentVersion = versionMatch.Groups["value"].Value;
+            if (!TryGetRequiredBump(currentVersion, out string bumped))
+            {
+                return element.Value;
+            }
+
+            string newAttrs = attrs.Substring(0, versionMatch.Index)
+                + versionMatch.Groups["pre"].Value
+                + bumped
+                + versionMatch.Groups["post"].Value
+                + attrs.Substring(versionMatch.Index + versionMatch.Length);
+
+            changed = true;
+            return "<" + element.Groups["tag"].Value + newAttrs + element.Groups["slash"].Value + ">";
+        });
+
+        if (changed)
+        {
+            rewrittenXml = result;
+        }
+
+        return changed;
+    }
+
+    /// <summary>
+    /// A minimal semantic-version value (numeric release plus an optional
+    /// dot-separated prerelease), compared per the SemVer 2.0.0 precedence rules.
+    /// Build metadata (<c>+...</c>) is ignored. Missing minor/patch segments are
+    /// treated as zero so <c>3.11</c> equals <c>3.11.0</c>.
+    /// </summary>
+    private readonly struct SemVer
+    {
+        private readonly int major;
+        private readonly int minor;
+        private readonly int patch;
+        private readonly string[] prerelease;
+
+        private SemVer(int major, int minor, int patch, string[] prerelease)
+        {
+            this.major = major;
+            this.minor = minor;
+            this.patch = patch;
+            this.prerelease = prerelease;
+        }
+
+        public static SemVer Parse(string value)
+        {
+            if (!TryParse(value, out SemVer result))
+            {
+                throw new FormatException($"Invalid semantic version: '{value}'.");
+            }
+
+            return result;
+        }
+
+        public static bool TryParse(string value, out SemVer result)
+        {
+            result = default;
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            string core = value.Trim();
+
+            // Drop build metadata.
+            int plus = core.IndexOf('+');
+            if (plus >= 0)
+            {
+                core = core.Substring(0, plus);
+            }
+
+            string[] prerelease = Array.Empty<string>();
+            int dash = core.IndexOf('-');
+            if (dash >= 0)
+            {
+                string pre = core.Substring(dash + 1);
+                core = core.Substring(0, dash);
+                if (pre.Length == 0)
+                {
+                    return false;
+                }
+
+                prerelease = pre.Split('.');
+            }
+
+            string[] parts = core.Split('.');
+            if (parts.Length == 0 || parts.Length > 3)
+            {
+                return false;
+            }
+
+            int[] numbers = new int[3];
+            for (int i = 0; i < parts.Length; i++)
+            {
+                if (!int.TryParse(parts[i], NumberStyles.None, CultureInfo.InvariantCulture, out numbers[i]))
+                {
+                    return false;
+                }
+            }
+
+            result = new SemVer(numbers[0], numbers[1], numbers[2], prerelease);
+            return true;
+        }
+
+        public static int Compare(SemVer a, SemVer b)
+        {
+            int cmp = a.major.CompareTo(b.major);
+            if (cmp != 0)
+            {
+                return cmp;
+            }
+
+            cmp = a.minor.CompareTo(b.minor);
+            if (cmp != 0)
+            {
+                return cmp;
+            }
+
+            cmp = a.patch.CompareTo(b.patch);
+            if (cmp != 0)
+            {
+                return cmp;
+            }
+
+            // A version with a prerelease has LOWER precedence than the
+            // associated stable release (SemVer 2.0.0 §11).
+            bool aHasPre = a.prerelease.Length > 0;
+            bool bHasPre = b.prerelease.Length > 0;
+            if (!aHasPre && !bHasPre)
+            {
+                return 0;
+            }
+
+            if (!aHasPre)
+            {
+                return 1;
+            }
+
+            if (!bHasPre)
+            {
+                return -1;
+            }
+
+            return ComparePrerelease(a.prerelease, b.prerelease);
+        }
+
+        private static int ComparePrerelease(string[] a, string[] b)
+        {
+            int count = Math.Min(a.Length, b.Length);
+            for (int i = 0; i < count; i++)
+            {
+                bool aNum = int.TryParse(a[i], NumberStyles.None, CultureInfo.InvariantCulture, out int an);
+                bool bNum = int.TryParse(b[i], NumberStyles.None, CultureInfo.InvariantCulture, out int bn);
+
+                if (aNum && bNum)
+                {
+                    int cmp = an.CompareTo(bn);
+                    if (cmp != 0)
+                    {
+                        return cmp;
+                    }
+                }
+                else if (aNum)
+                {
+                    // Numeric identifiers have lower precedence than alphanumeric.
+                    return -1;
+                }
+                else if (bNum)
+                {
+                    return 1;
+                }
+                else
+                {
+                    int cmp = string.CompareOrdinal(a[i], b[i]);
+                    if (cmp != 0)
+                    {
+                        return cmp;
+                    }
+                }
+            }
+
+            // A larger set of prerelease fields has higher precedence when all
+            // preceding identifiers are equal.
+            return a.Length.CompareTo(b.Length);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1890TypePatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1890TypePatternTranslationTests.cs
@@ -97,6 +97,36 @@ namespace Corpus.Issue1890
         AssertRoundTripParses(rendered);
     }
 
+    [Fact]
+    public void SwitchExpression_QualifiedBareTypeArm_LowersToDiscardTypePattern()
+    {
+        // Issue #2258: a fully-qualified bare-type arm (`App.Auth.MfaChallenge =>`)
+        // is parsed by Roslyn as a ConstantPattern over a MemberAccessExpression
+        // (NOT a TypeSyntax), so it must be recognized as a type reference via its
+        // resolved symbol and lowered to `_ is T` — otherwise it renders as a bare
+        // value expression that gsc rejects (GS0157).
+        string rendered = Render(@"
+namespace App.Auth
+{
+    public class Challenge { }
+    public sealed class MfaChallenge : Challenge { }
+
+    public class Holder
+    {
+        public string Describe(Challenge c) => c switch
+        {
+            App.Auth.MfaChallenge => ""mfa"",
+            _ => ""other"",
+        };
+    }
+}
+");
+
+        Assert.Contains("case _ is MfaChallenge:", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("case App.Auth.MfaChallenge:", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
     private static void AssertRoundTripParses(string rendered)
     {
         RoundTripResult result = GSharpRoundTrip.Validate(rendered);

--- a/tools/cs2gs/Cs2Gs.Tests/NerdbankGitVersioningPolicyTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/NerdbankGitVersioningPolicyTests.cs
@@ -1,0 +1,144 @@
+// <copyright file="NerdbankGitVersioningPolicyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Tests for <see cref="NerdbankGitVersioningPolicy"/> (issue #2225): a below-floor
+/// literal <c>Nerdbank.GitVersioning</c> version must be bumped to the first
+/// G#-capable release (<c>3.11.13-beta</c>); an at-or-above version, a prerelease
+/// at or above the floor, or a non-literal (MSBuild property / range / wildcard)
+/// version must be left untouched.
+/// </summary>
+public sealed class NerdbankGitVersioningPolicyTests
+{
+    [Theory]
+    [InlineData("3.7.115")]        // Oahu's pinned version
+    [InlineData("3.6.146")]
+    [InlineData("3.11.12")]        // one patch below the floor's release
+    [InlineData("3.11.13-alpha")]  // same release, earlier prerelease
+    [InlineData("3.10.0")]
+    [InlineData("2.0.0")]
+    [InlineData("3.11")]           // 3.11.0 < 3.11.13-beta
+    public void BelowFloorLiteral_IsBumped(string version)
+    {
+        Assert.True(NerdbankGitVersioningPolicy.TryGetRequiredBump(version, out string bumped));
+        Assert.Equal(NerdbankGitVersioningPolicy.MinimumGSharpVersion, bumped);
+    }
+
+    [Theory]
+    [InlineData("3.11.13-beta")]   // exactly the floor
+    [InlineData("3.11.13")]        // stable release > the beta floor
+    [InlineData("3.11.14")]
+    [InlineData("3.12.0")]
+    [InlineData("4.0.0")]
+    [InlineData("3.11.13-beta.2")] // later prerelease of the same release
+    [InlineData("3.11.13-rc1")]    // 'rc1' > 'beta' alphabetically
+    public void AtOrAboveFloor_IsNotBumped(string version)
+    {
+        Assert.False(NerdbankGitVersioningPolicy.TryGetRequiredBump(version, out string bumped));
+        Assert.Null(bumped);
+    }
+
+    [Theory]
+    [InlineData("$(NbgvVersion)")] // MSBuild property indirection
+    [InlineData("[3.7.0,4.0.0)")]  // version range
+    [InlineData("3.*")]            // floating
+    [InlineData("3.7.*")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-version")]
+    public void NonLiteralOrUnparseable_IsNotBumped(string version)
+    {
+        Assert.False(NerdbankGitVersioningPolicy.TryGetRequiredBump(version, out string bumped));
+        Assert.Null(bumped);
+    }
+
+    [Fact]
+    public void BumpProjectXml_CentralPackageManagement_BumpsPackageVersion()
+    {
+        string xml =
+            "<Project>\n" +
+            "  <ItemGroup>\n" +
+            "    <PackageVersion Include=\"Nerdbank.GitVersioning\" Version=\"3.7.115\" />\n" +
+            "    <PackageVersion Include=\"xunit\" Version=\"2.9.2\" />\n" +
+            "  </ItemGroup>\n" +
+            "</Project>\n";
+
+        Assert.True(NerdbankGitVersioningPolicy.TryBumpProjectXml(xml, out string bumped));
+        Assert.Contains("Include=\"Nerdbank.GitVersioning\" Version=\"3.11.13-beta\"", bumped);
+        Assert.Contains("Include=\"xunit\" Version=\"2.9.2\"", bumped); // unrelated untouched
+    }
+
+    [Fact]
+    public void BumpProjectXml_PackageReference_VersionBeforeInclude_IsBumped()
+    {
+        string xml =
+            "<Project>\n" +
+            "  <ItemGroup>\n" +
+            "    <PackageReference Version=\"3.7.115\" Include=\"Nerdbank.GitVersioning\" PrivateAssets=\"all\" />\n" +
+            "  </ItemGroup>\n" +
+            "</Project>\n";
+
+        Assert.True(NerdbankGitVersioningPolicy.TryBumpProjectXml(xml, out string bumped));
+        Assert.Contains("Version=\"3.11.13-beta\"", bumped);
+        Assert.Contains("PrivateAssets=\"all\"", bumped);
+    }
+
+    [Fact]
+    public void BumpProjectXml_VersionlessReference_IsUnchanged()
+    {
+        // The CPM consumer side declares no Version — the version lives in
+        // Directory.Packages.props, so this file must not be rewritten.
+        string xml =
+            "<Project>\n" +
+            "  <ItemGroup>\n" +
+            "    <PackageReference Include=\"Nerdbank.GitVersioning\" PrivateAssets=\"all\" />\n" +
+            "  </ItemGroup>\n" +
+            "</Project>\n";
+
+        Assert.False(NerdbankGitVersioningPolicy.TryBumpProjectXml(xml, out string bumped));
+        Assert.Null(bumped);
+    }
+
+    [Fact]
+    public void BumpProjectXml_AlreadyAtFloor_IsUnchanged()
+    {
+        string xml =
+            "<Project>\n" +
+            "  <ItemGroup>\n" +
+            "    <PackageVersion Include=\"Nerdbank.GitVersioning\" Version=\"3.11.13-beta\" />\n" +
+            "  </ItemGroup>\n" +
+            "</Project>\n";
+
+        Assert.False(NerdbankGitVersioningPolicy.TryBumpProjectXml(xml, out _));
+    }
+
+    [Fact]
+    public void BumpProjectXml_PropertyVersion_IsUnchanged()
+    {
+        string xml =
+            "<Project>\n" +
+            "  <ItemGroup>\n" +
+            "    <PackageVersion Include=\"Nerdbank.GitVersioning\" Version=\"$(NbgvVersion)\" />\n" +
+            "  </ItemGroup>\n" +
+            "</Project>\n";
+
+        Assert.False(NerdbankGitVersioningPolicy.TryBumpProjectXml(xml, out _));
+    }
+
+    [Fact]
+    public void BumpProjectXml_CaseInsensitivePackageMatch_IsBumped()
+    {
+        string xml = "<Project><ItemGroup>" +
+            "<packageversion include=\"Nerdbank.GitVersioning\" version=\"3.7.115\" />" +
+            "</ItemGroup></Project>";
+
+        Assert.True(NerdbankGitVersioningPolicy.TryBumpProjectXml(xml, out string bumped));
+        Assert.Contains("3.11.13-beta", bumped);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -11313,8 +11313,25 @@ public sealed class CSharpToGSharpTranslator
         // that the identifier names a type). Such a pattern is a type test, not an
         // equality, so it must lower to `x is T` rather than `x == T`.
         private bool IsTypeReferencePattern(ExpressionSyntax expression) =>
-            expression is TypeSyntax
-            && this.context.GetSymbolInfo(expression).Symbol is ITypeSymbol;
+            this.context.GetSymbolInfo(expression).Symbol is ITypeSymbol;
+
+        // Maps a pattern expression that refers to a TYPE to its G# type
+        // reference. A bare type name parses as a TypeSyntax (IdentifierName /
+        // generic / array), but a fully-qualified type name (`App.Auth.MfaChallenge`)
+        // parses as a MemberAccessExpressionSyntax — which is NOT a TypeSyntax —
+        // so it is mapped through its resolved type symbol instead (issue #2258).
+        private GTypeReference MapTypeReferenceExpression(ExpressionSyntax expression)
+        {
+            if (expression is TypeSyntax typeSyntax)
+            {
+                return this.MapTypeSyntax(typeSyntax);
+            }
+
+            ITypeSymbol typeSymbol = this.context.GetSymbolInfo(expression).Symbol as ITypeSymbol;
+            return typeSymbol != null
+                ? this.typeMapper.Map(typeSymbol, this.context, expression.GetLocation())
+                : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
+        }
 
         private GExpression TranslateIsPattern(IsPatternExpressionSyntax isPattern)
         {
@@ -11414,7 +11431,7 @@ public sealed class CSharpToGSharpTranslator
                     return new BinaryExpression(
                         receiver,
                         "is",
-                        new TypeExpression(this.MapTypeSyntax((TypeSyntax)constant.Expression)));
+                        new TypeExpression(this.MapTypeReferenceExpression(constant.Expression)));
 
                 case ConstantPatternSyntax constant:
                     // `x is 0` / `x is "moov"` / `x is true`. G# `is` only tests a
@@ -11664,7 +11681,7 @@ public sealed class CSharpToGSharpTranslator
                         new ParenthesizedExpression(new BinaryExpression(
                             receiver,
                             "is",
-                            new TypeExpression(this.MapTypeSyntax((TypeSyntax)constant.Expression)))));
+                            new TypeExpression(this.MapTypeReferenceExpression(constant.Expression)))));
 
                 case ConstantPatternSyntax constant:
                     // `x is not 6` → `x != 6` (with numeric retyping to the receiver).
@@ -16908,7 +16925,7 @@ public sealed class CSharpToGSharpTranslator
                 // type test before falling through to the literal-equality case
                 // below.
                 case ConstantPatternSyntax constant when this.IsTypeReferencePattern(constant.Expression):
-                    return new TypePattern("_", this.MapTypeSyntax((TypeSyntax)constant.Expression));
+                    return new TypePattern("_", this.MapTypeReferenceExpression(constant.Expression));
 
                 case ConstantPatternSyntax constant:
                     return new ConstantPattern(this.TranslateExpression(constant.Expression));


### PR DESCRIPTION
Fixes #2256.

cs2gs fully-qualifies every type reference for safety, but a G# **source** type has no CLR type at bind time and is visible by *simple name* across a flat, cross-package scope. gsc failed to resolve several package-qualified source-type shapes that cs2gs emits, which blocked the **Oahu.Decrypt** migration (translation-unsupported -> 10 compile errors -> 0).

## Fixes

1. **Parser — dotted type-parameter constraints.** `func Register[TCallback Oahu.Decrypt.INewSplitCallback[TCallback]](...)` previously failed `GS0005`. Adds `TypeParameterSyntax.ConstraintType`, parses the constraint via `ParseTypeClause`, and skips `.` in `LooksLikeTypeParameterList`.
2. **Binder (type position).** Resolves a reference-set qualified generic type `A.B.IFoo[int32]` by trying the arity-mangled outer prefix, and a same-compilation qualified source type `A.B.IFoo` by simple-name fallback (previously `GS0113`/`GS0157`).
3. **ExpressionBinder (expression position).** Peels a redundant namespace/package prefix from a qualified source-type construction `Ns.Type[Args](...)` and static call `Ns.Type[Args].StaticMethod(...)`, binding the terminal by simple name. Generic type receivers parse as index expressions, so that shape is handled too. Generalized to any `Namespace.Type[...]`, not just the specific Oahu type that triggered it.
4. **DeclarationBinder.** Binds the new `ConstraintType` when present.

## Validation

- New `Issue2256QualifiedConstraintTests` (6 tests) pin all shapes.
- Full **Core.Tests** suite passes (5886 passed, 1 skipped).
- **Oahu.Decrypt** now migrates **fully green** (translate/compile/ilverify/test-parity all PASS) via cs2gs.

Note: the ilverify stage surfaced 13 expected-unverifiable `stackalloc`/`localloc` methods in the binary/crypto parsers; the C# compiler emits identical unverifiable IL for the same source, so these are handled by an `ilverify.allow-unsafe` marker in the Oahu corpus (issue #1933/#1985 mechanism), not a gsc change.
---

## Additional fixes — qualified CLR access & bare-type patterns (#2258)

Batched into this branch (related qualified-name resolution; amortizes CI):

5. **gsc — fully-qualified CLR static/enum member access.** `Microsoft.Extensions.Logging.LogLevel.Warning` (deep-namespace CLR enum member) and `…Abstractions.NullLoggerFactory.Instance` (CLR static field) failed `GS0157` in expression position: accessors are right-associative, so the leading `Microsoft` segment (matching no registered import) hit `ReportUnableToFindType`. `System.X.Y` worked only because `System` is implicitly imported. Extracted the progressive-prefix CLR-type walk out of `TryBindImportAccessor` into a shared helper and added a last-resort fallback that starts the walk from the bare leading name — generalizing to any referenced CLR type at any namespace depth.
6. **cs2gs — qualified bare-type switch arm.** Roslyn parses `App.Auth.MfaChallenge =>` (bare-type switch arm) as a `ConstantPattern` over a `MemberAccessExpression` (not a `TypeSyntax`), so cs2gs rendered it as a bare value expression that gsc rejects (`GS0157`). `IsTypeReferencePattern` now relies on the resolved symbol being an `ITypeSymbol` (an enum-member constant resolves to an `IFieldSymbol`), lowering these to `_ is T`. Generalized across boolean `is`, negated `is not`, and switch-arm type patterns.

Also partially addresses #2258 (the CLR struct object-initializer literal shape — `System.Text.Json.JsonWriterOptions{ … }` — remains, tracked in #2258; it fails even by simple name, so it's a distinct missing feature).

Validation: full **Core.Tests** re-run (5889 passed, 1 skipped); cs2gs Pattern/Switch/Golden suites (192+ tests) pass; new regression tests added (`Issue2256…EnumMemberAccess`, `Issue1890…QualifiedBareTypeArm`). Verified end-to-end: Oahu.Cli.Tui `Microsoft.*` and `App.Auth.*` `GS0157` errors eliminated.

---

## Additional features — nbgv version bump (#2225) & `--via-sdk` compile path (#2261)

Batched into this branch (amortizes CI). Both are additive; existing defaults unchanged.

7. **cs2gs — Nerdbank.GitVersioning floor bump (#2225).** nbgv only generates the `ThisAssembly` file for languages its MSBuild `<Language>` supports; G# support first shipped in `3.11.13-beta`. `NerdbankGitVersioningPolicy` (prerelease-aware SemVer compare + MSBuild XML rewrite) scans the app's `.csproj` and ancestor `Directory.Packages.props`/`Directory.Build.props`; when a referenced nbgv version is below the floor it emits a bumped copy into `<AppRunDir>/nbgv-bump/` with a manifest (source is never mutated). 27 unit tests. Verified on Oahu.Foundation: `3.7.115` -> `3.11.13-beta` (single-line diff).

8. **cs2gs — `--via-sdk` compile path (#2261).** Opt-in flag to compile migrated G# via `dotnet build` + the `Gsharp.NET.Sdk` MSBuild SDK instead of gsc directly, so Roslyn source generators (CommunityToolkit.Mvvm `[ObservableProperty]`/`[RelayCommand]`, `[LoggerMessage]`) run via gsgen's MSBuild targets. `SdkCompileRunner` reconstructs `PackageReference`/`Reference`/`Analyzer` items from the gsc reference set, writes an isolated `.gsproj` + local `nuget.config`, invokes `dotnet build`, and reuses `GscInvoker.ParseDiagnostics`. Plain `migrate` is byte-identical; `--via-sdk` falls back to gsc-direct if no local SDK nupkg exists. Verified on Oahu.UI: generated `OpenDownloadsFolderCommand` (GS0157), `RelayCommand` not-an-attribute (GS0200), and GS9100 all eliminated.
9. **gsc core — attribute-name resolution (ECMA-334 §22.3).** Coupled fix for #2261: `DeclarationBinder.ResolveAttributeType` no longer lets an exact-name candidate that isn't `System.Attribute`-derived (e.g. CommunityToolkit's `RelayCommand` ICommand class) shadow the `...Attribute`-suffixed candidate.

Validation: full **Core.Tests** (5889 passed, 1 skipped), 40 cs2gs nbgv/SdkCompileRunner tests, 119 attribute tests — all green.
