### PR TITLE
Fix #2258: peel qualified CLR prefix in struct-literal position

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -200,12 +200,84 @@ internal sealed partial class ExpressionBinder
         var typeSimpleName = terminalCall.Identifier.Text;
         var namespacePrefix = string.Join(".", segments);
 
-        if (!TryResolveQualifiedClrType(namespacePrefix, typeSimpleName, terminalCall, out var clrType, out var openGenericDef, out var symbolicArgs))
+        if (!TryResolveQualifiedClrType(namespacePrefix, typeSimpleName, terminalCall.TypeArgumentList, out var clrType, out var openGenericDef, out var symbolicArgs))
         {
             return false;
         }
 
         return TryBindClrConstructorFromType(clrType, terminalCall, out result, openGenericDef, symbolicArgs);
+    }
+
+    /// <summary>
+    /// Issue #2258: binds a fully-qualified imported-type object-initializer
+    /// literal written in expression position, e.g.
+    /// <c>System.Text.Json.JsonWriterOptions{ Indented: true }</c>. Such an
+    /// expression parses as an accessor chain whose terminal segment is the
+    /// struct literal (<see cref="StructLiteralExpressionSyntax"/>), so it never
+    /// reaches the simple-name literal path in <see cref="BindStructLiteralExpression(StructLiteralExpressionSyntax)"/>.
+    /// This walks the dotted name the same way <see cref="TryBindQualifiedClrConstructorCall"/>
+    /// does, resolves the closed CLR type via the active references/imports, and
+    /// binds the literal against it — generalizing to any referenced CLR type
+    /// (class or struct) at any namespace depth.
+    /// </summary>
+    /// <param name="syntax">The accessor expression to bind.</param>
+    /// <param name="result">The bound struct-literal expression on success.</param>
+    /// <returns>Whether the accessor was a fully-qualified struct literal that bound successfully.</returns>
+    private bool TryBindQualifiedClrStructLiteral(AccessorExpressionSyntax syntax, out BoundExpression result)
+    {
+        result = null;
+
+        if (syntax.IsNullConditional)
+        {
+            return false;
+        }
+
+        // Flatten the accessor chain into the leading namespace/type segments
+        // and the terminal struct literal. Anything that isn't a pure
+        // dotted-name chain ending in a struct literal is not a qualified
+        // literal.
+        var segments = new List<string>();
+        ExpressionSyntax current = syntax;
+        StructLiteralExpressionSyntax terminalLiteral = null;
+        while (true)
+        {
+            if (current is AccessorExpressionSyntax accessor)
+            {
+                if (accessor.IsNullConditional || !(accessor.LeftPart is NameExpressionSyntax leftName))
+                {
+                    return false;
+                }
+
+                segments.Add(leftName.IdentifierToken.Text);
+                current = accessor.RightPart;
+                continue;
+            }
+
+            if (current is StructLiteralExpressionSyntax literal)
+            {
+                terminalLiteral = literal;
+                break;
+            }
+
+            // A bare trailing name/call is not a struct literal.
+            return false;
+        }
+
+        if (terminalLiteral == null || terminalLiteral.TypeIdentifier.IsMissing)
+        {
+            return false;
+        }
+
+        var typeSimpleName = terminalLiteral.TypeIdentifier.Text;
+        var namespacePrefix = string.Join(".", segments);
+
+        if (!TryResolveQualifiedClrType(namespacePrefix, typeSimpleName, terminalLiteral.TypeArgumentList, out var clrType, out _, out _))
+        {
+            return false;
+        }
+
+        result = BindImportedTypeLiteralExpression(terminalLiteral, clrType);
+        return true;
     }
 
     /// <summary>
@@ -323,12 +395,16 @@ internal sealed partial class ExpressionBinder
     /// Resolves a closed CLR type from a fully-qualified dotted name written in
     /// source. Tries the name as written, the name with the leading segment
     /// expanded from a matching import alias/path, and the name prefixed by each
-    /// active import target. Generic type arguments on <paramref name="terminalCall"/>
+    /// active import target. Generic type arguments on <paramref name="typeArgumentList"/>
     /// are honoured by resolving the mangled open generic and closing it.
     /// </summary>
     /// <param name="namespacePrefix">The dotted segments preceding the type name (may be empty).</param>
-    /// <param name="typeSimpleName">The simple type name (the constructor call identifier).</param>
-    /// <param name="terminalCall">The terminal call, used for generic arity/arguments.</param>
+    /// <param name="typeSimpleName">The simple type name (the constructor call / struct literal identifier).</param>
+    /// <param name="typeArgumentList">
+    /// The terminal's explicit type-argument list (from a constructor call or a
+    /// struct literal), used for generic arity/arguments; <see langword="null"/>
+    /// for a non-generic reference.
+    /// </param>
     /// <param name="clrType">The resolved closed CLR type on success.</param>
     /// <param name="openGenericDefinition">
     /// Issue #671: when one or more type arguments are G# user-defined types
@@ -345,7 +421,7 @@ internal sealed partial class ExpressionBinder
     private bool TryResolveQualifiedClrType(
         string namespacePrefix,
         string typeSimpleName,
-        CallExpressionSyntax terminalCall,
+        TypeArgumentListSyntax typeArgumentList,
         out System.Type clrType,
         out System.Type openGenericDefinition,
         out ImmutableArray<TypeSymbol> symbolicTypeArgs)
@@ -354,7 +430,7 @@ internal sealed partial class ExpressionBinder
         openGenericDefinition = null;
         symbolicTypeArgs = default;
 
-        var arity = terminalCall.TypeArgumentList?.Arguments.Count ?? 0;
+        var arity = typeArgumentList?.Arguments.Count ?? 0;
 
         // Build the candidate dotted prefixes (everything before the simple
         // type name), most specific first.
@@ -411,7 +487,7 @@ internal sealed partial class ExpressionBinder
                     var hasSymbolicArg = false;
                     for (var i = 0; i < arity; i++)
                     {
-                        var ta = bindTypeClause(terminalCall.TypeArgumentList.Arguments[i]);
+                        var ta = bindTypeClause(typeArgumentList.Arguments[i]);
                         if (ta == null)
                         {
                             argsResolved = false;
@@ -479,7 +555,7 @@ internal sealed partial class ExpressionBinder
         // This covers `Outer.Inner()`, `Ns.Outer.Inner()`, and deeply-nested
         // chains like `Outer.Middle.Inner()` where the prefix segments include
         // both namespace and outer-type components.
-        if (TryResolveAsNestedTypeChain(namespacePrefix, typeSimpleName, arity, terminalCall, out clrType))
+        if (TryResolveAsNestedTypeChain(namespacePrefix, typeSimpleName, arity, typeArgumentList, out clrType))
         {
             return true;
         }
@@ -493,7 +569,7 @@ internal sealed partial class ExpressionBinder
     /// find the outer type, then remaining segments and the terminal name are
     /// walked as nested types via <see cref="ReferenceResolver.TryResolveNestedType"/>.
     /// </summary>
-    private bool TryResolveAsNestedTypeChain(string namespacePrefix, string typeSimpleName, int arity, CallExpressionSyntax terminalCall, out System.Type clrType)
+    private bool TryResolveAsNestedTypeChain(string namespacePrefix, string typeSimpleName, int arity, TypeArgumentListSyntax typeArgumentList, out System.Type clrType)
     {
         clrType = null;
         if (string.IsNullOrEmpty(namespacePrefix))
@@ -573,7 +649,7 @@ internal sealed partial class ExpressionBinder
                 var argsResolved = true;
                 for (var i = 0; i < arity; i++)
                 {
-                    var ta = bindTypeClause(terminalCall.TypeArgumentList.Arguments[i]);
+                    var ta = bindTypeClause(typeArgumentList.Arguments[i]);
                     if (ta?.ClrType == null)
                     {
                         argsResolved = false;
@@ -650,6 +726,15 @@ internal sealed partial class ExpressionBinder
         if (TryBindQualifiedClrConstructorCall(syntax, out var qualifiedCtorCall))
         {
             return qualifiedCtorCall;
+        }
+
+        // Issue #2258: a fully-qualified imported-type object-initializer
+        // literal (`System.Text.Json.JsonWriterOptions{ Indented: true }`)
+        // parses as an accessor chain whose terminal segment is the struct
+        // literal, so it never reaches the simple-name literal path below.
+        if (TryBindQualifiedClrStructLiteral(syntax, out var qualifiedClrLiteral))
+        {
+            return qualifiedClrLiteral;
         }
 
         // A same-compilation SOURCE type constructed/referenced through a

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -924,14 +924,17 @@ internal sealed partial class ExpressionBinder
             var preferredArity = syntax.TypeArgumentList != null ? syntax.TypeArgumentList.Arguments.Count : -1;
             if (!scope.TryLookupTypeAlias(typeName, preferredArity, out var resolvedType) || !(resolvedType is StructSymbol resolvedStruct))
             {
-                // Issue #1199: a composite literal `T{Field: value}` also targets
-                // an IMPORTED reference-type class (a BCL class such as
-                // `System.Text.Json.JsonSerializerOptions`). These resolve through
-                // the import table — not `TryLookupTypeAlias`, which only surfaces
-                // user-declared types — so route the literal through the same
-                // imported-class lookup that the constructor-call path uses and
-                // lower it to a C#-style object-initializer (construct via the
-                // parameterless ctor, then assign each named member).
+                // Issue #1199 / #2258: a composite literal `T{Field: value}` also
+                // targets an IMPORTED reference-type class (a BCL class such as
+                // `System.Text.Json.JsonSerializerOptions`) or an imported
+                // value-type struct (`System.Text.Json.JsonWriterOptions`). These
+                // resolve through the import table — not `TryLookupTypeAlias`,
+                // which only surfaces user-declared types — so route the literal
+                // through the same imported-class lookup that the
+                // constructor-call path uses and lower it to a C#-style
+                // object-initializer (construct via the parameterless
+                // constructor, or the zero value for a value type with none,
+                // then assign each named member).
                 if (syntax.TypeArgumentList == null
                     && scope.TryLookupImportedClass(typeName, declaration: null, out var importedClass)
                     && importedClass.ClassType is { IsGenericTypeDefinition: false })
@@ -940,14 +943,9 @@ internal sealed partial class ExpressionBinder
                     {
                         structSymbol = importedAggregate;
                     }
-                    else if (!importedClass.ClassType.IsValueType)
-                    {
-                        return BindImportedClassLiteralExpression(syntax, importedClass.ClassType);
-                    }
                     else
                     {
-                        Diagnostics.ReportUnableToFindType(syntax.TypeIdentifier.Location, typeName);
-                        return new BoundErrorExpression(null);
+                        return BindImportedTypeLiteralExpression(syntax, importedClass.ClassType);
                     }
                 }
                 else if (structSymbol == null)
@@ -1234,6 +1232,19 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #2258: dispatches a composite literal <c>T{Member: value, ...}</c>
+    /// on an imported CLR type (resolved either by simple name through the
+    /// import table, or by a fully-qualified namespace path via
+    /// <see cref="TryBindQualifiedClrStructLiteral"/>) to the reference-type or
+    /// value-type binder, mirroring the C# object-initializer contract for
+    /// either kind.
+    /// </summary>
+    private BoundExpression BindImportedTypeLiteralExpression(StructLiteralExpressionSyntax syntax, Type clrType)
+        => clrType.IsValueType
+            ? BindImportedValueTypeLiteralExpression(syntax, clrType)
+            : BindImportedClassLiteralExpression(syntax, clrType);
+
+    /// <summary>
     /// Issue #1199: binds a composite literal <c>T{Member: value, ...}</c> on an
     /// IMPORTED reference-type class (e.g. <c>JsonSerializerOptions{WriteIndented:
     /// true}</c>). It lowers to the same shape as the object-initializer suffix
@@ -1271,6 +1282,50 @@ internal sealed partial class ExpressionBinder
             ImmutableArray<BoundExpression>.Empty,
             resultType);
 
+        return BindImportedTypeObjectInitializer(syntax, clrType, resultType, construction);
+    }
+
+    /// <summary>
+    /// Issue #2258: binds a composite literal <c>T{Member: value, ...}</c> on an
+    /// IMPORTED VALUE-TYPE struct (e.g.
+    /// <c>System.Text.Json.JsonWriterOptions{ Indented: true }</c>). Unlike a
+    /// reference type, reflection never synthesizes a public parameterless
+    /// constructor for a plain value type (one only appears when the type
+    /// explicitly declares a C# 10+ parameterless struct constructor), so the
+    /// instance is seeded with its default/zero value (mirroring IL
+    /// <c>initobj</c>) when no explicit parameterless constructor is found. The
+    /// remaining member-assignment lowering is shared with the reference-type
+    /// path; the value-type receiver is written in place through its local slot
+    /// (see <c>EmitClrPropertyAssignment</c>'s addressable-receiver handling), so
+    /// no copy-back step is needed.
+    /// </summary>
+    private BoundExpression BindImportedValueTypeLiteralExpression(StructLiteralExpressionSyntax syntax, Type clrType)
+    {
+        var resultType = TypeSymbol.FromClrType(clrType);
+        var parameterlessCtor = ClrTypeUtilities
+            .SafeGetConstructors(clrType, BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(c => c.GetParameters().Length == 0);
+        BoundExpression construction = parameterlessCtor != null
+            ? new BoundClrConstructorCallExpression(
+                syntax,
+                clrType,
+                parameterlessCtor,
+                ImmutableArray<BoundExpression>.Empty,
+                resultType)
+            : new BoundDefaultExpression(syntax, resultType);
+
+        return BindImportedTypeObjectInitializer(syntax, clrType, resultType, construction);
+    }
+
+    /// <summary>
+    /// Issue #1199 / #2258: shared object-initializer lowering for an imported
+    /// CLR type composite literal — assigns each named settable property/field
+    /// through a synthetic local seeded with <paramref name="construction"/>
+    /// (a constructor call or a default-value expression), and yields the
+    /// local. Shared by the reference-type and value-type literal binders.
+    /// </summary>
+    private BoundExpression BindImportedTypeObjectInitializer(StructLiteralExpressionSyntax syntax, Type clrType, TypeSymbol resultType, BoundExpression construction)
+    {
         var tempName = "$implit" + System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter).ToString(System.Globalization.CultureInfo.InvariantCulture);
         var tempVar = new LocalVariableSymbol(tempName, isReadOnly: true, resultType);
         scope.TryDeclareVariable(tempVar);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2258QualifiedClrLiteralTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2258QualifiedClrLiteralTests.cs
@@ -1,0 +1,139 @@
+// <copyright file="Issue2258QualifiedClrLiteralTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2258: cs2gs fully-qualifies every CLR (referenced-assembly) type
+/// reference, the same way it qualifies source types (#2256/#2257). gsc
+/// already peels a qualified prefix off a CLR *constructor* call
+/// (<c>TryBindQualifiedClrConstructorCall</c>) and, as of the #2256/#2257
+/// follow-up, off CLR *enum-member* and *static-member* access
+/// (<c>TryBindFullyQualifiedClrStaticAccess</c>). The remaining gap was the
+/// CLR *struct/class object-initializer literal* position
+/// (<c>Type{ Member: value }</c>): a fully-qualified reference to such a
+/// literal failed GS0157, and — for an imported VALUE-TYPE struct — even a
+/// simple name with an explicit import failed, because
+/// <c>BindStructLiteralExpression</c> only knew how to construct an imported
+/// reference type (via its public parameterless constructor); it had no path
+/// for a plain imported value type, which virtually never has one.
+/// <para>
+/// These tests pin: (1) a fully-qualified CLR struct literal with a deep,
+/// non-<c>System</c> namespace prefix and no explicit import at all binds and
+/// evaluates correctly; (2) an imported CLR value-type literal referenced by
+/// its simple name (via an explicit import) binds and evaluates; and, for
+/// completeness alongside the sibling positions, (3) a fully-qualified CLR
+/// enum-member access and (4) a fully-qualified CLR static-member access, both
+/// under a multi-segment, non-<c>System</c>-only namespace, still bind
+/// without diagnostics.
+/// </para>
+/// </summary>
+public class Issue2258QualifiedClrLiteralTests
+{
+    [Fact]
+    public void QualifiedClrStructLiteral_NoImport_BindsAndEvaluates()
+    {
+        // The exact shape reported in issue #2258:
+        // `System.Text.Json.JsonWriterOptions{ Indented: true }`. No import at
+        // all is declared, so the literal must resolve purely from the
+        // fully-qualified dotted name. Force-load the assembly so the
+        // default host-assembly reference set (issue #2256 test convention)
+        // includes it.
+        _ = typeof(System.Text.Json.JsonWriterOptions).Assembly;
+
+        var source = @"
+let opts = System.Text.Json.JsonWriterOptions{Indented: true}
+opts.Indented
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void QualifiedClrStructLiteral_DeepNamespace_ValueType_BindsAndEvaluates()
+    {
+        // A qualified CLR VALUE-TYPE literal (no explicit parameterless
+        // constructor on System.Numerics.Vector2 — the instance must be seeded
+        // with its default/zero value) whose members are public mutable
+        // fields (not properties), exercising the field-assignment path of the
+        // shared object-initializer lowering.
+        var source = @"
+let v = System.Numerics.Vector2{X: 1.5f, Y: 2.5f}
+v.X
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1.5f, result.Value);
+    }
+
+    [Fact]
+    public void ImportedClrValueTypeLiteral_SimpleName_BindsAndEvaluates()
+    {
+        // Root-cause regression: prior to the fix, a plain imported CLR VALUE
+        // TYPE failed the composite-literal even by simple name with an
+        // explicit import, because only imported reference types (and gsc's
+        // own cross-assembly "semantic aggregate" structs) were supported.
+        var source = @"
+import System.Numerics
+
+let v = Vector2{X: 3.5f, Y: 4.5f}
+v.Y
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(4.5f, result.Value);
+    }
+
+    [Fact]
+    public void QualifiedClrEnumMember_DeepNamespace_Binds()
+    {
+        // A multi-segment (non-`System`-only) namespace enum-member access:
+        // `System.Text.Json.JsonCommentHandling.Skip`. Proves the walk
+        // correctly peels every intermediate namespace segment, not just the
+        // implicitly-imported root.
+        _ = typeof(System.Text.Json.JsonCommentHandling).Assembly;
+
+        var source = @"
+import System.Text.Json
+
+let c = System.Text.Json.JsonCommentHandling.Skip
+c
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedClrStaticMember_DeepNamespace_Binds()
+    {
+        // A multi-segment (non-`System`-only) namespace static-property
+        // access: `System.Text.Json.JsonSerializerOptions.Default`.
+        _ = typeof(System.Text.Json.JsonSerializerOptions).Assembly;
+
+        var source = @"
+import System.Text.Json
+
+let o = System.Text.Json.JsonSerializerOptions.Default
+o
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary

Issue #2258 is the direct analog of #2256/#2257: gsc should peel a fully-qualified-name (FQN) CLR namespace prefix off certain member accesses so that a fully-qualified reference to a referenced-assembly (CLR/BCL) type resolves the same way an imported/short name does.

Investigating the three positions listed in the issue:

1. **Enum-member access** (e.g. `System.StringComparison.Ordinal`) — already fixed in #2257 (`TryBindFullyQualifiedClrStaticAccess`).
2. **Static-member access** (e.g. `System.Math.PI`, `System.String.Empty`) — already fixed in #2257 (same helper).
3. **Struct-literal / data construction** (e.g. `System.Text.Json.JsonWriterOptions{ Indented: true }`) — not handled anywhere: such an expression parses as a dotted `AccessorExpressionSyntax` chain whose terminal segment is a struct literal, and no existing code path walked that chain looking for a qualified CLR type. This PR closes that gap.

While implementing position 3, a deeper, related gap surfaced: even a simple-name imported CLR value-type literal (with an explicit `import`) failed, because `BindStructLiteralExpression` only knew how to construct an imported reference type (via its public parameterless constructor) or one of gsc's own cross-assembly "semantic aggregate" structs. A plain imported value type had no path at all and unconditionally reported `GS0157`. Real BCL/3rd-party value types essentially never expose a synthesized parameterless constructor (e.g. `System.Numerics.Vector2`, `System.Text.Json.JsonWriterOptions`), so this was the true missing feature, not just prefix-peeling.

## Changes

- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs`
  - Generalized `TryResolveQualifiedClrType` / `TryResolveAsNestedTypeChain` to accept a `TypeArgumentListSyntax` instead of being tied to a `CallExpressionSyntax`, so the resolver can be shared by both constructor calls and struct literals.
  - Added `TryBindQualifiedClrStructLiteral`, mirroring `TryBindQualifiedClrConstructorCall`: flattens the dotted accessor chain into namespace segments plus a terminal struct literal, resolves the CLR type via the shared resolver, and dispatches to `BindImportedTypeLiteralExpression`. Wired into `BindAccessorExpression` right after the constructor-call check. Generalizes to any namespace depth and any imported CLR type, not just `System.*`.
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs`
  - `BindStructLiteralExpression`'s simple-name imported-type branch now routes through the new `BindImportedTypeLiteralExpression` dispatcher instead of unconditionally reporting `GS0157` for value types.
  - Added `BindImportedTypeLiteralExpression` (dispatches on `Type.IsValueType`), `BindImportedValueTypeLiteralExpression` (seeds the instance from an explicit parameterless constructor if one exists, otherwise a default-value expression mirroring IL `initobj`), and extracted the shared member-assignment lowering into `BindImportedTypeObjectInitializer`, reused by both the reference-type and value-type binders.
  - No emitter changes were needed: value-type property/field assignment through `EmitClrPropertyAssignment`'s existing addressable-receiver (`ldloca`) handling already supports this once construction is seeded correctly.

## Tests

Added `test/Core.Tests/CodeAnalysis/Binding/Issue2258QualifiedClrLiteralTests.cs`:

- `QualifiedClrStructLiteral_NoImport_BindsAndEvaluates` — fully-qualified struct literal, no import at all (`System.Text.Json.JsonWriterOptions{Indented: true}`).
- `QualifiedClrStructLiteral_DeepNamespace_ValueType_BindsAndEvaluates` — fully-qualified value-type literal under a deep, non-`System`-only namespace (`System.Numerics.Vector2{X:1.5f, Y:2.5f}`).
- `ImportedClrValueTypeLiteral_SimpleName_BindsAndEvaluates` — the root-cause regression: a simple-name imported value-type literal with an explicit `import`.
- `QualifiedClrEnumMember_DeepNamespace_Binds` / `QualifiedClrStaticMember_DeepNamespace_Binds` — added for completeness alongside positions 1 & 2, confirming they still bind under a deep namespace.

Full suite: `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` → 5895 passed, 0 failed, 1 skipped.

`dotnet build src/Compiler/Compiler.csproj -c Release` → 0 warnings, 0 errors (StyleCop-clean).

No new `SyntaxKind`/`BoundNodeKind` were introduced (confirmed via the coverage-matrix golden test passing), so no coverage-matrix updates were required.

Closes #2258.
