### PR TITLE
gsgen: fix CS0433/CS0518 corlib ambiguity degrading generator-backtranslated primitives to object

### DIFF
--- a/tools/gsgen/GSharp.GeneratorHost.Tests/GsgenCliTests.cs
+++ b/tools/gsgen/GSharp.GeneratorHost.Tests/GsgenCliTests.cs
@@ -143,6 +143,51 @@ public class GsgenCliTests : IDisposable
     }
 
     [Fact]
+    public void EndToEnd_RealGeneratorDll_WithRefPackReferences_PrimitiveMemberKeepsCorrectType()
+    {
+        // Regression test (issue #2261 verification): when the CALLER already
+        // supplies a complete REF-assembly closure — as the SDK's GsgenTask
+        // does via @(ReferencePathWithRefAssemblies) for a real --via-sdk
+        // build — BuildMetadataReferences must NOT additionally union in the
+        // host's own IMPL assemblies (e.g. System.Private.CoreLib.dll from
+        // the shared runtime). Mixing a framework's REF assemblies (from the
+        // targeting pack, used here) with its IMPL assembly for the same
+        // well-known types is a classic Roslyn "type exists in both ..."
+        // (CS0433) trap that makes even System.String/System.Object
+        // unresolvable (CS0518), silently degrading every primitive/string-
+        // typed generator-produced member (e.g. CommunityToolkit MVVM's
+        // [ObservableProperty] backing members) to the G# `object`
+        // placeholder. RuntimeReferencePaths() (used by the sibling test
+        // above) is IMPL-only and never reproduced this, which is why this
+        // bug went undetected until a real --via-sdk Oahu.UI migration
+        // surfaced it.
+        IReadOnlyList<string> refPackPaths = RefPackReferencePaths();
+        if (refPackPaths.Count == 0)
+        {
+            return; // Targeting pack not available in this environment; skip defensively.
+        }
+
+        string generatorDll = GeneratorDllFactory.Value;
+
+        var outDir = Path.Combine(this.workDir, "gen");
+        var gs = this.WriteGs("Foo.gs", "package App\n\n@Obsolete\npartial class Foo {\n}\n");
+
+        var args = new List<string> { $"/gs:{gs}", $"/analyzer:{generatorDll}", $"/out:{outDir}" };
+        args.AddRange(refPackPaths.Select(p => $"/r:{p}"));
+
+        var stdout = new StringWriter();
+        int exit = GsgenProgram.Run(args.ToArray(), stdout);
+
+        Assert.Equal(0, exit);
+
+        var generated = Directory.EnumerateFiles(outDir, "*.g.gs").ToList();
+        var single = Assert.Single(generated);
+        var content = File.ReadAllText(single);
+        Assert.Contains("prop Greeting string", content);
+        Assert.DoesNotContain("prop Greeting object", content);
+    }
+
+    [Fact]
     public void OrphanCleanup_DeletesStalePartNotRegenerated()
     {
         string generatorDll = GeneratorDllFactory.Value;
@@ -271,6 +316,46 @@ public class GsgenCliTests : IDisposable
             .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
             .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && File.Exists(p))
             .ToList();
+    }
+
+    /// <summary>
+    /// Locates the <c>Microsoft.NETCore.App.Ref</c> targeting-pack directory
+    /// alongside the running SDK and returns its REF-assembly DLLs — the same
+    /// kind of reference-assembly-only closure MSBuild resolves into
+    /// <c>@(ReferencePathWithRefAssemblies)</c> for a real SDK-style build,
+    /// deliberately WITHOUT any IMPL assembly (no <c>System.Private.CoreLib.dll</c>
+    /// from the shared runtime). Returns an empty list if the pack cannot be
+    /// found so callers can skip defensively rather than fail on unusual
+    /// installs.
+    /// </summary>
+    private static IReadOnlyList<string> RefPackReferencePaths()
+    {
+        string runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        string dotnetRoot = Path.GetFullPath(Path.Combine(runtimeDir, "..", "..", ".."));
+        string packsDir = Path.Combine(dotnetRoot, "packs", "Microsoft.NETCore.App.Ref");
+        if (!Directory.Exists(packsDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        string packVersionDir = Directory.GetDirectories(packsDir)
+            .OrderByDescending(d => d, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+        if (packVersionDir is null)
+        {
+            return Array.Empty<string>();
+        }
+
+        string refRoot = Path.Combine(packVersionDir, "ref");
+        if (!Directory.Exists(refRoot))
+        {
+            return Array.Empty<string>();
+        }
+
+        string refDir = Directory.GetDirectories(refRoot)
+            .OrderByDescending(d => d, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+        return refDir is null ? Array.Empty<string>() : Directory.GetFiles(refDir, "*.dll");
     }
 
     /// <summary>

--- a/tools/gsgen/Gsgen.Cli/GsgenProgram.cs
+++ b/tools/gsgen/Gsgen.Cli/GsgenProgram.cs
@@ -152,13 +152,35 @@ public static class GsgenProgram
     /// stub compilation zero references, leaving even <c>System.Obsolete</c>
     /// unresolved and every attribute-driven generator predicate a silent no-op.
     /// </summary>
+    /// <remarks>
+    /// The host fallback is applied ONLY when <paramref name="referencePaths"/>
+    /// resolves to zero usable files. A caller that already supplies its own
+    /// reference closure (e.g. the SDK's <c>GsgenTask</c>, forwarding
+    /// <c>@(ReferencePathWithRefAssemblies)</c> — the project's real,
+    /// transitively-closed REF-assembly set) must not have the host's OWN
+    /// runtime IMPL assemblies (e.g. <c>System.Private.CoreLib.dll</c> from
+    /// <c>shared/Microsoft.NETCore.App/&lt;ver&gt;/</c>) unioned in alongside
+    /// it: mixing a framework's REF assembly (from the targeting pack) with
+    /// its IMPL assembly (from the shared runtime) for the same well-known
+    /// types is a classic Roslyn "type exists in both ... and ..." (CS0433)
+    /// trap, and the resulting ambiguity makes even <c>System.String</c>/
+    /// <c>System.Object</c>/<c>System.Void</c> resolve as <see cref="SpecialType.None"/>
+    /// (CS0518 "predefined type ... is not defined"), which degraded EVERY
+    /// primitive/string-typed generator-produced member (e.g. CommunityToolkit
+    /// MVVM's <c>[ObservableProperty]</c> backing fields) to the G#
+    /// <c>object</c> placeholder even though reference/user types resolved
+    /// fine (they never go through <c>SpecialType</c>).
+    /// </remarks>
     private static IReadOnlyList<MetadataReference> BuildMetadataReferences(IReadOnlyList<string> referencePaths)
     {
         var explicitPaths = referencePaths.Where(File.Exists).ToArray();
-        var seenFileNames = new HashSet<string>(
-            explicitPaths.Select(Path.GetFileName), StringComparer.OrdinalIgnoreCase);
+        if (explicitPaths.Length > 0)
+        {
+            return explicitPaths.Select(p => (MetadataReference)MetadataReference.CreateFromFile(p)).ToList();
+        }
 
-        var all = new List<string>(explicitPaths);
+        var seenFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var all = new List<string>();
         foreach (var host in GsReferenceResolver.HostTrustedPlatformAssemblyPaths())
         {
             if (seenFileNames.Add(Path.GetFileName(host)))


### PR DESCRIPTION
## Summary

While empirically verifying #2261's `--via-sdk` generator coverage (see the tracking comment posted on #2261 for the full per-category evidence), found and fixed a concrete, small bug in `gsgen`'s reference resolution for its generator-output back-translation compilation.

## The bug

`GsgenProgram.BuildMetadataReferences` unconditionally unioned the host's own trusted-platform-assembly (IMPL) references on top of the caller's already-complete explicit reference closure. For a real `--via-sdk` build, the caller (`GsgenTask`, forwarding `@(ReferencePathWithRefAssemblies)`) already supplies the project's full REF-assembly closure. Adding the host's IMPL assemblies (e.g. `System.Private.CoreLib.dll` from the shared runtime) on top of a REF assembly (e.g. `System.Runtime.dll` from the targeting pack) for the same framework caused Roslyn to report the well-known BCL types as ambiguous (`CS0433`/`CS0518`), which silently degraded every primitive/string-typed generator-produced member (e.g. CommunityToolkit MVVM's `[ObservableProperty]` backing members, Nerdbank.GitVersioning's `ThisAssembly` constants) to the G# `object` placeholder.

## The fix

The host-TPA fallback now only applies when the caller's explicit reference list resolves to zero usable files -- matching the method's own documented original intent (issue #2215: "a caller that omits `/r:`").

## Verification

- `e2etests/gsgen-e2e.sh` (MVVM sample): `Message` property now correctly typed `string` (was `object`).
- `e2etests/foreign-cs-e2e.sh` (nbgv/ThisAssembly stand-in): all constants now correctly typed `string` (was `object`).
- Real `corpus/Oahu.UI` `--via-sdk` migration: compile errors dropped from 78 to 47; zero remaining errors reference `object`-typed generator members. `BookLibraryViewModel.g.gs` now shows `prop HasSelectedBook bool`, `prop FilterText string`, `prop SelectedCount int32`, etc. instead of `object`.
- `GSharp.GeneratorHost.Tests`: 27/27 pass (added a new regression test that reproduces the bug using the real `Microsoft.NETCore.App.Ref` targeting-pack reference closure -- the existing tests only used `TRUSTED_PLATFORM_ASSEMBLIES`, which is impl-only and never triggered the ambiguity; confirmed the new test fails without the fix and passes with it).
- `Cs2Gs.Tests`: 1281/1281 pass.

Closes #2274.
