### PR TITLE
gsc: fix all-terminal switch-statement IL emission (#2283) and default-interface-property satisfaction (#2293)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1323,10 +1323,11 @@ public sealed class Binder
             }
         }
 
-        // Issue #1030: bind default bodies on static-virtual interface
-        // *property* accessors (get_/set_). These mirror the static-virtual
-        // method default-body loop above: a default-bodied accessor is a
-        // non-abstract Static|Virtual slot whose lowered body is registered in
+        // Issue #1030 / #2293: bind default bodies on interface *property*
+        // accessors (get_/set_), both static-virtual and ordinary instance
+        // properties. This mirrors the default-interface-method loop above: a
+        // default-bodied accessor (arrow `->` or block body) is a
+        // non-abstract Virtual slot whose lowered body is registered in
         // functionBodies keyed by the accessor FunctionSymbol. Abstract
         // accessors (no body) are skipped and remain abstract MethodDef rows.
         foreach (var ifaceSym in globalScope.Interfaces)
@@ -1338,11 +1339,6 @@ public sealed class Binder
 
             foreach (var prop in ifaceSym.Properties)
             {
-                if (!prop.IsStatic)
-                {
-                    continue;
-                }
-
                 if (prop.GetterSymbol != null && prop.GetterBodySyntax != null)
                 {
                     BindInterfaceAccessorBody(cache, dirtyTrees, parentScope, prop.GetterSymbol, prop.GetterBodySyntax, functionBodies, diagnostics, requireAllPathsReturn: true);

--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -147,7 +147,7 @@ public sealed class ControlFlowGraph
     /// </summary>
     /// <param name="switchStatement">The pattern switch statement.</param>
     /// <returns>Whether the switch definitely returns on every path.</returns>
-    private static bool SwitchAlwaysReturns(BoundPatternSwitchStatement switchStatement)
+    internal static bool SwitchAlwaysReturns(BoundPatternSwitchStatement switchStatement)
     {
         var hasDefault = false;
         foreach (var arm in switchStatement.Arms)

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -3889,6 +3889,15 @@ internal sealed class DeclarationBinder
 
                     if (!found)
                     {
+                        // Issue #2293: an interface property whose required
+                        // accessors all carry a default (arrow/block) body is
+                        // satisfied by inheritance, exactly like a
+                        // default-interface method — no GS0187 needed.
+                        if (PropertyHasDefaultBody(iprop))
+                        {
+                            continue;
+                        }
+
                         Diagnostics.ReportInterfaceMethodNotImplemented(
                             syntax.Identifier.Location,
                             structSymbol.Name,
@@ -4292,6 +4301,37 @@ internal sealed class DeclarationBinder
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Issue #2293: returns <c>true</c> when the supplied interface property
+    /// is fully satisfied by the interface's own default (arrow/block-bodied)
+    /// accessor implementations — i.e. every accessor the property actually
+    /// requires (getter when <see cref="PropertySymbol.HasGetter"/>, setter
+    /// when <see cref="PropertySymbol.HasSetter"/>) is a non-abstract default
+    /// slot with a real body. This mirrors <see cref="InterfaceSymbol.HasDefaultBody(FunctionSymbol)"/>
+    /// for default-interface *methods*: a class that omits the property
+    /// entirely still satisfies the contract by inheriting the interface's
+    /// default accessor bodies. An accessor without a default body (a
+    /// body-less/abstract slot) still requires the implementer to provide it,
+    /// so this returns <c>false</c> in that case even if the other accessor
+    /// has a default.
+    /// </summary>
+    /// <param name="property">The interface property to inspect.</param>
+    /// <returns>True when every required accessor has a default body.</returns>
+    private static bool PropertyHasDefaultBody(PropertySymbol property)
+    {
+        if (property.HasGetter && (property.GetterSymbol == null || property.GetterSymbol.IsAbstract))
+        {
+            return false;
+        }
+
+        if (property.HasSetter && (property.SetterSymbol == null || property.SetterSymbol.IsAbstract))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     private void VerifyClrInterfaceImplementations(StructDeclarationSyntax syntax, StructSymbol structSymbol)
@@ -5611,10 +5651,22 @@ internal sealed class DeclarationBinder
                 // and `T.Prop` constrained dispatch. A bodied accessor is a
                 // *default* static slot; a body-less accessor is an *abstract*
                 // slot the implementer must provide.
-                if (isStaticInterfaceProperty)
+                //
+                // Issue #2293: an ordinary (non-static) instance interface
+                // property is given the exact same accessor-symbol treatment —
+                // mirroring how default-interface *methods* already work
+                // (ADR-0085 / issue #726). A bodied accessor (arrow `->` or
+                // block) is a default instance slot (non-abstract, dispatched
+                // through the interface, no override required from
+                // implementers); a body-less accessor is still an abstract
+                // slot the implementer must provide. Only the receiver type
+                // (`null` + Static for the static-virtual case vs. the owning
+                // InterfaceSymbol for the instance case) and the Static flag
+                // differ between the two.
                 {
                     var getAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsGetter);
                     var setAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsSetterOrInit);
+                    TypeSymbol accessorReceiverType = isStaticInterfaceProperty ? null : interfaceSymbol;
 
                     if (hasGetter)
                     {
@@ -5625,15 +5677,19 @@ internal sealed class DeclarationBinder
                             declaration: null,
                             package,
                             Accessibility.Public,
-                            receiverType: null);
-                        getterSymbol.IsStatic = true;
-                        getterSymbol.StaticOwnerType = interfaceSymbol;
+                            receiverType: accessorReceiverType);
+                        if (isStaticInterfaceProperty)
+                        {
+                            getterSymbol.IsStatic = true;
+                            getterSymbol.StaticOwnerType = interfaceSymbol;
+                        }
+
                         getterSymbol.IsSpecialName = true;
                         if (getAccessor?.Body != null)
                         {
-                            // Issue #1030: a default-bodied static-virtual
-                            // interface property accessor is a *default* slot
-                            // (Static | Virtual, non-abstract) emitting a real
+                            // Issue #1030 / #2293: a default-bodied interface
+                            // property accessor (static-virtual or instance)
+                            // is a non-abstract Virtual slot emitting a real
                             // method body. The body is bound in the Binder's
                             // interface accessor-body pass and registered in
                             // functionBodies keyed by this getter symbol.
@@ -5658,16 +5714,20 @@ internal sealed class DeclarationBinder
                             declaration: null,
                             package,
                             Accessibility.Public,
-                            receiverType: null);
-                        setterSymbol.IsStatic = true;
-                        setterSymbol.StaticOwnerType = interfaceSymbol;
+                            receiverType: accessorReceiverType);
+                        if (isStaticInterfaceProperty)
+                        {
+                            setterSymbol.IsStatic = true;
+                            setterSymbol.StaticOwnerType = interfaceSymbol;
+                        }
+
                         setterSymbol.IsSpecialName = true;
                         setterSymbol.IsInitOnlySetter = isInitOnly;
                         if (setAccessor?.Body != null)
                         {
-                            // Issue #1030: default-bodied static-virtual
-                            // interface property setter — a non-abstract
-                            // default slot with a real method body.
+                            // Issue #1030 / #2293: default-bodied interface
+                            // property setter — a non-abstract default slot
+                            // with a real method body.
                             setterSymbol.IsAbstract = false;
                             propSymbol.SetterBodySyntax = setAccessor.Body;
                         }

--- a/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
@@ -1263,15 +1263,19 @@ internal sealed class MemberDefEmitter
             MethodDefinitionHandle? emittedGetter = null;
             if (prop.HasGetter && accessorHandles.Getter.HasValue)
             {
-                // Issue #1030: a default-bodied static-virtual interface
-                // property getter is a non-abstract Static|Virtual slot with a
-                // real IL body. Route it through the regular function-emit
-                // pipeline (signature + body + parameter rows), which stamps
-                // Static|Virtual|NewSlot|SpecialName for an interface-owned
-                // static accessor. The MethodDef row lands in the planned
-                // accessor position because this runs in accessor order.
-                if (prop.IsStatic
-                    && prop.GetterSymbol != null
+                // Issue #1030 / #2293: a default-bodied interface property
+                // getter — static-virtual or ordinary instance — is a
+                // non-abstract Virtual slot with a real IL body. Route it
+                // through the regular function-emit pipeline (signature +
+                // body + parameter rows), which stamps
+                // Static|Virtual|NewSlot|SpecialName for a static accessor,
+                // or Virtual|NewSlot|SpecialName (receiver = interface, no
+                // Static) for an instance default accessor — mirroring how
+                // default-interface *methods* are emitted (EmitFunction's
+                // receiver-is-interface branch). The MethodDef row lands in
+                // the planned accessor position because this runs in
+                // accessor order.
+                if (prop.GetterSymbol != null
                     && !prop.GetterSymbol.IsAbstract
                     && this.emitCtx.Program.Functions.TryGetValue(prop.GetterSymbol, out var getterBody))
                 {
@@ -1305,9 +1309,9 @@ internal sealed class MemberDefEmitter
             MethodDefinitionHandle? emittedSetter = null;
             if (prop.HasSetter && accessorHandles.Setter.HasValue)
             {
-                // Issue #1030: default-bodied static-virtual interface setter.
-                if (prop.IsStatic
-                    && prop.SetterSymbol != null
+                // Issue #1030 / #2293: default-bodied interface setter
+                // (static-virtual or ordinary instance).
+                if (prop.SetterSymbol != null
                     && !prop.SetterSymbol.IsAbstract
                     && this.emitCtx.Program.Functions.TryGetValue(prop.SetterSymbol, out var setterBody))
                 {

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
@@ -56,7 +56,16 @@ internal sealed partial class MethodBodyEmitter
         this.EmitExpression(node.Discriminant);
         this.il.StoreLocal(discriminantSlot);
 
-        var endLabel = this.il.DefineLabel();
+        // If the switch is exhaustive (has a `default` arm) and every arm
+        // definitely returns/throws, no path ever falls through to an "end"
+        // of the switch — emitting a trailing `Br endLabel`/`MarkLabel(endLabel)`
+        // in that case produces a label reachable only via dead branches,
+        // which crashes ilverify's predecessor bookkeeping (issue #2283).
+        // Reuse the same reachability analysis the binder already uses for
+        // definite-return checking (ControlFlowGraph.SwitchAlwaysReturns) so
+        // this stays in sync with that logic.
+        var alwaysReturns = ControlFlowGraph.SwitchAlwaysReturns(node);
+        var endLabel = alwaysReturns ? default : this.il.DefineLabel();
         BoundPatternSwitchArm defaultArm = null;
 
         foreach (var arm in node.Arms)
@@ -80,7 +89,11 @@ internal sealed partial class MethodBodyEmitter
             }
 
             this.EmitStatement(arm.Body);
-            this.il.Branch(ILOpCode.Br, endLabel);
+            if (!alwaysReturns)
+            {
+                this.il.Branch(ILOpCode.Br, endLabel);
+            }
+
             this.il.MarkLabel(nextArm);
         }
 
@@ -89,7 +102,10 @@ internal sealed partial class MethodBodyEmitter
             this.EmitStatement(defaultArm.Body);
         }
 
-        this.il.MarkLabel(endLabel);
+        if (!alwaysReturns)
+        {
+            this.il.MarkLabel(endLabel);
+        }
     }
 
     // Phase C: switch-expression emit. Mirrors the pattern-switch

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1567,22 +1567,22 @@ internal sealed class ReflectionMetadataEmitter
 
                 this.cache.PropertyAccessorHandles[prop] = (getterHandle, setterHandle);
 
-                // ADR-0089 / issue #1019: for a static-virtual interface
-                // property, register the accessor FunctionSymbols against
-                // their planned MethodDef rows so `constrained.` dispatch
-                // (`T.Prop` → get_Prop) resolves the slot handle, exactly as
-                // for static-virtual interface methods.
-                if (prop.IsStatic)
+                // ADR-0089 / issue #1019, #2293: register the accessor
+                // FunctionSymbols against their planned MethodDef rows for
+                // BOTH static-virtual and ordinary instance interface
+                // properties, mirroring the instance-method registration
+                // above (`i.Methods`). This lets `constrained.` dispatch
+                // (`T.Prop` → get_Prop) and ordinary interface-typed callvirt
+                // sites resolve the accessor's slot handle even when the
+                // implementer relies on the interface's default body.
+                if (prop.GetterSymbol != null && getterHandle.HasValue)
                 {
-                    if (prop.GetterSymbol != null && getterHandle.HasValue)
-                    {
-                        this.cache.MethodHandles[prop.GetterSymbol] = getterHandle.Value;
-                    }
+                    this.cache.MethodHandles[prop.GetterSymbol] = getterHandle.Value;
+                }
 
-                    if (prop.SetterSymbol != null && setterHandle.HasValue)
-                    {
-                        this.cache.MethodHandles[prop.SetterSymbol] = setterHandle.Value;
-                    }
+                if (prop.SetterSymbol != null && setterHandle.HasValue)
+                {
+                    this.cache.MethodHandles[prop.SetterSymbol] = setterHandle.Value;
                 }
             }
 

--- a/test/Compiler.Tests/Emit/Issue2283SwitchAllTerminalArmsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2283SwitchAllTerminalArmsEmitTests.cs
@@ -1,0 +1,291 @@
+// <copyright file="Issue2283SwitchAllTerminalArmsEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2283 (re-migration follow-up): re-migrating Oahu.SystemManagement
+/// off main @ 51152eb4 still crashed <c>ilverify</c> with the identical
+/// <c>MarkPredecessorWithLowerOffset</c> <see cref="IndexOutOfRangeException"/>
+/// even after the channel-receive stack-imbalance fix (the other set of
+/// <c>Issue2283*</c> tests) landed — that fix addressed a narrower symptom of
+/// a broader <c>switch</c>-statement IL-emission bug.
+/// <para>
+/// Root cause, localized via <c>ilverify --include</c>: a pattern
+/// <c>switch</c> <em>statement</em> where every arm — including
+/// <c>default</c> — is terminal (ends in <c>return</c>/<c>throw</c>), with no
+/// code after the switch. <c>EmitPatternSwitchStatement</c>
+/// (<c>MethodBodyEmitter.Patterns.cs</c>) unconditionally emitted
+/// <c>Br endLabel</c> after every arm body and unconditionally
+/// <c>MarkLabel(endLabel)</c> at the end, even when no arm could ever reach
+/// that label — producing a label at the exact end of the method body
+/// reachable only via dead branches, which ILVerify's predecessor
+/// bookkeeping can't index.
+/// </para>
+/// <para>
+/// The fix reuses <c>ControlFlowGraph.SwitchAlwaysReturns</c> — the exact
+/// reachability check the binder already uses for definite-return analysis
+/// (issue #1596) — to detect this case and skip emitting the trailing
+/// <c>Br endLabel</c> / <c>MarkLabel(endLabel)</c> entirely when the switch
+/// is exhaustive (has a <c>default</c>) and every arm definitely
+/// returns/throws. All other shapes (non-exhaustive switches, switches with a
+/// non-terminal arm, switches followed by more code, and switches using
+/// <c>break</c>) keep emitting the end label exactly as before.
+/// </para>
+/// </summary>
+public class Issue2283SwitchAllTerminalArmsEmitTests
+{
+    [Fact]
+    public void AllArmsTerminal_AsLastStatement_VerifiesAndRuns()
+    {
+        // The exact minimal repro from the issue's confirmed-root-cause
+        // comment: a switch statement, as the LAST statement in the method,
+        // whose every arm (including default) returns.
+        const string source = """
+            package Issue2283.AllTerminal
+            import System
+
+            class T6 {
+                func F(x int32) string {
+                    switch x {
+                        case 1 { return "a" }
+                        case 2 { return "b" }
+                        default { return "c" }
+                    }
+                }
+            }
+
+            let t = T6()
+            Console.WriteLine(t.F(1))
+            Console.WriteLine(t.F(2))
+            Console.WriteLine(t.F(3))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("a\nb\nc\n", output);
+    }
+
+    [Fact]
+    public void MixedTerminalAndNonTerminalArms_VerifiesAndRuns()
+    {
+        // Not every arm is terminal: the fallthrough/end label IS needed
+        // (some arm falls through to code after the switch), so this must
+        // still emit (and correctly reach) the end label.
+        const string source = """
+            package Issue2283.MixedTerminal
+            import System
+
+            class T7 {
+                func F(x int32) string {
+                    var result = ""
+                    switch x {
+                        case 1 { return "a" }
+                        case 2 { result = "b" }
+                        default { return "c" }
+                    }
+                    return result + "!"
+                }
+            }
+
+            let t = T7()
+            Console.WriteLine(t.F(1))
+            Console.WriteLine(t.F(2))
+            Console.WriteLine(t.F(3))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("a\nb!\nc\n", output);
+    }
+
+    [Fact]
+    public void AllArmsTerminal_FollowedByMoreCode_VerifiesAndRuns()
+    {
+        // The switch is NOT the last statement — even though every arm of the
+        // switch itself is terminal, the switch is exhaustive (has a
+        // default), so control genuinely never falls out of the switch. Code
+        // after the switch must still be reachable via the normal path (the
+        // switch's own arms never resume execution there directly, but the
+        // method as a whole must still verify).
+        const string source = """
+            package Issue2283.TerminalThenMoreCode
+            import System
+
+            class T8 {
+                func F(x int32) string {
+                    var prefix = "before:"
+                    switch x {
+                        case 1 { return prefix + "a" }
+                        case 2 { return prefix + "b" }
+                        default { return prefix + "c" }
+                    }
+                }
+            }
+
+            let t = T8()
+            Console.WriteLine(t.F(1))
+            Console.WriteLine(t.F(3))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("before:a\nbefore:c\n", output);
+    }
+
+    [Fact]
+    public void AllArmsTerminal_NoDefault_VerifiesAndRuns()
+    {
+        // Without a `default` arm the switch is NOT exhaustive — the
+        // discriminant may match nothing, so the "no match" path still needs
+        // to fall through to the end label. This must keep working exactly as
+        // before the fix.
+        const string source = """
+            package Issue2283.NoDefaultTerminal
+            import System
+
+            class T9 {
+                func F(x int32) string {
+                    switch x {
+                        case 1 { return "a" }
+                        case 2 { return "b" }
+                    }
+                    return "fallthrough"
+                }
+            }
+
+            let t = T9()
+            Console.WriteLine(t.F(1))
+            Console.WriteLine(t.F(2))
+            Console.WriteLine(t.F(3))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("a\nb\nfallthrough\n", output);
+    }
+
+    [Fact]
+    public void SwitchInsideLoopWithBreakAfterNonTerminalArm_VerifiesAndRuns()
+    {
+        // A pattern-switch statement (G# case arms don't fall through, so
+        // `break` is not a switch-arm construct here — it's a loop-exit
+        // construct) nested inside a loop, with a non-terminal arm followed
+        // by a loop `break`. Exercises the switch's own end-label path
+        // (needed because one arm is non-terminal) composing correctly with
+        // an enclosing loop's control flow — this must not regress with the
+        // fix.
+        const string source = """
+            package Issue2283.LoopBreakAfterSwitch
+            import System
+
+            class T10 {
+                func F(x int32) string {
+                    var result = "none"
+                    for var i = 0; i < 3; i++ {
+                        switch x {
+                            case 1 { result = "one" }
+                            case 2 { return "two" }
+                            default { return "default" }
+                        }
+                        break
+                    }
+                    return result
+                }
+            }
+
+            let t = T10()
+            Console.WriteLine(t.F(1))
+            Console.WriteLine(t.F(2))
+            Console.WriteLine(t.F(3))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("one\ntwo\ndefault\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2283_switch_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2293DefaultInterfacePropertyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2293DefaultInterfacePropertyTests.cs
@@ -1,0 +1,237 @@
+// <copyright file="Issue2293DefaultInterfacePropertyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2293: a class that relies on an interface's default (arrow/block
+/// bodied) PROPERTY implementation — i.e. does not re-declare the property
+/// itself — was wrongly reported as not implementing the interface (GS0187).
+/// Default-bodied interface FUNCTIONS were already accepted (ADR-0085 / issue
+/// #726); the gap was specific to default-bodied interface PROPERTIES.
+/// <para>
+/// Root cause: <c>VerifyInterfaceImplementations</c>'s property-satisfaction
+/// loop (<c>DeclarationBinder.cs</c>) only asked "does the class provide a
+/// member for this property?" (<c>TypeMemberModel.TryGetProperty</c> /
+/// primary-constructor-parameter fallback) and reported GS0187 whenever it
+/// did not — it never asked whether the INTERFACE PROPERTY ITSELF already
+/// had a default body. Separately, only static-virtual interface properties
+/// ever got their accessor bodies bound/emitted at all
+/// (<c>Binder.cs</c>'s default-body loop skipped non-static properties, and
+/// <c>MemberDefEmitter.EmitInterfacePropertyAccessors</c> only routed the
+/// real-body path through <c>IsStatic</c>), so even suppressing the
+/// diagnostic without that plumbing would have produced an unloadable type.
+/// </para>
+/// <para>
+/// The fix generalizes the default-interface-member machinery that already
+/// existed for static-virtual properties to ordinary instance properties too
+/// (mirroring how instance default methods already work): accessor
+/// <see cref="Core.CodeAnalysis.Symbols.FunctionSymbol"/>s are created for
+/// every interface property (not just static ones), a body-bearing accessor
+/// is bound and emitted as a non-abstract virtual slot, and the
+/// completeness check accepts an interface property as satisfied when every
+/// accessor it requires (getter/setter) has a default body — exactly as a
+/// default interface method needs no override. An accessor with NO default
+/// body still requires the implementer to provide it.
+/// </para>
+/// </summary>
+public class Issue2293DefaultInterfacePropertyTests
+{
+    [Fact]
+    public void ClassRelyingOnDefaultInterfaceProperty_NoDiagnostics()
+    {
+        // The exact issue repro: neither NeedsTimedRefresh (a default arrow
+        // property) nor OnActivated (a default block-bodied method) is
+        // re-declared by the implementing class.
+        const string source = """
+            package Test
+            interface ITabScreen {
+                prop NeedsTimedRefresh bool -> false
+                func OnActivated() { }
+            }
+            class LibraryScreen : ITabScreen {
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ClassRelyingOnDefaultInterfaceMethod_StillCompiles()
+    {
+        // Guard: default-bodied interface METHODS (already working before
+        // this fix) must keep working when combined with a default property
+        // on the same interface.
+        const string source = """
+            package Test
+            interface IGreeter {
+                func Greet() string { return "hi" }
+            }
+            class SilentGreeter : IGreeter {
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void InterfacePropertyWithNoDefaultBody_StillRequiresImplementation()
+    {
+        // A property without a default body (bare get/set requirement) is
+        // NOT satisfied automatically — omitting it must still report GS0187.
+        const string source = """
+            package Test
+            interface ITabScreen {
+                prop Title string { get; }
+            }
+            class MissingTitleScreen : ITabScreen {
+            }
+            """;
+
+        var gs0187 = Bind(source).Where(d => d.Id == "GS0187").ToList();
+        Assert.Single(gs0187);
+    }
+
+    [Fact]
+    public void GetOnlyDefaultInterfaceProperty_SatisfiedWithoutOverride_NoDiagnostics()
+    {
+        const string source = """
+            package Test
+            interface IFlag {
+                prop Enabled bool -> true
+            }
+            class DefaultFlag : IFlag {
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void GetSetDefaultInterfaceProperty_SatisfiedWithoutOverride_NoDiagnostics()
+    {
+        // A default property with BOTH a get and set accessor body is fully
+        // satisfied by the interface's own implementation.
+        const string source = """
+            package Test
+            interface ICounter {
+                prop Count int32 {
+                    get { return 0 }
+                    set { }
+                }
+            }
+            class DefaultCounter : ICounter {
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void PartiallyDefaultedProperty_MissingSetterBody_StillReportsGS0187()
+    {
+        // Only the getter has a default body; the setter is abstract (no
+        // body) — the implementer must still supply the property (and,
+        // implicitly, the setter) to satisfy the contract.
+        const string source = """
+            package Test
+            interface IPartial {
+                prop Value int32 {
+                    get { return 0 }
+                    set;
+                }
+            }
+            class MissingSetterImpl : IPartial {
+            }
+            """;
+
+        var gs0187 = Bind(source).Where(d => d.Id == "GS0187").ToList();
+        Assert.Single(gs0187);
+    }
+
+    [Fact]
+    public void ClassOverridingDefaultInterfaceProperty_NoDiagnostics()
+    {
+        // A class MAY still re-declare the property to override the default
+        // — that must keep compiling with no diagnostics either.
+        const string source = """
+            package Test
+            interface ITabScreen {
+                prop NeedsTimedRefresh bool -> false
+            }
+            class RefreshingScreen : ITabScreen {
+                prop NeedsTimedRefresh bool -> true
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void EmittedType_ImplementsInterface_AndDispatchesDefaultPropertyThroughIt()
+    {
+        // The binder no longer reports GS0187, but the emitted assembly must
+        // also be loadable and functionally correct: the interface's own
+        // get_NeedsTimedRefresh must be a real (non-abstract) accessor the
+        // implementing type inherits — dispatching through the interface
+        // reference must observe the interface's default value.
+        const string source = """
+            package Test
+            interface ITabScreen {
+                prop NeedsTimedRefresh bool -> false
+            }
+            class LibraryScreen : ITabScreen {
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext("Issue2293_EmitDispatch", isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+
+            var libraryScreen = asm.GetTypes().First(t => t.Name == "LibraryScreen");
+            var iTabScreen = asm.GetTypes().First(t => t.Name == "ITabScreen");
+            Assert.True(iTabScreen.IsAssignableFrom(libraryScreen), "LibraryScreen must implement ITabScreen");
+
+            var instance = Activator.CreateInstance(libraryScreen);
+
+            var getter = iTabScreen.GetMethod("get_NeedsTimedRefresh");
+            Assert.NotNull(getter);
+            var viaInterface = getter.Invoke(instance, null);
+            Assert.Equal(false, viaInterface);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.GlobalScope.Diagnostics.ToList();
+    }
+}


### PR DESCRIPTION
## Fix A — #2283: switch STATEMENT with all-terminal arms emits invalid IL

**Root cause**: `EmitPatternSwitchStatement` (`src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs`) unconditionally emitted a trailing `Br endLabel` after every non-default arm body, and unconditionally called `MarkLabel(endLabel)` at the end — even when the switch was exhaustive (has a `default` arm) and every arm definitely returns/throws. In that case no branch can ever reach `endLabel`, producing a label at the exact end of the method body reachable only via dead branches. `ilverify`'s `MarkPredecessorWithLowerOffset` cannot index that and crashes with `IndexOutOfRangeException`.

**Fix**: reuse `ControlFlowGraph.SwitchAlwaysReturns` — the exact reachability/definite-return check the binder already uses for the "all paths return" analysis (issue #1596) — to detect this case up front. When the switch is exhaustive and every arm always returns/throws, skip emitting the trailing `Br endLabel` after each arm and skip `MarkLabel(endLabel)` entirely. All other shapes (non-exhaustive switches with no `default`, switches with at least one non-terminal arm, and switches followed by more code) keep emitting the end label exactly as before — verified by the new tests below.

Also made `ControlFlowGraph.SwitchAlwaysReturns` `internal` (was `private`) so the emitter can call it directly instead of re-implementing the reachability logic.

**Tests** (`test/Compiler.Tests/Emit/Issue2283SwitchAllTerminalArmsEmitTests.cs`, emit + ilverify + run):
- All-terminal switch as the last statement (the exact issue repro)
- Mixed terminal/non-terminal arms
- All-terminal switch followed by more code
- All-terminal switch with no `default` (still falls through correctly)
- Switch nested inside a loop with a following `break` (composition with enclosing control flow)

## Fix B — #2293: default-bodied interface PROPERTY not accepted as satisfying interface contract (spurious GS0187)

**Root cause**: default-bodied interface *functions* were already accepted without requiring the implementer to redeclare them (ADR-0085 / issue #726), but default-bodied interface *properties* were not, for two compounding reasons:
1. `VerifyInterfaceImplementations`'s property-satisfaction loop (`DeclarationBinder.cs`) only asked whether the implementing class provides a member for the property — it never checked whether the interface property itself already had a default body.
2. Only *static-virtual* interface properties ever got their accessor bodies bound (`Binder.cs`) and emitted as real (non-abstract) `MethodDef`s (`MemberDefEmitter.EmitInterfacePropertyAccessors`) — ordinary instance default properties had no accessor `FunctionSymbol`s created at all, so even suppressing the diagnostic without this plumbing would have produced an unloadable type.

**Fix**: generalized the existing static-virtual default-property machinery to ordinary instance properties too — accessor `FunctionSymbol`s (with `receiverType` = the owning interface instead of `null`/`IsStatic`) are now created for every interface property, a body-bearing accessor is bound and emitted as a non-abstract virtual slot (reusing the same `EmitFunction` path that already emits default interface methods), and `VerifyInterfaceImplementations` now accepts an interface property as satisfied when every accessor it requires (getter/setter) already has a default body — exactly mirroring how default interface methods need no override. A property whose required accessor has **no** default body still requires the implementer to provide it.

**Tests** (`test/Core.Tests/CodeAnalysis/Binding/Issue2293DefaultInterfacePropertyTests.cs`, binder diagnostics + emit/load/dispatch):
- Exact issue repro (default property + default method, neither redeclared) — no diagnostics
- Default interface method alone still compiles (regression guard)
- Property with no default body still requires implementation (GS0187)
- Get-only and get/set default properties
- Partially-defaulted property (default getter, abstract setter) still requires implementation
- Class overriding a default property still compiles
- Emit + load + dispatch through the interface's own default accessor (would surface a `TypeLoadException` if the accessor were missing)

## Testing
- `dotnet build src/Compiler/Compiler.csproj -c Release` — clean, 0 warnings/errors
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — **5932 passed**, 1 skipped (pre-existing), 0 failed
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release` — **2791 passed**, 0 failed (after building the `Gsharp.Extensions` SDK project, which some golden/sample tests depend on but is not built by `Compiler.csproj` alone)

Closes #2283
Closes #2293