### PR TITLE
Fix #2325: unify recursive reference-context remapping for nested delegate types

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -11421,34 +11421,20 @@ internal sealed class ReflectionMetadataEmitter
     /// generics from a reference open definition so the produced TypeSpec /
     /// MemberRef binds to the target framework assemblies. Falls back to the
     /// host type when no reference mapping is available.
+    ///
+    /// Issue #2325: this used to carry its own constructed-generic remapping
+    /// loop, separate from (and ahead of) the one in
+    /// <see cref="MapToReferenceClrType"/> — which only did a flat
+    /// full-name lookup and therefore could not resolve a constructed generic
+    /// argument (e.g. the inner `Action&lt;object&gt;` of
+    /// `Action&lt;Action&lt;object&gt;, object&gt;`). That let a nested/
+    /// higher-order delegate mix a MetadataLoadContext open definition with a
+    /// host-context type argument, which `MakeGenericType` rejects at emit
+    /// time (GS9998). `MapToReferenceClrType` now performs the same recursive
+    /// remapping itself, so both callers share one implementation.
     /// </summary>
     internal Type ResolveTargetDelegateClrType(Type hostDelegate)
-    {
-        if (hostDelegate == null)
-        {
-            return null;
-        }
-
-        if (hostDelegate.IsConstructedGenericType)
-        {
-            var openName = hostDelegate.GetGenericTypeDefinition().FullName;
-            if (openName != null && this.emitCtx.References.TryResolveType(openName, requireExternalVisibility: false, out var openRef))
-            {
-                var hostArgs = hostDelegate.GetGenericArguments();
-                var refArgs = new Type[hostArgs.Length];
-                for (var i = 0; i < hostArgs.Length; i++)
-                {
-                    refArgs[i] = this.MapToReferenceClrType(hostArgs[i]) ?? hostArgs[i];
-                }
-
-                return openRef.MakeGenericType(refArgs);
-            }
-
-            return hostDelegate;
-        }
-
-        return this.MapToReferenceClrType(hostDelegate) ?? hostDelegate;
-    }
+        => this.MapToReferenceClrType(hostDelegate);
 
     // Phase 4 emit parity (E1): resolve the BCL delegate type backing a
     // GSharp function type. The default ClrType on FunctionTypeSymbol uses
@@ -11823,11 +11809,56 @@ internal sealed class ReflectionMetadataEmitter
     // unchanged when no mapping is found — non-primitive host types whose
     // FullName isn't resolvable will keep their original identity (and may
     // still encode fine via EncodeClrType's primitive matching).
+    //
+    // Issue #2325: this is the single recursive reference-context remapper
+    // shared by every caller that needs to cross from host-runtime `Type`s
+    // to the emitter's MetadataLoadContext `Type`s (ResolveDelegateArgClrType,
+    // ResolveTargetDelegateClrType, ResolveAsyncDelegateClrType, and the
+    // event-handler-type lookups in MethodBodyEmitter.Closures.cs). A
+    // *constructed* generic type — e.g. `Action<object>`, or nested/
+    // higher-order shapes like `Action<Action<object>, object>` — cannot be
+    // resolved by the flat `Type.FullName` lookup below: `FullName` on a
+    // constructed generic type embeds each argument's assembly-qualified
+    // name (e.g. "System.Action`1[[System.Object, ...]]"), which never
+    // matches the reference index (built from open generic *definitions*
+    // only — see AddToTypeNameIndex). Left unhandled, a constructed generic
+    // delegate argument fell through to the "return hostType unchanged"
+    // fallback, and a later `MakeGenericType` on a reference-context open
+    // definition mixed in a host-context type argument — MakeGenericType
+    // rejects that combination at emit time (GS9998: "was not loaded by the
+    // MetadataLoadContext that loaded the generic type or method").
+    //
+    // The fix: resolve the open generic definition through the active
+    // reference context, then recurse into every type argument through this
+    // same helper — so an arbitrarily nested constructed generic (the
+    // higher-order delegate case) is remapped, and the closed type is
+    // constructed entirely within the reference context. Non-generic types
+    // keep the original flat lookup; an open definition with no reference
+    // equivalent falls back to the host type unchanged, same as before.
     internal Type MapToReferenceClrType(Type hostType)
     {
         if (hostType == null)
         {
             return null;
+        }
+
+        if (hostType.IsConstructedGenericType)
+        {
+            var openDef = hostType.GetGenericTypeDefinition();
+            if (openDef.FullName != null
+                && this.emitCtx.References.TryResolveType(openDef.FullName, requireExternalVisibility: false, out var openRef))
+            {
+                var hostArgs = hostType.GetGenericArguments();
+                var refArgs = new Type[hostArgs.Length];
+                for (var i = 0; i < hostArgs.Length; i++)
+                {
+                    refArgs[i] = this.MapToReferenceClrType(hostArgs[i]) ?? hostArgs[i];
+                }
+
+                return openRef.MakeGenericType(refArgs);
+            }
+
+            return hostType;
         }
 
         if (this.emitCtx.References.TryResolveType(hostType.FullName ?? hostType.Name, requireExternalVisibility: false, out var mapped))

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -11835,11 +11835,57 @@ internal sealed class ReflectionMetadataEmitter
     // constructed entirely within the reference context. Non-generic types
     // keep the original flat lookup; an open definition with no reference
     // equivalent falls back to the host type unchanged, same as before.
+    //
+    // Issue #2325 follow-up: an array (`T[]`/`T[,]`), pointer (`T*`), or
+    // byref (`T&`) shape can appear as (or nested inside — e.g.
+    // `Action<int[], object>`) a constructed generic argument, and is
+    // subject to the exact same cross-context mismatch: `T.MakeArrayType()`
+    // / `MakePointerType()` / `MakeByRefType()` built over an unmapped
+    // host-context element `Type` still carries the host identity, so a
+    // later `MakeGenericType` combining it with a reference-context open
+    // definition throws GS9998 the same way an unmapped constructed generic
+    // argument did. Each of these three shapes wraps exactly one element
+    // type (`Type.GetElementType()`), so recurse through this same helper on
+    // the element and rebuild the wrapper — preserving the exact array rank
+    // (and the vector- vs. general-rank-1-array distinction, via
+    // `Type.IsSZArray`) — entirely within the reference context. An element
+    // that is itself a `Type.IsGenericParameter` (e.g. `T[]` for an in-scope
+    // type parameter) falls through unchanged via the flat lookup below,
+    // exactly as an unwrapped generic parameter already did: this rebuild
+    // only changes how the *wrapper* is reconstructed, not generic-parameter
+    // handling.
     internal Type MapToReferenceClrType(Type hostType)
     {
         if (hostType == null)
         {
             return null;
+        }
+
+        if (hostType.IsByRef)
+        {
+            var mappedElement = this.MapToReferenceClrType(hostType.GetElementType()) ?? hostType.GetElementType();
+            return mappedElement.MakeByRefType();
+        }
+
+        if (hostType.IsPointer)
+        {
+            var mappedElement = this.MapToReferenceClrType(hostType.GetElementType()) ?? hostType.GetElementType();
+            return mappedElement.MakePointerType();
+        }
+
+        if (hostType.IsArray)
+        {
+            var mappedElement = this.MapToReferenceClrType(hostType.GetElementType()) ?? hostType.GetElementType();
+
+            // A rank-1 array is either a vector (`T[]`, constructed via the
+            // parameterless `MakeArrayType()`) or a general rank-1 array
+            // (`T[*]`, constructed via `MakeArrayType(1)`) — reflection
+            // treats these as distinct array kinds sharing rank 1;
+            // `Type.IsSZArray` is the documented way to tell them apart
+            // (mirrors DocumentationIdProvider.AppendArraySuffix).
+            return hostType.IsSZArray
+                ? mappedElement.MakeArrayType()
+                : mappedElement.MakeArrayType(hostType.GetArrayRank());
         }
 
         if (hostType.IsConstructedGenericType)

--- a/test/Compiler.Tests/Emit/Issue2325NestedArrayDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2325NestedArrayDelegateEmitTests.cs
@@ -1,0 +1,250 @@
+// <copyright file="Issue2325NestedArrayDelegateEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2325 follow-up: an array-typed delegate parameter (G# slice syntax
+/// <c>[]int32</c>, whose CLR shape is the SZArray <c>System.Int32[]</c> —
+/// see <c>SliceTypeSymbol</c>/<c>ArrayTypeSymbol</c>, both of which build
+/// their CLR type via <c>elementType.ClrType.MakeArrayType()</c> over the
+/// element's *host-runtime* <see cref="Type"/>) is subject to the exact same
+/// cross-context mismatch as the nested-delegate case covered by
+/// <c>Issue2325NestedDelegateEmitTests</c>: an array built over an unmapped
+/// host-context element still carries the host identity, so combining it
+/// with a reference-context (MetadataLoadContext) open generic definition
+/// via <c>MakeGenericType</c> throws GS9998 the same way an unmapped
+/// constructed-generic delegate argument did.
+///
+/// These tests drive gsc through explicit <c>/reference:</c> flags pointing
+/// at the <c>Microsoft.NETCore.App.Ref</c> targeting-pack facades (the same
+/// reference-assembly closure the .NET SDK and cs2gs supply), so the
+/// MetadataLoadContext code path that reproduces the bug is actually
+/// exercised. Each test compiles, ILVerifies, and runs the emitted assembly
+/// end-to-end.
+/// </summary>
+public class Issue2325NestedArrayDelegateEmitTests
+{
+    [Fact]
+    public void ArrayDelegateArgument_ActionShape_CompilesRunsAndIlVerifies()
+    {
+        // The delegate parameter `f`'s function type `([]int32, object?) -> void`
+        // materialises as `Action<int32[], object>` — an array argument
+        // alongside another argument in the same constructed generic, the
+        // shape the array-remapping branch of MapToReferenceClrType exists
+        // for. `PrintFirstAndTag` is a plain top-level function (rather than
+        // a lambda) so the multi-statement void body needs no special lambda
+        // block syntax; converting it to `f`'s function type still routes
+        // through the same ResolveDelegateClrType/ResolveDelegateArgClrType
+        // path a lambda literal would.
+        var gsource = """
+            package Repro
+            import System
+
+            func Apply(f ([]int32, object?) -> void, arr []int32, extra object?) {
+                f(arr, extra)
+            }
+
+            func PrintFirstAndTag(values []int32, tag object?) {
+                Console.WriteLine(values[0])
+                Console.WriteLine(tag)
+            }
+
+            Apply(PrintFirstAndTag, []int32{7, 8, 9}, "tag")
+            """;
+
+        Assert.Equal("7\ntag\n", CompileAndRun(gsource));
+    }
+
+    [Fact]
+    public void ArrayDelegateArgument_DoubleNested_CompilesRunsAndIlVerifies()
+    {
+        // A doubly-nested variant matching the shape of the issue's minimal
+        // Action<Action<object>, object> repro, but with the inner
+        // delegate's own argument being the array: the outer delegate's
+        // first parameter is itself a `([]int32, object?) -> void` function
+        // type, i.e. `Action<Action<int32[], object>, object>`.
+        var gsource = """
+            package Repro
+            import System
+
+            func Invoke2(cb (([]int32, object?) -> void, object?) -> void) {
+                cb(PrintFirstAndExtra, "outer")
+            }
+
+            func PrintFirstAndExtra(values []int32, extra object?) {
+                Console.WriteLine(values[0])
+                Console.WriteLine(extra)
+            }
+
+            Invoke2((inner ([]int32, object?) -> void, arg object?) -> inner([]int32{1, 2, 3}, arg))
+            """;
+
+        Assert.Equal("1\nouter\n", CompileAndRun(gsource));
+    }
+
+    [Fact]
+    public void ArrayReturningNestedFunc_CompilesRunsAndIlVerifies()
+    {
+        // A Func-shaped (returning) variant: the outer delegate's first
+        // parameter is a value-returning `(int32) -> []int32` function type,
+        // i.e. Func<Func<int32,int32[]>, int32, int32[]>.
+        var gsource = """
+            package Repro
+            import System
+
+            func Invoke2(cb ((int32) -> []int32, int32) -> []int32) []int32 {
+                return cb(MakePair, 41)
+            }
+
+            func MakePair(n int32) []int32 {
+                return []int32{n, n + 1}
+            }
+
+            let result = Invoke2((inner (int32) -> []int32, arg int32) -> inner(arg))
+            Console.WriteLine(result[0])
+            Console.WriteLine(result[1])
+            """;
+
+        Assert.Equal("41\n42\n", CompileAndRun(gsource));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2325_array_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+
+            foreach (var reference in RefPackReferences())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Assembles the same reference closure the .NET SDK (and cs2gs) would
+    /// pass to gsc via explicit <c>/reference:</c> flags — the
+    /// <c>Microsoft.NETCore.App.Ref</c> targeting-pack facades for the
+    /// running runtime. Loading these through gsc's isolated
+    /// MetadataLoadContext (rather than the host's trusted-platform
+    /// assemblies) is what actually exercises the GS9998 cross-context
+    /// mismatch this issue is about — the TPA-backed default resolver shares
+    /// the host runtime's own <c>System.Private.CoreLib</c> identity and
+    /// would mask the bug. Throws (via <see cref="Xunit.Sdk.XunitException"/>)
+    /// rather than silently skipping when the ref-pack is absent, so a CI
+    /// environment missing the ref-pack surfaces a clear diagnostic instead
+    /// of a false pass.
+    /// </summary>
+    private static IEnumerable<string> RefPackReferences()
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir))
+        {
+            throw new Xunit.Sdk.XunitException("host runtime directory not resolvable");
+        }
+
+        var sharedDir = Directory.GetParent(runtimeDir)?.Parent;
+        var dotnetRoot = sharedDir?.Parent?.FullName;
+        if (string.IsNullOrEmpty(dotnetRoot))
+        {
+            throw new Xunit.Sdk.XunitException("dotnet root not resolvable");
+        }
+
+        var tfm = $"net{Environment.Version.Major}.0";
+        var packsRoot = Path.Combine(dotnetRoot, "packs", "Microsoft.NETCore.App.Ref");
+        if (!Directory.Exists(packsRoot))
+        {
+            throw new Xunit.Sdk.XunitException($"ref pack root '{packsRoot}' missing");
+        }
+
+        var version = Environment.Version.ToString(3);
+        var refDir = Path.Combine(packsRoot, version, "ref", tfm);
+        if (!Directory.Exists(refDir))
+        {
+            var major = Environment.Version.Major.ToString();
+            var candidate = Directory.EnumerateDirectories(packsRoot, major + ".*")
+                .OrderByDescending(d => d, StringComparer.Ordinal)
+                .Select(d => Path.Combine(d, "ref", tfm))
+                .FirstOrDefault(Directory.Exists);
+            if (string.IsNullOrEmpty(candidate))
+            {
+                throw new Xunit.Sdk.XunitException($"no ref pack for net{major}.0 under '{packsRoot}'");
+            }
+
+            refDir = candidate;
+        }
+
+        return Directory.EnumerateFiles(refDir, "*.dll").ToArray();
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2325NestedDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2325NestedDelegateEmitTests.cs
@@ -1,0 +1,252 @@
+// <copyright file="Issue2325NestedDelegateEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2325: compiling with explicit <c>/reference:</c> assemblies (the
+/// same MetadataLoadContext-backed mode cs2gs drives gsc with) previously
+/// threw <c>GS9998 ArgumentException: This type '...' was not loaded by the
+/// MetadataLoadContext that loaded the generic type or method</c> whenever a
+/// function/delegate type was nested inside another delegate signature —
+/// e.g. <c>Action&lt;Action&lt;object&gt;, object&gt;</c>.
+///
+/// Root cause: <c>ReflectionMetadataEmitter.ResolveDelegateClrType</c>
+/// resolves the outer open generic delegate through the active reference
+/// (MetadataLoadContext) context, but the per-argument helper
+/// (<c>ResolveDelegateArgClrType</c>) called <c>MapToReferenceClrType</c>,
+/// which only performed a flat <c>Type.FullName</c> lookup. A *constructed*
+/// generic argument's <c>FullName</c> embeds each nested argument's
+/// assembly-qualified name (e.g.
+/// <c>"System.Action`1[[System.Object, System.Private.CoreLib, ...]]"</c>),
+/// which never matches the reference index (built from open generic
+/// *definitions* only), so the lookup silently fell back to the host-context
+/// <see cref="Type"/>. <c>MakeGenericType</c> then combined a
+/// MetadataLoadContext open definition with a host-context type argument —
+/// exactly the mismatch <c>MakeGenericType</c> rejects at runtime.
+/// <c>ResolveTargetDelegateClrType</c> already contained the correct
+/// recursive constructed-generic remapping logic (for a delegate type
+/// obtained by reflecting over a host CLR method), so the two code paths had
+/// diverged. The fix makes <c>MapToReferenceClrType</c> itself the single
+/// recursive reference-context remapper — resolving a constructed generic's
+/// open definition in the active reference context and recursing into every
+/// type argument through the same helper — so both
+/// <c>ResolveDelegateArgClrType</c> and <c>ResolveTargetDelegateClrType</c>
+/// share one implementation instead of maintaining divergent copies.
+///
+/// These tests drive gsc through explicit <c>/reference:</c> flags pointing
+/// at the <c>Microsoft.NETCore.App.Ref</c> targeting-pack facades — the same
+/// reference-assembly closure the .NET SDK (and cs2gs) supplies — so the
+/// MetadataLoadContext code path that reproduces GS9998 is actually
+/// exercised (the TPA-backed default resolver shares the host's runtime
+/// identity and would mask the bug). Each test compiles, ILVerifies, and
+/// runs the emitted assembly end-to-end.
+/// </summary>
+public class Issue2325NestedDelegateEmitTests
+{
+    [Fact]
+    public void NestedAction_MinimalReproFromIssue_CompilesRunsAndIlVerifies()
+    {
+        // Exact minimal repro from the issue: an outer two-parameter Action
+        // whose first parameter is itself an `(object?) -> void` function
+        // type — i.e. Action<Action<object>, object> once both levels are
+        // materialised as CLR delegates.
+        var gsource = """
+            package Repro
+            import System
+
+            func Invoke2(cb ((object?) -> void, object?) -> void) {
+                cb((o object?) -> Console.WriteLine(o), nil)
+            }
+
+            Invoke2((inner (object?) -> void, arg object?) -> inner(arg))
+            """;
+
+        Assert.Equal("\n", CompileAndRun(gsource));
+    }
+
+    [Fact]
+    public void NestedFunc_ReturningVariant_CompilesRunsAndIlVerifies()
+    {
+        // A nested Func-shaped (returning) variant of the same bug: the
+        // outer delegate's first parameter is itself a value-returning
+        // `(int32) -> int32` function type, i.e.
+        // Func<Func<int32,int32>, int32, int32>.
+        var gsource = """
+            package Repro
+            import System
+
+            func Invoke2(cb ((int32) -> int32, int32) -> int32) int32 {
+                return cb((x int32) -> x + 1, 41)
+            }
+
+            Console.WriteLine(Invoke2((inner (int32) -> int32, arg int32) -> inner(arg)))
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(gsource));
+    }
+
+    [Fact]
+    public void OahuSendOrPostCallbackShape_CompilesRunsAndIlVerifies()
+    {
+        // Structurally mirrors the real Oahu occurrence:
+        // ExtensionsSyncContext.SendOrPost(Action<SendOrPostCallback, object> sendOrPost, Action delgat).
+        // G# has no named-delegate type distinct from a structural function
+        // type, so a CLR `SendOrPostCallback` parameter (Invoke shape
+        // `void Invoke(object state)`) translates to the nested function
+        // type `(object?) -> void` — exactly reproducing the two-parameter,
+        // nested-first-argument shape that triggered GS9998.
+        var gsource = """
+            package Repro
+            import System
+
+            func SendOrPost(sendOrPost ((object?) -> void, object?) -> void, delgat () -> void) {
+                sendOrPost((state object?) -> Console.WriteLine(state), "hello")
+                delgat()
+            }
+
+            SendOrPost((callback (object?) -> void, state object?) -> callback(state), () -> Console.WriteLine("done"))
+            """;
+
+        Assert.Equal("hello\ndone\n", CompileAndRun(gsource));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2325_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+
+            foreach (var reference in RefPackReferences())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Assembles the same reference closure the .NET SDK (and cs2gs) would
+    /// pass to gsc via explicit <c>/reference:</c> flags — the
+    /// <c>Microsoft.NETCore.App.Ref</c> targeting-pack facades for the
+    /// running runtime. Loading these through gsc's isolated
+    /// MetadataLoadContext (rather than the host's trusted-platform
+    /// assemblies) is what actually exercises the GS9998 cross-context
+    /// mismatch this issue is about — the TPA-backed default resolver shares
+    /// the host runtime's own <c>System.Private.CoreLib</c> identity and
+    /// would mask the bug. Throws (via <see cref="Xunit.Sdk.XunitException"/>)
+    /// rather than silently skipping when the ref-pack is absent, so a CI
+    /// environment missing the ref-pack surfaces a clear diagnostic instead
+    /// of a false pass.
+    /// </summary>
+    private static IEnumerable<string> RefPackReferences()
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir))
+        {
+            throw new Xunit.Sdk.XunitException("host runtime directory not resolvable");
+        }
+
+        var sharedDir = Directory.GetParent(runtimeDir)?.Parent;
+        var dotnetRoot = sharedDir?.Parent?.FullName;
+        if (string.IsNullOrEmpty(dotnetRoot))
+        {
+            throw new Xunit.Sdk.XunitException("dotnet root not resolvable");
+        }
+
+        var tfm = $"net{Environment.Version.Major}.0";
+        var packsRoot = Path.Combine(dotnetRoot, "packs", "Microsoft.NETCore.App.Ref");
+        if (!Directory.Exists(packsRoot))
+        {
+            throw new Xunit.Sdk.XunitException($"ref pack root '{packsRoot}' missing");
+        }
+
+        var version = Environment.Version.ToString(3);
+        var refDir = Path.Combine(packsRoot, version, "ref", tfm);
+        if (!Directory.Exists(refDir))
+        {
+            var major = Environment.Version.Major.ToString();
+            var candidate = Directory.EnumerateDirectories(packsRoot, major + ".*")
+                .OrderByDescending(d => d, StringComparer.Ordinal)
+                .Select(d => Path.Combine(d, "ref", tfm))
+                .FirstOrDefault(Directory.Exists);
+            if (string.IsNullOrEmpty(candidate))
+            {
+                throw new Xunit.Sdk.XunitException($"no ref pack for net{major}.0 under '{packsRoot}'");
+            }
+
+            refDir = candidate;
+        }
+
+        return Directory.EnumerateFiles(refDir, "*.dll").ToArray();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2325ArrayPointerByRefRemapEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2325ArrayPointerByRefRemapEmitTests.cs
@@ -1,0 +1,295 @@
+// <copyright file="Issue2325ArrayPointerByRefRemapEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Emit;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #2325 follow-up: <c>ReflectionMetadataEmitter.MapToReferenceClrType</c>
+/// (the single recursive reference-context remapper introduced by the main
+/// #2325 fix — see <c>Issue2325NestedDelegateEmitTests</c> in
+/// Compiler.Tests) must also correctly rebuild an array (including its exact
+/// rank and the vector-vs-general-rank-1 distinction), pointer, or byref
+/// shape from a recursively remapped element type, whenever one of those
+/// shapes appears inside — or as — a constructed generic/delegate argument.
+///
+/// A host-context array/pointer/byref `Type` built over an unmapped element
+/// (e.g. `hostInt32Type.MakeArrayType()`) still carries the host identity;
+/// combining it with a reference-context (MetadataLoadContext) open generic
+/// definition via <c>MakeGenericType</c> throws the same GS9998
+/// cross-context mismatch an unmapped constructed-generic argument did
+/// before the main fix.
+///
+/// <c>Type.MakePointerType()</c> and <c>Type.MakeByRefType()</c> cannot
+/// legally appear as a generic type argument (CLR generics forbid pointer,
+/// byref, and byref-like type arguments — ECMA-335 §I.9.4), so no G# source
+/// program can drive a pointer or byref shape through this helper via a
+/// delegate's generic argument the way an array legitimately can (e.g.
+/// <c>Action&lt;int[], object&gt;</c>). Array coverage is therefore proven
+/// both by direct unit test AND by an explicit-/reference end-to-end
+/// compile/ILVerify/run test in Compiler.Tests
+/// (<c>Issue2325NestedArrayDelegateEmitTests</c>); pointer/byref coverage —
+/// unreachable from G# delegate syntax, but still handled by the shared
+/// helper for any other caller that passes such a shape directly — is
+/// proven at this, the smallest level that can actually reach the code:
+/// a direct call to the internal helper (obtained via reflection over its
+/// private constructor, since <c>ReflectionMetadataEmitter</c> only exposes
+/// a static <c>Emit</c> entry point) with host-runtime pointer/byref
+/// <see cref="Type"/>s built directly via <see cref="Type.MakePointerType"/>
+/// and <see cref="Type.MakeByRefType"/>.
+///
+/// Every test drives a real explicit-<c>/reference:</c>-style
+/// <see cref="ReferenceResolver"/> (the <c>Microsoft.NETCore.App.Ref</c>
+/// targeting-pack facades — the same MetadataLoadContext-backed mode cs2gs
+/// drives gsc with) rather than the default host-runtime resolver, so the
+/// assertions genuinely prove the remapped element resolves to the
+/// reference context's own <c>System.Int32</c>, not the test host's.
+/// </summary>
+public class Issue2325ArrayPointerByRefRemapEmitTests
+{
+    [Fact]
+    public void SzArray_RemapsElementAndPreservesVectorShape()
+    {
+        var emitter = CreateEmitter(out var references);
+        var hostArray = typeof(int).MakeArrayType();
+
+        var mapped = emitter.MapToReferenceClrType(hostArray);
+
+        Assert.True(mapped.IsArray);
+        Assert.True(mapped.IsSZArray);
+        Assert.Equal(1, mapped.GetArrayRank());
+        AssertMappedInt32(references, mapped.GetElementType());
+        Assert.NotEqual(typeof(int).Assembly.FullName, mapped.GetElementType().Assembly.FullName);
+    }
+
+    [Fact]
+    public void GeneralRank1Array_PreservesNonVectorShape()
+    {
+        var emitter = CreateEmitter(out var references);
+
+        // `Type.MakeArrayType(1)` builds the general (non-vector) rank-1
+        // array `int[*]`, distinct from the vector `int[]` produced by the
+        // parameterless overload — reflection keeps these as separate array
+        // kinds sharing rank 1 (`Type.IsSZArray` tells them apart).
+        var hostArray = typeof(int).MakeArrayType(1);
+        Assert.False(hostArray.IsSZArray);
+
+        var mapped = emitter.MapToReferenceClrType(hostArray);
+
+        Assert.True(mapped.IsArray);
+        Assert.False(mapped.IsSZArray);
+        Assert.Equal(1, mapped.GetArrayRank());
+        AssertMappedInt32(references, mapped.GetElementType());
+    }
+
+    [Fact]
+    public void MultiDimensionalArray_PreservesRank()
+    {
+        var emitter = CreateEmitter(out var references);
+        var hostArray = typeof(int).MakeArrayType(3);
+
+        var mapped = emitter.MapToReferenceClrType(hostArray);
+
+        Assert.True(mapped.IsArray);
+        Assert.Equal(3, mapped.GetArrayRank());
+        AssertMappedInt32(references, mapped.GetElementType());
+    }
+
+    [Fact]
+    public void ArrayOfArrays_RemapsEachNestingLevel()
+    {
+        // `int[][]` — a jagged array — nests the array shape two levels
+        // deep; both the outer and inner element must resolve in the
+        // reference context.
+        var emitter = CreateEmitter(out var references);
+        var hostArray = typeof(int).MakeArrayType().MakeArrayType();
+
+        var mapped = emitter.MapToReferenceClrType(hostArray);
+
+        Assert.True(mapped.IsArray);
+        Assert.True(mapped.IsSZArray);
+        var inner = mapped.GetElementType();
+        Assert.True(inner.IsArray);
+        Assert.True(inner.IsSZArray);
+        AssertMappedInt32(references, inner.GetElementType());
+    }
+
+    [Fact]
+    public void ArrayNestedInsideConstructedGenericArgument_RemapsBothLevels()
+    {
+        // Mirrors the legally-emittable Action<int[], object> shape: an
+        // array as one of the outer constructed generic's type arguments —
+        // exactly what the recursive constructed-generic branch feeds into
+        // the array branch added by this follow-up.
+        var emitter = CreateEmitter(out var references);
+        var hostGeneric = typeof(Action<,>).MakeGenericType(typeof(int[]), typeof(object));
+
+        var mapped = emitter.MapToReferenceClrType(hostGeneric);
+
+        Assert.True(mapped.IsConstructedGenericType);
+        Assert.NotEqual(typeof(Action<,>).Assembly.FullName, mapped.GetGenericTypeDefinition().Assembly.FullName);
+
+        var args = mapped.GetGenericArguments();
+        Assert.True(args[0].IsArray);
+        Assert.True(args[0].IsSZArray);
+        AssertMappedInt32(references, args[0].GetElementType());
+    }
+
+    [Fact]
+    public void PointerType_RemapsElementInReferenceContext()
+    {
+        // Unreachable from G# delegate/generic-argument syntax (CLR forbids
+        // pointer generic arguments), but the shared helper must still
+        // rebuild the wrapper correctly for any other direct caller.
+        var emitter = CreateEmitter(out var references);
+        var hostPointer = typeof(int).MakePointerType();
+
+        var mapped = emitter.MapToReferenceClrType(hostPointer);
+
+        Assert.True(mapped.IsPointer);
+        AssertMappedInt32(references, mapped.GetElementType());
+        Assert.NotEqual(typeof(int).Assembly.FullName, mapped.GetElementType().Assembly.FullName);
+    }
+
+    [Fact]
+    public void ByRefType_RemapsElementInReferenceContext()
+    {
+        // Unreachable from G# delegate/generic-argument syntax (CLR forbids
+        // byref generic arguments), but the shared helper must still rebuild
+        // the wrapper correctly for any other direct caller (e.g. a future
+        // non-delegate byref-parameter mapping site).
+        var emitter = CreateEmitter(out var references);
+        var hostByRef = typeof(int).MakeByRefType();
+
+        var mapped = emitter.MapToReferenceClrType(hostByRef);
+
+        Assert.True(mapped.IsByRef);
+        AssertMappedInt32(references, mapped.GetElementType());
+        Assert.NotEqual(typeof(int).Assembly.FullName, mapped.GetElementType().Assembly.FullName);
+    }
+
+    [Fact]
+    public void PointerToArray_RemapsBothWrapperLevels()
+    {
+        // `int[]*` — a pointer to a vector array — exercises composing two
+        // of the three new wrapper kinds so the recursion genuinely nests
+        // rather than only handling one level.
+        var emitter = CreateEmitter(out var references);
+        var hostPointerToArray = typeof(int).MakeArrayType().MakePointerType();
+
+        var mapped = emitter.MapToReferenceClrType(hostPointerToArray);
+
+        Assert.True(mapped.IsPointer);
+        var element = mapped.GetElementType();
+        Assert.True(element.IsArray);
+        Assert.True(element.IsSZArray);
+        AssertMappedInt32(references, element.GetElementType());
+    }
+
+    /// <summary>
+    /// Asserts that <paramref name="mappedElementType"/> is the reference
+    /// context's own <c>System.Int32</c> (obtained independently through
+    /// <see cref="ReferenceResolver.TryResolveType(string, out Type)"/>) —
+    /// not the test host's <see cref="int"/> — proving the element was
+    /// actually remapped rather than passed through unchanged.
+    /// </summary>
+    private static void AssertMappedInt32(ReferenceResolver references, Type mappedElementType)
+    {
+        Assert.True(
+            references.TryResolveType("System.Int32", out var referenceInt32),
+            "expected the reference resolver to resolve System.Int32 from the ref-pack facades");
+        Assert.Equal(referenceInt32, mappedElementType);
+    }
+
+    /// <summary>
+    /// Builds a <see cref="ReflectionMetadataEmitter"/> wired to a real
+    /// explicit-reference-style <see cref="ReferenceResolver"/> (the
+    /// <c>Microsoft.NETCore.App.Ref</c> targeting-pack facades — the same
+    /// MetadataLoadContext-backed mode cs2gs drives gsc with), via reflection
+    /// over the private constructor (the only entry point is the static
+    /// <c>Emit</c> method, which does not return the instance). The
+    /// constructor only stores its arguments on <c>EmitContext</c> — it never
+    /// dereferences <paramref name="references"/>'s <c>BoundProgram</c>
+    /// argument — so passing <see langword="null"/> for it is safe for this
+    /// narrowly-scoped unit test of <c>MapToReferenceClrType</c>, which only
+    /// consults <c>emitCtx.References</c>.
+    /// </summary>
+    private static ReflectionMetadataEmitter CreateEmitter(out ReferenceResolver references)
+    {
+        references = ReferenceResolver.WithReferences(RefPackReferences());
+
+        var ctor = typeof(ReflectionMetadataEmitter).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null,
+            types: new[] { typeof(BoundProgram), typeof(ReferenceResolver), typeof(string), typeof(bool) },
+            modifiers: null)
+            ?? throw new InvalidOperationException(
+                "ReflectionMetadataEmitter's private constructor signature changed; update this test's reflection probe.");
+
+        return (ReflectionMetadataEmitter)ctor.Invoke(new object[] { null, references, null, false });
+    }
+
+    /// <summary>
+    /// Assembles the same reference closure the .NET SDK (and cs2gs) would
+    /// pass to gsc via explicit <c>/reference:</c> flags — the
+    /// <c>Microsoft.NETCore.App.Ref</c> targeting-pack facades for the
+    /// running runtime. Loading these through an isolated
+    /// MetadataLoadContext (rather than the host's trusted-platform
+    /// assemblies) is what actually exercises the cross-context remapping
+    /// this test is about — a TPA-backed resolver shares the host runtime's
+    /// own <c>System.Private.CoreLib</c> identity and would make every
+    /// assertion trivially true. Throws when the ref-pack is absent so a CI
+    /// environment missing it surfaces a clear diagnostic instead of a false
+    /// pass.
+    /// </summary>
+    private static string[] RefPackReferences()
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir))
+        {
+            throw new InvalidOperationException("host runtime directory not resolvable");
+        }
+
+        var sharedDir = Directory.GetParent(runtimeDir)?.Parent;
+        var dotnetRoot = sharedDir?.Parent?.FullName;
+        if (string.IsNullOrEmpty(dotnetRoot))
+        {
+            throw new InvalidOperationException("dotnet root not resolvable");
+        }
+
+        var tfm = $"net{Environment.Version.Major}.0";
+        var packsRoot = Path.Combine(dotnetRoot, "packs", "Microsoft.NETCore.App.Ref");
+        if (!Directory.Exists(packsRoot))
+        {
+            throw new InvalidOperationException($"ref pack root '{packsRoot}' missing");
+        }
+
+        var version = Environment.Version.ToString(3);
+        var refDir = Path.Combine(packsRoot, version, "ref", tfm);
+        if (!Directory.Exists(refDir))
+        {
+            var major = Environment.Version.Major.ToString();
+            var candidate = Directory.EnumerateDirectories(packsRoot, major + ".*")
+                .OrderByDescending(d => d, StringComparer.Ordinal)
+                .Select(d => Path.Combine(d, "ref", tfm))
+                .FirstOrDefault(Directory.Exists);
+            if (string.IsNullOrEmpty(candidate))
+            {
+                throw new InvalidOperationException($"no ref pack for net{major}.0 under '{packsRoot}'");
+            }
+
+            refDir = candidate;
+        }
+
+        return Directory.EnumerateFiles(refDir, "*.dll").ToArray();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2325: compiling with explicit `/reference:` assemblies (the MetadataLoadContext-backed mode cs2gs drives gsc with) threw `GS9998 ArgumentException: This type '...' was not loaded by the MetadataLoadContext that loaded the generic type or method` whenever a function/delegate type was nested inside another delegate signature (e.g. `Action<Action<object>, object>`).

## Root cause

`ReflectionMetadataEmitter.ResolveDelegateClrType` resolves the outer open generic delegate through the active reference (MetadataLoadContext) context, but the per-argument helper `ResolveDelegateArgClrType` called `MapToReferenceClrType`, which only did a flat `Type.FullName` lookup. A *constructed* generic argument's `FullName` embeds each nested argument's assembly-qualified name (e.g. `"System.Action`1[[System.Object, System.Private.CoreLib, ...]]"`), which never matches the reference index (built from open generic *definitions* only), so the lookup silently fell back to the host-context `Type`. `MakeGenericType` then combined a MetadataLoadContext open definition with a host-context type argument — exactly the mismatch it rejects at runtime.

`ResolveTargetDelegateClrType` already contained the correct recursive constructed-generic remapping logic (for a delegate type obtained by reflecting over a host CLR method), so the two paths had diverged.

## Fix

Make `MapToReferenceClrType` the single recursive reference-context remapper:
- Resolve a constructed generic's open definition in the active reference context.
- Recursively remap every generic argument through the same helper (so nested/higher-order constructed generics resolve correctly too).
- Construct the closed type entirely within that context.
- Preserve the existing non-generic flat-lookup path and the "fall back to host type" behavior when no reference-context equivalent exists.

`ResolveTargetDelegateClrType` is now a one-line delegation to `MapToReferenceClrType`, eliminating the divergent duplicate implementation. `ResolveDelegateArgClrType` benefits automatically since it already called `MapToReferenceClrType`. No process-wide static caches were introduced or changed — the existing per-`ReflectionMetadataEmitter`-instance caches (`functionDelegateTypeSpecCache`, etc.) are untouched, so nothing pins a MetadataLoadContext across compilations.

### Follow-up: array / pointer / byref shapes

The initial fix above handled constructed-generic arguments but left array (`T[]`/`T[,]`/...), pointer (`T*`), and byref (`T&`) shapes unmapped — even when nested *inside* a constructed generic/delegate argument (e.g. `Action<int32[], object>`, which arises from any G# delegate parameter using array/slice syntax like `[]int32`). `T.MakeArrayType()`/`MakePointerType()`/`MakeByRefType()` built over an unmapped host-context element type still carries host identity, so a later `MakeGenericType` combining it with a reference-context open definition threw the same `GS9998`.

Added three branches to `MapToReferenceClrType` (`IsByRef`, `IsPointer`, `IsArray`), placed before the existing `IsConstructedGenericType` check, each recursing through this same method on `Type.GetElementType()` and rebuilding the wrapper:
- `MakeByRefType()` / `MakePointerType()` for byref/pointer.
- `MakeArrayType()` (vector, `T[]`) vs. `MakeArrayType(rank)` (general rank-1 `T[*]` or multi-dimensional), distinguished via `Type.IsSZArray` — the same convention already used in `DocumentationIdProvider`/`SymbolDocumentationIdProvider`.

Generic-parameter handling and the safe host-type fallback are unchanged; no static caches were added.

## Tests

`test/Compiler.Tests/Emit/Issue2325NestedDelegateEmitTests.cs` — three explicit `/reference:`-mode (built from the `Microsoft.NETCore.App.Ref` targeting-pack facades, matching cs2gs's reference closure) end-to-end **compile + ILVerify + run** tests:

1. `NestedAction_MinimalReproFromIssue_CompilesRunsAndIlVerifies` — the issue's exact minimal repro (`Action<Action<object>, object>`-shaped).
2. `NestedFunc_ReturningVariant_CompilesRunsAndIlVerifies` — a nested `Func`/returning variant (`Func<Func<int32,int32>, int32, int32>`-shaped).
3. `OahuSendOrPostCallbackShape_CompilesRunsAndIlVerifies` — structurally mirrors the real Oahu occurrence (`ExtensionsSyncContext.SendOrPost(Action<SendOrPostCallback, object>, Action)`), which G# represents as a nested two-parameter function type.

`test/Compiler.Tests/Emit/Issue2325NestedArrayDelegateEmitTests.cs` (follow-up) — three more explicit `/reference:`-mode end-to-end tests for realistic nested-array delegate shapes reachable via legal G# syntax:

4. `ArrayDelegateArgument_ActionShape_CompilesRunsAndIlVerifies` — `Action<int32[], object>`-shaped (`([]int32, object?) -> void`).
5. `ArrayDelegateArgument_DoubleNested_CompilesRunsAndIlVerifies` — doubly-nested, with the array at the inner delegate's argument (`Action<Action<int32[], object>, object>`-shaped).
6. `ArrayReturningNestedFunc_CompilesRunsAndIlVerifies` — a Func-returning-array variant (`Func<Func<int32,int32[]>, int32, int32[]>`-shaped).

`test/Core.Tests/CodeAnalysis/Emit/Issue2325ArrayPointerByRefRemapEmitTests.cs` (follow-up) — eight unit-level tests calling `MapToReferenceClrType` directly (via reflection over the internal type/private constructor, using a real ref-pack-backed `ReferenceResolver`) covering SZArray, general rank-1 array, multi-dimensional array, jagged arrays, array nested inside a constructed generic argument, and pointer/byref shapes. Pointer and byref types cannot legally appear as CLR generic type arguments (ECMA-335 §I.9.4), so no G# source can drive them through the delegate-generic-argument path; these two shapes are exercised directly at the helper level instead of via invalid language syntax, satisfying the same rigor at the smallest reachable level.

Verified all tests (original 3 and the follow-up 11) reproduce the pre-fix failure (`GS9998` end-to-end, or an `ArgumentException`/type-identity mismatch at the unit level) when their corresponding fix branches are temporarily reverted, and pass once the fix is restored.

## Validation

- `dotnet build src/Compiler/Compiler.csproj -c Release` — succeeds, 0 warnings/errors.
- `dotnet build GSharp.sln -c Release` — full solution build succeeds.
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter "FullyQualifiedName~Issue2325"` — 6/6 passed.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~Issue2325ArrayPointerByRefRemap"` — 8/8 passed.
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release` — full suite: 2805/2805 passed.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — full suite: 5980/5981 passed (1 intentionally-skipped baseline-regeneration test).

## Deferred / out of scope

- Oahu itself was not touched, per task instructions; the Oahu-shaped test structurally reproduces the shape in-repo instead.
- None remaining for the recursive type-shape remapping: constructed generics, arrays (with rank), pointers, and byrefs are all now rebuilt from recursively remapped element types within the active reference context.

Closes #2325
