### PR TITLE
cs2gs: forgive oblivious null-conditional element/member RHS at element-access sinks

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2259ObliviousNullConditionalIndexTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2259ObliviousNullConditionalIndexTranslationTests.cs
@@ -1,0 +1,196 @@
+// <copyright file="Issue2259ObliviousNullConditionalIndexTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #2259: a null-conditional element/member
+/// access result (<c>expr?[i]</c> / <c>expr?.Member</c>) — or any other
+/// analyzer-promoted-nullable value — assigned into an ELEMENT-access target
+/// (an array element, a <c>Dictionary</c>/user-indexer write) trips a
+/// <c>T? -&gt; T</c> GS0156 once gsc's strict nullability sees the RHS's true
+/// <c>T?</c> type. Unlike a field/property/local/parameter assignment target,
+/// which the whole-program taint analysis widens to <c>T?</c> at its OWN
+/// declaration, an element-access target has no single declaration to widen,
+/// so the fix asserts <c>!!</c> at the RHS use site instead — exactly like
+/// every other promoted-nullable-into-non-nullable sink (return/argument/
+/// tuple/event). The dominant real-world shape is
+/// <c>Oahu.Foundation</c>'s <c>EnumUtil.cs</c>: <c>parts[i] = punct.Infix?[x - ByteA];</c>
+/// where <c>Infix</c> is a <c>string[]</c>.
+/// </summary>
+public class Issue2259ObliviousNullConditionalIndexTranslationTests
+{
+    [Fact]
+    public void Oblivious_NullConditionalIndex_AssignedToArrayElement_AssertsNonNull()
+    {
+        // Mirrors the Oahu.Foundation EnumUtil.cs repro: `Infix` is a
+        // `string[]`, so `punct.Infix?[x]` yields `string?`, assigned into the
+        // non-null `string` element `parts[i]`.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Punctuation
+    {
+        public string[] Infix;
+    }
+
+    public class C
+    {
+        public void Run(Punctuation punct, string[] parts, int i, int x)
+        {
+            parts[i] = punct.Infix?[x];
+        }
+    }
+}");
+
+        Assert.Contains("parts[i] = punct.Infix?[x]!!", printed);
+    }
+
+    [Fact]
+    public void Oblivious_NullConditionalMember_AssignedToArrayElement_AssertsNonNull()
+    {
+        // Generalizes the shape beyond `string`/index access to a `?.Member`
+        // read of a custom reference type, assigned into an array element of
+        // that SAME custom type.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Foo
+    {
+        public string Name;
+    }
+
+    public class Wrapper
+    {
+        public Foo Value;
+    }
+
+    public class C
+    {
+        public void Run(Wrapper w, Foo[] items, int i)
+        {
+            items[i] = w?.Value;
+        }
+    }
+}");
+
+        Assert.Contains("items[i] = w?.Value!!", printed);
+    }
+
+    [Fact]
+    public void Oblivious_PromotedLocal_AssignedToIndexerWrite_AssertsNonNull()
+    {
+        // Mirrors Oahu.Core's ProgrammaticLogin.cs `inputs[name] = value;`
+        // shape: `value` is a ternary-null-tainted local (promoted to
+        // `string?`) assigned into a `Dictionary<string, string>` indexer
+        // write, not a `?[]`/`?.` conditional-access RHS at all — proving the
+        // fix covers any promoted-nullable RHS, not just conditional access.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    using System.Collections.Generic;
+
+    public class C
+    {
+        public void Run(Dictionary<string, string> inputs, string name, bool ok)
+        {
+            string value = ok ? ""x"" : null;
+            inputs[name] = value;
+        }
+    }
+}");
+
+        Assert.Contains("inputs[name] = value!!", printed);
+    }
+
+    [Fact]
+    public void Enabled_NullConditionalIndex_AssignedToArrayElement_StaysUnpromoted()
+    {
+        // The SAME shape under a nullable-ENABLED compilation (`Infix` is
+        // explicitly `string?[]`, so the assignment is a legal, if
+        // warning-worthy, `string? -> string` conversion): the fix is gated to
+        // oblivious compilations only, so no `!!` is inserted and the RHS is
+        // byte-identical to pre-#2259 behavior.
+        string printed = TranslateEnabled(@"
+namespace Demo
+{
+    public class Punctuation
+    {
+        public string?[] Infix = System.Array.Empty<string?>();
+    }
+
+    public class C
+    {
+        public void Run(Punctuation punct, string[] parts, int i, int x)
+        {
+            parts[i] = punct.Infix?[x];
+        }
+    }
+}");
+
+        Assert.Contains("parts[i] = punct.Infix?[x]", printed);
+        Assert.DoesNotContain("!!", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string TranslateEnabled(string source)
+    {
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.EnabledInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Select(r => r).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -6224,6 +6224,51 @@ public sealed class CSharpToGSharpTranslator
                 : translatedRhs;
         }
 
+        // Issue #2259 (oblivious sink): an ELEMENT-access assignment target
+        // (`arr[i] = …`, a `Dictionary`/user-indexer write, …) whose RHS is a
+        // null-conditional access result (`x?[i]` / `x?.Member`) or any other
+        // promoted-nullable value trips a `T? -> T` GS0156 once gsc's strict
+        // nullability sees the RHS's true `T?` type. A field/property/local/
+        // parameter assignment TARGET is instead widened to `T?` at its own
+        // declaration by the whole-program taint analysis (see
+        // ObliviousNullabilityAnalyzer's SimpleAssignmentExpression edge in
+        // CollectEdges), but an element-access target has no single declaration
+        // to widen — promoting the whole array/collection's element type would
+        // ripple to every other read of it — so the minimal, generalized fix is
+        // a `!!` assertion at the RHS use site instead, exactly like every other
+        // promoted-nullable-into-non-nullable sink (return/argument/tuple/event).
+        // Gated to an oblivious compilation and skipped when the resolved LHS
+        // indexer is itself declared or promoted nullable (nothing to forgive),
+        // so a nullable-enabled compilation and an already-nullable sink are
+        // byte-identical.
+        private GExpression ForgiveElementAccessAssignmentRhs(
+            AssignmentExpressionSyntax assignment, GExpression translatedRhs)
+        {
+            if (!this.IsObliviousCompilation()
+                || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                || translatedRhs is NonNullAssertionExpression
+                || assignment.Left is not ElementAccessExpressionSyntax
+                || !this.IsNullablePromotedValue(assignment.Right))
+            {
+                return translatedRhs;
+            }
+
+            ITypeSymbol leftType = this.context.GetTypeInfo(assignment.Left).Type;
+            if (leftType is not { IsReferenceType: true }
+                || leftType.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                return translatedRhs;
+            }
+
+            if (this.context.GetSymbolInfo(assignment.Left).Symbol is IPropertySymbol indexer
+                && this.IsPromotedToNullableReference(indexer))
+            {
+                return translatedRhs;
+            }
+
+            return new NonNullAssertionExpression(translatedRhs);
+        }
+
         // For a compound numeric assignment `x OP= y` (`+= -= *= /= %= &= |= ^=`),
         // G# requires the RHS to share the LHS's numeric type; a mismatched RHS is
         // coerced to the LHS type via the conversion-call form (e.g. `x += int64(y)`).
@@ -7342,6 +7387,7 @@ public sealed class CSharpToGSharpTranslator
                     assignRhs = this.CoerceCompoundAssignmentRhs(assignment, assignRhs);
                     assignRhs = this.CoercePointerConversion(assignment.Right, assignRhs);
                     assignRhs = this.ForgiveEventSubscriptionRhs(assignment, assignRhs);
+                    assignRhs = this.ForgiveElementAccessAssignmentRhs(assignment, assignRhs);
                     return new AssignmentStatement(
                         this.TranslateAssignmentTarget(assignment.Left),
                         assignRhs,


### PR DESCRIPTION
## Problem

Issue #2259: the cs2gs oblivious-nullability promotion pass
(`ObliviousNullabilityAnalyzer` + translator) already widens a
field/property/local/parameter/return-type assignment TARGET to `T?`
when its own declaration is (transitively) null-tainted. But it never
covered the **null-conditional element/member access result**
(`expr?[i]` / `expr?.Member`, and other analyzer-promoted-nullable
values) assigned into an **element-access target** — an array
element, a `Dictionary`/user-indexer write. Unlike a
field/property/local/parameter, an element-access target has no
single declaration to widen (promoting the whole array/collection's
element type would ripple to every other read of it), so the RHS's
true `T?` type trips gsc's strict nullability with GS0156
("Cannot convert type 'T?' to 'T'").

Dominant real-world site (Oahu.Foundation's `EnumUtil.cs`):
```csharp
parts[i] = punct.Infix?[x - ByteA];   // Infix is string[]; ?[] yields string?
```

## Fix

Added `ForgiveElementAccessAssignmentRhs` in
`CSharpToGSharpTranslator.cs`, wired into the assignment-statement
pipeline alongside the existing `ForgiveEventSubscriptionRhs`. When
the LHS is an `ElementAccessExpressionSyntax` whose declared/resolved
type is a non-nullable reference and the RHS is a promoted-nullable
value (`IsNullablePromotedValue`, already shared by the event-sink
path), it asserts `!!` at the RHS — the same null-forgiveness pattern
used for every other promoted-nullable-into-non-nullable sink
(return/argument/tuple/event). Gated to `IsObliviousCompilation()`
and skipped when the resolved indexer symbol is itself already
nullable/promoted, so nullable-enabled compilations and
already-handled sinks are byte-identical.

This generalizes to **any** element/member type (not just `string`) —
verified with a custom reference-type element and with a plain
promoted-local RHS into a `Dictionary` indexer write (no `?[]`/`?.` at
all), matching a second real GS0156 site in Oahu.Core's
`ProgrammaticLogin.cs`.

## Tests

New file `Issue2259ObliviousNullConditionalIndexTranslationTests.cs`:
- `Oblivious_NullConditionalIndex_AssignedToArrayElement_AssertsNonNull` — the `EnumUtil.cs` `?[]` shape.
- `Oblivious_NullConditionalMember_AssignedToArrayElement_AssertsNonNull` — `?.Member` shape, custom reference type (not `string`).
- `Oblivious_PromotedLocal_AssignedToIndexerWrite_AssertsNonNull` — the `ProgrammaticLogin.cs` `Dictionary` indexer shape.
- `Enabled_NullConditionalIndex_AssignedToArrayElement_StaysUnpromoted` — same shape under nullable-enabled C#, confirms byte-identical output (no `!!` inserted).

All 4 pass, plus the full oblivious/nullability/assignment/element/indexer/array regression subsets (357 tests) pass with no regressions.

## Oahu validation

Ran `cs2gs migrate` against the real Oahu corpus (`--config Release`):

- **Oahu.Foundation**: the `EnumUtil.gs` GS0156 at the `?[]` sink is gone (1 unrelated `GS0157 ThisAssembly` error remains).
- **Oahu.Core**: GS0156 count **12 → 11** (the `ProgrammaticLogin.gs` `inputs[name] = value` indexer sink is now fixed); no other diagnostic ID regressed (GS0154/55/57/58/59/60 counts unchanged or improved).

Closes #2259.
