### PR TITLE
Fix #2273: resolve import type-alias (import R = Namespace.Type) at use sites

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -5600,6 +5600,47 @@ public sealed class Binder
             return TypeSymbol.FromClrType(importedClass.ClassType);
         }
 
+        // Issue #2273: `import R = Namespace.Type` names a TYPE outright (not a
+        // namespace) — a C# `using R = Some.Type;` analog. Unlike a plain
+        // `import Some.Namespace`, whose target is never itself a type, an
+        // ALIAS's target is resolved directly as a type so `R` is usable
+        // anywhere the aliased type's own name would be: here (type-clause
+        // position, e.g. `var x R = ...`), and — via this same method — at
+        // static-member/nested-type use sites that fall back to it. Handles
+        // both an imported CLR type (`import R = System.Math` then `R.PI`) and
+        // a same-compilation SOURCE type declared in another package (the
+        // conventional resx `import R = ...Properties.Resources` pattern),
+        // generalized to any namespace depth.
+        if (scope.TryLookupImport(name, out var aliasImport) && aliasImport.IsAlias)
+        {
+            var aliasTarget = aliasImport.Target;
+
+            if (scope.References.TryResolveType(aliasTarget, out var clrAliasType))
+            {
+                if (ImportedTypeSymbol.TryCreateSemanticAggregate(clrAliasType, scope.References, out var clrAggregate))
+                {
+                    return clrAggregate;
+                }
+
+                return TypeSymbol.FromClrType(clrAliasType);
+            }
+
+            // Source types are visible by simple (possibly nested) name across
+            // packages, but have no reflectable CLR type while binding, so the
+            // resolver above never sees them. Resolve the alias target's final
+            // dotted segment as a source type name instead.
+            var lastDot = aliasTarget.LastIndexOf('.');
+            var aliasSimpleName = lastDot >= 0 ? aliasTarget.Substring(lastDot + 1) : aliasTarget;
+            if (!string.Equals(aliasSimpleName, name, System.StringComparison.Ordinal))
+            {
+                var aliasedSourceType = LookupType(aliasSimpleName, preferredArity);
+                if (aliasedSourceType != null && !ReferenceEquals(aliasedSourceType, TypeSymbol.Error))
+                {
+                    return aliasedSourceType;
+                }
+            }
+        }
+
         return null;
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1009,6 +1009,42 @@ internal sealed partial class ExpressionBinder
             {
                 classSymbol = typeFromImport;
             }
+            else if (scope.TryLookupImport(name, out var matchedTypeAliasImport)
+                && matchedTypeAliasImport.IsAlias
+                && lookupType(name) is TypeSymbol aliasedType)
+            {
+                // Issue #2273: `import R = Namespace.Type` where the aliased
+                // target is a same-compilation SOURCE type (a class/struct,
+                // enum, or interface declared elsewhere in this compilation —
+                // e.g. the conventional resx `import R = ...Properties.Resources`
+                // pattern) rather than a CLR type. `TryBindImportAccessor` above
+                // only resolves CLR alias targets via the reference resolver, so
+                // a source-type alias falls through to here; `lookupType` (bound
+                // to `Binder.LookupType`) now also resolves an alias's target
+                // through the same import, so it recovers the aliased type
+                // symbol directly.
+                if (aliasedType is EnumSymbol foundAliasEnum)
+                {
+                    enumSymbol = foundAliasEnum;
+                }
+                else if (aliasedType is StructSymbol foundAliasStruct)
+                {
+                    userStructSymbol = foundAliasStruct;
+                }
+                else if (aliasedType is InterfaceSymbol foundAliasInterface)
+                {
+                    userInterfaceSymbol = foundAliasInterface;
+                }
+                else if (aliasedType.ClrType != null)
+                {
+                    classSymbol = new ImportedClassSymbol(aliasedType.ClrType, leftName, references: scope.References);
+                }
+                else
+                {
+                    Diagnostics.ReportUnableToFindType(leftName.Location, name);
+                    return new BoundErrorExpression(null);
+                }
+            }
             else if (scope.TryLookupImportedClass(name, leftName, out var importedClass))
             {
                 classSymbol = importedClass;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2273ImportTypeAliasTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2273ImportTypeAliasTests.cs
@@ -1,0 +1,128 @@
+// <copyright file="Issue2273ImportTypeAliasTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2273: <c>import R = Namespace.Type</c> (the analog of C#
+/// <c>using R = Namespace.Type;</c>) must let a bare <c>R</c> resolve as the
+/// aliased TYPE at use sites — static member access, type-clause position,
+/// and nested-type access — for both a same-compilation SOURCE type declared
+/// in another package (the conventional resx <c>using R = ...Properties.Resources;</c>
+/// pattern) and an imported CLR type.
+/// </summary>
+public class Issue2273ImportTypeAliasTests
+{
+    [Fact]
+    public void Alias_To_CrossPackage_Source_Type_Resolves_Static_Member_Access()
+    {
+        var holderTree = SyntaxTree.Parse(SourceText.From(@"
+package App.Nested
+
+class Holder {
+    shared {
+        const Message string = ""hi""
+    }
+}
+"));
+        var mainTree = SyntaxTree.Parse(SourceText.From(@"
+package App
+
+import R = App.Nested.Holder
+
+var result = R.Message
+"));
+        var result = Evaluate(holderTree, mainTree);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("hi", result.Value);
+    }
+
+    [Fact]
+    public void Alias_To_Imported_Clr_Type_Resolves_Static_Member_Access()
+    {
+        var result = Evaluate(@"
+import R = System.Math
+
+var result = R.Sqrt(16.0)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(4.0, result.Value);
+    }
+
+    [Fact]
+    public void Alias_To_CrossPackage_Source_Type_Resolves_In_TypeClause_Position()
+    {
+        var holderTree = SyntaxTree.Parse(SourceText.From(@"
+package App.Nested
+
+class Holder {
+    prop Value int32
+
+    shared {
+        func MakeOne() Holder {
+            var h Holder = Holder{Value: 42}
+            return h
+        }
+    }
+}
+"));
+        var mainTree = SyntaxTree.Parse(SourceText.From(@"
+package App
+
+import R = App.Nested.Holder
+
+var h R = R.MakeOne()
+var result = h.Value
+"));
+        var result = Evaluate(holderTree, mainTree);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void Alias_To_Outer_Type_Resolves_Nested_Type_Access()
+    {
+        var outerTree = SyntaxTree.Parse(SourceText.From(@"
+package App.Nested
+
+class Outer {
+    class Inner {
+        shared {
+            const Message string = ""nested-hi""
+        }
+    }
+}
+"));
+        var mainTree = SyntaxTree.Parse(SourceText.From(@"
+package App
+
+import R = App.Nested.Outer
+
+var result = R.Inner.Message
+"));
+        var result = Evaluate(outerTree, mainTree);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("nested-hi", result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        return Evaluate(syntaxTree);
+    }
+
+    private static EvaluationResult Evaluate(params SyntaxTree[] syntaxTrees)
+    {
+        var compilation = new Compilation(syntaxTrees);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary

`import R = Namespace.Type` (the analog of C# `using R = Namespace.Type;`) previously only worked when the target was a namespace. When the target was a TYPE, `R` failed to resolve at use sites with `GS0157: Cannot find type R. Are you missing an import?` — blocking the conventional resx pattern (`using R = ...Properties.Resources;` then `R.SomeMessage`) among others.

## Root cause

`Binder.BindImport` creates a generic `ImportSymbol(localName, targetPath, import)` regardless of whether the target resolves to a namespace or a type. Downstream:

- Member access on an alias (`R.Member`) already had a CLR-type fallback (`TryBindImportAccessor` tries `ReferenceResolver.TryResolveType` on the alias target), so `import R = System.Console` + `R.WriteLine(...)` already worked — but a same-compilation SOURCE type target (declared in another package, with no CLR representation while binding) fell through to `Diagnostics.ReportUnableToFindType`.
- Type-clause position (`var x R = ...`) never consulted imports/aliases at all — `Binder.LookupType` had no path from an alias name to its target type, so even the CLR-alias case failed there.

## Fix

- `Binder.LookupType`: when a simple name matches an *alias* import (`import.IsAlias`), resolve the alias's target directly as a type — first via `ReferenceResolver.TryResolveType` (CLR target), then, if that fails, by recursively looking up the target's simple (final dotted-segment) name (same-compilation source type, visible by simple name across packages exactly like nested/cross-package types already are). This single change fixes type-clause position for both source and CLR alias targets.
- `ExpressionBinder.Access` (member access binder): added a fallback alongside the existing `TryBindImportAccessor` CLR path — when the aliased name doesn't resolve as a CLR type there, consult the same `lookupType` (now alias-aware) to recover the aliased source type (class/struct/enum/interface) and route it through the identical struct/enum/interface static-access machinery already used for un-aliased type names. Nested-type access through the alias (`R.Nested.Member`) works for free since it reduces to the ordinary struct/nested-type accessor path once `R` resolves to the outer type.

Generalized to any namespace depth and both source and imported CLR types — not special-cased to the resx scenario.

## Testing

- New `test/Core.Tests/CodeAnalysis/Binding/Issue2273ImportTypeAliasTests.cs`:
  - Alias to a cross-package source type — static member access.
  - Alias to an imported CLR type (`System.Math.Sqrt`) — static member access.
  - Alias to a cross-package source type — type-clause position (`var h R = ...`).
  - Alias to an outer type — nested-type access (`R.Inner.Message`).
- Full `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: **5899 passed, 0 failed, 1 skipped** (skipped is the pre-existing `RegenerateBaseline` fact, gated).
- Manually rebuilt `gsc` and compiled/ran the issue's minimal repro (two files, `App` + `App.Nested`): prints `hi`. Also verified `import M = System.Math` + `R.PI`/`R.Sqrt`, alias in type-clause position, and nested-type access through an alias — all compile and run correctly. `ilverify` reports the emitted assembly fully verified.

Closes #2273.