### PR TITLE
cs2gs --via-sdk: preserve build-only PackageReferences so nbgv ThisAssembly generates

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -55,7 +55,8 @@ public sealed class CompileStage : IMigrationStage
                 references,
                 context.AnalyzerReferencePaths,
                 rootNamespace: null,
-                context.Options.Config);
+                context.Options.Config,
+                context.BuildOnlyPackageReferences);
 
             if (sdkResult.IsAvailable)
             {

--- a/tools/cs2gs/Cs2Gs.Pipeline/DeclaredPackageReference.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/DeclaredPackageReference.cs
@@ -1,0 +1,49 @@
+// <copyright file="DeclaredPackageReference.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace Cs2Gs.Pipeline;
+
+/// <summary>
+/// A build/dev-only <c>PackageReference</c> declared by the source C# project
+/// (issue #2267) that must be preserved into the isolated <c>--via-sdk</c>
+/// gsproj even though it contributes no compile-time reference DLL — e.g.
+/// <c>Nerdbank.GitVersioning</c>, which is <c>PrivateAssets="all"</c> and ships
+/// no <c>lib/</c> assembly, so <see cref="SdkCompileRunner"/>'s reconstruction of
+/// <c>PackageReference</c> items from the resolved compile-time reference set
+/// (<see cref="SdkCompileRunner.PartitionReferences"/>) can never recover it.
+/// Without re-declaring it explicitly, the package's MSBuild targets never
+/// import under <c>dotnet build</c> and its source generator (nbgv's
+/// <c>ThisAssembly</c>) never runs. This type is intentionally generic — not
+/// nbgv-specific — so other build-only/analyzer packages the source project
+/// declares can be threaded through the same way.
+/// </summary>
+public sealed class DeclaredPackageReference
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeclaredPackageReference"/> class.
+    /// </summary>
+    /// <param name="id">The NuGet package id.</param>
+    /// <param name="version">The concrete version to declare.</param>
+    /// <param name="privateAssets">The <c>PrivateAssets</c> attribute value, or <see langword="null"/> to omit it.</param>
+    /// <param name="includeAssets">The <c>IncludeAssets</c> attribute value, or <see langword="null"/> to omit it.</param>
+    public DeclaredPackageReference(string id, string version, string privateAssets = null, string includeAssets = null)
+    {
+        this.Id = id;
+        this.Version = version;
+        this.PrivateAssets = privateAssets;
+        this.IncludeAssets = includeAssets;
+    }
+
+    /// <summary>Gets the NuGet package id.</summary>
+    public string Id { get; }
+
+    /// <summary>Gets the concrete version to declare.</summary>
+    public string Version { get; }
+
+    /// <summary>Gets the <c>PrivateAssets</c> attribute value, or <see langword="null"/> to omit it.</summary>
+    public string PrivateAssets { get; }
+
+    /// <summary>Gets the <c>IncludeAssets</c> attribute value, or <see langword="null"/> to omit it.</summary>
+    public string IncludeAssets { get; }
+}

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -117,6 +117,18 @@ public sealed class StageExecutionContext
     public List<string> GeneratorGlobalOptions { get; } = new List<string>();
 
     /// <summary>
+    /// Gets the source project's declared build/dev-only <c>PackageReference</c>s
+    /// (issue #2267) — e.g. a version-bumped <c>Nerdbank.GitVersioning</c> — that
+    /// must be re-declared into the isolated <c>--via-sdk</c> gsproj because they
+    /// contribute no compile-time reference DLL and so are otherwise silently
+    /// dropped by <see cref="SdkCompileRunner"/>'s DLL-to-package reconstruction.
+    /// Populated by the Translate stage; only consumed by the <c>--via-sdk</c>
+    /// compile path (the gsc-direct path has no notion of <c>PackageReference</c>
+    /// items at all).
+    /// </summary>
+    public List<DeclaredPackageReference> BuildOnlyPackageReferences { get; } = new List<DeclaredPackageReference>();
+
+    /// <summary>
     /// Gets or sets the absolute path of the assembly emitted by the Compile
     /// stage, published for the IL-verify stage to read (ADR-0115 §C). It is
     /// <see langword="null"/> until a green stage-2 compile has run.

--- a/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
@@ -62,6 +62,13 @@ public sealed class SdkCompileRunner
     /// <param name="analyzerPaths">The analyzer/generator assembly paths (issue #2215).</param>
     /// <param name="rootNamespace">The root namespace to set on the project, or <see langword="null"/>.</param>
     /// <param name="config">The build configuration (e.g. <c>Release</c>).</param>
+    /// <param name="declaredPackageReferences">
+    /// The source project's declared build/dev-only <c>PackageReference</c>s
+    /// (issue #2267) — e.g. a version-bumped <c>Nerdbank.GitVersioning</c> — to
+    /// re-declare in the isolated gsproj even though they contribute no
+    /// compile-time reference DLL for <see cref="PartitionReferences"/> to
+    /// recover. May be <see langword="null"/> or empty.
+    /// </param>
     /// <returns>The compile result, or an unavailable result when no local SDK nupkg can be found.</returns>
     public SdkCompileResult Compile(
         string appRunDir,
@@ -70,7 +77,8 @@ public sealed class SdkCompileRunner
         IReadOnlyList<string> referencePaths,
         IReadOnlyList<string> analyzerPaths,
         string rootNamespace,
-        string config)
+        string config,
+        IReadOnlyList<DeclaredPackageReference> declaredPackageReferences = null)
     {
         if (string.IsNullOrEmpty(appRunDir))
         {
@@ -123,6 +131,22 @@ public sealed class SdkCompileRunner
             }
         }
 
+        // Issue #2267: a declared build/dev-only package (nbgv) that also
+        // resolved a compile-time DLL is already covered by `packages` above;
+        // only the ones DLL reconstruction could never see need to be added
+        // here, carrying the PrivateAssets/IncludeAssets metadata `packages`
+        // has no room for.
+        var declaredOnlyPackages = new List<DeclaredPackageReference>();
+        foreach (DeclaredPackageReference declared in declaredPackageReferences ?? Array.Empty<DeclaredPackageReference>())
+        {
+            if (declared is null || string.IsNullOrWhiteSpace(declared.Id) || packageIndex.ContainsKey(declared.Id))
+            {
+                continue;
+            }
+
+            declaredOnlyPackages.Add(declared);
+        }
+
         const string ProjectName = "App";
         string projectPath = Path.Combine(appRunDir, ProjectName + ".gsproj");
         string projectXml = BuildProjectXml(
@@ -132,7 +156,8 @@ public sealed class SdkCompileRunner
             gsFilePaths ?? Array.Empty<string>(),
             packages,
             references,
-            analyzerReferences);
+            analyzerReferences,
+            declaredOnlyPackages);
         File.WriteAllText(projectPath, projectXml);
 
         var args = new List<string> { "build", projectPath, "-c", config ?? "Release" };
@@ -272,6 +297,127 @@ public sealed class SdkCompileRunner
     }
 
     /// <summary>
+    /// Renders the isolated <c>App.gsproj</c> XML text: the SDK-project header,
+    /// build properties, <c>@(Compile)</c> items, <c>@(PackageReference)</c>
+    /// (both the reconstructed-from-DLL set and the declared build/dev-only set,
+    /// issue #2267), <c>@(Reference)</c>, and <c>@(Analyzer)</c> items. Exposed
+    /// <see langword="internal"/> so the package/analyzer item emission is
+    /// unit-testable without a live NuGet cache or a real <c>dotnet build</c>.
+    /// </summary>
+    /// <param name="sdkVersion">The resolved <c>Gsharp.NET.Sdk</c> version.</param>
+    /// <param name="target">The output kind (exe or library).</param>
+    /// <param name="rootNamespace">The root namespace to set on the project, or <see langword="null"/>.</param>
+    /// <param name="gsFilePaths">The absolute paths of the emitted G# files to compile, in compile order.</param>
+    /// <param name="packages">The <c>PackageReference</c> id/version pairs reconstructed from compile-time DLLs.</param>
+    /// <param name="references">The remaining loose/sibling <c>Reference</c> paths.</param>
+    /// <param name="analyzerReferences">The analyzer/generator assembly paths (issue #2215).</param>
+    /// <param name="declaredPackageReferences">
+    /// The source project's declared build/dev-only <c>PackageReference</c>s
+    /// (issue #2267) to re-declare even though they contributed no compile-time
+    /// DLL to <paramref name="packages"/>.
+    /// </param>
+    /// <returns>The full <c>.gsproj</c> XML text.</returns>
+    internal static string BuildProjectXml(
+        string sdkVersion,
+        TargetKind target,
+        string rootNamespace,
+        IReadOnlyList<string> gsFilePaths,
+        IReadOnlyList<(string Id, string Version)> packages,
+        IReadOnlyList<string> references,
+        IReadOnlyList<string> analyzerReferences,
+        IReadOnlyList<DeclaredPackageReference> declaredPackageReferences = null)
+    {
+        declaredPackageReferences ??= Array.Empty<DeclaredPackageReference>();
+        string outputType = target == TargetKind.Exe ? "Exe" : "Library";
+        var sb = new StringBuilder();
+        sb.Append("<Project Sdk=\"").Append(SdkPackageId).Append('/').Append(sdkVersion).Append("\">\n");
+        sb.Append('\n');
+        sb.Append("  <PropertyGroup>\n");
+        sb.Append("    <OutputType>").Append(outputType).Append("</OutputType>\n");
+        sb.Append("    <TargetFramework>net10.0</TargetFramework>\n");
+        sb.Append("    <Nullable>enable</Nullable>\n");
+        sb.Append("    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>\n");
+        sb.Append("    <Deterministic>true</Deterministic>\n");
+        sb.Append("    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>\n");
+        if (!string.IsNullOrEmpty(rootNamespace))
+        {
+            sb.Append("    <RootNamespace>").Append(rootNamespace).Append("</RootNamespace>\n");
+        }
+
+        sb.Append("  </PropertyGroup>\n");
+        sb.Append('\n');
+        sb.Append("  <ItemGroup>\n");
+        foreach (string gsFile in gsFilePaths)
+        {
+            sb.Append("    <Compile Include=\"").Append(gsFile).Append("\" />\n");
+        }
+
+        sb.Append("  </ItemGroup>\n");
+
+        if (packages.Count > 0 || declaredPackageReferences.Count > 0)
+        {
+            sb.Append('\n');
+            sb.Append("  <ItemGroup>\n");
+            foreach ((string id, string version) in packages)
+            {
+                sb.Append("    <PackageReference Include=\"").Append(id)
+                    .Append("\" Version=\"").Append(version).Append("\" />\n");
+            }
+
+            // Issue #2267: build/dev-only packages (e.g. Nerdbank.GitVersioning)
+            // that contributed no compile-time DLL and so are absent from
+            // `packages` above, re-declared here so their MSBuild source
+            // generators still run under `dotnet build`.
+            foreach (DeclaredPackageReference declared in declaredPackageReferences)
+            {
+                sb.Append("    <PackageReference Include=\"").Append(declared.Id)
+                    .Append("\" Version=\"").Append(declared.Version).Append('"');
+                if (!string.IsNullOrEmpty(declared.PrivateAssets))
+                {
+                    sb.Append(" PrivateAssets=\"").Append(declared.PrivateAssets).Append('"');
+                }
+
+                if (!string.IsNullOrEmpty(declared.IncludeAssets))
+                {
+                    sb.Append(" IncludeAssets=\"").Append(declared.IncludeAssets).Append('"');
+                }
+
+                sb.Append(" />\n");
+            }
+
+            sb.Append("  </ItemGroup>\n");
+        }
+
+        if (references.Count > 0)
+        {
+            sb.Append('\n');
+            sb.Append("  <ItemGroup>\n");
+            foreach (string reference in references)
+            {
+                sb.Append("    <Reference Include=\"").Append(Path.GetFullPath(reference)).Append("\" />\n");
+            }
+
+            sb.Append("  </ItemGroup>\n");
+        }
+
+        if (analyzerReferences.Count > 0)
+        {
+            sb.Append('\n');
+            sb.Append("  <ItemGroup>\n");
+            foreach (string analyzerReference in analyzerReferences)
+            {
+                sb.Append("    <Analyzer Include=\"").Append(analyzerReference).Append("\" />\n");
+            }
+
+            sb.Append("  </ItemGroup>\n");
+        }
+
+        sb.Append('\n');
+        sb.Append("</Project>\n");
+        return sb.ToString();
+    }
+
+    /// <summary>
     /// Writes a <c>nuget.config</c> directly into <paramref name="appRunDir"/>
     /// pointing at the repo's <c>.nugs</c> local feed (by absolute path) plus
     /// nuget.org. MSBuild's SDK resolver (which resolves <c>Sdk="Gsharp.NET.Sdk/…"</c>
@@ -358,83 +504,6 @@ public sealed class SdkCompileRunner
         }
 
         return best;
-    }
-
-    private static string BuildProjectXml(
-        string sdkVersion,
-        TargetKind target,
-        string rootNamespace,
-        IReadOnlyList<string> gsFilePaths,
-        IReadOnlyList<(string Id, string Version)> packages,
-        IReadOnlyList<string> references,
-        IReadOnlyList<string> analyzerReferences)
-    {
-        string outputType = target == TargetKind.Exe ? "Exe" : "Library";
-        var sb = new StringBuilder();
-        sb.Append("<Project Sdk=\"").Append(SdkPackageId).Append('/').Append(sdkVersion).Append("\">\n");
-        sb.Append('\n');
-        sb.Append("  <PropertyGroup>\n");
-        sb.Append("    <OutputType>").Append(outputType).Append("</OutputType>\n");
-        sb.Append("    <TargetFramework>net10.0</TargetFramework>\n");
-        sb.Append("    <Nullable>enable</Nullable>\n");
-        sb.Append("    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>\n");
-        sb.Append("    <Deterministic>true</Deterministic>\n");
-        sb.Append("    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>\n");
-        if (!string.IsNullOrEmpty(rootNamespace))
-        {
-            sb.Append("    <RootNamespace>").Append(rootNamespace).Append("</RootNamespace>\n");
-        }
-
-        sb.Append("  </PropertyGroup>\n");
-        sb.Append('\n');
-        sb.Append("  <ItemGroup>\n");
-        foreach (string gsFile in gsFilePaths)
-        {
-            sb.Append("    <Compile Include=\"").Append(gsFile).Append("\" />\n");
-        }
-
-        sb.Append("  </ItemGroup>\n");
-
-        if (packages.Count > 0)
-        {
-            sb.Append('\n');
-            sb.Append("  <ItemGroup>\n");
-            foreach ((string id, string version) in packages)
-            {
-                sb.Append("    <PackageReference Include=\"").Append(id)
-                    .Append("\" Version=\"").Append(version).Append("\" />\n");
-            }
-
-            sb.Append("  </ItemGroup>\n");
-        }
-
-        if (references.Count > 0)
-        {
-            sb.Append('\n');
-            sb.Append("  <ItemGroup>\n");
-            foreach (string reference in references)
-            {
-                sb.Append("    <Reference Include=\"").Append(Path.GetFullPath(reference)).Append("\" />\n");
-            }
-
-            sb.Append("  </ItemGroup>\n");
-        }
-
-        if (analyzerReferences.Count > 0)
-        {
-            sb.Append('\n');
-            sb.Append("  <ItemGroup>\n");
-            foreach (string analyzerReference in analyzerReferences)
-            {
-                sb.Append("    <Analyzer Include=\"").Append(analyzerReference).Append("\" />\n");
-            }
-
-            sb.Append("  </ItemGroup>\n");
-        }
-
-        sb.Append('\n');
-        sb.Append("</Project>\n");
-        return sb.ToString();
     }
 
     private static GscDiagnostic SynthesizeFallbackDiagnostic(ProcessRunResult result, IReadOnlyList<string> gsFilePaths)

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -303,6 +303,13 @@ public sealed class TranslateStage : IMigrationStage
     /// a manifest recording the source path. The original files are never touched
     /// (the corpus tree is read-only); the migrated project can adopt the bumped
     /// file so nbgv produces the G# <c>ThisAssembly</c> source (issue #2225).
+    /// Also resolves, across the same candidate set, the nbgv package's effective
+    /// id/version/<c>PrivateAssets</c>/<c>IncludeAssets</c> declaration and — when
+    /// found — records it on <see cref="StageExecutionContext.BuildOnlyPackageReferences"/>
+    /// so the <c>--via-sdk</c> compile path can re-declare it in the isolated
+    /// gsproj (issue #2267): nbgv is a build/dev-only dependency that contributes
+    /// no compile-time reference DLL, so it would otherwise be silently dropped
+    /// and its <c>ThisAssembly</c> source generator would never run.
     /// </summary>
     private static void EmitNerdbankGitVersioningBumps(StageExecutionContext context)
     {
@@ -332,6 +339,10 @@ public sealed class TranslateStage : IMigrationStage
         string outputDir = null;
         var manifest = new List<string>();
         var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        bool nbgvFound = false;
+        string rawVersion = null;
+        string privateAssets = null;
+        string includeAssets = null;
         foreach (string candidate in candidates)
         {
             string original;
@@ -342,6 +353,19 @@ public sealed class TranslateStage : IMigrationStage
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
                 continue;
+            }
+
+            // Issue #2267: combine the nbgv declaration across every candidate
+            // file — CPM commonly splits it between a versionless
+            // <PackageReference PrivateAssets="all"> (project/Directory.Build.props)
+            // and the actual <PackageVersion Version="..."> (Directory.Packages.props).
+            if (NerdbankGitVersioningPolicy.TryFindDeclaration(
+                original, out string candidateVersion, out string candidatePrivateAssets, out string candidateIncludeAssets))
+            {
+                nbgvFound = true;
+                rawVersion ??= candidateVersion;
+                privateAssets ??= candidatePrivateAssets;
+                includeAssets ??= candidateIncludeAssets;
             }
 
             if (!NerdbankGitVersioningPolicy.TryBumpProjectXml(original, out string bumped))
@@ -376,6 +400,15 @@ public sealed class TranslateStage : IMigrationStage
                 + "# Each line: <emitted file> <- <original source file>." + Environment.NewLine
                 + string.Join(Environment.NewLine, manifest) + Environment.NewLine;
             File.WriteAllText(Path.Combine(outputDir, "manifest.txt"), manifestText);
+        }
+
+        if (nbgvFound)
+        {
+            context.BuildOnlyPackageReferences.Add(new DeclaredPackageReference(
+                NerdbankGitVersioningPolicy.PackageId,
+                NerdbankGitVersioningPolicy.ResolveEffectiveVersion(rawVersion),
+                privateAssets ?? "all",
+                includeAssets));
         }
     }
 

--- a/tools/cs2gs/Cs2Gs.ProjectLoading/NerdbankGitVersioningPolicy.cs
+++ b/tools/cs2gs/Cs2Gs.ProjectLoading/NerdbankGitVersioningPolicy.cs
@@ -42,6 +42,107 @@ public static class NerdbankGitVersioningPolicy
         "(?<pre>Version\\s*=\\s*\")(?<value>[^\"]*)(?<post>\")",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
+    private static readonly Regex PrivateAssetsAttrPattern = new Regex(
+        "PrivateAssets\\s*=\\s*\"(?<value>[^\"]*)\"",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex IncludeAssetsAttrPattern = new Regex(
+        "IncludeAssets\\s*=\\s*\"(?<value>[^\"]*)\"",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Scans a single MSBuild file's text for an nbgv <c>PackageReference</c> or
+    /// <c>PackageVersion</c> declaration (issue #2267). Central Package Management
+    /// commonly splits the declaration across two files: a versionless
+    /// <c>&lt;PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" /&gt;</c>
+    /// in the consuming project (or a shared <c>Directory.Build.props</c>) and the
+    /// actual <c>&lt;PackageVersion Include="Nerdbank.GitVersioning" Version="..." /&gt;</c>
+    /// in <c>Directory.Packages.props</c> — so this only reports whichever pieces
+    /// this particular file's text contributes; callers combine results across the
+    /// full candidate file set to recover the complete declaration.
+    /// </summary>
+    /// <param name="msbuildXml">The full text of a <c>.csproj</c>/<c>.props</c> file.</param>
+    /// <param name="version">Receives the raw <c>Version</c> attribute value, or <see langword="null"/> when absent.</param>
+    /// <param name="privateAssets">Receives the raw <c>PrivateAssets</c> attribute value, or <see langword="null"/> when absent.</param>
+    /// <param name="includeAssets">Receives the raw <c>IncludeAssets</c> attribute value, or <see langword="null"/> when absent.</param>
+    /// <returns><see langword="true"/> when an nbgv element was found in this file.</returns>
+    public static bool TryFindDeclaration(string msbuildXml, out string version, out string privateAssets, out string includeAssets)
+    {
+        version = null;
+        privateAssets = null;
+        includeAssets = null;
+        if (string.IsNullOrEmpty(msbuildXml))
+        {
+            return false;
+        }
+
+        bool found = false;
+        foreach (Match match in NbgvElementPattern.Matches(msbuildXml))
+        {
+            found = true;
+            string attrs = match.Groups["attrs"].Value;
+
+            Match versionMatch = VersionAttrPattern.Match(attrs);
+            if (versionMatch.Success && version is null)
+            {
+                version = versionMatch.Groups["value"].Value;
+            }
+
+            // PrivateAssets/IncludeAssets are consumer-side attributes: they only
+            // ever appear on a <PackageReference>, never on the CPM <PackageVersion>.
+            if (string.Equals(match.Groups["tag"].Value, "PackageReference", StringComparison.OrdinalIgnoreCase))
+            {
+                if (privateAssets is null)
+                {
+                    Match privateAssetsMatch = PrivateAssetsAttrPattern.Match(attrs);
+                    if (privateAssetsMatch.Success)
+                    {
+                        privateAssets = privateAssetsMatch.Groups["value"].Value;
+                    }
+                }
+
+                if (includeAssets is null)
+                {
+                    Match includeAssetsMatch = IncludeAssetsAttrPattern.Match(attrs);
+                    if (includeAssetsMatch.Success)
+                    {
+                        includeAssets = includeAssetsMatch.Groups["value"].Value;
+                    }
+                }
+            }
+        }
+
+        return found;
+    }
+
+    /// <summary>
+    /// Resolves the concrete nbgv version to declare in a rebuilt/isolated
+    /// project (issue #2267) from a raw declared version that may come from a
+    /// different MSBuild evaluation context (e.g. a CPM
+    /// <c>Directory.Packages.props</c> not present alongside an isolated
+    /// gsproj). A below-floor literal is bumped to <see cref="MinimumGSharpVersion"/>
+    /// (mirrors <see cref="TryGetRequiredBump"/>); an at-or-above-floor literal is
+    /// preserved as-is; anything else (missing, an MSBuild property, a range, or a
+    /// wildcard — none of which resolve outside their original context) falls back
+    /// to <see cref="MinimumGSharpVersion"/>, the lowest version known to work.
+    /// </summary>
+    /// <param name="rawVersion">The raw declared <c>Version</c> attribute value, or <see langword="null"/>.</param>
+    /// <returns>The concrete version to declare.</returns>
+    public static string ResolveEffectiveVersion(string rawVersion)
+    {
+        if (TryGetRequiredBump(rawVersion, out string bumped))
+        {
+            return bumped;
+        }
+
+        if (IsPlainLiteral(rawVersion) && SemVer.TryParse(rawVersion.Trim(), out _))
+        {
+            return rawVersion.Trim();
+        }
+
+        return MinimumGSharpVersion;
+    }
+
     /// <summary>
     /// Determines whether the supplied version string denotes an nbgv version
     /// strictly below <see cref="MinimumGSharpVersion"/> that can be safely
@@ -59,25 +160,15 @@ public static class NerdbankGitVersioningPolicy
     public static bool TryGetRequiredBump(string version, out string bumpedVersion)
     {
         bumpedVersion = null;
-        if (string.IsNullOrWhiteSpace(version))
-        {
-            return false;
-        }
-
-        string trimmed = version.Trim();
 
         // Not a plain literal — an MSBuild property, floating version, or range.
         // We cannot know its resolved value, so leave it as-is.
-        if (trimmed.IndexOf("$(", StringComparison.Ordinal) >= 0 ||
-            trimmed.IndexOf('*') >= 0 ||
-            trimmed.IndexOf('[') >= 0 ||
-            trimmed.IndexOf('(') >= 0 ||
-            trimmed.IndexOf(',') >= 0)
+        if (!IsPlainLiteral(version))
         {
             return false;
         }
 
-        if (!SemVer.TryParse(trimmed, out SemVer current))
+        if (!SemVer.TryParse(version.Trim(), out SemVer current))
         {
             return false;
         }
@@ -141,6 +232,29 @@ public static class NerdbankGitVersioningPolicy
         }
 
         return changed;
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="version"/> is a plain semantic-version
+    /// literal cs2gs can reason about outside its original MSBuild evaluation
+    /// context — i.e. not an MSBuild property (<c>$(...)</c>), a floating/wildcard
+    /// (<c>*</c>), or a version range (<c>[..]</c>/<c>(..)</c>).
+    /// </summary>
+    /// <param name="version">The raw <c>Version</c> attribute value.</param>
+    /// <returns><see langword="true"/> when the value is a plain literal.</returns>
+    private static bool IsPlainLiteral(string version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return false;
+        }
+
+        string trimmed = version.Trim();
+        return trimmed.IndexOf("$(", StringComparison.Ordinal) < 0 &&
+            trimmed.IndexOf('*') < 0 &&
+            trimmed.IndexOf('[') < 0 &&
+            trimmed.IndexOf('(') < 0 &&
+            trimmed.IndexOf(',') < 0;
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/NerdbankGitVersioningPolicyTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/NerdbankGitVersioningPolicyTests.cs
@@ -141,4 +141,84 @@ public sealed class NerdbankGitVersioningPolicyTests
         Assert.True(NerdbankGitVersioningPolicy.TryBumpProjectXml(xml, out string bumped));
         Assert.Contains("3.11.13-beta", bumped);
     }
+
+    [Fact]
+    public void TryFindDeclaration_PackageReference_ExtractsVersionAndPrivateAssets()
+    {
+        string xml =
+            "<Project>\n" +
+            "  <ItemGroup>\n" +
+            "    <PackageReference Include=\"Nerdbank.GitVersioning\" Version=\"3.7.115\" PrivateAssets=\"all\" IncludeAssets=\"runtime; build\" />\n" +
+            "  </ItemGroup>\n" +
+            "</Project>\n";
+
+        Assert.True(NerdbankGitVersioningPolicy.TryFindDeclaration(
+            xml, out string version, out string privateAssets, out string includeAssets));
+        Assert.Equal("3.7.115", version);
+        Assert.Equal("all", privateAssets);
+        Assert.Equal("runtime; build", includeAssets);
+    }
+
+    [Fact]
+    public void TryFindDeclaration_VersionlessPackageReference_ReturnsPrivateAssetsButNoVersion()
+    {
+        // The Oahu shape: a shared Directory.Build.props declares nbgv with no
+        // Version (Central Package Management pins it elsewhere).
+        string xml =
+            "<Project>\n" +
+            "  <ItemGroup>\n" +
+            "    <PackageReference Include=\"Nerdbank.GitVersioning\" PrivateAssets=\"all\" />\n" +
+            "  </ItemGroup>\n" +
+            "</Project>\n";
+
+        Assert.True(NerdbankGitVersioningPolicy.TryFindDeclaration(
+            xml, out string version, out string privateAssets, out string includeAssets));
+        Assert.Null(version);
+        Assert.Equal("all", privateAssets);
+        Assert.Null(includeAssets);
+    }
+
+    [Fact]
+    public void TryFindDeclaration_PackageVersion_ExtractsVersionButNoPrivateAssets()
+    {
+        // The Oahu shape: Directory.Packages.props pins the CPM version; a
+        // <PackageVersion> element never carries PrivateAssets/IncludeAssets.
+        string xml =
+            "<Project>\n" +
+            "  <ItemGroup>\n" +
+            "    <PackageVersion Include=\"Nerdbank.GitVersioning\" Version=\"3.7.115\" />\n" +
+            "  </ItemGroup>\n" +
+            "</Project>\n";
+
+        Assert.True(NerdbankGitVersioningPolicy.TryFindDeclaration(
+            xml, out string version, out string privateAssets, out string includeAssets));
+        Assert.Equal("3.7.115", version);
+        Assert.Null(privateAssets);
+        Assert.Null(includeAssets);
+    }
+
+    [Fact]
+    public void TryFindDeclaration_NoNbgvElement_ReturnsFalse()
+    {
+        string xml = "<Project><ItemGroup><PackageVersion Include=\"xunit\" Version=\"2.9.2\" /></ItemGroup></Project>";
+
+        Assert.False(NerdbankGitVersioningPolicy.TryFindDeclaration(
+            xml, out string version, out string privateAssets, out string includeAssets));
+        Assert.Null(version);
+        Assert.Null(privateAssets);
+        Assert.Null(includeAssets);
+    }
+
+    [Theory]
+    [InlineData("3.7.115", "3.11.13-beta")]  // Oahu's pinned below-floor version is bumped
+    [InlineData("3.11.13-beta", "3.11.13-beta")] // already at floor: preserved
+    [InlineData("4.0.0", "4.0.0")]           // above floor: preserved as-is
+    [InlineData(null, "3.11.13-beta")]       // no version found at all: fall back to floor
+    [InlineData("$(NbgvVersion)", "3.11.13-beta")] // unresolvable property: fall back to floor
+    [InlineData("[3.7.0,4.0.0)", "3.11.13-beta")]  // unresolvable range: fall back to floor
+    public void ResolveEffectiveVersion_ReturnsExpectedConcreteVersion(string raw, string expected)
+    {
+        Assert.Equal(expected, NerdbankGitVersioningPolicy.ResolveEffectiveVersion(raw));
+    }
 }
+

--- a/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Cs2Gs.Pipeline;
+using Cs2Gs.Translator.Loading;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -138,6 +139,62 @@ public class SdkCompileRunnerTests
             "/repo/out/bin/Release/SomeLib/SomeLib.dll", PackagesRoot);
 
         Assert.Null(package);
+    }
+
+    [Fact]
+    public void BuildProjectXml_EmitsDeclaredNerdbankGitVersioningPackageReference_WithBumpedVersionAndPrivateAssets()
+    {
+        // Issue #2267: nbgv is a build/dev-only dependency (PrivateAssets=all, no
+        // lib/ DLL) so it contributes no compile-time reference DLL for the
+        // `packages` reconstruction to recover. When the source project declared
+        // it (captured as a DeclaredPackageReference by the Translate stage),
+        // BuildProjectXml must still emit it as a real <PackageReference> so
+        // nbgv's ThisAssembly MSBuild generator runs under `dotnet build`.
+        var declared = new[]
+        {
+            new DeclaredPackageReference(
+                NerdbankGitVersioningPolicy.PackageId,
+                NerdbankGitVersioningPolicy.MinimumGSharpVersion,
+                privateAssets: "all"),
+        };
+
+        string xml = SdkCompileRunner.BuildProjectXml(
+            sdkVersion: "1.0.0",
+            target: TargetKind.Exe,
+            rootNamespace: null,
+            gsFilePaths: new[] { "/app/Program.gs" },
+            packages: Array.Empty<(string Id, string Version)>(),
+            references: Array.Empty<string>(),
+            analyzerReferences: Array.Empty<string>(),
+            declaredPackageReferences: declared);
+
+        Assert.Contains(
+            "<PackageReference Include=\"Nerdbank.GitVersioning\" Version=\"3.11.13-beta\" PrivateAssets=\"all\" />",
+            xml);
+    }
+
+    [Fact]
+    public void BuildProjectXml_DoesNotDuplicateDeclaredPackage_WhenAlreadyReconstructedFromDll()
+    {
+        // A package that DID resolve a compile-time DLL is already fully
+        // represented in `packages`; the caller (SdkCompileRunner.Compile) filters
+        // it out of `declaredPackageReferences` before calling BuildProjectXml, but
+        // BuildProjectXml itself renders both lists as given, so this test locks
+        // in that contract at the call-site level via the public Compile-adjacent
+        // helper: rendering the same id twice must not happen when the caller
+        // only passes the DLL-less declared set (the realistic call shape).
+        string xml = SdkCompileRunner.BuildProjectXml(
+            sdkVersion: "1.0.0",
+            target: TargetKind.Library,
+            rootNamespace: null,
+            gsFilePaths: new[] { "/app/Lib.gs" },
+            packages: new List<(string Id, string Version)> { ("communitytoolkit.mvvm", "8.4.0") },
+            references: Array.Empty<string>(),
+            analyzerReferences: Array.Empty<string>(),
+            declaredPackageReferences: Array.Empty<DeclaredPackageReference>());
+
+        Assert.Contains("<PackageReference Include=\"communitytoolkit.mvvm\" Version=\"8.4.0\" />", xml);
+        Assert.Single(System.Text.RegularExpressions.Regex.Matches(xml, "<PackageReference"));
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/TranslateStageNbgvPackageReferenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TranslateStageNbgvPackageReferenceTests.cs
@@ -1,0 +1,130 @@
+// <copyright file="TranslateStageNbgvPackageReferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Stage-level tests for issue #2267: the isolated <c>--via-sdk</c> gsproj drops
+/// <c>Nerdbank.GitVersioning</c> entirely because it is a build/dev-only
+/// dependency (<c>PrivateAssets="all"</c>, no compile-time reference DLL), so
+/// its <c>ThisAssembly</c> MSBuild source generator never runs. <see cref="TranslateStage"/>
+/// must recover the source project's nbgv declaration — even when, as in Oahu,
+/// it is split by Central Package Management across a versionless
+/// <c>&lt;PackageReference&gt;</c> in a shared <c>Directory.Build.props</c> and
+/// the actual <c>&lt;PackageVersion&gt;</c> in <c>Directory.Packages.props</c> —
+/// and publish it on <see cref="StageExecutionContext.BuildOnlyPackageReferences"/>
+/// so <see cref="CompileStage"/>/<see cref="SdkCompileRunner"/> can re-declare it.
+/// </summary>
+public class TranslateStageNbgvPackageReferenceTests
+{
+    [Fact]
+    public async Task TranslateStage_CpmSplitNbgvDeclaration_PublishesBumpedBuildOnlyPackageReference()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        // Mirrors Oahu's real layout: repo-root Directory.Packages.props pins a
+        // below-floor literal nbgv version; a nested Directory.Build.props
+        // declares the versionless, PrivateAssets="all" consumer-side reference.
+        string repoDir = NewScratchDir("translate-nbgv-cpm");
+        File.WriteAllText(
+            Path.Combine(repoDir, "Directory.Packages.props"),
+            """
+            <Project>
+              <ItemGroup>
+                <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        string srcDir = Path.Combine(repoDir, "src");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(
+            Path.Combine(srcDir, "Directory.Build.props"),
+            """
+            <Project>
+              <ItemGroup>
+                <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        string projectDir = Path.Combine(srcDir, "Sample");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "Sample.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <OutputType>Exe</OutputType>
+                <RootNamespace>Sample.App</RootNamespace>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(
+            Path.Combine(projectDir, "Program.cs"),
+            "public class Program { public static void Main() { } }");
+
+        string appRunDir = NewOutputRoot("translate-nbgv-cpm");
+        var app = new CorpusApp("test/NbgvCpmApp", projectPath, TargetKind.Exe);
+        var options = new PipelineOptions { GscPath = compiler };
+        var gsc = new GscInvoker(compiler);
+        var triage = new TriageBuilder("test-run", "2026-01-01T00:00:00Z", "0.0.0", app.Id);
+        var context = new StageExecutionContext(app, options, gsc, appRunDir, triage);
+
+        StageOutcome outcome = await new TranslateStage().ExecuteAsync(context);
+
+        Assert.Equal(StageStatus.Passed, outcome.Status);
+
+        DeclaredPackageReference nbgvReference = Assert.Single(context.BuildOnlyPackageReferences);
+        Assert.Equal(NerdbankGitVersioningPolicy.PackageId, nbgvReference.Id);
+        Assert.Equal(NerdbankGitVersioningPolicy.MinimumGSharpVersion, nbgvReference.Version);
+        Assert.Equal("all", nbgvReference.PrivateAssets);
+    }
+
+    private static string NewOutputRoot(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "pipeline-tests", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string NewScratchDir(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "loader-tests", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/gsgen/GSharp.GeneratorHost.Tests/GsgenCliTests.cs
+++ b/tools/gsgen/GSharp.GeneratorHost.Tests/GsgenCliTests.cs
@@ -143,6 +143,51 @@ public class GsgenCliTests : IDisposable
     }
 
     [Fact]
+    public void EndToEnd_RealGeneratorDll_WithRefPackReferences_PrimitiveMemberKeepsCorrectType()
+    {
+        // Regression test (issue #2261 verification): when the CALLER already
+        // supplies a complete REF-assembly closure — as the SDK's GsgenTask
+        // does via @(ReferencePathWithRefAssemblies) for a real --via-sdk
+        // build — BuildMetadataReferences must NOT additionally union in the
+        // host's own IMPL assemblies (e.g. System.Private.CoreLib.dll from
+        // the shared runtime). Mixing a framework's REF assemblies (from the
+        // targeting pack, used here) with its IMPL assembly for the same
+        // well-known types is a classic Roslyn "type exists in both ..."
+        // (CS0433) trap that makes even System.String/System.Object
+        // unresolvable (CS0518), silently degrading every primitive/string-
+        // typed generator-produced member (e.g. CommunityToolkit MVVM's
+        // [ObservableProperty] backing members) to the G# `object`
+        // placeholder. RuntimeReferencePaths() (used by the sibling test
+        // above) is IMPL-only and never reproduced this, which is why this
+        // bug went undetected until a real --via-sdk Oahu.UI migration
+        // surfaced it.
+        IReadOnlyList<string> refPackPaths = RefPackReferencePaths();
+        if (refPackPaths.Count == 0)
+        {
+            return; // Targeting pack not available in this environment; skip defensively.
+        }
+
+        string generatorDll = GeneratorDllFactory.Value;
+
+        var outDir = Path.Combine(this.workDir, "gen");
+        var gs = this.WriteGs("Foo.gs", "package App\n\n@Obsolete\npartial class Foo {\n}\n");
+
+        var args = new List<string> { $"/gs:{gs}", $"/analyzer:{generatorDll}", $"/out:{outDir}" };
+        args.AddRange(refPackPaths.Select(p => $"/r:{p}"));
+
+        var stdout = new StringWriter();
+        int exit = GsgenProgram.Run(args.ToArray(), stdout);
+
+        Assert.Equal(0, exit);
+
+        var generated = Directory.EnumerateFiles(outDir, "*.g.gs").ToList();
+        var single = Assert.Single(generated);
+        var content = File.ReadAllText(single);
+        Assert.Contains("prop Greeting string", content);
+        Assert.DoesNotContain("prop Greeting object", content);
+    }
+
+    [Fact]
     public void OrphanCleanup_DeletesStalePartNotRegenerated()
     {
         string generatorDll = GeneratorDllFactory.Value;
@@ -271,6 +316,46 @@ public class GsgenCliTests : IDisposable
             .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
             .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && File.Exists(p))
             .ToList();
+    }
+
+    /// <summary>
+    /// Locates the <c>Microsoft.NETCore.App.Ref</c> targeting-pack directory
+    /// alongside the running SDK and returns its REF-assembly DLLs — the same
+    /// kind of reference-assembly-only closure MSBuild resolves into
+    /// <c>@(ReferencePathWithRefAssemblies)</c> for a real SDK-style build,
+    /// deliberately WITHOUT any IMPL assembly (no <c>System.Private.CoreLib.dll</c>
+    /// from the shared runtime). Returns an empty list if the pack cannot be
+    /// found so callers can skip defensively rather than fail on unusual
+    /// installs.
+    /// </summary>
+    private static IReadOnlyList<string> RefPackReferencePaths()
+    {
+        string runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        string dotnetRoot = Path.GetFullPath(Path.Combine(runtimeDir, "..", "..", ".."));
+        string packsDir = Path.Combine(dotnetRoot, "packs", "Microsoft.NETCore.App.Ref");
+        if (!Directory.Exists(packsDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        string packVersionDir = Directory.GetDirectories(packsDir)
+            .OrderByDescending(d => d, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+        if (packVersionDir is null)
+        {
+            return Array.Empty<string>();
+        }
+
+        string refRoot = Path.Combine(packVersionDir, "ref");
+        if (!Directory.Exists(refRoot))
+        {
+            return Array.Empty<string>();
+        }
+
+        string refDir = Directory.GetDirectories(refRoot)
+            .OrderByDescending(d => d, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+        return refDir is null ? Array.Empty<string>() : Directory.GetFiles(refDir, "*.dll");
     }
 
     /// <summary>

--- a/tools/gsgen/Gsgen.Cli/GsgenProgram.cs
+++ b/tools/gsgen/Gsgen.Cli/GsgenProgram.cs
@@ -152,13 +152,35 @@ public static class GsgenProgram
     /// stub compilation zero references, leaving even <c>System.Obsolete</c>
     /// unresolved and every attribute-driven generator predicate a silent no-op.
     /// </summary>
+    /// <remarks>
+    /// The host fallback is applied ONLY when <paramref name="referencePaths"/>
+    /// resolves to zero usable files. A caller that already supplies its own
+    /// reference closure (e.g. the SDK's <c>GsgenTask</c>, forwarding
+    /// <c>@(ReferencePathWithRefAssemblies)</c> — the project's real,
+    /// transitively-closed REF-assembly set) must not have the host's OWN
+    /// runtime IMPL assemblies (e.g. <c>System.Private.CoreLib.dll</c> from
+    /// <c>shared/Microsoft.NETCore.App/&lt;ver&gt;/</c>) unioned in alongside
+    /// it: mixing a framework's REF assembly (from the targeting pack) with
+    /// its IMPL assembly (from the shared runtime) for the same well-known
+    /// types is a classic Roslyn "type exists in both ... and ..." (CS0433)
+    /// trap, and the resulting ambiguity makes even <c>System.String</c>/
+    /// <c>System.Object</c>/<c>System.Void</c> resolve as <see cref="SpecialType.None"/>
+    /// (CS0518 "predefined type ... is not defined"), which degraded EVERY
+    /// primitive/string-typed generator-produced member (e.g. CommunityToolkit
+    /// MVVM's <c>[ObservableProperty]</c> backing fields) to the G#
+    /// <c>object</c> placeholder even though reference/user types resolved
+    /// fine (they never go through <c>SpecialType</c>).
+    /// </remarks>
     private static IReadOnlyList<MetadataReference> BuildMetadataReferences(IReadOnlyList<string> referencePaths)
     {
         var explicitPaths = referencePaths.Where(File.Exists).ToArray();
-        var seenFileNames = new HashSet<string>(
-            explicitPaths.Select(Path.GetFileName), StringComparer.OrdinalIgnoreCase);
+        if (explicitPaths.Length > 0)
+        {
+            return explicitPaths.Select(p => (MetadataReference)MetadataReference.CreateFromFile(p)).ToList();
+        }
 
-        var all = new List<string>(explicitPaths);
+        var seenFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var all = new List<string>();
         foreach (var host in GsReferenceResolver.HostTrustedPlatformAssemblyPaths())
         {
             if (seenFileNames.Add(Path.GetFileName(host)))


### PR DESCRIPTION
## Summary

Under `cs2gs --via-sdk`, `Nerdbank.GitVersioning`'s `ThisAssembly` source was never generated because nbgv is a build/dev-only dependency (`PrivateAssets="all"`, no `lib/` DLL). `SdkCompileRunner.BuildProjectXml` reconstructs `<PackageReference>` items solely from resolved compile-time reference DLLs, so nbgv — contributing none — was silently dropped from the isolated `App.gsproj`, and its MSBuild source generator never ran (GS0157: `Cannot find type ThisAssembly`).

## Fix

Plumb the source project's declared nbgv `PackageReference` (bumped to the existing `#2225` floor, `>= 3.11.13-beta`) from `TranslateStage` into `SdkCompileRunner`'s generated gsproj:

- **`NerdbankGitVersioningPolicy`**: new `TryFindDeclaration` recovers an nbgv declaration's `Version`/`PrivateAssets`/`IncludeAssets`, correctly handling the Central Package Management split (a versionless `<PackageReference PrivateAssets="all">` in the consuming project/`Directory.Build.props` + the pinned version in `Directory.Packages.props` — Oahu's actual shape). New `ResolveEffectiveVersion` computes the concrete version for the isolated project, reusing the existing `TryGetRequiredBump` floor logic rather than duplicating it.
- **`TranslateStage.EmitNerdbankGitVersioningBumps`**: also resolves the effective nbgv declaration across the same candidate file set (app `.csproj` + ancestor `Directory.Packages.props`/`Directory.Build.props`) it already scans for the `#2225` bump, and publishes it on a new `StageExecutionContext.BuildOnlyPackageReferences` list.
- **`DeclaredPackageReference`** (new type): intentionally generic, not nbgv-specific, so other declared build-only/analyzer `PackageReference`s can be threaded through the same mechanism later.
- **`CompileStage`**: forwards `context.BuildOnlyPackageReferences` to `SdkCompileRunner.Compile`.
- **`SdkCompileRunner`**: accepts `declaredPackageReferences`, skips any already covered by a resolved compile-time DLL (avoids a duplicate `<PackageReference>`), and `BuildProjectXml` (made `internal` for testability) renders the rest with `PrivateAssets`/`IncludeAssets` preserved.

## Testing

- `SdkCompileRunnerTests`: `BuildProjectXml` emits the nbgv `PackageReference` with the bumped version + `PrivateAssets="all"`, and does not duplicate a package already reconstructed from a DLL.
- `NerdbankGitVersioningPolicyTests`: `TryFindDeclaration` across the plain, versionless (CPM consumer-side), and `PackageVersion` (CPM version-side) shapes; `ResolveEffectiveVersion` bump/preserve/fallback matrix.
- `TranslateStageNbgvPackageReferenceTests`: stage-level test reproducing Oahu's exact CPM split (root `Directory.Packages.props` + nested `Directory.Build.props`) and asserting `BuildOnlyPackageReferences` is populated with the bumped nbgv reference.

Run via filter:
```
dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~SdkCompileRunnerTests|FullyQualifiedName~NerdbankGitVersioningPolicyTests|FullyQualifiedName~TranslateStageNbgvPackageReferenceTests"
```
56/56 passed (also re-verified `MigrationPipelineTests` and `Issue2215AnalyzerReferenceTests`, 12/12 passed, unaffected).

## End-to-end validation (Oahu.Foundation, `--via-sdk`)

Before: compile failed with `GS0157: Cannot find type ThisAssembly` (plus the unrelated `#2259` `?[]` nullability gap).

After: the generated `App.gsproj` now contains:
```xml
<PackageReference Include="Nerdbank.GitVersioning" Version="3.11.13-beta" PrivateAssets="all" />
```
and nbgv's generator emits `obj/Release/net10.0/App.Version.gs`:
```
internal class ThisAssembly {
  shared {
    internal let AssemblyConfiguration string = "Release"
    ...
    internal let GitCommitId string = "615d75dd344c30f86e5ff1869f20d9deb1c7b598"
    ...
  }
}
```
The only remaining compile error is the pre-existing, unrelated `#2259` `GS0156` (`?[]` conditional-indexer nullability) — matching the issue's stated validation target exactly.

Closes #2267.
