### PR TITLE
gsc: support duck-typed (pattern-based) async-enumerables in `await for` (#2280)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -317,13 +317,24 @@ internal sealed class MemberLookup
 
     /// <summary>
     /// Probes <paramref name="type"/> for an
-    /// <c>IAsyncEnumerable&lt;T&gt;</c> implementation and returns its
-    /// element type when present.
+    /// <c>IAsyncEnumerable&lt;T&gt;</c> implementation, OR (issue #2280,
+    /// parallel to the sync <c>GetEnumerator()</c> pattern support for
+    /// #939/#990) the fully duck-typed <c>await foreach</c> pattern — a
+    /// public instance <c>GetAsyncEnumerator(...)</c> method independent of
+    /// any interface — and returns the element type when either shape is
+    /// present. The interface path is tried first (fast path, and it is the
+    /// only path that recovers a same-compilation user element type through
+    /// the symbolic <see cref="ImportedTypeSymbol"/> machinery); the pattern
+    /// path is the fallback used for CLR wrapper types that implement no
+    /// interfaces at all, such as
+    /// <c>System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable&lt;T&gt;</c>
+    /// (the type produced by <c>IAsyncEnumerable&lt;T&gt;.ConfigureAwait(bool)</c>).
     /// </summary>
     /// <param name="type">The <see cref="TypeSymbol"/> to probe.</param>
     /// <param name="elementType">The bound element type symbol, on success.</param>
     /// <returns><see langword="true"/> when the type implements
-    /// <c>IAsyncEnumerable&lt;T&gt;</c>.</returns>
+    /// <c>IAsyncEnumerable&lt;T&gt;</c> or exposes the pattern-based
+    /// <c>await foreach</c> shape.</returns>
     public static bool TryGetAsyncEnumerableElementType(TypeSymbol type, out TypeSymbol elementType)
     {
         elementType = null;
@@ -382,6 +393,132 @@ internal sealed class MemberLookup
             }
         }
 
+        // Issue #2280: neither `type` nor its OpenDefinition (when
+        // symbolic) implements `IAsyncEnumerable[T]`. Fall back to the
+        // duck-typed `await foreach` pattern before giving up — this is
+        // what makes `ConfiguredCancelableAsyncEnumerable[T]` (returned by
+        // `IAsyncEnumerable[T].ConfigureAwait(false)`) and other
+        // fully-pattern-based async enumerables iterable.
+        if (TryResolveClrPatternAsyncEnumerator(clr, out _, out _, out var currentMember))
+        {
+            elementType = TypeSymbol.FromClrType(GetClrMemberValueType(currentMember));
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #2280: resolves the C# spec's duck-typed <c>await foreach</c>
+    /// pattern directly on <paramref name="clrType"/> — a public instance
+    /// <c>GetAsyncEnumerator(...)</c> method (accepting zero arguments, or a
+    /// single optional argument such as <c>CancellationToken</c>), whose
+    /// return type in turn exposes a parameterless <c>MoveNextAsync()</c>
+    /// method and a <c>Current</c> member — all independent of any
+    /// interface. Mirrors <see cref="TryGetClrPatternEnumerableElementType"/>
+    /// (the sync <c>GetEnumerator()</c> pattern probe for #939/#990) for the
+    /// async shape.
+    /// </summary>
+    /// <param name="clrType">The CLR type to probe.</param>
+    /// <param name="getAsyncEnumerator">The resolved <c>GetAsyncEnumerator</c> method, on success.</param>
+    /// <param name="moveNextAsync">The resolved <c>MoveNextAsync</c> method on the enumerator type, on success.</param>
+    /// <param name="currentMember">The resolved <c>Current</c> property or field on the enumerator type, on success.</param>
+    /// <returns><see langword="true"/> when the pattern-based shape matches.</returns>
+    public static bool TryResolveClrPatternAsyncEnumerator(
+        Type clrType,
+        out MethodInfo getAsyncEnumerator,
+        out MethodInfo moveNextAsync,
+        out MemberInfo currentMember)
+    {
+        getAsyncEnumerator = null;
+        moveNextAsync = null;
+        currentMember = null;
+
+        if (clrType == null)
+        {
+            return false;
+        }
+
+        // Prefer a parameterless `GetAsyncEnumerator()` (the shape produced
+        // by `ConfiguredCancelableAsyncEnumerable[T]`) over a single-argument
+        // overload (the shape produced by `IAsyncEnumerable[T]` itself, which
+        // takes an optional `CancellationToken`) when a type happens to
+        // expose both — matching how the interface fast path always wins
+        // when present, so the pattern probe's own preference order rarely
+        // matters in practice.
+        MethodInfo zeroArgCandidate = null;
+        MethodInfo oneArgCandidate = null;
+        foreach (var candidate in ClrTypeUtilities.SafeGetMethods(clrType, BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!string.Equals(candidate.Name, "GetAsyncEnumerator", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var parameters = candidate.GetParameters();
+            if (parameters.Length == 0 && zeroArgCandidate == null)
+            {
+                zeroArgCandidate = candidate;
+            }
+            else if (parameters.Length == 1 && oneArgCandidate == null)
+            {
+                oneArgCandidate = candidate;
+            }
+        }
+
+        var resolved = zeroArgCandidate ?? oneArgCandidate;
+        if (resolved == null)
+        {
+            return false;
+        }
+
+        var enumeratorType = resolved.ReturnType;
+        var moveNext = SafeGetMethodIncludingSelfAndInterfaces(enumeratorType, "MoveNextAsync", Type.EmptyTypes);
+        if (moveNext == null)
+        {
+            return false;
+        }
+
+        if (!TryGetClrCurrentMemberIncludingSelfAndInterfaces(enumeratorType, out var current))
+        {
+            return false;
+        }
+
+        getAsyncEnumerator = resolved;
+        moveNextAsync = moveNext;
+        currentMember = current;
+        return true;
+    }
+
+    /// <summary>
+    /// Looks up the <c>Current</c> member on a duck-typed CLR enumerator —
+    /// preferring a property over a field — walking the type's transitive
+    /// implemented interfaces in addition to the type itself. The async
+    /// counterpart to <see cref="TryGetClrCurrentMemberType"/>, which only
+    /// probes the type directly (sufficient for the sync pattern, whose
+    /// enumerator is always concrete); kept separate so that call site is
+    /// left untouched.
+    /// </summary>
+    /// <param name="enumeratorType">The duck-typed enumerator type.</param>
+    /// <param name="currentMember">The resolved <c>Current</c> property or field, on success.</param>
+    /// <returns><see langword="true"/> when a <c>Current</c> member exists.</returns>
+    public static bool TryGetClrCurrentMemberIncludingSelfAndInterfaces(Type enumeratorType, out MemberInfo currentMember)
+    {
+        var currentProperty = SafeGetPropertyIncludingSelfAndInterfaces(enumeratorType, "Current");
+        if (currentProperty != null)
+        {
+            currentMember = currentProperty;
+            return true;
+        }
+
+        var currentField = ClrTypeUtilities.SafeGetField(enumeratorType, "Current", BindingFlags.Instance | BindingFlags.Public);
+        if (currentField != null)
+        {
+            currentMember = currentField;
+            return true;
+        }
+
+        currentMember = null;
         return false;
     }
 
@@ -3114,6 +3251,23 @@ internal sealed class MemberLookup
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Returns the value type of a <c>Current</c> member resolved by
+    /// <see cref="TryResolveClrPatternAsyncEnumerator"/> — a property or a
+    /// field.
+    /// </summary>
+    /// <param name="member">The member to inspect.</param>
+    /// <returns>The member's value type.</returns>
+    private static Type GetClrMemberValueType(MemberInfo member)
+    {
+        return member switch
+        {
+            PropertyInfo property => property.PropertyType,
+            FieldInfo field => field.FieldType,
+            _ => null,
+        };
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -670,31 +670,69 @@ public sealed class Evaluator
             asyncEnumerableInterface = streamType;
         }
 
-        if (asyncEnumerableInterface == null)
-        {
-            throw new EvaluatorException(
-                $"'await for' operand of CLR type '{streamType}' does not implement IAsyncEnumerable<T>.",
-                node);
-        }
-
         var cancellationToken = ScopeFrames.Count > 0
             ? ScopeFrames.Peek().Cts.Token
             : System.Threading.CancellationToken.None;
 
-        var getEnumerator = asyncEnumerableInterface.GetMethod(
-            "GetAsyncEnumerator",
-            new[] { typeof(System.Threading.CancellationToken) });
-        var enumerator = getEnumerator.Invoke(stream, [cancellationToken]);
+        MethodInfo getEnumerator;
+        object[] getEnumeratorArgs;
+        MethodInfo moveNextAsync;
+        MemberInfo currentMember;
+        if (asyncEnumerableInterface != null)
+        {
+            // Fast path: the type implements `IAsyncEnumerable[T]`.
+            getEnumerator = asyncEnumerableInterface.GetMethod(
+                "GetAsyncEnumerator",
+                new[] { typeof(System.Threading.CancellationToken) });
+            getEnumeratorArgs = new object[] { cancellationToken };
+
+            var enumeratorInterface = typeof(System.Collections.Generic.IAsyncEnumerator<>)
+                .MakeGenericType(asyncEnumerableInterface.GetGenericArguments()[0]);
+            moveNextAsync = enumeratorInterface.GetMethod("MoveNextAsync", Type.EmptyTypes);
+            currentMember = enumeratorInterface.GetProperty("Current");
+        }
+        else if (MemberLookup.TryResolveClrPatternAsyncEnumerator(streamType, out var patternGetEnumerator, out var patternMoveNextAsync, out var patternCurrentMember))
+        {
+            // Issue #2280: the duck-typed `await foreach` pattern — a
+            // public instance `GetAsyncEnumerator(...)` independent of any
+            // interface, e.g. `ConfiguredCancelableAsyncEnumerable[T]`
+            // (returned by `IAsyncEnumerable[T].ConfigureAwait(false)`),
+            // which implements no interfaces at all.
+            getEnumerator = patternGetEnumerator;
+            getEnumeratorArgs = getEnumerator.GetParameters().Length == 0
+                ? Array.Empty<object>()
+                : new object[] { cancellationToken };
+            moveNextAsync = patternMoveNextAsync;
+            currentMember = patternCurrentMember;
+        }
+        else
+        {
+            throw new EvaluatorException(
+                $"'await for' operand of CLR type '{streamType}' does not implement IAsyncEnumerable<T> and exposes no pattern-based GetAsyncEnumerator.",
+                node);
+        }
+
+        var enumerator = getEnumerator.Invoke(stream, getEnumeratorArgs);
         if (enumerator == null)
         {
             throw new EvaluatorException("'await for' GetAsyncEnumerator returned null.", node);
         }
 
-        var enumeratorInterface = typeof(System.Collections.Generic.IAsyncEnumerator<>)
-            .MakeGenericType(asyncEnumerableInterface.GetGenericArguments()[0]);
-        var moveNextAsync = enumeratorInterface.GetMethod("MoveNextAsync", Type.EmptyTypes);
-        var currentProperty = enumeratorInterface.GetProperty("Current");
-        var disposeAsync = typeof(System.IAsyncDisposable).GetMethod("DisposeAsync", Type.EmptyTypes);
+        // Issue #2280: `DisposeAsync` may be reached through
+        // `IAsyncDisposable` (the common case for compiler-generated
+        // iterators), or — for a fully duck-typed enumerator — as a plain
+        // public instance method found directly on the enumerator's runtime
+        // type. Per the C# spec, when neither shape is present no
+        // disposal is performed.
+        var enumeratorClrType = enumerator.GetType();
+        MethodInfo disposeAsync = typeof(System.IAsyncDisposable).IsAssignableFrom(enumeratorClrType)
+            ? typeof(System.IAsyncDisposable).GetMethod("DisposeAsync", Type.EmptyTypes)
+            : enumeratorClrType.GetMethod(
+                "DisposeAsync",
+                BindingFlags.Instance | BindingFlags.Public,
+                binder: null,
+                types: Type.EmptyTypes,
+                modifiers: null);
 
         try
         {
@@ -707,7 +745,12 @@ public sealed class Evaluator
                     break;
                 }
 
-                var current = currentProperty.GetValue(enumerator);
+                var current = currentMember switch
+                {
+                    PropertyInfo currentProperty => currentProperty.GetValue(enumerator),
+                    FieldInfo currentField => currentField.GetValue(enumerator),
+                    _ => throw new EvaluatorException("'await for' Current member has an unsupported shape.", node),
+                };
                 Assign(node.ValueVariable, current);
                 EvaluateStatement((BoundBlockStatement)node.Body);
 
@@ -3862,23 +3905,32 @@ public sealed class Evaluator
             return null;
         }
 
-        // Issue #148: `await for` desugaring produces `await __enum.MoveNextAsync()`
-        // and `await __enum.DisposeAsync()`, which return `ValueTask<bool>` /
-        // `ValueTask`. Use the same synchronous-await pragma the await-for
-        // path uses for the underlying enumerator calls.
         if (operand == null)
         {
             throw new EvaluatorException("'await' operand did not evaluate to an awaitable.", node);
         }
 
+        // Issue #2280 (parallel to the emitter's generic `AwaitableShape`,
+        // which already resolves ANY duck-typed awaitable structurally):
+        // this interpreter path previously only recognized `ValueTask`/
+        // `ValueTask<T>` by name after the Task fast path above — a shared
+        // gap that broke `await` on `ConfiguredTaskAwaitable(<T>)`/
+        // `ConfiguredValueTaskAwaitable(<T>)` (returned by
+        // `.ConfigureAwait(...)`, including the `MoveNextAsync`/
+        // `DisposeAsync` results of a pattern-based `await for` enumerator,
+        // see #148's desugaring), and any other fully custom duck-typed
+        // awaitable. Resolve via the C# spec's
+        // `GetAwaiter()`/`IsCompleted`/`GetResult()` pattern instead of a
+        // type-name allowlist; `BlockOnValueTask` already implements that
+        // resolution reflectively.
         var operandType = operand.GetType();
-        if (operandType.FullName == "System.Threading.Tasks.ValueTask" ||
-            (operandType.IsGenericType && operandType.GetGenericTypeDefinition().FullName == "System.Threading.Tasks.ValueTask`1"))
+        var getAwaiterMethod = operandType.GetMethod("GetAwaiter", Type.EmptyTypes);
+        if (getAwaiterMethod == null)
         {
-            return BlockOnValueTask(operand);
+            throw new EvaluatorException("'await' operand did not evaluate to a Task.", node);
         }
 
-        throw new EvaluatorException("'await' operand did not evaluate to a Task.", node);
+        return BlockOnValueTask(operand);
     }
 
     private static object EvaluateDefaultExpression(BoundDefaultExpression node)

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -589,31 +589,56 @@ public sealed class Lowerer : BoundTreeRewriter
             }
         }
 
-        if (asyncEnumerableInterface == null)
-        {
-            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
-        }
-
         // Issue #652: resolve all helper types from the same MetadataLoadContext
         // as the stream type. Using typeof(...) here would yield host-runtime types
         // that cannot be mixed with MLC-loaded types in MakeGenericType/GetMethod
         // calls, causing ArgumentException ("Type must be a type provided by the
         // MetadataLoadContext").  Instead, derive everything from the interface and
         // method signatures that are already in the correct context.
+        System.Reflection.MethodInfo getAsyncEnumerator;
+        System.Reflection.MethodInfo moveNextAsync;
+        System.Reflection.MemberInfo currentMember;
+        if (asyncEnumerableInterface != null)
+        {
+            // Fast path: GetAsyncEnumerator is the sole method on IAsyncEnumerable<T>.
+            getAsyncEnumerator = asyncEnumerableInterface.GetMethod("GetAsyncEnumerator");
+            if (getAsyncEnumerator == null)
+            {
+                return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+            }
 
-        // GetAsyncEnumerator is the sole method on IAsyncEnumerable<T>.
-        var getAsyncEnumerator = asyncEnumerableInterface.GetMethod("GetAsyncEnumerator");
-        if (getAsyncEnumerator == null)
+            var ifaceEnumeratorClr = getAsyncEnumerator.ReturnType;
+            moveNextAsync = ifaceEnumeratorClr.GetMethod("MoveNextAsync");
+            currentMember = ifaceEnumeratorClr.GetProperty("Current");
+        }
+        else if (!MemberLookup.TryResolveClrPatternAsyncEnumerator(streamClr, out getAsyncEnumerator, out moveNextAsync, out currentMember))
+        {
+            // Issue #2280: neither the `IAsyncEnumerable[T]` interface nor
+            // the duck-typed `await foreach` pattern (a public instance
+            // `GetAsyncEnumerator(...)` whose enumerator exposes
+            // `MoveNextAsync()`/`Current`) is present — e.g.
+            // `System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable[T]`
+            // (from `IAsyncEnumerable[T].ConfigureAwait(false)`) qualifies
+            // via this fallback since it implements no interfaces at all.
+            // The binder already validated one of the two shapes exists, so
+            // this branch should not be reachable for well-typed programs.
+            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+        }
+
+        if (moveNextAsync == null || currentMember == null)
         {
             return new BoundExpressionStatement(null, new BoundErrorExpression(null));
         }
 
-        // IAsyncEnumerator<T> — from the return type (already in MLC context).
+        // Issue #2280: `DisposeAsync` may be reached through the
+        // `IAsyncDisposable` interface (the common case for compiler-
+        // generated iterators), or — for a fully duck-typed enumerator such
+        // as `ConfiguredCancelableAsyncEnumerable[T].Enumerator`, which
+        // implements no interfaces — as a plain public instance method found
+        // directly on the enumerator type. Per the C# spec, when neither
+        // shape is present the loop performs no disposal at all (rather than
+        // failing to bind), so `disposeAsync` is allowed to stay null here.
         var enumeratorClr = getAsyncEnumerator.ReturnType;
-        var moveNextAsync = enumeratorClr.GetMethod("MoveNextAsync");
-        var currentProperty = enumeratorClr.GetProperty("Current");
-
-        // IAsyncDisposable.DisposeAsync — find via enumerator's implemented interfaces.
         System.Reflection.MethodInfo disposeAsync = null;
         foreach (var iface in enumeratorClr.GetInterfaces())
         {
@@ -624,23 +649,43 @@ public sealed class Lowerer : BoundTreeRewriter
             }
         }
 
-        if (moveNextAsync == null || currentProperty == null || disposeAsync == null)
+        if (disposeAsync == null)
         {
-            return new BoundExpressionStatement(null, new BoundErrorExpression(null));
+            disposeAsync = enumeratorClr.GetMethod(
+                "DisposeAsync",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public,
+                binder: null,
+                types: System.Type.EmptyTypes,
+                modifiers: null);
         }
 
-        // ValueTask<bool> — from MoveNextAsync's return type (MLC context).
+        // The awaited result type of MoveNextAsync()/DisposeAsync() — from
+        // their actual return types (MLC context). These may be
+        // `ValueTask<bool>`/`ValueTask` (the interface shape) or a
+        // duck-typed awaitable such as `ConfiguredValueTaskAwaitable<bool>`/
+        // `ConfiguredValueTaskAwaitable` (the pattern shape produced by
+        // `.ConfigureAwait(false)`) — `BoundAwaitExpression`'s lowering
+        // (`AwaitableShape.Resolve`) already resolves the
+        // `GetAwaiter`/`IsCompleted`/`GetResult` triple structurally for any
+        // CLR type, so no special-casing is needed here beyond using the
+        // real return type instead of a hardcoded `ValueTask`.
         var valueTaskBoolClr = moveNextAsync.ReturnType;
-
-        // CancellationToken — from GetAsyncEnumerator's parameter (MLC context).
-        var cancellationTokenClr = getAsyncEnumerator.GetParameters()[0].ParameterType;
-
-        // ValueTask (non-generic) — from DisposeAsync's return type (MLC context).
-        var valueTaskClr = disposeAsync.ReturnType;
-
-        var cancellationTokenType = TypeSymbol.FromClrType(cancellationTokenClr);
         var valueTaskBoolType = TypeSymbol.FromClrType(valueTaskBoolClr);
-        var valueTaskType = TypeSymbol.FromClrType(valueTaskClr);
+
+        // GetAsyncEnumerator's arity: either the interface's single optional
+        // `CancellationToken` parameter, or the fully duck-typed parameterless
+        // overload (e.g. `ConfiguredCancelableAsyncEnumerable[T].GetAsyncEnumerator()`).
+        var getAsyncEnumeratorParams = getAsyncEnumerator.GetParameters();
+        ImmutableArray<BoundExpression> getEnumeratorArgs;
+        if (getAsyncEnumeratorParams.Length == 0)
+        {
+            getEnumeratorArgs = ImmutableArray<BoundExpression>.Empty;
+        }
+        else
+        {
+            var paramType = TypeSymbol.FromClrType(getAsyncEnumeratorParams[0].ParameterType);
+            getEnumeratorArgs = ImmutableArray.Create<BoundExpression>(new BoundDefaultExpression(null, paramType));
+        }
 
         // Issue #1002 (parallel to #774 for sync `for-in`): when the stream
         // is a symbolic `ImportedTypeSymbol IAsyncEnumerable[Shape]` whose
@@ -652,7 +697,9 @@ public sealed class Lowerer : BoundTreeRewriter
         // `valueVariable` (Shape) — even though the runtime tolerates the
         // reference. Synthesize a symbolic `IAsyncEnumerator[Shape]` so
         // the BoundClrPropertyAccessExpression carries the user's `Shape`,
-        // mirroring the synchronous symbolic-open path.
+        // mirroring the synchronous symbolic-open path. This symbolic
+        // recovery only applies to the interface fast path — the pattern
+        // fallback's `enumeratorClr` always carries a concrete CLR type.
         TypeSymbol enumeratorType;
         TypeSymbol currentType;
         if (stream.Type is ImportedTypeSymbol streamImp
@@ -671,7 +718,7 @@ public sealed class Lowerer : BoundTreeRewriter
         else
         {
             enumeratorType = TypeSymbol.FromClrType(enumeratorClr);
-            currentType = TypeSymbol.FromClrType(currentProperty.PropertyType);
+            currentType = GetClrMemberType(currentMember);
         }
 
         var enumeratorSymbol = new LocalVariableSymbol("$awaitEnum", isReadOnly: true, type: enumeratorType);
@@ -681,7 +728,7 @@ public sealed class Lowerer : BoundTreeRewriter
             stream,
             getAsyncEnumerator,
             enumeratorType,
-            ImmutableArray.Create<BoundExpression>(new BoundDefaultExpression(null, cancellationTokenType)));
+            getEnumeratorArgs);
         var enumeratorDecl = new BoundVariableDeclaration(null, enumeratorSymbol, getEnumCall);
 
         // Issue #937: the loop's continue label sits at the MoveNextAsync
@@ -701,7 +748,7 @@ public sealed class Lowerer : BoundTreeRewriter
         var moveNextAwait = new BoundAwaitExpression(null, moveNextCall, TypeSymbol.Bool);
         var moreDecl = new BoundVariableDeclaration(null, moreSymbol, moveNextAwait);
 
-        var currentAccess = new BoundClrPropertyAccessExpression(null, enumeratorExpr, currentProperty, currentType);
+        var currentAccess = new BoundClrPropertyAccessExpression(null, enumeratorExpr, currentMember, currentType);
         var assignValue = new BoundExpressionStatement(
             null,
             new BoundAssignmentExpression(null, valueVariable, currentAccess));
@@ -716,6 +763,16 @@ public sealed class Lowerer : BoundTreeRewriter
         tryStatements.Add(new BoundLabelStatement(null, endLabel));
         var tryBlock = new BoundBlockStatement(null, tryStatements.ToImmutable());
 
+        if (disposeAsync == null)
+        {
+            // Issue #2280: no `IAsyncDisposable`/pattern `DisposeAsync()` at
+            // all — per the C# spec the loop performs no disposal (matches
+            // `await foreach`'s own behavior for such enumerators).
+            return new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(enumeratorDecl, tryBlock));
+        }
+
+        var valueTaskClr = disposeAsync.ReturnType;
+        var valueTaskType = TypeSymbol.FromClrType(valueTaskClr);
         var disposeCall = new BoundImportedInstanceCallExpression(
             null,
             enumeratorExpr,

--- a/test/Compiler.Tests/Emit/Issue2280AwaitForPatternAsyncEnumerableEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2280AwaitForPatternAsyncEnumerableEmitTests.cs
@@ -1,0 +1,404 @@
+// <copyright file="Issue2280AwaitForPatternAsyncEnumerableEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2280: <c>await for x in stream.ConfigureAwait(false) { ... }</c>
+/// failed to bind with GS0134 because
+/// <c>System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable&lt;T&gt;</c>
+/// (returned by <c>IAsyncEnumerable&lt;T&gt;.ConfigureAwait(bool)</c>) implements
+/// no interfaces at all — it is a fully duck-typed (pattern-based) async
+/// enumerable per the C# <c>await foreach</c> spec: a parameterless
+/// <c>GetAsyncEnumerator()</c> whose enumerator exposes <c>Current</c> and
+/// <c>MoveNextAsync() -&gt; ConfiguredValueTaskAwaitable&lt;bool&gt;</c> (not
+/// <c>ValueTask&lt;bool&gt;</c>), and disposes via a pattern
+/// <c>DisposeAsync() -&gt; ConfiguredValueTaskAwaitable</c> (not
+/// <c>IAsyncDisposable</c>).
+/// <para>
+/// These end-to-end tests pin the fix at runtime for: (1) the exact issue
+/// repro (<c>.ConfigureAwait(false)</c> on an <c>IAsyncEnumerable[T]</c>), (2)
+/// a fully hand-rolled duck-typed async enumerable with no interfaces
+/// anywhere in its shape, proving the fix generalizes beyond
+/// <c>ConfiguredCancelableAsyncEnumerable[T]</c> to the full C# pattern, and
+/// (3) a regression guard for the pre-existing plain
+/// <c>IAsyncEnumerable[T]</c> interface path.
+/// </para>
+/// </summary>
+public class Issue2280AwaitForPatternAsyncEnumerableEmitTests
+{
+    #region Exact issue repro: IAsyncEnumerable[T].ConfigureAwait(false)
+
+    [Fact]
+    public void AwaitFor_ConfigureAwaitFalse_On_IAsyncEnumerable_Compiles_And_Runs()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Numbers() IAsyncEnumerable[int32] {
+                yield 1
+                await Task.Yield()
+                yield 2
+            }
+
+            async func Run() {
+                var sum = 0
+                await for n in Numbers().ConfigureAwait(false) {
+                    sum = sum + n
+                }
+                Console.WriteLine(sum)
+            }
+
+            Run().Wait()
+            """;
+
+        var (assembly, stdout) = CompileRunCapture(source);
+        Assert.Equal("3", stdout.Trim());
+    }
+
+    [Fact]
+    public void AwaitFor_ConfigureAwaitFalse_Break_Disposes_Enumerator()
+    {
+        // Early `break` must still route through the pattern-based
+        // DisposeAsync() (a ConfiguredValueTaskAwaitable, not IAsyncDisposable).
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Numbers() IAsyncEnumerable[int32] {
+                yield 1
+                await Task.Yield()
+                yield 2
+                await Task.Yield()
+                yield 3
+            }
+
+            async func Run() {
+                var sum = 0
+                await for n in Numbers().ConfigureAwait(false) {
+                    sum = sum + n
+                    if n == 2 {
+                        break
+                    }
+                }
+                Console.WriteLine(sum)
+            }
+
+            Run().Wait()
+            """;
+
+        var (assembly, stdout) = CompileRunCapture(source);
+        Assert.Equal("3", stdout.Trim());
+    }
+
+    #endregion
+
+    #region Regression: plain IAsyncEnumerable[T] (no ConfigureAwait) still works
+
+    [Fact]
+    public void AwaitFor_PlainIAsyncEnumerable_Regression_Compiles_And_Runs()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Numbers() IAsyncEnumerable[int32] {
+                yield 1
+                await Task.Yield()
+                yield 2
+            }
+
+            async func Run() {
+                var sum = 0
+                await for n in Numbers() {
+                    sum = sum + n
+                }
+                Console.WriteLine(sum)
+            }
+
+            Run().Wait()
+            """;
+
+        var (assembly, stdout) = CompileRunCapture(source);
+        Assert.Equal("3", stdout.Trim());
+    }
+
+    #endregion
+
+    #region Fully hand-rolled duck-typed async enumerable (no interfaces anywhere)
+
+    [Fact]
+    public void AwaitFor_FullyDuckTypedCustomAsyncEnumerable_Compiles_And_Runs()
+    {
+        // A custom C# helper library whose entire await-foreach surface —
+        // the enumerable's GetAsyncEnumerator(), the enumerator's
+        // MoveNextAsync()/Current/DisposeAsync(), and the awaitables
+        // MoveNextAsync()/DisposeAsync() return — implements NO interfaces
+        // except the minimal INotifyCompletion the C# awaiter pattern itself
+        // requires. This proves the fix is the general pattern-based
+        // `await foreach` shape, not a ConfiguredCancelableAsyncEnumerable[T]
+        // special case.
+        var helperLibPath = BuildCustomDuckTypedAsyncEnumerableLibrary();
+
+        var source = """
+            package Probe
+            import System
+            import CustomAsyncDuck
+
+            async func Run() {
+                var sum = 0
+                var stream = Factory.Create()
+                await for n in stream {
+                    sum = sum + n
+                }
+                Console.WriteLine(sum)
+            }
+
+            Run().Wait()
+            """;
+
+        var (assembly, stdout) = CompileRunCapture(source, extraReferences: new[] { helperLibPath });
+        Assert.Equal("6", stdout.Trim());
+    }
+
+    private static string BuildCustomDuckTypedAsyncEnumerableLibrary()
+    {
+        const string HelperSource = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            namespace CustomAsyncDuck
+            {
+                public struct MoveNextAwaiter : ICriticalNotifyCompletion
+                {
+                    private readonly bool result;
+
+                    public MoveNextAwaiter(bool result) => this.result = result;
+
+                    public bool IsCompleted => true;
+
+                    public bool GetResult() => this.result;
+
+                    public void OnCompleted(Action continuation) => continuation();
+
+                    public void UnsafeOnCompleted(Action continuation) => continuation();
+                }
+
+                public struct MoveNextAwaitable
+                {
+                    private readonly bool result;
+
+                    public MoveNextAwaitable(bool result) => this.result = result;
+
+                    public MoveNextAwaiter GetAwaiter() => new MoveNextAwaiter(this.result);
+                }
+
+                public struct DisposeAwaiter : ICriticalNotifyCompletion
+                {
+                    public bool IsCompleted => true;
+
+                    public void GetResult()
+                    {
+                    }
+
+                    public void OnCompleted(Action continuation) => continuation();
+
+                    public void UnsafeOnCompleted(Action continuation) => continuation();
+                }
+
+                public struct DisposeAwaitable
+                {
+                    public DisposeAwaiter GetAwaiter() => new DisposeAwaiter();
+                }
+
+                // Implements NO interfaces at all (not IAsyncDisposable).
+                public sealed class CustomAsyncEnumerator
+                {
+                    private readonly int[] items;
+                    private int index = -1;
+                    public bool Disposed;
+
+                    public CustomAsyncEnumerator(int[] items) => this.items = items;
+
+                    public int Current => this.items[this.index];
+
+                    public MoveNextAwaitable MoveNextAsync()
+                    {
+                        this.index++;
+                        return new MoveNextAwaitable(this.index < this.items.Length);
+                    }
+
+                    public DisposeAwaitable DisposeAsync()
+                    {
+                        this.Disposed = true;
+                        return new DisposeAwaitable();
+                    }
+                }
+
+                // Implements NO interfaces at all (not IAsyncEnumerable[T]).
+                public sealed class CustomAsyncEnumerable
+                {
+                    private readonly int[] items;
+
+                    public CustomAsyncEnumerable(int[] items) => this.items = items;
+
+                    public CustomAsyncEnumerator GetAsyncEnumerator() => new CustomAsyncEnumerator(this.items);
+                }
+
+                public static class Factory
+                {
+                    public static CustomAsyncEnumerable Create() => new CustomAsyncEnumerable(new[] { 1, 2, 3 });
+                }
+            }
+            """;
+
+        var tree = CSharpSyntaxTree.ParseText(HelperSource, new CSharpParseOptions(LanguageVersion.Latest));
+        var references = RuntimeReferencePaths()
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "CustomAsyncDuck",
+            new[] { tree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var dir = Directory.CreateTempSubdirectory("gs_2280_helperlib_").FullName;
+        var path = Path.Combine(dir, "CustomAsyncDuck.dll");
+
+        using (var stream = File.Create(path))
+        {
+            var result = compilation.Emit(stream);
+            if (!result.Success)
+            {
+                var diagnostics = string.Join(
+                    Environment.NewLine,
+                    result.Diagnostics.Select(d => d.ToString()));
+                throw new InvalidOperationException($"Failed to compile helper library:\n{diagnostics}");
+            }
+        }
+
+        return path;
+    }
+
+    private static IReadOnlyList<string> RuntimeReferencePaths()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? string.Empty;
+        return tpa
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && File.Exists(p))
+            .ToList();
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static (Assembly assembly, string stdout) CompileRunCapture(string source, string[] extraReferences = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2280_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+        };
+
+        if (extraReferences != null)
+        {
+            foreach (var reference in extraReferences)
+            {
+                args.Add("/r:" + reference);
+            }
+        }
+
+        args.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath, extraReferences);
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        if (extraReferences != null)
+        {
+            // The helper assembly isn't on the default load path, so resolve
+            // it explicitly when the runtime probes for it while invoking
+            // <Main>$.
+            AppDomain.CurrentDomain.AssemblyResolve += (_, resolveArgs) =>
+            {
+                var name = new AssemblyName(resolveArgs.Name).Name;
+                foreach (var reference in extraReferences)
+                {
+                    if (string.Equals(Path.GetFileNameWithoutExtension(reference), name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return Assembly.LoadFrom(reference);
+                    }
+                }
+
+                return null;
+            };
+        }
+
+        // Run the entry point and capture stdout
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
+        var captured = new StringWriter();
+        var prevOut2 = Console.Out;
+        Console.SetOut(captured);
+        try
+        {
+            entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { System.Array.Empty<string>() });
+        }
+        finally
+        {
+            Console.SetOut(prevOut2);
+        }
+
+        return (assembly, captured.ToString().Replace("\r\n", "\n"));
+    }
+
+    #endregion
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/AwaitForRangeStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AwaitForRangeStatementTests.cs
@@ -38,6 +38,30 @@ total
     }
 
     [Fact]
+    public void AwaitFor_ConfigureAwaitFalse_DrainsAsyncEnumerable()
+    {
+        // Issue #2280: `stream.ConfigureAwait(false)` returns
+        // `ConfiguredCancelableAsyncEnumerable[T]`, a fully duck-typed
+        // (pattern-based) async enumerable that implements no interfaces at
+        // all. Confirms the binder recognizes the pattern shape (element-type
+        // inference) and the interpreter can drain it end-to-end.
+        var source = @"
+import System.Linq
+import System.Threading.Tasks
+import GSharp.Core.Tests.CodeAnalysis.Binding
+
+var total = 0
+await for v in AsyncStreamFixture.Counts().ConfigureAwait(false) {
+    total = total + v
+}
+total
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1 + 2 + 3, result.Value);
+    }
+
+    [Fact]
     public void AwaitFor_NonAsyncEnumerable_Diagnoses()
     {
         // A type that doesn't implement IAsyncEnumerable<T>; the binder


### PR DESCRIPTION
## Summary

`await for x in stream.ConfigureAwait(false) { ... }` failed to compile with `GS0134` when `stream` is `IAsyncEnumerable[T]`. `IAsyncEnumerable<T>.ConfigureAwait(bool)` returns `System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T>`, which implements **no interfaces at all** — it is a fully duck-typed (pattern-based) async enumerable per the C# `await foreach` spec:

```
ConfiguredCancelableAsyncEnumerable<T>.GetAsyncEnumerator()   // zero params, not GetAsyncEnumerator(CancellationToken)
  -> Enumerator (implements NO interfaces)
       .MoveNextAsync() -> ConfiguredValueTaskAwaitable<bool>   (NOT ValueTask<bool>)
       .Current -> T
       .DisposeAsync() -> ConfiguredValueTaskAwaitable          (NOT via IAsyncDisposable)
```

This closes #2280 by generalizing `await for` binding and lowering to the full C# spec pattern (mirroring the existing sync `for ... in` `GetEnumerator()` pattern support from #939/#990), rather than special-casing `ConfiguredCancelableAsyncEnumerable[T]`.

## Root cause (both gaps confirmed)

1. **`MemberLookup.TryGetAsyncEnumerableElementType`** only recognized types implementing `IAsyncEnumerable<T>` (walking `EnumerateSelfAndInterfaces`), so element-type inference failed and `GS0134` fired before iteration was even attempted.
2. **`Lowerer.LowerAwaitForRange`** hardcoded the whole desugaring around the `IAsyncEnumerable<T>` interface: it assumed `GetAsyncEnumerator(CancellationToken)` always has exactly one parameter (`GetParameters()[0]`, which would throw `IndexOutOfRangeException` for the parameterless pattern overload), and it discovered `DisposeAsync` solely via `IAsyncDisposable` found through `GetInterfaces()` (the configured `Enumerator` implements no interfaces, so this returned `null` and bailed to a `BoundErrorExpression`).

**A third, shared gap** was found and fixed while investigating: the tree-walking **interpreter** (`Evaluator.cs`, a separate code path from the emitter/`Lowerer`) had the identical two gaps in `EvaluateAwaitForRangeStatement`, *and* its plain `await` handling (`EvaluateAwaitExpression`) was hardcoded to recognize only `Task`/`ValueTask`/`ValueTask<T>` by type name — which breaks on `ConfiguredValueTaskAwaitable(<T>)` (returned by the pattern's `MoveNextAsync`/`DisposeAsync`). The **emitter's** own `await` lowering (`BoundAwaitExpression` + `Lowering/Async/AwaitableShape`) was already fully generic — `AwaitableShape.Resolve` structurally resolves `GetAwaiter()`/`IsCompleted`/`GetResult()` for any CLR type — so no changes were needed there.

## Fix

- **Binder** (`src/Core/CodeAnalysis/Binding/MemberLookup.cs`): `TryGetAsyncEnumerableElementType` now falls back to a new `TryResolveClrPatternAsyncEnumerator` probe when no `IAsyncEnumerable<T>` interface is found — looks for a public instance `GetAsyncEnumerator(...)` accepting 0 or 1 arguments directly on the type (independent of any interface), then probes its return type for a `MoveNextAsync()` method and a `Current` property/field, again independent of any interface. Mirrors `TryGetClrPatternEnumerableElementType` (the sync `GetEnumerator()` pattern probe for #939/#990).
- **Lowering** (`src/Core/CodeAnalysis/Lowering/Lowerer.cs`): `LowerAwaitForRange` tries the `IAsyncEnumerable<T>` interface first (unchanged fast path), then falls back to the same pattern probe. `GetAsyncEnumerator` is invoked with the correct arity (0 args, or `default(ParamType)` for a single-parameter overload) instead of assuming a `CancellationToken` parameter always exists. `MoveNextAsync`'s actual return type (whether `ValueTask<bool>` or a duck-typed `ConfiguredValueTaskAwaitable<bool>`) flows into `BoundAwaitExpression` unchanged — no special-casing needed since the await lowering already resolves it structurally. `DisposeAsync` is looked up via `IAsyncDisposable` first, then as a pattern method found directly on the enumerator type; when neither is present, **no disposal is emitted** (matches the C# spec) instead of bailing to an error.
- **Interpreter** (`src/Core/CodeAnalysis/Evaluator.cs`): `EvaluateAwaitForRangeStatement` gets the identical binder-mirrored fallback (via the same `MemberLookup.TryResolveClrPatternAsyncEnumerator`). `EvaluateAwaitExpression` is generalized to resolve any awaitable via `GetAwaiter()`/`GetResult()` (reusing the pre-existing `BlockOnValueTask` reflection helper) instead of a `Task`/`ValueTask`-by-name allowlist.

The existing `IAsyncEnumerable<T>` interface path is unchanged and remains the fast path in all three components (binder, lowering, interpreter); the pattern-based resolution is purely a fallback, so no regression risk for existing `await for` users.

## Tests

- `test/Compiler.Tests/Emit/Issue2280AwaitForPatternAsyncEnumerableEmitTests.cs` (new, compile+run, IL-verified):
  - Exact issue repro: `await for n in Numbers().ConfigureAwait(false) { ... }` over `IAsyncEnumerable[int32]`.
  - Early `break` inside the `ConfigureAwait(false)` loop still disposes via the pattern `DisposeAsync()`.
  - Regression: plain `IAsyncEnumerable[T]` (no `ConfigureAwait`) still works.
  - A fully hand-rolled duck-typed async enumerable — compiled as a separate C# helper library with **no interfaces anywhere** in its `await foreach` surface (`GetAsyncEnumerator`, `MoveNextAsync`, `Current`, `DisposeAsync`, and the awaitables they return) — proving the fix is the general pattern, not a `ConfiguredCancelableAsyncEnumerable[T]` special case.
- `test/Core.Tests/CodeAnalysis/Binding/AwaitForRangeStatementTests.cs`: added an interpreter-path `ConfigureAwait(false)` regression test alongside the existing binder-level `await for` coverage.

### Results

- `Issue2280AwaitForPatternAsyncEnumerableEmitTests` + `Issue652AwaitForAsyncEnumerableEmitTests` + broader `AwaitFor`/`AsyncEnumerable` filter (Compiler.Tests): **16 passed, 0 failed**.
- `AwaitForRangeStatementTests` (Core.Tests): **5 passed, 0 failed**.
- Broader `Async` filter, Core.Tests: **329 passed, 0 failed**.
- Broader `Async` filter, Compiler.Tests: **140 passed, 0 failed**.
- Full solution build (`GSharp.sln`, Release): **0 warnings, 0 errors** (StyleCop/analyzer-clean).

Closes #2280
