### PR TITLE
gsc: collapse interchangeable duplicate overload candidates (#2265)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -2982,11 +2982,122 @@ internal static class OverloadResolution
             }
         }
 
+        // Phase 2g — the full NuGet transitive closure can surface the exact
+        // same method more than once: e.g. `MemoryExtensions.AsSpan` reachable
+        // via both `System.Memory` and a type-forwarding facade, or
+        // `ConfigureAwait`/`WithCancellation`/`GetValueOrDefault` reachable via
+        // multiple reference assemblies. Those duplicates are genuinely
+        // interchangeable (identical declaring type, name, generic arity, and
+        // parameter types), so collapse them to a single representative rather
+        // than reporting a spurious ambiguity. Distinct real overloads (e.g.
+        // `Ceiling(Decimal)` vs `Ceiling(Double)`) differ in parameter types
+        // and are never collapsed.
+        if (pool.Count > 1)
+        {
+            var deduped = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)>(pool.Count);
+            foreach (var candidate in pool)
+            {
+                var isDuplicate = false;
+                foreach (var kept in deduped)
+                {
+                    if (AreInterchangeableDuplicates(kept.Method, kept.ParamTypes, candidate.Method, candidate.ParamTypes))
+                    {
+                        isDuplicate = true;
+                        break;
+                    }
+                }
+
+                if (!isDuplicate)
+                {
+                    deduped.Add(candidate);
+                }
+            }
+
+            if (deduped.Count < pool.Count)
+            {
+                pool = deduped;
+            }
+
+            if (pool.Count == 1)
+            {
+                return Result<T>.Single(pool[0].Method, BuildMappingArray(pool[0].Mapping, argumentNames), pool[0].IsExpanded);
+            }
+        }
+
         // If nothing dominated above, report the surviving pool as ambiguous.
         var ambiguous = pool
             .Select(c => c.Method)
             .ToImmutableArray();
         return Result<T>.AmbiguousResult(ambiguous);
+    }
+
+    /// <summary>
+    /// Determines whether two applicable candidates are the same logical method
+    /// surfaced twice through the reference closure (identical declaring type,
+    /// name, generic arity, and resolved parameter types). Such duplicates arise
+    /// from type-forwarding facades / duplicated reference assemblies and are
+    /// interchangeable, so overload resolution collapses them instead of
+    /// reporting a spurious ambiguity. Cross-reflection-context type identity is
+    /// compared with <see cref="ClrTypeUtilities.AreSame(Type, Type)"/>, which
+    /// matches by assembly-agnostic full name.
+    /// </summary>
+    private static bool AreInterchangeableDuplicates(MethodBase a, Type[] aParamTypes, MethodBase b, Type[] bParamTypes)
+    {
+        if (a is null || b is null || aParamTypes is null || bParamTypes is null)
+        {
+            return false;
+        }
+
+        if (!string.Equals(a.Name, b.Name, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!ClrTypeUtilities.AreSame(a.DeclaringType, b.DeclaringType))
+        {
+            return false;
+        }
+
+        if (GetGenericArity(a) != GetGenericArity(b))
+        {
+            return false;
+        }
+
+        if (aParamTypes.Length != bParamTypes.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < aParamTypes.Length; i++)
+        {
+            if (!ClrTypeUtilities.AreSame(aParamTypes[i], bParamTypes[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the generic arity of a method (the number of its generic type
+    /// parameters), or <c>0</c> for a non-generic method.
+    /// </summary>
+    private static int GetGenericArity(MethodBase method)
+    {
+        if (method is null || !method.IsGenericMethod)
+        {
+            return 0;
+        }
+
+        try
+        {
+            return method.GetGenericArguments().Length;
+        }
+        catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+        {
+            return 0;
+        }
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionTests.cs
@@ -66,6 +66,22 @@ public class OverloadResolutionTests
     }
 
     [Fact]
+    public void Resolve_CollapsesInterchangeableDuplicateCandidates()
+    {
+        // The full NuGet transitive closure can surface the exact same method
+        // twice (e.g. MemoryExtensions.AsSpan reachable via System.Memory and
+        // via a type-forwarding facade). Such duplicates share an identical
+        // declaring type, name, generic arity, and parameter types, so they
+        // must collapse to a single representative rather than being reported
+        // as a spurious ambiguity.
+        var method = typeof(Fixture).GetMethod(nameof(Fixture.F_Int), BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(method);
+        var result = OverloadResolution.Resolve(new[] { method, method }, new[] { typeof(int) });
+        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, result.Outcome);
+        Assert.Equal(nameof(Fixture.F_Int), result.Best.Name);
+    }
+
+    [Fact]
     public void Resolve_TieBreakAppliesPerArgument()
     {
         // (int, int) args; pick F_Long_Long over F_Float_Float for both args.


### PR DESCRIPTION
## Summary

When a G# program is compiled against the full NuGet transitive closure (e.g. via the `cs2gs --via-sdk` / MSBuild-SDK path), calls to common BCL extension methods fail with `GS0160: Call to 'X' is ambiguous between 2 applicable overloads` where **both listed candidates are identical**.

Observed in the Oahu migration corpus:

```
Call to 'AsSpan' is ambiguous between 2 applicable overloads. Candidates: AsSpan[Byte](Byte[], Int32); AsSpan[Byte](Byte[], Int32).
Call to 'ConfigureAwait' is ambiguous ... Candidates: ConfigureAwait[Object](IAsyncEnumerable[Object], Boolean); ConfigureAwait[Object](IAsyncEnumerable[Object], Boolean).
Call to 'Sort' is ambiguous ... Candidates: Sort[Int64](Span[Int64]); Sort[Int64](Span[Int64]).
Call to 'GetValueOrDefault' ... ; Call to 'WithCancellation' ... ; Call to 'AsMemory' ...
```

## Root cause

The full reference closure surfaces the **exact same method more than once** — e.g. `System.MemoryExtensions.AsSpan` is reachable via both `System.Memory` and a type-forwarding facade / shim assembly. gsc collected each occurrence as a separate candidate. After all tie-breaks these interchangeable duplicates survive together, and overload resolution reports them as ambiguous instead of collapsing them.

This only reproduces with the realistic full NuGet closure (`--via-sdk`); the minimal gsc-direct reference set does not surface the duplicate, which is why it was previously masked.

## Fix

In `OverloadResolution.RankApplicable`, added a de-duplication phase (Phase 2g) immediately before the ambiguity is reported: candidates that share the same name, declaring-type identity, generic arity, and resolved parameter types (compared with `ClrTypeUtilities.AreSame`, which is assembly-agnostic / cross-reflection-context safe) are collapsed to a single representative. Genuinely distinct overloads (e.g. `Ceiling(Decimal)` vs `Ceiling(Double)`) differ in parameter types and are never collapsed.

Generalized: fires for any duplicated method from the reference closure, not just the specific BCL extension methods above.

## Impact

Clears ~55 of the 60 GS0160 occurrences in the Oahu `--via-sdk` corpus run. **`Oahu.Decrypt` now passes all stages (translate/compile/ilverify/test-parity) end-to-end under `--via-sdk`.**

## Validation

- New unit test `OverloadResolutionTests.Resolve_CollapsesInterchangeableDuplicateCandidates`.
- Full Core.Tests: 5889 passed, 0 failed.
- Oahu.Decrypt `--via-sdk`: 1/1 green.

Closes #2265.