### PR TITLE
cs2gs: preserve project references and generate solutions

### DIFF
--- a/tools/cs2gs/Cs2Gs.Cli/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/Program.cs
@@ -161,6 +161,7 @@ internal static class Program
         }
 
         (string corpus, List<string> appIds, PipelineOptions options, string baselinePath, bool baselineStrict) = parsed.Value;
+        options.SourceRoot = Path.GetFullPath(corpus);
 
         IReadOnlyList<CorpusApp> apps;
         if (appIds.Count > 0)
@@ -437,6 +438,9 @@ internal static class Program
                     case "--via-sdk":
                         options.CompileViaSdk = true;
                         break;
+                    case "--no-via-sdk":
+                        options.CompileViaSdk = false;
+                        break;
                     default:
                         Console.Error.WriteLine($"cs2gs: unknown option '{arg}'.");
                         PrintUsage();
@@ -589,8 +593,8 @@ internal static class Program
         Console.WriteLine("  --baseline <file> Gate on the gap ledger (tools/cs2gs/triage/gaps.json): fail only on");
         Console.WriteLine("                    NEW or REGRESSED fingerprints; known-open gaps are tolerated.");
         Console.WriteLine("  --baseline-strict Also fail on STALE ledger entries (nightly mode).");
-        Console.WriteLine("  --via-sdk         Build emitted G# via 'dotnet build' + Gsharp.NET.Sdk so source");
-        Console.WriteLine("                    generators run (issue #2261).");
+        Console.WriteLine("  --via-sdk         Build emitted G# via 'dotnet build' + Gsharp.NET.Sdk (default).");
+        Console.WriteLine("  --no-via-sdk      Use the legacy direct-gsc compile path.");
         Console.WriteLine();
         Console.WriteLine("report options:");
         Console.WriteLine("  --run <dir>       Existing run directory containing run.json (required).");

--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -58,7 +58,10 @@ public sealed class CompileStage : IMigrationStage
                 context.AdditionalGeneratorFiles,
                 context.RootNamespace,
                 context.Options.Config,
-                context.BuildOnlyPackageReferences);
+                context.BuildOnlyPackageReferences,
+                context.PackageReferences,
+                context.ProjectReferences,
+                context.Options.GeneratedProjectPaths);
 
             if (sdkResult.IsAvailable)
             {
@@ -73,8 +76,13 @@ public sealed class CompileStage : IMigrationStage
                 return Task.FromResult(BuildFailureOutcome(context, sdkResult.Errors, sdkSyntheticMessage));
             }
 
-            // Issue #2261: no locally-built Gsharp.NET.Sdk nupkg is available.
-            // Fall back to the gsc-direct path rather than failing the app.
+            string unavailableMessage = "dotnet build (--via-sdk) is unavailable: " +
+                sdkResult.UnavailableReason +
+                " Pass --no-via-sdk to explicitly use the legacy direct-gsc path.";
+            return Task.FromResult(BuildFailureOutcome(
+                context,
+                Array.Empty<GscDiagnostic>(),
+                unavailableMessage));
         }
 
         GscResult result = context.Gsc.Compile(

--- a/tools/cs2gs/Cs2Gs.Pipeline/DeclaredProjectItem.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/DeclaredProjectItem.cs
@@ -1,0 +1,121 @@
+// <copyright file="DeclaredProjectItem.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Cs2Gs.Pipeline;
+
+/// <summary>
+/// A declared MSBuild item copied from a source project into its generated
+/// G# project, including item-group conditions and all item metadata.
+/// </summary>
+public sealed class DeclaredProjectItem
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeclaredProjectItem"/> class.
+    /// </summary>
+    /// <param name="itemGroupCondition">The containing ItemGroup condition.</param>
+    /// <param name="element">The namespace-free item XML.</param>
+    /// <param name="sourceInclude">The absolute source ProjectReference target.</param>
+    public DeclaredProjectItem(string itemGroupCondition, XElement element, string sourceInclude = null)
+    {
+        this.ItemGroupCondition = itemGroupCondition;
+        this.Element = element ?? throw new ArgumentNullException(nameof(element));
+        this.SourceInclude = sourceInclude;
+    }
+
+    /// <summary>Gets the containing ItemGroup condition, or <see langword="null"/>.</summary>
+    public string ItemGroupCondition { get; }
+
+    /// <summary>Gets the namespace-free item XML.</summary>
+    public XElement Element { get; }
+
+    /// <summary>Gets the absolute source ProjectReference target, when applicable.</summary>
+    public string SourceInclude { get; }
+}
+
+/// <summary>Reads and rewrites declared project dependency items.</summary>
+internal static class DeclaredProjectItems
+{
+    internal static IReadOnlyList<DeclaredProjectItem> Read(string projectPath, string itemName)
+    {
+        if (string.IsNullOrEmpty(projectPath) || !File.Exists(projectPath))
+        {
+            return Array.Empty<DeclaredProjectItem>();
+        }
+
+        XDocument document = XDocument.Load(projectPath, LoadOptions.PreserveWhitespace);
+        string projectDirectory = Path.GetDirectoryName(Path.GetFullPath(projectPath));
+        var items = new List<DeclaredProjectItem>();
+        foreach (XElement itemGroup in document.Descendants().Where(
+            e => e.Name.LocalName.Equals("ItemGroup", StringComparison.OrdinalIgnoreCase)))
+        {
+            string groupCondition = itemGroup.Attribute("Condition")?.Value;
+            foreach (XElement item in itemGroup.Elements().Where(
+                e => e.Name.LocalName.Equals(itemName, StringComparison.OrdinalIgnoreCase)))
+            {
+                XElement clone = StripNamespaces(item);
+                string sourceInclude = null;
+                if (itemName.Equals("ProjectReference", StringComparison.OrdinalIgnoreCase))
+                {
+                    string include = item.Attribute("Include")?.Value;
+                    if (!string.IsNullOrEmpty(include) && !include.Contains("$(", StringComparison.Ordinal))
+                    {
+                        sourceInclude = Path.GetFullPath(Path.Combine(projectDirectory, include));
+                    }
+                }
+
+                items.Add(new DeclaredProjectItem(groupCondition, clone, sourceInclude));
+            }
+        }
+
+        return items;
+    }
+
+    internal static IReadOnlyList<string> ProjectReferencePaths(string projectPath) =>
+        Read(projectPath, "ProjectReference")
+            .Select(item => item.SourceInclude)
+            .Where(path => !string.IsNullOrEmpty(path))
+            .ToList();
+
+    internal static IReadOnlyList<DeclaredProjectItem> RewriteProjectReferences(
+        IReadOnlyList<DeclaredProjectItem> items,
+        string generatedProjectDirectory,
+        IReadOnlyDictionary<string, string> generatedProjectPaths)
+    {
+        var rewritten = new List<DeclaredProjectItem>();
+        foreach (DeclaredProjectItem item in items ?? Array.Empty<DeclaredProjectItem>())
+        {
+            XElement element = new XElement(item.Element);
+            string targetPath = item.SourceInclude;
+            if (!string.IsNullOrEmpty(targetPath) &&
+                generatedProjectPaths is not null &&
+                generatedProjectPaths.TryGetValue(Path.GetFullPath(targetPath), out string generatedPath))
+            {
+                targetPath = generatedPath;
+            }
+
+            if (!string.IsNullOrEmpty(targetPath))
+            {
+                element.SetAttributeValue("Include", Path.GetRelativePath(generatedProjectDirectory, targetPath));
+            }
+
+            rewritten.Add(new DeclaredProjectItem(item.ItemGroupCondition, element, item.SourceInclude));
+        }
+
+        return rewritten;
+    }
+
+    private static XElement StripNamespaces(XElement element) =>
+        new XElement(
+            element.Name.LocalName,
+            element.Attributes()
+                .Where(attribute => !attribute.IsNamespaceDeclaration)
+                .Select(attribute => new XAttribute(attribute.Name.LocalName, attribute.Value)),
+            element.Nodes().Select(node => node is XElement child ? StripNamespaces(child) : node));
+}

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -134,6 +134,12 @@ public sealed class StageExecutionContext
     /// </summary>
     public List<DeclaredPackageReference> BuildOnlyPackageReferences { get; } = new List<DeclaredPackageReference>();
 
+    /// <summary>Gets the source project's declared PackageReference items.</summary>
+    public List<DeclaredProjectItem> PackageReferences { get; } = new List<DeclaredProjectItem>();
+
+    /// <summary>Gets the source project's declared ProjectReference items.</summary>
+    public List<DeclaredProjectItem> ProjectReferences { get; } = new List<DeclaredProjectItem>();
+
     /// <summary>
     /// Gets or sets the absolute path of the assembly emitted by the Compile
     /// stage, published for the IL-verify stage to read (ADR-0115 §C). It is

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -114,6 +114,13 @@ public sealed class MigrationPipeline
             this.options.OutputRoot ?? Path.Combine(Directory.GetCurrentDirectory(), "cs2gs-runs"));
         string runDir = Path.Combine(outputRoot, runId);
         Directory.CreateDirectory(runDir);
+        this.options.GeneratedProjectPaths = apps.ToDictionary(
+            app => Path.GetFullPath(app.ProjectPath),
+            app => Path.Combine(
+                runDir,
+                SanitizeAppId(app.Id),
+                Path.GetFileNameWithoutExtension(app.ProjectPath) + ".gsproj"),
+            StringComparer.OrdinalIgnoreCase);
 
         IReadOnlyDictionary<string, List<TriageRetryEntry>> priorHistory =
             LoadPriorRetryEntries(outputRoot, runId);
@@ -127,18 +134,29 @@ public sealed class MigrationPipeline
             Succeeded = true,
         };
 
-        foreach (CorpusApp app in apps)
+        var appResults = new Dictionary<string, AppResult>(StringComparer.OrdinalIgnoreCase);
+        foreach (CorpusApp app in OrderForSdkBuild(apps))
         {
             cancellationToken.ThrowIfCancellationRequested();
             AppResult appResult = await this.RunAppAsync(
                 app, gsc, gscVersion, runId, timestamp, runDir, priorHistory, cancellationToken)
                 .ConfigureAwait(false);
-            runResult.Apps.Add(appResult);
+            appResults[app.Id] = appResult;
             if (!appResult.Succeeded)
             {
                 runResult.Succeeded = false;
             }
         }
+
+        foreach (CorpusApp app in apps)
+        {
+            runResult.Apps.Add(appResults[app.Id]);
+        }
+
+        SolutionGenerator.Generate(
+            this.options.SourceRoot,
+            runDir,
+            this.options.GeneratedProjectPaths);
 
         if (runResult.Succeeded && runResult.Apps.Any(a => a.Unverified))
         {
@@ -149,6 +167,53 @@ public sealed class MigrationPipeline
         File.WriteAllText(runJsonPath, JsonSerializer.Serialize(runResult, TriageSerialization.Options));
 
         return runResult;
+    }
+
+    private IReadOnlyList<CorpusApp> OrderForSdkBuild(IReadOnlyList<CorpusApp> apps)
+    {
+        if (!this.options.CompileViaSdk || apps.Count <= 1)
+        {
+            return apps;
+        }
+
+        var byPath = apps.ToDictionary(
+            app => Path.GetFullPath(app.ProjectPath),
+            StringComparer.OrdinalIgnoreCase);
+        var ordered = new List<CorpusApp>(apps.Count);
+        var visiting = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void Visit(CorpusApp app)
+        {
+            string path = Path.GetFullPath(app.ProjectPath);
+            if (!visited.Add(path))
+            {
+                return;
+            }
+
+            if (!visiting.Add(path))
+            {
+                return;
+            }
+
+            foreach (string referencePath in DeclaredProjectItems.ProjectReferencePaths(path))
+            {
+                if (byPath.TryGetValue(referencePath, out CorpusApp dependency))
+                {
+                    Visit(dependency);
+                }
+            }
+
+            visiting.Remove(path);
+            ordered.Add(app);
+        }
+
+        foreach (CorpusApp app in apps)
+        {
+            Visit(app);
+        }
+
+        return ordered;
     }
 
     private static string NewRunId(DateTime utc)

--- a/tools/cs2gs/Cs2Gs.Pipeline/PipelineOptions.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/PipelineOptions.cs
@@ -4,6 +4,8 @@
 
 namespace Cs2Gs.Pipeline;
 
+using System.Collections.Generic;
+
 /// <summary>
 /// Whole-run options for a <see cref="MigrationPipeline"/> execution: the
 /// optional <c>gsc</c> override, the runs-root output directory, and the build
@@ -34,6 +36,9 @@ public sealed class PipelineOptions
     /// </summary>
     public string OutputRoot { get; set; }
 
+    /// <summary>Gets or sets the source directory being migrated.</summary>
+    public string SourceRoot { get; set; }
+
     /// <summary>
     /// Gets or sets the build configuration used to locate the default compiler
     /// (<c>Release</c> by default).
@@ -47,10 +52,14 @@ public sealed class PipelineOptions
     /// runs Roslyn source generators (e.g. CommunityToolkit.Mvvm's
     /// <c>[ObservableProperty]</c>/<c>[RelayCommand]</c>) through its gsgen
     /// MSBuild targets, which the direct-gsc path does not — the dominant
-    /// remaining Oahu-migration blocker. Defaults to
-    /// <see langword="false"/> so a plain migrate run is unchanged; when the
-    /// SDK build is unavailable (no locally-built nupkg), the stage falls back
-    /// to the gsc-direct path rather than failing.
+    /// remaining Oahu-migration blocker. Defaults to <see langword="true"/>;
+    /// callers can explicitly disable it to use the legacy gsc-direct path.
     /// </summary>
-    public bool CompileViaSdk { get; set; }
+    public bool CompileViaSdk { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the canonical source-project to generated-project mapping
+    /// established before migration starts.
+    /// </summary>
+    internal IReadOnlyDictionary<string, string> GeneratedProjectPaths { get; set; }
 }

--- a/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
@@ -12,7 +12,7 @@ using System.Text.RegularExpressions;
 namespace Cs2Gs.Pipeline;
 
 /// <summary>
-/// Opt-in stage-2 compile path (issue #2261): instead of invoking <c>gsc</c>
+/// Default stage-2 compile path (issue #2261): instead of invoking <c>gsc</c>
 /// directly, builds the emitted G# with <c>dotnet build</c> against the
 /// locally-built <c>Gsharp.NET.Sdk</c>. The SDK's gsgen MSBuild targets run the
 /// real Roslyn source generators (e.g. CommunityToolkit.Mvvm's
@@ -21,9 +21,8 @@ namespace Cs2Gs.Pipeline;
 /// original C# project would, which the direct-gsc path — a bare
 /// <c>MetadataLoadContext</c> over an explicit reference/analyzer list — does
 /// not reproduce. This is the dominant remaining Oahu-migration blocker.
-/// The gsc-direct path (<see cref="CompileStage"/> default) remains unchanged;
-/// this runner is only exercised when <see cref="PipelineOptions.CompileViaSdk"/>
-/// is set.
+/// The gsc-direct path remains available when
+/// <see cref="PipelineOptions.CompileViaSdk"/> is explicitly disabled.
 /// </summary>
 public sealed class SdkCompileRunner
 {
@@ -71,6 +70,9 @@ public sealed class SdkCompileRunner
     /// compile-time reference DLL for <see cref="PartitionReferences"/> to
     /// recover. May be <see langword="null"/> or empty.
     /// </param>
+    /// <param name="packageReferences">The source project's declared PackageReference items.</param>
+    /// <param name="projectReferences">The source project's declared ProjectReference items.</param>
+    /// <param name="generatedProjectPaths">The source-to-generated project mapping.</param>
     /// <returns>The compile result, or an unavailable result when no local SDK nupkg can be found.</returns>
     public SdkCompileResult Compile(
         string appRunDir,
@@ -82,7 +84,10 @@ public sealed class SdkCompileRunner
         IReadOnlyList<string> additionalFiles,
         string rootNamespace,
         string config,
-        IReadOnlyList<DeclaredPackageReference> declaredPackageReferences = null)
+        IReadOnlyList<DeclaredPackageReference> declaredPackageReferences = null,
+        IReadOnlyList<DeclaredProjectItem> packageReferences = null,
+        IReadOnlyList<DeclaredProjectItem> projectReferences = null,
+        IReadOnlyDictionary<string, string> generatedProjectPaths = null)
     {
         if (string.IsNullOrEmpty(appRunDir))
         {
@@ -116,6 +121,14 @@ public sealed class SdkCompileRunner
 
         (List<(string Id, string Version)> packages, List<string> references) =
             PartitionReferences(referencePaths ?? Array.Empty<string>(), nugetPackagesRoot, runtimeDir);
+        bool hasDeclaredDependencyItems = packageReferences is not null || projectReferences is not null;
+        if (hasDeclaredDependencyItems)
+        {
+            packages.Clear();
+            references = references
+                .Where(path => !IsRepresentedByProjectReference(path, projectReferences))
+                .ToList();
+        }
 
         var packageIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         for (int i = 0; i < packages.Count; i++)
@@ -136,7 +149,11 @@ public sealed class SdkCompileRunner
             {
                 // The PackageReference contributes its analyzer assets. Adding
                 // the same DLL explicitly would run generators twice.
-                AddOrUpgradePackage(packages, packageIndex, owningPackage.Value.Id, owningPackage.Value.Version);
+                if (!hasDeclaredDependencyItems)
+                {
+                    AddOrUpgradePackage(packages, packageIndex, owningPackage.Value.Id, owningPackage.Value.Version);
+                }
+
                 continue;
             }
 
@@ -149,9 +166,17 @@ public sealed class SdkCompileRunner
         // here, carrying the PrivateAssets/IncludeAssets metadata `packages`
         // has no room for.
         var declaredOnlyPackages = new List<DeclaredPackageReference>();
+        var declaredPackageIds = new HashSet<string>(
+            (packageReferences ?? Array.Empty<DeclaredProjectItem>())
+                .Select(item => item.Element.Attribute("Include")?.Value)
+                .Where(id => !string.IsNullOrEmpty(id)),
+            StringComparer.OrdinalIgnoreCase);
         foreach (DeclaredPackageReference declared in declaredPackageReferences ?? Array.Empty<DeclaredPackageReference>())
         {
-            if (declared is null || string.IsNullOrWhiteSpace(declared.Id) || packageIndex.ContainsKey(declared.Id))
+            if (declared is null ||
+                string.IsNullOrWhiteSpace(declared.Id) ||
+                packageIndex.ContainsKey(declared.Id) ||
+                declaredPackageIds.Contains(declared.Id))
             {
                 continue;
             }
@@ -166,6 +191,11 @@ public sealed class SdkCompileRunner
         IReadOnlyList<string> explicitAdditionalFiles = (additionalFiles ?? Array.Empty<string>())
             .Where(spec => RequiresExplicitProjectItem(appRunDir, spec))
             .ToList();
+        IReadOnlyList<DeclaredProjectItem> rewrittenProjectReferences =
+            DeclaredProjectItems.RewriteProjectReferences(
+                projectReferences,
+                appRunDir,
+                generatedProjectPaths);
         string projectXml = BuildProjectXml(
             sdk.Value.Version,
             target,
@@ -175,7 +205,9 @@ public sealed class SdkCompileRunner
             references,
             analyzerReferences,
             declaredOnlyPackages,
-            explicitAdditionalFiles);
+            explicitAdditionalFiles,
+            packageReferences,
+            rewrittenProjectReferences);
         File.WriteAllText(projectPath, projectXml);
 
         var args = new List<string> { "build", projectPath, "-c", config ?? "Release" };
@@ -335,6 +367,8 @@ public sealed class SdkCompileRunner
     /// DLL to <paramref name="packages"/>.
     /// </param>
     /// <param name="additionalFiles">The source generator inputs to emit as project items.</param>
+    /// <param name="packageReferences">The declared PackageReference items to preserve.</param>
+    /// <param name="projectReferences">The declared ProjectReference items to preserve.</param>
     /// <returns>The full <c>.gsproj</c> XML text.</returns>
     internal static string BuildProjectXml(
         string sdkVersion,
@@ -345,7 +379,9 @@ public sealed class SdkCompileRunner
         IReadOnlyList<string> references,
         IReadOnlyList<string> analyzerReferences,
         IReadOnlyList<DeclaredPackageReference> declaredPackageReferences = null,
-        IReadOnlyList<string> additionalFiles = null)
+        IReadOnlyList<string> additionalFiles = null,
+        IReadOnlyList<DeclaredProjectItem> packageReferences = null,
+        IReadOnlyList<DeclaredProjectItem> projectReferences = null)
     {
         declaredPackageReferences ??= Array.Empty<DeclaredPackageReference>();
         additionalFiles ??= Array.Empty<string>();
@@ -408,6 +444,9 @@ public sealed class SdkCompileRunner
 
             sb.Append("  </ItemGroup>\n");
         }
+
+        AppendDeclaredItems(sb, packageReferences);
+        AppendDeclaredItems(sb, projectReferences);
 
         if (references.Count > 0)
         {
@@ -475,6 +514,60 @@ public sealed class SdkCompileRunner
             relativePath.Equals("..", StringComparison.Ordinal) ||
             relativePath.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
             relativePath.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal);
+    }
+
+    private static void AppendDeclaredItems(StringBuilder sb, IReadOnlyList<DeclaredProjectItem> items)
+    {
+        foreach (IGrouping<string, DeclaredProjectItem> group in
+            (items ?? Array.Empty<DeclaredProjectItem>()).GroupBy(item => item.ItemGroupCondition))
+        {
+            sb.Append('\n');
+            sb.Append("  <ItemGroup");
+            if (!string.IsNullOrEmpty(group.Key))
+            {
+                sb.Append(' ').Append(new System.Xml.Linq.XAttribute("Condition", group.Key));
+            }
+
+            sb.Append(">\n");
+            foreach (DeclaredProjectItem item in group)
+            {
+                string xml = item.Element.ToString(System.Xml.Linq.SaveOptions.DisableFormatting);
+                sb.Append("    ").Append(xml).Append('\n');
+            }
+
+            sb.Append("  </ItemGroup>\n");
+        }
+    }
+
+    private static bool IsRepresentedByProjectReference(
+        string referencePath,
+        IReadOnlyList<DeclaredProjectItem> projectReferences)
+    {
+        if (TryParsePackageFromPath(referencePath, ResolveNugetPackagesRoot()) is not null)
+        {
+            return true;
+        }
+
+        string fullReferencePath = Path.GetFullPath(referencePath);
+        foreach (DeclaredProjectItem projectReference in projectReferences ?? Array.Empty<DeclaredProjectItem>())
+        {
+            if (string.IsNullOrEmpty(projectReference.SourceInclude))
+            {
+                continue;
+            }
+
+            string projectDirectory = Path.GetDirectoryName(projectReference.SourceInclude);
+            string relative = Path.GetRelativePath(projectDirectory, fullReferencePath);
+            if (!Path.IsPathRooted(relative) &&
+                !relative.Equals("..", StringComparison.Ordinal) &&
+                !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
+                !relative.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Pipeline/SolutionGenerator.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SolutionGenerator.cs
@@ -1,0 +1,146 @@
+// <copyright file="SolutionGenerator.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace Cs2Gs.Pipeline;
+
+/// <summary>Generates target .slnx files with migrated project paths rewritten.</summary>
+internal static class SolutionGenerator
+{
+    private static readonly Regex SlnProjectPattern = new Regex(
+        "^Project\\(\"[^\"]+\"\\) = \"[^\"]+\", \"(?<path>[^\"]+)\",",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    internal static IReadOnlyList<string> Generate(
+        string sourceRoot,
+        string targetRoot,
+        IReadOnlyDictionary<string, string> generatedProjectPaths)
+    {
+        if (string.IsNullOrEmpty(targetRoot) || generatedProjectPaths is null || generatedProjectPaths.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        Directory.CreateDirectory(targetRoot);
+        string fullSourceRoot = string.IsNullOrEmpty(sourceRoot)
+            ? CommonDirectory(generatedProjectPaths.Keys)
+            : Path.GetFullPath(sourceRoot);
+        IReadOnlyList<string> sourceSolutions = Directory.Exists(fullSourceRoot)
+            ? Directory.EnumerateFiles(fullSourceRoot, "*.sln", SearchOption.TopDirectoryOnly)
+                .Concat(Directory.EnumerateFiles(fullSourceRoot, "*.slnx", SearchOption.TopDirectoryOnly))
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToList()
+            : Array.Empty<string>();
+
+        var written = new List<string>();
+        var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (sourceSolutions.Count == 0)
+        {
+            string name = new DirectoryInfo(fullSourceRoot).Name;
+            written.Add(WriteSolution(
+                Path.Combine(targetRoot, name + ".slnx"),
+                generatedProjectPaths.Values,
+                targetRoot));
+            return written;
+        }
+
+        foreach (string sourceSolution in sourceSolutions)
+        {
+            var targetProjects = new List<string>();
+            foreach (string sourceProject in ReadProjects(sourceSolution))
+            {
+                string canonical = Path.GetFullPath(sourceProject);
+                targetProjects.Add(
+                    generatedProjectPaths.TryGetValue(canonical, out string generated)
+                        ? generated
+                        : canonical);
+            }
+
+            if (!targetProjects.Any(project =>
+                generatedProjectPaths.Values.Contains(project, StringComparer.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            string baseName = Path.GetFileNameWithoutExtension(sourceSolution);
+            string fileName = baseName + ".slnx";
+            for (int suffix = 2; !usedNames.Add(fileName); suffix++)
+            {
+                fileName = baseName + "." + suffix + ".slnx";
+            }
+
+            written.Add(WriteSolution(Path.Combine(targetRoot, fileName), targetProjects, targetRoot));
+        }
+
+        return written;
+    }
+
+    internal static IReadOnlyList<string> ReadProjects(string solutionPath)
+    {
+        string directory = Path.GetDirectoryName(Path.GetFullPath(solutionPath));
+        if (Path.GetExtension(solutionPath).Equals(".slnx", StringComparison.OrdinalIgnoreCase))
+        {
+            return XDocument.Load(solutionPath)
+                .Descendants()
+                .Where(element => element.Name.LocalName.Equals("Project", StringComparison.OrdinalIgnoreCase))
+                .Select(element => element.Attribute("Path")?.Value)
+                .Where(path => !string.IsNullOrEmpty(path))
+                .Select(path => Path.GetFullPath(Path.Combine(directory, path)))
+                .ToList();
+        }
+
+        return File.ReadLines(solutionPath)
+            .Select(line => SlnProjectPattern.Match(line))
+            .Where(match => match.Success)
+            .Select(match => match.Groups["path"].Value)
+            .Where(path => Path.GetExtension(path).EndsWith("proj", StringComparison.OrdinalIgnoreCase))
+            .Select(path => Path.GetFullPath(Path.Combine(
+                directory,
+                path.Replace('\\', Path.DirectorySeparatorChar))))
+            .ToList();
+    }
+
+    private static string WriteSolution(string path, IEnumerable<string> projects, string targetRoot)
+    {
+        var solution = new XElement(
+            "Solution",
+            projects
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Select(project =>
+                {
+                    var element = new XElement(
+                        "Project",
+                        new XAttribute(
+                            "Path",
+                            Path.GetRelativePath(targetRoot, project).Replace('\\', '/')));
+                    if (Path.GetExtension(project).Equals(".gsproj", StringComparison.OrdinalIgnoreCase))
+                    {
+                        element.SetAttributeValue("Type", "C#");
+                    }
+
+                    return element;
+                }));
+        File.WriteAllText(path, solution.ToString() + Environment.NewLine);
+        return path;
+    }
+
+    private static string CommonDirectory(IEnumerable<string> paths)
+    {
+        string[] fullPaths = paths.Select(Path.GetFullPath).ToArray();
+        string common = Path.GetDirectoryName(fullPaths[0]);
+        while (fullPaths.Any(path =>
+            !path.StartsWith(common + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)))
+        {
+            common = Path.GetDirectoryName(common);
+        }
+
+        return common;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -39,9 +39,15 @@ public sealed class TranslateStage : IMigrationStage
             throw new ArgumentNullException(nameof(context));
         }
 
-        IReadOnlyList<LoadedCSharpProject> projects = await CSharpProjectLoader
-            .LoadProjectWithReferencesAsync(context.App.ProjectPath, cancellationToken)
-            .ConfigureAwait(false);
+        IReadOnlyList<LoadedCSharpProject> projects = context.Options.CompileViaSdk
+            ? new[]
+            {
+                await CSharpProjectLoader.LoadProjectAsync(context.App.ProjectPath, cancellationToken)
+                    .ConfigureAwait(false),
+            }
+            : await CSharpProjectLoader
+                .LoadProjectWithReferencesAsync(context.App.ProjectPath, cancellationToken)
+                .ConfigureAwait(false);
         LoadedCSharpProject project = projects[0];
 
         var artifacts = new List<TriageArtifact>();
@@ -65,6 +71,11 @@ public sealed class TranslateStage : IMigrationStage
 
         var usedOutputPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         CopyProjectFiles(project.ProjectDirectory, context.AppRunDir, usedOutputPaths);
+        CopyCentralPackageManagementFile(project.ProjectDirectory, context.AppRunDir);
+        context.PackageReferences.AddRange(
+            DeclaredProjectItems.Read(context.App.ProjectPath, "PackageReference"));
+        context.ProjectReferences.AddRange(
+            DeclaredProjectItems.Read(context.App.ProjectPath, "ProjectReference"));
 
         // Translate the app itself (index 0) plus its transitively referenced
         // sibling projects (Refs #914). Sibling G# is emitted so the app's uses
@@ -329,6 +340,25 @@ public sealed class TranslateStage : IMigrationStage
             Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
             File.Copy(sourcePath, destinationPath, overwrite: true);
             usedOutputPaths.Add(relativePath);
+        }
+    }
+
+    private static void CopyCentralPackageManagementFile(string projectDirectory, string outputDirectory)
+    {
+        string directory = projectDirectory;
+        while (!string.IsNullOrEmpty(directory))
+        {
+            string sourcePath = Path.Combine(directory, "Directory.Packages.props");
+            if (File.Exists(sourcePath))
+            {
+                File.Copy(
+                    sourcePath,
+                    Path.Combine(outputDirectory, "Directory.Packages.props"),
+                    overwrite: true);
+                return;
+            }
+
+            directory = Directory.GetParent(directory)?.FullName;
         }
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2215AnalyzerReferenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2215AnalyzerReferenceTests.cs
@@ -68,7 +68,13 @@ public class Issue2215AnalyzerReferenceTests
             p => string.Equals(Path.GetFileName(p), Path.GetFileName(generatorDll), StringComparison.OrdinalIgnoreCase));
 
         string outRoot = NewOutputRoot("analyzer-ref");
-        var options = new PipelineOptions { GscPath = compiler, GsgenPath = gsgen, OutputRoot = outRoot };
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            GsgenPath = gsgen,
+            OutputRoot = outRoot,
+            CompileViaSdk = false,
+        };
         var pipeline = new MigrationPipeline(options, new IMigrationStage[] { new TranslateStage(), new CompileStage() });
 
         var app = new CorpusApp("test/AnalyzerRefApp", projectPath, TargetKind.Library);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2317ProjectReferenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2317ProjectReferenceTests.cs
@@ -1,0 +1,116 @@
+// <copyright file="Issue2317ProjectReferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>Regression tests for issue #2317 dependency and solution fidelity.</summary>
+public class Issue2317ProjectReferenceTests
+{
+    [Fact]
+    public void PipelineOptions_UsesSdkCompilationByDefault()
+    {
+        Assert.True(new PipelineOptions().CompileViaSdk);
+    }
+
+    [Fact]
+    public void RewriteProjectReferences_UsesGeneratedProjectForMigratedTarget()
+    {
+        using var directory = new ScratchDirectory();
+        string sourceApp = Path.Combine(directory.Path, "src", "App");
+        string sourceLib = Path.Combine(directory.Path, "src", "Lib");
+        string targetApp = Path.Combine(directory.Path, "out", "App");
+        string targetLib = Path.Combine(directory.Path, "out", "Lib", "Lib.gsproj");
+        Directory.CreateDirectory(sourceApp);
+        Directory.CreateDirectory(sourceLib);
+        Directory.CreateDirectory(targetApp);
+        string projectPath = Path.Combine(sourceApp, "App.csproj");
+        File.WriteAllText(
+            projectPath,
+            "<Project><ItemGroup Condition=\"'$(Configuration)' == 'Release'\">" +
+            "<ProjectReference Include=\"../Lib/Lib.csproj\" Aliases=\"lib\" />" +
+            "</ItemGroup></Project>");
+
+        IReadOnlyList<DeclaredProjectItem> items =
+            DeclaredProjectItems.Read(projectPath, "ProjectReference");
+        IReadOnlyList<DeclaredProjectItem> rewritten =
+            DeclaredProjectItems.RewriteProjectReferences(
+                items,
+                targetApp,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [Path.Combine(sourceLib, "Lib.csproj")] = targetLib,
+                });
+
+        DeclaredProjectItem item = Assert.Single(rewritten);
+        Assert.Equal("'$(Configuration)' == 'Release'", item.ItemGroupCondition);
+        Assert.Equal(
+            Path.GetRelativePath(targetApp, targetLib),
+            item.Element.Attribute("Include")?.Value);
+        Assert.Equal("lib", item.Element.Attribute("Aliases")?.Value);
+    }
+
+    [Fact]
+    public void GenerateSolutions_WritesSlnxAndRewritesOnlyMigratedProjects()
+    {
+        using var directory = new ScratchDirectory();
+        string source = Path.Combine(directory.Path, "source");
+        string target = Path.Combine(directory.Path, "target");
+        string app = Path.Combine(source, "App", "App.csproj");
+        string library = Path.Combine(source, "Lib", "Lib.csproj");
+        string generatedApp = Path.Combine(target, "corpus_App", "App.gsproj");
+        Directory.CreateDirectory(Path.GetDirectoryName(app));
+        Directory.CreateDirectory(Path.GetDirectoryName(library));
+        File.WriteAllText(app, "<Project />");
+        File.WriteAllText(library, "<Project />");
+        Directory.CreateDirectory(source);
+        File.WriteAllText(
+            Path.Combine(source, "Sample.sln"),
+            "Microsoft Visual Studio Solution File, Format Version 12.00\n" +
+            "Project(\"{66A26720-8FB5-11D2-AA7E-00C04F688DDE}\") = \"src\", \"src\", \"{0}\"\n" +
+            "EndProject\n" +
+            "Project(\"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}\") = \"App\", \"App\\App.csproj\", \"{1}\"\n" +
+            "EndProject\n" +
+            "Project(\"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}\") = \"Lib\", \"Lib\\Lib.csproj\", \"{2}\"\n" +
+            "EndProject\n");
+
+        IReadOnlyList<string> solutions = SolutionGenerator.Generate(
+            source,
+            target,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [app] = generatedApp,
+            });
+
+        string solution = Assert.Single(solutions);
+        Assert.Equal(".slnx", Path.GetExtension(solution));
+        IReadOnlyList<string> projects = SolutionGenerator.ReadProjects(solution);
+        Assert.Contains(generatedApp, projects, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains(library, projects, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private sealed class ScratchDirectory : IDisposable
+    {
+        public ScratchDirectory()
+        {
+            this.Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "cs2gs-issue2317-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(this.Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            Directory.Delete(this.Path, recursive: true);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
@@ -220,6 +220,46 @@ public class SdkCompileRunnerTests
     }
 
     [Fact]
+    public void BuildProjectXml_PreservesDeclaredDependencyMetadataAndConditions()
+    {
+        var packages = new[]
+        {
+            new DeclaredProjectItem(
+                "'$(TargetFramework)' == 'net10.0'",
+                System.Xml.Linq.XElement.Parse(
+                    "<PackageReference Include=\"Example\" Version=\"1.2.3\" " +
+                    "PrivateAssets=\"all\"><Aliases>sample</Aliases></PackageReference>")),
+        };
+        var projects = new[]
+        {
+            new DeclaredProjectItem(
+                null,
+                System.Xml.Linq.XElement.Parse(
+                    "<ProjectReference Include=\"../Lib/Lib.gsproj\" " +
+                    "ReferenceOutputAssembly=\"false\"><Private>true</Private></ProjectReference>")),
+        };
+
+        string xml = SdkCompileRunner.BuildProjectXml(
+            sdkVersion: "1.0.0",
+            target: TargetKind.Library,
+            rootNamespace: null,
+            gsFilePaths: new[] { "Lib.gs" },
+            packages: Array.Empty<(string Id, string Version)>(),
+            references: Array.Empty<string>(),
+            analyzerReferences: Array.Empty<string>(),
+            packageReferences: packages,
+            projectReferences: projects);
+
+        Assert.Contains("<ItemGroup Condition=\"'$(TargetFramework)' == 'net10.0'\">", xml);
+        Assert.Contains(
+            "<PackageReference Include=\"Example\" Version=\"1.2.3\" PrivateAssets=\"all\"><Aliases>sample</Aliases></PackageReference>",
+            xml);
+        Assert.Contains(
+            "<ProjectReference Include=\"../Lib/Lib.gsproj\" ReferenceOutputAssembly=\"false\"><Private>true</Private></ProjectReference>",
+            xml);
+    }
+
+    [Fact]
     public void RequiresExplicitProjectItem_UsesDefaultGlobForCopiedAvaloniaXaml()
     {
         Assert.False(SdkCompileRunner.RequiresExplicitProjectItem(

--- a/website/docs/tooling/cs2gs.md
+++ b/website/docs/tooling/cs2gs.md
@@ -58,7 +58,8 @@ Useful `migrate` options:
 | --- | --- |
 | `--corpus <dir>` | Corpus root. Defaults to `tools\cs2gs\corpus` when run from the repository. |
 | `--app <id>` | Migrate only one app. May be repeated. |
-| `--via-sdk` | Build the emitted G# via `dotnet build` + the `Gsharp.NET.Sdk` (instead of invoking `gsc` directly) so source generators run. |
+| `--via-sdk` | Build the emitted G# via `dotnet build` + the `Gsharp.NET.Sdk` so source generators run. This is the default. |
+| `--no-via-sdk` | Use the legacy direct-`gsc` translation path instead of the SDK build. |
 | `--out <dir>` | Runs root for artifacts; default is `cs2gs-runs`. |
 | `--config <name>` | Build configuration used to find tools; default is `Release`. |
 | `--baseline <file>` | Gate on the gap ledger. New and regressed fingerprints fail; known-open gaps are tolerated. |


### PR DESCRIPTION
## Summary
- preserve declared PackageReference and ProjectReference items, including conditions and metadata
- rewrite migrated project references to generated gsproj files while retaining mixed-language source projects
- make SDK translation the default and require --no-via-sdk for the legacy direct-gsc path
- generate updated .slnx files in the migration output, including multiple source solutions

## Validation
- targeted cs2gs regression tests
- real default-SDK L1 migration
- generated .slnx list and build

Fixes #2317