### PR TITLE
Fix #2303: block correctly on ConfigureAwait(false) awaiters in await for

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -790,31 +790,50 @@ public sealed class Evaluator
 
     private static object BlockOnValueTask(object valueTask)
     {
-        // Works uniformly for `Task`, `Task<T>`, `ValueTask`, and
-        // `ValueTask<T>`. ValueTask awaiters cannot be polled
-        // synchronously for an incomplete task — convert via `AsTask()`
-        // when available so the underlying `Task` awaiter is the one we
-        // call `GetResult()` on. Matches Phase 5.1's `await` pragma.
+        // Works uniformly for `Task`, `Task<T>`, `ValueTask`, `ValueTask<T>`,
+        // and any `ConfigureAwait(...)`-flavored awaitable
+        // (`ConfiguredTaskAwaitable(<T>)` / `ConfiguredValueTaskAwaitable(<T>)`).
+        //
+        // Issue #2303: this previously converted `ValueTask`-shaped operands
+        // to a real `Task` via `AsTask()` before blocking — but
+        // `ConfiguredValueTaskAwaitable(<T>)` (the type returned by
+        // `IAsyncEnumerable[T].ConfigureAwait(false)` and used pervasively by
+        // the `await for` pattern-based path, #2280) has no `AsTask` method,
+        // so its awaiter's `GetResult()` was invoked directly. Per the
+        // `IValueTaskSource` contract, `GetResult()` on such an awaiter is
+        // only valid once the operation has actually completed; calling it
+        // eagerly is a race — `ConfigureAwait(false)` lets the antecedent's
+        // continuation resume on any thread-pool thread, so `GetResult()`
+        // could run before that continuation reached its `yield`/completion,
+        // throwing `InvalidOperationException` intermittently. Instead,
+        // check `IsCompleted` first and, if not yet done, block on a
+        // completion signal registered via `OnCompleted`/`UnsafeOnCompleted`
+        // — the spec-mandated awaiter pattern — before calling `GetResult()`.
         if (valueTask == null)
         {
             return null;
         }
 
-        var type = valueTask.GetType();
-        var asTask = type.GetMethod("AsTask", Type.EmptyTypes);
-        object awaitable = asTask != null ? asTask.Invoke(valueTask, null) : valueTask;
-        if (awaitable == null)
-        {
-            return null;
-        }
-
-        var awaiter = awaitable.GetType().GetMethod("GetAwaiter", Type.EmptyTypes)?.Invoke(awaitable, null);
+        var awaiter = valueTask.GetType().GetMethod("GetAwaiter", Type.EmptyTypes)?.Invoke(valueTask, null);
         if (awaiter == null)
         {
             return null;
         }
 
-        var getResult = awaiter.GetType().GetMethod("GetResult", Type.EmptyTypes);
+        var awaiterType = awaiter.GetType();
+        var isCompletedProperty = awaiterType.GetProperty("IsCompleted");
+        var isCompleted = isCompletedProperty != null && (bool)isCompletedProperty.GetValue(awaiter);
+        if (!isCompleted)
+        {
+            using var completed = new ManualResetEventSlim(false);
+            var onCompletedMethod = awaiterType.GetMethod("UnsafeOnCompleted", new[] { typeof(Action) })
+                ?? awaiterType.GetMethod("OnCompleted", new[] { typeof(Action) });
+            Action continuation = () => completed.Set();
+            onCompletedMethod?.Invoke(awaiter, new object[] { continuation });
+            completed.Wait();
+        }
+
+        var getResult = awaiterType.GetMethod("GetResult", Type.EmptyTypes);
         try
         {
             return getResult?.Invoke(awaiter, null);

--- a/test/Core.Tests/CodeAnalysis/Binding/AwaitForRangeStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AwaitForRangeStatementTests.cs
@@ -37,7 +37,7 @@ total
         Assert.Equal(1 + 2 + 3, result.Value);
     }
 
-    [Fact(Skip = "Flaky in CI: intermittently reports a spurious binder diagnostic (reference-resolution race in the test fixture). Tracked by #2303.")]
+    [Fact]
     public void AwaitFor_ConfigureAwaitFalse_DrainsAsyncEnumerable()
     {
         // Issue #2280: `stream.ConfigureAwait(false)` returns


### PR DESCRIPTION
## Summary

Fixes #2303 by fixing the actual race that caused `AwaitFor_ConfigureAwaitFalse_DrainsAsyncEnumerable` to intermittently fail in CI.

## Root cause

`BlockOnValueTask` (the shared helper the interpreter uses for both `await` and `await for`) called an awaiter's `GetResult()` immediately after `GetAwaiter()`, without first checking `IsCompleted`.

- For `Task`/`Task<T>` awaiters this is safe: `GetResult()` blocks internally (via `Task.Wait()`).
- For `ConfiguredValueTaskAwaiter`, the awaiter type returned by `IAsyncEnumerable<T>.ConfigureAwait(false)` and exercised by the duck-typed `await for` pattern support added in #2280/#2286, this is **not** safe. Per the `IValueTaskSource` contract, calling `GetResult()` before the operation has completed throws `InvalidOperationException`.

Because `ConfigureAwait(false)` lets the antecedent's continuation resume on any thread-pool thread, there's a genuine race: `GetResult()` could run before the async iterator's continuation reached its next `yield`/completion. I reproduced this directly with a standalone stress harness: thousands of trials threw `InvalidOperationException` intermittently against the pre-fix logic, and zero failures after the fix.

That exception was caught by the interpreter's generic exception handler, re-wrapped as an `EvaluatorException`, and converted by `Compilation.Evaluate` into a `GS9999` diagnostic, which is exactly what caused the reported `Assert.Empty(result.Diagnostics)` failures (previously misattributed to a "binder diagnostic" / "reference-resolution race" when the test was quarantined).

## Fix

`BlockOnValueTask` now:
1. Checks the awaiter's `IsCompleted` first.
2. If not yet complete, blocks on a completion signal registered via the awaiter's `OnCompleted`/`UnsafeOnCompleted` (the C# spec-mandated awaiter pattern) instead of eagerly calling `GetResult()`.
3. Only then calls `GetResult()`.

This works uniformly for `Task`, `Task<T>`, `ValueTask`, `ValueTask<T>`, and any `ConfigureAwait(...)`-flavored awaitable (`ConfiguredTaskAwaitable(<T>)` / `ConfiguredValueTaskAwaitable(<T>)`), and drops the old `AsTask()`-conversion special case, which doesn't exist on `ConfiguredValueTaskAwaitable<T>` anyway, so it never actually helped this path.

## Testing

- Un-skipped `AwaitFor_ConfigureAwaitFalse_DrainsAsyncEnumerable`.
- Ran the full `Core.Tests` suite (5964 tests) multiple times, all green, no flakes.
- Verified the fix against a standalone reflection-based stress repro of the exact `ConfiguredValueTaskAwaitable<bool>` race.
