### PR TITLE
gsc: allow == / != nil for interface types and reference-capable type parameters

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -499,10 +499,43 @@ public sealed record BoundBinaryOperator
         //     System.MulticastDelegate-derived closure.
         //   * Named delegate types declared with `delegate` — DelegateTypeSymbol.
         //   * `sequence[T]` / `asyncSequence[T]` — IEnumerable<T> / IAsyncEnumerable<T>.
-        return nullableOrUnderlying is FunctionTypeSymbol
+        if (nullableOrUnderlying is FunctionTypeSymbol
             || nullableOrUnderlying is DelegateTypeSymbol
             || nullableOrUnderlying is SequenceTypeSymbol
-            || nullableOrUnderlying is AsyncSequenceTypeSymbol;
+            || nullableOrUnderlying is AsyncSequenceTypeSymbol)
+        {
+            return true;
+        }
+
+        // Issue #2300: interface-typed operands are always CLR reference
+        // types (a G#-declared InterfaceSymbol or an imported interface),
+        // so `iface == nil` / `iface != nil` must bind exactly like the
+        // reference-shaped structural types above — no `?` spelling is
+        // needed (or even expressible in a way that changes the CLR
+        // storage: an interface reference is nullable at the CLR layer
+        // regardless of the G# static-nullability annotation).
+        if (nullableOrUnderlying is InterfaceSymbol
+            || (nullableOrUnderlying is ImportedTypeSymbol importedInterface && importedInterface.ClrType is { IsInterface: true }))
+        {
+            return true;
+        }
+
+        // Issue #2300: an open type parameter (`T`) whose constraint does
+        // not guarantee a non-nullable value type — i.e. unconstrained,
+        // class-constrained, or interface-constrained — may be
+        // substituted with a reference type at any instantiation site, so
+        // `T == nil` / `T != nil` must be legal (mirroring C#'s allowance
+        // of `t == null` for an unconstrained `T`, lowered through a
+        // boxing comparison). Only a `struct`-constrained (or otherwise
+        // known-value-type) type parameter is excluded, because such a
+        // `T` can never be `nil` and its `T?` spelling erases to
+        // `Nullable<T>` instead of a bare reference slot.
+        if (nullableOrUnderlying is TypeParameterSymbol typeParameter)
+        {
+            return !typeParameter.HasValueTypeConstraint;
+        }
+
+        return false;
     }
 
     private static BoundBinaryOperator[] BuildSupportedOperators()

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -958,30 +958,34 @@ internal sealed partial class MethodBodyEmitter
             || (type is NullableTypeSymbol nullable && nullable.UnderlyingType == TypeSymbol.String);
 
     /// <summary>
-    /// Issue #831: matches `T? == nil` / `T? != nil` (and the symmetric
-    /// `nil == T?` / `nil != T?`) where the underlying T is an open
-    /// type parameter (class-constrained, struct-constrained, or
+    /// Issue #831 / #2300: matches `T? == nil` / `T? != nil` AND bare
+    /// `T == nil` / `T != nil` (and their symmetric `nil == ...` forms)
+    /// where T is an open type parameter (class-constrained, struct-
+    /// constrained-but-nullable-wrapped, interface-constrained, or
     /// unconstrained). The concrete value-type Nullable&lt;T&gt; arm
     /// (driven by <see cref="liftedBinarySlots"/>) only catches
     /// operands with a static <c>ClrType</c>; open type parameters
     /// have none, so this match fills the gap. The caller boxes the
-    /// matched operand using its full nullable type token, which
-    /// resolves to a bare reference slot for class/unconstrained T and
-    /// to <c>Nullable&lt;!!T&gt;</c> for struct T.
+    /// matched operand using its full type token, which resolves to a
+    /// bare reference slot for class/unconstrained/interface-constrained
+    /// T (bare or `T?` — both have the same storage shape) and to
+    /// <c>Nullable&lt;!!T&gt;</c> for a struct-constrained `T?` (a bare
+    /// struct-constrained `T` never reaches here — the binder's
+    /// <c>IsNullCompare</c> rejects it because it can never be nil).
     /// </summary>
     private static bool TryMatchTypeParameterNilCompare(
         BoundBinaryExpression node,
         out BoundExpression operand)
     {
         if (node.Right.Type == TypeSymbol.Null
-            && IsOpenTypeParameterNullable(node.Left.Type))
+            && IsOpenTypeParameterOrNullable(node.Left.Type))
         {
             operand = node.Left;
             return true;
         }
 
         if (node.Left.Type == TypeSymbol.Null
-            && IsOpenTypeParameterNullable(node.Right.Type))
+            && IsOpenTypeParameterOrNullable(node.Right.Type))
         {
             operand = node.Right;
             return true;
@@ -992,22 +996,23 @@ internal sealed partial class MethodBodyEmitter
     }
 
     /// <summary>
-    /// Issue #831: returns true when <paramref name="t"/> is a
-    /// <see cref="NullableTypeSymbol"/> wrapping an open type parameter
-    /// (regardless of constraint). The CLR storage of <c>T?</c> is
-    /// either a bare <c>!!T</c> reference slot (class/unconstrained T)
-    /// or a <c>Nullable&lt;!!T&gt;</c> value-typed slot (struct T) —
-    /// see <see cref="ReflectionMetadataEmitter.GetElementTypeToken"/>.
-    /// Both shapes need the same `box; ldnull; ceq` lowering for
-    /// nil-comparison to be verifier-clean: boxing a reference is a
-    /// JIT-elided no-op, while boxing <c>Nullable&lt;T&gt;</c> per
-    /// ECMA-335 III.4.1 yields a managed-null reference when
-    /// HasValue is false.
+    /// Issue #831 / #2300: returns true when <paramref name="t"/> is an
+    /// open type parameter, either bare (<c>T</c>) or wrapped in a
+    /// <see cref="NullableTypeSymbol"/> (<c>T?</c>), regardless of
+    /// constraint. The CLR storage is either a bare <c>!!T</c> reference
+    /// slot (class/unconstrained/interface-constrained T, bare or `?` —
+    /// same shape either way) or a <c>Nullable&lt;!!T&gt;</c> value-typed
+    /// slot (struct-constrained `T?`) — see
+    /// <see cref="ReflectionMetadataEmitter.GetElementTypeToken"/>. Both
+    /// shapes need the same `box; ldnull; ceq` lowering for nil-comparison
+    /// to be verifier-clean: boxing a reference is a JIT-elided no-op,
+    /// while boxing <c>Nullable&lt;T&gt;</c> per ECMA-335 III.4.1 yields a
+    /// managed-null reference when HasValue is false.
     /// </summary>
-    private static bool IsOpenTypeParameterNullable(TypeSymbol t)
+    private static bool IsOpenTypeParameterOrNullable(TypeSymbol t)
     {
-        return t is NullableTypeSymbol nullable
-            && nullable.UnderlyingType is TypeParameterSymbol;
+        return t is TypeParameterSymbol
+            || (t is NullableTypeSymbol nullable && nullable.UnderlyingType is TypeParameterSymbol);
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2300InterfaceAndTypeParameterNilCompareTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2300InterfaceAndTypeParameterNilCompareTests.cs
@@ -1,0 +1,269 @@
+// <copyright file="Issue2300InterfaceAndTypeParameterNilCompareTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2300: <c>x == nil</c> / <c>x != nil</c> reported <c>GS0129</c> when
+/// <c>x</c> was of an interface type or an unconstrained/class-constrained
+/// type-parameter type, even though both shapes are managed references at
+/// the CLR layer (an interface reference, or an open type parameter whose
+/// substitution may be a reference type). C#/Kotlin both allow a reference
+/// operand to be compared against <c>null</c> unconditionally.
+///
+/// The fix lives in two places:
+///  * <see cref="GSharp.Core.CodeAnalysis.Binding.BoundBinaryOperator.IsNullCompare(GSharp.Core.CodeAnalysis.Symbols.TypeSymbol, GSharp.Core.CodeAnalysis.Symbols.TypeSymbol)"/>
+///    (private — exercised indirectly here) now accepts a bare
+///    <c>InterfaceSymbol</c> (including imported CLR interfaces) and a bare
+///    <c>TypeParameterSymbol</c> whose constraint does not guarantee a
+///    non-nullable value type (i.e. everything except a
+///    <c>struct</c>-constrained type parameter).
+///  * The emitter's <c>TryMatchTypeParameterNilCompare</c> /
+///    <c>IsOpenTypeParameterOrNullable</c> (MethodBodyEmitter.Operators.cs)
+///    now also matches a BARE open type parameter (not just its <c>T?</c>
+///    wrapper), so the `box; ldnull; ceq` lowering used for `T? == nil`
+///    since issue #831 covers the new bare-`T` shape too.
+///
+/// A <c>struct</c>-constrained type parameter is deliberately excluded: such
+/// a `T` can never be nil, and its `T?` spelling erases to
+/// <c>Nullable&lt;T&gt;</c> rather than a bare reference slot.
+/// </summary>
+public class Issue2300InterfaceAndTypeParameterNilCompareTests
+{
+    [Fact]
+    public void Interface_Vs_Nil_Equality_Binds()
+    {
+        const string source = @"
+package P
+
+interface IProfile {
+    func Name() string;
+}
+
+func Guard(p IProfile) bool {
+    return p == nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void Interface_Vs_Nil_Inequality_Binds()
+    {
+        const string source = @"
+package P
+
+interface IProfile {
+    func Name() string;
+}
+
+func Guard(p IProfile) bool {
+    return p != nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void Nil_Vs_Interface_Symmetric_Binds()
+    {
+        // The IsNullCompare arm is symmetric — `nil == p` must bind the
+        // same as `p == nil`.
+        const string source = @"
+package P
+
+interface IProfile {
+    func Name() string;
+}
+
+func Guard(p IProfile) bool {
+    return nil == p
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void GenericInterface_Vs_Nil_Equality_Binds()
+    {
+        const string source = @"
+package P
+
+interface Iter[T any] {
+    func Next() T;
+}
+
+func Guard(it Iter[int32]) bool {
+    return it == nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void UnconstrainedTypeParameter_Vs_Nil_Equality_Binds()
+    {
+        // Verbatim shape from the issue body — `TPerson == nil` where
+        // TPerson is a free (unconstrained) type parameter.
+        const string source = @"
+package P
+
+func Guard[TPerson](value TPerson) bool {
+    return value == nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void UnconstrainedTypeParameter_Vs_Nil_Inequality_Binds()
+    {
+        const string source = @"
+package P
+
+func Guard[TPerson](value TPerson) bool {
+    return value != nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void Nil_Vs_UnconstrainedTypeParameter_Symmetric_Binds()
+    {
+        const string source = @"
+package P
+
+func Guard[T](value T) bool {
+    return nil == value
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void ClassConstrainedTypeParameter_Vs_Nil_Equality_Binds()
+    {
+        const string source = @"
+package P
+
+func Guard[T class](value T) bool {
+    return value == nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void InterfaceConstrainedTypeParameter_Vs_Nil_Equality_Binds()
+    {
+        const string source = @"
+package P
+
+interface IProfile {
+    func Name() string;
+}
+
+func Guard[T IProfile](value T) bool {
+    return value == nil
+}
+";
+        Assert.Empty(GetErrors(source));
+    }
+
+    [Fact]
+    public void StructConstrainedTypeParameter_Vs_Nil_StillDiagnoses()
+    {
+        // Guard-rail: a `struct`-constrained type parameter can never be
+        // nil (its `T?` spelling erases to Nullable<T>), so bare `T == nil`
+        // must continue to report GS0129 — the fix must not over-generalize
+        // to value-typed type parameters.
+        const string source = @"
+package P
+
+func Guard[T struct](value T) bool {
+    return value == nil
+}
+";
+        var errors = GetErrors(source);
+        Assert.Contains(errors, e => e.Message.Contains("is not defined for types"));
+    }
+
+    [Fact]
+    public void Interface_Vs_Nil_RuntimeEquality_FalseForNonNullInstance()
+    {
+        // Runtime check: a non-nil interface-typed argument must compare
+        // unequal to nil (and equal-inequality must yield `true`).
+        const string source = @"
+interface IProfile {
+    func Name() string;
+}
+class Person(N string) : IProfile {
+    func Name() string { return N }
+}
+func IsNil(p IProfile) bool {
+    return p == nil
+}
+func IsNotNil(p IProfile) bool {
+    return p != nil
+}
+let person = Person(""Ann"")
+(IsNil(person), IsNotNil(person))
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal((false, true), result.Value);
+    }
+
+    [Fact]
+    public void TypeParameter_Vs_Nil_RuntimeEquality_TrueForDefaultReferenceValue()
+    {
+        // Runtime check: `default(T)` for a reference-type instantiation of
+        // an unconstrained generic function is the CLR null reference, so
+        // the nil-comparison must observe it as equal to nil.
+        const string source = @"
+func IsNil[T](value T) bool {
+    return value == nil
+}
+func IsNotNil[T](value T) bool {
+    return value != nil
+}
+(IsNil(default(string)), IsNotNil(default(string)), IsNil(""hi""), IsNotNil(""hi""))
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal((true, false, false, true), result.Value);
+    }
+
+    private static ImmutableArray<Diagnostic> GetErrors(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree) { IsLibrary = true };
+        var parseDiagnostics = tree.Diagnostics;
+        var bindDiagnostics = compilation.GlobalScope.Diagnostics;
+        var programDiagnostics = compilation.BoundProgram.Diagnostics;
+        return parseDiagnostics
+            .Concat(bindDiagnostics)
+            .Concat(programDiagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Closes #2300

## Problem
`x == nil` / `x != nil` reported `GS0129` when `x` was an interface-typed operand or an unconstrained/class-constrained type-parameter operand, even though both shapes are always managed references at the CLR layer. Only the nullable-wrapper spellings (`IFoo?`, `T?`) and a handful of structural reference shapes (function/delegate/sequence types, issue #796) were previously recognized by the binder's nil-comparison arm.

## Root cause
`BoundBinaryOperator.IsNullCompare` — the predicate that decides whether the non-nil operand of `==`/`!=` is eligible for a nil comparison — did not recognize `InterfaceSymbol` (G#-declared or imported CLR interfaces) or `TypeParameterSymbol` at all, bare (non-`?`) forms.

## Fix
- `IsNullCompare` now also accepts:
  - `InterfaceSymbol`, and imported CLR interfaces (`ImportedTypeSymbol` with `ClrType.IsInterface`).
  - `TypeParameterSymbol` whose constraint does not guarantee a non-nullable value type — i.e. unconstrained, class-constrained, or interface-constrained. A `struct`-constrained type parameter is deliberately excluded (it can never be nil; its `T?` spelling erases to `Nullable<T>`).
- The emitter's `TryMatchTypeParameterNilCompare` (issue #831's `box; ldnull; ceq` lowering, previously only applied to `T?`) is generalized to also match a bare open type parameter `T`, since a bare class/unconstrained/interface-constrained `T` has the same opaque VAR/MVAR CLR storage shape as its `T?` form.
- Both operand orders (`x == nil` / `nil == x`) and both operators (`==`/`!=`) are covered symmetrically, matching the existing `IsNullCompare` dispatch.

## Tests
Added `test/Core.Tests/CodeAnalysis/Binding/Issue2300InterfaceAndTypeParameterNilCompareTests.cs`:
- Binder-diagnostic coverage: bare interface vs nil (both operators/orders), generic interface, unconstrained/class-constrained/interface-constrained type parameters vs nil, and a guard-rail confirming a `struct`-constrained type parameter still reports `GS0129`.
- Two runtime evaluation tests: a non-null interface instance compares unequal to nil (and the inequality is true), and `default(T)` for a reference-type generic instantiation compares equal to nil.

## Verification
- `dotnet build src/Compiler/Compiler.csproj -c Release` — 0 warnings, 0 errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — **5951 passed**, 1 skipped (pre-existing `RegenerateBaseline` skip), 1 pre-existing flaky failure (`AwaitFor_ConfigureAwaitFalse_DrainsAsyncEnumerable`, reproduces identically on `main` without this change — unrelated to binary-operator binding/emit).