### PR TITLE
cs2gs: file-scope + dedupe synthesized anonymous types (#2292)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
@@ -255,6 +255,14 @@ public sealed class TestParityStage : IMigrationStage
 
         var files = new List<GsharpSourceFile>();
         var usedGsFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Issue #2292: ONE translator instance shared across every document in
+        // this project (rather than a fresh one per file) so its package-scoped
+        // anonymous-type registry (see `CSharpToGSharpTranslator.
+        // anonymousTypeRegistriesByPackage`) is shared too — otherwise two
+        // files in the same package could each mint a colliding
+        // `AnonymousTypeN` name for two DIFFERENT anonymous shapes (GS0102).
+        var translator = new CSharpToGSharpTranslator();
         foreach (LoadedDocument document in project.Documents)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -264,7 +272,7 @@ public sealed class TestParityStage : IMigrationStage
                 document.SemanticModel,
                 document.FilePath);
 
-            CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, translationContext);
+            CompilationUnit unit = translator.TranslateDocument(document, translationContext);
             string printed = GSharpPrinter.Print(unit);
 
             TranslationDiagnostic unsupported = translationContext.Diagnostics

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2292AnonymousTypePackageScopeTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2292AnonymousTypePackageScopeTests.cs
@@ -1,0 +1,351 @@
+// <copyright file="Issue2292AnonymousTypePackageScopeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #2292: cs2gs's per-anonymous-shape data-class
+/// synthesis (issue #2282) reused a shape->name dictionary that lived on a
+/// FRESH <see cref="CSharpTypeMapper"/> created for every single document
+/// (<c>CSharpToGSharpTranslator.TranslateDocument</c>), so two DIFFERENT
+/// files sharing the same G# package (e.g. every migration in an EF
+/// <c>Migrations</c> folder — one file per migration, all in the same
+/// namespace) each started counting from <c>AnonymousType0</c>. A distinct
+/// shape in file B could therefore mint the exact synthetic name already used
+/// by an unrelated shape in file A, and the two <c>data class AnonymousType0</c>
+/// declarations collided (GS0102 "already declared") once both files were
+/// compiled together as the same package.
+/// <para>
+/// Note: WITHIN a single file/method boundary the shape dictionary and
+/// counter were already correctly scoped to the whole document (one
+/// <see cref="CSharpTypeMapper"/> per <c>TranslateDocument</c> call covers
+/// every method of every type in that file) — the collision only manifests
+/// ACROSS files of the same package, which is what the corpus evidence in
+/// #2292 (multiple Oahu.Data migration files) actually hit. The fix threads
+/// one <see cref="AnonymousTypeRegistry"/> per resolved package name through
+/// every mapper the translator creates, keyed on
+/// <c>CSharpToGSharpTranslator.anonymousTypeRegistriesByPackage</c>, so the
+/// synthetic-name counter and the shape-&gt;type dictionary are shared by
+/// every file in the package, not just every method in a file.
+/// </para>
+/// </summary>
+public class Issue2292AnonymousTypePackageScopeTests
+{
+    [Fact]
+    public void DistinctAnonymousShapes_InDifferentFiles_SamePackage_GetDistinctSyntheticNames()
+    {
+        const string SourceA = @"
+namespace Demo
+{
+    public sealed class MigrationA
+    {
+        public void Up()
+        {
+            var shapeA = new { Id = 1, Name = ""x"" };
+        }
+    }
+}";
+        const string SourceB = @"
+namespace Demo
+{
+    public sealed class MigrationB
+    {
+        public void Down()
+        {
+            var shapeB = new { Count = 1, Flag = true, Extra = 2.0 };
+        }
+    }
+}";
+        (string printedA, string printedB) = TranslateTwoFiles("MigrationA.cs", SourceA, "MigrationB.cs", SourceB);
+
+        // Each file mints a DISTINCT synthetic name for its DISTINCT shape —
+        // no two files in the same package emit the same 'AnonymousTypeN' for
+        // different shapes.
+        Assert.Contains("data class AnonymousType0(Id int32, Name string)", printedA);
+        Assert.Contains("data class AnonymousType1(Count int32, Flag bool, Extra float64)", printedB);
+        Assert.DoesNotContain("AnonymousType1", printedA);
+        Assert.DoesNotContain("data class AnonymousType0(Count", printedB);
+
+        // The proof that matters: gsc must compile BOTH files together (as one
+        // package) with no GS0102 "already declared" collision.
+        CompileFilesTogether(("MigrationA.gs", printedA), ("MigrationB.gs", printedB));
+    }
+
+    [Fact]
+    public void IdenticalAnonymousShape_InDifferentFiles_SamePackage_SharesOneSynthesizedType()
+    {
+        const string SourceA = @"
+namespace Demo
+{
+    public sealed class MigrationA
+    {
+        public void Up()
+        {
+            var shape = new { Id = 1, Name = ""x"" };
+        }
+    }
+}";
+        const string SourceB = @"
+namespace Demo
+{
+    public sealed class MigrationB
+    {
+        public void Down()
+        {
+            var shape = new { Id = 2, Name = ""y"" };
+        }
+    }
+}";
+        (string printedA, string printedB) = TranslateTwoFiles("MigrationA.cs", SourceA, "MigrationB.cs", SourceB);
+
+        // The FIRST file to need the shape declares it...
+        Assert.Contains("data class AnonymousType0(Id int32, Name string)", printedA);
+
+        // ...and the SECOND file reuses that same synthesized type by name
+        // rather than re-declaring its own copy (a re-declaration would ALSO
+        // be a GS0102 collision, even for an identical shape).
+        Assert.Contains("AnonymousType0{Id: 2, Name: \"y\"}", printedB);
+        Assert.DoesNotContain("data class AnonymousType", printedB);
+
+        CompileFilesTogether(("MigrationA.gs", printedA), ("MigrationB.gs", printedB));
+    }
+
+    [Fact]
+    public void DistinctAnonymousShapes_InDifferentMethods_SameFile_GetDistinctSyntheticNames()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class Migration
+    {
+        public void Up()
+        {
+            var shapeUp = new { Id = 1, Name = ""x"" };
+        }
+
+        public void Down()
+        {
+            var shapeDown = new { Count = 1, Flag = true };
+        }
+    }
+}");
+
+        Assert.Contains("data class AnonymousType0(Id int32, Name string)", printed);
+        Assert.Contains("data class AnonymousType1(Count int32, Flag bool)", printed);
+
+        CompileFilesTogether(("Migration.gs", printed));
+    }
+
+    /// <summary>
+    /// Part 2 (residual #2282): the EF-Core-style generic
+    /// <c>CreateTable</c>/<c>PrimaryKey</c> pattern — a generic method whose
+    /// type parameter is inferred from a lambda's anonymous-typed RETURN
+    /// value, crossing into ANOTHER lambda's parameter type, with a nested
+    /// named-member access (<c>x.Id</c>) on that parameter — must still
+    /// resolve end-to-end through the real <c>gsc</c> (not just round-trip
+    /// parse). cs2gs sidesteps the generic-inference question entirely by
+    /// annotating the lambda parameter with the CONCRETE synthesized type
+    /// (resolved from the bound C# semantic model, not re-inferred by gsc),
+    /// so gsc's binder never needs to flow a generic return type through
+    /// <c>Func/Action</c> type arguments itself.
+    /// </summary>
+    [Fact]
+    public void GenericMethodWithLambdaReturningAnonymousType_CompilesAndBindsMemberAccess()
+    {
+        string printed = TranslateUnit(@"
+using System;
+
+namespace Demo
+{
+    public sealed class ColumnsBuilder
+    {
+        public T Column<T>(string name) => default!;
+    }
+
+    public sealed class CreateTableBuilder<TColumns>
+    {
+        public void PrimaryKey(string name, Func<TColumns, object> columns) { }
+    }
+
+    public sealed class MigrationBuilder
+    {
+        public void CreateTable<TColumns>(
+            string name,
+            Func<ColumnsBuilder, TColumns> columns,
+            Action<CreateTableBuilder<TColumns>> constraints)
+        {
+        }
+    }
+
+    public sealed class Migration
+    {
+        public void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: ""Books"",
+                columns: table => new
+                {
+                    Id = table.Column<int>(name: ""Id""),
+                    Title = table.Column<string>(name: ""Title"")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey(""PK_Books"", x => x.Id);
+                });
+        }
+    }
+}");
+
+        Assert.Contains("data class AnonymousType0(Id int32, Title string)", printed);
+        Assert.Contains("CreateTableBuilder[AnonymousType0]", printed);
+        Assert.Contains("(x AnonymousType0) -> x.Id", printed);
+
+        // The real proof (not just round-trip parse): gsc must actually BIND
+        // the generic CreateTable/PrimaryKey calls and the x.Id member access
+        // with zero errors (GS0159/GS0158's original symptom).
+        CompileFilesTogether(("Migration.gs", printed));
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    /// <summary>
+    /// Translates two files loaded into the SAME in-memory C# project with
+    /// ONE shared <see cref="CSharpToGSharpTranslator"/> instance — mirroring
+    /// exactly how <c>TranslateStage</c>/<c>TestParityStage</c> translate
+    /// every document of a real project — so the package-scoped anonymous-type
+    /// registry is actually shared across the two files, the way it is in
+    /// production.
+    /// </summary>
+    private static (string PrintedA, string PrintedB) TranslateTwoFiles(
+        string fileNameA,
+        string sourceA,
+        string fileNameB,
+        string sourceB)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { (fileNameA, sourceA), (fileNameB, sourceB) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippets should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(2, project.Documents.Count);
+
+        var translator = new CSharpToGSharpTranslator();
+        LoadedDocument documentA = project.Documents[0];
+        LoadedDocument documentB = project.Documents[1];
+
+        var contextA = new TranslationContext(project.Compilation, documentA.SemanticModel, documentA.FilePath);
+        CompilationUnit unitA = translator.TranslateDocument(documentA, contextA);
+        string printedA = GSharpPrinter.Print(unitA);
+
+        var contextB = new TranslationContext(project.Compilation, documentB.SemanticModel, documentB.FilePath);
+        CompilationUnit unitB = translator.TranslateDocument(documentB, contextB);
+        string printedB = GSharpPrinter.Print(unitB);
+
+        Assert.True(GSharpRoundTrip.Validate(printedA).Success, "File A must round-trip:\n" + printedA);
+        Assert.True(GSharpRoundTrip.Validate(printedB).Success, "File B must round-trip:\n" + printedB);
+
+        return (printedA, printedB);
+    }
+
+    /// <summary>
+    /// Compiles every <c>(fileName, contents)</c> pair together, as ONE gsc
+    /// invocation (one package), asserting zero compiler errors — the
+    /// end-to-end proof that no synthesized 'AnonymousTypeN' declaration
+    /// collides (GS0102) and, for Part 2, that generic-method + lambda-return
+    /// inference over a synthesized type actually binds.
+    /// </summary>
+    private static void CompileFilesTogether(params (string FileName, string Contents)[] files)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-2292-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+
+        var gsPaths = new System.Collections.Generic.List<string>();
+        foreach ((string fileName, string contents) in files)
+        {
+            string gsPath = Path.Combine(workDir, fileName);
+            File.WriteAllText(gsPath, contents);
+            gsPaths.Add(gsPath);
+        }
+
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        string quotedSources = string.Join(" ", gsPaths.ConvertAll(p => $"\"{p}\""));
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:library /out:\"{dllPath}\" {quotedSources}");
+
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated files together with zero errors. Output:\n" + compileOut);
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -92,6 +92,19 @@ public sealed class CSharpToGSharpTranslator
     // (GS0102). Null (default) preserves the exact prior no-filter behavior.
     private readonly HashSet<string> retainedFilePaths;
 
+    // Issue #2292: one AnonymousTypeRegistry per resolved G# package, shared
+    // across every document this translator instance translates (every
+    // pipeline caller creates ONE CSharpToGSharpTranslator per project and
+    // calls TranslateDocument once per file in that project — see
+    // TranslateStage/TestParityStage), so two unrelated files sharing the
+    // same package draw synthetic anonymous-type names from ONE counter and
+    // reuse an identical shape's data class instead of each starting a fresh
+    // dictionary/counter at zero (which allowed a distinct shape in file B to
+    // mint the same name as an unrelated shape already declared in file A —
+    // a GS0102 collision once both files' output is compiled together).
+    private readonly Dictionary<string, AnonymousTypeRegistry> anonymousTypeRegistriesByPackage =
+        new(StringComparer.Ordinal);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="CSharpToGSharpTranslator"/> class.
     /// </summary>
@@ -197,7 +210,24 @@ public sealed class CSharpToGSharpTranslator
         IMethodSymbol entryPoint = context.Compilation.GetEntryPoint(default);
         INamedTypeSymbol entryType = entryPoint?.ContainingType;
 
-        var typeMapper = new CSharpTypeMapper();
+        // Issue #2292: share the anonymous-type registry with every other
+        // document already translated (by this same translator instance)
+        // into the same package, so distinct/identical shapes across FILES
+        // never collide (see `anonymousTypeRegistriesByPackage`'s comment).
+        // `package` is null for a file with no namespace declaration (the
+        // global namespace, e.g. a top-level-statements `Program.cs`) — a
+        // Dictionary key cannot be null, so the global namespace is keyed by
+        // the empty string instead (still one shared registry for every
+        // global-namespace file in this translator's project, exactly
+        // mirroring the non-null-package case).
+        string registryKey = package ?? string.Empty;
+        if (!this.anonymousTypeRegistriesByPackage.TryGetValue(registryKey, out AnonymousTypeRegistry anonymousTypeRegistry))
+        {
+            anonymousTypeRegistry = new AnonymousTypeRegistry();
+            this.anonymousTypeRegistriesByPackage[registryKey] = anonymousTypeRegistry;
+        }
+
+        var typeMapper = new CSharpTypeMapper(anonymousTypeRegistry);
         var visitor = new DeclarationVisitor(context, typeMapper, openBases, staticUsingTargets, entryPoint, partialTypeParts, this.preservePartialParts, this.markMergedTypePartial);
 
         var members = new List<GNode>();

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -62,20 +62,45 @@ public sealed class CSharpTypeMapper
     /// synthesized declaration instead of each minting its own (which would
     /// combinatorially explode across a large file). See
     /// <see cref="GetOrCreateAnonymousDataClass"/>.
+    /// <para>
+    /// Issue #2292: this dictionary (and the synthetic-name counter) is now
+    /// owned by an <see cref="AnonymousTypeRegistry"/> that is shared across
+    /// EVERY <see cref="CSharpTypeMapper"/> instance translating documents
+    /// into the SAME G# package (<c>CSharpToGSharpTranslator</c> creates one
+    /// mapper per source file but keeps one registry per resolved package),
+    /// rather than living directly on this per-file mapper. Two unrelated
+    /// files in the same package used to each start their own private
+    /// dictionary/counter at zero, so a distinct shape in file B could still
+    /// mint the SAME synthetic name (<c>AnonymousType0</c>) as an unrelated
+    /// shape already declared in file A — both top-level declarations landing
+    /// in the same package caused GS0102 "already declared" even though
+    /// per-file the mapper looked file-scoped. Sharing the registry across the
+    /// whole package closes that gap while still deduplicating identical
+    /// shapes package-wide (a shape already declared by an earlier file is
+    /// reused, not re-declared, by a later one).
+    /// </para>
     /// </summary>
-    private readonly Dictionary<string, NamedTypeReference> anonymousDataClassesByShape =
-        new(System.StringComparer.Ordinal);
+    private readonly AnonymousTypeRegistry anonymousTypeRegistry;
 
     /// <summary>
     /// Issue #2282: the synthesized anonymous-type <c>data class</c>
-    /// declarations, in first-seen order, collected here (rather than emitted
-    /// inline) because <see cref="Map"/> is called from many contexts (a
+    /// declarations first minted by THIS mapper (i.e. this source file),
+    /// in first-seen order, collected here (rather than emitted inline)
+    /// because <see cref="Map"/> is called from many contexts (a
     /// parameter type, a field type, a generic argument, ...) that have no
     /// direct way to append a new top-level type declaration to the
     /// compilation unit being built. <c>CSharpToGSharpTranslator.TranslateDocument</c>
     /// drains this list into the compilation unit's members once, after every
     /// member has been translated (mirroring how <see cref="ShortenedNamespaces"/>
     /// is drained into synthesized imports).
+    /// <para>
+    /// Issue #2292: a shape already declared by an EARLIER file sharing this
+    /// mapper's <see cref="anonymousTypeRegistry"/> is intentionally NOT
+    /// re-added here (see <see cref="GetOrCreateAnonymousDataClass"/>) so the
+    /// data class is declared exactly once per package, in the first file
+    /// that needed it, instead of once per file (which would itself be a
+    /// GS0102 duplicate-declaration collision even for an IDENTICAL shape).
+    /// </para>
     /// </summary>
     private readonly List<TypeDeclaration> pendingAnonymousDataClasses = new();
 
@@ -95,6 +120,32 @@ public sealed class CSharpTypeMapper
     /// project) rather than in source.
     /// </summary>
     private HashSet<string> importedNamespaceNames;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CSharpTypeMapper"/> class
+    /// with a private, unshared anonymous-type registry (every prior call
+    /// site's behavior — used by standalone/single-file callers such as
+    /// existing tests that never span multiple documents in the same
+    /// package).
+    /// </summary>
+    public CSharpTypeMapper()
+        : this(new AnonymousTypeRegistry())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CSharpTypeMapper"/> class
+    /// sharing <paramref name="anonymousTypeRegistry"/> with every other
+    /// mapper translating a document into the same G# package (issue #2292).
+    /// </summary>
+    /// <param name="anonymousTypeRegistry">
+    /// The package-scoped registry of already-synthesized anonymous-type
+    /// shapes and the next available synthetic-name index.
+    /// </param>
+    public CSharpTypeMapper(AnonymousTypeRegistry anonymousTypeRegistry)
+    {
+        this.anonymousTypeRegistry = anonymousTypeRegistry ?? new AnonymousTypeRegistry();
+    }
 
     /// <summary>
     /// Gets every namespace shortened into a bare/qualified-nested type name by
@@ -266,11 +317,13 @@ public sealed class CSharpTypeMapper
     /// <para>
     /// Every distinct anonymous-type SHAPE (the ordered list of member name +
     /// fully-qualified property type) reuses the same synthesized type across
-    /// the whole document — keyed structurally via <see cref="anonymousDataClassesByShape"/>,
-    /// not by Roslyn symbol identity — so two syntactically-identical
-    /// anonymous types declared in different places still share one
-    /// declaration, avoiding a combinatorial explosion of synthesized types
-    /// across a large file.
+    /// the whole PACKAGE (issue #2292; formerly just the document) — keyed
+    /// structurally via <see cref="anonymousTypeRegistry"/>, not by Roslyn
+    /// symbol identity — so two syntactically-identical anonymous types
+    /// declared in different places (even different files of the same
+    /// package) still share one declaration, avoiding a combinatorial
+    /// explosion of synthesized types and, just as importantly, avoiding two
+    /// DISTINCT shapes across files ever minting the same synthetic name.
     /// </para>
     /// </summary>
     /// <param name="anonymousType">The anonymous type symbol.</param>
@@ -284,12 +337,20 @@ public sealed class CSharpTypeMapper
             "|",
             properties.Select(p => p.Name + ":" + p.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
 
-        if (this.anonymousDataClassesByShape.TryGetValue(shapeKey, out NamedTypeReference existing))
+        // Issue #2292: the shape->name dictionary and the synthetic-name
+        // counter both live on the shared package-scoped `anonymousTypeRegistry`
+        // (not on this per-file mapper), so a shape already synthesized by an
+        // EARLIER file in the same package is reused here (no re-declaration,
+        // avoiding a same-name GS0102 for an identical shape), and a shape
+        // that is new to this file still draws its synthetic index from the
+        // package-wide counter (so a distinct shape never collides with a
+        // name already minted by another file in the same package).
+        if (this.anonymousTypeRegistry.TryGetExisting(shapeKey, out NamedTypeReference existing))
         {
             return existing;
         }
 
-        string syntheticName = $"AnonymousType{this.anonymousDataClassesByShape.Count}";
+        string syntheticName = this.anonymousTypeRegistry.NextSyntheticName();
         var parameters = properties
             .Select(p => new Cs2Gs.CodeModel.Ast.Parameter(CSharpToGSharpTranslator.SanitizeIdentifier(p.Name), this.Map(p.Type, context, location)))
             .ToList();
@@ -307,7 +368,7 @@ public sealed class CSharpTypeMapper
             visibility: Visibility.Internal);
 
         var reference = new NamedTypeReference(syntheticName);
-        this.anonymousDataClassesByShape[shapeKey] = reference;
+        this.anonymousTypeRegistry.Register(shapeKey, reference);
         this.pendingAnonymousDataClasses.Add(declaration);
         return reference;
     }
@@ -902,4 +963,59 @@ public sealed class CSharpTypeMapper
 
         return new ArrowTypeReference(parameters, returns, isAsync);
     }
+}
+
+/// <summary>
+/// Issue #2292: the shape-&gt;synthesized-type dictionary and synthetic-name
+/// counter that <see cref="CSharpTypeMapper.GetOrCreateAnonymousDataClass"/>
+/// uses, factored out of <see cref="CSharpTypeMapper"/> so it can be shared
+/// across every mapper instance translating a document into the SAME G#
+/// package. <c>CSharpToGSharpTranslator</c> creates one <see cref="CSharpTypeMapper"/>
+/// per source file (so per-file state like <see cref="CSharpTypeMapper.ShortenedNamespaces"/>
+/// stays file-scoped) but keeps exactly one <see cref="AnonymousTypeRegistry"/>
+/// per resolved package name, keyed in a dictionary that outlives any single
+/// <c>TranslateDocument</c> call. Without this, two unrelated files in the
+/// same package each started counting from <c>AnonymousType0</c>, so a
+/// DISTINCT shape in file B could mint the exact name already used by an
+/// UNRELATED shape in file A — both top-level <c>data class</c> declarations
+/// landing in the same package/namespace, which is a GS0102 "already
+/// declared" collision at the gsc compile stage even though each file's own
+/// translation looked internally consistent.
+/// </summary>
+public sealed class AnonymousTypeRegistry
+{
+    private readonly Dictionary<string, NamedTypeReference> byShape = new(System.StringComparer.Ordinal);
+    private int nextIndex;
+
+    /// <summary>
+    /// Looks up an already-synthesized data-class reference for
+    /// <paramref name="shapeKey"/> (an anonymous type's ordered
+    /// member-name+type shape), reused verbatim regardless of which file
+    /// (sharing this registry) first synthesized it.
+    /// </summary>
+    /// <param name="shapeKey">The structural shape key.</param>
+    /// <param name="existing">The reused reference, when found.</param>
+    /// <returns><see langword="true"/> when a data class already exists for this shape.</returns>
+    public bool TryGetExisting(string shapeKey, out NamedTypeReference existing) =>
+        this.byShape.TryGetValue(shapeKey, out existing);
+
+    /// <summary>
+    /// Mints the next package-wide-unique synthetic name (<c>AnonymousType0</c>,
+    /// <c>AnonymousType1</c>, ...). Drawing from a single counter shared by
+    /// every file in the package (rather than each file counting from zero)
+    /// is what prevents two distinct shapes in different files from
+    /// colliding on the same name.
+    /// </summary>
+    /// <returns>The next unused synthetic type name.</returns>
+    public string NextSyntheticName() => $"AnonymousType{this.nextIndex++}";
+
+    /// <summary>
+    /// Records that <paramref name="shapeKey"/> now resolves to
+    /// <paramref name="reference"/>, so any later file sharing this registry
+    /// reuses it instead of re-declaring an identical data class (which would
+    /// itself be a same-name GS0102 collision even for an identical shape).
+    /// </summary>
+    /// <param name="shapeKey">The structural shape key.</param>
+    /// <param name="reference">The synthesized data class's type reference.</param>
+    public void Register(string shapeKey, NamedTypeReference reference) => this.byShape[shapeKey] = reference;
 }


### PR DESCRIPTION
## Summary

Follow-up to #2282. Fixes the file-scope/dedup gap in cs2gs's synthesized
anonymous-type `data class` naming (Part 1, GS0102) and verifies the
residual EF-Core generic-method + lambda-return pattern (Part 2,
GS0159/GS0158) end-to-end against the real `gsc`.

## Part 1 — synthetic-name counter collision (GS0102)

### Root cause

`CSharpTypeMapper.GetOrCreateAnonymousDataClass` already deduplicated
identical anonymous-type shapes and counted synthetic names
(`AnonymousType0`, `AnonymousType1`, ...) correctly **within a single
document** — one `CSharpTypeMapper` is created per `TranslateDocument`
call and covers every method of every type in that file, so two different
shapes in `Up()` and `Down()` of the *same* file already got distinct
names before this PR.

The real collision is **cross-file**: every pipeline caller
(`TranslateStage`, `TestParityStage`) calls `TranslateDocument` once per
source file in a project, and each call created a brand-new
`CSharpTypeMapper` with its own private shape dictionary and counter
starting at zero. Two unrelated files sharing the same G# package (e.g.
every migration file in an EF `Migrations` folder — one file per
migration, all in the same namespace) could therefore each mint
`data class AnonymousType0` for two **different** shapes, colliding once
both files were compiled together as the same package (GS0102 "already
declared").

Reproduced directly: translating two in-memory files in namespace `Demo`,
one with shape `{Id, Name}` and the other with shape
`{Count, Flag, Extra}`, both emitted `internal data class AnonymousType0`
with different member lists before this fix; compiling them together with
`gsc` failed with GS0102.

### Fix

- Factored the shape→name dictionary and synthetic-name counter out of
  `CSharpTypeMapper` into a new `AnonymousTypeRegistry`
  (`tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs`).
- `CSharpToGSharpTranslator` now keeps one `AnonymousTypeRegistry` per
  resolved package name (`anonymousTypeRegistriesByPackage`), shared
  across every document the translator instance translates (keyed by the
  empty string for the global/no-namespace case, since a file with no
  namespace resolves `package == null`).
- A shape already declared by an **earlier** file in the package is
  reused (not re-declared) by a later one; a **new** shape draws its
  synthetic index from the package-wide counter, so it can never collide
  with a name already minted by another file.
- `TestParityStage` hoisted its per-document `CSharpToGSharpTranslator`
  instantiation to one shared instance per project (mirroring
  `TranslateStage`, which already did this correctly) — a fresh
  translator per document would have defeated the package-wide sharing.

Files changed: `CSharpTypeMapper.cs`, `CSharpToGSharpTranslator.cs`,
`TestParityStage.cs`.

## Part 2 — generic method + lambda-return inference (residual #2282)

Investigated the EF-Core `CreateTable`/`PrimaryKey` pattern: a generic
method whose type parameter is inferred from a lambda's anonymous-typed
**return** value, crossing into **another** lambda's parameter type, with
a named-member access (`x.Id`) on that parameter.

**Finding: this already works correctly in cs2gs and does not need a
gsc-side fix.** cs2gs resolves the synthesized data-class type from the
bound C# semantic model (not from re-inferring it in G#) and annotates
the lambda parameter with that **concrete** synthesized type directly
(`(x AnonymousType0) -> x.Id`, `(table CreateTableBuilder[AnonymousType0]) -> { ... }`).
gsc's binder therefore never needs to flow a generic return type through
`Func`/`Action` type arguments itself — the ambiguity is already resolved
before the G# text is emitted.

Verified end-to-end: translated the full `CreateTable`/`PrimaryKey`
pattern and compiled the output with a freshly built `gsc` — **zero
compiler errors**. No residual gsc gap to file for this pattern.

## Tests

Added `tools/cs2gs/Cs2Gs.Tests/Issue2292AnonymousTypePackageScopeTests.cs`:

- `DistinctAnonymousShapes_InDifferentFiles_SamePackage_GetDistinctSyntheticNames`
  — two files, two different shapes → distinct synthesized names,
  verified by compiling both files together with the real `gsc` (no
  GS0102).
- `IdenticalAnonymousShape_InDifferentFiles_SamePackage_SharesOneSynthesizedType`
  — two files, the *same* shape → one synthesized type declared once and
  reused by the second file, compiled together with `gsc`.
- `DistinctAnonymousShapes_InDifferentMethods_SameFile_GetDistinctSyntheticNames`
  — regression guard for the already-working same-file case.
- `GenericMethodWithLambdaReturningAnonymousType_CompilesAndBindsMemberAccess`
  — the Part 2 EF pattern, compiled end-to-end with `gsc`.

### Results

```
dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release \
  --filter "FullyQualifiedName~Issue2292|FullyQualifiedName~Issue2282|FullyQualifiedName~Anonymous"

Passed!  - Failed: 0, Passed: 10, Skipped: 0, Total: 10
```

Also ran the broader translator/pipeline suite (excluding the
known-locally-flaky IL-verify/pipeline classes per repo guidance):
1271/1274 passed; the remaining 3 failures
(`TestParityStageTests.L1_AllFourStages_AreGreen_WithStdoutParity`,
`TestParityStageTests.L1_WrongGolden_ProducesTestParityFailureArtifact`,
`Issue1911ExplicitInterfaceImplementationTests.G06TypesConsole_MigratesGreen_EndToEnd`)
were verified to reproduce identically on `main` before this change (not
caused by this PR).

Closes #2292
