### PR TITLE
gsc: fix invalid branch IL emission that crashes ilverify (#2283)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -516,11 +516,30 @@ internal sealed partial class MethodBodyEmitter
         this.il.Call(this.outer.GetMethodEntityHandle(bounded));
     }
 
+    // Issue #2283: entry point used from expression-position emit
+    // (MethodBodyEmitter.Expressions.cs). MaterializeSpilledChannelReceives
+    // runs EmitChannelReceiveCore for every receive in the containing
+    // statement before any of the statement's IL is emitted, so by the time
+    // this is reached the result is already sitting in its slot — just load
+    // it. This guarantees the try/catch below only ever runs at an
+    // empty-stack point, regardless of where `<-ch` appears syntactically.
     private void EmitChannelReceiveExpression(BoundChannelReceiveExpression node)
     {
-        // try { result = ch.Reader.ReadAsync(default).AsTask().GetAwaiter().GetResult(); }
-        // catch (ChannelClosedException) { result = default(T); }
-        // ldloc result
+        Debug.Assert(
+            this.materializedChannelReceives.Contains(node),
+            "BoundChannelReceiveExpression reached emit without being materialised by MaterializeSpilledChannelReceives.");
+        this.il.LoadLocal(this.channelOpSlots[node].Result);
+    }
+
+    // try { result = ch.Reader.ReadAsync(default).AsTask().GetAwaiter().GetResult(); }
+    // catch (ChannelClosedException) { result = default(T); }
+    //
+    // Emits the try/catch at the CURRENT IL position and stores the outcome
+    // into the node's pre-allocated result slot, but does NOT load it back —
+    // callers own that (see MaterializeSpilledChannelReceives, which runs
+    // this at the empty-stack start of the containing statement).
+    private void EmitChannelReceiveCore(BoundChannelReceiveExpression node)
+    {
         var chType = (ChannelTypeSymbol)node.Channel.Type;
         var elementClr = ResolveChannelElementClrType(chType.ElementType);
         var channelClr = typeof(System.Threading.Channels.Channel<>).MakeGenericType(elementClr);
@@ -580,8 +599,6 @@ internal sealed partial class MethodBodyEmitter
 
         var catchTypeHandle = (EntityHandle)this.outer.GetTypeReference(ccExceptionClr);
         this.il.ControlFlowBuilder.AddCatchRegion(tryStart, tryEnd, handlerStart, handlerEnd, catchTypeHandle);
-
-        this.il.LoadLocal(resultSlot);
     }
 
     private void EmitChannelCloseExpression(BoundChannelCloseExpression node)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -66,6 +66,21 @@ internal sealed partial class MethodBodyEmitter
     private readonly Dictionary<BoundStackAllocExpression, int> stackAllocResultSlots;
     private readonly HashSet<BoundStackAllocExpression> materializedStackAllocs = new HashSet<BoundStackAllocExpression>();
 
+    // Issue #2283: a `<-ch` channel-receive expression emits its own inline
+    // try/catch (see EmitChannelReceiveCore) to translate a closed-channel
+    // exception into `default(T)`. ECMA-335 III.3.47 requires a protected
+    // block to be entered with an empty evaluation stack. When the receive is
+    // the WHOLE statement (or the direct initializer/RHS of one), the stack is
+    // already empty at that point and this is safe. But when it is a
+    // sub-expression — an operand of `+`, a call argument, embedded in a
+    // larger expression — earlier operands are already sitting on the stack
+    // when the receive's try/catch begins, producing invalid IL
+    // (ilverify TryNonEmptyStack / StackUnderflow, and an
+    // InvalidProgramException at run time). Track which receive nodes have
+    // already had their try/catch materialised so every occurrence — root or
+    // not — runs exactly once, at the start of its containing statement.
+    private readonly HashSet<BoundChannelReceiveExpression> materializedChannelReceives = new HashSet<BoundChannelReceiveExpression>();
+
     // Issue #1688: tracks which planned receiverSpillSlots entries have
     // already been evaluated-and-cached during this method's emission. A
     // compound member assignment (`getObj().F += x` / `getObj().P += x`)
@@ -234,6 +249,7 @@ internal sealed partial class MethodBodyEmitter
 
         this.RecordSequencePointFor(statement);
         this.MaterializeSpilledStackAllocs(statement);
+        this.MaterializeSpilledChannelReceives(statement);
         switch (statement)
         {
             case BoundBlockStatement block:
@@ -408,6 +424,40 @@ internal sealed partial class MethodBodyEmitter
 
             this.EmitStackAllocCore(sa);
             this.il.StoreLocal(this.stackAllocResultSlots[sa]);
+        }
+    }
+
+    // Issue #2283: before a statement's own IL is emitted (evaluation stack is
+    // empty here), materialise every `<-ch` channel-receive expression this
+    // statement contains, in source order, running each one's try/catch (see
+    // EmitChannelReceiveCore) at this empty-stack point and storing the
+    // result into its pre-allocated slot. The original operand position
+    // (EmitChannelReceiveExpression) then just loads that slot instead of
+    // re-emitting the try/catch — which would otherwise open a protected
+    // region while earlier operands of the same expression are still on the
+    // stack (ECMA-335 III.3.47 violation: ilverify TryNonEmptyStack /
+    // StackUnderflow, InvalidProgramException at run time). Nested statements
+    // are handled by their own EmitStatement pass, so this walker does not
+    // descend past the first statement boundary. This always runs — even for
+    // a receive that is already the whole statement — so there is exactly one
+    // code path, and it is unconditionally safe.
+    private void MaterializeSpilledChannelReceives(BoundStatement statement)
+    {
+        if (this.channelOpSlots.Count == 0)
+        {
+            return;
+        }
+
+        var receives = new List<BoundChannelReceiveExpression>();
+        new ChannelReceiveCollector(receives).Visit(statement);
+        foreach (var recv in receives)
+        {
+            if (!this.materializedChannelReceives.Add(recv))
+            {
+                continue;
+            }
+
+            this.EmitChannelReceiveCore(recv);
         }
     }
 
@@ -1149,6 +1199,43 @@ internal sealed partial class MethodBodyEmitter
             if (node is BoundStackAllocExpression sa && this.spilled.ContainsKey(sa))
             {
                 this.sink.Add(sa);
+            }
+        }
+    }
+
+    // Issue #2283: collects every BoundChannelReceiveExpression directly
+    // contained in a single statement (mirrors SpilledStackAllocCollector —
+    // does not descend past the first statement boundary; nested statements
+    // run their own MaterializeSpilledChannelReceives pass). Post-order, so a
+    // receive nested inside another receive's channel sub-expression (however
+    // unlikely) is materialised innermost-first.
+    private sealed class ChannelReceiveCollector : BoundTreeWalker
+    {
+        private readonly List<BoundChannelReceiveExpression> sink;
+        private bool entered;
+
+        public ChannelReceiveCollector(List<BoundChannelReceiveExpression> sink)
+        {
+            this.sink = sink;
+        }
+
+        public override void VisitStatement(BoundStatement node)
+        {
+            if (this.entered)
+            {
+                return;
+            }
+
+            this.entered = true;
+            base.VisitStatement(node);
+        }
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            base.VisitExpression(node);
+            if (node is BoundChannelReceiveExpression recv)
+            {
+                this.sink.Add(recv);
             }
         }
     }

--- a/test/Compiler.Tests/Emit/Issue2283ChannelReceiveSubExpressionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2283ChannelReceiveSubExpressionEmitTests.cs
@@ -1,0 +1,231 @@
+// <copyright file="Issue2283ChannelReceiveSubExpressionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2283 was reported as an <c>ilverify</c> CRASH
+/// (<c>IndexOutOfRangeException</c> in
+/// <c>Internal.IL.ILImporter.MarkPredecessorWithLowerOffset</c>) compiling
+/// control-flow-heavy Oahu.SystemManagement code (nested loops parsing shell
+/// output). The private source that triggered the crash is not available, and
+/// an extensive search for a minimal repro — nested/labeled loops with
+/// <c>break</c>/<c>continue</c>, deeply nested <c>try</c>/<c>catch</c>/
+/// <c>finally</c>, pattern-switch statements and expressions, <c>if let</c>/
+/// <c>guard let</c>, <c>using let</c>/<c>defer</c>, very long methods forcing
+/// long-form branch encoding, goroutines and <c>select</c> — did not reproduce
+/// that exact crash. gsc's branch emission goes through
+/// <c>System.Reflection.Metadata</c>'s <c>InstructionEncoder</c>/
+/// <c>ControlFlowBuilder</c>, which auto-sizes and fixes up branch targets, so
+/// a short-branch-overflow or manual offset miscalculation was ruled out as
+/// the likely cause.
+/// <para>
+/// That search did surface a real, confirmed, closely related IL-emission
+/// stack-balance bug in the SAME problem domain (protected-region placement
+/// relative to the evaluation stack, the class of bug
+/// <c>MarkPredecessorWithLowerOffset</c>'s crash strongly implies): a channel
+/// receive expression (<c>&lt;-ch</c>) emitted its <c>try</c>/<c>catch</c>
+/// (translating a closed-channel exception into <c>default(T)</c>) INLINE at
+/// its point of evaluation, unconditionally. Per ECMA-335 III.3.47 a
+/// protected region must be entered with an EMPTY evaluation stack. When the
+/// receive is a sub-expression of a larger expression — e.g.
+/// <c>total = total + &lt;-ch</c>, or inside a loop condition/call argument —
+/// earlier operands are already on the stack when the try region opens,
+/// producing invalid IL: ilverify reports <c>TryNonEmptyStack</c> and
+/// <c>StackUnderflow</c>, and the JIT throws
+/// <see cref="InvalidProgramException"/> at run time.
+/// </para>
+/// <para>
+/// The fix follows the existing "stackalloc spilling" pattern from Issue
+/// #1522: every <c>BoundChannelReceiveExpression</c> in a statement is
+/// materialised — its <c>try</c>/<c>catch</c> executed and result stored to a
+/// pre-allocated local — at the START of that statement's emission, when the
+/// stack is guaranteed empty (<c>MaterializeSpilledChannelReceives</c> in
+/// <c>MethodBodyEmitter.cs</c>, called from <c>EmitStatement</c>). The
+/// original expression-position emit (<c>EmitChannelReceiveExpression</c> in
+/// <c>MethodBodyEmitter.Calls.cs</c>) then just loads that already-computed
+/// result local instead of re-emitting the try/catch in place.
+/// </para>
+/// These tests compile, ilverify, and run the exact failure shapes: a
+/// channel-receive as an operand of <c>+</c>, and the same pattern nested
+/// inside a loop with <c>continue</c>/<c>break</c> (mirroring the
+/// control-flow-heavy shape from the original report).
+/// </summary>
+public class Issue2283ChannelReceiveSubExpressionEmitTests
+{
+    [Fact]
+    public void ChannelReceive_AsAdditionOperand_VerifiesAndRuns()
+    {
+        const string source = """
+            package Issue2283.AddOperand
+            import System
+            import Gsharp.Extensions.Go
+
+            let ch = make(chan int32, 1)
+            ch <- 7
+            var total = 0
+            total = total + <-ch
+            Console.WriteLine(total)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void ChannelReceive_InLoopWithBreakAndContinue_VerifiesAndRuns()
+    {
+        const string source = """
+            package Issue2283.LoopBreakContinue
+            import System
+            import Gsharp.Extensions.Go
+
+            let ch = make(chan int32, 5)
+            for var i = 0; i < 5; i++ {
+                ch <- i
+            }
+            var total = 0
+            for var i = 0; i < 5; i++ {
+                if i == 2 {
+                    continue
+                }
+                total = total + <-ch
+                if total > 100 {
+                    break
+                }
+            }
+            Console.WriteLine(total)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("6\n", output);
+    }
+
+    [Fact]
+    public void ChannelReceive_AsCallArgument_VerifiesAndRuns()
+    {
+        const string source = """
+            package Issue2283.CallArgument
+            import System
+            import Gsharp.Extensions.Go
+
+            func Sum2283(a int32, b int32) int32 -> a + b
+
+            let ch = make(chan int32, 1)
+            ch <- 5
+            Console.WriteLine(Sum2283(10, <-ch))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("15\n", output);
+    }
+
+    [Fact]
+    public void ChannelReceive_StatementRoot_StillVerifiesAndRuns()
+    {
+        // Regression guard: a bare `let x = <-ch` (already at an empty-stack
+        // root position) is unaffected by the spilling fix and keeps working.
+        const string source = """
+            package Issue2283.StatementRoot
+            import System
+            import Gsharp.Extensions.Go
+
+            let ch = make(chan int32, 1)
+            ch <- 3
+            let v = <-ch
+            Console.WriteLine(v)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2283_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Issue #2283 reports that gsc emitted invalid branch IL for control-flow-heavy `Oahu.SystemManagement` code, crashing `ilverify` with `IndexOutOfRangeException` in `Internal.IL.ILImporter.MarkPredecessorWithLowerOffset` (suspect source: nested `for`/`if` parsing shell output in `LinuxHardwareIdProvider.cs`).

## Reproduction attempt (not reproduced)

The Oahu private source that triggered the crash isn't available in this environment. I spent significant effort trying to reproduce the exact crash with synthetic G# programs, including:

- Nested C-style `for` loops with `break`/`continue`, including labeled loops (`outer: ... break outer`/`continue outer`) and string/char indexing.
- Deeply nested `try`/`catch`/`finally` around loops, including labeled break/continue crossing a `try` boundary (forcing IL `leave`).
- Pattern-switch (`switch n { case 1 { } }`) both as a statement and expression, nested inside loops and `try`/`finally`.
- `if let`/`guard let`, `??=`, `?.` nested in loops.
- `using let` + `defer` (block-scoped dispose) wrapping nested loops.
- Very long methods (~450 lines, 60+ branches per loop) intended to force branches whose target offset exceeds the signed-byte range.
- Goroutines (`go`) and `select` in loops, closures capturing loop variables.

All of these (~30+ variants) compiled, ran correctly, and passed `ilverify` cleanly. I also confirmed gsc's branch emission goes entirely through `System.Reflection.Metadata`'s `InstructionEncoder`/`ControlFlowBuilder`, which auto-sizes short vs. long branch encodings and performs its own target-offset fixup — this rules out the classic "short-branch overflow" and "manual offset off-by-one" bug shapes as the likely cause here, since there is no manually-encoded short-form branch anywhere in the emitter.

**I was not able to reproduce the exact reported crash.** Per the task's explicit fallback, I instead audited the branch/protected-region emission code for the bug *class* the crash implies (a stack/branch-target bookkeeping inconsistency around control flow) and found and fixed a real, verified bug in the same problem domain.

## Root cause (bug actually found and fixed)

`EmitChannelReceiveExpression` (`src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs`) emitted a channel-receive expression's (`<-ch`) `try { ... } catch (ChannelClosedException) { ... }` region **inline, at the point of evaluation, unconditionally** — regardless of the current evaluation-stack depth.

ECMA-335 III.3.47 requires a protected region to be entered with an **empty** evaluation stack. When `<-ch` is a sub-expression of a larger expression (e.g. `total = total + <-ch`, a call argument, a loop condition), earlier operands are already on the stack when the try region opens. This produces invalid IL:

- `ilverify` reports `TryNonEmptyStack` and `StackUnderflow`.
- The JIT throws `System.InvalidProgramException` at run time (verified locally with `total = total + <-ch`, `total = total + <-ch` inside a loop with `continue`/`break`, and `Sum(10, <-ch)` as a call argument).

This is confirmed, reproducible, and in the exact same conceptual territory as the reported crash (protected-region/branch/stack bookkeeping around control flow), even though it isn't the literal reported scenario.

## Fix

Applied the same "spill to an empty-stack point" pattern already used for `stackalloc` (issue #1522):

- Every `BoundChannelReceiveExpression` found in a statement is now materialised — its try/catch executed and result stored to a pre-allocated local — at the very **start** of that statement's emission, when the evaluation stack is guaranteed empty (`MaterializeSpilledChannelReceives` in `MethodBodyEmitter.cs`, called from `EmitStatement` alongside the existing `MaterializeSpilledStackAllocs`).
- A new `ChannelReceiveCollector : BoundTreeWalker` (mirroring `SpilledStackAllocCollector`) collects the receive nodes belonging to the current statement only (does not descend into nested statements, which run their own pass).
- `EmitChannelReceiveExpression` in `MethodBodyEmitter.Calls.cs` is split into `EmitChannelReceiveCore` (the try/catch + store, unchanged logic) and a thin public entry point that asserts the node was already materialised and just loads the pre-computed result local — so the try/catch runs exactly once, always at an empty-stack point, regardless of where `<-ch` appears syntactically.

This always-materialize-at-statement-start approach is simpler than the stackalloc pattern's root/non-root distinction (no separate "is this the statement root" detection needed), since materializing early is behaviorally identical to in-place emission for the already-root case.

Files changed:
- `src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs` (+field, `MaterializeSpilledChannelReceives`, `ChannelReceiveCollector`)
- `src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs` (split `EmitChannelReceiveExpression` → core + wrapper)
- `test/Compiler.Tests/Emit/Issue2283ChannelReceiveSubExpressionEmitTests.cs` (new regression tests)

## Tests

New `Issue2283ChannelReceiveSubExpressionEmitTests` (4 tests, all pass): channel-receive as an addition operand, nested in a loop with `continue`/`break`, as a call argument, and the statement-root case (regression guard that the unaffected path still works). Each test compiles, calls `IlVerifier.Verify` (clean, no ignored codes), and runs the program asserting correct output.

Ran the full targeted `Emit` test suite (2586 tests): 2581 passed, 5 failed — all 5 failures are a pre-existing, unrelated environment gap (`Gsharp.Extensions.dll not found`, a separate SDK project not built by this workflow), confirmed present on `main` before this change via `git stash` bisection.

Also ran full `Core`/`Compiler.Tests` project builds with `--no-incremental`: 0 warnings, 0 errors (StyleCop/analyzer-clean).

## Honesty note

The exact reported crash (`MarkPredecessorWithLowerOffset` `IndexOutOfRangeException`) was **not reproduced**. This PR fixes a different, real, verified IL-emission correctness bug uncovered during that investigation, in the same problem domain (protected regions vs. evaluation-stack state around control flow). If the Oahu code that triggered the original crash does not involve channels, this PR likely does not close the literal crash — but it is a genuine bug fix worth having regardless, and represents the most complete, honest result of the investigation given the constraints (private source unavailable, crash unreproduced after ~30+ varied control-flow shapes).

Related to #2283 (real adjacent branch/stack IL bug fixed and verified; the exact Oahu.SystemManagement ilverify crash was NOT reproduced, so this may not fully resolve #2283 — leaving it open until confirmed against the Oahu re-migration)