### PR TITLE
cs2gs: fix named-argument skip that mis-fires on reduced extension-method calls (#2260)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2260NamedArgumentSkipExtensionReceiverTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2260NamedArgumentSkipExtensionReceiverTests.cs
@@ -1,0 +1,149 @@
+// <copyright file="Issue2260NamedArgumentSkipExtensionReceiverTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2260: a named-argument call invoked in reduced/dot EXTENSION-METHOD
+/// form (e.g. <c>table.AddBoldColumn("Length", noWrap: true)</c> against
+/// <c>AddBoldColumn(this Table table, string header, Align align = Align.Left,
+/// bool noWrap = false)</c>) that skips an earlier optional parameter whose
+/// default is NON-LITERAL (e.g. an enum member or <c>default(T)</c>) mis-fired
+/// the "not a simple literal" gap and silently dropped the skipped argument
+/// from the emitted call.
+/// </summary>
+/// <remarks>
+/// Root cause: <c>TranslateNamedArguments</c> resolves every argument's
+/// <c>Ordinal</c> via <c>IArgumentOperation.Parameter</c>, which is always
+/// bound against the extension method's UNREDUCED definition — i.e. the
+/// receiver ("this") parameter occupies ordinal 0 — even though the call was
+/// written in reduced/dot form, where the receiver is bound implicitly and
+/// never appears as a syntactic argument at all. The gap-filling loop started
+/// at ordinal 0 unconditionally, so it always tried to fill the (non-optional,
+/// no-default) receiver parameter FIRST, failed immediately, and gave up
+/// before ever reaching the real skipped optional parameter — dropping it
+/// from the emitted call instead of reporting or filling it. The fix computes
+/// how many leading ordinals the reduced call's receiver consumes (the
+/// difference between the unreduced and reduced parameter counts) and starts
+/// the gap-filling loop after them, so the loop only ever considers ordinals
+/// that correspond to real syntactic argument positions.
+/// </remarks>
+public class Issue2260NamedArgumentSkipExtensionReceiverTests
+{
+    [Fact]
+    public void NamedArgument_SkipsExtensionOptionalParameterWithEnumMemberDefault_FillsDefaultPositionally()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public enum Align { Left, Right }
+
+    public class Table { }
+
+    public static class TableExtensions
+    {
+        public static Table AddBoldColumn(this Table table, string header, Align align = Align.Left, bool noWrap = false)
+        {
+            return table;
+        }
+    }
+
+    public class C
+    {
+        public void Caller(Table table)
+        {
+            table.AddBoldColumn(""Length"", noWrap: true);
+        }
+    }
+}");
+        Assert.Contains("AddBoldColumn(\"Length\", Align.Left, true)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NamedArgument_SkipsExtensionOptionalParameterWithDefaultKeywordDefault_FillsDefaultPositionally()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public struct Options { public int X; }
+
+    public class Table { }
+
+    public static class TableExtensions
+    {
+        public static Table AddOptions(this Table table, string header, Options options = default, bool noWrap = false)
+        {
+            return table;
+        }
+    }
+
+    public class C
+    {
+        public void Caller(Table table)
+        {
+            table.AddOptions(""Length"", noWrap: true);
+        }
+    }
+}");
+        Assert.Contains("AddOptions(\"Length\", default(Options), true)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NamedArgument_OnExtensionCallWithNoSkippedParameter_StillWorks()
+    {
+        // Baseline: an extension-method call whose named argument does NOT skip
+        // any optional parameter must be unaffected by the ordinal-offset fix.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Table { }
+
+    public static class TableExtensions
+    {
+        public static Table AddColumn(this Table table, string header, bool noWrap = false)
+        {
+            return table;
+        }
+    }
+
+    public class C
+    {
+        public void Caller(Table table)
+        {
+            table.AddColumn(header: ""Length"", noWrap: true);
+        }
+    }
+}");
+        Assert.Contains("AddColumn(\"Length\", true)", printed, StringComparison.Ordinal);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -15077,8 +15077,27 @@ public sealed class CSharpToGSharpTranslator
             int maxOrdinal = resolved.Max(r => r.Parameter.Ordinal);
             IMethodSymbol invokedMethod = resolved[0].Parameter.ContainingSymbol as IMethodSymbol;
 
+            // Issue #2260: `operation.Parameter` (and hence every ordinal in
+            // `resolved`/`invokedMethod.Parameters`) is always resolved against the
+            // UNREDUCED extension-method definition — e.g. `AddBoldColumn(this
+            // Table table, string header, Align align = Align.Left, bool noWrap =
+            // false)` — even when the call is written in reduced/dot form
+            // (`table.AddBoldColumn("Length", noWrap: true)`), where the receiver
+            // is bound implicitly and never appears in `arguments` at all. Without
+            // this adjustment, ordinal 0 (the receiver parameter, which has no
+            // default and is not itself skippable) is mistaken for a skipped
+            // OPTIONAL parameter and the fill fails immediately — before ever
+            // reaching the real skipped parameter (`align`) — silently dropping it
+            // from the emitted call instead of filling it. Any gap between the
+            // unreduced arity and the reduced arity the call was actually bound
+            // through is exactly the receiver's parameter count, so those leading
+            // ordinals must be skipped entirely rather than treated as fillable.
+            int ordinalOffset = invokedMethod != null && invokedForArguments?.ReducedFrom != null
+                ? Math.Max(0, invokedMethod.Parameters.Length - invokedForArguments.Parameters.Length)
+                : 0;
+
             var result = new List<GExpression>();
-            for (int ordinal = 0; ordinal <= maxOrdinal; ordinal++)
+            for (int ordinal = ordinalOffset; ordinal <= maxOrdinal; ordinal++)
             {
                 if (byOrdinal.TryGetValue(ordinal, out ArgumentSyntax explicitArgument))
                 {


### PR DESCRIPTION
## Summary

Fixes #2260. A named-argument call invoked in reduced/dot **extension-method** form (e.g. `table.AddBoldColumn("Length", noWrap: true)` against `AddBoldColumn(this Table table, string header, bool noWrap = false)`) that skips an earlier optional parameter reported a bogus "not a simple literal" gap and dropped the skipped argument from the emitted call, blocking `cs2gs migrate` (Oahu.Cli site: `.AddBoldColumn("Length", noWrap: true)`).

## Root cause

`TranslateNamedArguments` resolves every explicit argument's `Parameter.Ordinal` via `IArgumentOperation.Parameter`, which is always bound against the extension method's **unreduced** definition — the receiver ("this") parameter occupies ordinal 0 — even when the call is written in reduced/dot form, where the receiver is bound implicitly and never appears as a syntactic argument at all.

The gap-filling loop unconditionally started at ordinal 0, so it always tried to fill the receiver parameter first. The receiver has no default value and isn't itself skippable, so the fill failed immediately and the whole call fell back to source-order emission — before the loop ever reached the real skipped optional parameter (which, when its default is non-literal, e.g. an enum member or `default(T)`, is exactly the shape issue #2260 calls out). The skipped argument was silently dropped from the emitted call instead of being filled or reported.

I verified the existing default-reconstruction logic (`BuildOptionalParameterDefault` / `MapConstantValue` / `MapEnumConstant`, hardened for decimal in #2236) already handles every non-literal default shape correctly — enum members, `default`/`default(T)`, `const` references — for ordinary (non-extension) calls. The only actual bug was the ordinal misalignment introduced by extension-method reduction.

## Fix (strategy)

This isn't a G#-default-args-omission case (strategy A) nor a from-scratch default-expression re-derivation case (strategy B) — the skipped parameter's default was already being reconstructed correctly by the existing machinery; the bug was purely an off-by-N ordinal bookkeeping error introduced by extension-method reduction. The fix computes the ordinal offset the reduced call introduces (the difference between the unreduced and reduced parameter counts, i.e. the receiver's parameter count) and starts the gap-filling loop after it, so the loop only ever considers ordinals that correspond to real syntactic argument positions. This generalizes to any non-literal default shape, since it doesn't change how defaults are reconstructed at all — only which ordinals are eligible to need one.

## Tests

Added Issue2260NamedArgumentSkipExtensionReceiverTests.cs:
- NamedArgument_SkipsExtensionOptionalParameterWithEnumMemberDefault_FillsDefaultPositionally
- NamedArgument_SkipsExtensionOptionalParameterWithDefaultKeywordDefault_FillsDefaultPositionally
- NamedArgument_OnExtensionCallWithNoSkippedParameter_StillWorks (baseline/no-regression)

Targeted filters pass: Issue1727 / Issue2236 / Issue2260 / Issue1901LambdaDefaults (28 passed) and all extension-method-related translation test files (41 passed). Building the translator, CLI, and test projects is 0 warnings / 0 errors (StyleCop-clean).

## Before/after on Oahu.Cli

Before: `cs2gs migrate` failed the translate stage for the whole app with `CS2GS-GAP named argument list skips parameter 'table' whose default value is not a simple literal`.

After: translate stage passes; the emitted call is `.AddBoldColumn("Title").AddBoldColumn("Author").AddBoldColumn("Length", true)` (correct — Oahu.Cli's real AddBoldColumn has no parameter between header and noWrap, so no positional filler is even needed once the ordinal offset is corrected). Oahu.Cli still fails the later compile stage for an unrelated, pre-existing environment reason (missing local gsgen tool path), not addressed by this PR.

Closes #2260.
