### PR TITLE
cs2gs: preserve project layout and generator inputs

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -343,12 +343,20 @@ public sealed class CompileStage : IMigrationStage
     {
         if (!string.IsNullOrEmpty(diagnosticFile))
         {
-            string name = Path.GetFileName(diagnosticFile);
-            EmittedGsFile match = files.FirstOrDefault(f =>
-                string.Equals(Path.GetFileName(f.GsPath), name, StringComparison.OrdinalIgnoreCase));
-            if (match is not null)
+            string diagnosticFullPath = Path.GetFullPath(diagnosticFile);
+            EmittedGsFile exactMatch = files.FirstOrDefault(f =>
+                string.Equals(Path.GetFullPath(f.GsPath), diagnosticFullPath, StringComparison.OrdinalIgnoreCase));
+            if (exactMatch is not null)
             {
-                return match;
+                return exactMatch;
+            }
+
+            string name = Path.GetFileName(diagnosticFile);
+            EmittedGsFile[] matches = files.Where(f =>
+                string.Equals(Path.GetFileName(f.GsPath), name, StringComparison.OrdinalIgnoreCase)).ToArray();
+            if (matches.Length == 1)
+            {
+                return matches[0];
             }
         }
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -50,11 +50,13 @@ public sealed class CompileStage : IMigrationStage
         {
             SdkCompileResult sdkResult = new SdkCompileRunner().Compile(
                 context.AppRunDir,
+                Path.GetFileNameWithoutExtension(context.App.ProjectPath),
                 gsFiles,
                 context.App.TargetKind,
                 references,
                 context.AnalyzerReferencePaths,
-                rootNamespace: null,
+                context.AdditionalGeneratorFiles,
+                context.RootNamespace,
                 context.Options.Config,
                 context.BuildOnlyPackageReferences);
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
@@ -316,8 +316,17 @@ public class GsharpTestProjectRunner
         // the corpus does (no GitVersioning, StyleCop, or AssemblyName rewrite),
         // which otherwise breaks for the Gsharp language CodeDomProvider.
         const string Empty = "<Project>\n</Project>\n";
-        File.WriteAllText(Path.Combine(workDir, "Directory.Build.props"), Empty);
-        File.WriteAllText(Path.Combine(workDir, "Directory.Build.targets"), Empty);
+        string propsPath = Path.Combine(workDir, "Directory.Build.props");
+        string targetsPath = Path.Combine(workDir, "Directory.Build.targets");
+        if (!File.Exists(propsPath))
+        {
+            File.WriteAllText(propsPath, Empty);
+        }
+
+        if (!File.Exists(targetsPath))
+        {
+            File.WriteAllText(targetsPath, Empty);
+        }
     }
 
     internal static string FindRepoRoot()

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -117,6 +117,12 @@ public sealed class StageExecutionContext
     public List<string> GeneratorGlobalOptions { get; } = new List<string>();
 
     /// <summary>
+    /// Gets or sets the source project's root namespace, captured by the
+    /// Translate stage for the SDK compile project.
+    /// </summary>
+    public string RootNamespace { get; set; }
+
+    /// <summary>
     /// Gets the source project's declared build/dev-only <c>PackageReference</c>s
     /// (issue #2267) — e.g. a version-bumped <c>Nerdbank.GitVersioning</c> — that
     /// must be re-declared into the isolated <c>--via-sdk</c> gsproj because they

--- a/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
@@ -51,6 +51,7 @@ public sealed class SdkCompileRunner
     /// locally-built <c>Gsharp.NET.Sdk</c>.
     /// </summary>
     /// <param name="appRunDir">The per-app output directory to scaffold the build project under.</param>
+    /// <param name="projectName">The source project name to preserve for the generated <c>.gsproj</c> and assembly.</param>
     /// <param name="gsFilePaths">The absolute paths of the emitted G# files to compile, in compile order.</param>
     /// <param name="target">The output kind (exe or library).</param>
     /// <param name="referencePaths">
@@ -60,6 +61,7 @@ public sealed class SdkCompileRunner
     /// MSBuild items instead.
     /// </param>
     /// <param name="analyzerPaths">The analyzer/generator assembly paths (issue #2215).</param>
+    /// <param name="additionalFiles">The source generator inputs, including AXAML item metadata (issue #2223).</param>
     /// <param name="rootNamespace">The root namespace to set on the project, or <see langword="null"/>.</param>
     /// <param name="config">The build configuration (e.g. <c>Release</c>).</param>
     /// <param name="declaredPackageReferences">
@@ -72,10 +74,12 @@ public sealed class SdkCompileRunner
     /// <returns>The compile result, or an unavailable result when no local SDK nupkg can be found.</returns>
     public SdkCompileResult Compile(
         string appRunDir,
+        string projectName,
         IReadOnlyList<string> gsFilePaths,
         TargetKind target,
         IReadOnlyList<string> referencePaths,
         IReadOnlyList<string> analyzerPaths,
+        IReadOnlyList<string> additionalFiles,
         string rootNamespace,
         string config,
         IReadOnlyList<DeclaredPackageReference> declaredPackageReferences = null)
@@ -83,6 +87,11 @@ public sealed class SdkCompileRunner
         if (string.IsNullOrEmpty(appRunDir))
         {
             throw new ArgumentException("An app run directory is required.", nameof(appRunDir));
+        }
+
+        if (string.IsNullOrWhiteSpace(projectName))
+        {
+            throw new ArgumentException("A project name is required.", nameof(projectName));
         }
 
         string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
@@ -122,13 +131,16 @@ public sealed class SdkCompileRunner
                 continue;
             }
 
-            analyzerReferences.Add(Path.GetFullPath(analyzerPath));
-
             (string Id, string Version)? owningPackage = TryParsePackageFromPath(analyzerPath, nugetPackagesRoot);
             if (owningPackage is not null)
             {
+                // The PackageReference contributes its analyzer assets. Adding
+                // the same DLL explicitly would run generators twice.
                 AddOrUpgradePackage(packages, packageIndex, owningPackage.Value.Id, owningPackage.Value.Version);
+                continue;
             }
+
+            analyzerReferences.Add(Path.GetFullPath(analyzerPath));
         }
 
         // Issue #2267: a declared build/dev-only package (nbgv) that also
@@ -147,8 +159,7 @@ public sealed class SdkCompileRunner
             declaredOnlyPackages.Add(declared);
         }
 
-        const string ProjectName = "App";
-        string projectPath = Path.Combine(appRunDir, ProjectName + ".gsproj");
+        string projectPath = Path.Combine(appRunDir, projectName + ".gsproj");
         string projectXml = BuildProjectXml(
             sdk.Value.Version,
             target,
@@ -157,7 +168,8 @@ public sealed class SdkCompileRunner
             packages,
             references,
             analyzerReferences,
-            declaredOnlyPackages);
+            declaredOnlyPackages,
+            additionalFiles);
         File.WriteAllText(projectPath, projectXml);
 
         var args = new List<string> { "build", projectPath, "-c", config ?? "Release" };
@@ -184,7 +196,7 @@ public sealed class SdkCompileRunner
             }
         }
 
-        string assemblyPath = FindEmittedAssembly(appRunDir, ProjectName, config);
+        string assemblyPath = FindEmittedAssembly(appRunDir, projectName, config);
         return SdkCompileResult.Completed(result.ExitCode, result.Output, diagnostics, assemblyPath);
     }
 
@@ -297,7 +309,7 @@ public sealed class SdkCompileRunner
     }
 
     /// <summary>
-    /// Renders the isolated <c>App.gsproj</c> XML text: the SDK-project header,
+    /// Renders the migrated, source-named <c>.gsproj</c> XML text: the SDK-project header,
     /// build properties, <c>@(Compile)</c> items, <c>@(PackageReference)</c>
     /// (both the reconstructed-from-DLL set and the declared build/dev-only set,
     /// issue #2267), <c>@(Reference)</c>, and <c>@(Analyzer)</c> items. Exposed
@@ -316,6 +328,7 @@ public sealed class SdkCompileRunner
     /// (issue #2267) to re-declare even though they contributed no compile-time
     /// DLL to <paramref name="packages"/>.
     /// </param>
+    /// <param name="additionalFiles">The source generator inputs to emit as project items.</param>
     /// <returns>The full <c>.gsproj</c> XML text.</returns>
     internal static string BuildProjectXml(
         string sdkVersion,
@@ -325,9 +338,11 @@ public sealed class SdkCompileRunner
         IReadOnlyList<(string Id, string Version)> packages,
         IReadOnlyList<string> references,
         IReadOnlyList<string> analyzerReferences,
-        IReadOnlyList<DeclaredPackageReference> declaredPackageReferences = null)
+        IReadOnlyList<DeclaredPackageReference> declaredPackageReferences = null,
+        IReadOnlyList<string> additionalFiles = null)
     {
         declaredPackageReferences ??= Array.Empty<DeclaredPackageReference>();
+        additionalFiles ??= Array.Empty<string>();
         string outputType = target == TargetKind.Exe ? "Exe" : "Library";
         var sb = new StringBuilder();
         sb.Append("<Project Sdk=\"").Append(SdkPackageId).Append('/').Append(sdkVersion).Append("\">\n");
@@ -407,6 +422,23 @@ public sealed class SdkCompileRunner
             foreach (string analyzerReference in analyzerReferences)
             {
                 sb.Append("    <Analyzer Include=\"").Append(analyzerReference).Append("\" />\n");
+            }
+
+            sb.Append("  </ItemGroup>\n");
+        }
+
+        if (additionalFiles.Count > 0)
+        {
+            sb.Append('\n');
+            sb.Append("  <ItemGroup>\n");
+            foreach (string spec in additionalFiles)
+            {
+                string[] segments = spec.Split(';', StringSplitOptions.RemoveEmptyEntries);
+                string path = segments[0];
+                bool isAvaloniaXaml = segments.Skip(1).Any(
+                    s => string.Equals(s, "SourceItemGroup=AvaloniaXaml", StringComparison.OrdinalIgnoreCase));
+                string itemName = isAvaloniaXaml ? "AvaloniaXaml" : "AdditionalFiles";
+                sb.Append("    <").Append(itemName).Append(" Include=\"").Append(path).Append("\" />\n");
             }
 
             sb.Append("  </ItemGroup>\n");

--- a/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
@@ -160,16 +160,22 @@ public sealed class SdkCompileRunner
         }
 
         string projectPath = Path.Combine(appRunDir, projectName + ".gsproj");
+        IReadOnlyList<string> projectSources = (gsFilePaths ?? Array.Empty<string>())
+            .Select(path => Path.GetRelativePath(appRunDir, path))
+            .ToList();
+        IReadOnlyList<string> explicitAdditionalFiles = (additionalFiles ?? Array.Empty<string>())
+            .Where(spec => RequiresExplicitProjectItem(appRunDir, spec))
+            .ToList();
         string projectXml = BuildProjectXml(
             sdk.Value.Version,
             target,
             rootNamespace,
-            gsFilePaths ?? Array.Empty<string>(),
+            projectSources,
             packages,
             references,
             analyzerReferences,
             declaredOnlyPackages,
-            additionalFiles);
+            explicitAdditionalFiles);
         File.WriteAllText(projectPath, projectXml);
 
         var args = new List<string> { "build", projectPath, "-c", config ?? "Release" };
@@ -447,6 +453,28 @@ public sealed class SdkCompileRunner
         sb.Append('\n');
         sb.Append("</Project>\n");
         return sb.ToString();
+    }
+
+    internal static bool RequiresExplicitProjectItem(string projectDirectory, string spec)
+    {
+        if (string.IsNullOrEmpty(spec))
+        {
+            return false;
+        }
+
+        string[] segments = spec.Split(';', StringSplitOptions.RemoveEmptyEntries);
+        bool isAvaloniaXaml = segments.Skip(1).Any(
+            s => string.Equals(s, "SourceItemGroup=AvaloniaXaml", StringComparison.OrdinalIgnoreCase));
+        if (!isAvaloniaXaml)
+        {
+            return true;
+        }
+
+        string relativePath = Path.GetRelativePath(projectDirectory, segments[0]);
+        return Path.IsPathRooted(relativePath) ||
+            relativePath.Equals("..", StringComparison.Ordinal) ||
+            relativePath.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
+            relativePath.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -63,7 +63,8 @@ public sealed class TranslateStage : IMigrationStage
             return StageOutcome.Failed(artifacts);
         }
 
-        var usedGsFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var usedOutputPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        CopyProjectFiles(project.ProjectDirectory, context.AppRunDir, usedOutputPaths);
 
         // Translate the app itself (index 0) plus its transitively referenced
         // sibling projects (Refs #914). Sibling G# is emitted so the app's uses
@@ -112,7 +113,11 @@ public sealed class TranslateStage : IMigrationStage
                 // file-driven generator output (e.g. Avalonia's InitializeComponent).
                 foreach (string additionalFile in currentProject.AdditionalFiles)
                 {
-                    string spec = additionalFile;
+                    string copiedPath = MirroredPath(
+                        additionalFile,
+                        currentProject.ProjectDirectory,
+                        context.AppRunDir);
+                    string spec = File.Exists(copiedPath) ? copiedPath : additionalFile;
                     string ext = Path.GetExtension(additionalFile);
                     if (ext.Equals(".axaml", StringComparison.OrdinalIgnoreCase) ||
                         ext.Equals(".xaml", StringComparison.OrdinalIgnoreCase) ||
@@ -133,7 +138,7 @@ public sealed class TranslateStage : IMigrationStage
 
                     if (!string.IsNullOrEmpty(currentProject.ProjectDirectory))
                     {
-                        context.GeneratorGlobalOptions.Add("ProjectDir=" + currentProject.ProjectDirectory);
+                        context.GeneratorGlobalOptions.Add("ProjectDir=" + context.AppRunDir);
                     }
                 }
             }
@@ -166,15 +171,21 @@ public sealed class TranslateStage : IMigrationStage
                 CompilationUnit unit = translator.TranslateDocument(document, translationContext);
                 string printed = GSharpPrinter.Print(unit);
 
-                string gsFileName = EmittedFileNaming.UniqueGsFileName(document.FilePath, usedGsFileNames);
-                string gsPath = Path.Combine(context.AppRunDir, gsFileName);
+                string gsRelativePath = OutputPathForSource(
+                    document.FilePath,
+                    currentProject,
+                    isReferencedProject,
+                    usedOutputPaths);
+                string gsPath = Path.Combine(context.AppRunDir, gsRelativePath);
+                Directory.CreateDirectory(Path.GetDirectoryName(gsPath));
                 File.WriteAllText(gsPath, printed);
 
                 var declaredTypeNames = new List<string>();
                 var baseClassNames = new List<string>();
                 CollectTypeGraph(unit.Members, declaredTypeNames, baseClassNames);
 
-                string relativeGsPath = MigrationPipeline.SanitizeAppId(context.App.Id) + "/" + gsFileName;
+                string relativeGsPath = MigrationPipeline.SanitizeAppId(context.App.Id) + "/" +
+                    gsRelativePath.Replace(Path.DirectorySeparatorChar, '/');
                 var emitted = new EmittedGsFile(
                     gsPath,
                     relativeGsPath,
@@ -245,20 +256,17 @@ public sealed class TranslateStage : IMigrationStage
 
                 string className = Path.GetFileNameWithoutExtension(resxPath);
 
-                // EmittedFileNaming.UniqueGsFileName sanitizes a single-extension
-                // ".gs" name, so drive uniqueness off the resx path itself (e.g.
-                // "Resources.resx" -> "Resources.gs") and re-derive the real
-                // "*.Designer.gs" name from whatever de-duplicated base name it
-                // picked (e.g. "Properties.Resources.gs" on a folder collision) —
-                // this still correctly detects a clash against a hand-written
-                // "Resources.cs" translated into "Resources.gs", since both would
-                // declare a same-named type in the output directory.
-                string uniqueBaseGsName = EmittedFileNaming.UniqueGsFileName(resxPath, usedGsFileNames);
-                string gsFileName = Path.GetFileNameWithoutExtension(uniqueBaseGsName) + GSharp.Core.Resx.ResxCodeGenerator.DesignerFileSuffix;
-                string gsPath = Path.Combine(context.AppRunDir, gsFileName);
+                string gsRelativePath = OutputPathForResx(
+                    resxPath,
+                    currentProject,
+                    isReferencedProject,
+                    usedOutputPaths);
+                string gsPath = Path.Combine(context.AppRunDir, gsRelativePath);
+                Directory.CreateDirectory(Path.GetDirectoryName(gsPath));
                 File.WriteAllText(gsPath, generated);
 
-                string relativeGsPath = MigrationPipeline.SanitizeAppId(context.App.Id) + "/" + gsFileName;
+                string relativeGsPath = MigrationPipeline.SanitizeAppId(context.App.Id) + "/" +
+                    gsRelativePath.Replace(Path.DirectorySeparatorChar, '/');
                 var emittedResx = new EmittedGsFile(
                     gsPath,
                     relativeGsPath,
@@ -294,6 +302,133 @@ public sealed class TranslateStage : IMigrationStage
         EmitNerdbankGitVersioningBumps(context);
 
         return artifacts.Count == 0 ? StageOutcome.Passed() : StageOutcome.Failed(artifacts);
+    }
+
+    private static void CopyProjectFiles(
+        string projectDirectory,
+        string outputDirectory,
+        ISet<string> usedOutputPaths)
+    {
+        if (string.IsNullOrEmpty(projectDirectory) || !Directory.Exists(projectDirectory))
+        {
+            return;
+        }
+
+        foreach (string sourcePath in Directory.EnumerateFiles(projectDirectory, "*", SearchOption.AllDirectories))
+        {
+            string relativePath = Path.GetRelativePath(projectDirectory, sourcePath);
+            if (HasExcludedDirectory(relativePath) ||
+                Path.GetExtension(sourcePath).Equals(".cs", StringComparison.OrdinalIgnoreCase) ||
+                Path.GetExtension(sourcePath).Equals(".csproj", StringComparison.OrdinalIgnoreCase) ||
+                IsUnderDirectory(sourcePath, outputDirectory))
+            {
+                continue;
+            }
+
+            string destinationPath = Path.Combine(outputDirectory, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
+            File.Copy(sourcePath, destinationPath, overwrite: true);
+            usedOutputPaths.Add(relativePath);
+        }
+    }
+
+    private static string OutputPathForSource(
+        string sourcePath,
+        LoadedCSharpProject project,
+        bool isReferencedProject,
+        ISet<string> usedOutputPaths)
+    {
+        string relativePath = RelativeSourcePath(sourcePath, project.ProjectDirectory);
+        relativePath = Path.ChangeExtension(relativePath, ".gs");
+        return UniqueOutputPath(PrefixReferencedProject(relativePath, project, isReferencedProject), usedOutputPaths);
+    }
+
+    private static string OutputPathForResx(
+        string sourcePath,
+        LoadedCSharpProject project,
+        bool isReferencedProject,
+        ISet<string> usedOutputPaths)
+    {
+        string relativePath = RelativeSourcePath(sourcePath, project.ProjectDirectory);
+        string directory = Path.GetDirectoryName(relativePath);
+        string fileName = Path.GetFileNameWithoutExtension(relativePath) +
+            GSharp.Core.Resx.ResxCodeGenerator.DesignerFileSuffix;
+        relativePath = string.IsNullOrEmpty(directory) ? fileName : Path.Combine(directory, fileName);
+        return UniqueOutputPath(PrefixReferencedProject(relativePath, project, isReferencedProject), usedOutputPaths);
+    }
+
+    private static string PrefixReferencedProject(
+        string relativePath,
+        LoadedCSharpProject project,
+        bool isReferencedProject)
+    {
+        if (!isReferencedProject)
+        {
+            return relativePath;
+        }
+
+        string projectName = project.Compilation.AssemblyName ?? "ReferencedProject";
+        foreach (char invalid in Path.GetInvalidFileNameChars())
+        {
+            projectName = projectName.Replace(invalid, '_');
+        }
+
+        return Path.Combine(".references", projectName, relativePath);
+    }
+
+    private static string RelativeSourcePath(string sourcePath, string projectDirectory)
+    {
+        string relativePath = Path.GetRelativePath(projectDirectory, sourcePath);
+        return IsOutsideDirectory(relativePath) ? Path.GetFileName(sourcePath) : relativePath;
+    }
+
+    private static string UniqueOutputPath(string relativePath, ISet<string> usedOutputPaths)
+    {
+        if (usedOutputPaths.Add(relativePath))
+        {
+            return relativePath;
+        }
+
+        string directory = Path.GetDirectoryName(relativePath);
+        string extension = Path.GetExtension(relativePath);
+        string baseName = Path.GetFileNameWithoutExtension(relativePath);
+        for (int suffix = 2; ; suffix++)
+        {
+            string fileName = baseName + "." + suffix + extension;
+            string candidate = string.IsNullOrEmpty(directory) ? fileName : Path.Combine(directory, fileName);
+            if (usedOutputPaths.Add(candidate))
+            {
+                return candidate;
+            }
+        }
+    }
+
+    private static string MirroredPath(string sourcePath, string projectDirectory, string outputDirectory)
+    {
+        string relativePath = Path.GetRelativePath(projectDirectory, sourcePath);
+        return IsOutsideDirectory(relativePath) ? sourcePath : Path.Combine(outputDirectory, relativePath);
+    }
+
+    private static bool HasExcludedDirectory(string relativePath)
+    {
+        string[] segments = relativePath.Split(
+            new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+            StringSplitOptions.RemoveEmptyEntries);
+        return segments.Any(s =>
+            s.Equals("bin", StringComparison.OrdinalIgnoreCase) ||
+            s.Equals("obj", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsOutsideDirectory(string relativePath) =>
+        Path.IsPathRooted(relativePath) ||
+        relativePath.Equals("..", StringComparison.Ordinal) ||
+        relativePath.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
+        relativePath.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal);
+
+    private static bool IsUnderDirectory(string path, string directory)
+    {
+        string relativePath = Path.GetRelativePath(directory, path);
+        return !IsOutsideDirectory(relativePath);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -100,6 +100,8 @@ public sealed class TranslateStage : IMigrationStage
             // (or, worse, collide with) output that belongs to the sibling.
             if (!isReferencedProject)
             {
+                context.RootNamespace = currentProject.RootNamespace;
+
                 foreach (string analyzerPath in currentProject.AnalyzerReferencePaths)
                 {
                     context.AnalyzerReferencePaths.Add(analyzerPath);

--- a/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
@@ -219,6 +219,41 @@ public class SdkCompileRunnerTests
             xml);
     }
 
+    [Fact]
+    public void RequiresExplicitProjectItem_UsesDefaultGlobForCopiedAvaloniaXaml()
+    {
+        Assert.False(SdkCompileRunner.RequiresExplicitProjectItem(
+            "/migration/Oahu.UI",
+            "/migration/Oahu.UI/Views/BookLibraryView.axaml;SourceItemGroup=AvaloniaXaml"));
+        Assert.True(SdkCompileRunner.RequiresExplicitProjectItem(
+            "/migration/Oahu.UI",
+            "/source/Oahu.UI/Views/BookLibraryView.axaml;SourceItemGroup=AvaloniaXaml"));
+    }
+
+    [Fact]
+    public void WriteIsolationBoundary_PreservesCopiedProjectBuildFiles()
+    {
+        string directory = Path.Combine(
+            Directory.GetCurrentDirectory(),
+            "sdkcompilerunnertests-isolation-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string propsPath = Path.Combine(directory, "Directory.Build.props");
+        const string Props = "<Project><PropertyGroup><Custom>true</Custom></PropertyGroup></Project>";
+        File.WriteAllText(propsPath, Props);
+
+        try
+        {
+            GsharpTestProjectRunner.WriteIsolationBoundary(directory);
+
+            Assert.Equal(Props, File.ReadAllText(propsPath));
+            Assert.True(File.Exists(Path.Combine(directory, "Directory.Build.targets")));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
     /// <summary>
     /// A scratch directory populated with one fake shared-framework assembly
     /// file, so <see cref="SdkCompileRunner.PartitionReferences"/>'s runtime-dir

--- a/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
@@ -197,6 +197,28 @@ public class SdkCompileRunnerTests
         Assert.Single(System.Text.RegularExpressions.Regex.Matches(xml, "<PackageReference"));
     }
 
+    [Fact]
+    public void BuildProjectXml_PreservesRootNamespaceAndAvaloniaXamlItems()
+    {
+        string xml = SdkCompileRunner.BuildProjectXml(
+            sdkVersion: "1.0.0",
+            target: TargetKind.Library,
+            rootNamespace: "Oahu.Core.UI.Avalonia",
+            gsFilePaths: new[] { "/migration/BookLibraryView_axaml.gs" },
+            packages: new List<(string Id, string Version)> { ("avalonia", "11.2.7") },
+            references: Array.Empty<string>(),
+            analyzerReferences: Array.Empty<string>(),
+            additionalFiles: new[]
+            {
+                "/source/Views/BookLibraryView.axaml;SourceItemGroup=AvaloniaXaml",
+            });
+
+        Assert.Contains("<RootNamespace>Oahu.Core.UI.Avalonia</RootNamespace>", xml);
+        Assert.Contains(
+            "<AvaloniaXaml Include=\"/source/Views/BookLibraryView.axaml\" />",
+            xml);
+    }
+
     /// <summary>
     /// A scratch directory populated with one fake shared-framework assembly
     /// file, so <see cref="SdkCompileRunner.PartitionReferences"/>'s runtime-dir

--- a/tools/cs2gs/Cs2Gs.Tests/TranslateStageResxTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TranslateStageResxTests.cs
@@ -41,7 +41,8 @@ public class TranslateStageResxTests
         }
 
         string projectDir = NewScratchDir("translate-resx");
-        File.WriteAllText(Path.Combine(projectDir, "Directory.Build.props"), "<Project></Project>");
+        const string DirectoryBuildProps = "<Project><PropertyGroup><SampleProperty>true</SampleProperty></PropertyGroup></Project>";
+        File.WriteAllText(Path.Combine(projectDir, "Directory.Build.props"), DirectoryBuildProps);
         string projectPath = Path.Combine(projectDir, "Sample.csproj");
         File.WriteAllText(projectPath, """
             <Project Sdk="Microsoft.NET.Sdk">
@@ -78,6 +79,19 @@ public class TranslateStageResxTests
         File.WriteAllText(
             Path.Combine(projectDir, "Program.cs"),
             "public class Program { public static void Main() { } }");
+        string viewsDir = Path.Combine(projectDir, "Views");
+        Directory.CreateDirectory(viewsDir);
+        File.WriteAllText(
+            Path.Combine(viewsDir, "MainView.cs"),
+            "namespace Sample.App.Views; public class MainView { }");
+        File.WriteAllText(Path.Combine(viewsDir, "MainView.axaml"), "<UserControl />");
+        string assetsDir = Path.Combine(projectDir, "Assets");
+        Directory.CreateDirectory(assetsDir);
+        File.WriteAllBytes(Path.Combine(assetsDir, "logo.bin"), new byte[] { 1, 2, 3 });
+        Directory.CreateDirectory(Path.Combine(projectDir, "bin"));
+        File.WriteAllText(Path.Combine(projectDir, "bin", "ignored.txt"), "ignore");
+        Directory.CreateDirectory(Path.Combine(projectDir, "obj"));
+        File.WriteAllText(Path.Combine(projectDir, "obj", "ignored.txt"), "ignore");
 
         string outRoot = NewOutputRoot("translate-resx");
         var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
@@ -96,6 +110,23 @@ public class TranslateStageResxTests
         string generated = File.ReadAllText(designerFile);
         Assert.Contains("Sample.App.Properties", generated);
         Assert.Contains("Greeting", generated);
+
+        string appOutputDir = Directory.GetParent(Path.GetDirectoryName(designerFile)).FullName;
+        Assert.True(File.Exists(Path.Combine(appOutputDir, "Program.gs")));
+        Assert.True(File.Exists(Path.Combine(appOutputDir, "Views", "MainView.gs")));
+        Assert.Equal(
+            "<UserControl />",
+            File.ReadAllText(Path.Combine(appOutputDir, "Views", "MainView.axaml")));
+        Assert.Equal(
+            new byte[] { 1, 2, 3 },
+            File.ReadAllBytes(Path.Combine(appOutputDir, "Assets", "logo.bin")));
+        Assert.True(File.Exists(Path.Combine(appOutputDir, "Properties", "Resources.resx")));
+        Assert.Equal(
+            DirectoryBuildProps,
+            File.ReadAllText(Path.Combine(appOutputDir, "Directory.Build.props")));
+        Assert.False(File.Exists(Path.Combine(appOutputDir, "Sample.csproj")));
+        Assert.False(Directory.Exists(Path.Combine(appOutputDir, "bin")));
+        Assert.False(Directory.Exists(Path.Combine(appOutputDir, "obj")));
 
         // The hand-authored Resources.Designer.cs must not itself have been
         // translated into a second competing .gs file.


### PR DESCRIPTION
## Summary
- preserve the source project directory structure in migration output
- translate project C# documents to G# at the corresponding relative path
- copy every other project file unchanged, excluding the original csproj plus bin and obj
- retain RESX files and generate each strongly typed Designer.gs beside its RESX
- generate a source-named gsproj with relative Compile paths and the original root namespace
- let copied AXAML files enter AvaloniaXaml through the normal default-item glob and #2312 hook
- avoid duplicate package-owned analyzers

## Root cause
#2312 fixed the G# SDK extensibility hook, but cs2gs flattened translated files into a separate run directory and left non-code assets in the original source tree. Its SDK project therefore had no local AXAML files for Avalonia default discovery, discarded captured generator inputs, and used the placeholder App project identity.

## Oahu.UI result
- output project is Oahu.UI.gsproj with RootNamespace=Oahu.Core.UI.Avalonia
- Converters, ViewModels, and Views retain their source layout
- all six AXAML files are copied unchanged and discovered without an explicit AvaloniaXaml ItemGroup
- Avalonia generates InitializeComponent and named fields exactly once
- every non-C# Oahu.UI source file matches the migrated copy byte-for-byte
- unique compile failures remain at 25, all unrelated to AXAML codebehind generation

## Tests
- migration and source-generator regression selection: 32 passed
- real Oahu.UI --via-sdk migration
- source/output content and translated-path comparison

Fixes #2294