### PR TITLE
Fix #2319: CPM Directory.Packages.props copy is bumped; generated NBGV PackageReference omits Version under CPM

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/CentralPackageManagementPolicy.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CentralPackageManagementPolicy.cs
@@ -1,0 +1,112 @@
+// <copyright file="CentralPackageManagementPolicy.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Cs2Gs.Pipeline;
+
+/// <summary>
+/// Detects whether a migrated app's ancestor <c>Directory.Packages.props</c>
+/// actually enables NuGet Central Package Management (issue #2319). Merely
+/// having a <c>Directory.Packages.props</c> file present does not enable CPM —
+/// NuGet requires the <c>ManagePackageVersionsCentrally</c> MSBuild property to
+/// be explicitly set <c>true</c>, most commonly inside that same file but
+/// occasionally in a shared ancestor <c>Directory.Build.props</c> instead. This
+/// distinction matters because the <c>--via-sdk</c> compile path must never
+/// emit a <c>Version=</c> attribute on a <c>PackageReference</c> it synthesizes
+/// when the generated app's copied <c>Directory.Packages.props</c> is actually
+/// governing versions — NuGet's CPM validation (NU1008) rejects that
+/// combination outright.
+/// </summary>
+public static class CentralPackageManagementPolicy
+{
+    private static readonly Regex ManagePackageVersionsCentrallyPattern = new Regex(
+        "<ManagePackageVersionsCentrally>\\s*(?<value>true|false)\\s*</ManagePackageVersionsCentrally>",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Determines whether Central Package Management is enabled for a copied
+    /// <c>Directory.Packages.props</c>.
+    /// </summary>
+    /// <param name="projectDirectory">The source project's own directory (the walk starts here).</param>
+    /// <param name="centralPackagesDirectory">
+    /// The directory containing the <c>Directory.Packages.props</c> that was
+    /// found and copied (the walk stops here, inclusive).
+    /// </param>
+    /// <param name="centralPackagesFileText">The already-read text of that <c>Directory.Packages.props</c>.</param>
+    /// <returns><see langword="true"/> when <c>ManagePackageVersionsCentrally</c> resolves to <c>true</c>.</returns>
+    public static bool IsEnabled(
+        string projectDirectory,
+        string centralPackagesDirectory,
+        string centralPackagesFileText)
+    {
+        // The documented, overwhelmingly common location: the property lives
+        // directly in Directory.Packages.props alongside the PackageVersion
+        // items it governs.
+        if (TryReadDeclaredValue(centralPackagesFileText, out bool declaredInCpmFile))
+        {
+            return declaredInCpmFile;
+        }
+
+        // Fall back to any ancestor Directory.Build.props between the project
+        // and the Directory.Packages.props directory (inclusive), closest to
+        // the project first, since a shared Directory.Build.props sometimes
+        // carries the property instead (e.g. so it can be toggled per-branch
+        // alongside other repo-wide build properties).
+        string directory = projectDirectory;
+        while (!string.IsNullOrEmpty(directory))
+        {
+            string candidate = Path.Combine(directory, "Directory.Build.props");
+            if (File.Exists(candidate))
+            {
+                string text;
+                try
+                {
+                    text = File.ReadAllText(candidate);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    text = null;
+                }
+
+                if (text is not null && TryReadDeclaredValue(text, out bool declaredInBuildProps))
+                {
+                    return declaredInBuildProps;
+                }
+            }
+
+            if (string.Equals(
+                Path.GetFullPath(directory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                Path.GetFullPath(centralPackagesDirectory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                StringComparison.OrdinalIgnoreCase))
+            {
+                break;
+            }
+
+            directory = Directory.GetParent(directory)?.FullName;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadDeclaredValue(string msbuildXml, out bool value)
+    {
+        value = false;
+        if (string.IsNullOrEmpty(msbuildXml))
+        {
+            return false;
+        }
+
+        Match match = ManagePackageVersionsCentrallyPattern.Match(msbuildXml);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        value = string.Equals(match.Groups["value"].Value, "true", StringComparison.OrdinalIgnoreCase);
+        return true;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -61,7 +61,8 @@ public sealed class CompileStage : IMigrationStage
                 context.BuildOnlyPackageReferences,
                 context.PackageReferences,
                 context.ProjectReferences,
-                context.Options.GeneratedProjectPaths);
+                context.Options.GeneratedProjectPaths,
+                context.UsesCentralPackageManagement);
 
             if (sdkResult.IsAvailable)
             {

--- a/tools/cs2gs/Cs2Gs.Pipeline/DeclaredProjectItem.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/DeclaredProjectItem.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using Cs2Gs.Translator.Loading;
 
 namespace Cs2Gs.Pipeline;
 
@@ -82,6 +83,64 @@ internal static class DeclaredProjectItems
             .Select(item => item.SourceInclude)
             .Where(path => !string.IsNullOrEmpty(path))
             .ToList();
+
+    /// <summary>
+    /// Bumps a below-floor literal <c>Version</c> attribute on a declared
+    /// <c>Nerdbank.GitVersioning</c> <c>PackageReference</c> item (issue #2319,
+    /// following #2225/#2267). When the source project's own <c>.csproj</c>
+    /// declares nbgv directly — rather than via an ancestor
+    /// <c>Directory.Build.props</c>/<c>Directory.Packages.props</c> split, the
+    /// shape <see cref="TranslateStage.EmitNerdbankGitVersioningBumps"/>'s
+    /// <see cref="StageExecutionContext.BuildOnlyPackageReferences"/> path
+    /// exists to recover — this same declared item is what
+    /// <c>SdkCompileRunner.BuildProjectXml</c>'s declared-item passthrough
+    /// re-emits <b>verbatim</b> into the generated <c>.gsproj</c>. Without this
+    /// rewrite the below-floor version silently survives into the isolated
+    /// build and nbgv never emits the G# <c>ThisAssembly</c> source. Every
+    /// other declared <c>PackageReference</c> item (including nbgv items that
+    /// are already at or above the floor, or carry a non-literal version this
+    /// policy cannot safely reason about) is returned unchanged — this never
+    /// touches ordinary package references, and a CPM project's own
+    /// versionless nbgv <c>PackageReference</c> has no <c>Version</c> attribute
+    /// to bump in the first place, so CPM behavior is unaffected.
+    /// </summary>
+    /// <param name="items">The declared <c>PackageReference</c> items read from the source project.</param>
+    /// <returns>
+    /// <paramref name="items"/> unchanged when no item needs bumping, otherwise
+    /// an equivalent list with the nbgv item's <c>Version</c> attribute bumped.
+    /// </returns>
+    internal static IReadOnlyList<DeclaredProjectItem> BumpNerdbankGitVersioningVersion(
+        IReadOnlyList<DeclaredProjectItem> items)
+    {
+        if (items is null || items.Count == 0)
+        {
+            return items ?? Array.Empty<DeclaredProjectItem>();
+        }
+
+        List<DeclaredProjectItem> rewritten = null;
+        for (int i = 0; i < items.Count; i++)
+        {
+            DeclaredProjectItem item = items[i];
+            string include = item.Element.Attribute("Include")?.Value;
+            string version = item.Element.Attribute("Version")?.Value;
+            bool isNbgv = string.Equals(
+                include, NerdbankGitVersioningPolicy.PackageId, StringComparison.OrdinalIgnoreCase);
+            if (!isNbgv || !NerdbankGitVersioningPolicy.TryGetRequiredBump(version, out string bumped))
+            {
+                rewritten?.Add(item);
+                continue;
+            }
+
+            // First bump found: materialize the prefix of untouched items so
+            // the returned list mirrors the input verbatim up to this point.
+            rewritten ??= new List<DeclaredProjectItem>(items.Take(i));
+            var element = new XElement(item.Element);
+            element.SetAttributeValue("Version", bumped);
+            rewritten.Add(new DeclaredProjectItem(item.ItemGroupCondition, element, item.SourceInclude));
+        }
+
+        return rewritten ?? items;
+    }
 
     internal static IReadOnlyList<DeclaredProjectItem> RewriteProjectReferences(
         IReadOnlyList<DeclaredProjectItem> items,

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -134,6 +134,17 @@ public sealed class StageExecutionContext
     /// </summary>
     public List<DeclaredPackageReference> BuildOnlyPackageReferences { get; } = new List<DeclaredPackageReference>();
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the generated app's copied
+    /// <c>Directory.Packages.props</c> actually enables NuGet Central Package
+    /// Management (<c>ManagePackageVersionsCentrally</c>, issue #2319). Set by
+    /// the Translate stage; consumed by the <c>--via-sdk</c> compile path so any
+    /// <c>PackageReference</c> it synthesizes (e.g. the bumped nbgv reference)
+    /// omits <c>Version=</c> — CPM forbids that attribute on project-level
+    /// <c>PackageReference</c> items and NuGet fails restore (NU1008) otherwise.
+    /// </summary>
+    public bool UsesCentralPackageManagement { get; set; }
+
     /// <summary>Gets the source project's declared PackageReference items.</summary>
     public List<DeclaredProjectItem> PackageReferences { get; } = new List<DeclaredProjectItem>();
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -145,7 +145,15 @@ public sealed class StageExecutionContext
     /// </summary>
     public bool UsesCentralPackageManagement { get; set; }
 
-    /// <summary>Gets the source project's declared PackageReference items.</summary>
+    /// <summary>
+    /// Gets the source project's declared PackageReference items. A below-floor
+    /// literal <c>Nerdbank.GitVersioning</c> <c>Version</c> declared directly on
+    /// this list's item (as opposed to split across an ancestor
+    /// <c>Directory.Build.props</c>/<c>Directory.Packages.props</c>, which
+    /// <see cref="BuildOnlyPackageReferences"/> instead covers) is already
+    /// bumped by the Translate stage (issue #2319) before being copied verbatim
+    /// into the generated <c>.gsproj</c>.
+    /// </summary>
     public List<DeclaredProjectItem> PackageReferences { get; } = new List<DeclaredProjectItem>();
 
     /// <summary>Gets the source project's declared ProjectReference items.</summary>

--- a/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
@@ -73,6 +73,14 @@ public sealed class SdkCompileRunner
     /// <param name="packageReferences">The source project's declared PackageReference items.</param>
     /// <param name="projectReferences">The source project's declared ProjectReference items.</param>
     /// <param name="generatedProjectPaths">The source-to-generated project mapping.</param>
+    /// <param name="usesCentralPackageManagement">
+    /// Whether the generated app's copied <c>Directory.Packages.props</c>
+    /// actually enables NuGet Central Package Management (issue #2319). When
+    /// <see langword="true"/>, any <c>PackageReference</c> this method
+    /// synthesizes (e.g. <paramref name="declaredPackageReferences"/>) omits
+    /// <c>Version=</c> — CPM's own <c>PackageVersion</c> items supply it, and
+    /// NuGet's restore fails (NU1008) if both are present.
+    /// </param>
     /// <returns>The compile result, or an unavailable result when no local SDK nupkg can be found.</returns>
     public SdkCompileResult Compile(
         string appRunDir,
@@ -87,7 +95,8 @@ public sealed class SdkCompileRunner
         IReadOnlyList<DeclaredPackageReference> declaredPackageReferences = null,
         IReadOnlyList<DeclaredProjectItem> packageReferences = null,
         IReadOnlyList<DeclaredProjectItem> projectReferences = null,
-        IReadOnlyDictionary<string, string> generatedProjectPaths = null)
+        IReadOnlyDictionary<string, string> generatedProjectPaths = null,
+        bool usesCentralPackageManagement = false)
     {
         if (string.IsNullOrEmpty(appRunDir))
         {
@@ -207,7 +216,8 @@ public sealed class SdkCompileRunner
             declaredOnlyPackages,
             explicitAdditionalFiles,
             packageReferences,
-            rewrittenProjectReferences);
+            rewrittenProjectReferences,
+            usesCentralPackageManagement);
         File.WriteAllText(projectPath, projectXml);
 
         var args = new List<string> { "build", projectPath, "-c", config ?? "Release" };
@@ -369,6 +379,15 @@ public sealed class SdkCompileRunner
     /// <param name="additionalFiles">The source generator inputs to emit as project items.</param>
     /// <param name="packageReferences">The declared PackageReference items to preserve.</param>
     /// <param name="projectReferences">The declared ProjectReference items to preserve.</param>
+    /// <param name="usesCentralPackageManagement">
+    /// Whether the generated app's copied <c>Directory.Packages.props</c>
+    /// actually enables NuGet Central Package Management (issue #2319). When
+    /// <see langword="true"/>, every synthesized <c>PackageReference</c> below
+    /// (both <paramref name="packages"/> and <paramref name="declaredPackageReferences"/>)
+    /// omits <c>Version=</c>, since CPM requires the version to come exclusively
+    /// from a <c>PackageVersion</c> item and rejects a project-level
+    /// <c>Version=</c> attribute outright (NU1008).
+    /// </param>
     /// <returns>The full <c>.gsproj</c> XML text.</returns>
     internal static string BuildProjectXml(
         string sdkVersion,
@@ -381,7 +400,8 @@ public sealed class SdkCompileRunner
         IReadOnlyList<DeclaredPackageReference> declaredPackageReferences = null,
         IReadOnlyList<string> additionalFiles = null,
         IReadOnlyList<DeclaredProjectItem> packageReferences = null,
-        IReadOnlyList<DeclaredProjectItem> projectReferences = null)
+        IReadOnlyList<DeclaredProjectItem> projectReferences = null,
+        bool usesCentralPackageManagement = false)
     {
         declaredPackageReferences ??= Array.Empty<DeclaredPackageReference>();
         additionalFiles ??= Array.Empty<string>();
@@ -417,18 +437,30 @@ public sealed class SdkCompileRunner
             sb.Append("  <ItemGroup>\n");
             foreach ((string id, string version) in packages)
             {
-                sb.Append("    <PackageReference Include=\"").Append(id)
-                    .Append("\" Version=\"").Append(version).Append("\" />\n");
+                sb.Append("    <PackageReference Include=\"").Append(id).Append('"');
+                if (!usesCentralPackageManagement)
+                {
+                    sb.Append(" Version=\"").Append(version).Append('"');
+                }
+
+                sb.Append(" />\n");
             }
 
             // Issue #2267: build/dev-only packages (e.g. Nerdbank.GitVersioning)
             // that contributed no compile-time DLL and so are absent from
             // `packages` above, re-declared here so their MSBuild source
-            // generators still run under `dotnet build`.
+            // generators still run under `dotnet build`. Issue #2319: under
+            // Central Package Management the version comes exclusively from
+            // the copied Directory.Packages.props's PackageVersion item — a
+            // Version= attribute here as well is rejected by NuGet (NU1008).
             foreach (DeclaredPackageReference declared in declaredPackageReferences)
             {
-                sb.Append("    <PackageReference Include=\"").Append(declared.Id)
-                    .Append("\" Version=\"").Append(declared.Version).Append('"');
+                sb.Append("    <PackageReference Include=\"").Append(declared.Id).Append('"');
+                if (!usesCentralPackageManagement)
+                {
+                    sb.Append(" Version=\"").Append(declared.Version).Append('"');
+                }
+
                 if (!string.IsNullOrEmpty(declared.PrivateAssets))
                 {
                     sb.Append(" PrivateAssets=\"").Append(declared.PrivateAssets).Append('"');

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -73,7 +73,8 @@ public sealed class TranslateStage : IMigrationStage
         CopyProjectFiles(project.ProjectDirectory, context.AppRunDir, usedOutputPaths);
         CopyCentralPackageManagementFile(project.ProjectDirectory, context.AppRunDir, context);
         context.PackageReferences.AddRange(
-            DeclaredProjectItems.Read(context.App.ProjectPath, "PackageReference"));
+            DeclaredProjectItems.BumpNerdbankGitVersioningVersion(
+                DeclaredProjectItems.Read(context.App.ProjectPath, "PackageReference")));
         context.ProjectReferences.AddRange(
             DeclaredProjectItems.Read(context.App.ProjectPath, "ProjectReference"));
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -71,7 +71,7 @@ public sealed class TranslateStage : IMigrationStage
 
         var usedOutputPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         CopyProjectFiles(project.ProjectDirectory, context.AppRunDir, usedOutputPaths);
-        CopyCentralPackageManagementFile(project.ProjectDirectory, context.AppRunDir);
+        CopyCentralPackageManagementFile(project.ProjectDirectory, context.AppRunDir, context);
         context.PackageReferences.AddRange(
             DeclaredProjectItems.Read(context.App.ProjectPath, "PackageReference"));
         context.ProjectReferences.AddRange(
@@ -343,7 +343,30 @@ public sealed class TranslateStage : IMigrationStage
         }
     }
 
-    private static void CopyCentralPackageManagementFile(string projectDirectory, string outputDirectory)
+    /// <summary>
+    /// Locates the ancestor <c>Directory.Packages.props</c> that governs the
+    /// source project (Central Package Management) and writes it into the
+    /// generated app root — the file NuGet actually restores the generated
+    /// <c>.gsproj</c> against. Issue #2319: a below-floor literal nbgv
+    /// <c>PackageVersion</c> is bumped here, in this copy, using the same
+    /// <see cref="NerdbankGitVersioningPolicy.TryBumpProjectXml"/> the
+    /// project-file bump path already uses — the previous behavior copied the
+    /// file verbatim and wrote the bumped text to an inert
+    /// <c>nbgv-bump/Directory.Packages.props</c> that nothing ever restored
+    /// against, so NuGet still saw the below-floor version while
+    /// <see cref="SdkCompileRunner"/> independently emitted a bumped
+    /// <c>Version=</c> attribute on the generated NBGV <c>PackageReference</c> —
+    /// a combination Central Package Management rejects outright (NU1008).
+    /// Also records on <paramref name="context"/> whether the copied file
+    /// actually enables CPM (<c>ManagePackageVersionsCentrally</c>), so the
+    /// <c>--via-sdk</c> compile path knows to omit <c>Version=</c> from any
+    /// <c>PackageReference</c> it synthesizes rather than reconstructs
+    /// verbatim from the source project.
+    /// </summary>
+    private static void CopyCentralPackageManagementFile(
+        string projectDirectory,
+        string outputDirectory,
+        StageExecutionContext context)
     {
         string directory = projectDirectory;
         while (!string.IsNullOrEmpty(directory))
@@ -351,10 +374,22 @@ public sealed class TranslateStage : IMigrationStage
             string sourcePath = Path.Combine(directory, "Directory.Packages.props");
             if (File.Exists(sourcePath))
             {
-                File.Copy(
-                    sourcePath,
-                    Path.Combine(outputDirectory, "Directory.Packages.props"),
-                    overwrite: true);
+                string original;
+                try
+                {
+                    original = File.ReadAllText(sourcePath);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    return;
+                }
+
+                string content = NerdbankGitVersioningPolicy.TryBumpProjectXml(original, out string bumped)
+                    ? bumped
+                    : original;
+                File.WriteAllText(Path.Combine(outputDirectory, "Directory.Packages.props"), content);
+                context.UsesCentralPackageManagement =
+                    CentralPackageManagementPolicy.IsEnabled(projectDirectory, directory, content);
                 return;
             }
 

--- a/tools/cs2gs/Cs2Gs.Tests/CentralPackageManagementPolicyTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/CentralPackageManagementPolicyTests.cs
@@ -1,0 +1,137 @@
+// <copyright file="CentralPackageManagementPolicyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="CentralPackageManagementPolicy"/> (issue #2319):
+/// the presence of a <c>Directory.Packages.props</c> file does not by itself
+/// enable NuGet Central Package Management — the
+/// <c>ManagePackageVersionsCentrally</c> MSBuild property must resolve
+/// <see langword="true"/>, either in that file itself (the documented,
+/// overwhelmingly common location) or in a shared ancestor
+/// <c>Directory.Build.props</c>.
+/// </summary>
+public class CentralPackageManagementPolicyTests
+{
+    [Fact]
+    public void IsEnabled_ReturnsTrue_WhenPropertyDeclaredInCentralPackagesFile()
+    {
+        using var scratch = new ScratchDirectory();
+        string projectDir = Path.Combine(scratch.Path, "src", "App");
+        Directory.CreateDirectory(projectDir);
+
+        bool enabled = CentralPackageManagementPolicy.IsEnabled(
+            projectDir,
+            scratch.Path,
+            """
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        Assert.True(enabled);
+    }
+
+    [Fact]
+    public void IsEnabled_ReturnsFalse_WhenCentralPackagesFilePresentButPropertyUnset()
+    {
+        using var scratch = new ScratchDirectory();
+        string projectDir = Path.Combine(scratch.Path, "src", "App");
+        Directory.CreateDirectory(projectDir);
+
+        bool enabled = CentralPackageManagementPolicy.IsEnabled(
+            projectDir,
+            scratch.Path,
+            """
+            <Project>
+              <ItemGroup>
+                <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        Assert.False(enabled);
+    }
+
+    [Fact]
+    public void IsEnabled_ReturnsFalse_WhenPropertyExplicitlyFalse()
+    {
+        using var scratch = new ScratchDirectory();
+        string projectDir = Path.Combine(scratch.Path, "src", "App");
+        Directory.CreateDirectory(projectDir);
+
+        bool enabled = CentralPackageManagementPolicy.IsEnabled(
+            projectDir,
+            scratch.Path,
+            """
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        Assert.False(enabled);
+    }
+
+    [Fact]
+    public void IsEnabled_FallsBackToAncestorDirectoryBuildProps_WhenCentralPackagesFileOmitsProperty()
+    {
+        using var scratch = new ScratchDirectory();
+        string srcDir = Path.Combine(scratch.Path, "src");
+        string projectDir = Path.Combine(srcDir, "App");
+        Directory.CreateDirectory(projectDir);
+
+        // The property is set in a Directory.Build.props between the project
+        // and the Directory.Packages.props directory, not in the CPM file
+        // itself (a less common but valid layout).
+        File.WriteAllText(
+            Path.Combine(srcDir, "Directory.Build.props"),
+            """
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        bool enabled = CentralPackageManagementPolicy.IsEnabled(
+            projectDir,
+            scratch.Path,
+            """
+            <Project>
+              <ItemGroup>
+                <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        Assert.True(enabled);
+    }
+
+    private sealed class ScratchDirectory : IDisposable
+    {
+        public ScratchDirectory()
+        {
+            this.Path = System.IO.Path.Combine(
+                AppContext.BaseDirectory, "scratch-projects", "cpm-policy", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(this.Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            Directory.Delete(this.Path, recursive: true);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/DeclaredProjectItemsNbgvBumpTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/DeclaredProjectItemsNbgvBumpTests.cs
@@ -1,0 +1,148 @@
+// <copyright file="DeclaredProjectItemsNbgvBumpTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Xml.Linq;
+using Cs2Gs.Pipeline;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="DeclaredProjectItems.BumpNerdbankGitVersioningVersion"/>
+/// (issue #2319 follow-up): when the source project's own <c>.csproj</c>
+/// declares <c>Nerdbank.GitVersioning</c> directly with a literal below-floor
+/// <c>Version</c> — rather than splitting the declaration across an ancestor
+/// <c>Directory.Build.props</c>/<c>Directory.Packages.props</c>, the shape
+/// <see cref="StageExecutionContext.BuildOnlyPackageReferences"/> exists to
+/// recover — this item is copied <b>verbatim</b> into the generated
+/// <c>.gsproj</c> by <c>SdkCompileRunner.BuildProjectXml</c>'s declared-item
+/// passthrough, so the bump has to happen on this list, not just via
+/// <see cref="StageExecutionContext.BuildOnlyPackageReferences"/>.
+/// </summary>
+public class DeclaredProjectItemsNbgvBumpTests
+{
+    [Fact]
+    public void BumpNerdbankGitVersioningVersion_BumpsBelowFloorLiteralVersion_PreservingOtherMetadata()
+    {
+        var items = new[]
+        {
+            new DeclaredProjectItem(
+                null,
+                XElement.Parse(
+                    "<PackageReference Include=\"Nerdbank.GitVersioning\" Version=\"3.7.115\" " +
+                    "PrivateAssets=\"all\" />")),
+        };
+
+        IReadOnlyList<DeclaredProjectItem> rewritten = DeclaredProjectItems.BumpNerdbankGitVersioningVersion(items);
+
+        DeclaredProjectItem item = Assert.Single(rewritten);
+        Assert.Equal(NerdbankGitVersioningPolicy.MinimumGSharpVersion, item.Element.Attribute("Version")?.Value);
+        Assert.Equal("all", item.Element.Attribute("PrivateAssets")?.Value);
+        Assert.Equal("Nerdbank.GitVersioning", item.Element.Attribute("Include")?.Value);
+    }
+
+    [Fact]
+    public void BumpNerdbankGitVersioningVersion_LeavesAtOrAboveFloorVersion_Unchanged()
+    {
+        var items = new[]
+        {
+            new DeclaredProjectItem(
+                null,
+                XElement.Parse(
+                    "<PackageReference Include=\"Nerdbank.GitVersioning\" Version=\"3.11.13-beta\" />")),
+        };
+
+        IReadOnlyList<DeclaredProjectItem> rewritten = DeclaredProjectItems.BumpNerdbankGitVersioningVersion(items);
+
+        Assert.Same(items, rewritten);
+    }
+
+    [Fact]
+    public void BumpNerdbankGitVersioningVersion_LeavesOrdinaryPackageReferences_Unchanged()
+    {
+        var items = new[]
+        {
+            new DeclaredProjectItem(
+                null,
+                XElement.Parse("<PackageReference Include=\"CommunityToolkit.Mvvm\" Version=\"1.0.0\" />")),
+        };
+
+        IReadOnlyList<DeclaredProjectItem> rewritten = DeclaredProjectItems.BumpNerdbankGitVersioningVersion(items);
+
+        Assert.Same(items, rewritten);
+    }
+
+    [Fact]
+    public void BumpNerdbankGitVersioningVersion_LeavesVersionlessCpmStylePackageReference_Unchanged()
+    {
+        // CPM's consumer-side PackageReference carries no Version attribute at
+        // all — nothing to bump, and this policy must never invent one (that
+        // would reintroduce issue #2319's NU1008 under CPM).
+        var items = new[]
+        {
+            new DeclaredProjectItem(
+                null,
+                XElement.Parse("<PackageReference Include=\"Nerdbank.GitVersioning\" PrivateAssets=\"all\" />")),
+        };
+
+        IReadOnlyList<DeclaredProjectItem> rewritten = DeclaredProjectItems.BumpNerdbankGitVersioningVersion(items);
+
+        Assert.Same(items, rewritten);
+        Assert.Null(Assert.Single(rewritten).Element.Attribute("Version"));
+    }
+
+    [Fact]
+    public void BumpNerdbankGitVersioningVersion_LeavesNonLiteralVersion_Unchanged()
+    {
+        // An MSBuild property reference cannot be safely reasoned about
+        // outside its original evaluation context (mirrors
+        // NerdbankGitVersioningPolicy.TryGetRequiredBump's own contract).
+        var items = new[]
+        {
+            new DeclaredProjectItem(
+                null,
+                XElement.Parse(
+                    "<PackageReference Include=\"Nerdbank.GitVersioning\" Version=\"$(NbgvVersion)\" />")),
+        };
+
+        IReadOnlyList<DeclaredProjectItem> rewritten = DeclaredProjectItems.BumpNerdbankGitVersioningVersion(items);
+
+        Assert.Same(items, rewritten);
+    }
+
+    [Fact]
+    public void BumpNerdbankGitVersioningVersion_OnlyRewritesTheMatchingItem_AmongMultipleDeclaredPackages()
+    {
+        var items = new[]
+        {
+            new DeclaredProjectItem(
+                null,
+                XElement.Parse("<PackageReference Include=\"Serilog\" Version=\"3.1.1\" />")),
+            new DeclaredProjectItem(
+                "'$(Configuration)' == 'Release'",
+                XElement.Parse(
+                    "<PackageReference Include=\"Nerdbank.GitVersioning\" Version=\"3.6.143\" " +
+                    "PrivateAssets=\"all\" />")),
+        };
+
+        IReadOnlyList<DeclaredProjectItem> rewritten = DeclaredProjectItems.BumpNerdbankGitVersioningVersion(items);
+
+        Assert.Equal(2, rewritten.Count);
+        Assert.Equal("Serilog", rewritten[0].Element.Attribute("Include")?.Value);
+        Assert.Equal("3.1.1", rewritten[0].Element.Attribute("Version")?.Value);
+        Assert.Equal(
+            NerdbankGitVersioningPolicy.MinimumGSharpVersion,
+            rewritten[1].Element.Attribute("Version")?.Value);
+        Assert.Equal("'$(Configuration)' == 'Release'", rewritten[1].ItemGroupCondition);
+    }
+
+    [Fact]
+    public void BumpNerdbankGitVersioningVersion_HandlesEmptyOrNullInput()
+    {
+        Assert.Empty(DeclaredProjectItems.BumpNerdbankGitVersioningVersion(null));
+        Assert.Empty(DeclaredProjectItems.BumpNerdbankGitVersioningVersion(System.Array.Empty<DeclaredProjectItem>()));
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2319AppLocalNbgvPackageReferenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2319AppLocalNbgvPackageReferenceTests.cs
@@ -1,0 +1,158 @@
+// <copyright file="Issue2319AppLocalNbgvPackageReferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// End-to-end regression coverage for issue #2319's app-local follow-up: a
+/// non-CPM project whose own <c>.csproj</c> declares <c>Nerdbank.GitVersioning</c>
+/// directly with a literal below-floor <c>Version</c> (no ancestor
+/// <c>Directory.Build.props</c>/<c>Directory.Packages.props</c> split) used to
+/// keep that below-floor version, because the declared-item passthrough in
+/// <c>SdkCompileRunner.BuildProjectXml</c> copies the app's own
+/// <c>PackageReference</c> verbatim, and <c>SdkCompileRunner.Compile</c>'s
+/// duplicate-avoidance filter (<c>declaredPackageIds</c>) then discards the
+/// correctly-bumped entry <see cref="TranslateStage.ExecuteAsync"/> separately
+/// records on <see cref="StageExecutionContext.BuildOnlyPackageReferences"/>,
+/// since the id is already "declared". This exercises the real Translate +
+/// Compile (<c>--via-sdk</c>) stages together and, when a locally-built
+/// <c>Gsharp.NET.Sdk</c> nupkg is available, runs a real <c>dotnet build</c> to
+/// prove the fix, not just the generated XML shape.
+/// </summary>
+public class Issue2319AppLocalNbgvPackageReferenceTests
+{
+    [Fact]
+    public async Task Pipeline_AppLocalNbgvFixture_BumpsDeclaredPackageReferenceVersionWithoutDuplication()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null || repoRoot is null ||
+            GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            // Gated like every other live --via-sdk e2e test in this suite:
+            // build GSharp.sln (and pack the SDK) first.
+            return;
+        }
+
+        // Non-CPM: no Directory.Packages.props/Directory.Build.props anywhere
+        // in the ancestry — the app's own .csproj is the sole and complete
+        // declaration, with a literal below-floor Version attribute.
+        string sourceRoot = NewScratchDir("issue2319-applocal-nbgv");
+        string projectDir = Path.Combine(sourceRoot, "src", "Sample");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "Sample.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <OutputType>Exe</OutputType>
+                <RootNamespace>Sample.App</RootNamespace>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" PrivateAssets="all" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(
+            Path.Combine(projectDir, "Program.cs"),
+            "public class Program { public static void Main() { } }");
+
+        string outputRoot = NewOutputRoot("issue2319-applocal-nbgv");
+        var app = new CorpusApp("test/AppLocalNbgvApp", projectPath, TargetKind.Exe);
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+
+            // CompileViaSdk left at its true default (issue #2261) — this is
+            // exactly the path where the below-floor literal Version used to
+            // survive verbatim into the generated .gsproj.
+        };
+        var pipeline = new MigrationPipeline(options, new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+
+        string appRunDir = Path.Combine(outputRoot, result.RunId, MigrationPipeline.SanitizeAppId(app.Id));
+        string generatedProjectXml = File.ReadAllText(
+            Directory.GetFiles(appRunDir, "*.gsproj", SearchOption.TopDirectoryOnly).Single());
+
+        // Expected fix (1): the app's own declared PackageReference is bumped
+        // in place — not left at the original below-floor literal.
+        Assert.Contains(
+            "<PackageReference Include=\"Nerdbank.GitVersioning\" Version=\"3.11.13-beta\" PrivateAssets=\"all\" />",
+            generatedProjectXml);
+        Assert.DoesNotContain("3.7.115", generatedProjectXml);
+
+        // Expected fix (2): no duplicate PackageReference for nbgv — the
+        // separately-recorded BuildOnlyPackageReferences entry must still be
+        // filtered out by SdkCompileRunner.Compile's declaredPackageIds check
+        // now that the surviving declared copy already carries the fix.
+        int occurrences = CountOccurrences(generatedProjectXml, "Include=\"Nerdbank.GitVersioning\"");
+        Assert.Equal(1, occurrences);
+
+        // Expected fix (3): the real dotnet build (via-sdk) actually succeeds.
+        Assert.True(
+            appResult.Succeeded,
+            "Expected the --via-sdk build to succeed for the app-local nbgv fixture. AppResult: " +
+                string.Join(
+                    "; ",
+                    appResult.Stages.Select(s => s.Stage + "=" + s.Status)));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+
+    private static string NewOutputRoot(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "pipeline-tests", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string NewScratchDir(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "scratch-projects", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, projectDirName, dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2319CentralPackageManagementNbgvTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2319CentralPackageManagementNbgvTests.cs
@@ -1,0 +1,171 @@
+// <copyright file="Issue2319CentralPackageManagementNbgvTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// End-to-end regression coverage for issue #2319: a Central Package
+/// Management (CPM) repository whose <c>Directory.Packages.props</c> pins a
+/// below-floor <c>Nerdbank.GitVersioning</c> (nbgv) version used to fail
+/// <c>--via-sdk</c> restore with NU1008, because the copied
+/// <c>Directory.Packages.props</c> kept the original below-floor version while
+/// <see cref="SdkCompileRunner"/> independently emitted a bumped
+/// <c>Version=</c> attribute on the generated nbgv <c>PackageReference</c> —
+/// a combination CPM rejects outright. This exercises the real Translate +
+/// Compile (<c>--via-sdk</c>) stages together and, when a locally-built
+/// <c>Gsharp.NET.Sdk</c> nupkg is available, runs a real <c>dotnet build</c> to
+/// prove the fix, not just the generated XML shape.
+/// </summary>
+public class Issue2319CentralPackageManagementNbgvTests
+{
+    [Fact]
+    public async Task Pipeline_CpmNbgvFixture_BumpsCopiedPropsAndOmitsVersionOnGeneratedPackageReference()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null || repoRoot is null ||
+            GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            // Gated like every other live --via-sdk e2e test in this suite:
+            // build GSharp.sln (and pack the SDK) first.
+            return;
+        }
+
+        // Mirrors the reported repro: a repo-root Directory.Packages.props
+        // that actually enables CPM and pins a below-floor literal nbgv
+        // version, with the consumer-side versionless PackageReference
+        // declared in a nested Directory.Build.props (Oahu's own layout).
+        string sourceRoot = NewScratchDir("issue2319-cpm-nbgv");
+        File.WriteAllText(
+            Path.Combine(sourceRoot, "Directory.Packages.props"),
+            """
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        string srcDir = Path.Combine(sourceRoot, "src");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(
+            Path.Combine(srcDir, "Directory.Build.props"),
+            """
+            <Project>
+              <ItemGroup>
+                <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        string projectDir = Path.Combine(srcDir, "Sample");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "Sample.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <OutputType>Exe</OutputType>
+                <RootNamespace>Sample.App</RootNamespace>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(
+            Path.Combine(projectDir, "Program.cs"),
+            "public class Program { public static void Main() { } }");
+
+        string outputRoot = NewOutputRoot("issue2319-cpm-nbgv");
+        var app = new CorpusApp("test/CpmNbgvApp", projectPath, TargetKind.Exe);
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+
+            // CompileViaSdk left at its true default (issue #2261) — this is
+            // exactly the path that failed with NU1008 before the fix.
+        };
+        var pipeline = new MigrationPipeline(options, new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+
+        string appRunDir = Path.Combine(outputRoot, result.RunId, MigrationPipeline.SanitizeAppId(app.Id));
+        string generatedProps = Path.Combine(appRunDir, "Directory.Packages.props");
+        string generatedProjectXml = File.ReadAllText(
+            Directory.GetFiles(appRunDir, "*.gsproj", SearchOption.TopDirectoryOnly).Single());
+
+        // Expected fix (1): the copied Directory.Packages.props — the file
+        // actually consumed by the generated app — carries the bumped
+        // version, not the inert nbgv-bump side channel.
+        Assert.True(File.Exists(generatedProps), "Expected a copied Directory.Packages.props in the app run dir.");
+        string propsText = File.ReadAllText(generatedProps);
+        Assert.Contains(
+            "<PackageVersion Include=\"Nerdbank.GitVersioning\" Version=\"3.11.13-beta\" />",
+            propsText);
+        Assert.DoesNotContain("3.7.115", propsText);
+
+        // Expected fix (2): the generated NBGV PackageReference carries no
+        // Version= attribute — CPM supplies it exclusively via PackageVersion.
+        Assert.Contains(
+            "<PackageReference Include=\"Nerdbank.GitVersioning\" PrivateAssets=\"all\" />",
+            generatedProjectXml);
+        Assert.DoesNotContain(
+            "<PackageReference Include=\"Nerdbank.GitVersioning\" Version=",
+            generatedProjectXml);
+
+        // Expected fix (3): the real dotnet build (via-sdk) actually succeeds —
+        // before the fix this failed restore with NU1008.
+        Assert.True(
+            appResult.Succeeded,
+            "Expected the --via-sdk build to succeed for the CPM+nbgv fixture. AppResult: " +
+                string.Join(
+                    "; ",
+                    appResult.Stages.Select(s => s.Stage + "=" + s.Status)));
+    }
+
+    private static string NewOutputRoot(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "pipeline-tests", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string NewScratchDir(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "scratch-projects", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, projectDirName, dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/SdkCompileRunnerTests.cs
@@ -174,6 +174,62 @@ public class SdkCompileRunnerTests
     }
 
     [Fact]
+    public void BuildProjectXml_OmitsVersionOnDeclaredNbgvPackageReference_WhenCentralPackageManagementIsUsed()
+    {
+        // Issue #2319: under CPM the version comes exclusively from the copied
+        // Directory.Packages.props's <PackageVersion> item. A Version=
+        // attribute on the generated <PackageReference> as well is rejected by
+        // NuGet's CPM validation (NU1008), so BuildProjectXml must omit it here.
+        var declared = new[]
+        {
+            new DeclaredPackageReference(
+                NerdbankGitVersioningPolicy.PackageId,
+                NerdbankGitVersioningPolicy.MinimumGSharpVersion,
+                privateAssets: "all"),
+        };
+
+        string xml = SdkCompileRunner.BuildProjectXml(
+            sdkVersion: "1.0.0",
+            target: TargetKind.Exe,
+            rootNamespace: null,
+            gsFilePaths: new[] { "/app/Program.gs" },
+            packages: Array.Empty<(string Id, string Version)>(),
+            references: Array.Empty<string>(),
+            analyzerReferences: Array.Empty<string>(),
+            declaredPackageReferences: declared,
+            usesCentralPackageManagement: true);
+
+        Assert.Contains(
+            "<PackageReference Include=\"Nerdbank.GitVersioning\" PrivateAssets=\"all\" />",
+            xml);
+        Assert.DoesNotContain("Version=", xml);
+    }
+
+    [Fact]
+    public void BuildProjectXml_OmitsVersionOnReconstructedPackage_WhenCentralPackageManagementIsUsed()
+    {
+        // Issue #2319: the same Version= suppression must apply to the
+        // DLL-reconstructed `packages` set, not just the declared build-only
+        // set, so BuildProjectXml stays internally consistent whenever CPM
+        // governs the generated app (even though in the real --via-sdk
+        // CompileStage call shape `packages` is always empty once declared
+        // PackageReference items are present).
+        string xml = SdkCompileRunner.BuildProjectXml(
+            sdkVersion: "1.0.0",
+            target: TargetKind.Library,
+            rootNamespace: null,
+            gsFilePaths: new[] { "/app/Lib.gs" },
+            packages: new List<(string Id, string Version)> { ("communitytoolkit.mvvm", "8.4.0") },
+            references: Array.Empty<string>(),
+            analyzerReferences: Array.Empty<string>(),
+            declaredPackageReferences: Array.Empty<DeclaredPackageReference>(),
+            usesCentralPackageManagement: true);
+
+        Assert.Contains("<PackageReference Include=\"communitytoolkit.mvvm\" />", xml);
+        Assert.DoesNotContain("Version=", xml);
+    }
+
+    [Fact]
     public void BuildProjectXml_DoesNotDuplicateDeclaredPackage_WhenAlreadyReconstructedFromDll()
     {
         // A package that DID resolve a compile-time DLL is already fully

--- a/tools/cs2gs/Cs2Gs.Tests/TranslateStageNbgvPackageReferenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TranslateStageNbgvPackageReferenceTests.cs
@@ -43,6 +43,9 @@ public class TranslateStageNbgvPackageReferenceTests
             Path.Combine(repoDir, "Directory.Packages.props"),
             """
             <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+              </PropertyGroup>
               <ItemGroup>
                 <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
               </ItemGroup>
@@ -92,6 +95,67 @@ public class TranslateStageNbgvPackageReferenceTests
         Assert.Equal(NerdbankGitVersioningPolicy.PackageId, nbgvReference.Id);
         Assert.Equal(NerdbankGitVersioningPolicy.MinimumGSharpVersion, nbgvReference.Version);
         Assert.Equal("all", nbgvReference.PrivateAssets);
+
+        // Issue #2319: the copied Directory.Packages.props — the file NuGet
+        // actually restores the generated app against — must itself carry the
+        // bumped version; a verbatim copy plus the previous inert
+        // nbgv-bump/Directory.Packages.props left the below-floor version in
+        // place for restore. The Translate stage must also record that CPM
+        // governs this app so the Compile stage omits Version= from any
+        // PackageReference it synthesizes.
+        Assert.True(context.UsesCentralPackageManagement);
+        string copiedProps = File.ReadAllText(Path.Combine(appRunDir, "Directory.Packages.props"));
+        Assert.Contains(
+            "<PackageVersion Include=\"Nerdbank.GitVersioning\" Version=\"3.11.13-beta\" />",
+            copiedProps);
+        Assert.DoesNotContain("3.7.115", copiedProps);
+    }
+
+    [Fact]
+    public async Task TranslateStage_NonCpmProject_LeavesCentralPackageManagementDisabledAndCopiesNoPropsFile()
+    {
+        // Preserve non-CPM behavior (issue #2319): when the source project's
+        // ancestry has no Directory.Packages.props at all, no such file should
+        // be copied, and UsesCentralPackageManagement must stay false so the
+        // Compile stage keeps emitting a normal Version= attribute.
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        string repoDir = NewScratchDir("translate-nbgv-noncpm");
+        string projectDir = Path.Combine(repoDir, "src", "Sample");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "Sample.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <OutputType>Exe</OutputType>
+                <RootNamespace>Sample.App</RootNamespace>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" PrivateAssets="all" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(
+            Path.Combine(projectDir, "Program.cs"),
+            "public class Program { public static void Main() { } }");
+
+        string appRunDir = NewOutputRoot("translate-nbgv-noncpm");
+        var app = new CorpusApp("test/NbgvNonCpmApp", projectPath, TargetKind.Exe);
+        var options = new PipelineOptions { GscPath = compiler };
+        var gsc = new GscInvoker(compiler);
+        var triage = new TriageBuilder("test-run", "2026-01-01T00:00:00Z", "0.0.0", app.Id);
+        var context = new StageExecutionContext(app, options, gsc, appRunDir, triage);
+
+        StageOutcome outcome = await new TranslateStage().ExecuteAsync(context);
+
+        Assert.Equal(StageStatus.Passed, outcome.Status);
+        Assert.False(context.UsesCentralPackageManagement);
+        Assert.False(File.Exists(Path.Combine(appRunDir, "Directory.Packages.props")));
     }
 
     private static string NewOutputRoot(string label)

--- a/tools/cs2gs/Cs2Gs.Tests/TranslateStageNbgvPackageReferenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TranslateStageNbgvPackageReferenceTests.cs
@@ -112,7 +112,7 @@ public class TranslateStageNbgvPackageReferenceTests
     }
 
     [Fact]
-    public async Task TranslateStage_NonCpmProject_LeavesCentralPackageManagementDisabledAndCopiesNoPropsFile()
+    public async Task TranslateStage_NonCpmProject_LeavesCentralPackageManagementDisabledAndBumpsAppLocalDeclaration()
     {
         // Preserve non-CPM behavior (issue #2319): when the source project's
         // ancestry has no Directory.Packages.props at all, no such file should
@@ -156,6 +156,24 @@ public class TranslateStageNbgvPackageReferenceTests
         Assert.Equal(StageStatus.Passed, outcome.Status);
         Assert.False(context.UsesCentralPackageManagement);
         Assert.False(File.Exists(Path.Combine(appRunDir, "Directory.Packages.props")));
+
+        // Issue #2319 follow-up: an app-local literal Version= below the floor
+        // is declared directly (not split across an ancestor Directory.Build/
+        // Packages.props), so BuildOnlyPackageReferences alone cannot recover
+        // it — SdkCompileRunner.Compile's declaredPackageIds filter would
+        // discard that entry as a duplicate of this already-"declared" item,
+        // and SdkCompileRunner.BuildProjectXml copies this item verbatim. The
+        // bump must therefore happen here, on context.PackageReferences itself.
+        DeclaredProjectItem nbgvItem = Assert.Single(
+            context.PackageReferences,
+            item => string.Equals(
+                item.Element.Attribute("Include")?.Value,
+                NerdbankGitVersioningPolicy.PackageId,
+                StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(
+            NerdbankGitVersioningPolicy.MinimumGSharpVersion,
+            nbgvItem.Element.Attribute("Version")?.Value);
+        Assert.Equal("all", nbgvItem.Element.Attribute("PrivateAssets")?.Value);
     }
 
     private static string NewOutputRoot(string label)


### PR DESCRIPTION
## Summary

Fixes #2319. `cs2gs migrate --via-sdk` failed NuGet restore (NU1008) for Central Package Management (CPM) repositories using Nerdbank.GitVersioning (nbgv), because the below-floor nbgv version bump never reached the file NuGet actually restores against, while the generated `.gsproj` still carried a `Version=` attribute that CPM forbids. This PR also completes a related edge case: an app-local literal, below-floor nbgv `Version=` declared directly in the app's own `.csproj` (non-CPM) was likewise not bumped.

## Root cause (CPM + NU1008)

- `TranslateStage.CopyCentralPackageManagementFile` copied the source `Directory.Packages.props` **verbatim** into the generated app root.
- `TranslateStage.EmitNerdbankGitVersioningBumps` wrote the correctly-bumped CPM content to an **inert, never-restored-against** `nbgv-bump/Directory.Packages.props`.
- `SdkCompileRunner.BuildProjectXml` independently emitted a bumped `Version=` attribute on the generated nbgv `PackageReference`.
- NuGet's CPM validation rejects a project-level `Version=` attribute alongside `ManagePackageVersionsCentrally=true` outright (NU1008), so restore failed before gsc ever ran.

## Root cause (app-local declared Version, non-CPM)

- When the app's own `.csproj` declares `Nerdbank.GitVersioning` directly with a literal below-floor `Version=` (not split across an ancestor `Directory.Build.props`), that declared item is copied **verbatim** into the generated `.gsproj` via `SdkCompileRunner.BuildProjectXml`'s existing declared-item passthrough.
- `SdkCompileRunner.Compile`'s duplicate-avoidance filter (`declaredPackageIds`) then discards the separately-computed, correctly-bumped `BuildOnlyPackageReferences` entry as an already-"declared" duplicate, so the below-floor version silently survived.

## Fix

- `TranslateStage.CopyCentralPackageManagementFile` now bumps the **actual copied** `Directory.Packages.props` content in place, reusing the existing `NerdbankGitVersioningPolicy.TryBumpProjectXml` helper (no duplicated bump logic) instead of a verbatim `File.Copy`.
- New `CentralPackageManagementPolicy.IsEnabled` detects whether `ManagePackageVersionsCentrally` actually resolves `true` for the copied file — checking the file itself first (the documented, common location), then falling back to an ancestor `Directory.Build.props`. Presence of `Directory.Packages.props` alone does **not** enable CPM per NuGet's own docs.
- `StageExecutionContext.UsesCentralPackageManagement` threads that signal from `TranslateStage` through `CompileStage` into `SdkCompileRunner.Compile`/`BuildProjectXml`, which now omits `Version=` from any `PackageReference` it synthesizes (both the nbgv "declared build-only" set and the DLL-reconstructed set) whenever CPM governs the generated app.
- New `DeclaredProjectItems.BumpNerdbankGitVersioningVersion` rewrites a matching app-local declared nbgv `PackageReference`'s below-floor literal `Version` attribute in place — again reusing `NerdbankGitVersioningPolicy.TryGetRequiredBump` (no duplicated bump logic) — leaving every other declared item/attribute untouched. `TranslateStage` now routes the app's own declared `PackageReference` items through this rewrite before they reach `context.PackageReferences`.
- Non-CPM apps, and ordinary (non-nbgv) package references, are unaffected — verified by dedicated regression tests.

This generalizes beyond Oahu: any CPM + nbgv (or CPM + any build-only declared package) repository hits the same fix, since detection is based on the actual `ManagePackageVersionsCentrally` property rather than any Oahu-specific path; likewise the app-local bump applies to any project declaring nbgv directly, regardless of repo layout.

## Tests

- `CentralPackageManagementPolicyTests` (new): unit coverage for the CPM-detection helper — property set in the CPM file, absent, explicitly `false`, and the ancestor `Directory.Build.props` fallback.
- `SdkCompileRunnerTests` (extended): `BuildProjectXml` omits `Version=` for both the declared-only and DLL-reconstructed package sets when `usesCentralPackageManagement: true`; existing non-CPM cases unchanged.
- `TranslateStageNbgvPackageReferenceTests` (extended): the existing CPM-split nbgv fixture now also asserts the copied `Directory.Packages.props` is bumped in place (`3.11.13-beta`, not `3.7.115`) and `UsesCentralPackageManagement` is `true`; the non-CPM regression case now additionally asserts `context.PackageReferences` carries the bumped version for the app-local declaration (previously it only asserted no props file is copied).
- `Issue2319CentralPackageManagementNbgvTests` (new, integration-level): runs the **real** Translate + Compile (`--via-sdk`) stages against a CPM+nbgv fixture mirroring the issue's repro shape. Gated on a locally-built `Gsharp.NET.Sdk` nupkg (same pattern as other live e2e tests in this suite); when available it performs a **real `dotnet build`** end to end and asserts it now succeeds where it previously failed with NU1008, the copied props file is bumped, and the generated `PackageReference` has no `Version=` attribute. Verified to fail pre-fix and pass post-fix.
- `DeclaredProjectItemsNbgvBumpTests` (new): unit coverage for the new app-local bump helper — below-floor bump, at/above-floor no-op, ordinary packages untouched, versionless CPM-style item untouched, non-literal (`$(...)`) version untouched, only the matching item rewritten among several declared items, null/empty input.
- `Issue2319AppLocalNbgvPackageReferenceTests` (new, integration-level): runs the real Translate + Compile (`--via-sdk`) stages against a non-CPM fixture where the app's own `.csproj` declares nbgv directly with a literal below-floor `Version`. Asserts the generated `.gsproj` carries the bumped version with no duplicate `PackageReference`, and (when a local SDK nupkg is available) performs a real `dotnet build`. Verified to fail pre-fix (unbumped `3.7.115` survives) and pass post-fix.

## Validation

- `dotnet build tools/cs2gs/Cs2Gs.Pipeline/Cs2Gs.Pipeline.csproj -c Release` — succeeds, 0 warnings/errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` (full suite) — **1329/1329 passed**.
- `dotnet build GSharp.sln -c Release` — succeeds, 0 warnings/errors.

## Scope

- `EmitNerdbankGitVersioningBumps`'s `nbgv-bump/` manifest-writing behavior is left untouched — it remains a harmless diagnostic side-channel, no longer consulted for either fixed case since both are now bumped directly at their point of copy/read.

Closes #2319.