### PR TITLE
sdk: define GenerateMSBuildEditorConfigFileShouldRun hook so gsgen sees AXAML AdditionalFiles (#2294)

### DIFF
--- a/docs/adr/0145-source-generator-host-native-gsharp.md
+++ b/docs/adr/0145-source-generator-host-native-gsharp.md
@@ -359,6 +359,33 @@ gsc consumes the emitted `.g.gs`):
   Avalonia is merely the first consumer. Verified via
   `tools/gsgen/GSharp.GeneratorHost.Tests/AdditionalTextGeneratorTests.cs` and
   `GsgenArgsAdditionalFilesTests.cs`.
+- **`@(AdditionalFiles)` population for a native `.gsproj`** (issue #2294) —
+  the §C forwarding above assumes `@(AdditionalFiles)` is already populated by
+  the time `_GsharpRunSourceGenerators` runs, which csc-oriented packages don't
+  all guarantee the same way. `CompilerVisibleProperty`/`CompilerVisibleItemMetadata`
+  are plain `ItemGroup`s and work unconditionally (CommunityToolkit.Mvvm's
+  feature-switch wiring), but `Avalonia.Generators.props`' `_InjectAdditionalFiles`
+  target — the step that actually copies `@(AvaloniaXaml)` into
+  `@(AdditionalFiles)` — is declared `BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun"`,
+  a target only defined by `Microsoft.Managed.Core.targets` (imported solely by
+  C#/VB `Microsoft.NET.Sdk` projects, never by Gsharp's). MSBuild silently
+  no-ops a `BeforeTargets` reference to a nonexistent target name, so that
+  injection never ran for a `.gsproj` and `@(AdditionalFiles)` reached gsgen
+  empty — even though every other link (§C's `HostAdditionalText`/
+  `HostAnalyzerConfigOptionsProvider`, `SourceItemGroup` propagation) was
+  already correct and tested. Fixed generically, not as an Avalonia special
+  case: `Gsharp.NET.Core.Sdk.targets` now declares a no-op
+  `GenerateMSBuildEditorConfigFileShouldRun` target and adds it to
+  `_GsharpRunSourceGenerators`'s `DependsOnTargets`, so *any* package using this
+  common csc extensibility point to inject `@(AdditionalFiles)` now works under
+  the Gsharp SDK too. Pinned by
+  `test/Sdk.Tests/SdkLayoutTests.cs::Core_Targets_Declares_GenerateMSBuildEditorConfigFileShouldRun_Hook`.
+  This is the first instance of a broader pattern worth watching: packages that
+  hook standard `Microsoft.Managed.Core.targets`/`Microsoft.Common.CurrentVersion.targets`
+  target names (rather than plain properties/items) silently no-op under a
+  from-scratch SDK unless that target name is also defined here. The
+  Nerdbank.GitVersioning gap below is the same family of issue from the other
+  direction (a `$(Language)` property gate instead of a missing target name).
 - **Avalonia runtime XAML (`CompileAvaloniaXaml`)** — the post-compile IL-rewrite
   task that makes compiled XAML load at runtime needs *no* new host/SDK code: the
   G# SDK imports `Microsoft.NET.Sdk` and its `CoreCompile` emits the assembly at

--- a/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
+++ b/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
@@ -175,13 +175,29 @@
     </ItemGroup>
   </Target>
 
+  <!-- Issue #2294 / ADR-0145 parity gap: several generator-adjacent NuGet
+       packages populate @(AdditionalFiles) themselves by hooking a standard
+       csc/vbc extensibility target rather than a plain ItemGroup. The
+       canonical example is Avalonia: Avalonia.Generators.props injects the
+       project's AXAML into @(AdditionalFiles) via
+       `BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun"` — a target
+       defined only in Microsoft.Managed.Core.targets, which a Gsharp project
+       never imports (§E). MSBuild silently no-ops a BeforeTargets reference to
+       a target name that does not exist, so that injection never ran and
+       @(AdditionalFiles) reached gsgen empty even though gsgen's
+       AdditionalText/SourceItemGroup plumbing (issue #2223) already fully
+       supports it. Defining the same hook name here — even as a no-op body —
+       is enough for such packages' BeforeTargets to fire, matching csc's
+       extensibility surface without special-casing Avalonia. -->
+  <Target Name="GenerateMSBuildEditorConfigFileShouldRun" />
+
   <!-- (2) Run gsgen over the user's .gs (BEFORE generated files are added to
        @(Compile)), the resolved reference closure, and the resolved analyzers.
        Incremental: re-runs only when a source/analyzer/reference/project file is
        newer than the manifest. -->
   <Target Name="_GsharpRunSourceGenerators"
           BeforeTargets="CoreCompile"
-          DependsOnTargets="_GsharpPartitionForeignCompile;_GsharpResolveAnalyzers;_GsharpCollectGeneratorOptions;ResolveReferences"
+          DependsOnTargets="_GsharpPartitionForeignCompile;GenerateMSBuildEditorConfigFileShouldRun;_GsharpResolveAnalyzers;_GsharpCollectGeneratorOptions;ResolveReferences"
           Condition=" '$(GsharpRunSourceGenerators)' != 'false' "
           Inputs="@(Compile);@(_GsharpForeignCompile);@(AdditionalFiles);@(GsharpAnalyzer);@(ReferencePathWithRefAssemblies);$(MSBuildAllProjects)"
           Outputs="$(IntermediateOutputPath)gsgen\gsgen.manifest">

--- a/test/Sdk.Tests/SdkLayoutTests.cs
+++ b/test/Sdk.Tests/SdkLayoutTests.cs
@@ -176,4 +176,31 @@ public class SdkLayoutTests
         Assert.Contains("'$(DebugType)' != 'embedded'", condition, System.StringComparison.Ordinal);
         Assert.Contains("'$(DebugType)' != 'none'", condition, System.StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void Core_Targets_Declares_GenerateMSBuildEditorConfigFileShouldRun_Hook()
+    {
+        // Issue #2294: Avalonia.Generators.props (and any other package that
+        // populates @(AdditionalFiles) via BeforeTargets, rather than a plain
+        // ItemGroup) hooks BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun".
+        // That target only exists because Microsoft.Managed.Core.targets defines
+        // it for C#/VB SDK projects; a Gsharp project never imports it, so without
+        // this pinned no-op target the hook silently never fires and
+        // @(AdditionalFiles) never receives the injected items. This test pins
+        // both the target's existence and its position ahead of gsgen's own
+        // AdditionalFiles-consuming target so a future edit can't reintroduce the
+        // gap silently.
+        var path = Path.Combine(RepoRoot.SdkSourceDir, "build", "Gsharp.NET.Core.Sdk.targets");
+        var doc = XDocument.Load(path);
+
+        var hook = doc.Descendants(MsbuildNs + "Target")
+            .FirstOrDefault(t => (string)t.Attribute("Name") == "GenerateMSBuildEditorConfigFileShouldRun");
+        Assert.NotNull(hook);
+
+        var runGenerators = doc.Descendants(MsbuildNs + "Target")
+            .First(t => (string)t.Attribute("Name") == "_GsharpRunSourceGenerators");
+        var dependsOn = ((string)runGenerators.Attribute("DependsOnTargets"))
+            .Split(';', System.StringSplitOptions.RemoveEmptyEntries);
+        Assert.Contains("GenerateMSBuildEditorConfigFileShouldRun", dependsOn);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the root cause behind the AXAML gap flagged in #2294, generically rather than as an Avalonia special case.

**Root cause:** the Gsharp SDK defines its own `CoreCompile` and never imports `Microsoft.Managed.Core.targets`, so the target `GenerateMSBuildEditorConfigFileShouldRun` never exists in a `.gsproj` build. MSBuild silently no-ops any `BeforeTargets` reference to a nonexistent target name, so `Avalonia.Generators.props`'s `_InjectAdditionalFiles` target (`BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun"`), which copies `@(AvaloniaXaml)` into `@(AdditionalFiles)`, never ran for a native G# project. Everything downstream — `HostAdditionalText`, `SourceItemGroup` metadata propagation, `HostAnalyzerConfigOptionsProvider` (all built for #2223's cs2gs-migration direction) — already worked correctly; the AXAML files just never arrived in `@(AdditionalFiles)` in the first place.

**Fix:** declare a no-op `GenerateMSBuildEditorConfigFileShouldRun` target in `Gsharp.NET.Core.Sdk.targets` and add it to `_GsharpRunSourceGenerators`'s `DependsOnTargets`. This is a generic csc-extensibility-point fix: any NuGet package that populates `@(AdditionalFiles)` via this common hook (not just Avalonia) now works under the Gsharp SDK.

## Changes
- `src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets`: new no-op hook target + `DependsOnTargets` wiring.
- `test/Sdk.Tests/SdkLayoutTests.cs`: structural test pinning the hook target's existence and its position ahead of `_GsharpRunSourceGenerators`.
- `docs/adr/0145-source-generator-host-native-gsharp.md`: documents the gap and the fix, and flags it as an instance of a broader pattern (packages hooking standard `Microsoft.Managed.Core.targets`/`Microsoft.Common.CurrentVersion.targets` target names silently no-op under a from-scratch SDK) alongside the existing Nerdbank.GitVersioning gap noted in the same ADR.

## Testing
- `dotnet test test/Sdk.Tests/Sdk.Tests.csproj -c Release --filter FullyQualifiedName~SdkLayoutTests` — 15/15 passed (including the new test).
- `bash e2etests/gsgen-e2e.sh` — re-run to confirm no regression; same pre-existing, documented CommunityToolkit.Mvvm back-translation gap (unrelated to this change), gsgen wiring unaffected.

## Follow-up
This should close the AXAML-specific portion of #2294 once validated against the real Oahu.UI Avalonia corpus.
