### PR TITLE
Fix #2278: support imported generic data classes

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2805,7 +2805,7 @@ public sealed class Binder
                 // array — the exact shape the metadata importer produces for
                 // imported members (see ClrNullability) — so the emitter re-stamps
                 // a `[NullableAttribute]` and the inner nullability round-trips.
-                var concrete = TypeSymbol.FromClrType(closed);
+                var concrete = ResolveClosedGenericTypeClauseSymbol(closed);
                 if (!closed.IsValueType)
                 {
                     var symArgs = symbolicArgs.ToImmutable();
@@ -3588,7 +3588,7 @@ public sealed class Binder
                 return ImportedTypeSymbol.GetConstructed(closed, clrType, symbolicArgs.MoveToImmutable());
             }
 
-            return TypeSymbol.FromClrType(closed);
+            return ResolveClosedGenericTypeClauseSymbol(closed);
         }
         catch (System.ArgumentException)
         {
@@ -3826,7 +3826,7 @@ public sealed class Binder
                 return ImportedTypeSymbol.GetConstructed(closed, nestedDef, symbolicArgs.MoveToImmutable());
             }
 
-            return TypeSymbol.FromClrType(closed);
+            return ResolveClosedGenericTypeClauseSymbol(closed);
         }
         catch (System.ArgumentException)
         {
@@ -5477,6 +5477,26 @@ public sealed class Binder
     /// </returns>
     private Type ResolveClrTypeForGenericArg(TypeSymbol typeSymbol)
         => NullableLifting.ResolveClrTypeForGenericArg(this.scope.References, typeSymbol);
+
+    /// <summary>
+    /// Issue #2278: resolves a CLOSED generic CLR type (constructed from a
+    /// type-clause position — a parameter/return/local type-annotation, e.g.
+    /// <c>Box[int32]</c>, as opposed to a primary-constructor CALL) to its
+    /// semantic-aggregate <see cref="StructSymbol"/> when it is an imported
+    /// generic <c>data class</c>/<c>data struct</c>, so a type-clause use
+    /// resolves to the SAME aggregate identity that construction and member
+    /// access already do — matching the non-generic behavior wired up by
+    /// issue #2263. Falls back to the ordinary <see cref="TypeSymbol.FromClrType(Type)"/>
+    /// projection for every other closed generic type.
+    /// </summary>
+    /// <param name="closed">The closed (fully constructed) generic CLR type.</param>
+    /// <returns>The semantic aggregate when <paramref name="closed"/> is a marked data type; otherwise the ordinary imported-type projection.</returns>
+    private TypeSymbol ResolveClosedGenericTypeClauseSymbol(Type closed)
+    {
+        return ImportedTypeSymbol.TryCreateSemanticAggregate(closed, this.scope.References, out var aggregate)
+            ? aggregate
+            : TypeSymbol.FromClrType(closed);
+    }
 
     // Issue #337: build an (unresolved) CLR member method-group expression for a
     // member name that resolves to a method on an imported static type or a CLR

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -2776,6 +2776,22 @@ internal sealed class OverloadResolver
         return new BoundStructLiteralExpression(ctorCall.Syntax, classType, initializers.ToImmutable());
     }
 
+    /// <summary>
+    /// Issue #2278: returns whether <paramref name="classType"/> is the
+    /// semantic aggregate for an already-CLOSED imported generic type (e.g.
+    /// <c>Box[int32]</c> built by reflecting over the closed CLR type
+    /// <c>Box&lt;int&gt;</c>). Such an aggregate is not itself a generic
+    /// definition (<see cref="StructSymbol.IsGenericDefinition"/> is
+    /// <see langword="false"/> — its members are already fully substituted),
+    /// but a construction call against it still legitimately carries the
+    /// original explicit <c>[...]</c> type-argument list the caller used to
+    /// select the closed CLR type in the first place.
+    /// </summary>
+    /// <param name="classType">The candidate aggregate.</param>
+    /// <returns><see langword="true"/> when <paramref name="classType"/> is a closed-generic imported aggregate.</returns>
+    private static bool IsClosedGenericImportedAggregate(StructSymbol classType)
+        => classType.ClrType != null && classType.ClrType.IsGenericType && !classType.ClrType.IsGenericTypeDefinition;
+
     private BoundExpression BindConstructorCallExpressionCore(CallExpressionSyntax syntax, StructSymbol classType)
     {
         // ADR-0047 §6 / #175: primary-constructor call `Foo(...)` is a
@@ -2971,8 +2987,17 @@ internal sealed class OverloadResolver
 
             classType = StructSymbol.Construct(classType, typeArgs.MoveToImmutable(), MapClrType);
         }
-        else if (syntax.TypeArgumentList != null)
+        else if (syntax.TypeArgumentList != null && !IsClosedGenericImportedAggregate(classType))
         {
+            // Issue #2278: a `classType` that is itself the semantic aggregate
+            // for an already-CLOSED imported generic data type (e.g.
+            // `Box[int32]`) is not a generic DEFINITION — its `TypeParameters`
+            // is empty because reflection over the closed CLR type already
+            // substituted every member. The caller
+            // (TryBindClrConstructorCall) resolved and consumed the explicit
+            // `[...]` type-argument list itself (via `Type.MakeGenericType`)
+            // before building this aggregate, so seeing one here is expected
+            // and must not be treated as an arity mismatch.
             Diagnostics.ReportWrongTypeArgumentCount(syntax.TypeArgumentList.Location, classType.Name, 0, syntax.TypeArgumentList.Arguments.Count);
             return new BoundErrorExpression(syntax);
         }

--- a/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
@@ -158,19 +158,28 @@ public sealed class ImportedTypeSymbol : TypeSymbol
             return false;
         }
 
-        if (!type.IsValueType)
+        // Issue #2278: a generic type's OPEN definition (e.g. `Box<>`,
+        // `Pair<,>`) is always excluded, for both a `data class` and a `data
+        // struct` — building an aggregate from it would be 0-arity (its
+        // members typed by the raw, unsubstituted type parameter) and would
+        // shadow every real closed instantiation at construction sites. A
+        // CLOSED generic (`Box<int>`, `Pair<K,V>`) is fine: it is a distinct
+        // CLR `Type` per instantiation whose `MetadataToken` still matches the
+        // marker (tokens are shared between a generic type's open definition
+        // and every closed construction), and reflecting over it (fields,
+        // properties, methods) yields already-substituted member types — so
+        // the aggregate built below is correctly and independently shaped per
+        // closed generic type, with no shared/shadowed identity.
+        if (type.IsGenericTypeDefinition)
+        {
+            return false;
+        }
+
+        if (!type.IsValueType && !semantics.IsData)
         {
             // A plain (non-data) reference class is never marked by the
-            // emitter, so only genuine data classes reach here. Generic data
-            // classes are out of scope: their open definition would otherwise
-            // build a 0-arity aggregate that shadows the real generic type at
-            // construction sites, so they keep importing as an ordinary CLR
-            // class (a `with` on one still reports GS0161 rather than
-            // mis-binding).
-            if (!semantics.IsData || type.IsGenericType || type.IsGenericTypeDefinition)
-            {
-                return false;
-            }
+            // emitter, so only genuine data classes reach here.
+            return false;
         }
 
         var consumerAssemblyName = references?.CurrentAssemblyName ?? string.Empty;
@@ -260,7 +269,7 @@ public sealed class ImportedTypeSymbol : TypeSymbol
         }
 
         var aggregate = new StructSymbol(
-            name: type.Name,
+            name: BuildAggregateDisplayName(type),
             fields: fieldBuilder.ToImmutable(),
             accessibility: MapTypeAccessibility(type),
             declaration: null,
@@ -277,6 +286,35 @@ public sealed class ImportedTypeSymbol : TypeSymbol
         aggregate.SetMethods(BuildMethods(type, aggregate, includeInternal));
         aggregate.SetStaticMethods(BuildStaticMethods(type, aggregate, includeInternal));
         return aggregate;
+    }
+
+    /// <summary>
+    /// Issue #2278: renders the aggregate's display name. For a plain
+    /// (non-generic) imported data type this is just the CLR type's own
+    /// name (matching pre-#2278 behavior). For a CLOSED generic data
+    /// type this rebuilds a G#-flavored constructed-generic name (e.g.
+    /// <c>Box[int32]</c>, <c>Pair[int32, string]</c>) from the reflected
+    /// arguments rather than surfacing the raw backtick-arity CLR name
+    /// (<c>Box`1</c>) in diagnostics and hover text.
+    /// </summary>
+    /// <param name="type">The reflected CLR type the aggregate is built from.</param>
+    /// <returns>A display-friendly name for the aggregate.</returns>
+    private static string BuildAggregateDisplayName(Type type)
+    {
+        if (!type.IsGenericType || type.IsGenericTypeDefinition)
+        {
+            return type.Name;
+        }
+
+        var baseName = StripGenericArity(type.Name);
+        var args = type.GetGenericArguments().Select(BuildAggregateDisplayName);
+        return $"{baseName}[{string.Join(", ", args)}]";
+    }
+
+    private static string StripGenericArity(string name)
+    {
+        var tick = name.IndexOf('`', StringComparison.Ordinal);
+        return tick >= 0 ? name.Substring(0, tick) : name;
     }
 
     private static ImmutableArray<ParameterSymbol> BuildPrimaryConstructorParameters(

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2278ImportedGenericDataClassTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2278ImportedGenericDataClassTests.cs
@@ -1,0 +1,291 @@
+// <copyright file="Issue2278ImportedGenericDataClassTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2278 (follow-up to #2263): an imported GENERIC <c>data class</c>
+/// must support construction, member access, and <c>with</c>/copy exactly
+/// like the non-generic case #2263 fixed — for ANY arity (1, 2, ...), for a
+/// nested generic type argument (<c>Box[List[int32]]</c> / <c>Box[Box[int32]]</c>),
+/// and for a data class whose fields reference the class's own type
+/// parameters. #2263 explicitly excluded generics because the OPEN
+/// definition would otherwise build a 0-arity aggregate shadowing every
+/// closed instantiation; this fix builds the semantic aggregate from the
+/// CLOSED CLR generic type instead (a distinct <see cref="Type"/> per
+/// instantiation, sharing the marker's metadata token with the open
+/// definition), so each closed generic keeps its own correctly-shaped,
+/// consistent identity.
+/// </summary>
+public class Issue2278ImportedGenericDataClassTests
+{
+    private const string LibrarySource = """
+        package Geometry
+
+        data class Box[T](Value T)
+
+        data class Pair[K, V](Key K, Value V)
+        """;
+
+    [Fact]
+    public void Imported_Arity1_GenericDataClass_With_Compiles_In_Let_Argument_And_Return_Positions()
+    {
+        var libraryPath = EmitLibrary(nameof(this.Imported_Arity1_GenericDataClass_With_Compiles_In_Let_Argument_And_Return_Positions));
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Geometry.Consumer";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+                import Geometry
+
+                // return + argument positions: receiver is a parameter typed as
+                // the imported closed generic data class, result typed the same way.
+                func Shift(b Box[int32]) Box[int32] -> b with { Value = 99 }
+
+                func Run() int32 {
+                    // let-initializer position: construct then `with`.
+                    let a = Box[int32](1)
+                    let b = a with { Value = 7 }
+                    let c = Shift(a)
+                    return a.Value + b.Value + c.Value
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Geometry.Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void Imported_Arity2_GenericDataClass_With_And_MemberAccess_Compile()
+    {
+        var libraryPath = EmitLibrary(nameof(this.Imported_Arity2_GenericDataClass_With_And_MemberAccess_Compile));
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Geometry.Consumer";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+                import Geometry
+
+                func Run() int32 {
+                    let p = Pair[int32, string](1, "hi")
+                    let p2 = p with { Value = "bye" }
+                    return p.Key + p2.Key
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Geometry.Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void Imported_NestedGenericArgument_GenericDataClass_With_And_MemberAccess_Compile()
+    {
+        var libraryPath = EmitLibrary(nameof(this.Imported_NestedGenericArgument_GenericDataClass_With_And_MemberAccess_Compile));
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Geometry.Consumer";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+                import Geometry
+
+                func Run() int32 {
+                    // Box[Box[int32]] — a nested generic type argument (the outer
+                    // Box closes over another closed instantiation of itself).
+                    let inner = Box[int32](5)
+                    let outer = Box[Box[int32]](inner)
+                    let outer2 = outer with { Value = Box[int32](9) }
+                    return outer.Value.Value + outer2.Value.Value
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Geometry.Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void Imported_NullableOfGenericDataClass_Compiles()
+    {
+        var libraryPath = EmitLibrary(nameof(this.Imported_NullableOfGenericDataClass_Compiles));
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Geometry.Consumer";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+                import Geometry
+
+                func Run() bool {
+                    var m Box[int32]? = nil
+                    let wasNil = m == nil
+                    m = Box[int32](3)
+                    return wasNil && m.Value == 3
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Geometry.Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void Imported_GenericDataClass_With_Clones_With_Reference_Semantics_At_Runtime()
+    {
+        var libraryPath = EmitLibrary(nameof(this.Imported_GenericDataClass_With_Clones_With_Reference_Semantics_At_Runtime));
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Geometry.Runner";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Runner
+                import Geometry
+
+                func Shift(b Box[int32]) Box[int32] -> b with { Value = 99 }
+
+                func Main() {
+                    let a = Box[int32](1)
+                    let b = Shift(a)
+
+                    let p = Pair[int32, string](1, "hi")
+                    let p2 = p with { Value = "bye" }
+
+                    // Original left untouched (reference semantics), clone updated.
+                    Console.WriteLine(a.Value)
+                    Console.WriteLine(b.Value)
+                    Console.WriteLine(p.Key)
+                    Console.WriteLine(p.Value)
+                    Console.WriteLine(p2.Key)
+                    Console.WriteLine(p2.Value)
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Geometry.Runner");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        var output = LoadInvokeCaptureStdout(peStream, libraryPath, "Issue2278-Runner");
+        var lines = output
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(new[] { "1", "99", "1", "hi", "1", "bye" }, lines);
+    }
+
+    [Fact]
+    public void Imported_GenericDataClass_Resolves_Deterministically_Across_Repeated_Compilations()
+    {
+        var libraryPath = EmitLibrary(nameof(this.Imported_GenericDataClass_Resolves_Deterministically_Across_Repeated_Compilations));
+
+        const string ConsumerSource = """
+            package Consumer
+            import Geometry
+
+            func Shift(b Box[int32]) Box[int32] -> b with { Value = 99 }
+
+            func Run() int32 {
+                let a = Box[int32](1)
+                let b = Shift(a)
+                return b.Value
+            }
+            """;
+
+        // Mirrors the #2263 flicker regression test: a fresh resolver per
+        // iteration avoids any cross-run cache carry-over, and every
+        // iteration must resolve the imported generic data class to its
+        // semantic aggregate consistently (never a bare ImportedTypeSymbol).
+        for (var i = 0; i < 12; i++)
+        {
+            using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+            resolver.CurrentAssemblyName = "Geometry.Consumer";
+
+            var consumer = new Compilation(resolver, SyntaxTree.Parse(SourceText.From(ConsumerSource)));
+            using var peStream = new MemoryStream();
+            var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Geometry.Consumer");
+            Assert.True(
+                result.Success,
+                $"iteration {i} must not flicker: " + string.Join(Environment.NewLine, result.Diagnostics));
+        }
+    }
+
+    private static string EmitLibrary(string caseName)
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2278", caseName);
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Geometry.Library.dll");
+
+        var library = new Compilation(SyntaxTree.Parse(SourceText.From(LibrarySource)))
+        {
+            IsLibrary = true,
+        };
+
+        using var peStream = File.Create(libraryPath);
+        var result = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Geometry.Library");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return libraryPath;
+    }
+
+    private static string LoadInvokeCaptureStdout(MemoryStream peStream, string libraryPath, string contextName)
+    {
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        loadContext.Resolving += (context, name) =>
+            string.Equals(name.Name, "Geometry.Library", StringComparison.Ordinal)
+                ? context.LoadFromAssemblyPath(libraryPath)
+                : null;
+
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var entry = asm.EntryPoint;
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
Closes #2278

## Root cause

#2263 added cross-assembly `data class` support: gsc emits a "data
semantics" marker attribute on imported `data class`/`data struct`
types, and `ImportedTypeSymbol.TryCreateSemanticAggregate` builds a
semantic-aggregate `StructSymbol` so construction, member access, and
`with`/copy resolve to ONE consistent identity in every position
(let-initializer, argument, return, member access).

#2263 explicitly excluded **any** generic type — open or closed — with
this reasoning: building the aggregate from the OPEN generic definition
(e.g. `Box<>`) would be 0-arity (its members typed by the raw,
unsubstituted type parameter `T`) and would shadow every real closed
instantiation at construction sites. So a generic `data class` kept
importing as an ordinary CLR class, and `with` on one reported GS0161.

## Design choice: Option A (build the aggregate from the CLOSED CLR type)

I investigated both options described in the issue and chose **Option
A**: build the semantic aggregate from the **closed** CLR generic type
(e.g. `Box<int>`) rather than threading `TypeParameters` + substitution
through a generic aggregate (Option B).

Why Option A is correct and sufficient:
- A closed generic instantiation (`Box<int>`, `Box<string>`, ...) is a
  **distinct CLR `Type` object** per instantiation, so caching the
  aggregate per closed `Type` (the existing
  `ReferenceResolver.GetOrAddSemanticAggregate` cache, keyed on `Type`)
  naturally gives each instantiation its own correct, independent
  aggregate — no shadowing.
- `Type.MetadataToken` for a constructed generic type is the **same**
  token as its open definition (verified empirically, including under a
  `MetadataLoadContext`), so `ImportedAssemblySemantics.TryGetTypeSemantics`
  (keyed by metadata token) still finds the marker for a closed type.
- Reflecting over the closed type (`GetFields`, `GetProperties`,
  `GetMethods`, `GetConstructor`) returns members with type parameters
  **already substituted** (e.g. a field declared `Value T` reflects as
  `Value : System.Int32` on `Box<int>`) — confirmed this also holds when
  the type is loaded through a `MetadataLoadContext` (the reference-only
  load context gsc uses for referenced assemblies), so there's no
  `NotSupportedException` risk that Option A might otherwise run into.
- The existing emit path (`GetTypeHandleForMember`, `GetCtorReference`,
  `GetFieldReference`) already builds a `TypeSpec`-parented `MemberRef`
  for any closed generic CLR type, imported or not — so construction,
  field access, and `with`'s field-copy lowering all "just work" once the
  aggregate is built from the correctly-shaped closed type.

This generalizes to **any** arity, a nested generic type argument
(`Box[Box[int32]]`), and a data class whose members reference the
class's own type parameters — the substitution is done entirely by the
CLR reflection layer, not by any new arity- or shape-specific code.

Option B (a generic aggregate carrying `TypeParameters` + substitution
at each use site) would have required threading substitution through
every consumer of `StructSymbol` (construction, `with`, member access,
emit) — essentially duplicating work the CLR reflection API already
does for free once you reflect over the closed type.

## Changes

- **`ImportedTypeSymbol.TryCreateSemanticAggregate`**: only excludes the
  OPEN generic type definition now (`type.IsGenericTypeDefinition`),
  not every generic type. Applies uniformly to both the `data class`
  (reference-type) and `data struct` (value-type) branches.
- **`ImportedTypeSymbol.BuildSemanticAggregate`**: builds a
  G#-flavored display name (`Box[int32]`, `Pair[int32, string]`) for a
  closed generic aggregate instead of surfacing the raw backtick-arity
  CLR name (`Box\`1`) in diagnostics/hover.
- **`OverloadResolver.BindConstructorCallExpressionCore`**: a
  closed-generic imported aggregate is not itself a generic definition
  (`TypeParameters` is empty — members are already substituted), so a
  construction call against it (`Box[int32](5)`) legitimately still
  carries the explicit `[...]` type-argument list the caller
  (`TryBindClrConstructorCall`) used to select the closed CLR type via
  `MakeGenericType`. Added a guard (`IsClosedGenericImportedAggregate`)
  so this is not misreported as a GS0148 arity mismatch.
- **`Binder`**: routes every closed-generic **type-clause** position
  (function parameter/return type, local variable type annotation,
  nested-type-segment construction) through the same
  `TryCreateSemanticAggregate` resolution already used at
  construction/member-access sites (new `ResolveClosedGenericTypeClauseSymbol`
  helper), so a type annotation like `Box[int32]` in a function
  signature resolves to the identical aggregate identity rather than a
  bare `ImportedTypeSymbol` — this was needed for `with` to work on a
  function parameter/return typed as a generic imported data class.

## Memory-safety

No new process-wide cache was added. This reuses the existing
resolver-instance cache (`ReferenceResolver.GetOrAddSemanticAggregate`),
still keyed per CLR `Type` (now a closed generic `Type` in the new
case) exactly as before — its lifetime remains tied to the
`ReferenceResolver`/`MetadataLoadContext` that owns the type, so no
strong process-wide pinning is introduced (the #2269 OOM regression
class of bug).

## Validation

- `dotnet build src/Compiler/Compiler.csproj -c Release`: 0
  Warning(s), 0 Error(s).
- Manual smoke test via `gsc` CLI: arity-1 (`Box[T]`), arity-2
  (`Pair[K,V]`), nested generic argument (`Box[Box[int32]]`), function
  parameter/return type-clause position, and `Box[int32]?`
  (nullable-of-generic) all compile and produce correct runtime output
  when loaded and executed.
- New regression tests:
  `test/Core.Tests/CodeAnalysis/Binding/Issue2278ImportedGenericDataClassTests.cs`
  (6 tests) — arity-1 construction/`with`/argument/return positions;
  arity-2 (`Pair[K,V]`); nested generic argument
  (`Box[Box[int32]]`); nullable-of-generic (`Box[int32]?`); a runtime
  reference-semantics clone check across a real emitted+loaded
  assembly (mirrors #2263's runtime test); and a 12-iteration
  determinism check mirroring #2263's flicker regression test.
- **Full `Core.Tests` suite**: `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --no-build`
  → **5908 passed, 1 skipped, 0 failed**.
