### PR TITLE
Fix #2307: qualify metadata types with source homonyms

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2222TopLevelTypeQualificationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2222TopLevelTypeQualificationTranslationTests.cs
@@ -183,6 +183,79 @@ namespace Consumer
         Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
     }
 
+    [Fact]
+    public void MetadataType_WithSourceHomonym_IsEmittedQualified()
+    {
+        MetadataReference libRef = CompileLibrary(
+            @"
+namespace Oahu.BooksDatabase
+{
+    public class Codec
+    {
+        public string Name { get; set; }
+    }
+}
+",
+            "Issue2307OahuData");
+
+        SyntaxTree sourceHomonym = CSharpSyntaxTree.ParseText(
+            @"
+namespace Oahu.Audible.Json
+{
+    public class Codec
+    {
+        public int Id { get; set; }
+    }
+}
+",
+            new CSharpParseOptions(LanguageVersion.Latest),
+            path: "AudibleCodec.cs");
+        SyntaxTree caller = CSharpSyntaxTree.ParseText(
+            @"
+using System.Collections.Generic;
+using System.Linq;
+using Oahu.Audible.Json;
+using Oahu.BooksDatabase;
+
+namespace Oahu.Core
+{
+    public class C
+    {
+        public Oahu.BooksDatabase.Codec Find(
+            ICollection<Oahu.BooksDatabase.Codec> codecs,
+            string name)
+        {
+            return codecs.FirstOrDefault(
+                (Oahu.BooksDatabase.Codec c) => c.Name == name);
+        }
+    }
+}
+",
+            new CSharpParseOptions(LanguageVersion.Latest),
+            path: "Caller.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue2307.MetadataTypeWithSourceHomonym",
+            new[] { sourceHomonym, caller },
+            CSharpProjectLoader.RuntimeReferences().Append(libRef).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(caller);
+        var document = new LoadedDocument("Caller.cs", caller, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+
+        Assert.Contains("ICollection[Oahu.BooksDatabase.Codec]", printed);
+        Assert.Contains("(c Oahu.BooksDatabase.Codec)", printed);
+
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
+    }
+
     /// <summary>
     /// Issue #2222 ordering blindspot: namespace <c>First</c> is reached via
     /// an explicit <c>using</c>, but the colliding namespace <c>Second</c> is

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -742,7 +742,17 @@ public sealed class CSharpTypeMapper
     private bool HasSourceHomonym(INamedTypeSymbol named, TranslationContext context)
     {
         this.sourceSimpleNameCounts ??= BuildSourceSimpleNameCounts(context.Compilation);
-        return this.sourceSimpleNameCounts.TryGetValue(named.Name, out var count) && count > 1;
+        if (!this.sourceSimpleNameCounts.TryGetValue(named.Name, out var count))
+        {
+            return false;
+        }
+
+        // Issue #2307: for a source symbol, one census entry is the symbol
+        // itself, so ambiguity starts at two. A metadata symbol is not in the
+        // source census at all, so even one same-named source declaration is a
+        // distinct homonym and the metadata reference must stay qualified.
+        int selfCount = named.Locations.Any(l => l.IsInSource) ? 1 : 0;
+        return count > selfCount;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- preserve qualification for metadata types when translated source declares a same-named type
- prevent Oahu `BooksDatabase.Codec`, `Series`, and `Chapter` references from binding to `Audible.Json` homonyms
- add an Oahu-shaped LINQ regression using an imported `ICollection<Codec>` receiver

## Findings
The reported LINQ failures were cascading diagnostics, not a gsc LINQ lookup defect. Existing and isolated tests resolve LINQ over imported generic receivers correctly. cs2gs instead shortened metadata type names despite colliding translated source types, corrupting receiver and lambda types before extension lookup.

With this change, the real Oahu.Core migration drops GS0159 diagnostics from 40 to 14 and total compiler errors from 172 to 107. All reported `FirstOrDefault`, `Where`, `OrderBy`, and `GroupBy` failures are eliminated; remaining GS0159 diagnostics involve unrelated APIs.

## Tests
- `Issue2222TopLevelTypeQualificationTranslationTests`: 5 passed
- broader Cs2Gs run: 470 passed, 0 failed before the existing test-host crash
- real Oahu.Core/Oahu.Cli.App migration completed translation and confirmed qualified metadata names

Fixes #2307