### PR TITLE
cs2gs: preserve nullable inferred locals used in nil checks

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2202ExternalObliviousReturnForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2202ExternalObliviousReturnForgivenessTranslationTests.cs
@@ -155,6 +155,55 @@ namespace Demo
         Assert.DoesNotContain("!!!!",  printed);
     }
 
+    [Fact]
+    public void NullableEnabled_InferredLocalFromObliviousExternalReturn_RendersNullableType()
+    {
+        string printed = TranslateEnabledWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Run(ExtLib ext)
+        {
+            var response = ext.GetResponse();
+            if (response is null) return;
+            System.Console.WriteLine(response.Value);
+        }
+    }
+}");
+
+        Assert.Contains("response ExternalResponse? =", printed);
+        Assert.Contains("if response == nil", printed);
+    }
+
+    [Fact]
+    public void NullableEnabled_InferredLocalFromAnnotatedNullableReturn_RendersNullableType()
+    {
+        string printed = TranslateEnabledWithObliviousLibrary(@"
+using System.Linq;
+
+namespace Demo
+{
+    public sealed class AuthSession
+    {
+        public string AccountId { get; init; } = string.Empty;
+    }
+
+    public class C
+    {
+        public AuthSession? Find(AuthSession[] sessions)
+        {
+            var match = sessions.FirstOrDefault();
+            if (match is not null) return match;
+            return null;
+        }
+    }
+}");
+
+        Assert.Contains("match AuthSession? =", printed);
+        Assert.Contains("if match != nil", printed);
+    }
+
     /// <summary>
     /// Compiles a tiny "external" library WITHOUT a nullable context (oblivious),
     /// then translates the <paramref name="source"/> snippet referencing it in an
@@ -247,7 +296,14 @@ public class AnnotatedLib
 public class ExtLib
 {
     public string Combine(string separator) { return separator; }
+    public ExternalResponse GetResponse() { return null; }
 }
+
+public class ExternalResponse
+{
+    public string Value { get; set; }
+}
+
 ";
         MetadataReference libRef = CompileObliviousLibrary(LibSource, "ObliviousExtLibForEnabled");
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -6065,15 +6065,13 @@ public sealed class CSharpToGSharpTranslator
                 }
                 else if (initializer != null &&
                     this.context.GetDeclaredSymbol(declarator) is ILocalSymbol inferredLocal &&
-                    this.IsPromotedToNullableReference(inferredLocal))
+                    (this.IsUsedAsNullable(inferredLocal, this.GetNullabilityScope(inferredLocal))
+                        || this.IsPromotedToNullableReference(inferredLocal)))
                 {
-                    // Issue #1072 (inferred-type form): a `var x = e` local with no
-                    // explicit type whose initializer is a non-nullable reference but
-                    // which is compared to `nil` / assigned `nil` in scope is really
-                    // nullable. Type inference over the non-null initializer would
-                    // pick the non-nullable type, so the `== nil` / `!= nil` guard
-                    // fails (GS0129) or a later `= nil` fails (GS0156). Emit an
-                    // explicit `T?` annotation so the binding is nullable.
+                    // Issue #1072/#2305 (inferred-type form): a `var x = e` local
+                    // whose uses prove it nullable needs an explicit `T?`.
+                    // Otherwise G# may re-infer a non-null type from `e`, making a
+                    // later nil check fail GS0129.
                     type = MakeNullable(this.typeMapper.Map(
                         inferredLocal.Type, this.context, declaration.Type.GetLocation()));
                 }


### PR DESCRIPTION
Closes #2305

Nullable-enabled C# inferred locals can already be nullable in Roslyn, but cs2gs only emitted an explicit nullable type when its oblivious-nullability promotion path fired. For `var` locals null-checked with `is null` / `is not null`, that path short-circuited because Roslyn already considered the local nullable, so G# re-inferred a bare non-null type from the initializer and rejected the emitted nil comparison with GS0129.

This makes the inferred-local path consult the existing local null-usage analysis directly before relying on G# inference.

Validated against the real Oahu projects: the reported locals now emit as `LibraryResponse?` and `AuthSession?`, and both reported GS0129 diagnostics disappear.

Tests:
- Focused translator regressions: 8 passed
- Real Oahu.Core + Oahu.Cli.App migration: both #2305 diagnostics eliminated
- Full Cs2Gs.Tests run reached 526 passing tests before the existing test-host crash in report tests; no test failures
