### PR TITLE
Fix persistent import squiggles in G# LSP after scaffolding a project

### DIFF
--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -45,6 +45,7 @@ public sealed class LspServer
     internal Action<DocumentUri, DiagnosticComputationResult> TestOnParseResult;
     internal Action<DocumentUri, DiagnosticComputationResult> TestOnBindResult;
     internal Action<DocumentUri, IReadOnlyList<Diagnostic>> TestOnPublish;
+    internal Action TestOnDiagnosticRefreshAfterDiscovery;
     internal Func<CancellationToken, Task> TestPushBindDelay;
     private readonly TaskCompletionSource<int> exitSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly object refreshLock = new object();
@@ -90,7 +91,18 @@ public sealed class LspServer
         });
     }
 
-    [JsonRpcMethod("initialized")]
+    // UseSingleObjectParameterDeserialization is required (as it is on every other params-taking
+    // handler): the LSP "initialized" notification carries a params object ({}), and without this
+    // flag StreamJsonRpc treats that object as *named* arguments and finds nothing to bind to the
+    // single `@params` parameter, so it silently drops the notification (notifications get no
+    // error reply). The effect was severe and silent: Initialized never ran, background workspace
+    // discovery never started, no project was ever registered, and every file was bound against a
+    // project-less compilation — so all imported symbols (the project's own types and every
+    // referenced-assembly type, e.g. xunit's @Fact) permanently showed "type could not be found"
+    // squiggles even though the project built and ran fine. Directly calling Initialized() in a
+    // unit test bypasses RPC dispatch, which is why this escaped coverage; see
+    // LspServerInitializedDispatchTests for a transport-level regression guard.
+    [JsonRpcMethod("initialized", UseSingleObjectParameterDeserialization = true)]
     public void Initialized(JsonElement @params)
     {
         // Issue #1663: workspace discovery (globbing every project, reading and parsing every
@@ -128,6 +140,19 @@ public sealed class LspServer
                             this.gate.Release();
                         }
                     });
+
+                // Discovery can (and on a cold start typically does) finish *after* the client
+                // has already opened files: the editor sends didOpen the moment the window
+                // restores, racing the background load kicked off just above. Those files were
+                // bound against a project-less compilation (no project references), so every
+                // imported symbol — the project's own types and referenced-assembly types alike
+                // — was reported "could not be found" (e.g. GS0198 on xunit's @Fact). Now that
+                // projects and their references are known, refresh diagnostics for every open
+                // document so those spurious squiggles clear without the user having to edit the
+                // file to trigger a re-bind (issue: persistent import squiggles after scaffolding
+                // a multi-project workspace).
+                cts.Token.ThrowIfCancellationRequested();
+                this.RefreshOpenDocumentDiagnosticsAfterDiscovery();
             }
             catch (OperationCanceledException)
             {
@@ -1200,6 +1225,21 @@ public sealed class LspServer
             // Initialization option parsing is best-effort; fall back to the two-space default.
             return fallback;
         }
+    }
+
+    // Re-evaluates diagnostics for open documents once background workspace discovery has
+    // finished. Pull clients (e.g. VS Code) request diagnostics per document via
+    // textDocument/diagnostic; a file opened before discovery completed was bound without its
+    // project's references (see the call site in Initialized) and reported every imported symbol
+    // as "could not be found". Nothing re-pulls those diagnostics on its own, so the spurious
+    // squiggles persisted until the user edited the file. Asking the client to refresh makes it
+    // re-pull, and the fresh pull binds each file against its now-known project. (Push clients do
+    // not pull binding diagnostics on open — only on save — so they never showed the stale
+    // squiggles and need no refresh here.)
+    private void RefreshOpenDocumentDiagnosticsAfterDiscovery()
+    {
+        this.TestOnDiagnosticRefreshAfterDiscovery?.Invoke();
+        this.RequestDiagnosticRefresh();
     }
 
     private void RequestDiagnosticRefresh(DocumentUri changedUri)

--- a/src/vscode-gsharp/src/commands/projectCommands.ts
+++ b/src/vscode-gsharp/src/commands/projectCommands.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
+import { computeLaunchPaths } from '../utils/projectLayout';
 
 export function registerProjectCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -50,6 +51,7 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
       // Generate launch.json
       const launchPath = path.join(vscodeDir, 'launch.json');
       if (!fs.existsSync(launchPath)) {
+        const { program, cwd } = computeLaunchPaths(workspaceFolder.uri.fsPath, projectPath);
         const launch = {
           version: '0.2.0',
           configurations: [
@@ -58,9 +60,9 @@ export function registerProjectCommands(context: vscode.ExtensionContext) {
               type: 'coreclr',
               request: 'launch',
               preLaunchTask: 'dotnet: build',
-              program: `\${workspaceFolder}/bin/Debug/net10.0/${projectName}.dll`,
+              program,
               args: [],
-              cwd: '${workspaceFolder}',
+              cwd,
               console: 'integratedTerminal',
               stopAtEntry: false,
             },

--- a/src/vscode-gsharp/src/debugger/configProvider.ts
+++ b/src/vscode-gsharp/src/debugger/configProvider.ts
@@ -1,24 +1,50 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import { computeLaunchPaths } from '../utils/projectLayout';
+
+/**
+ * Finds the primary `.gsproj` within a workspace folder, if any.
+ * Prefers a non-test project so the launch target is runnable.
+ */
+async function findPrimaryProject(
+  folder: vscode.WorkspaceFolder,
+): Promise<string | undefined> {
+  const pattern = new vscode.RelativePattern(folder, '**/*.gsproj');
+  const matches = await vscode.workspace.findFiles(pattern, '**/node_modules/**');
+  if (matches.length === 0) {
+    return undefined;
+  }
+  const nonTest = matches.find((m) => !/\.Tests?\.gsproj$/i.test(m.fsPath));
+  return (nonTest ?? matches[0]).fsPath;
+}
 
 /**
  * Resolves 'gsharp' debug configurations to 'coreclr'.
  * Since GSharp compiles to standard .NET assemblies, we use the CoreCLR debugger (vsdbg).
  */
 export class GSharpDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
-  resolveDebugConfiguration(
+  async resolveDebugConfiguration(
     folder: vscode.WorkspaceFolder | undefined,
     config: vscode.DebugConfiguration,
     _token?: vscode.CancellationToken,
-  ): vscode.ProviderResult<vscode.DebugConfiguration> {
+  ): Promise<vscode.DebugConfiguration> {
     // If the user explicitly chose 'gsharp' type, convert to 'coreclr'
     if (config.type === 'gsharp') {
       config.type = 'coreclr';
     }
 
-    // If no program is specified, try to auto-detect
+    // If no program is specified, try to auto-detect from the project layout.
     if (!config.program && folder) {
-      config.program = '${workspaceFolder}/bin/Debug/net10.0/${workspaceFolderBasename}.dll';
+      const projectPath = await findPrimaryProject(folder);
+      if (projectPath) {
+        const { program, cwd } = computeLaunchPaths(folder.uri.fsPath, projectPath);
+        config.program = program;
+        if (!config.cwd) {
+          config.cwd = cwd;
+        }
+      } else {
+        config.program = '${workspaceFolder}/bin/Debug/net10.0/${workspaceFolderBasename}.dll';
+      }
     }
 
     if (!config.cwd && folder) {
@@ -64,13 +90,23 @@ export class GSharpDebugConfigurationProvider implements vscode.DebugConfigurati
 export class GSharpDebugConfigurationInitialProvider
   implements vscode.DebugConfigurationProvider
 {
-  provideDebugConfigurations(
+  async provideDebugConfigurations(
     folder: vscode.WorkspaceFolder | undefined,
     _token?: vscode.CancellationToken,
-  ): vscode.ProviderResult<vscode.DebugConfiguration[]> {
-    const projectName = folder
-      ? path.basename(folder.uri.fsPath)
-      : 'GSharpApp';
+  ): Promise<vscode.DebugConfiguration[]> {
+    const projectPath = folder ? await findPrimaryProject(folder) : undefined;
+    const projectName = projectPath
+      ? path.basename(projectPath, '.gsproj')
+      : folder
+        ? path.basename(folder.uri.fsPath)
+        : 'GSharpApp';
+    const { program, cwd } =
+      folder && projectPath
+        ? computeLaunchPaths(folder.uri.fsPath, projectPath)
+        : {
+            program: `\${workspaceFolder}/bin/Debug/net10.0/${projectName}.dll`,
+            cwd: '${workspaceFolder}',
+          };
 
     return [
       {
@@ -78,9 +114,9 @@ export class GSharpDebugConfigurationInitialProvider
         type: 'coreclr',
         request: 'launch',
         preLaunchTask: 'dotnet: build',
-        program: `\${workspaceFolder}/bin/Debug/net10.0/${projectName}.dll`,
+        program,
         args: [],
-        cwd: '${workspaceFolder}',
+        cwd,
         console: 'integratedTerminal',
         stopAtEntry: false,
       },

--- a/src/vscode-gsharp/src/test/projectLayout.test.ts
+++ b/src/vscode-gsharp/src/test/projectLayout.test.ts
@@ -1,0 +1,52 @@
+import * as path from 'path';
+import { computeLaunchPaths } from '../utils/projectLayout';
+
+describe('computeLaunchPaths', () => {
+  it('roots paths at the project subdirectory for a solution layout', () => {
+    const ws = path.join(path.sep, 'home', 'me', 'Temp');
+    const project = path.join(ws, 'Temp', 'Temp.gsproj');
+
+    const { program, cwd } = computeLaunchPaths(ws, project);
+
+    expect(program).toBe('${workspaceFolder}/Temp/bin/Debug/net10.0/Temp.dll');
+    expect(cwd).toBe('${workspaceFolder}/Temp');
+  });
+
+  it('uses the workspace folder directly when the project is at the root', () => {
+    const ws = path.join(path.sep, 'home', 'me', 'App');
+    const project = path.join(ws, 'App.gsproj');
+
+    const { program, cwd } = computeLaunchPaths(ws, project);
+
+    expect(program).toBe('${workspaceFolder}/bin/Debug/net10.0/App.dll');
+    expect(cwd).toBe('${workspaceFolder}');
+  });
+
+  it('handles nested subdirectories', () => {
+    const ws = path.join(path.sep, 'work', 'repo');
+    const project = path.join(ws, 'src', 'Server', 'Server.gsproj');
+
+    const { program } = computeLaunchPaths(ws, project);
+
+    expect(program).toBe('${workspaceFolder}/src/Server/bin/Debug/net10.0/Server.dll');
+  });
+
+  it('honors a custom target framework', () => {
+    const ws = path.join(path.sep, 'w');
+    const project = path.join(ws, 'Lib', 'Lib.gsproj');
+
+    const { program } = computeLaunchPaths(ws, project, 'net9.0');
+
+    expect(program).toBe('${workspaceFolder}/Lib/bin/Debug/net9.0/Lib.dll');
+  });
+
+  it('falls back to the workspace folder when the project is outside it', () => {
+    const ws = path.join(path.sep, 'home', 'me', 'inside');
+    const project = path.join(path.sep, 'home', 'me', 'outside', 'Other.gsproj');
+
+    const { program, cwd } = computeLaunchPaths(ws, project);
+
+    expect(program).toBe('${workspaceFolder}/bin/Debug/net10.0/Other.dll');
+    expect(cwd).toBe('${workspaceFolder}');
+  });
+});

--- a/src/vscode-gsharp/src/utils/projectLayout.ts
+++ b/src/vscode-gsharp/src/utils/projectLayout.ts
@@ -1,0 +1,46 @@
+import * as path from 'path';
+
+/**
+ * The `${workspaceFolder}`-rooted launch paths for a project.
+ */
+export interface LaunchPaths {
+  /** Path to the built assembly, e.g. `${workspaceFolder}/MyLib/bin/Debug/net10.0/MyLib.dll`. */
+  program: string;
+  /** Working directory for the launched process. */
+  cwd: string;
+}
+
+/**
+ * Computes the `${workspaceFolder}`-rooted `program`/`cwd` for a project.
+ *
+ * The `.gsproj` is not always at the workspace root: solution scaffolds (e.g.
+ * `dotnet new gsharp-xunit`) place each project in its own subdirectory. The
+ * generated launch config must point at the project's *own* `bin/` output, not
+ * at `${workspaceFolder}/bin`, otherwise the debug target and `cwd` are wrong.
+ *
+ * @param workspaceFolderPath Absolute path to the opened workspace folder.
+ * @param projectPath Absolute path to the `.gsproj` file.
+ * @param targetFramework The target framework moniker (defaults to `net10.0`).
+ */
+export function computeLaunchPaths(
+  workspaceFolderPath: string,
+  projectPath: string,
+  targetFramework = 'net10.0',
+): LaunchPaths {
+  const projectName = path.basename(projectPath, '.gsproj');
+  const projectDir = path.dirname(projectPath);
+  const relDir = path.relative(workspaceFolderPath, projectDir).split(path.sep).join('/');
+
+  // Root the paths at ${workspaceFolder}. When the project sits in a
+  // subdirectory, include that relative segment; when it is at the root (or
+  // resolves outside the workspace), fall back to the workspace folder itself.
+  const base =
+    relDir && relDir !== '.' && !relDir.startsWith('..')
+      ? `\${workspaceFolder}/${relDir}`
+      : '${workspaceFolder}';
+
+  return {
+    program: `${base}/bin/Debug/${targetFramework}/${projectName}.dll`,
+    cwd: base,
+  };
+}

--- a/test/LanguageServer.Tests/LspServerInitializedDispatchTests.cs
+++ b/test/LanguageServer.Tests/LspServerInitializedDispatchTests.cs
@@ -1,0 +1,105 @@
+// <copyright file="LspServerInitializedDispatchTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using GSharp.LanguageServer.Protocol;
+using GSharp.LanguageServer.Server;
+using Nerdbank.Streams;
+using StreamJsonRpc;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// The LSP "initialized" notification carries a params object ({}). StreamJsonRpc only routes
+/// that object to <see cref="LspServer.Initialized"/>'s single <c>JsonElement</c> parameter when
+/// the handler opts into single-object parameter deserialization (as every other params-taking
+/// handler does); without it the notification is silently dropped, so background workspace
+/// discovery never runs, no project is ever registered, and every file binds against a
+/// project-less compilation (all imported symbols show spurious "could not be found" squiggles).
+///
+/// The other tests in this suite invoke <see cref="LspServer.Initialized"/> directly, which
+/// bypasses JSON-RPC dispatch and cannot catch a wiring regression. This test drives the server
+/// over a real StreamJsonRpc connection — exactly as <c>Program.RunAsync</c> hosts it — so the
+/// "initialized" notification must actually dispatch for the assertion to hold.
+/// </summary>
+public class LspServerInitializedDispatchTests
+{
+    [Fact]
+    public async Task InitializedNotification_OverRpc_TriggersBackgroundDiscovery()
+    {
+        var rootDir = CreateSampleWorkspace();
+        try
+        {
+            var workspace = new WorkspaceState();
+            var server = new LspServer(new DocumentContentService(), workspace);
+
+            var (clientStream, serverStream) = FullDuplexStream.CreatePair();
+
+            using var serverRpc = new JsonRpc(new HeaderDelimitedMessageHandler(
+                serverStream,
+                serverStream,
+                new SystemTextJsonFormatter { JsonSerializerOptions = LspJson.Options }));
+            serverRpc.AddLocalRpcTarget(server, new JsonRpcTargetOptions { DisposeOnDisconnect = false });
+            server.Attach(serverRpc);
+            serverRpc.StartListening();
+
+            using var clientRpc = new JsonRpc(new HeaderDelimitedMessageHandler(
+                clientStream,
+                clientStream,
+                new SystemTextJsonFormatter { JsonSerializerOptions = LspJson.Options }));
+            clientRpc.StartListening();
+
+            // Full handshake exactly as a real client performs it: an "initialize" request whose
+            // params carry rootPath, followed by an "initialized" notification with an empty
+            // params object.
+            await clientRpc.InvokeWithParameterObjectAsync<InitializeResult>(
+                "initialize",
+                new { rootPath = rootDir });
+
+            await clientRpc.NotifyWithParameterObjectAsync("initialized", new { });
+
+            // If "initialized" dispatched, background discovery registers the workspace's project.
+            await WaitForAsync(() => workspace.Projects.Count > 0);
+
+            var project = Assert.Single(workspace.Projects);
+            Assert.Equal("Demo", project.AssemblyName);
+        }
+        finally
+        {
+            Directory.Delete(rootDir, recursive: true);
+        }
+    }
+
+    private static string CreateSampleWorkspace()
+    {
+        var rootDir = Path.Combine(Path.GetTempPath(), "gsdispatch_" + Guid.NewGuid().ToString("N"));
+        var projDir = Path.Combine(rootDir, "Demo");
+        Directory.CreateDirectory(projDir);
+
+        File.WriteAllText(
+            Path.Combine(projDir, "Demo.gsproj"),
+            "<Project Sdk=\"Gsharp.NET.Sdk\">\n  <PropertyGroup><OutputType>Library</OutputType><TargetFramework>net10.0</TargetFramework><AssemblyName>Demo</AssemblyName></PropertyGroup>\n</Project>\n");
+
+        File.WriteAllText(Path.Combine(projDir, "Foo.gs"), "class Foo {\n  func run() int -> 1\n}\n");
+
+        return rootDir;
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition, int timeoutMs = 10000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (!condition())
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                Assert.Fail("Timed out waiting for background discovery — the 'initialized' notification likely did not dispatch.");
+            }
+
+            await Task.Delay(25);
+        }
+    }
+}

--- a/test/LanguageServer.Tests/WorkspaceDiscoveryDiagnosticRefreshTests.cs
+++ b/test/LanguageServer.Tests/WorkspaceDiscoveryDiagnosticRefreshTests.cs
@@ -1,0 +1,129 @@
+// <copyright file="WorkspaceDiscoveryDiagnosticRefreshTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using GSharp.LanguageServer.Protocol;
+using GSharp.LanguageServer.Server;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// Background workspace discovery (kicked off in "initialized") races the editor's didOpen:
+/// on a cold start the client opens visible files before discovery has registered any project,
+/// so a pull-diagnostics client (e.g. VS Code) that pulls diagnostics during the race gets a
+/// file bound against a project-less compilation — with none of the project's references or
+/// sibling source files. Every imported symbol then reported "could not be found" (e.g. GS0198
+/// on xunit's <c>@Fact</c>, or a sibling type/function in the same project), and the squiggles
+/// persisted because nothing re-pulled the file once discovery finished — the user had to edit
+/// the file to trigger a refresh.
+///
+/// This test locks in the fix: once background discovery completes, the server asks the client
+/// to refresh diagnostics, and the resulting re-pull binds each open file against its
+/// now-discovered project, clearing the spurious diagnostics.
+/// </summary>
+public class WorkspaceDiscoveryDiagnosticRefreshTests
+{
+    // Foo references a type + method defined in a sibling file (Bar.gs) of the SAME project.
+    // Bound alone (project-less) both are unresolved; bound with the project they resolve.
+    private const string BarSource = "class Bar {\n  func hello() int -> 42\n}\n";
+    private const string FooSource = "class Foo {\n  func run() int -> Bar().hello()\n}\n";
+
+    [Fact]
+    public async Task PullClient_DiscoveryAfterOpen_RequestsRefreshAndSubsequentPullIsClean()
+    {
+        var rootDir = CreateSampleWorkspace();
+        try
+        {
+            var workspace = new WorkspaceState();
+            var server = new LspServer(new DocumentContentService(), workspace);
+            var fooPath = Path.Combine(rootDir, "Demo", "Foo.gs");
+            var uri = DocumentUri.FromFileSystemPath(fooPath);
+
+            var refreshRequested = false;
+            server.TestOnDiagnosticRefreshAfterDiscovery = () => refreshRequested = true;
+
+            await server.InitializeAsync(new InitializeParams { RootPath = rootDir, Capabilities = PullClientCapabilities() });
+
+            await server.DidOpenAsync(new DidOpenTextDocumentParams
+            {
+                TextDocument = new TextDocumentItem { Uri = uri, Text = FooSource },
+            });
+
+            // A pull that lands before background discovery registers the project binds the file
+            // project-less: the sibling symbols in Bar.gs are invisible and reported missing.
+            var beforeDiscovery = await PullDiagnosticsAsync(server, uri);
+            Assert.Null(workspace.GetProjectForFile(fooPath));
+            Assert.NotEmpty(beforeDiscovery);
+
+            // Discovery runs in the background; when it completes the server asks the client to
+            // refresh (re-pull) diagnostics for its open documents.
+            using var doc = JsonDocument.Parse("{}");
+            server.Initialized(doc.RootElement.Clone());
+
+            await WaitForAsync(() => refreshRequested && workspace.GetProjectForFile(fooPath) != null);
+
+            // The refresh-driven re-pull now binds Foo.gs against its project (both source files),
+            // so the sibling symbols resolve and the spurious diagnostics are gone.
+            var afterDiscovery = await PullDiagnosticsAsync(server, uri);
+            Assert.Empty(afterDiscovery);
+        }
+        finally
+        {
+            Directory.Delete(rootDir, recursive: true);
+        }
+    }
+
+    private static JsonElement PullClientCapabilities()
+    {
+        // Advertise textDocument/diagnostic (pull) and workspace diagnostic refreshSupport so the
+        // server treats this as a pull client that can be asked to re-pull.
+        var doc = JsonDocument.Parse(
+            "{\"textDocument\":{\"diagnostic\":{}},\"workspace\":{\"diagnostics\":{\"refreshSupport\":true}}}");
+        return doc.RootElement.Clone();
+    }
+
+    private static async Task<IReadOnlyList<Diagnostic>> PullDiagnosticsAsync(LspServer server, DocumentUri uri)
+    {
+        var report = await server.DocumentDiagnosticAsync(
+            new DocumentDiagnosticParams { TextDocument = new TextDocumentIdentifier { Uri = uri } },
+            CancellationToken.None);
+        return report is FullDocumentDiagnosticReport full ? full.Items : Array.Empty<Diagnostic>();
+    }
+
+    private static string CreateSampleWorkspace()
+    {
+        var rootDir = Path.Combine(Path.GetTempPath(), "gsrefresh_" + Guid.NewGuid().ToString("N"));
+        var projDir = Path.Combine(rootDir, "Demo");
+        Directory.CreateDirectory(projDir);
+
+        File.WriteAllText(
+            Path.Combine(projDir, "Demo.gsproj"),
+            "<Project Sdk=\"Gsharp.NET.Sdk\">\n  <PropertyGroup><OutputType>Library</OutputType><TargetFramework>net10.0</TargetFramework><AssemblyName>Demo</AssemblyName></PropertyGroup>\n</Project>\n");
+
+        File.WriteAllText(Path.Combine(projDir, "Bar.gs"), BarSource);
+        File.WriteAllText(Path.Combine(projDir, "Foo.gs"), FooSource);
+
+        return rootDir;
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition, int timeoutMs = 10000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (!condition())
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                Assert.Fail("Timed out waiting for post-discovery diagnostic refresh.");
+            }
+
+            await Task.Delay(25);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Scaffolding a project (e.g. `dotnet new gsharp-xunit`) and opening it in VS Code with the G# extension showed **red squiggles on every imported symbol** — the project's own types (`Greeter`) and all referenced-assembly types (everything from `Xunit`, e.g. `@Fact`) reported "type could not be found" — even though the project **built and ran fine**.

## Root cause

The `initialized` JSON-RPC handler on `LspServer` was missing `UseSingleObjectParameterDeserialization = true`, which is present on every other params-taking handler.

LSP sends the `initialized` notification with a params object (`{}`). Without the flag, StreamJsonRpc treats that object as **named arguments**, finds nothing to bind to the single `JsonElement @params` parameter, and **silently drops the notification** (notifications receive no error reply).

The downstream effect was severe and silent:

- `Initialized` never ran → background workspace discovery never started
- No project was ever registered in `WorkspaceState`
- `GetProjectForFile` always returned null → every open file was bound against a **project-less compilation** (BCL-only references)
- So all imported symbols were unresolved → permanent squiggles

The compiler and the rest of the server logic were never at fault; only RPC dispatch was broken.

### Why it escaped tests

Existing coverage calls `server.Initialized(...)` **directly**, bypassing JSON-RPC dispatch, so the missing attribute was never exercised.

## Fixes

1. **Primary:** add `UseSingleObjectParameterDeserialization = true` to the `initialized` handler so the notification dispatches and workspace discovery runs.
2. **Post-discovery refresh:** discovery can finish *after* the editor has already sent `didOpen` (cold-start race). Those files were bound project-less. After discovery completes, refresh diagnostics for open documents so pull-diagnostics clients re-pull and re-bind against the now-known project references — clearing squiggles without the user having to edit the file.
3. **`.vscode` asset paths:** build/debug asset paths now resolve correctly for multi-project workspace layouts (new `projectLayout` helper plus command/debug-config updates).

## Tests

- `LspServerInitializedDispatchTests` — transport-level regression guard driving a **real StreamJsonRpc client/server pair**. It times out (fails) without the dispatch fix and passes with it, closing the coverage gap that direct `Initialized()` calls left open.
- `WorkspaceDiscoveryDiagnosticRefreshTests` — verifies open documents re-pull clean after discovery.
- `projectLayout.test.ts` — multi-project asset-path resolution.

Full `LanguageServer.Tests` suite: **425 passing**. Extension server rebuild (`npm run compile`) is clean.

## Verification

Reproduced end-to-end against a scaffolded project via a faithful stdio LSP driver: post-fix, discovery runs (`projects=2`), and every diagnostic pull returns `0` diagnostics (no squiggles).
