### PR TITLE
docs: document gsi REPL and cs2gs global tools

### DIFF
--- a/website/docs/tooling/cs2gs.md
+++ b/website/docs/tooling/cs2gs.md
@@ -8,6 +8,16 @@ draft: false
 
 `cs2gs` is the repository's C#→G# migration tool and gap-discovery pipeline. It lives under `tools\cs2gs\`, uses Roslyn as an external C# front end, emits canonical G#, and then validates the result through the real G# toolchain. It is sibling tooling: `gsc` does not reference Roslyn.
 
+## Install as a global tool
+
+`cs2gs` is published as the [`Gsharp.Cs2Gs`](https://www.nuget.org/packages/Gsharp.Cs2Gs/) .NET global tool (it requires a .NET 10 runtime):
+
+```sh
+dotnet tool install --global Gsharp.Cs2Gs
+```
+
+Once installed, the `cs2gs` command is on your `PATH`, and the examples below use it directly. Update or remove it with `dotnet tool update --global Gsharp.Cs2Gs` and `dotnet tool uninstall --global Gsharp.Cs2Gs`. When working from a source build of this repository instead, invoke the same verbs through the built assembly — `dotnet out\bin\Release\Cs2Gs.Cli\cs2gs.dll <verb>`.
+
 ## What it does
 
 A migration run is deterministic and stage-based:
@@ -21,10 +31,10 @@ Every run writes artifacts, `report.html`, and `summary.json` under the run dire
 
 ## Basic usage
 
-The Release tool's help currently reports:
+The tool's help reports:
 
-```powershell
-dotnet out\bin\Release\Cs2Gs.Cli\cs2gs.dll --help
+```sh
+cs2gs --help
 ```
 
 ```text
@@ -38,8 +48,8 @@ cs2gs triage sync [--gaps <file>] [--write] [--no-test-reason <why>]
 
 For a normal corpus run:
 
-```powershell
-dotnet out\bin\Release\Cs2Gs.Cli\cs2gs.dll migrate --corpus tools\cs2gs\corpus --out cs2gs-runs
+```sh
+cs2gs migrate --corpus tools\cs2gs\corpus --out cs2gs-runs
 ```
 
 Useful `migrate` options:
@@ -48,7 +58,7 @@ Useful `migrate` options:
 | --- | --- |
 | `--corpus <dir>` | Corpus root. Defaults to `tools\cs2gs\corpus` when run from the repository. |
 | `--app <id>` | Migrate only one app. May be repeated. |
-| `--gsc <path>` | Override `gsc.dll`; default is `out\bin\<Config>\Compiler\gsc.dll`. |
+| `--via-sdk` | Build the emitted G# via `dotnet build` + the `Gsharp.NET.Sdk` (instead of invoking `gsc` directly) so source generators run. |
 | `--out <dir>` | Runs root for artifacts; default is `cs2gs-runs`. |
 | `--config <name>` | Build configuration used to find tools; default is `Release`. |
 | `--baseline <file>` | Gate on the gap ledger. New and regressed fingerprints fail; known-open gaps are tolerated. |

--- a/website/docs/tooling/repl.md
+++ b/website/docs/tooling/repl.md
@@ -1,0 +1,112 @@
+---
+title: "The REPL and script runner (gsi)"
+sidebar_position: 2
+draft: false
+---
+
+# The REPL and script runner (`gsi`)
+
+`gsi` is G#'s interactive REPL and single-file script runner. It ships as
+the [`Gsharp.Repl`](https://www.nuget.org/packages/Gsharp.Repl/) .NET
+global tool and is the fastest way to try the language without creating a
+project. It is a full-screen, keyboard-first TUI built on
+Spectre.Console that reuses the same `Core` compilation engine and
+`LanguageServer` analysis as the compiler, so the prompt behaves like a
+small editor (live syntax colors, completion, hover, and diagnostics)
+rather than a plain line reader.
+
+## Install
+
+`gsi` requires a .NET 10 runtime.
+
+```sh
+dotnet tool install --global Gsharp.Repl
+```
+
+Update or remove it with the usual global-tool commands:
+
+```sh
+dotnet tool update --global Gsharp.Repl
+dotnet tool uninstall --global Gsharp.Repl
+```
+
+## Command-line usage
+
+```text
+Usage: gsi [file.gs] [--help] [--version]
+  file.gs      Run the given G# script and exit.
+  --help, -h   Show this help and exit.
+  --version    Show the gsi version and exit.
+  (no args)    Start the interactive REPL.
+```
+
+### Interactive REPL
+
+Run `gsi` with no arguments in an interactive terminal to open the REPL:
+
+```sh
+gsi
+```
+
+Each submission becomes a transcript "cell" (your input plus its result
+or diagnostics). Because the session state carries forward, you can build
+up definitions incrementally:
+
+```gsharp
+» let xs = [1, 2, 3]
+» import System.Linq
+» xs.Select((x int32) -> x * 2).Sum()
+= 12
+```
+
+The REPL is organised into keyboard-selectable tabs — **REPL**,
+**History**, **Variables**, **Diagnostics**, **Help**, and **Settings** —
+and includes a command palette (open it with `:`) for session commands:
+
+| Command | Effect |
+| --- | --- |
+| `reset` | Clear all accumulated session state and start fresh. |
+| `clear` | Clear the current editor input. |
+| `theme [name]` | Switch the color theme, or cycle themes when no name is given. |
+| `load <file.gs>` | Evaluate a `.gs` file into the current session. |
+| `exit` / `quit` | Leave the REPL. |
+
+`gsi` needs an interactive terminal; if its input is redirected it exits
+with a message instead of starting the UI.
+
+### Run a script and exit
+
+Pass a `.gs` file to evaluate it in-process and print the final value.
+This is handy for quick experiments and shell one-offs — no `.gsproj`
+required:
+
+```sh
+gsi hello.gs
+```
+
+```gsharp
+package Hello
+
+import System
+
+func greet(name string) string {
+    return "Hello, $name!"
+}
+
+Console.WriteLine(greet("world"))
+```
+
+Diagnostics are written to standard error, and the process exits with a
+non-zero status if evaluation fails, so `gsi file.gs` composes cleanly in
+scripts and CI checks.
+
+## How it relates to `gsc`
+
+`gsi` and the compiler share lexing, parsing, binding, and lowering. The
+REPL always runs on the **interpreter** path (the same in-process
+evaluation `gsc` uses when you omit `/out:`), which is ideal for
+exploration and tests. When you are ready to produce a managed assembly,
+switch to a `.gsproj` project or invoke `gsc` with `/out:`. Some CLR
+interop features are emit-only; see the [`gsc` reference](./gsc.md) and
+the [introduction](../intro.md) for the differences between the
+interpreter and emit paths.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -80,6 +80,7 @@ const sidebars: SidebarsConfig = {
 
   toolingSidebar: [
     'tooling/gsc',
+    'tooling/repl',
     'tooling/sdk-projects',
     'tooling/cs2gs',
     'tooling/vscode',


### PR DESCRIPTION
## Summary

Documents the two published G# global tools on the docs site.

- **New page** `website/docs/tooling/repl.md` — the `gsi` REPL and single-file script runner (`Gsharp.Repl`): install, CLI usage (`gsi`, `gsi file.gs`, `--help`/`--version`), interactive tabs and command palette (`reset`/`clear`/`theme`/`load`/`exit`), and how it relates to `gsc`.
- **Sidebar** — adds `tooling/repl` to `toolingSidebar` (after `tooling/gsc`).
- **`cs2gs.md`** — adds an "Install as a global tool" section (`dotnet tool install --global Gsharp.Cs2Gs`), switches the `migrate` examples to invoke the global `cs2gs` command instead of the repo-relative `.dll`, and documents `--via-sdk` in place of the source-build `--gsc` path override.

## Validation

`npx docusaurus build` succeeds with the new page and sidebar entry.