### PR TITLE
gsc: unify cross-assembly imported type identity (#2290) and recognize imported C# records for with/copy (#2291)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -79,16 +79,31 @@ public sealed class Conversion
             return Conversion.Identity;
         }
 
-        if (from is StructSymbol { ClrType: not null } fromImportedStruct
-            && to is ImportedTypeSymbol
-            && ClrTypeUtilities.AreSame(fromImportedStruct.ClrType, to.ClrType))
-        {
-            return Conversion.Identity;
-        }
-
-        if (from is ImportedTypeSymbol
-            && to is StructSymbol { ClrType: not null } toImportedStruct
-            && ClrTypeUtilities.AreSame(from.ClrType, toImportedStruct.ClrType))
+        // Issue #2290: a referenced (cross-assembly) type can be independently
+        // re-minted into TWO non-reference-equal TypeSymbol wrappers for the
+        // SAME underlying CLR type — e.g. an imported `data class`/`data
+        // struct` resolves to its semantic-aggregate StructSymbol via one
+        // binding path (issue #2263) but to a plain ImportedTypeSymbol via
+        // another, or the very same ImportedTypeSymbol-eligible type is
+        // reflected through two distinct (but metadata-equivalent) `Type`
+        // instances — e.g. resolved via a fully-qualified name in one spot and
+        // brought into scope via `import` in another, each hitting the
+        // per-Type cache with a different `Type` object when the two lookups
+        // do not share reference identity. Only the two symbol kinds that
+        // ever wrap a REAL referenced CLR type (`ImportedTypeSymbol`, and a
+        // `StructSymbol` semantic aggregate built for an imported data type —
+        // recognized by its non-null `ClrType`, since a same-compilation
+        // user `struct`/`data struct` has none while binding) participate:
+        // this deliberately excludes wrapper symbols (e.g.
+        // `NullableTypeSymbol`) that merely borrow their underlying type's
+        // `ClrType` without denoting the SAME type. Whenever both sides
+        // qualify and their CLR types are the same underlying metadata type
+        // (`ClrTypeUtilities.AreSame`, safe across a MetadataLoadContext
+        // boundary), the two symbols denote one identical type — treat the
+        // conversion as identity rather than reporting a confusing "Cannot
+        // convert type 'X' to 'X'"-looking error.
+        if (IsImportedTypeIdentity(from) && IsImportedTypeIdentity(to)
+            && ClrTypeUtilities.AreSame(from.ClrType, to.ClrType))
         {
             return Conversion.Identity;
         }
@@ -1731,6 +1746,16 @@ public sealed class Conversion
         var retConv = Classify(fnReturn, targetReturn);
         return retConv.Exists && retConv.IsImplicit;
     }
+
+    // Issue #2290: identifies the two symbol kinds that ever wrap a genuine
+    // referenced CLR type — a plain `ImportedTypeSymbol`, or a `StructSymbol`
+    // semantic aggregate built for an imported `data class`/`data struct`
+    // (issue #2263). A same-compilation user `struct`/`data struct`
+    // `StructSymbol` has a null `ClrType` while binding (its CLR shape is
+    // still being built), so it is correctly excluded here — only an
+    // ALREADY-imported aggregate's non-null `ClrType` qualifies.
+    private static bool IsImportedTypeIdentity(TypeSymbol type)
+        => type is ImportedTypeSymbol || (type is StructSymbol && type.ClrType != null);
 
     // Issue #421 P2-5: enum⇄numeric and enum⇄enum conversions. Both
     // directions are explicit per C# §10.3.3 / §10.3.4 — the binder must

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -59,47 +59,104 @@ internal sealed partial class ExpressionBinder
         scope.TryDeclareVariable(tempVar);
 
         var seen = new HashSet<string>();
-        var explicitValues = new Dictionary<string, (FieldSymbol Field, StructSymbol DeclaringType, BoundExpression Value)>();
+        var explicitValues = new Dictionary<string, (FieldSymbol Field, PropertySymbol Property, BoundExpression Value)>();
         foreach (var initSyntax in overrides)
         {
-            var fieldName = initSyntax.FieldIdentifier.Text;
-            if (!seen.Add(fieldName))
+            var memberName = initSyntax.FieldIdentifier.Text;
+            if (!seen.Add(memberName))
             {
-                Diagnostics.ReportSymbolAlreadyDeclared(initSyntax.FieldIdentifier.Location, fieldName);
+                Diagnostics.ReportSymbolAlreadyDeclared(initSyntax.FieldIdentifier.Location, memberName);
                 continue;
             }
 
-            if (!TypeMemberModel.TryGetFieldIncludingInherited(structType, fieldName, MemberQuery.Instance(MemberKinds.Field), out var field, out var declaringType))
+            if (TypeMemberModel.TryGetFieldIncludingInherited(structType, memberName, MemberQuery.Instance(MemberKinds.Field), out var field, out var fieldDeclaringType))
             {
-                Diagnostics.ReportUnableToFindMember(initSyntax.FieldIdentifier.Location, fieldName);
+                // Issue #2059: a `with` update is a write to the named field —
+                // enforce the same `protected`/`private` accessibility rule as a
+                // plain assignment / composite literal member init (issue #950 /
+                // #2044 / #2059).
+                if (!AccessibilityChecker.IsAccessible(field.Accessibility, fieldDeclaringType, this.function))
+                {
+                    Diagnostics.ReportMemberInaccessible(initSyntax.FieldIdentifier.Location, field.Name, fieldDeclaringType.Name, field.Accessibility);
+                }
+
+                var fieldValueExpr = BindExpression(initSyntax.Value);
+                fieldValueExpr = conversions.BindConversion(initSyntax.Value.Location, fieldValueExpr, field.Type);
+                explicitValues[memberName] = (field, null, fieldValueExpr);
                 continue;
             }
 
-            // Issue #2059: a `with` update is a write to the named field —
-            // enforce the same `protected`/`private` accessibility rule as a
-            // plain assignment / composite literal member init (issue #950 /
-            // #2044 / #2059).
-            if (!AccessibilityChecker.IsAccessible(field.Accessibility, declaringType, this.function))
+            // Issue #2291: an imported C# record surfaces its positional
+            // members as auto-properties (compiler-mangled backing fields),
+            // not plain public fields like a gsc-native data class — fall
+            // back to a settable property with the same name so `with`
+            // updates a record's positional member through its setter/init
+            // accessor instead of failing to find a field at all.
+            if (TypeMemberModel.TryGetProperty(structType, memberName, out var property, out var propertyDeclaringType) && property.HasSetter)
             {
-                Diagnostics.ReportMemberInaccessible(initSyntax.FieldIdentifier.Location, field.Name, declaringType.Name, field.Accessibility);
+                if (!AccessibilityChecker.IsAccessible(property.Accessibility, propertyDeclaringType, this.function))
+                {
+                    Diagnostics.ReportMemberInaccessible(initSyntax.FieldIdentifier.Location, property.Name, propertyDeclaringType.Name, property.Accessibility);
+                }
+
+                var propertyValueExpr = BindExpression(initSyntax.Value);
+                propertyValueExpr = conversions.BindConversion(initSyntax.Value.Location, propertyValueExpr, property.Type);
+                explicitValues[memberName] = (null, property, propertyValueExpr);
+                continue;
             }
 
-            var valueExpr = BindExpression(initSyntax.Value);
-            valueExpr = conversions.BindConversion(initSyntax.Value.Location, valueExpr, field.Type);
-            explicitValues[fieldName] = (field, declaringType, valueExpr);
+            Diagnostics.ReportUnableToFindMember(initSyntax.FieldIdentifier.Location, memberName);
         }
 
         var initializers = ImmutableArray.CreateBuilder<BoundFieldInitializer>();
+        var handledMembers = new HashSet<string>();
         foreach (var field in structType.Fields)
         {
+            handledMembers.Add(field.Name);
             if (explicitValues.TryGetValue(field.Name, out var explicitValue))
             {
-                initializers.Add(new BoundFieldInitializer(explicitValue.Field, explicitValue.Value));
+                initializers.Add(new BoundFieldInitializer(field, explicitValue.Value));
             }
             else
             {
                 var access = new BoundFieldAccessExpression(null, new BoundVariableExpression(null, tempVar), structType, field);
                 initializers.Add(new BoundFieldInitializer(field, access));
+            }
+        }
+
+        // Issue #2291: an imported C# record's positional members that are
+        // NOT backed by a visible field (property-only, e.g. auto-properties
+        // whose mangled backing field is intentionally hidden from the
+        // aggregate's field list) still need to participate in `with`/`copy`.
+        // `PrimaryConstructorParameters` names the record's full positional
+        // shape regardless of whether each member resolved to a field or a
+        // property (see ImportedTypeSymbol.BuildPrimaryConstructorParameters),
+        // so walking it here — skipping names already handled as a real
+        // field above — surfaces exactly the property-only positional
+        // members, for every kind of data class (gsc-native or imported).
+        if (!structType.PrimaryConstructorParameters.IsDefaultOrEmpty)
+        {
+            foreach (var parameter in structType.PrimaryConstructorParameters)
+            {
+                if (!handledMembers.Add(parameter.Name))
+                {
+                    continue;
+                }
+
+                if (!TypeMemberModel.TryGetProperty(structType, parameter.Name, out var property, out _) || !property.HasSetter)
+                {
+                    continue;
+                }
+
+                if (explicitValues.TryGetValue(parameter.Name, out var explicitValue))
+                {
+                    initializers.Add(new BoundFieldInitializer(property, explicitValue.Value));
+                }
+                else
+                {
+                    var access = new BoundPropertyAccessExpression(null, new BoundVariableExpression(null, tempVar), structType, property);
+                    initializers.Add(new BoundFieldInitializer(property, access));
+                }
             }
         }
 
@@ -684,9 +741,17 @@ internal sealed partial class ExpressionBinder
         // fail non-deterministically. Bind construction through the semantic
         // aggregate FIRST (it lowers to the same struct-literal node as `with`)
         // so a data class resolves to the SAME StructSymbol everywhere.
+        // Issue #2291: a `data struct` (including an imported C# `record
+        // struct`) has the identical dual-identity problem — its CLR type
+        // also carries a real primary `.ctor`, so without this same
+        // aggregate-first check for value types, TryBindClrConstructorFromType
+        // below binds `Point(1, 2)` to a plain (non-aggregate) ImportedTypeSymbol,
+        // and the resulting receiver never satisfies `structType.IsData` for
+        // `with`/copy. Generalize the check to both kinds (drop the
+        // `IsClass`-only restriction) so a data class AND a data struct both
+        // resolve construction through the one semantic aggregate.
         if (openGenericDefinition == null
             && ImportedTypeSymbol.TryCreateSemanticAggregate(clrType, scope.References, out var dataClassAggregate)
-            && dataClassAggregate.IsClass
             && dataClassAggregate.IsData
             && dataClassAggregate.HasPrimaryConstructor)
         {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -2759,6 +2759,13 @@ internal sealed class OverloadResolver
     /// shared with the <c>with</c>/copy lowering. The constructor's arguments
     /// are already reordered into primary-constructor parameter order, so each
     /// argument maps onto the field named by the parameter at the same index.
+    /// Issue #2291: an imported C# record surfaces its positional members as
+    /// auto-properties (mangled backing fields), not plain public fields like
+    /// a gsc-native data class — a parameter with no matching field falls
+    /// back to a settable property with the same name so the emitter's
+    /// positional-constructor construction path (<c>MethodBodyEmitter.
+    /// EmitImportedPositionalRecordLiteral</c>) sees a value for every
+    /// positional member regardless of which kind of data class it is.
     /// </summary>
     private static BoundExpression LowerImportedDataClassConstruction(BoundConstructorCallExpression ctorCall)
     {
@@ -2770,6 +2777,12 @@ internal sealed class OverloadResolver
             if (classType.TryGetField(parameters[i].Name, out var field))
             {
                 initializers.Add(new BoundFieldInitializer(field, ctorCall.Arguments[i]));
+                continue;
+            }
+
+            if (TypeMemberModel.TryGetProperty(classType, parameters[i].Name, out var property) && property.HasSetter)
+            {
+                initializers.Add(new BoundFieldInitializer(property, ctorCall.Arguments[i]));
             }
         }
 
@@ -3126,6 +3139,15 @@ internal sealed class OverloadResolver
                     if (classType.TryGetField(parameters[i].Name, out var field))
                     {
                         fieldInitializersV.Add(new BoundFieldInitializer(field, packedArgs[i]));
+                        continue;
+                    }
+
+                    // Issue #2291: an imported C# `record struct`'s positional
+                    // members are auto-properties, not plain fields — fall
+                    // back to a settable property with the same name.
+                    if (TypeMemberModel.TryGetProperty(classType, parameters[i].Name, out var propertyV) && propertyV.HasSetter)
+                    {
+                        fieldInitializersV.Add(new BoundFieldInitializer(propertyV, packedArgs[i]));
                     }
                 }
 
@@ -3353,6 +3375,15 @@ internal sealed class OverloadResolver
                 if (classType.TryGetField(parameters[i].Name, out var field))
                 {
                     fieldInitializers.Add(new BoundFieldInitializer(field, boundArguments[i]));
+                    continue;
+                }
+
+                // Issue #2291: an imported C# `record struct`'s positional
+                // members are auto-properties, not plain fields — fall back
+                // to a settable property with the same name.
+                if (TypeMemberModel.TryGetProperty(classType, parameters[i].Name, out var property) && property.HasSetter)
+                {
+                    fieldInitializers.Add(new BoundFieldInitializer(property, boundArguments[i]));
                 }
             }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1077,6 +1077,24 @@ internal sealed partial class MethodBodyEmitter
         // Class literal: newobj <ctor>; (dup; <value>; stfld) per init.
         if (literal.StructType.IsClass)
         {
+            // Issue #2291: an imported C# `record class` has NO public
+            // parameterless constructor — only its positional primary
+            // constructor and a synthesized copy constructor
+            // (`.ctor(SameType)`). #2263's parameterless-ctor + per-member
+            // stfld/setter strategy cannot construct it at all. Detect that
+            // shape up front and construct through the positional primary
+            // constructor instead, passing each member's already-resolved
+            // value (explicit override or a copy read off the temp
+            // variable) as a constructor argument in declaration order.
+            if (!isGeneric
+                && !this.outer.cache.ClassCtorHandles.ContainsKey(literal.StructType)
+                && literal.StructType.ClrType is { } importedClrTypeForCtorCheck
+                && importedClrTypeForCtorCheck.GetConstructor(Type.EmptyTypes) == null)
+            {
+                this.EmitImportedPositionalRecordLiteral(literal, importedClrTypeForCtorCheck);
+                return;
+            }
+
             EntityHandle ctorHandle;
             if (isGeneric)
             {
@@ -1197,6 +1215,106 @@ internal sealed partial class MethodBodyEmitter
 
         // Leave the constructed struct value on the stack.
         this.il.LoadLocal(slot);
+    }
+
+    /// <summary>
+    /// Issue #2291: constructs an imported C# `record class` — which has no
+    /// public parameterless constructor, only its positional primary
+    /// constructor and a synthesized copy constructor — by calling the
+    /// primary constructor directly with each positional member's resolved
+    /// value (an explicit `with` override, or a copy read off the source
+    /// instance) as an argument, in declaration order. Any remaining
+    /// initializer not covered by a primary-constructor parameter (e.g. an
+    /// ordinary non-positional field or property) is still applied
+    /// afterwards via `dup`+`stfld`/setter call, exactly like the
+    /// parameterless-ctor path in <see cref="EmitStructLiteral"/>.
+    /// </summary>
+    private void EmitImportedPositionalRecordLiteral(BoundStructLiteralExpression literal, Type importedClrType)
+    {
+        var parameters = literal.StructType.PrimaryConstructorParameters;
+        if (parameters.IsDefaultOrEmpty)
+        {
+            throw new InvalidOperationException(
+                $"Imported data class '{literal.StructType.Name}' has no parameterless constructor and no positional primary-constructor shape to construct through.");
+        }
+
+        var primaryCtor = ResolveImportedPositionalConstructor(importedClrType, parameters.Length)
+            ?? throw new InvalidOperationException(
+                $"Imported data class '{literal.StructType.Name}' has no positional constructor matching its {parameters.Length}-member shape.");
+
+        var initializersByName = new Dictionary<string, BoundFieldInitializer>(StringComparer.Ordinal);
+        foreach (var init in literal.Initializers)
+        {
+            initializersByName[init.MemberName] = init;
+        }
+
+        var consumed = new HashSet<BoundFieldInitializer>();
+        foreach (var parameter in parameters)
+        {
+            if (!initializersByName.TryGetValue(parameter.Name, out var init))
+            {
+                throw new InvalidOperationException(
+                    $"Imported data class '{literal.StructType.Name}' is missing a value for positional member '{parameter.Name}'.");
+            }
+
+            this.EmitExpression(init.Value);
+            consumed.Add(init);
+        }
+
+        this.il.OpCode(ILOpCode.Newobj);
+        this.il.Token(this.outer.GetCtorReference(primaryCtor));
+
+        foreach (var init in literal.Initializers)
+        {
+            if (consumed.Contains(init))
+            {
+                continue;
+            }
+
+            if (init.Property != null)
+            {
+                var setterHandle = this.ResolveStructLiteralSetter(literal.StructType, init.Property, isGeneric: true);
+                this.il.OpCode(ILOpCode.Dup);
+                this.EmitExpression(init.Value);
+                this.il.OpCode(ILOpCode.Callvirt);
+                this.il.Token(setterHandle);
+                continue;
+            }
+
+            var fieldHandle = this.outer.ResolveFieldToken(literal.StructType, init.Field);
+            this.il.OpCode(ILOpCode.Dup);
+            this.EmitExpression(init.Value);
+            this.il.OpCode(ILOpCode.Stfld);
+            this.il.Token(fieldHandle);
+        }
+    }
+
+    /// <summary>
+    /// Issue #2291: finds the public instance constructor on an imported
+    /// record class matching its positional shape — <paramref name="parameterCount"/>
+    /// parameters, excluding the synthesized copy constructor
+    /// (`.ctor(SameType)`, recognizable as a single parameter whose type is
+    /// the declaring type itself).
+    /// </summary>
+    private static ConstructorInfo ResolveImportedPositionalConstructor(Type importedClrType, int parameterCount)
+    {
+        foreach (var ctor in ClrTypeUtilities.SafeGetConstructors(importedClrType, BindingFlags.Public | BindingFlags.Instance))
+        {
+            var ctorParameters = ctor.GetParameters();
+            if (ctorParameters.Length != parameterCount)
+            {
+                continue;
+            }
+
+            if (ctorParameters.Length == 1 && ClrTypeUtilities.AreSame(ctorParameters[0].ParameterType, importedClrType))
+            {
+                continue;
+            }
+
+            return ctor;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -798,6 +798,13 @@ internal sealed partial class MethodBodyEmitter
         {
             getterHandle = handles.Getter.Value;
         }
+        else if ((access.StructType as StructSymbol)?.ClrType != null)
+        {
+            // Issue #2291: a property on an IMPORTED type (e.g. a C# record's
+            // auto-property) has no planned PropertyAccessorHandles entry —
+            // resolve its getter MethodRef directly off the imported CLR type.
+            getterHandle = this.outer.ResolveUserPropertyAccessorToken(access.StructType as StructSymbol, access.Property, wantSetter: false);
+        }
         else
         {
             throw new InvalidOperationException(
@@ -866,6 +873,12 @@ internal sealed partial class MethodBodyEmitter
         else if (this.outer.cache.PropertyAccessorHandles.TryGetValue(assn.Property, out var handles) && handles.Setter.HasValue)
         {
             setterHandle = handles.Setter.Value;
+        }
+        else if ((assn.StructType as StructSymbol)?.ClrType != null)
+        {
+            // Issue #2291: mirrors the getter fallback above for IMPORTED
+            // properties with no planned PropertyAccessorHandles entry.
+            setterHandle = this.outer.ResolveUserPropertyAccessorToken(assn.StructType as StructSymbol, assn.Property, wantSetter: true);
         }
         else
         {

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -690,6 +690,38 @@ public static class ClrTypeUtilities
     }
 
     /// <summary>
+    /// Issue #2291: safely determines whether a property accessor OVERRIDES a
+    /// base declaration, tolerating a <see cref="System.Reflection.MetadataLoadContext"/>
+    /// that does not support <see cref="MethodInfo.GetBaseDefinition"/> (it
+    /// throws <see cref="NotSupportedException"/> unconditionally for every
+    /// virtual method, not just an unresolvable one). A genuine C# record's
+    /// <c>EqualityContract</c> property getter is <c>virtual</c> (so a derived
+    /// record can widen it), which is exactly the shape that first surfaced
+    /// this: building a semantic aggregate for an imported record under an
+    /// MLC-backed resolver must not crash just because ONE property happens to
+    /// be virtual. Falls back to "not an override" on failure — the same
+    /// conservative default every other MLC-safe query in this file uses.
+    /// </summary>
+    /// <param name="accessor">The property accessor (getter or setter) to probe.</param>
+    /// <returns><c>true</c> when the accessor is confirmed to override a base declaration.</returns>
+    public static bool SafeIsOverride(MethodInfo accessor)
+    {
+        if (accessor is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return accessor.GetBaseDefinition() != accessor;
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex))
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Issue #1181: collects the transitive closure of imported/BCL base
     /// interfaces declared on <paramref name="interfaceSymbol"/> or on any of
     /// its user base interfaces. A user interface

--- a/src/Core/CodeAnalysis/Symbols/ImportedAssemblySemantics.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedAssemblySemantics.cs
@@ -55,6 +55,89 @@ internal static class ImportedAssemblySemantics
         }
     }
 
+    /// <summary>
+    /// Issue #2291: recognizes a genuine C# compiler-emitted <c>record</c> /
+    /// <c>record struct</c> shape when the assembly it lives in was compiled
+    /// by the C# compiler (not gsc) and therefore never wrote a
+    /// <see cref="TypeSemanticsMetadataKey"/> marker for it. Every C# record
+    /// synthesizes a <c>PrintMembers</c> method and a copy constructor
+    /// (<c>.ctor(SameType)</c>); a <c>record class</c> additionally
+    /// synthesizes a public parameterless <c>&lt;Clone&gt;$</c> method and a
+    /// protected/internal <c>EqualityContract</c> property (a <c>record
+    /// struct</c> has neither — value-type copying makes them unnecessary).
+    /// Requiring the FULL marker set for the type's value/reference kind
+    /// keeps this from ever misclassifying a hand-written class/struct that
+    /// merely happens to declare one of these members incidentally.
+    /// </summary>
+    /// <param name="type">The externally-referenced CLR type to inspect.</param>
+    /// <param name="semantics">The synthesized semantics on success.</param>
+    /// <returns><see langword="true"/> when <paramref name="type"/> has the full record shape.</returns>
+    public static bool TryDetectCSharpRecordSemantics(Type type, out ImportedTypeSemantics semantics)
+    {
+        semantics = null;
+        if (type == null || type.IsPrimitive || type.IsEnum || type.IsInterface || type.IsGenericTypeDefinition)
+        {
+            return false;
+        }
+
+        const BindingFlags InstanceAny = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+        // Look up methods/constructors WITHOUT passing an explicit parameter
+        // `Type[]` to `GetMethod`/`GetConstructor` overloads — under a
+        // `MetadataLoadContext`-backed resolver, `typeof(StringBuilder)` (or
+        // any host-runtime `Type`) is NOT "a type provided by the
+        // MetadataLoadContext" that loaded `type`, and the reflection binder
+        // throws `ArgumentException` rather than simply reporting no match.
+        // Enumerating and matching by simple name/FullName instead works
+        // uniformly for both the live-reflection and MLC-backed resolvers.
+        var hasPrintMembers = ClrTypeUtilities.SafeGetMethods(type, InstanceAny).Any(m =>
+            string.Equals(m.Name, "PrintMembers", StringComparison.Ordinal)
+            && m.ReturnType.FullName == "System.Boolean"
+            && m.GetParameters() is [{ ParameterType.FullName: "System.Text.StringBuilder" }]);
+
+        if (!hasPrintMembers)
+        {
+            return false;
+        }
+
+        // Issue #2291 follow-up: a `record class` needs an explicit copy
+        // constructor (`.ctor(SameType)`) plus `<Clone>$`/`EqualityContract`
+        // because `with` on a reference type must allocate a brand-new
+        // instance. A `record struct` has NEITHER — value-type assignment
+        // already copies the whole instance, so the C# compiler never
+        // synthesizes a copy constructor, `<Clone>$`, or `EqualityContract`
+        // for it (verified by inspecting the compiler-emitted metadata
+        // shape of `public record struct Point(int X, int Y)`). Requiring
+        // those reference-type-only markers on a record STRUCT would always
+        // fail detection, so `PrintMembers` alone — a marker unique to
+        // compiler-synthesized records — is the correct, sufficient
+        // signature for the value-type case.
+        if (!type.IsValueType)
+        {
+            var hasCopyConstructor = ClrTypeUtilities.SafeGetConstructors(type, InstanceAny).Any(c =>
+                c.GetParameters() is [{ } onlyParameter] && ClrTypeUtilities.AreSame(onlyParameter.ParameterType, type));
+            var hasClone = ClrTypeUtilities.SafeGetMethods(type, BindingFlags.Public | BindingFlags.Instance).Any(m =>
+                string.Equals(m.Name, "<Clone>$", StringComparison.Ordinal)
+                && m.GetParameters().Length == 0
+                && type.IsAssignableFrom(m.ReturnType));
+            var hasEqualityContract = type.GetProperty("EqualityContract", BindingFlags.NonPublic | BindingFlags.Instance) is { } equalityContractProperty
+                && equalityContractProperty.PropertyType.FullName == "System.Type";
+            if (!hasCopyConstructor || !hasClone || !hasEqualityContract)
+            {
+                return false;
+            }
+        }
+
+        var (parameterNames, parameterFieldTokens) = BuildRecordPrimaryConstructorShape(type);
+        semantics = new ImportedTypeSemantics(
+            MetadataToken: type.MetadataToken,
+            IsValueType: type.IsValueType,
+            IsData: true,
+            PrimaryConstructorParameterNames: parameterNames,
+            PrimaryConstructorParameterFieldTokens: parameterFieldTokens);
+        return true;
+    }
+
     public static bool GrantsInternalAccessTo(Assembly assembly, string consumerAssemblyName)
     {
         if (assembly == null || string.IsNullOrWhiteSpace(consumerAssemblyName))
@@ -90,6 +173,70 @@ internal static class ImportedAssemblySemantics
         {
             return false;
         }
+    }
+
+    // Issue #2291: the record's POSITIONAL primary constructor is the public
+    // instance constructor (other than the synthesized copy constructor,
+    // `.ctor(SameType)`) whose parameters name-match, 1:1 and in order, a
+    // public auto-property of the record (the shape every C#
+    // `record`/`record struct` positional declaration produces). A record
+    // with no positional parameters (e.g. `record struct Empty;`) has no such
+    // constructor — <c>with</c> then has nothing to set, which still compiles
+    // (an empty `{ }`  member list).
+    private static (ImmutableArray<string> Names, ImmutableArray<int> FieldTokens) BuildRecordPrimaryConstructorShape(Type type)
+    {
+        var autoProperties = type
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetMethod != null && p.SetMethod != null && p.GetIndexParameters().Length == 0)
+            .ToDictionary(p => p.Name, StringComparer.Ordinal);
+
+        if (autoProperties.Count == 0)
+        {
+            return (ImmutableArray<string>.Empty, ImmutableArray<int>.Empty);
+        }
+
+        ConstructorInfo bestMatch = null;
+        var bestParameters = Array.Empty<ParameterInfo>();
+        foreach (var ctor in type.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var parameters = ctor.GetParameters();
+
+            // Skip the synthesized copy constructor — it never denotes the
+            // positional shape.
+            if (parameters.Length == 1 && ClrTypeUtilities.AreSame(parameters[0].ParameterType, type))
+            {
+                continue;
+            }
+
+            if (parameters.Length == 0 || parameters.Length <= bestParameters.Length)
+            {
+                continue;
+            }
+
+            if (parameters.All(p => autoProperties.ContainsKey(p.Name ?? string.Empty)))
+            {
+                bestMatch = ctor;
+                bestParameters = parameters;
+            }
+        }
+
+        if (bestMatch == null)
+        {
+            return (ImmutableArray<string>.Empty, ImmutableArray<int>.Empty);
+        }
+
+        var namesBuilder = ImmutableArray.CreateBuilder<string>(bestParameters.Length);
+        var tokensBuilder = ImmutableArray.CreateBuilder<int>(bestParameters.Length);
+        foreach (var parameter in bestParameters)
+        {
+            var name = parameter.Name;
+            namesBuilder.Add(name);
+
+            var backingField = type.GetField($"<{name}>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance);
+            tokensBuilder.Add(backingField?.MetadataToken ?? 0);
+        }
+
+        return (namesBuilder.ToImmutable(), tokensBuilder.ToImmutable());
     }
 
     private static AssemblySemantics ReadAssemblySemantics(Assembly assembly)

--- a/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
@@ -141,8 +141,20 @@ public sealed class ImportedTypeSymbol : TypeSymbol
             || type.IsPrimitive
             || type.IsEnum
             || type.IsGenericParameter
-            || type.IsInterface
-            || !ImportedAssemblySemantics.TryGetTypeSemantics(type, out var semantics))
+            || type.IsInterface)
+        {
+            return false;
+        }
+
+        // Issue #2291: an externally-referenced assembly that was compiled by
+        // the C# compiler (not gsc) never carries the `GSharp.TypeSemantics`
+        // marker, even when the type is a genuine C# `record`/`record struct`.
+        // Fall back to recognizing the compiler-emitted record SHAPE (the
+        // `PrintMembers`/copy-constructor/`<Clone>$`/`EqualityContract`
+        // markers every C# record synthesizes) so such a type still resolves
+        // to a data-class semantic aggregate and `with`/copy keep working.
+        if (!ImportedAssemblySemantics.TryGetTypeSemantics(type, out var semantics)
+            && !ImportedAssemblySemantics.TryDetectCSharpRecordSemantics(type, out semantics))
         {
             return false;
         }
@@ -213,7 +225,8 @@ public sealed class ImportedTypeSymbol : TypeSymbol
 
     private static StructSymbol BuildSemanticAggregate(Type type, string consumerAssemblyName)
     {
-        if (!ImportedAssemblySemantics.TryGetTypeSemantics(type, out var semantics))
+        if (!ImportedAssemblySemantics.TryGetTypeSemantics(type, out var semantics)
+            && !ImportedAssemblySemantics.TryDetectCSharpRecordSemantics(type, out semantics))
         {
             return null;
         }
@@ -263,7 +276,7 @@ public sealed class ImportedTypeSymbol : TypeSymbol
                 hasSetter: setter != null && IsVisible(setter, includeInternal),
                 isAutoProperty: false,
                 isVirtual: (getter ?? setter)?.IsVirtual == true,
-                isOverride: (getter ?? setter)?.GetBaseDefinition() != (getter ?? setter),
+                isOverride: ClrTypeUtilities.SafeIsOverride(getter ?? setter),
                 isStatic: (getter ?? setter)?.IsStatic == true,
                 isInitOnly: setter != null && IsInitOnlySetter(setter)));
         }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2290CrossAssemblyTypeIdentityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2290CrossAssemblyTypeIdentityTests.cs
@@ -1,0 +1,190 @@
+// <copyright file="Issue2290CrossAssemblyTypeIdentityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2290: a referenced (cross-assembly) type can be independently
+/// re-minted into two non-reference-equal <see cref="TypeSymbol"/> wrappers
+/// for the SAME underlying CLR type — the confirmed mechanism is that a
+/// <see cref="System.Reflection.MetadataLoadContext"/>-backed
+/// <see cref="ReferenceResolver"/> does not canonicalize <see cref="Type"/>
+/// identity ACROSS two separate resolver instances that both load the same
+/// on-disk assembly (each gets its own <c>MetadataLoadContext</c>, so
+/// <c>Assembly.GetType(name)</c> from each returns a distinct <see cref="Type"/>
+/// object for "the same" metadata type — <c>ReferenceEquals</c> is
+/// <see langword="false"/> even though <see cref="ClrTypeUtilities.AreSame"/>
+/// is <see langword="true"/>). <see cref="ImportedTypeSymbol.Get(Type)"/>
+/// caches by <see cref="Type"/> identity, so the two <c>Type</c> objects mint
+/// two distinct, non-reference-equal <see cref="ImportedTypeSymbol"/>
+/// instances. <see cref="Conversion.Classify(TypeSymbol, TypeSymbol)"/>
+/// previously only special-cased an <see cref="ImportedTypeSymbol"/> ⇄
+/// <see cref="StructSymbol"/> pair (issue #2263); it now treats ANY pairing of
+/// the two symbol kinds that wrap a genuine referenced CLR type — including
+/// two <see cref="ImportedTypeSymbol"/> instances, or two semantic-aggregate
+/// <see cref="StructSymbol"/> instances — as an identity conversion whenever
+/// their underlying <see cref="Type"/> is the same metadata type.
+/// </summary>
+public class Issue2290CrossAssemblyTypeIdentityTests
+{
+    private const string PlainClassLibrarySource = """
+        package A.B
+
+        class Chapter {
+        }
+        """;
+
+    private const string DataClassLibrarySource = """
+        package A.B
+
+        data class Chapter(Title string)
+
+        class Book {
+            func GetChapter() Chapter -> Chapter("intro")
+        }
+        """;
+
+    [Fact]
+    public void TwoSeparateResolvers_SameDll_ResolvePlainClass_ToNonReferenceEqual_ButMetadataIdentical_Types()
+    {
+        var libraryPath = EmitLibrary(PlainClassLibrarySource, nameof(this.TwoSeparateResolvers_SameDll_ResolvePlainClass_ToNonReferenceEqual_ButMetadataIdentical_Types));
+
+        using var resolverA = ReferenceResolver.WithReferences(new[] { libraryPath });
+        using var resolverB = ReferenceResolver.WithReferences(new[] { libraryPath });
+
+        Assert.True(resolverA.TryResolveType("A.B.Chapter", out var typeA));
+        Assert.True(resolverB.TryResolveType("A.B.Chapter", out var typeB));
+
+        // Confirms the mechanism: independent resolvers do not canonicalize
+        // Type identity for the same underlying assembly.
+        Assert.False(ReferenceEquals(typeA, typeB));
+        Assert.True(ClrTypeUtilities.AreSame(typeA, typeB));
+
+        var symbolA = ImportedTypeSymbol.Get(typeA);
+        var symbolB = ImportedTypeSymbol.Get(typeB);
+        Assert.False(ReferenceEquals(symbolA, symbolB));
+
+        var conversion = Conversion.Classify(symbolA, symbolB);
+        Assert.True(conversion.Exists);
+        Assert.True(conversion.IsIdentity);
+
+        var reverse = Conversion.Classify(symbolB, symbolA);
+        Assert.True(reverse.Exists);
+        Assert.True(reverse.IsIdentity);
+    }
+
+    [Fact]
+    public void TwoSeparateResolvers_SameDll_ResolveDataClass_SemanticAggregates_AsIdentityConvertible()
+    {
+        var libraryPath = EmitLibrary(DataClassLibrarySource, nameof(this.TwoSeparateResolvers_SameDll_ResolveDataClass_SemanticAggregates_AsIdentityConvertible));
+
+        using var resolverA = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolverA.CurrentAssemblyName = "Consumer";
+        using var resolverB = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolverB.CurrentAssemblyName = "Consumer";
+
+        Assert.True(resolverA.TryResolveType("A.B.Chapter", out var typeA));
+        Assert.True(resolverB.TryResolveType("A.B.Chapter", out var typeB));
+        Assert.False(ReferenceEquals(typeA, typeB));
+
+        Assert.True(ImportedTypeSymbol.TryCreateSemanticAggregate(typeA, resolverA, out var aggregateA));
+        Assert.True(ImportedTypeSymbol.TryCreateSemanticAggregate(typeB, resolverB, out var aggregateB));
+        Assert.False(ReferenceEquals(aggregateA, aggregateB));
+
+        var conversion = Conversion.Classify(aggregateA, aggregateB);
+        Assert.True(conversion.Exists);
+        Assert.True(conversion.IsIdentity);
+    }
+
+    [Fact]
+    public void Qualified_And_Imported_BareName_Chapter_Convert_BothDirections_Cleanly()
+    {
+        var libraryPath = EmitLibrary(PlainClassLibrarySource, nameof(this.Qualified_And_Imported_BareName_Chapter_Convert_BothDirections_Cleanly));
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Consumer";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+                import A.B
+
+                func Take(c A.B.Chapter) { }
+
+                func Run() {
+                    let bareCh Chapter = Book().GetChapter()
+                    Take(bareCh)
+                    let qualCh A.B.Chapter = bareCh
+                    let bareCh2 Chapter = qualCh
+                }
+
+                class Book {
+                    func GetChapter() Chapter -> Chapter()
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void Qualified_And_Imported_BareName_DataClassChapter_Convert_BothDirections_Cleanly()
+    {
+        var libraryPath = EmitLibrary(DataClassLibrarySource, nameof(this.Qualified_And_Imported_BareName_DataClassChapter_Convert_BothDirections_Cleanly));
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Consumer";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+                import A.B
+
+                func Take(c A.B.Chapter) { }
+
+                func Run() {
+                    let bareCh Chapter = Book().GetChapter()
+                    Take(bareCh)
+                    let qualCh A.B.Chapter = bareCh
+                    let bareCh2 Chapter = qualCh
+                    let copy = bareCh2 with { Title = "renamed" }
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static string EmitLibrary(string source, string caseName)
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2290", caseName);
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Lib2290.dll");
+
+        var library = new Compilation(SyntaxTree.Parse(SourceText.From(source)))
+        {
+            IsLibrary = true,
+        };
+
+        using var peStream = File.Create(libraryPath);
+        var result = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Lib2290");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return libraryPath;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2291ImportedRecordWithCopyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2291ImportedRecordWithCopyTests.cs
@@ -1,0 +1,186 @@
+// <copyright file="Issue2291ImportedRecordWithCopyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2291: an externally-referenced assembly that is a genuine C#
+/// <c>record</c>/<c>record struct</c> but was compiled by the C# compiler
+/// (not gsc) never carries the <c>GSharp.TypeSemantics</c> assembly-metadata
+/// marker gsc writes for its own data classes/structs. Without a fallback,
+/// gsc cannot recognize the type as a data class, so <c>x with { ... }</c> /
+/// <c>copy</c> on it fails GS0161 even though it is a real record.
+/// <see cref="ImportedAssemblySemantics.TryDetectCSharpRecordSemantics"/> now
+/// recognizes the compiler-emitted record SHAPE — <c>PrintMembers</c> plus a
+/// copy constructor for both a <c>record class</c> and a <c>record struct</c>,
+/// plus <c>&lt;Clone&gt;$</c>/<c>EqualityContract</c> additionally required
+/// for a <c>record class</c> — as a fallback data-class marker, generalized to
+/// both record kinds. A plain (non-record) imported class/struct still fails
+/// GS0161 (negative control).
+/// </summary>
+public class Issue2291ImportedRecordWithCopyTests
+{
+    [Fact]
+    public void Imported_CSharpRecordClass_With_Compiles()
+    {
+        var libraryPath = EmitCSharpLibrary(
+            nameof(this.Imported_CSharpRecordClass_With_Compiles),
+            "namespace Records { public record Person(string Name, int Age); }");
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Consumer";
+
+        var consumer = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+                import Records
+
+                func Run() int32 {
+                    let p = Person("Ada", 30)
+                    let p2 = p with { Age = 5 }
+                    return p2.Age
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void Imported_CSharpRecordStruct_With_Compiles()
+    {
+        var libraryPath = EmitCSharpLibrary(
+            nameof(this.Imported_CSharpRecordStruct_With_Compiles),
+            "namespace Records { public record struct Point(int X, int Y); }");
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Consumer";
+
+        var consumer = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+                import Records
+
+                func Run() int32 {
+                    let p = Point(1, 2)
+                    let p2 = p with { X = 9 }
+                    return p2.X + p2.Y
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void Imported_CSharpRecordClass_Copy_Compiles()
+    {
+        var libraryPath = EmitCSharpLibrary(
+            nameof(this.Imported_CSharpRecordClass_Copy_Compiles),
+            "namespace Records { public record Person(string Name, int Age); }");
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Consumer";
+
+        var consumer = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+                import Records
+
+                func Run() int32 {
+                    let p = Person("Ada", 30)
+                    let p2 = p.copy(Age: 5)
+                    return p2.Age
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void Imported_PlainCSharpClass_With_StillReportsGs0161()
+    {
+        var libraryPath = EmitCSharpLibrary(
+            nameof(this.Imported_PlainCSharpClass_With_StillReportsGs0161),
+            "namespace Records { public class PlainPerson { public string Name { get; set; } public int Age { get; set; } } }");
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Consumer";
+
+        var consumer = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+                import Records
+
+                func Run() int32 {
+                    let p = PlainPerson()
+                    let p2 = p with { Age = 5 }
+                    return p2.Age
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Consumer");
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0161");
+    }
+
+    private static string EmitCSharpLibrary(string caseName, string recordSource)
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2291", caseName);
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "CSharpLib2291.dll");
+
+        var syntaxTree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(
+            recordSource,
+            new CSharpParseOptions(LanguageVersion.Latest));
+
+        var referencePaths = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+            ?.Split(Path.PathSeparator)
+            ?? Array.Empty<string>();
+
+        var references = referencePaths
+            .Where(File.Exists)
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "CSharpLib2291",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var emitResult = compilation.Emit(peStream);
+            Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+        }
+
+        return libraryPath;
+    }
+}


### PR DESCRIPTION
## Summary

Two related cross-assembly binder gaps in the same subsystem: gsc's handling of imported (externally-referenced) types.

### #2290 — cross-project TypeSymbol identity split

**Root cause (confirmed):** two independent `ReferenceResolver`/`MetadataLoadContext` instances loading the *same* on-disk referenced assembly produce non-reference-equal `System.Type` objects for "the same" metadata type. When a G# consumer resolves a type both via its fully-qualified name and via a bare name brought into scope by `import`, the two resolution paths can end up backed by `Type` instances from different `MetadataLoadContext`s, so the resulting `TypeSymbol` wrappers compared as *unequal* even though they represent the identical underlying type — producing a spurious `Cannot convert type 'X' to 'X'`/GS0155/GS0156 error.

This matches the task's hypothesis, but the precise trigger is the *dual-MLC* scenario (not a general reference-vs-value-equality gap for a single load context).

**Fix:** generalized the conversion classifier's identity check (`Conversion.Classify` / `IsImportedTypeIdentity`) to use `ClrTypeUtilities.AreSame` when comparing two imported types, so two `TypeSymbol`s are treated as identity-convertible whenever their underlying CLR types are the same metadata type — even across distinct `MetadataLoadContext`s. This is the most general fix point: it covers conversions regardless of which resolution path (qualified name vs. `import`-scoped bare name) produced each `TypeSymbol`, without requiring every call site that mints an imported `TypeSymbol` to also intern/cache it.

**Memory-pinning guard:** no new cache was introduced for this fix — it only changes an equality *comparison*, not how symbols are created/cached, so the existing `ConditionalWeakTable`-backed caches (`ImportedAssemblySemantics.Cache`, the semantic-aggregate cache in `ImportedTypeSymbol`) are untouched and remain resolver/MLC-scoped.

**Tests:** `test/Core.Tests/CodeAnalysis/Binding/Issue2290CrossAssemblyTypeIdentityTests.cs` (4 tests) — covers qualified-vs-`import` identity for conversion, assignment, and member access.

### #2291 — cross-assembly data-class metadata loss (GS0161 on with/copy)

An externally-referenced assembly compiled by the **C# compiler** (not gsc) never carries the `GSharp.TypeSemantics` marker gsc writes for its own data classes/structs, so a genuine C# `record`/`record struct` was never recognized as a data class and `with`/`copy` failed GS0161.

**Record-shape markers used** (`ImportedAssemblySemantics.TryDetectCSharpRecordSemantics`):
- `PrintMembers(StringBuilder) : bool` — required for **both** `record class` and `record struct`.
- `record class` additionally requires: a copy constructor (`.ctor(SameType)`), `<Clone>$()`, and a protected/internal `EqualityContract` property. A `record struct` has **none** of these three (value-type assignment already copies, so the C# compiler never synthesizes them) — confirmed by directly reflecting over compiler-emitted IL for both record kinds.

**This turned out to require considerably more than the detection-only hint in the issue.** Once a record was *recognized* as a data class, `with`/`copy` and even plain construction still failed, because:
- A C# record's positional members are auto-properties (backing fields are compiler-mangled and filtered out of gsc's `Fields` model entirely), but `with`/`copy` and two separate #2263-era construction-lowering paths in `OverloadResolver.cs` only ever matched primary-constructor parameter names against real `FieldSymbol`s.
- A record **class** has no parameterless constructor (only its positional primary ctor + copy ctor), so the existing struct-literal emission path (`newobj <parameterless-ctor>(); stfld/callvirt...`) could never construct one at all.
- Property getter access on an imported type had no code path at all (previously only exercised for gsc-emitted properties or generic-constructed-type member refs).

**Files changed:**
- `src/Core/CodeAnalysis/Symbols/ImportedAssemblySemantics.cs` — `TryDetectCSharpRecordSemantics` (record-shape detection, generalized for record class vs. record struct); `BuildRecordPrimaryConstructorShape` hardened against `Type` reference-identity per the #2290 lesson.
- `src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs` — wires the record-shape fallback into semantic-aggregate construction; uses the new `SafeIsOverride` helper.
- `src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs` — new `SafeIsOverride(MethodInfo)`: `MethodInfo.GetBaseDefinition()` throws `NotSupportedException` unconditionally under a `MetadataLoadContext`; wrap it defensively.
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs` — `LowerCopyOrWith` falls back to a settable `PropertySymbol` (both for an explicit override and for the default copy-from-receiver of every primary-constructor parameter not otherwise overridden); also generalizes the data-struct aggregate-first construction check to cover value types, not just classes.
- `src/Core/CodeAnalysis/Binding/OverloadResolver.cs` — the class-path (`LowerImportedDataClassConstruction`) and both struct-path (fixed-arity and variadic) construction lowerings now fall back to a settable property when no real field matches a primary-constructor parameter name.
- `src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs` — new `EmitImportedPositionalRecordLiteral`/`ResolveImportedPositionalConstructor`: when an imported class type has no parameterless constructor, resolves and calls its positional primary constructor directly, then applies any remaining non-positional initializers via the existing pattern.
- `src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs` — property getter/setter resolution falls back to resolving an imported property's accessor directly off its CLR type when no planned `PropertyAccessorHandles` entry exists.

**Memory-pinning guard:** no new process-wide cache was added; all record-shape/semantic-aggregate lookups continue to go through the existing `ConditionalWeakTable`-backed, resolver-scoped caches.

**Tests:** `test/Core.Tests/CodeAnalysis/Binding/Issue2291ImportedRecordWithCopyTests.cs` (4 tests) — imported C# `record` class `with`, imported `record struct` `with`, imported `record` class `copy`, and a negative control (a plain non-record imported class still reports GS0161 on `with`).

## Test results

- `Issue2290CrossAssemblyTypeIdentityTests`: 4/4 passed.
- `Issue2291ImportedRecordWithCopyTests`: 4/4 passed.
- Targeted regression filters (`~Conversion|~Overload|~ImportedType|~CrossAssembly`): 431/431 passed.
- Targeted regression filters (`~Record|~WithExpression|~Copy|~DataClass|~DataStruct`): 100/100 passed.
- Full `Core.Tests` suite (regression guard, run once): **5932/5933 passed**, 1 skipped (`RegenerateBaseline`, intentional). The single failure (`AwaitFor_ConfigureAwaitFalse_DrainsAsyncEnumerable`) is an unrelated, pre-existing async-timing test — confirmed to pass in isolation and untouched by this change.
- `dotnet build src/Compiler/Compiler.csproj -c Release`: 0 warnings, 0 errors (StyleCop-clean).

Closes #2290
Closes #2291
