### PR TITLE
Fix #2323: gsc emitter accepts generic slice-to-interface conversions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -1144,6 +1144,75 @@ public sealed class Conversion
     }
 
     /// <summary>
+    /// Issue #1162: symbolic counterpart to <see cref="SliceImplementsInterface"/>
+    /// for a slice <c>[]T</c> whose element <c>T</c> is a same-compilation user
+    /// type and whose backing <see cref="TypeSymbol.ClrType"/> is therefore
+    /// <see langword="null"/> during binding. The backing CLR array cannot be
+    /// walked, so instead match the target interface's open definition against
+    /// the known generic interfaces that a one-dimensional <c>T[]</c> implements
+    /// (<c>IEnumerable&lt;T&gt;</c>, <c>IReadOnlyList&lt;T&gt;</c>,
+    /// <c>IReadOnlyCollection&lt;T&gt;</c>, <c>IList&lt;T&gt;</c>,
+    /// <c>ICollection&lt;T&gt;</c>) and require the single type argument to match
+    /// the slice element. Slice invariance is preserved because
+    /// <see cref="AreTypeArgumentsEquivalent"/> demands an exact element match.
+    ///
+    /// Issue #2323: made <see langword="internal"/> (rather than
+    /// <see langword="private"/>) so <c>MethodBodyEmitter.IsReferenceCompatible</c>
+    /// can call this SAME symbolic rule instead of maintaining a divergent
+    /// copy — the binder accepted these conversions, but the emitter's
+    /// reference-compatibility check only mirrored the element-INDEPENDENT
+    /// #2140 array interfaces, throwing <see cref="NotSupportedException"/>
+    /// for the five generic single-type-argument interfaces when the slice
+    /// element is a generic type parameter or same-compilation user type.
+    /// </summary>
+    /// <param name="slice">The source slice type <c>[]T</c>.</param>
+    /// <param name="targetInterface">The candidate target interface type.</param>
+    /// <returns>
+    /// <see langword="true"/> when <paramref name="slice"/> converts to
+    /// <paramref name="targetInterface"/> under the symbolic slice-to-
+    /// interface rule; otherwise <see langword="false"/>.
+    /// </returns>
+    internal static bool SliceImplementsInterfaceSymbolically(SliceTypeSymbol slice, TypeSymbol targetInterface)
+    {
+        // Issue #2140: element-INDEPENDENT non-generic array interfaces.
+        // Every one-dimensional array implements these regardless of its
+        // element type, so a `[]T` (generic-type-parameter or same-
+        // compilation-user element, null backing ClrType) converts to them
+        // unconditionally. Match by the target's full name.
+        if (IsElementIndependentArrayInterface(targetInterface))
+        {
+            return true;
+        }
+
+        if (targetInterface is not ImportedTypeSymbol imported
+            || imported.OpenDefinition is null
+            || imported.TypeArguments.Length != 1)
+        {
+            return false;
+        }
+
+        var openName = imported.OpenDefinition.FullName;
+        if (openName is null)
+        {
+            return false;
+        }
+
+        var isArrayInterface =
+            string.Equals(openName, typeof(System.Collections.Generic.IEnumerable<>).FullName, StringComparison.Ordinal)
+            || string.Equals(openName, typeof(System.Collections.Generic.IReadOnlyList<>).FullName, StringComparison.Ordinal)
+            || string.Equals(openName, typeof(System.Collections.Generic.IReadOnlyCollection<>).FullName, StringComparison.Ordinal)
+            || string.Equals(openName, typeof(System.Collections.Generic.IList<>).FullName, StringComparison.Ordinal)
+            || string.Equals(openName, typeof(System.Collections.Generic.ICollection<>).FullName, StringComparison.Ordinal);
+
+        if (!isArrayInterface)
+        {
+            return false;
+        }
+
+        return AreTypeArgumentsEquivalent(imported.TypeArguments[0], slice.ElementType);
+    }
+
+    /// <summary>
     /// Review follow-up (#1927/PR #1955): reports whether a variance type
     /// argument is a CLR reference type. CLR generic-interface variance
     /// (ECMA-335 II.9.7) only applies to reference-typed arguments; a value
@@ -2238,59 +2307,6 @@ public sealed class Conversion
         }
 
         return false;
-    }
-
-    /// <summary>
-    /// Issue #1162: symbolic counterpart to <see cref="SliceImplementsInterface"/>
-    /// for a slice <c>[]T</c> whose element <c>T</c> is a same-compilation user
-    /// type and whose backing <see cref="TypeSymbol.ClrType"/> is therefore
-    /// <see langword="null"/> during binding. The backing CLR array cannot be
-    /// walked, so instead match the target interface's open definition against
-    /// the known generic interfaces that a one-dimensional <c>T[]</c> implements
-    /// (<c>IEnumerable&lt;T&gt;</c>, <c>IReadOnlyList&lt;T&gt;</c>,
-    /// <c>IReadOnlyCollection&lt;T&gt;</c>, <c>IList&lt;T&gt;</c>,
-    /// <c>ICollection&lt;T&gt;</c>) and require the single type argument to match
-    /// the slice element. Slice invariance is preserved because
-    /// <see cref="AreTypeArgumentsEquivalent"/> demands an exact element match.
-    /// </summary>
-    private static bool SliceImplementsInterfaceSymbolically(SliceTypeSymbol slice, TypeSymbol targetInterface)
-    {
-        // Issue #2140: element-INDEPENDENT non-generic array interfaces.
-        // Every one-dimensional array implements these regardless of its
-        // element type, so a `[]T` (generic-type-parameter or same-
-        // compilation-user element, null backing ClrType) converts to them
-        // unconditionally. Match by the target's full name.
-        if (IsElementIndependentArrayInterface(targetInterface))
-        {
-            return true;
-        }
-
-        if (targetInterface is not ImportedTypeSymbol imported
-            || imported.OpenDefinition is null
-            || imported.TypeArguments.Length != 1)
-        {
-            return false;
-        }
-
-        var openName = imported.OpenDefinition.FullName;
-        if (openName is null)
-        {
-            return false;
-        }
-
-        var isArrayInterface =
-            string.Equals(openName, typeof(System.Collections.Generic.IEnumerable<>).FullName, StringComparison.Ordinal)
-            || string.Equals(openName, typeof(System.Collections.Generic.IReadOnlyList<>).FullName, StringComparison.Ordinal)
-            || string.Equals(openName, typeof(System.Collections.Generic.IReadOnlyCollection<>).FullName, StringComparison.Ordinal)
-            || string.Equals(openName, typeof(System.Collections.Generic.IList<>).FullName, StringComparison.Ordinal)
-            || string.Equals(openName, typeof(System.Collections.Generic.ICollection<>).FullName, StringComparison.Ordinal);
-
-        if (!isArrayInterface)
-        {
-            return false;
-        }
-
-        return AreTypeArgumentsEquivalent(imported.TypeArguments[0], slice.ElementType);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -858,6 +858,29 @@ internal sealed partial class MethodBodyEmitter
             }
         }
 
+        // Issue #2323: extends #2140 to the five generic single-type-
+        // argument array interfaces — IEnumerable<T>, ICollection<T>,
+        // IList<T>, IReadOnlyList<T>, IReadOnlyCollection<T> — for a slice
+        // `[]T` whose element `T` is a generic type parameter or same-
+        // compilation user type. Such elements leave the slice's backing
+        // `ClrType` null during emit, so neither the #521 CLR reference-
+        // upcast arm nor the #570 `ImplementsInterfaceByName` arm above can
+        // fire (both require a non-null `ClrType` on `a`). The binder
+        // already accepts this exact conversion via
+        // `Conversion.SliceImplementsInterfaceSymbolically`; delegate to
+        // that SAME symbolic rule here rather than re-deriving a second,
+        // potentially divergent open-definition / type-argument match, so
+        // binder acceptance and emitter reference-compatibility can never
+        // disagree. That helper's `AreTypeArgumentsEquivalent` comparison
+        // still rejects a mismatched element type, preserving slice
+        // invariance and GS0155 for genuine element mismatches.
+        if (a is SliceTypeSymbol aSliceSymbolic
+            && aSliceSymbolic.ClrType == null
+            && Conversion.SliceImplementsInterfaceSymbolically(aSliceSymbolic, b))
+        {
+            return true;
+        }
+
         return false;
     }
 

--- a/test/Compiler.Tests/Emit/Issue2323GenericSliceInterfaceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2323GenericSliceInterfaceEmitTests.cs
@@ -1,0 +1,311 @@
+// <copyright file="Issue2323GenericSliceInterfaceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2323: the binder already accepts a slice <c>[]T</c> converting to
+/// each of the five supported one-argument generic collection interfaces —
+/// <c>IEnumerable[T]</c>, <c>ICollection[T]</c>, <c>IList[T]</c>,
+/// <c>IReadOnlyList[T]</c>, <c>IReadOnlyCollection[T]</c> — when <c>T</c> is a
+/// generic type parameter (via <c>Conversion.SliceImplementsInterfaceSymbolically</c>),
+/// but <c>MethodBodyEmitter.IsReferenceCompatible</c> only mirrored the
+/// element-INDEPENDENT #2140 array supertypes and threw
+/// <see cref="NotSupportedException"/> (surfaced as GS9998) for these five
+/// generic interfaces. These tests prove the paired emitter fix end-to-end —
+/// compile, ILVerify, and run — for all five interfaces using the exact
+/// shape from the issue's minimal repro (a generic <c>Holder[T]</c> class),
+/// plus negative coverage proving mismatched element types and unsupported
+/// generic interfaces are still rejected at BIND time (never reaching the
+/// emitter).
+/// </summary>
+public class Issue2323GenericSliceInterfaceEmitTests
+{
+    [Fact]
+    public void GenericParamElementSlice_ToIEnumerable_CompilesRunsAndIlVerifies()
+    {
+        var gsource = """
+            package Repro
+            import System
+            import System.Collections.Generic
+
+            class Holder[T] {
+                var items IEnumerable[T]
+                init(values []T) { items = values }
+                func Count() int32 {
+                    var n int32 = 0
+                    for x in items { n = n + 1 }
+                    return n
+                }
+            }
+
+            var h = Holder[int32]([]int32{1, 2, 3})
+            Console.WriteLine(h.Count())
+            """;
+
+        Assert.Equal("3\n", CompileAndRun(gsource));
+    }
+
+    [Fact]
+    public void GenericParamElementSlice_ToICollection_CompilesRunsAndIlVerifies()
+    {
+        var gsource = """
+            package Repro
+            import System
+            import System.Collections.Generic
+
+            class Holder[T] {
+                var items ICollection[T]
+                init(values []T) { items = values }
+            }
+
+            var h = Holder[int32]([]int32{1, 2, 3, 4})
+            Console.WriteLine(h.items.Count)
+            """;
+
+        Assert.Equal("4\n", CompileAndRun(gsource));
+    }
+
+    [Fact]
+    public void GenericParamElementSlice_ToIList_CompilesRunsAndIlVerifies()
+    {
+        var gsource = """
+            package Repro
+            import System
+            import System.Collections.Generic
+
+            class Holder[T] {
+                var items IList[T]
+                init(values []T) { items = values }
+            }
+
+            var h = Holder[int32]([]int32{1, 2, 3})
+            Console.WriteLine(h.items.Count)
+            Console.WriteLine(h.items[1])
+            """;
+
+        Assert.Equal("3\n2\n", CompileAndRun(gsource));
+    }
+
+    [Fact]
+    public void GenericParamElementSlice_ToIReadOnlyList_CompilesRunsAndIlVerifies()
+    {
+        var gsource = """
+            package Repro
+            import System
+            import System.Collections.Generic
+
+            class Holder[T] {
+                var items IReadOnlyList[T]
+                init(values []T) { items = values }
+            }
+
+            var h = Holder[int32]([]int32{7, 9})
+            Console.WriteLine(h.items[0])
+            Console.WriteLine(h.items.Count)
+            """;
+
+        Assert.Equal("7\n2\n", CompileAndRun(gsource));
+    }
+
+    [Fact]
+    public void GenericParamElementSlice_ToIReadOnlyCollection_CompilesRunsAndIlVerifies()
+    {
+        var gsource = """
+            package Repro
+            import System
+            import System.Collections.Generic
+
+            class Holder[T] {
+                var items IReadOnlyCollection[T]
+                init(values []T) { items = values }
+            }
+
+            var h = Holder[int32]([]int32{1, 2, 3, 4, 5})
+            Console.WriteLine(h.items.Count)
+            """;
+
+        Assert.Equal("5\n", CompileAndRun(gsource));
+    }
+
+    [Fact]
+    public void GenericParamElementSlice_ToIList_WithStringInstantiation_CompilesRunsAndIlVerifies()
+    {
+        // Same generic Holder[T], closed over a reference-type argument
+        // instead of the primitive int32 used above.
+        var gsource = """
+            package Repro
+            import System
+            import System.Collections.Generic
+
+            class Holder[T] {
+                var items IList[T]
+                init(values []T) { items = values }
+            }
+
+            var h = Holder[string]([]string{"a", "b", "c"})
+            Console.WriteLine(h.items.Count)
+            Console.WriteLine(h.items[2])
+            """;
+
+        Assert.Equal("3\nc\n", CompileAndRun(gsource));
+    }
+
+    [Fact]
+    public void Negative_GenericParamElementSlice_ToMismatchedIList_FailsAtBind()
+    {
+        // Slice invariance must hold: []T does NOT convert to IList[U] for a
+        // different generic parameter U. Must fail to compile (never reach
+        // the emitter), not crash with GS9998.
+        var gsource = """
+            package Repro
+            import System.Collections.Generic
+
+            class Holder[T, U] {
+                var items IList[U]
+                init(values []T) { items = values }
+            }
+            """;
+
+        var (exitCode, stderr) = Compile(gsource);
+        Assert.NotEqual(0, exitCode);
+        Assert.DoesNotContain("GS9998", stderr);
+    }
+
+    [Fact]
+    public void Negative_GenericParamElementSlice_ToUnsupportedGenericInterface_FailsAtBind()
+    {
+        // ISet[T] is not one of the five supported array supertype
+        // interfaces; []T must not convert to it.
+        var gsource = """
+            package Repro
+            import System.Collections.Generic
+
+            class Holder[T] {
+                var items ISet[T]
+                init(values []T) { items = values }
+            }
+            """;
+
+        var (exitCode, stderr) = Compile(gsource);
+        Assert.NotEqual(0, exitCode);
+        Assert.DoesNotContain("GS9998", stderr);
+    }
+
+    private static (int ExitCode, string Stderr) Compile(string source, string[] ignoredIlErrorCodes = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2323_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            return (compileExit, compileOut.ToString() + compileErr.ToString());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2323_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2323GenericSliceInterfaceBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2323GenericSliceInterfaceBinderTests.cs
@@ -1,0 +1,191 @@
+// <copyright file="Issue2323GenericSliceInterfaceBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2323: pins the binder-side acceptance (already implemented by
+/// <c>Conversion.SliceImplementsInterfaceSymbolically</c>) of a slice
+/// <c>[]T</c> converting to each of the five supported one-argument generic
+/// collection interfaces — <c>IEnumerable[T]</c>, <c>ICollection[T]</c>,
+/// <c>IList[T]</c>, <c>IReadOnlyList[T]</c>, <c>IReadOnlyCollection[T]</c> —
+/// when <c>T</c> is a generic type parameter whose backing
+/// <see cref="GSharp.Core.CodeAnalysis.Symbols.TypeSymbol.ClrType"/> is
+/// <see langword="null"/> during binding. No prior issue (#1162, #2140) had a
+/// binder test explicitly covering the generic-type-parameter element case for
+/// these five interfaces, only the element-INDEPENDENT non-generic
+/// supertypes (#2140) and the same-compilation user-type element case
+/// (#1162). The corresponding <c>Issue2323GenericSliceInterfaceEmitTests</c>
+/// proves the paired emitter fix end-to-end.
+/// </summary>
+public class Issue2323GenericSliceInterfaceBinderTests
+{
+    [Fact]
+    public void GenericParamElementArray_ToIEnumerable_NoDiagnostics()
+    {
+        const string source = @"
+package P
+import System.Collections.Generic
+class G[T] {
+    func ToEnum(arr []T) IEnumerable[T] { return arr }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void GenericParamElementArray_ToICollection_NoDiagnostics()
+    {
+        const string source = @"
+package P
+import System.Collections.Generic
+class G[T] {
+    func ToColl(arr []T) ICollection[T] { return arr }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void GenericParamElementArray_ToIList_NoDiagnostics()
+    {
+        const string source = @"
+package P
+import System.Collections.Generic
+class G[T] {
+    func ToList(arr []T) IList[T] { return arr }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void GenericParamElementArray_ToIReadOnlyList_NoDiagnostics()
+    {
+        const string source = @"
+package P
+import System.Collections.Generic
+class G[T] {
+    func ToRoList(arr []T) IReadOnlyList[T] { return arr }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void GenericParamElementArray_ToIReadOnlyCollection_NoDiagnostics()
+    {
+        const string source = @"
+package P
+import System.Collections.Generic
+class G[T] {
+    func ToRoColl(arr []T) IReadOnlyCollection[T] { return arr }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void GenericParamElementArray_ToAllFiveInterfaces_NoDiagnostics()
+    {
+        const string source = @"
+package P
+import System.Collections.Generic
+class G[T] {
+    func ToEnum(arr []T) IEnumerable[T] { return arr }
+    func ToColl(arr []T) ICollection[T] { return arr }
+    func ToList(arr []T) IList[T] { return arr }
+    func ToRoList(arr []T) IReadOnlyList[T] { return arr }
+    func ToRoColl(arr []T) IReadOnlyCollection[T] { return arr }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void GenericParamElementArray_ToMismatchedIList_StillRejected()
+    {
+        // Slice invariance must hold: []T does NOT convert to IList[U] for a
+        // different generic parameter U.
+        const string source = @"
+package P
+import System.Collections.Generic
+class G[T, U] {
+    func Bad(arr []T) IList[U] { return arr }
+}
+";
+        var diags = GetDiagnostics(source);
+        Assert.NotEmpty(diags);
+        Assert.Contains(diags, d => d.Id == "GS0154" || d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void GenericParamElementArray_ToUnsupportedGenericInterface_StillRejected()
+    {
+        // ISet[T] is not one of the five supported array supertype
+        // interfaces; a []T slice must not convert to it.
+        const string source = @"
+package P
+import System.Collections.Generic
+class G[T] {
+    func Bad(arr []T) ISet[T] { return arr }
+}
+";
+        var diags = GetDiagnostics(source);
+        Assert.NotEmpty(diags);
+        Assert.Contains(diags, d => d.Id == "GS0154" || d.Id == "GS0155");
+    }
+
+    private static ImmutableArrayOfDiagnostic GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var parseDiagnostics = tree.Diagnostics;
+        var bindDiagnostics = compilation.GlobalScope.Diagnostics;
+        var programDiagnostics = compilation.BoundProgram.Diagnostics;
+        var all = parseDiagnostics
+            .Concat(bindDiagnostics)
+            .Concat(programDiagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+        return new ImmutableArrayOfDiagnostic(all);
+    }
+
+    /// <summary>
+    /// Thin wrapper so the test cases can call <c>Assert.Empty</c> against a
+    /// <see cref="ImmutableArray{T}"/> without exposing the GSharp diagnostic
+    /// surface to xUnit's enumerable inference.
+    /// </summary>
+    private readonly struct ImmutableArrayOfDiagnostic : IReadOnlyCollection<Diagnostic>
+    {
+        private readonly ImmutableArray<Diagnostic> diagnostics;
+
+        public ImmutableArrayOfDiagnostic(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public int Count => this.diagnostics.Length;
+
+        public IEnumerator<Diagnostic> GetEnumerator()
+        {
+            foreach (var diagnostic in this.diagnostics)
+            {
+                yield return diagnostic;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2323: the binder already accepted a slice `[]T` converting to the five supported one-argument generic collection interfaces (`IEnumerable<T>`, `ICollection<T>`, `IList<T>`, `IReadOnlyList<T>`, `IReadOnlyCollection<T>`) when `T` is a generic type parameter or a same-compilation user type, via `Conversion.SliceImplementsInterfaceSymbolically`. But `MethodBodyEmitter.IsReferenceCompatible` only mirrored the element-INDEPENDENT #2140 array supertypes (`System.Array`, non-generic `IEnumerable`/`ICollection`/`IList`, `ICloneable`, etc.), so emission threw `NotSupportedException` (surfaced as `GS9998`) for these five generic interfaces. Binding succeeded, then emission crashed — this blocked `Oahu.Foundation`.

## Root cause & fix

- `Conversion.SliceImplementsInterfaceSymbolically` (private) already implemented the exact acceptance rule needed by the emitter: match the target's open generic definition against the five supported interfaces, require exactly one type argument, and compare it to the slice element via `AreTypeArgumentsEquivalent` (symbol identity / CLR identity / same-compilation symbolic identity).
- Made this method `internal` (moved it next to the existing shared binder/emitter helper `Conversion.IsVarianceCompatibleInterfaceConversion`, which follows the same precedent) so `MethodBodyEmitter.IsReferenceCompatible` can call the same rule directly instead of re-deriving a second, potentially divergent copy of the open-definition/type-argument matching logic.
- Added a single new arm to `IsReferenceCompatible`: when the slice's backing `ClrType` is `null` (generic type parameter or same-compilation user element), delegate to `Conversion.SliceImplementsInterfaceSymbolically`. This treats the valid conversion as a no-op reference conversion, exactly mirroring the binder.
- Mismatched element types and unsupported generic interfaces (e.g. `ISet<T>`) are unaffected — they are still rejected at bind time (`AreTypeArgumentsEquivalent` enforces slice invariance), so they never reach the emitter.

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue2323GenericSliceInterfaceBinderTests.cs` — binder-level pinning of `[]T -> {IEnumerable,ICollection,IList,IReadOnlyList,IReadOnlyCollection}[T]` for a generic type parameter `T` (no prior issue's binder tests covered this specific case), plus negative tests for a mismatched type parameter and an unsupported generic interface (`ISet<T>`).
- `test/Compiler.Tests/Emit/Issue2323GenericSliceInterfaceEmitTests.cs` — end-to-end compile + ILVerify + run coverage for all five interfaces using a generic `Holder[T]` class mirroring the issue's minimal repro (plus a reference-type `Holder[string]` instantiation), and two negative tests proving the mismatched-element and unsupported-interface cases fail at bind time (`GS9998` must never appear) rather than crashing the emitter.
- Reused/extended the existing `Issue1162UserElementArrayEmitTests` / `Issue2140GenericArraySupertypesBinderTests` compile-and-run/diagnostics patterns rather than introducing a new test harness.

## Validation

- `dotnet build src/Compiler/Compiler.csproj -c Release` — succeeds (0 warnings, 0 errors).
- `dotnet build GSharp.sln --configuration Release -graph` — succeeds (0 warnings, 0 errors).
- `dotnet test GSharp.sln --configuration Release --no-build` — full solution gate green:
  - `GSharp.Core.Tests.dll`: 5972 passed, 0 failed, 1 skipped (pre-existing baseline-regeneration skip)
  - `GSharp.Compiler.Tests.dll`: 2799 passed, 0 failed
  - `GSharp.Cs2Gs.Tests.dll`: 1354 passed, 0 failed
  - All other test projects (Extensions, Interpreter, LanguageServer, Sdk, GeneratorHost): all passed, 0 failed
- Manually reproduced the issue's exact `Holder[T]` repro before the fix (GS9998), confirmed it now compiles, ILVerifies, and runs correctly after the fix.

## Deferred work

None identified — the fix and tests cover all five interfaces named in the issue, both generic-type-parameter and negative/rejection cases. No changes were made to Oahu.

Closes #2323
