### PR TITLE
Fix #2321: narrow policy exempts benign NuGet audit advisories from CS2GS0001

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
@@ -168,6 +168,15 @@ public sealed class TestParityStage : IMigrationStage
             return StageOutcome.Failed(new[] { loadArtifact });
         }
 
+        // Issue #2321: a benign NuGet audit vulnerability advisory (CS2GS0003)
+        // never fails the .Tests project load above, but must not be dropped
+        // silently either — record it regardless of whether translation below
+        // is Ready or (still) Pending.
+        foreach (Diagnostic advisory in tests.AdvisoryDiagnostics)
+        {
+            this.Note(context, "NuGet audit advisory (CS2GS0003, non-fatal) in .Tests project: " + advisory.GetMessage());
+        }
+
         if (tests.PendingReason is not null)
         {
             // Gated intentionally (ADR-0115 §E) until test-translation lands —
@@ -253,6 +262,14 @@ public sealed class TestParityStage : IMigrationStage
             return TranslatedProject.LoadFailed(project.WorkspaceLoadErrors);
         }
 
+        // Issue #2321: a benign NuGet audit vulnerability advisory (CS2GS0003)
+        // does not fail the workspace load gate above; carry it forward to the
+        // caller so it can be recorded (not silently dropped) regardless of
+        // whether translation below ends up Ready or Pending.
+        List<Diagnostic> advisoryDiagnostics = project.LoadDiagnostics
+            .Where(d => d.Id == CSharpProjectLoader.NuGetAuditAdvisoryDiagnosticId)
+            .ToList();
+
         var files = new List<GsharpSourceFile>();
         var usedGsFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -281,7 +298,8 @@ public sealed class TestParityStage : IMigrationStage
             {
                 return TranslatedProject.Pending(
                     $"test-translation pending map-advanced — unsupported C# construct " +
-                    $"'{unsupported.ConstructKind}' in {Path.GetFileName(document.FilePath)}: {unsupported.Message}");
+                    $"'{unsupported.ConstructKind}' in {Path.GetFileName(document.FilePath)}: {unsupported.Message}",
+                    advisoryDiagnostics);
             }
 
             RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
@@ -290,14 +308,15 @@ public sealed class TestParityStage : IMigrationStage
                 return TranslatedProject.Pending(
                     $"test-translation pending map-advanced — emitted G# for " +
                     $"{Path.GetFileName(document.FilePath)} did not round-trip-parse: " +
-                    (roundTrip.Errors.FirstOrDefault() ?? "unknown parse error"));
+                    (roundTrip.Errors.FirstOrDefault() ?? "unknown parse error"),
+                    advisoryDiagnostics);
             }
 
             string gsFileName = EmittedFileNaming.UniqueGsFileName(document.FilePath, usedGsFileNames);
             files.Add(new GsharpSourceFile(gsFileName, printed));
         }
 
-        return TranslatedProject.Ready(files);
+        return TranslatedProject.Ready(files, advisoryDiagnostics);
     }
 
     private static (int Exit, string Stdout, string Stderr, bool TimedOut) RunProgram(string assemblyPath, string workingDirectory)
@@ -358,11 +377,13 @@ public sealed class TestParityStage : IMigrationStage
         private TranslatedProject(
             IReadOnlyList<GsharpSourceFile> files,
             string pendingReason,
-            IReadOnlyList<Diagnostic> loadErrors)
+            IReadOnlyList<Diagnostic> loadErrors,
+            IReadOnlyList<Diagnostic> advisoryDiagnostics)
         {
             this.Files = files ?? Array.Empty<GsharpSourceFile>();
             this.PendingReason = pendingReason;
             this.LoadErrors = loadErrors;
+            this.AdvisoryDiagnostics = advisoryDiagnostics ?? Array.Empty<Diagnostic>();
         }
 
         public IReadOnlyList<GsharpSourceFile> Files { get; }
@@ -372,13 +393,21 @@ public sealed class TestParityStage : IMigrationStage
         /// <summary>Gets the load-error diagnostics, or <see langword="null"/> if the project bound.</summary>
         public IReadOnlyList<Diagnostic> LoadErrors { get; }
 
-        public static TranslatedProject Ready(IReadOnlyList<GsharpSourceFile> files) =>
-            new TranslatedProject(files, null, null);
+        /// <summary>
+        /// Gets the benign NuGet audit vulnerability advisories (issue #2321,
+        /// <see cref="CSharpProjectLoader.NuGetAuditAdvisoryDiagnosticId"/>,
+        /// CS2GS0003) MSBuildWorkspace reported while opening this project.
+        /// Always empty for a <see cref="LoadFailed"/> project.
+        /// </summary>
+        public IReadOnlyList<Diagnostic> AdvisoryDiagnostics { get; }
 
-        public static TranslatedProject Pending(string reason) =>
-            new TranslatedProject(Array.Empty<GsharpSourceFile>(), reason, null);
+        public static TranslatedProject Ready(IReadOnlyList<GsharpSourceFile> files, IReadOnlyList<Diagnostic> advisoryDiagnostics) =>
+            new TranslatedProject(files, null, null, advisoryDiagnostics);
+
+        public static TranslatedProject Pending(string reason, IReadOnlyList<Diagnostic> advisoryDiagnostics) =>
+            new TranslatedProject(Array.Empty<GsharpSourceFile>(), reason, null, advisoryDiagnostics);
 
         public static TranslatedProject LoadFailed(IReadOnlyList<Diagnostic> loadErrors) =>
-            new TranslatedProject(Array.Empty<GsharpSourceFile>(), null, loadErrors);
+            new TranslatedProject(Array.Empty<GsharpSourceFile>(), null, loadErrors, null);
     }
 }

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -69,6 +69,13 @@ public sealed class TranslateStage : IMigrationStage
             return StageOutcome.Failed(artifacts);
         }
 
+        // Issue #2321: a benign NuGet audit vulnerability advisory (CS2GS0003)
+        // does not fail the workspace load above, but must not be dropped
+        // silently either — record it in the per-app translate.log, the same
+        // best-effort append-only text log TestParityStage's Note already
+        // uses for non-fatal, informational events (test-parity.log).
+        NoteNuGetAuditAdvisories(context, project);
+
         var usedOutputPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         CopyProjectFiles(project.ProjectDirectory, context.AppRunDir, usedOutputPaths);
         CopyCentralPackageManagementFile(project.ProjectDirectory, context.AppRunDir, context);
@@ -314,6 +321,46 @@ public sealed class TranslateStage : IMigrationStage
         EmitNerdbankGitVersioningBumps(context);
 
         return artifacts.Count == 0 ? StageOutcome.Passed() : StageOutcome.Failed(artifacts);
+    }
+
+    /// <summary>
+    /// Issue #2321: records any benign NuGet audit vulnerability advisory
+    /// (<see cref="CSharpProjectLoader.NuGetAuditAdvisoryDiagnosticId"/>,
+    /// CS2GS0003) MSBuildWorkspace reported while opening <paramref name="project"/>
+    /// into the per-app <c>translate.log</c>. The advisory never fails this
+    /// stage — <see cref="CSharpProjectLoader"/> already excludes it from
+    /// <see cref="LoadedCSharpProject.ErrorDiagnostics"/> — this only keeps it
+    /// from being silently dropped once <see cref="LoadedCSharpProject.LoadDiagnostics"/>
+    /// is no longer inspected past the <see cref="LoadedCSharpProject.WorkspaceLoadFailed"/>
+    /// gate above.
+    /// </summary>
+    private static void NoteNuGetAuditAdvisories(StageExecutionContext context, LoadedCSharpProject project)
+    {
+        foreach (Diagnostic advisory in project.LoadDiagnostics
+            .Where(d => d.Id == CSharpProjectLoader.NuGetAuditAdvisoryDiagnosticId))
+        {
+            Note(context, "NuGet audit advisory (CS2GS0003, non-fatal): " + advisory.GetMessage());
+        }
+    }
+
+    /// <summary>
+    /// A best-effort, append-only per-app text log — the Translate-stage
+    /// counterpart of <see cref="TestParityStage"/>'s identical <c>Note</c>
+    /// helper (which writes <c>test-parity.log</c>). Never fails the stage on
+    /// a log write.
+    /// </summary>
+    private static void Note(StageExecutionContext context, string message)
+    {
+        try
+        {
+            File.AppendAllText(
+                Path.Combine(context.AppRunDir, "translate.log"),
+                message + Environment.NewLine);
+        }
+        catch (IOException)
+        {
+            // A best-effort diagnostic log; never fail the stage on a log write.
+        }
     }
 
     private static void CopyProjectFiles(

--- a/tools/cs2gs/Cs2Gs.ProjectLoading/CSharpProjectLoader.cs
+++ b/tools/cs2gs/Cs2Gs.ProjectLoading/CSharpProjectLoader.cs
@@ -48,6 +48,20 @@ public static class CSharpProjectLoader
     /// </summary>
     public const string WorkspaceLoadFailureDiagnosticId = "CS2GS0001";
 
+    /// <summary>
+    /// Diagnostic id for a benign NuGet audit vulnerability advisory (issue
+    /// #2321) — a <see cref="WorkspaceDiagnosticKind.Failure"/> MSBuildWorkspace
+    /// diagnostic that <see cref="NuGetAuditAdvisoryPolicy.IsBenignAdvisory(string)"/>
+    /// recognized as the stable NU1901-NU1904 advisory shape. Recorded at
+    /// <see cref="DiagnosticSeverity.Info"/> — visible in
+    /// <see cref="LoadedCSharpProject.LoadDiagnostics"/> for anything that later
+    /// wants to surface it, but excluded from
+    /// <see cref="LoadedCSharpProject.ErrorDiagnostics"/> so it does not trip
+    /// <see cref="LoadedCSharpProject.BoundWithoutErrors"/> or
+    /// <see cref="LoadedCSharpProject.WorkspaceLoadFailed"/>.
+    /// </summary>
+    public const string NuGetAuditAdvisoryDiagnosticId = "CS2GS0003";
+
     private static readonly object MSBuildRegistrationLock = new object();
 
     /// <summary>
@@ -76,6 +90,20 @@ public static class CSharpProjectLoader
         id: "CS2GS0002",
         title: "Generated source file excluded from translation",
         messageFormat: "Skipped '{0}' because it is recognized as generated code",
+        category: "Cs2Gs.Loading",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Issue #2321: a NuGet audit vulnerability advisory (NU1901-NU1904 shape)
+    /// that MSBuildWorkspace misclassified as a
+    /// <see cref="WorkspaceDiagnosticKind.Failure"/>. Recorded informationally
+    /// instead of as an error — the package still restores and builds.
+    /// </summary>
+    private static readonly DiagnosticDescriptor NuGetAuditAdvisoryDescriptor = new DiagnosticDescriptor(
+        id: NuGetAuditAdvisoryDiagnosticId,
+        title: "Benign NuGet audit vulnerability advisory",
+        messageFormat: "MSBuild workspace reported a NuGet vulnerability advisory (non-fatal): {0}",
         category: "Cs2Gs.Loading",
         defaultSeverity: DiagnosticSeverity.Info,
         isEnabledByDefault: true);
@@ -124,10 +152,9 @@ public static class CSharpProjectLoader
         // previously never inspected, so the translator proceeded on a degraded
         // compilation and the user only saw confusing downstream binding errors.
         // Surface them as load errors so BoundWithoutErrors reflects reality.
-        loadDiagnostics.AddRange(
-            workspace.Diagnostics
-                .Where(d => d.Kind == WorkspaceDiagnosticKind.Failure)
-                .Select(d => Diagnostic.Create(MSBuildWorkspaceLoadFailureDescriptor, Location.None, d.Message)));
+        // Issue #2321: a benign NuGet audit vulnerability advisory (NU1901-NU1904)
+        // is exempted from that gate — see ClassifyWorkspaceLoadDiagnostics.
+        loadDiagnostics.AddRange(ClassifyWorkspaceLoadDiagnostics(workspace));
 
         return await BuildLoadedProjectAsync(project, loadDiagnostics, cancellationToken).ConfigureAwait(false);
     }
@@ -169,10 +196,9 @@ public static class CSharpProjectLoader
         Project project = await workspace.OpenProjectAsync(fullPath, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
-        workspaceFailures.AddRange(
-            workspace.Diagnostics
-                .Where(d => d.Kind == WorkspaceDiagnosticKind.Failure)
-                .Select(d => Diagnostic.Create(MSBuildWorkspaceLoadFailureDescriptor, Location.None, d.Message)));
+        // Issue #2321: same policy as LoadProjectAsync — a benign NuGet audit
+        // vulnerability advisory must not trip the workspace-load-failure gate.
+        workspaceFailures.AddRange(ClassifyWorkspaceLoadDiagnostics(workspace));
 
         var results = new List<LoadedCSharpProject>
         {
@@ -298,6 +324,36 @@ public static class CSharpProjectLoader
                     queue.Enqueue(referenced);
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Issue #2321: classifies every <see cref="WorkspaceDiagnosticKind.Failure"/>
+    /// diagnostic MSBuildWorkspace recorded while opening a project into either
+    /// a genuine <see cref="MSBuildWorkspaceLoadFailureDescriptor"/> error, or —
+    /// when <see cref="NuGetAuditAdvisoryPolicy.IsBenignAdvisory(string)"/>
+    /// recognizes the message as the stable NU1901-NU1904 advisory shape — a
+    /// non-fatal <see cref="NuGetAuditAdvisoryDescriptor"/> info diagnostic.
+    /// Applied identically by both <see cref="LoadProjectAsync"/> and
+    /// <see cref="LoadProjectWithReferencesAsync"/> so neither path lets a
+    /// benign vulnerability warning trip <see cref="WorkspaceLoadFailureDiagnosticId"/>
+    /// (CS2GS0001), while every other soft-fail (missing SDK/imports, an
+    /// unresolvable <c>ProjectReference</c>, an unsupported TFM, NU1900
+    /// audit-fetch failures, or a mixed/multiline message with any non-advisory
+    /// line) remains fatal.
+    /// </summary>
+    private static IEnumerable<Diagnostic> ClassifyWorkspaceLoadDiagnostics(MSBuildWorkspace workspace)
+    {
+        foreach (WorkspaceDiagnostic diagnostic in workspace.Diagnostics)
+        {
+            if (diagnostic.Kind != WorkspaceDiagnosticKind.Failure)
+            {
+                continue;
+            }
+
+            yield return NuGetAuditAdvisoryPolicy.IsBenignAdvisory(diagnostic.Message)
+                ? Diagnostic.Create(NuGetAuditAdvisoryDescriptor, Location.None, diagnostic.Message)
+                : Diagnostic.Create(MSBuildWorkspaceLoadFailureDescriptor, Location.None, diagnostic.Message);
         }
     }
 

--- a/tools/cs2gs/Cs2Gs.ProjectLoading/NuGetAuditAdvisoryPolicy.cs
+++ b/tools/cs2gs/Cs2Gs.ProjectLoading/NuGetAuditAdvisoryPolicy.cs
@@ -1,0 +1,119 @@
+// <copyright file="NuGetAuditAdvisoryPolicy.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace Cs2Gs.Translator.Loading;
+
+/// <summary>
+/// Issue #2321: <see cref="Microsoft.CodeAnalysis.MSBuild.MSBuildWorkspace"/>
+/// records every warning-or-worse line MSBuild logs while opening a project as
+/// a <see cref="Microsoft.CodeAnalysis.WorkspaceDiagnosticKind.Failure"/> —
+/// including the non-fatal NuGet audit vulnerability advisories NuGet emits as
+/// warnings NU1901 (low), NU1902 (moderate), NU1903 (high), and NU1904
+/// (critical) per
+/// https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu1901-nu1904.
+/// A package flagged by one of those carries a known vulnerability but still
+/// restores and builds; it must not make <see cref="CSharpProjectLoader"/> gate
+/// the project out with <see cref="CSharpProjectLoader.WorkspaceLoadFailureDiagnosticId"/>
+/// (CS2GS0001).
+/// </summary>
+/// <remarks>
+/// This policy recognizes ONLY that one stable advisory message shape as
+/// benign. It intentionally does not match:
+/// <list type="bullet">
+/// <item><description>
+/// NU1900 (a failure to even fetch vulnerability data, or a source that
+/// returned an out-of-band severity value such as "unknown" — see
+/// https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu1900):
+/// these mean the audit itself is unreliable, not that a benign advisory was
+/// found, and must stay fatal.
+/// </description></item>
+/// <item><description>
+/// Genuine MSBuild workspace load failures — missing SDK/imports, an
+/// unresolvable <c>ProjectReference</c>, an unsupported target framework, etc.
+/// </description></item>
+/// <item><description>
+/// A mixed or multiline diagnostic message where any non-blank line is not
+/// itself an advisory: every line must independently match, or the whole
+/// message is treated as fatal.
+/// </description></item>
+/// </list>
+/// </remarks>
+public static class NuGetAuditAdvisoryPolicy
+{
+    // MSBuildWorkspace wraps each captured MSBuild diagnostic line as:
+    //   Msbuild failed when processing the file '<path>' with message: <text>
+    // (observed verbatim from Microsoft.CodeAnalysis.Workspaces.MSBuild). The
+    // policy tolerates this wrapper, but also accepts the bare <text> so it
+    // keeps working if a caller ever passes the inner message directly.
+    private static readonly Regex WorkspaceWrapperPrefix = new Regex(
+        @"^Msbuild\ failed\ when\ processing\ the\ file\ '[^']*'\ with\ message:\s*",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnorePatternWhitespace);
+
+    // When the SDK's audit warnings are elevated by <TreatWarningsAsErrors>,
+    // MSBuild prepends this literal marker ahead of the advisory text (also
+    // observed verbatim); it carries no independent failure information, so it
+    // is stripped before the advisory-shape check.
+    private static readonly Regex WarningAsErrorPrefix = new Regex(
+        @"^Warning\ As\ Error:\s*",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnorePatternWhitespace);
+
+    // The stable NU1901-NU1904 advisory shape: "Package '<id>' <version> has a
+    // known <low|moderate|high|critical> severity vulnerability, <url>". The
+    // severity is deliberately restricted to those four literal words — NU1900
+    // can report a server-supplied severity of "unknown" for the exact same
+    // sentence shape, and that case must stay fatal (the audit source itself
+    // returned bad data), not be treated as a benign advisory.
+    private static readonly Regex AdvisoryCoreShape = new Regex(
+        @"^Package\ '[^']+'\ \S+\ has\ a\ known\ (?:low|moderate|high|critical)\ severity\ vulnerability,\ https?://\S+$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnorePatternWhitespace);
+
+    /// <summary>
+    /// Determines whether a <see cref="Microsoft.CodeAnalysis.WorkspaceDiagnostic"/>
+    /// message reported at <see cref="Microsoft.CodeAnalysis.WorkspaceDiagnosticKind.Failure"/>
+    /// is, in its entirety, one or more benign NuGet audit vulnerability
+    /// advisories (the NU1901-NU1904 shape) and therefore must not be treated
+    /// as a fatal project-load failure.
+    /// </summary>
+    /// <param name="message">The raw <c>WorkspaceDiagnostic.Message</c> text.</param>
+    /// <returns>
+    /// <see langword="true"/> only if every non-blank line of
+    /// <paramref name="message"/> independently matches the advisory shape;
+    /// <see langword="false"/> for a <see langword="null"/>/blank message, for
+    /// any genuine workspace failure, and for a mixed/multiline message that
+    /// carries even one non-advisory line.
+    /// </returns>
+    public static bool IsBenignAdvisory(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return false;
+        }
+
+        string[] lines = message.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
+        bool sawAdvisoryLine = false;
+        foreach (string rawLine in lines)
+        {
+            string line = rawLine.Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            line = WorkspaceWrapperPrefix.Replace(line, string.Empty);
+            line = WarningAsErrorPrefix.Replace(line, string.Empty).Trim();
+
+            if (!AdvisoryCoreShape.IsMatch(line))
+            {
+                return false;
+            }
+
+            sawAdvisoryLine = true;
+        }
+
+        return sawAdvisoryLine;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/CSharpProjectLoaderDiagnosticsTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/CSharpProjectLoaderDiagnosticsTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -50,6 +51,100 @@ public class CSharpProjectLoaderDiagnosticsTests
 
         Assert.NotEmpty(project.LoadDiagnostics);
         Assert.Contains(project.LoadDiagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.False(
+            project.BoundWithoutErrors,
+            "A project with an unresolvable ProjectReference must not report BoundWithoutErrors=true.");
+    }
+
+    /// <summary>
+    /// Issue #2321 (loader path 1 of 2): a project whose only MSBuild workspace
+    /// failure is a NuGet audit vulnerability advisory (the NU1901-NU1904
+    /// shape — here NU1903/high for the well-known
+    /// <c>Newtonsoft.Json 12.0.1</c> advisory GHSA-5crp-9r3c-p9vr) must still
+    /// bind: the advisory must not trip <see cref="CSharpProjectLoader.WorkspaceLoadFailureDiagnosticId"/>
+    /// (CS2GS0001), <see cref="LoadedCSharpProject.WorkspaceLoadFailed"/>, or
+    /// <see cref="LoadedCSharpProject.BoundWithoutErrors"/>. The advisory
+    /// remains visible as an informational
+    /// <see cref="CSharpProjectLoader.NuGetAuditAdvisoryDiagnosticId"/> (CS2GS0003)
+    /// diagnostic instead of being dropped silently.
+    /// </summary>
+    [Fact]
+    public async Task LoadProjectAsync_NuGetAuditAdvisoryDoesNotFailWorkspaceLoad()
+    {
+        string projectDir = NewScratchDir("nuget-audit-advisory");
+        WriteVulnerablePackageProject(projectDir, "Vulnerable.csproj");
+
+        LoadedCSharpProject project = await CSharpProjectLoader.LoadProjectAsync(
+            Path.Combine(projectDir, "Vulnerable.csproj"));
+
+        Assert.False(
+            project.WorkspaceLoadFailed,
+            "A benign NuGet audit vulnerability advisory (NU1901-NU1904 shape) must not trip CS2GS0001.");
+        Assert.True(
+            project.BoundWithoutErrors,
+            "A benign NuGet audit vulnerability advisory must not report BoundWithoutErrors=false.");
+        Assert.DoesNotContain(
+            project.ErrorDiagnostics,
+            d => d.Id == CSharpProjectLoader.WorkspaceLoadFailureDiagnosticId);
+        Assert.Contains(
+            project.LoadDiagnostics,
+            d => d.Id == CSharpProjectLoader.NuGetAuditAdvisoryDiagnosticId && d.Severity == DiagnosticSeverity.Info);
+    }
+
+    /// <summary>
+    /// Issue #2321 (loader path 2 of 2): the same benign-advisory exemption
+    /// applies to <see cref="CSharpProjectLoader.LoadProjectWithReferencesAsync"/>
+    /// — the second project-loading path that independently gates on MSBuild
+    /// workspace load failures.
+    /// </summary>
+    [Fact]
+    public async Task LoadProjectWithReferencesAsync_NuGetAuditAdvisoryDoesNotFailWorkspaceLoad()
+    {
+        string projectDir = NewScratchDir("nuget-audit-advisory-with-refs");
+        WriteVulnerablePackageProject(projectDir, "Vulnerable.csproj");
+
+        System.Collections.Generic.IReadOnlyList<LoadedCSharpProject> projects =
+            await CSharpProjectLoader.LoadProjectWithReferencesAsync(Path.Combine(projectDir, "Vulnerable.csproj"));
+
+        LoadedCSharpProject project = Assert.Single(projects);
+        Assert.False(
+            project.WorkspaceLoadFailed,
+            "A benign NuGet audit vulnerability advisory (NU1901-NU1904 shape) must not trip CS2GS0001.");
+        Assert.True(project.BoundWithoutErrors);
+        Assert.Contains(
+            project.LoadDiagnostics,
+            d => d.Id == CSharpProjectLoader.NuGetAuditAdvisoryDiagnosticId && d.Severity == DiagnosticSeverity.Info);
+    }
+
+    /// <summary>
+    /// Issue #2321 regression guard: <see cref="CSharpProjectLoader.LoadProjectWithReferencesAsync"/>
+    /// must keep gating on a GENUINE workspace load failure exactly like
+    /// <see cref="LoadProjectAsync_SurfacesMSBuildWorkspaceLoadFailure"/> proves
+    /// for <see cref="CSharpProjectLoader.LoadProjectAsync"/> — the narrowed
+    /// policy must not have weakened this second loading path.
+    /// </summary>
+    [Fact]
+    public async Task LoadProjectWithReferencesAsync_SurfacesMSBuildWorkspaceLoadFailure()
+    {
+        string projectDir = NewScratchDir("with-references-load-failure");
+        File.WriteAllText(Path.Combine(projectDir, "Directory.Build.props"), "<Project></Project>");
+        string projectPath = Path.Combine(projectDir, "Broken.csproj");
+        File.WriteAllText(projectPath, @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include=""..\DoesNotExist\DoesNotExist.csproj"" />
+  </ItemGroup>
+</Project>
+");
+        File.WriteAllText(Path.Combine(projectDir, "Program.cs"), "public class Program { public static void Main() { } }");
+
+        System.Collections.Generic.IReadOnlyList<LoadedCSharpProject> projects =
+            await CSharpProjectLoader.LoadProjectWithReferencesAsync(projectPath);
+
+        LoadedCSharpProject project = Assert.Single(projects);
+        Assert.True(project.WorkspaceLoadFailed);
         Assert.False(
             project.BoundWithoutErrors,
             "A project with an unresolvable ProjectReference must not report BoundWithoutErrors=true.");
@@ -216,5 +311,66 @@ namespace Sample
         string root = Path.Combine(AppContext.BaseDirectory, "loader-tests", label, Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         return root;
+    }
+
+    /// <summary>
+    /// Issue #2321: writes a buildable console project referencing
+    /// <c>Newtonsoft.Json 12.0.1</c>, whose known high-severity vulnerability
+    /// (GHSA-5crp-9r3c-p9vr) NuGet reports as warning NU1903 during restore —
+    /// the exact benign advisory shape this policy must exempt. An empty
+    /// <c>Directory.Build.props</c> override stops MSBuild's directory search
+    /// from climbing to this repo's own root props (which sets
+    /// <c>TreatWarningsAsErrors</c>), matching this file's other scratch
+    /// projects and keeping the test independent of that repo-wide setting.
+    /// </summary>
+    private static void WriteVulnerablePackageProject(string projectDir, string projectFileName)
+    {
+        File.WriteAllText(Path.Combine(projectDir, "Directory.Build.props"), "<Project></Project>");
+        string projectPath = Path.Combine(projectDir, projectFileName);
+        File.WriteAllText(projectPath, @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Newtonsoft.Json"" Version=""12.0.1"" />
+  </ItemGroup>
+</Project>
+");
+        File.WriteAllText(
+            Path.Combine(projectDir, "Program.cs"),
+            "public class Program { public static void Main() { } }");
+
+        // Issue #2321: the advisory only surfaces through MSBuildWorkspace once
+        // the project has an on-disk obj/project.assets.json to replay — same
+        // as any already-restored/built app cs2gs is pointed at in practice (a
+        // brand-new, never-restored project simply has no resolved package
+        // assets for OpenProjectAsync to evaluate against). Run a real
+        // `dotnet restore` here to reproduce that real-world precondition.
+        RunDotnetRestore(projectPath);
+    }
+
+    private static void RunDotnetRestore(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", $"restore \"{projectPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using Process process = Process.Start(startInfo);
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        // `dotnet restore` itself exits 0 here because the vulnerability is a
+        // plain warning (not elevated) under the empty Directory.Build.props
+        // override — a non-zero exit means something unrelated broke restore
+        // (e.g. no network access to nuget.org), which every assertion below
+        // would otherwise misattribute to the policy under test.
+        Assert.True(
+            process.ExitCode == 0,
+            $"Prerequisite `dotnet restore` failed (exit {process.ExitCode}); cannot exercise the NuGet audit advisory path.\nstdout:\n{stdout}\nstderr:\n{stderr}");
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/NuGetAuditAdvisoryPolicyTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/NuGetAuditAdvisoryPolicyTests.cs
@@ -1,0 +1,184 @@
+// <copyright file="NuGetAuditAdvisoryPolicyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Pure policy tests for issue #2321: <see cref="NuGetAuditAdvisoryPolicy"/>
+/// must recognize ONLY the stable NU1901-NU1904 NuGet audit vulnerability
+/// advisory shape as benign, and must keep every other
+/// <see cref="Microsoft.CodeAnalysis.WorkspaceDiagnosticKind.Failure"/> message
+/// — including NU1900, genuine MSBuild workspace load failures, and any
+/// mixed/multiline message with a non-advisory line — fatal. Message shapes in
+/// the "benign" cases are the verbatim text captured from a real
+/// <c>MSBuildWorkspace.Diagnostics</c> entry while investigating #2321 (a
+/// project referencing <c>Newtonsoft.Json 12.0.1</c>, which carries the known
+/// high-severity advisory GHSA-5crp-9r3c-p9vr); the NU1900 shapes are the
+/// examples from
+/// https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu1900.
+/// </summary>
+public class NuGetAuditAdvisoryPolicyTests
+{
+    [Theory]
+    [InlineData("Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-example")]
+    [InlineData("Package 'Contoso.Utilities' 1.0.0 has a known low severity vulnerability, https://cve.contoso.com/advisories/1")]
+    [InlineData("Package 'Contoso.Utilities' 1.0.0 has a known moderate severity vulnerability, https://cve.contoso.com/advisories/1")]
+    [InlineData("Package 'Contoso.Utilities' 1.0.0 has a known critical severity vulnerability, https://cve.contoso.com/advisories/1")]
+    [InlineData("PACKAGE 'Contoso.Utilities' 1.0.0 HAS A KNOWN HIGH SEVERITY VULNERABILITY, https://cve.contoso.com/advisories/1")]
+    public void IsBenignAdvisory_BareNU190xShape_IsBenign(string message)
+    {
+        Assert.True(NuGetAuditAdvisoryPolicy.IsBenignAdvisory(message));
+    }
+
+    [Fact]
+    public void IsBenignAdvisory_RealWorkspaceWrappedMessage_IsBenign()
+    {
+        // Verbatim shape observed from workspace.Diagnostics when
+        // MSBuildWorkspace opens a project referencing a vulnerable package
+        // (Newtonsoft.Json 12.0.1, NU1903/high, GHSA-5crp-9r3c-p9vr).
+        const string message =
+            "Msbuild failed when processing the file '/repo/App/App.csproj' with message: " +
+            "Package 'Newtonsoft.Json' 12.0.1 has a known high severity vulnerability, " +
+            "https://github.com/advisories/GHSA-5crp-9r3c-p9vr";
+
+        Assert.True(NuGetAuditAdvisoryPolicy.IsBenignAdvisory(message));
+    }
+
+    [Fact]
+    public void IsBenignAdvisory_RealWorkspaceWrappedMessage_WarningAsError_IsBenign()
+    {
+        // Verbatim shape observed when the SDK's audit warnings are elevated by
+        // <TreatWarningsAsErrors> (as this repo's own build props do): MSBuild
+        // prepends a literal "Warning As Error: " marker ahead of the advisory
+        // text, but the underlying advisory is exactly as benign.
+        const string message =
+            "Msbuild failed when processing the file '/repo/App/App.csproj' with message: " +
+            "Warning As Error: Package 'Newtonsoft.Json' 12.0.1 has a known high severity vulnerability, " +
+            "https://github.com/advisories/GHSA-5crp-9r3c-p9vr";
+
+        Assert.True(NuGetAuditAdvisoryPolicy.IsBenignAdvisory(message));
+    }
+
+    [Fact]
+    public void IsBenignAdvisory_MultipleAdvisoryLines_AllBenign_IsBenign()
+    {
+        const string message =
+            "Package 'A' 1.0.0 has a known high severity vulnerability, https://example.com/a\n" +
+            "Package 'B' 2.0.0 has a known low severity vulnerability, https://example.com/b";
+
+        Assert.True(NuGetAuditAdvisoryPolicy.IsBenignAdvisory(message));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsBenignAdvisory_NullOrBlank_IsNotBenign(string message)
+    {
+        Assert.False(NuGetAuditAdvisoryPolicy.IsBenignAdvisory(message));
+    }
+
+    [Fact]
+    public void IsBenignAdvisory_NU1900_AuditSourceUnavailable_IsNotBenign()
+    {
+        // NU1900 Example 1 (https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu1900):
+        // the audit source itself could not be reached — must remain fatal so
+        // migrations do not silently proceed on stale/missing vulnerability data.
+        const string message = "warning NU1900: Error occurred while getting package vulnerability data: (more information)";
+
+        Assert.False(NuGetAuditAdvisoryPolicy.IsBenignAdvisory(message));
+    }
+
+    [Fact]
+    public void IsBenignAdvisory_NU1900_UnknownSeverity_IsNotBenign()
+    {
+        // NU1900 Example 2: same "Package ... has a known ... severity
+        // vulnerability, <url>" sentence shape as NU1901-NU1904, but with an
+        // out-of-band "unknown" severity — the source returned invalid data,
+        // which is a real audit failure, not a benign advisory.
+        const string message = "Package 'Contoso.Utilities' 1.0.0 has a known unknown severity vulnerability, https://cve.contoso.com/advisories/1";
+
+        Assert.False(NuGetAuditAdvisoryPolicy.IsBenignAdvisory(message));
+    }
+
+    [Fact]
+    public void IsBenignAdvisory_MissingProjectReference_IsNotBenign()
+    {
+        // Verbatim shape observed from workspace.Diagnostics for an
+        // unresolvable <ProjectReference> (issue #1742's original scenario).
+        const string message =
+            "Msbuild failed when processing the file '/repo/App/App.csproj' with message: " +
+            "The referenced project ../DoesNotExist/DoesNotExist.csproj does not exist.";
+
+        Assert.False(NuGetAuditAdvisoryPolicy.IsBenignAdvisory(message));
+    }
+
+    [Fact]
+    public void IsBenignAdvisory_ProjectFileNotFound_IsNotBenign()
+    {
+        const string message = "Project file not found: '/repo/DoesNotExist/DoesNotExist.csproj'";
+
+        Assert.False(NuGetAuditAdvisoryPolicy.IsBenignAdvisory(message));
+    }
+
+    [Fact]
+    public void IsBenignAdvisory_UnsupportedTargetFramework_IsNotBenign()
+    {
+        const string message =
+            "Msbuild failed when processing the file '/repo/App/App.csproj' with message: " +
+            "The current .NET SDK does not support targeting .NET Silly 1.0. Either target .NET 8.0 or lower, " +
+            "or use a version of the .NET SDK that supports .NET Silly 1.0.";
+
+        Assert.False(NuGetAuditAdvisoryPolicy.IsBenignAdvisory(message));
+    }
+
+    [Fact]
+    public void IsBenignAdvisory_MissingSdkImport_IsNotBenign()
+    {
+        const string message =
+            "Msbuild failed when processing the file '/repo/App/App.csproj' with message: " +
+            "The imported project \"/usr/share/dotnet/sdk/Missing.Sdk/Sdk.props\" was not found.";
+
+        Assert.False(NuGetAuditAdvisoryPolicy.IsBenignAdvisory(message));
+    }
+
+    [Fact]
+    public void IsBenignAdvisory_MixedMultilineMessage_WithNonAdvisorySegment_IsNotBenign()
+    {
+        // One genuinely benign advisory line plus one real-failure line: the
+        // whole diagnostic must remain fatal because it carries a non-advisory
+        // segment (issue #2321 explicitly requires this).
+        const string message =
+            "Package 'A' 1.0.0 has a known high severity vulnerability, https://example.com/a\n" +
+            "The referenced project ../DoesNotExist/DoesNotExist.csproj does not exist.";
+
+        Assert.False(NuGetAuditAdvisoryPolicy.IsBenignAdvisory(message));
+    }
+
+    [Fact]
+    public void IsBenignAdvisory_AdvisoryLineWithTrailingExtraText_IsNotBenign()
+    {
+        // Extra content appended after the advisory URL on the SAME line is a
+        // non-advisory segment sharing the line — must not match.
+        const string message =
+            "Package 'A' 1.0.0 has a known high severity vulnerability, https://example.com/a and also something else broke";
+
+        Assert.False(NuGetAuditAdvisoryPolicy.IsBenignAdvisory(message));
+    }
+
+    [Fact]
+    public void IsBenignAdvisory_AdvisoryLineWithLeadingExtraText_IsNotBenign()
+    {
+        // Arbitrary free-form text ahead of the advisory sentence (not the
+        // recognized MSBuildWorkspace wrapper or "Warning As Error:" marker)
+        // must not be silently swallowed by a permissive prefix match.
+        const string message =
+            "Something else failed first. Package 'A' 1.0.0 has a known high severity vulnerability, https://example.com/a";
+
+        Assert.False(NuGetAuditAdvisoryPolicy.IsBenignAdvisory(message));
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/TestParityStageNuGetAuditAdvisoryTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TestParityStageNuGetAuditAdvisoryTests.cs
@@ -1,0 +1,174 @@
+// <copyright file="TestParityStageNuGetAuditAdvisoryTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Follow-up to issue #2321: the library xUnit-parity path of
+/// <see cref="TestParityStage"/> loads the sibling <c>.Tests</c> project via
+/// <c>CSharpProjectLoader.LoadProjectAsync</c> — a THIRD, separate load call
+/// site (distinct from <see cref="TranslateStage"/>'s primary app load) that
+/// can also surface a benign NuGet audit vulnerability advisory
+/// (<c>CS2GS0003</c>). Before this fix nothing carried that diagnostic
+/// forward from <c>TranslateProjectAsync</c> to the caller, so it was loaded
+/// successfully yet silently dropped. It must now be recorded (never fail the
+/// stage on it) in the per-app <c>test-parity.log</c>, via the existing
+/// <c>Note</c> helper.
+/// </summary>
+public class TestParityStageNuGetAuditAdvisoryTests
+{
+    /// <summary>
+    /// A <c>.Tests</c> project whose only MSBuild workspace diagnostic is the
+    /// benign NuGet audit advisory (here NU1903/high for the well-known
+    /// <c>Newtonsoft.Json 12.0.1</c> advisory GHSA-5crp-9r3c-p9vr) must not
+    /// fail the stage, and must leave a visible, non-fatal trace naming the
+    /// CS2GS0003 diagnostic in <c>&lt;AppRunDir&gt;/test-parity.log</c>.
+    /// </summary>
+    [Fact]
+    public async Task TestParityStage_TestsProjectNuGetAuditAdvisory_DoesNotFailAndIsNoted()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        string testsDir = NewScratchDir("testparity-nuget-audit-advisory");
+        string testsProjectPath = Path.Combine(testsDir, "Vulnerable.Tests.csproj");
+        WriteVulnerablePackageProject(testsDir, "Vulnerable.Tests.csproj", "SomeTests.cs");
+
+        string baselinePath = Path.Combine(testsDir, "baseline.tests.json");
+        File.WriteAllText(
+            baselinePath,
+            "{\"schemaVersion\":\"1.0\",\"app\":\"Vulnerable.Tests\",\"framework\":\"xunit\"," +
+            "\"total\":0,\"passed\":0,\"failed\":0,\"skipped\":0,\"tests\":[]}");
+
+        string appRunDir = NewOutputRoot("testparity-nuget-audit-advisory");
+        var app = new CorpusApp(
+            "test/VulnerableTestsAdvisory",
+            testsProjectPath, // main project unused by the library path itself
+            TargetKind.Library,
+            testsProjectPath: testsProjectPath,
+            testsBaselinePath: baselinePath);
+
+        var options = new PipelineOptions { GscPath = compiler };
+        var gsc = new GscInvoker(compiler);
+        var triage = new TriageBuilder("run_1", "2026-06-21T20:00:00Z", gsc.GetVersion(), app.Id);
+        var context = new StageExecutionContext(app, options, gsc, appRunDir, triage);
+
+        var stage = new TestParityStage();
+        StageOutcome outcome = await stage.ExecuteAsync(context);
+
+        // The advisory itself must never cause a CS2GS0001-style load failure
+        // (whatever else may or may not pass/skip/fail below it in this
+        // minimal harness — e.g. the deliberately-empty library project this
+        // test does not populate — is unrelated to the policy under test).
+        Assert.DoesNotContain(outcome.Artifacts, a => a.Diagnostic.Id == "CS2GS0001");
+
+        string logPath = Path.Combine(appRunDir, "test-parity.log");
+        Assert.True(File.Exists(logPath), "Expected test-parity.log to be written.");
+        string logContent = File.ReadAllText(logPath);
+        Assert.Contains("CS2GS0003", logContent);
+        Assert.Contains("Newtonsoft.Json", logContent);
+    }
+
+    private static string NewOutputRoot(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "pipeline-tests", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string NewScratchDir(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "loader-tests", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Issue #2321: writes a buildable <c>.Tests</c>-shaped project referencing
+    /// <c>Newtonsoft.Json 12.0.1</c>, whose known high-severity vulnerability
+    /// (GHSA-5crp-9r3c-p9vr) NuGet reports as warning NU1903 during restore —
+    /// the exact benign advisory shape this policy must exempt. An empty
+    /// <c>Directory.Build.props</c> override stops MSBuild's directory search
+    /// from climbing to this repo's own root props (which sets
+    /// <c>TreatWarningsAsErrors</c>), matching the convention already used in
+    /// <c>CSharpProjectLoaderDiagnosticsTests</c>.
+    /// </summary>
+    private static void WriteVulnerablePackageProject(string projectDir, string projectFileName, string sourceFileName)
+    {
+        File.WriteAllText(Path.Combine(projectDir, "Directory.Build.props"), "<Project></Project>");
+        string projectPath = Path.Combine(projectDir, projectFileName);
+        File.WriteAllText(projectPath, @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Newtonsoft.Json"" Version=""12.0.1"" />
+  </ItemGroup>
+</Project>
+");
+        File.WriteAllText(
+            Path.Combine(projectDir, sourceFileName),
+            "public class SomeTests { public void T() { } }");
+
+        // Issue #2321: the advisory only surfaces through MSBuildWorkspace once
+        // the project has an on-disk obj/project.assets.json to replay — same
+        // as any already-restored/built app cs2gs is pointed at in practice.
+        // Run a real `dotnet restore` here to reproduce that precondition.
+        RunDotnetRestore(projectPath);
+    }
+
+    private static void RunDotnetRestore(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", $"restore \"{projectPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using Process process = Process.Start(startInfo);
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        // `dotnet restore` itself exits 0 here because the vulnerability is a
+        // plain warning (not elevated) under the empty Directory.Build.props
+        // override — a non-zero exit means something unrelated broke restore
+        // (e.g. no network access to nuget.org), which every assertion below
+        // would otherwise misattribute to the policy under test.
+        Assert.True(
+            process.ExitCode == 0,
+            $"Prerequisite `dotnet restore` failed (exit {process.ExitCode}); cannot exercise the NuGet audit advisory path.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/TranslateStageNuGetAuditAdvisoryTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TranslateStageNuGetAuditAdvisoryTests.cs
@@ -1,0 +1,162 @@
+// <copyright file="TranslateStageNuGetAuditAdvisoryTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Follow-up to issue #2321: <c>CSharpProjectLoader</c> classifies a benign
+/// NuGet audit vulnerability advisory (the NU1901-NU1904 shape) as an
+/// informational <c>CS2GS0003</c> diagnostic instead of the fatal
+/// <c>CS2GS0001</c> workspace-load failure, but nothing downstream of
+/// <see cref="TranslateStage"/> previously inspected
+/// <c>LoadedCSharpProject.LoadDiagnostics</c> for it — the advisory loaded
+/// successfully, yet was silently dropped from every generated migration
+/// artifact. <see cref="TranslateStage"/> must now record it (never fail the
+/// stage on it) in the per-app <c>translate.log</c>, mirroring the existing
+/// <c>TestParityStage.Note</c> / <c>test-parity.log</c> pattern.
+/// </summary>
+public class TranslateStageNuGetAuditAdvisoryTests
+{
+    /// <summary>
+    /// A project whose only MSBuild workspace diagnostic is the benign NuGet
+    /// audit advisory (here NU1903/high for the well-known
+    /// <c>Newtonsoft.Json 12.0.1</c> advisory GHSA-5crp-9r3c-p9vr) must PASS
+    /// the stage and still leave a visible, non-fatal trace in
+    /// <c>&lt;AppRunDir&gt;/translate.log</c> naming the CS2GS0003 diagnostic.
+    /// </summary>
+    [Fact]
+    public async Task TranslateStage_NuGetAuditAdvisory_PassesAndIsNotedInTranslateLog()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        string projectDir = NewScratchDir("translate-nuget-audit-advisory");
+        string projectPath = Path.Combine(projectDir, "Vulnerable.csproj");
+        WriteVulnerablePackageProject(projectDir, "Vulnerable.csproj");
+
+        string outRoot = NewOutputRoot("translate-nuget-audit-advisory");
+        var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
+        var pipeline = new MigrationPipeline(options, new IMigrationStage[] { new TranslateStage() });
+
+        var app = new CorpusApp("test/VulnerableAdvisory", projectPath, TargetKind.Exe);
+
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+
+        Assert.True(
+            appResult.Succeeded,
+            "A benign NuGet audit vulnerability advisory (NU1901-NU1904 shape) must not fail the Translate stage.");
+        Assert.Equal("passed", appResult.Stages[0].Status);
+
+        string[] translateLogs = Directory.GetFiles(outRoot, "translate.log", SearchOption.AllDirectories);
+        string translateLog = Assert.Single(translateLogs);
+        string logContent = File.ReadAllText(translateLog);
+        Assert.Contains("CS2GS0003", logContent);
+        Assert.Contains("Newtonsoft.Json", logContent);
+    }
+
+    private static string NewOutputRoot(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "pipeline-tests", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string NewScratchDir(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "loader-tests", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Issue #2321: writes a buildable console project referencing
+    /// <c>Newtonsoft.Json 12.0.1</c>, whose known high-severity vulnerability
+    /// (GHSA-5crp-9r3c-p9vr) NuGet reports as warning NU1903 during restore —
+    /// the exact benign advisory shape this policy must exempt. An empty
+    /// <c>Directory.Build.props</c> override stops MSBuild's directory search
+    /// from climbing to this repo's own root props (which sets
+    /// <c>TreatWarningsAsErrors</c>), matching the convention already used in
+    /// <c>CSharpProjectLoaderDiagnosticsTests</c>.
+    /// </summary>
+    private static void WriteVulnerablePackageProject(string projectDir, string projectFileName)
+    {
+        File.WriteAllText(Path.Combine(projectDir, "Directory.Build.props"), "<Project></Project>");
+        string projectPath = Path.Combine(projectDir, projectFileName);
+        File.WriteAllText(projectPath, @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Newtonsoft.Json"" Version=""12.0.1"" />
+  </ItemGroup>
+</Project>
+");
+        File.WriteAllText(
+            Path.Combine(projectDir, "Program.cs"),
+            "public class Program { public static void Main() { } }");
+
+        // Issue #2321: the advisory only surfaces through MSBuildWorkspace once
+        // the project has an on-disk obj/project.assets.json to replay — same
+        // as any already-restored/built app cs2gs is pointed at in practice.
+        // Run a real `dotnet restore` here to reproduce that precondition.
+        RunDotnetRestore(projectPath);
+    }
+
+    private static void RunDotnetRestore(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", $"restore \"{projectPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using Process process = Process.Start(startInfo);
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        // `dotnet restore` itself exits 0 here because the vulnerability is a
+        // plain warning (not elevated) under the empty Directory.Build.props
+        // override — a non-zero exit means something unrelated broke restore
+        // (e.g. no network access to nuget.org), which every assertion below
+        // would otherwise misattribute to the policy under test.
+        Assert.True(
+            process.ExitCode == 0,
+            $"Prerequisite `dotnet restore` failed (exit {process.ExitCode}); cannot exercise the NuGet audit advisory path.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2321.

`MSBuildWorkspace` records every warning-or-worse line MSBuild logs while opening a project as `WorkspaceDiagnosticKind.Failure` — including the non-fatal NuGet audit vulnerability advisories NuGet emits as NU1901 (low), NU1902 (moderate), NU1903 (high), and NU1904 (critical). Both `CSharpProjectLoader` project-loading paths (`LoadProjectAsync` and `LoadProjectWithReferencesAsync`) blindly promoted every such diagnostic to `CS2GS0001`, incorrectly failing the workspace load for an otherwise-buildable project (blocking 8 of 12 Oahu apps).

## Root-cause investigation

I reproduced the exact `WorkspaceDiagnostic.Message` shapes MSBuildWorkspace emits (captured verbatim via a throwaway harness against a project referencing the well-known vulnerable `Newtonsoft.Json 12.0.1` / NU1903 / `GHSA-5crp-9r3c-p9vr`):

- Plain warning: `Msbuild failed when processing the file '<path>' with message: Package 'Newtonsoft.Json' 12.0.1 has a known high severity vulnerability, https://github.com/advisories/GHSA-5crp-9r3c-p9vr`
- Elevated by `<TreatWarningsAsErrors>` (as this repo's own `Directory.Build.props` sets): same wrapper, plus a literal `Warning As Error: ` marker ahead of the advisory text.
- Genuine failures (missing SDK import, unresolved `ProjectReference`, unsupported TFM) use a completely different shape and never match the advisory pattern.
- NU1900 (audit-fetch failure, or a source-reported "unknown" severity) shares the same sentence shape but never uses `low|moderate|high|critical`, so it's excluded by construction.

## Changes

- **`tools/cs2gs/Cs2Gs.ProjectLoading/NuGetAuditAdvisoryPolicy.cs`** (new): a narrow, pure-text classifier, `IsBenignAdvisory(string message)`, that recognizes only the stable `Package '<id>' <version> has a known <low|moderate|high|critical> severity vulnerability, <url>` shape (tolerating the MSBuildWorkspace wrapper and the `Warning As Error:` marker). Every non-blank line of the message must independently match, so a mixed/multiline diagnostic carrying any non-advisory segment stays fatal.
- **`tools/cs2gs/Cs2Gs.ProjectLoading/CSharpProjectLoader.cs`**: both `LoadProjectAsync` and `LoadProjectWithReferencesAsync` now route every `WorkspaceDiagnosticKind.Failure` through a new shared `ClassifyWorkspaceLoadDiagnostics` helper. A benign advisory becomes an **Info**-severity `CS2GS0003` diagnostic (new id) — kept in `LoadDiagnostics` for visibility, but excluded from `ErrorDiagnostics`, so it no longer trips `BoundWithoutErrors` / `WorkspaceLoadFailed` / `CS2GS0001`. Everything else still becomes the existing **Error**-severity `CS2GS0001`, unchanged.

## Tests

- **`NuGetAuditAdvisoryPolicyTests.cs`** (new, pure policy): NU1901-NU1904 shapes (bare, MSBuildWorkspace-wrapped, `Warning As Error`, multiple advisory lines, case-insensitivity), NU1900 (both documented example shapes), null/blank input, genuine workspace failures (missing SDK import, unresolved `ProjectReference`, project-not-found, unsupported TFM), and mixed/multiline or same-line-extra-text messages that must stay fatal.
- **`CSharpProjectLoaderDiagnosticsTests.cs`**: added
  - `LoadProjectAsync_NuGetAuditAdvisoryDoesNotFailWorkspaceLoad` and `LoadProjectWithReferencesAsync_NuGetAuditAdvisoryDoesNotFailWorkspaceLoad` — real integration regressions (an actual `dotnet restore` against `Newtonsoft.Json 12.0.1`) proving the advisory doesn't fail either loading path and is visible as `CS2GS0003`.
  - `LoadProjectWithReferencesAsync_SurfacesMSBuildWorkspaceLoadFailure` — the `LoadProjectWithReferencesAsync` counterpart proving a genuine failure (unresolved `ProjectReference`) still fails that path.
  - The pre-existing `LoadProjectAsync_SurfacesMSBuildWorkspaceLoadFailure` (unresolved `ProjectReference` failure) is **unchanged**.

## Validation

- `dotnet build tools/cs2gs/Cs2Gs.ProjectLoading/Cs2Gs.ProjectLoading.csproj` — 0 warnings/errors.
- `dotnet build tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj` — 0 warnings/errors.
- `dotnet test` (targeted): `NuGetAuditAdvisoryPolicyTests` + `CSharpProjectLoaderDiagnosticsTests` — 28/28 passed.
- `dotnet test` (full `Cs2Gs.Tests`) — **1352/1352 passed**.
- `dotnet build tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj` — 0 warnings/errors (downstream consumer builds clean).

## Follow-up: closing the visibility gap

The migration reporting path (`TriageArtifact`/`TriageBuilder`, `RunResult`/`AppResult`/`StageResult`, `StageOutcome`, and the `Cs2Gs.Report` HTML/JSON writers) is a **failure-only** schema — `TriageArtifact` is written once per stage failure, `RunResult`'s per-run manifest has no "warnings/notes" field, and `StageOutcome` only supports `Passed()`/`Skipped()`/`Failed(artifacts)`. Adding a "passed-with-notes" concept there would be a schema/architecture change, which was explicitly out of scope. Instead, I confirmed by reading `TranslateStage.ExecuteAsync` and `TestParityStage.TranslateProjectAsync` that **nothing downstream inspected `LoadedCSharpProject.LoadDiagnostics` for the new Info-level `CS2GS0003` diagnostic** — it loaded successfully but was silently dropped on the floor. That's now fixed using an existing, narrow precedent already in this codebase (`TestParityStage.Note`, a best-effort append-only per-app text log):

- **`tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs`**: after the `WorkspaceLoadFailed` gate (which still fails the stage on a genuine load failure, unchanged), a new `NoteNuGetAuditAdvisories` helper appends any `CS2GS0003` diagnostics to a new per-app `translate.log`, using a new `Note` helper mirroring `TestParityStage.Note` byte-for-byte in behavior (best-effort `File.AppendAllText`, swallows `IOException`, never fails the stage).
- **`tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs`**: the `.Tests` companion project load (`TranslateProjectAsync`, a third/separate `CSharpProjectLoader` call site) now threads its `CS2GS0003` diagnostics through a new `TranslatedProject.AdvisoryDiagnostics` property (via updated `Ready`/`Pending` factories) back to `RunLibraryParityAsync`, which logs them with the pre-existing `this.Note(...)` helper into the pre-existing `test-parity.log` — no new log file, no new schema.
- Both changes are purely additive/log-based: the advisory diagnostic itself is still never fatal, and no `RunResult`/`TriageArtifact`/HTML/JSON schema was touched.
- New tests: `TranslateStageNuGetAuditAdvisoryTests` (`.Tests`-free primary-app path — proves `translate.log` gets the `CS2GS0003` note and the stage still passes) and `TestParityStageNuGetAuditAdvisoryTests` (`.Tests` companion-project path — proves `test-parity.log` gets the note and no `CS2GS0001` failure is ever produced from the advisory). `dotnet test` (full `Cs2Gs.Tests`) — **1354/1354 passed** after this follow-up.

## Deferred / out of scope

- `TriageBuilder`/`RunResult`/HTML/JSON reporting schema still carries no general "non-fatal notice" concept; extending it there remains a genuine architecture change and stays out of scope. `CS2GS0003` remains fully and programmatically accessible to any caller via `LoadedCSharpProject.LoadDiagnostics` (used directly by the new log-based surfacing above), so no consumer visibility is actually lost — only the JSON/HTML report schema doesn't (yet) have a dedicated "advisory" field.
- Oahu itself was not touched, per instructions.

