### PR TITLE
gsc: extend cross-context imported-type identity through structural wrappers (#2299)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -108,6 +108,27 @@ public sealed class Conversion
             return Conversion.Identity;
         }
 
+        // Issue #2299: the #2290 check above only handles a DIRECT
+        // ImportedTypeSymbol/StructSymbol-aggregate pair. The identical
+        // cross-context split just as easily reaches one level down, through
+        // a structural wrapper symbol that itself is deliberately excluded
+        // from the direct check above (its `ClrType` is merely borrowed from
+        // its element, so comparing the WRAPPER's `ClrType` would be wrong —
+        // e.g. two `[]Series` wrappers whose CLR array types are already
+        // reference-distinct even for the SAME element). Whenever both sides
+        // are the SAME wrapper kind (`[]T` slice, `T?` nullable, `T&`/`T*`
+        // byref/pointer, `seq[T]`, `chan[T]`, an async sequence, a
+        // fixed-length array of matching length, or a `map[K]V`), recurse
+        // into the wrapped element type(s) via `Classify` itself — reusing
+        // the direct check (and this same recursive step, so nested wrappers
+        // like `[]?Series` or `[][]Series` unwind depth-first) rather than
+        // duplicating the cross-context comparison logic per wrapper kind.
+        if (from != null && to != null && from.GetType() == to.GetType()
+            && TryClassifyWrappedElementIdentity(from, to))
+        {
+            return Conversion.Identity;
+        }
+
         // Issue #1018: the bottom (`never`) type of a throw-expression is
         // implicitly convertible to ANY target type — a throw never yields a
         // value, so it satisfies any target without a runtime conversion.
@@ -1756,6 +1777,66 @@ public sealed class Conversion
     // ALREADY-imported aggregate's non-null `ClrType` qualifies.
     private static bool IsImportedTypeIdentity(TypeSymbol type)
         => type is ImportedTypeSymbol || (type is StructSymbol && type.ClrType != null);
+
+    // Issue #2299: for a matching pair of structural wrapper symbols (see the
+    // call site above), extracts and compares the wrapped element type(s).
+    // `ArrayTypeSymbol` additionally requires the fixed lengths to match, and
+    // `MapTypeSymbol` requires BOTH the key and the value types to compare
+    // identical. Any other/mismatched symbol kind returns `false` so the
+    // caller falls through to the ordinary (non-identity) classification
+    // rules — this helper only ever WIDENS what counts as identity, never
+    // narrows an existing rule.
+    private static bool TryClassifyWrappedElementIdentity(TypeSymbol from, TypeSymbol to)
+    {
+        switch (from)
+        {
+            case SliceTypeSymbol fromSlice when to is SliceTypeSymbol toSlice:
+                return IsCrossContextIdenticalElement(fromSlice.ElementType, toSlice.ElementType);
+            case NullableTypeSymbol fromNullable when to is NullableTypeSymbol toNullable:
+                return IsCrossContextIdenticalElement(fromNullable.UnderlyingType, toNullable.UnderlyingType);
+            case ByRefTypeSymbol fromByRef when to is ByRefTypeSymbol toByRef:
+                return IsCrossContextIdenticalElement(fromByRef.PointeeType, toByRef.PointeeType);
+            case PointerTypeSymbol fromPointer when to is PointerTypeSymbol toPointer:
+                return IsCrossContextIdenticalElement(fromPointer.PointeeType, toPointer.PointeeType);
+            case SequenceTypeSymbol fromSequence when to is SequenceTypeSymbol toSequence:
+                return IsCrossContextIdenticalElement(fromSequence.ElementType, toSequence.ElementType);
+            case ChannelTypeSymbol fromChannel when to is ChannelTypeSymbol toChannel:
+                return IsCrossContextIdenticalElement(fromChannel.ElementType, toChannel.ElementType);
+            case AsyncSequenceTypeSymbol fromAsync when to is AsyncSequenceTypeSymbol toAsync:
+                return IsCrossContextIdenticalElement(fromAsync.ElementType, toAsync.ElementType);
+            case ArrayTypeSymbol fromArray when to is ArrayTypeSymbol toArray:
+                return fromArray.Length == toArray.Length
+                    && IsCrossContextIdenticalElement(fromArray.ElementType, toArray.ElementType);
+            case MapTypeSymbol fromMap when to is MapTypeSymbol toMap:
+                return IsCrossContextIdenticalElement(fromMap.KeyType, toMap.KeyType)
+                    && IsCrossContextIdenticalElement(fromMap.ValueType, toMap.ValueType);
+            default:
+                return false;
+        }
+    }
+
+    // Issue #2299: element-level identity check used by
+    // `TryClassifyWrappedElementIdentity`. Reference-equal elements are
+    // trivially identical; otherwise recurses through `Classify` itself so
+    // the direct ImportedTypeSymbol/StructSymbol check (and, transitively,
+    // this same wrapper check) applies to the element too — this is what
+    // lets nested wrappers (e.g. `[]?Series`, `[][]Series`) unwind depth-first
+    // without duplicating the cross-context comparison per level.
+    private static bool IsCrossContextIdenticalElement(TypeSymbol a, TypeSymbol b)
+    {
+        if (a == b)
+        {
+            return true;
+        }
+
+        if (a == null || b == null)
+        {
+            return false;
+        }
+
+        var elementConversion = Classify(a, b);
+        return elementConversion.Exists && elementConversion.IsIdentity;
+    }
 
     // Issue #421 P2-5: enum⇄numeric and enum⇄enum conversions. Both
     // directions are explicit per C# §10.3.3 / §10.3.4 — the binder must

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2299CrossContextWrapperTypeIdentityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2299CrossContextWrapperTypeIdentityTests.cs
@@ -1,0 +1,239 @@
+// <copyright file="Issue2299CrossContextWrapperTypeIdentityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2299 (follow-up to #2290): the cross-reference-context
+/// <see cref="TypeSymbol"/> identity split — two independent
+/// <see cref="ReferenceResolver"/> instances loading the SAME on-disk
+/// assembly each mint their own <see cref="System.Reflection.MetadataLoadContext"/>,
+/// so the SAME metadata type resolves to two non-reference-equal CLR
+/// <see cref="Type"/> objects (and, in turn, two non-reference-equal
+/// <see cref="ImportedTypeSymbol"/> wrappers) — also breaks one level down,
+/// through any structural wrapper symbol (<see cref="SliceTypeSymbol"/>,
+/// <see cref="NullableTypeSymbol"/>, <see cref="ArrayTypeSymbol"/>,
+/// <see cref="MapTypeSymbol"/>, etc.) whose element is the split imported
+/// type — e.g. two <c>[]Series</c> slices for the "same" <c>Series</c> are
+/// themselves non-reference-equal AND were previously classified as
+/// <see cref="Conversion.None"/>, because the #2290 fix in
+/// <see cref="Conversion.Classify(TypeSymbol, TypeSymbol)"/> only special-cased
+/// a DIRECT <see cref="ImportedTypeSymbol"/>/<see cref="StructSymbol"/> pair —
+/// wrapper symbols were deliberately excluded (their own <c>ClrType</c> is
+/// borrowed from the element, so comparing the WRAPPER's <c>ClrType</c>
+/// would be wrong). <see cref="Conversion.Classify(TypeSymbol, TypeSymbol)"/>
+/// now recurses into the wrapped element type(s) whenever both sides are the
+/// SAME wrapper kind, reusing the direct check (and this same recursive
+/// step) so nested wrappers unwind depth-first.
+/// </summary>
+public class Issue2299CrossContextWrapperTypeIdentityTests
+{
+    private const string PlainClassLibrarySource = """
+        package A.B
+
+        class Series {
+        }
+        """;
+
+    private const string TwoTypesLibrarySource = """
+        package A.B
+
+        class Series {
+        }
+
+        class Chapter {
+        }
+        """;
+
+    [Fact]
+    public void TwoSeparateResolvers_SliceOfImportedType_ClassifiesAsIdentity()
+    {
+        var libraryPath = this.EmitLibrary(PlainClassLibrarySource, nameof(this.TwoSeparateResolvers_SliceOfImportedType_ClassifiesAsIdentity));
+
+        using var resolverA = ReferenceResolver.WithReferences(new[] { libraryPath });
+        using var resolverB = ReferenceResolver.WithReferences(new[] { libraryPath });
+
+        Assert.True(resolverA.TryResolveType("A.B.Series", out var seriesA));
+        Assert.True(resolverB.TryResolveType("A.B.Series", out var seriesB));
+        Assert.False(ReferenceEquals(seriesA, seriesB));
+        Assert.True(ClrTypeUtilities.AreSame(seriesA, seriesB));
+
+        var symbolA = ImportedTypeSymbol.Get(seriesA);
+        var symbolB = ImportedTypeSymbol.Get(seriesB);
+        Assert.False(ReferenceEquals(symbolA, symbolB));
+
+        var sliceA = SliceTypeSymbol.Get(symbolA);
+        var sliceB = SliceTypeSymbol.Get(symbolB);
+        Assert.False(ReferenceEquals(sliceA, sliceB));
+
+        var conversion = Conversion.Classify(sliceA, sliceB);
+        Assert.True(conversion.Exists, "expected a conversion to exist for []Series slices resolved via two independent resolvers");
+        Assert.True(conversion.IsIdentity, "expected an identity conversion for structurally-same []Series");
+
+        var reverse = Conversion.Classify(sliceB, sliceA);
+        Assert.True(reverse.Exists);
+        Assert.True(reverse.IsIdentity);
+    }
+
+    [Fact]
+    public void TwoSeparateResolvers_NullableOfImportedType_ClassifiesAsIdentity()
+    {
+        var libraryPath = this.EmitLibrary(PlainClassLibrarySource, nameof(this.TwoSeparateResolvers_NullableOfImportedType_ClassifiesAsIdentity));
+
+        using var resolverA = ReferenceResolver.WithReferences(new[] { libraryPath });
+        using var resolverB = ReferenceResolver.WithReferences(new[] { libraryPath });
+
+        Assert.True(resolverA.TryResolveType("A.B.Series", out var seriesA));
+        Assert.True(resolverB.TryResolveType("A.B.Series", out var seriesB));
+
+        var symbolA = ImportedTypeSymbol.Get(seriesA);
+        var symbolB = ImportedTypeSymbol.Get(seriesB);
+
+        var nullableA = NullableTypeSymbol.Get(symbolA);
+        var nullableB = NullableTypeSymbol.Get(symbolB);
+        Assert.False(ReferenceEquals(nullableA, nullableB));
+
+        var conversion = Conversion.Classify(nullableA, nullableB);
+        Assert.True(conversion.Exists, "expected a conversion to exist for Series? resolved via two independent resolvers");
+        Assert.True(conversion.IsIdentity, "expected an identity conversion for structurally-same Series?");
+    }
+
+    [Fact]
+    public void TwoSeparateResolvers_FixedArrayOfImportedType_RequiresMatchingLengthAndClassifiesAsIdentity()
+    {
+        var libraryPath = this.EmitLibrary(PlainClassLibrarySource, nameof(this.TwoSeparateResolvers_FixedArrayOfImportedType_RequiresMatchingLengthAndClassifiesAsIdentity));
+
+        using var resolverA = ReferenceResolver.WithReferences(new[] { libraryPath });
+        using var resolverB = ReferenceResolver.WithReferences(new[] { libraryPath });
+
+        Assert.True(resolverA.TryResolveType("A.B.Series", out var seriesA));
+        Assert.True(resolverB.TryResolveType("A.B.Series", out var seriesB));
+
+        var symbolA = ImportedTypeSymbol.Get(seriesA);
+        var symbolB = ImportedTypeSymbol.Get(seriesB);
+
+        var sameLengthA = ArrayTypeSymbol.Get(symbolA, 4);
+        var sameLengthB = ArrayTypeSymbol.Get(symbolB, 4);
+        var identity = Conversion.Classify(sameLengthA, sameLengthB);
+        Assert.True(identity.Exists);
+        Assert.True(identity.IsIdentity);
+
+        var differentLengthB = ArrayTypeSymbol.Get(symbolB, 5);
+        var mismatched = Conversion.Classify(sameLengthA, differentLengthB);
+        Assert.False(mismatched.Exists && mismatched.IsIdentity, "arrays of differing fixed length must NOT classify as identity");
+    }
+
+    [Fact]
+    public void TwoSeparateResolvers_MapOfImportedType_ClassifiesAsIdentity()
+    {
+        var libraryPath = this.EmitLibrary(PlainClassLibrarySource, nameof(this.TwoSeparateResolvers_MapOfImportedType_ClassifiesAsIdentity));
+
+        using var resolverA = ReferenceResolver.WithReferences(new[] { libraryPath });
+        using var resolverB = ReferenceResolver.WithReferences(new[] { libraryPath });
+
+        Assert.True(resolverA.TryResolveType("A.B.Series", out var seriesA));
+        Assert.True(resolverB.TryResolveType("A.B.Series", out var seriesB));
+
+        var symbolA = ImportedTypeSymbol.Get(seriesA);
+        var symbolB = ImportedTypeSymbol.Get(seriesB);
+
+        var mapA = MapTypeSymbol.Get(TypeSymbol.String, symbolA);
+        var mapB = MapTypeSymbol.Get(TypeSymbol.String, symbolB);
+
+        var conversion = Conversion.Classify(mapA, mapB);
+        Assert.True(conversion.Exists, "expected a conversion to exist for map[string]Series resolved via two independent resolvers");
+        Assert.True(conversion.IsIdentity, "expected an identity conversion for structurally-same map[string]Series");
+    }
+
+    [Fact]
+    public void TwoSeparateResolvers_SlicesOfDifferentElementTypes_DoNotClassifyAsIdentity()
+    {
+        var libraryPath = this.EmitLibrary(TwoTypesLibrarySource, nameof(this.TwoSeparateResolvers_SlicesOfDifferentElementTypes_DoNotClassifyAsIdentity));
+
+        using var resolverA = ReferenceResolver.WithReferences(new[] { libraryPath });
+        using var resolverB = ReferenceResolver.WithReferences(new[] { libraryPath });
+
+        Assert.True(resolverA.TryResolveType("A.B.Series", out var seriesA));
+        Assert.True(resolverB.TryResolveType("A.B.Chapter", out var chapterB));
+
+        var symbolA = ImportedTypeSymbol.Get(seriesA);
+        var symbolB = ImportedTypeSymbol.Get(chapterB);
+
+        var sliceA = SliceTypeSymbol.Get(symbolA);
+        var sliceB = SliceTypeSymbol.Get(symbolB);
+
+        var conversion = Conversion.Classify(sliceA, sliceB);
+        Assert.False(conversion.Exists && conversion.IsIdentity, "[]Series and []Chapter must NOT classify as identity even across independent resolvers");
+    }
+
+    [Fact]
+    public void SingleResolver_ListOfImportedType_PassedAcrossImportedFunctionBoundary_EmitsCleanly()
+    {
+        var libraryPath = this.EmitLibrary(
+            """
+            package A.B
+            import System.Collections.Generic
+
+            class Series {
+            }
+
+            class Catalog {
+                func GetAll() List[Series] -> List[Series]()
+
+                func Add(items List[Series], s Series) {
+                    items.Add(s)
+                }
+            }
+            """,
+            nameof(this.SingleResolver_ListOfImportedType_PassedAcrossImportedFunctionBoundary_EmitsCleanly));
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Consumer";
+
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+                import A.B
+                import System.Collections.Generic
+
+                func Run() {
+                    let catalog = Catalog()
+                    let all List[Series] = catalog.GetAll()
+                    catalog.Add(all, Series())
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private string EmitLibrary(string source, string caseName)
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2299", caseName);
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Lib2299.dll");
+
+        var library = new Compilation(SyntaxTree.Parse(SourceText.From(source)))
+        {
+            IsLibrary = true,
+        };
+
+        using var peStream = File.Create(libraryPath);
+        var result = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Lib2299");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return libraryPath;
+    }
+}


### PR DESCRIPTION
Closes #2299

## Root cause

Follow-up to #2290/#2296. That fix made `Conversion.Classify`'s cross-reference-context identity check (`ImportedTypeSymbol`/`StructSymbol` pairs compared via `ClrTypeUtilities.AreSame`) handle the DIRECT case — e.g. a bare `Chapter` converting with `Oahu.BooksDatabase.Chapter`. The same underlying split — two independent `ReferenceResolver`/`MetadataLoadContext` instances minting non-reference-equal CLR `Type` objects (and thus non-reference-equal `TypeSymbol` wrappers) for the SAME metadata type — still broke one level down: any **structural wrapper symbol** (`SliceTypeSymbol` `[]T`, `NullableTypeSymbol` `T?`, `ByRefTypeSymbol`, `PointerTypeSymbol`, `SequenceTypeSymbol` `seq[T]`, `ChannelTypeSymbol` `chan[T]`, `AsyncSequenceTypeSymbol`, fixed `ArrayTypeSymbol`, and `MapTypeSymbol` `map[K]V`) whose element is the split imported type was deliberately excluded from the #2290 check, since comparing the WRAPPER's own `ClrType` (borrowed from its element) instead of the element's would be wrong.

This is exactly the shape of the reported regression: `List[Series]` vs `List[Oahu.BooksDatabase.Series]` failing `GS0154`, and the resulting member/extension-method/overload-resolution cascades (`GS0158`/`GS0159`) once a receiver's constructed type wasn't recognized as identical.

## The fix

`Conversion.Classify` now recurses into the wrapped element type(s) whenever both sides of a comparison are the SAME wrapper kind, reusing the existing direct `ImportedTypeSymbol`/`StructSymbol` check (and this same recursive step, so nested wrappers like `[]?Series` unwind depth-first without duplicated per-kind logic). `ArrayTypeSymbol` additionally requires matching fixed lengths; `MapTypeSymbol` requires both the key and value types to match. This generalizes to any generic/collection/nullable/pointer wrapper around any imported metadata type — not just `List<T>` or the Oahu instance.

## Alternative considered and rejected

Investigated interning `ImportedTypeSymbol.Get(Type)` by structural (`AreSame`) equality instead of CLR reference equality. This broke `MakeGenericType`/emit/reflection-`Invoke` correctness by silently substituting a `Type` object from the wrong `MetadataLoadContext` ("Type must be a type provided by the runtime", "was not loaded by the MetadataLoadContext that loaded the generic type or method"). The safe fix operates purely at the symbol-comparison level in `Conversion.Classify` and never conflates distinct `Type` instances — no changes to `ImportedTypeSymbol`'s cache or CLR `Type` identity anywhere.

Extensive testing confirmed constructed-generic-argument identity (`List[Series]` via bare/qualified spelling, across independent resolvers) and extension-method receiver matching were already fixed by prior work (`ClrTypeUtilities.AreSame`/`IsSameAs` recursion, issue #1103's `BoundScope.ReceiverMatches`) — the wrapper-type gap closed here was the one remaining hole.

## Tests

Adds `test/Core.Tests/CodeAnalysis/Binding/Issue2299CrossContextWrapperTypeIdentityTests.cs`:
- Slice/nullable/array/map wrapper identity across two independent resolvers loading the same DLL.
- Negative cases: mismatched element types and mismatched array lengths must NOT classify as identity.
- An end-to-end `List[Series]` compile/emit test passing the constructed type across an imported function boundary.

Full `Core.Tests` suite: 5945 passed, 1 skipped, 0 failed (one known-flaky, unrelated async `ConfigureAwait` test — `AwaitFor_ConfigureAwaitFalse_DrainsAsyncEnumerable` — failed once in the full run but passed cleanly in isolation on rerun; unrelated to this change, which only touches `Conversion.cs` type-identity classification).

## Files changed
- `src/Core/CodeAnalysis/Binding/Conversion.cs` — the fix.
- `test/Core.Tests/CodeAnalysis/Binding/Issue2299CrossContextWrapperTypeIdentityTests.cs` — new regression tests.
