### PR TITLE
Fix #2327: guard enum-reflection predicates against TypeBuilderInstantiation crashes

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -2008,29 +2008,18 @@ public sealed class Conversion
             return true;
         }
 
-        var clr = type?.ClrType;
-        if (clr == null)
-        {
-            return false;
-        }
-
-        // Issue #1100: a constructed generic delegate closed over a
-        // same-compilation user type (whose CLR backing is an in-flight emit
-        // TypeBuilder) surfaces as a
+        // Issue #1100 / generalized by #2327: a constructed generic delegate
+        // closed over a same-compilation user type (whose CLR backing is an
+        // in-flight emit TypeBuilder) surfaces as a
         // System.Reflection.Emit.TypeBuilderInstantiation. Its reflection
         // predicates throw NotSupportedException ("TypeBuilder generic
-        // instantiation does not support resolving members") — IsEnum probes the
-        // base-type chain via IsSubclassOf, which is one of the unsupported
-        // operations. Such a delegate type is never an enum, so treat a throw as
-        // a definite "not enum-like".
-        try
-        {
-            return clr.IsEnum;
-        }
-        catch (NotSupportedException)
-        {
-            return false;
-        }
+        // instantiation does not support resolving members") — IsEnum probes
+        // the base-type chain via IsSubclassOf, which is one of the
+        // unsupported operations. Such a delegate type is never an enum, so
+        // treat a throw as a definite "not enum-like". Routed through the
+        // shared ClrTypeUtilities.IsEnumSafe helper so every enum-reflection
+        // call site in the binder/emitter shares one guard.
+        return type?.ClrType.IsEnumSafe() == true;
     }
 
     private static bool IsReferenceLikeTarget(TypeSymbol type)

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -9100,8 +9100,13 @@ internal sealed class DeclarationBinder
             return true;
         }
 
-        var clr = type?.ClrType;
-        return clr != null && clr.IsEnum;
+        // Issue #2327: `type.ClrType` may be a
+        // System.Reflection.Emit.TypeBuilderInstantiation whose `IsEnum`
+        // throws NotSupportedException. Route through the shared safe
+        // helper (generalizing the #1100/#2135 pattern established in
+        // Conversion.IsEnumLikeType / IsInterfaceLikeType) rather than
+        // probing `ClrType.IsEnum` directly.
+        return type?.ClrType.IsEnumSafe() == true;
     }
 
     private static bool TryParseTargetKind(string text, out AttributeTargetKind kind)

--- a/src/Core/CodeAnalysis/Binding/EnumOperatorTable.cs
+++ b/src/Core/CodeAnalysis/Binding/EnumOperatorTable.cs
@@ -189,9 +189,18 @@ internal static class EnumOperatorTable
             return false;
         }
 
-        if (type.ClrType?.IsEnum == true)
+        // Issue #2327: `type.ClrType` may be a
+        // System.Reflection.Emit.TypeBuilderInstantiation — e.g. a
+        // compiler-synthesized structural function-type delegate closed
+        // over an in-flight TypeBuilder definition — whose `IsEnum` throws
+        // NotSupportedException. Route through the shared safe helper
+        // (generalizing the #1100/#2135 pattern) instead of probing
+        // `ClrType.IsEnum` directly; a throw means "definitely not an enum",
+        // so IsUnsignedOrChar correctly falls through to its signed default.
+        var underlying = type.ClrType.GetEnumUnderlyingTypeSafe();
+        if (underlying != null)
         {
-            var underlyingName = Enum.GetUnderlyingType(type.ClrType).FullName;
+            var underlyingName = underlying.FullName;
             return underlyingName == "System.Byte"
                 || underlyingName == "System.UInt16"
                 || underlyingName == "System.UInt32"
@@ -222,7 +231,10 @@ internal static class EnumOperatorTable
             return true;
         }
 
-        return type?.ClrType != null && type.ClrType.IsEnum;
+        // Issue #2327: guard against NotSupportedException from a
+        // TypeBuilderInstantiation-backed ClrType (see IsUnsignedEnumUnderlying
+        // above for the full rationale).
+        return type?.ClrType.IsEnumSafe() == true;
     }
 
     /// <summary>
@@ -239,9 +251,12 @@ internal static class EnumOperatorTable
             return es.UnderlyingType;
         }
 
-        if (enumType?.ClrType?.IsEnum == true)
+        // Issue #2327: guard against NotSupportedException from a
+        // TypeBuilderInstantiation-backed ClrType (see IsUnsignedEnumUnderlying
+        // above for the full rationale).
+        var clrUnderlying = enumType?.ClrType.GetEnumUnderlyingTypeSafe();
+        if (clrUnderlying != null)
         {
-            var clrUnderlying = Enum.GetUnderlyingType(enumType.ClrType);
             return TypeSymbol.FromClrType(clrUnderlying);
         }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -480,13 +480,19 @@ internal sealed partial class MethodBodyEmitter
             return enumSym.UnderlyingType;
         }
 
-        var clr = type?.ClrType;
-        if (clr != null && clr.IsEnum)
+        // Issue #2327: `type.ClrType` may be a
+        // System.Reflection.Emit.TypeBuilderInstantiation (e.g. a
+        // compiler-synthesized structural function-type delegate closed
+        // over an in-flight TypeBuilder definition), whose `IsEnum` throws
+        // NotSupportedException. Route through the shared safe helper
+        // (generalizing the #1100/#2135 pattern) rather than probing
+        // `ClrType.IsEnum` directly — a throw means the type is definitely
+        // not an enum, matching the guard used by EnumOperatorTable.
+        var underlying = type?.ClrType.GetEnumUnderlyingTypeSafe();
+        if (underlying != null)
         {
-            // Loaded via a MetadataLoadContext or normal load: use the
-            // CLR's own underlying-type API, then map back to a
-            // TypeSymbol for the numeric lattice.
-            var underlying = System.Enum.GetUnderlyingType(clr);
+            // Loaded via a MetadataLoadContext or normal load: map the CLR
+            // underlying type back to a TypeSymbol for the numeric lattice.
             return TypeSymbol.FromClrType(underlying);
         }
 

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -64,6 +64,64 @@ public static class ClrTypeUtilities
     }
 
     /// <summary>
+    /// Issue #2327: single shared guard for every enum-reflection predicate
+    /// in the binder/emitter (generalizes the #1100 / #2135 pattern already
+    /// established for <c>IsAssignableFrom</c>/<c>IsInterface</c> probes).
+    /// <see cref="Type.IsEnum"/> walks the base-type chain via
+    /// <c>IsSubclassOf(typeof(Enum))</c> under the hood, which is one of the
+    /// operations <c>System.Reflection.Emit.TypeBuilderInstantiation</c>
+    /// (a constructed generic — e.g. a compiler-synthesized structural
+    /// function-type delegate — closed over an in-flight <see cref="TypeBuilder"/>
+    /// definition) throws <see cref="NotSupportedException"/> for. Such a type
+    /// is never a genuine CLR enum, so a throw here is treated as a definite
+    /// "not an enum" rather than propagating and crashing emit/binding.
+    /// </summary>
+    /// <param name="type">The CLR type to probe. May be <see langword="null"/>.</param>
+    /// <returns><c>true</c> when <paramref name="type"/> is a real CLR enum.</returns>
+    public static bool IsEnumSafe(this Type type)
+    {
+        if (type is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return type.IsEnum;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #2327: safe companion to <see cref="IsEnumSafe"/> — resolves the
+    /// CLR underlying primitive of an enum type without risking the same
+    /// <see cref="NotSupportedException"/> a <c>TypeBuilderInstantiation</c>
+    /// (or other unsupported reflection type) can throw from
+    /// <see cref="Enum.GetUnderlyingType"/>'s own <c>IsEnum</c> validation.
+    /// </summary>
+    /// <param name="type">The candidate enum CLR type. May be <see langword="null"/>.</param>
+    /// <returns>The underlying primitive <see cref="Type"/>, or <see langword="null"/> when <paramref name="type"/> is not a genuine CLR enum.</returns>
+    public static Type GetEnumUnderlyingTypeSafe(this Type type)
+    {
+        if (!type.IsEnumSafe())
+        {
+            return null;
+        }
+
+        try
+        {
+            return Enum.GetUnderlyingType(type);
+        }
+        catch (NotSupportedException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Returns whether two <see cref="Type"/>s refer to the same logical CLR
     /// type, regardless of which reflection context produced them. Two types
     /// are considered the same when their <see cref="Type.FullName"/>s match.

--- a/test/Compiler.Tests/Emit/Issue2327EnumReflectionSafetyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2327EnumReflectionSafetyEmitTests.cs
@@ -1,0 +1,277 @@
+// <copyright file="Issue2327EnumReflectionSafetyEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2327: comparing a nullable structural function type to <c>nil</c>
+/// (<c>==</c> / <c>!=</c>) unconditionally routes through
+/// <c>MethodBodyEmitter.IsUnsignedOrChar</c>, which asks
+/// <c>EnumOperatorTable.IsUnsignedEnumUnderlying</c> whether the operand's CLR
+/// type is an enum. Under explicit <c>/reference:</c> (MetadataLoadContext)
+/// compilation, a compiler-synthesized structural delegate type closed over
+/// an imported BCL parameter type is a
+/// <see cref="System.Reflection.Emit.TypeBuilderInstantiation"/>, whose
+/// <c>Type.IsEnum</c> throws <see cref="NotSupportedException"/> via the
+/// unsupported <c>IsSubclassOf</c> path. These tests drive gsc through the
+/// same explicit reference-pack closure the .NET SDK (and cs2gs) supply —
+/// see <c>Issue2325NestedArrayDelegateEmitTests.RefPackReferences</c> for the
+/// precedent — so the MetadataLoadContext path that reproduces GS9998 is
+/// actually exercised, then ILVerify and run each emitted assembly end-to-end
+/// for both <c>==</c> and <c>!=</c>.
+/// </summary>
+public class Issue2327EnumReflectionSafetyEmitTests
+{
+    [Theory]
+    [InlineData("Guid", "(g Guid) -> {}")]
+    [InlineData("TimeSpan", "(t TimeSpan) -> {}")]
+    [InlineData("Uri", "(u Uri) -> {}")]
+    [InlineData("Exception", "(e Exception) -> {}")]
+    [InlineData("EventArgs", "(e EventArgs) -> {}")]
+    [InlineData("ConsoleCancelEventArgs", "(e ConsoleCancelEventArgs) -> {}")]
+    public void NullableFunctionType_OverImportedBclParameter_NilComparisons_CompileRunAndIlVerify(
+        string paramTypeName, string handlerLambda)
+    {
+        var source = $$"""
+            package Repro
+            import System
+
+            func IsNil(h (({{paramTypeName}}) -> void)?) bool -> h == nil
+            func IsNotNil(h (({{paramTypeName}}) -> void)?) bool -> h != nil
+
+            func Main() {
+                Console.WriteLine(IsNil(nil))
+                Console.WriteLine(IsNotNil(nil))
+                Console.WriteLine(IsNil({{handlerLambda}}))
+                Console.WriteLine(IsNotNil({{handlerLambda}}))
+            }
+            """;
+
+        Assert.Equal("True\nFalse\nFalse\nTrue\n", CompileAndRun(source));
+    }
+
+    /// <summary>
+    /// Exact Oahu shape: <c>ProcessHost.RunProcess</c> compares a nullable
+    /// <c>DataReceivedEventHandler</c> to <c>nil</c> after cs2gs structurally
+    /// translates the C# delegate type to
+    /// <c>((object, DataReceivedEventArgs) -&gt; void)?</c>.
+    /// </summary>
+    [Fact]
+    public void NullableFunctionType_ProcessHostDataReceivedEventHandlerShape_NilComparisons_CompileRunAndIlVerify()
+    {
+        var source = """
+            package Repro
+            import System
+            import System.Diagnostics
+
+            func IsNil(h ((object, DataReceivedEventArgs) -> void)?) bool -> h == nil
+            func IsNotNil(h ((object, DataReceivedEventArgs) -> void)?) bool -> h != nil
+
+            func Main() {
+                Console.WriteLine(IsNil(nil))
+                Console.WriteLine(IsNotNil(nil))
+                Console.WriteLine(IsNil((s object, e DataReceivedEventArgs) -> {}))
+                Console.WriteLine(IsNotNil((s object, e DataReceivedEventArgs) -> {}))
+            }
+            """;
+
+        Assert.Equal("True\nFalse\nFalse\nTrue\n", CompileAndRun(source));
+    }
+
+    /// <summary>
+    /// Primitive-alias control: per the issue, primitive aliases never
+    /// reproduce the crash (their CLR backing is a plain BCL struct, never a
+    /// TypeBuilderInstantiation). Confirms the fix does not regress the
+    /// already-working case.
+    /// </summary>
+    [Fact]
+    public void NullableFunctionType_OverPrimitiveParameter_NilComparisons_CompileRunAndIlVerify()
+    {
+        var source = """
+            package Repro
+            import System
+
+            func IsNil(h ((int32) -> void)?) bool -> h == nil
+            func IsNotNil(h ((int32) -> void)?) bool -> h != nil
+
+            func Main() {
+                Console.WriteLine(IsNil(nil))
+                Console.WriteLine(IsNotNil(nil))
+                Console.WriteLine(IsNil((n int32) -> {}))
+                Console.WriteLine(IsNotNil((n int32) -> {}))
+            }
+            """;
+
+        Assert.Equal("True\nFalse\nFalse\nTrue\n", CompileAndRun(source));
+    }
+
+    /// <summary>
+    /// Same-compilation user-type control: per the issue, a same-compilation
+    /// class parameter never reproduces the crash either. The class itself is
+    /// a TypeBuilder while being defined, but by the time the structural
+    /// delegate closes over it the type is complete, so this exercises the
+    /// non-crashing sibling shape alongside the imported-BCL-parameter cases
+    /// above.
+    /// </summary>
+    [Fact]
+    public void NullableFunctionType_OverSameCompilationUserType_NilComparisons_CompileRunAndIlVerify()
+    {
+        var source = """
+            package Repro
+            import System
+
+            class Widget {}
+
+            func IsNil(h ((Widget) -> void)?) bool -> h == nil
+            func IsNotNil(h ((Widget) -> void)?) bool -> h != nil
+
+            func Main() {
+                Console.WriteLine(IsNil(nil))
+                Console.WriteLine(IsNotNil(nil))
+                Console.WriteLine(IsNil((w Widget) -> {}))
+                Console.WriteLine(IsNotNil((w Widget) -> {}))
+            }
+            """;
+
+        Assert.Equal("True\nFalse\nFalse\nTrue\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2327_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+
+            foreach (var reference in RefPackReferences())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Assembles the same reference closure the .NET SDK (and cs2gs) would
+    /// pass to gsc via explicit <c>/reference:</c> flags — the
+    /// <c>Microsoft.NETCore.App.Ref</c> targeting-pack facades for the
+    /// running runtime. Loading these through gsc's isolated
+    /// MetadataLoadContext (rather than the host's trusted-platform
+    /// assemblies) is what actually exercises the GS9998 cross-context
+    /// mismatch this issue is about — the TPA-backed default resolver shares
+    /// the host runtime's own <c>System.Private.CoreLib</c> identity and
+    /// would mask the bug. Throws (via <see cref="Xunit.Sdk.XunitException"/>)
+    /// rather than silently skipping when the ref-pack is absent, so a CI
+    /// environment missing the ref-pack surfaces a clear diagnostic instead
+    /// of a false pass.
+    /// </summary>
+    private static IEnumerable<string> RefPackReferences()
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir))
+        {
+            throw new Xunit.Sdk.XunitException("host runtime directory not resolvable");
+        }
+
+        var sharedDir = Directory.GetParent(runtimeDir)?.Parent;
+        var dotnetRoot = sharedDir?.Parent?.FullName;
+        if (string.IsNullOrEmpty(dotnetRoot))
+        {
+            throw new Xunit.Sdk.XunitException("dotnet root not resolvable");
+        }
+
+        var tfm = $"net{Environment.Version.Major}.0";
+        var packsRoot = Path.Combine(dotnetRoot, "packs", "Microsoft.NETCore.App.Ref");
+        if (!Directory.Exists(packsRoot))
+        {
+            throw new Xunit.Sdk.XunitException($"ref pack root '{packsRoot}' missing");
+        }
+
+        var version = Environment.Version.ToString(3);
+        var refDir = Path.Combine(packsRoot, version, "ref", tfm);
+        if (!Directory.Exists(refDir))
+        {
+            var major = Environment.Version.Major.ToString();
+            var candidate = Directory.EnumerateDirectories(packsRoot, major + ".*")
+                .OrderByDescending(d => d, StringComparer.Ordinal)
+                .Select(d => Path.Combine(d, "ref", tfm))
+                .FirstOrDefault(Directory.Exists);
+            if (string.IsNullOrEmpty(candidate))
+            {
+                throw new Xunit.Sdk.XunitException($"no ref pack for net{major}.0 under '{packsRoot}'");
+            }
+
+            refDir = candidate;
+        }
+
+        return Directory.EnumerateFiles(refDir, "*.dll").ToArray();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2327. Under explicit `/reference:` (MetadataLoadContext) compilation, comparing a nullable structural function type to `nil` (`==`/`!=`) could throw `NotSupportedException` from `TypeBuilderInstantiation.IsSubclassOf`, surfacing as `GS9998`.

`MethodBodyEmitter.EmitBinary` unconditionally calls `IsUnsignedOrChar` for every binary operator, which reaches `EnumOperatorTable.IsUnsignedEnumUnderlying` and an unguarded `Type.IsEnum` probe. A compiler-synthesized structural function-type delegate closed over an imported BCL parameter type (e.g. `((Guid) -> void)?`) is a `System.Reflection.Emit.TypeBuilderInstantiation` at emit time, and its `IsEnum` throws via the unsupported `IsSubclassOf` path.

## Root cause & fix

This generalizes the existing #1100 / #2135 reflection-safety pattern into two small shared helpers on `ClrTypeUtilities`:

- `IsEnumSafe(this Type)` - wraps `Type.IsEnum`, treating a `NotSupportedException` as a definite "not an enum".
- `GetEnumUnderlyingTypeSafe(this Type)` - safe companion wrapping `Enum.GetUnderlyingType`.

## Audit of sibling call sites

Fixed every unguarded `ClrType.IsEnum` call site reachable from binder/emit type-shape predicates, as identified in the issue:

- `EnumOperatorTable.IsUnsignedEnumUnderlying`, `IsEnumType`, `GetUnderlyingType`
- `MethodBodyEmitter.GetEnumUnderlyingTypeSymbol`
- `DeclarationBinder.IsEnumLikeType`
- `Conversion.IsEnumLikeType` (already had an inline try/catch guard from #1100; routed through the new shared helper for consistency, no behavior change)

Audited every other `.IsEnum` call site in the codebase (`ExpressionBinder.Calls`, `BlittableDetector`, `DeclarationBinder`'s const-folding/attribute-array paths, `Evaluator`'s arithmetic result wrapping, `ImportedAssemblySemantics`, `ImportedTypeSymbol`, `SymbolDisplay`, `CustomAttributeEncoder`) and confirmed none are reachable with a `TypeBuilderInstantiation` operand - enums can never be open/constructed generics, so a genuine CLR enum `Type` is never a `TypeBuilderInstantiation`, and these remaining sites either gate on `IsValueType` first or only ever see attribute-legal / imported non-generic types. No changes were needed there; this is noted as reviewed (no action required) rather than left as an open gap.

`Conversion.IsInterfaceLikeType` already had its own dedicated `IsInterface` try/catch guard from #1100 and was left as-is (different predicate, same established pattern, out of this issue's enum-focused scope).

## Tests

Added `test/Compiler.Tests/Emit/Issue2327EnumReflectionSafetyEmitTests.cs`: forced explicit-`/reference:` compile + ILVerify/run coverage for `==` and `!=` against `nil`, over nullable structural function types parameterized by:

- Representative imported BCL types: `Guid`, `TimeSpan`, `Uri`, `Exception`, `EventArgs`, `ConsoleCancelEventArgs`
- The exact Oahu `ProcessHost`/`DataReceivedEventHandler` shape: `((object, DataReceivedEventArgs) -> void)?`
- Primitive control: `((int32) -> void)?`
- Same-compilation user-type control: `((Widget) -> void)?`

Verified the repro crashes on `main` before the fix (confirmed `GS9998 NotSupportedException` for the issue's exact minimal repro) and passes after.

## Validation

- `dotnet build src/Compiler/Compiler.csproj -c Release` - 0 warnings, 0 errors
- New `Issue2327EnumReflectionSafetyEmitTests` - 9/9 passed
- `test/Core.Tests` (full suite) - 5980 passed, 1 skipped (pre-existing `RegenerateBaseline` skip)
- `test/Compiler.Tests` (full suite) - 2814/2814 passed
- `test/Interpreter.Tests` (full suite) - 420/420 passed
- `dotnet build GSharp.sln -c Release` - 0 warnings, 0 errors
- Existing enum operator tests (`EnumOperatorTableTests`, `Issue574EnumComparisonEmitTests`, `Issue534EnumBitwiseEmitTests`, `Issue6_6Enum*`, etc.) all remain green

## Deferred / out of scope

None identified as required. Oahu itself was not modified per instructions.
