### PR TITLE
Fix #2329: generalize capture boxing/rejection for catch, pattern-switch, select, and fixed-pointer variables

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -365,6 +365,8 @@ internal sealed class LambdaBinder
         // class, which the CLR forbids.
         // ADR-0058 / issue #376: a managed-pointer (*T / ByRefTypeSymbol) local also
         // cannot be captured — the closure may outlive the pointed-to variable.
+        // Issue #2330: an unmanaged pointer (PointerTypeSymbol) bound by a
+        // `fixed` statement is likewise rejected — see ReportFixedPointerCannotEscape.
         foreach (var capturedVariable in captured)
         {
             if (TypeSymbol.IsByRefLike(capturedVariable.Type))
@@ -376,6 +378,10 @@ internal sealed class LambdaBinder
                 Diagnostics.ReportByRefCannotEscape(
                     syntax.Location,
                     $"managed pointer '{capturedVariable.Name}' cannot be captured by a closure; the closure may outlive the pointed-to variable");
+            }
+            else if (capturedVariable.Type is PointerTypeSymbol)
+            {
+                Diagnostics.ReportFixedPointerCannotEscape(syntax.Location, capturedVariable.Name);
             }
         }
 
@@ -767,6 +773,7 @@ internal sealed class LambdaBinder
 
         // Issue #367 / ADR-0058: by-ref-like or managed-pointer locals cannot
         // be captured by a closure; mirror the function-literal checks.
+        // Issue #2330: same for an unmanaged `fixed` pointer.
         foreach (var capturedVariable in captured)
         {
             if (TypeSymbol.IsByRefLike(capturedVariable.Type))
@@ -778,6 +785,10 @@ internal sealed class LambdaBinder
                 Diagnostics.ReportByRefCannotEscape(
                     syntax.Location,
                     $"managed pointer '{capturedVariable.Name}' cannot be captured by a closure; the closure may outlive the pointed-to variable");
+            }
+            else if (capturedVariable.Type is PointerTypeSymbol)
+            {
+                Diagnostics.ReportFixedPointerCannotEscape(syntax.Location, capturedVariable.Name);
             }
         }
 

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1725,6 +1725,32 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// GS9008: issue #2330 — an unmanaged pointer (<c>*T</c>) bound by a
+    /// <c>fixed</c> statement (ADR-0125 / issue #1026) is only valid for the
+    /// lifetime of the pin: the pinned handle is released when the enclosing
+    /// <c>fixed</c> block exits. A nested closure may run after that point
+    /// (or, for local functions, be invoked repeatedly across further pins),
+    /// so capturing the pointer would let it escape its declaring scope's
+    /// lifetime — the same "escape" concern as the existing by-ref-like
+    /// (<c>ref struct</c>) and managed-pointer (<c>ref T</c>) capture
+    /// rejections, but for an unmanaged pointer instead. Rejected here, at
+    /// capture analysis, rather than left to reach
+    /// <c>CaptureBoxingRewriter</c>/emission, which previously crashed with
+    /// GS9998 ("has no local slot") because the pointer variable is
+    /// declaration-less (bound directly by <c>BoundFixedStatement</c>, not a
+    /// <c>BoundVariableDeclaration</c>) and was never boxed.
+    /// </summary>
+    /// <param name="location">The text location of the capturing closure.</param>
+    /// <param name="variableName">The captured fixed-pointer variable's name.</param>
+    public void ReportFixedPointerCannotEscape(TextLocation location, string variableName)
+    {
+        Report(
+            location,
+            "GS9008",
+            $"Unmanaged pointer '{variableName}' from a `fixed` statement cannot be captured by a closure; the pin is released when the enclosing `fixed` block exits.");
+    }
+
+    /// <summary>
     /// GS0398: an unmanaged pointer (ADR-0122 / issue #1014) targets a
     /// pointee type that is not blittable. Only <c>void</c>-equivalent
     /// (<c>uint8</c>) and blittable primitive pointees (and pointers to

--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -696,6 +696,162 @@ internal static class CaptureBoxingRewriter
         }
 
         /// <inheritdoc/>
+        protected override BoundStatement RewriteTryStatement(BoundTryStatement node)
+        {
+            var tryBlock = this.RewriteStatement(node.TryBlock);
+
+            var rewrittenClauses = ImmutableArray.CreateBuilder<BoundCatchClause>(node.CatchClauses.Length);
+            var clausesChanged = false;
+            foreach (var clause in node.CatchClauses)
+            {
+                var body = this.RewriteStatement(clause.Body);
+                if (clause.Variable != null && this.boxInfo.TryGetValue(clause.Variable, out var bi))
+                {
+                    body = PrependSeedStatements(body, this.BuildBoxSeedStatements(bi));
+                    clausesChanged = true;
+                }
+                else if (!ReferenceEquals(body, clause.Body))
+                {
+                    clausesChanged = true;
+                }
+
+                rewrittenClauses.Add(new BoundCatchClause(clause.ExceptionType, clause.Variable, body));
+            }
+
+            var finallyBlock = node.FinallyBlock == null ? null : this.RewriteStatement(node.FinallyBlock);
+
+            if (ReferenceEquals(tryBlock, node.TryBlock) && !clausesChanged && ReferenceEquals(finallyBlock, node.FinallyBlock))
+            {
+                return node;
+            }
+
+            return new BoundTryStatement(null, tryBlock, rewrittenClauses.ToImmutable(), finallyBlock);
+        }
+
+        /// <inheritdoc/>
+        protected override BoundStatement RewritePatternSwitchStatement(BoundPatternSwitchStatement node)
+        {
+            var discriminant = this.RewriteExpression(node.Discriminant);
+            ImmutableArray<BoundPatternSwitchArm>.Builder builder = null;
+            for (var i = 0; i < node.Arms.Length; i++)
+            {
+                var arm = node.Arms[i];
+                var pattern = arm.Pattern == null ? null : this.RewritePattern(arm.Pattern);
+                var guard = arm.Guard == null ? null : this.RewriteExpression(arm.Guard);
+                var body = this.RewriteStatement(arm.Body);
+
+                if (pattern is BoundTypePattern typePattern
+                    && typePattern.Variable != null
+                    && this.boxInfo.TryGetValue(typePattern.Variable, out var bi))
+                {
+                    body = PrependSeedStatements(body, this.BuildBoxSeedStatements(bi));
+                }
+
+                if (builder == null && (pattern != arm.Pattern || guard != arm.Guard || body != arm.Body))
+                {
+                    builder = ImmutableArray.CreateBuilder<BoundPatternSwitchArm>(node.Arms.Length);
+                    for (var j = 0; j < i; j++)
+                    {
+                        builder.Add(node.Arms[j]);
+                    }
+                }
+
+                builder?.Add(new BoundPatternSwitchArm(null, pattern, guard, body));
+            }
+
+            if (discriminant == node.Discriminant && builder == null)
+            {
+                return node;
+            }
+
+            return new BoundPatternSwitchStatement(null, discriminant, builder?.MoveToImmutable() ?? node.Arms);
+        }
+
+        /// <inheritdoc/>
+        protected override BoundExpression RewriteSwitchExpression(BoundSwitchExpression node)
+        {
+            var discriminant = this.RewriteExpression(node.Discriminant);
+            ImmutableArray<BoundSwitchExpressionArm>.Builder builder = null;
+
+            for (var i = 0; i < node.Arms.Length; i++)
+            {
+                var arm = node.Arms[i];
+                var pattern = arm.Pattern == null ? null : this.RewritePattern(arm.Pattern);
+                var guard = arm.Guard == null ? null : this.RewriteExpression(arm.Guard);
+                var result = this.RewriteExpression(arm.Result);
+
+                if (pattern is BoundTypePattern typePattern
+                    && typePattern.Variable != null
+                    && this.boxInfo.TryGetValue(typePattern.Variable, out var bi))
+                {
+                    // A switch-expression arm has no statement body to prepend
+                    // into — only a `Result` expression — so the seed becomes a
+                    // BoundBlockExpression's prefix statements (folding into an
+                    // existing one from a prior rewrite, e.g. #2130's expression-
+                    // tree lowering, rather than nesting).
+                    var seed = this.BuildBoxSeedStatements(bi);
+                    result = result is BoundBlockExpression existingBlock
+                        ? new BoundBlockExpression(null, seed.AddRange(existingBlock.Statements), existingBlock.Expression)
+                        : new BoundBlockExpression(null, seed, result);
+                }
+
+                if (builder == null && (pattern != arm.Pattern || guard != arm.Guard || result != arm.Result))
+                {
+                    builder = ImmutableArray.CreateBuilder<BoundSwitchExpressionArm>(node.Arms.Length);
+                    for (var j = 0; j < i; j++)
+                    {
+                        builder.Add(node.Arms[j]);
+                    }
+                }
+
+                builder?.Add(new BoundSwitchExpressionArm(null, pattern, guard, result));
+            }
+
+            if (discriminant == node.Discriminant && builder == null)
+            {
+                return node;
+            }
+
+            return new BoundSwitchExpression(null, discriminant, builder?.MoveToImmutable() ?? node.Arms, node.Type);
+        }
+
+        /// <inheritdoc/>
+        protected override BoundStatement RewriteSelectStatement(BoundSelectStatement node)
+        {
+            ImmutableArray<BoundSelectCase>.Builder builder = null;
+            for (var i = 0; i < node.Cases.Length; i++)
+            {
+                var arm = node.Cases[i];
+                var channel = arm.Channel == null ? null : this.RewriteExpression(arm.Channel);
+                var value = arm.Value == null ? null : this.RewriteExpression(arm.Value);
+                var body = this.RewriteStatement(arm.Body);
+
+                if (arm.Variable != null && this.boxInfo.TryGetValue(arm.Variable, out var bi))
+                {
+                    body = PrependSeedStatements(body, this.BuildBoxSeedStatements(bi));
+                }
+
+                if (builder == null && (channel != arm.Channel || value != arm.Value || body != arm.Body))
+                {
+                    builder = ImmutableArray.CreateBuilder<BoundSelectCase>(node.Cases.Length);
+                    for (var j = 0; j < i; j++)
+                    {
+                        builder.Add(node.Cases[j]);
+                    }
+                }
+
+                builder?.Add(new BoundSelectCase(arm.CaseKind, channel, value, arm.Variable, body));
+            }
+
+            if (builder == null)
+            {
+                return node;
+            }
+
+            return new BoundSelectStatement(null, builder.MoveToImmutable());
+        }
+
+        /// <inheritdoc/>
         protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
         {
             if (this.boxInfo.TryGetValue(node.Variable, out var bi) && bi.Original == node.Variable)
@@ -781,6 +937,64 @@ internal static class CaptureBoxingRewriter
                 node.FunctionType,
                 newBody,
                 newCaptured.ToImmutable());
+        }
+
+        // Issue #2329: a catch-clause variable, a select-arm receive-bind
+        // variable, and a pattern-switch/switch-expression type-pattern
+        // variable are all "declaration-less" from CaptureBoxingRewriter's
+        // point of view — the emitter stores their runtime value straight
+        // into their ordinary local slot from specialized dispatch logic
+        // (EmitCatchClauses' stloc of the caught exception, the select
+        // TryRead out-argument, EmitTypePattern's stloc after isinst), with
+        // no BoundVariableDeclaration node ever appearing in the tree (unlike
+        // `var n = e`, which RewriteVariableDeclaration boxes above, or an
+        // inline `out var x`, which OutVarBoxIntroductionScanner boxes at its
+        // address-of site). When one of these variables is captured by a
+        // nested lambda, boxInfo still hoists it into a Box (CaptureWalker
+        // does not distinguish how a captured VariableSymbol was introduced),
+        // but the box is never allocated or seeded anywhere — crashing emit
+        // with GS9998 "has no local slot" (the box local itself has no slot)
+        // exactly like the #1453 out-var gap.
+        //
+        // The fix mirrors the captured-parameter prologue (box constructed,
+        // then seeded from the plain-slot value) but scoped to the construct's
+        // own body/result instead of function entry: the plain slot still
+        // receives the runtime value via the unmodified emit dispatch path,
+        // and the first thing the (rewritten) body/result does is copy that
+        // value into the box before any box.Value read executes.
+        private ImmutableArray<BoundStatement> BuildBoxSeedStatements(BoxedVariable bi)
+        {
+            this.allocated.Add(bi.Original);
+            return ImmutableArray.Create<BoundStatement>(
+                new BoundVariableDeclaration(
+                    null,
+                    bi.BoxLocal,
+                    new BoundConstructorCallExpression(
+                        null,
+                        bi.BoxClass,
+                        ImmutableArray<BoundExpression>.Empty)),
+                new BoundExpressionStatement(
+                    null,
+                    new BoundFieldAssignmentExpression(
+                        null,
+                        bi.BoxLocal,
+                        bi.BoxClass,
+                        bi.BoxField,
+                        new BoundVariableExpression(null, bi.Original))));
+        }
+
+        // Prepends box-seed statements ahead of a construct's already-rewritten
+        // body, tolerating a non-block body (defensive: every current caller's
+        // grammar requires a brace-delimited body, but binding this generically
+        // avoids a latent cast failure if that ever changes).
+        private static BoundStatement PrependSeedStatements(BoundStatement body, ImmutableArray<BoundStatement> seed)
+        {
+            if (body is BoundBlockStatement block)
+            {
+                return new BoundBlockStatement(null, seed.AddRange(block.Statements));
+            }
+
+            return new BoundBlockStatement(null, seed.Add(body));
         }
     }
 }

--- a/test/Compiler.Tests/Emit/Issue2329CatchCaptureBoxingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2329CatchCaptureBoxingEmitTests.cs
@@ -1,0 +1,423 @@
+// <copyright file="Issue2329CatchCaptureBoxingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2329 — a lambda nested inside an enclosing <c>catch</c> block that
+/// captures the catch-clause variable crashed emit with <c>GS9998:
+/// InvalidOperationException: Variable '...' has no local slot or parameter
+/// index in the current method.</c>
+/// <para>
+/// Root cause: <c>LambdaBinder.CapturedVariableCollector</c> correctly records
+/// the catch variable as captured (this is the inverse of #1437, where the
+/// catch sits *inside* the lambda body — here the catch is in the enclosing
+/// function and a nested lambda captures its variable). But
+/// <see cref="GSharp.Core.CodeAnalysis.Lowering.CaptureBoxingRewriter"/> only
+/// allocated a capture-box at a <c>BoundVariableDeclaration</c> (for `var n =
+/// e`) or at an inline <c>out var x</c> address-of site (#1453). A catch
+/// variable's runtime value is written directly into its ordinary local slot
+/// by <c>MethodBodyEmitter.EmitCatchClauses</c>'s <c>stloc</c> — there is no
+/// declaration node anywhere in the tree — so the box was never constructed
+/// or seeded, leaving the box local itself without an IL slot.
+/// </para>
+/// <para>
+/// The fix generalizes box allocation: when a catch-clause variable is
+/// captured, <c>CaptureBoxingRewriter</c> now constructs its box and seeds
+/// it from the (still normally-slotted) catch variable at the very start of
+/// the (rewritten) catch body, mirroring the existing captured-parameter
+/// prologue pattern but scoped to the catch handler instead of function
+/// entry. The same gap and fix apply to two structurally identical
+/// "declaration-less" locals discovered while auditing adjacent
+/// local-introducing constructs per the issue's request: a pattern-switch /
+/// switch-expression type-pattern variable (<c>case s is string: ...</c>) and
+/// a <c>select</c> receive-bind arm variable (<c>case let v = &lt;-ch { ... }</c>)
+/// — both store the runtime value directly into the pattern/arm variable's
+/// ordinary slot via specialized emit dispatch, exactly like a catch clause.
+/// </para>
+/// <para>
+/// A <c>for i in a...b</c> loop variable was also audited: it is boxed
+/// correctly already, because the general <c>Lowerer</c> desugars it into an
+/// ordinary <c>var i = a</c> declaration (feeding the C-style counting loop)
+/// during binding, *before* <c>CaptureBoxingRewriter</c> runs — so the
+/// existing <c>RewriteVariableDeclaration</c> box path already covers it (and,
+/// matching C#'s <c>for</c> loop semantics, all closures over it correctly
+/// share one variable cell for the whole loop, not a fresh cell per
+/// iteration — a `for x in collection` foreach loop remains intentionally
+/// un-boxed, since its per-iteration-fresh variable already matches C#
+/// foreach semantics). An unsafe <c>fixed</c> pointer/pinned local capture
+/// remains a separate, deferred gap — see the repository notes.
+/// </para>
+/// Each test compiles, IL-verifies (inside <see cref="CompileAndRun"/>), and
+/// runs. Every package name is unique so the process-wide
+/// <c>FunctionTypeSymbol</c> cache cannot alias across in-process tests.
+/// </summary>
+public class Issue2329CatchCaptureBoxingEmitTests
+{
+    [Fact]
+    public void EndToEnd_MinimalCatchCaptureMemberAccess_Runs()
+    {
+        // The exact minimal repro from the issue body.
+        var source = """
+            package Probe2329Min
+            import System
+            func DoWork() {
+                try { throw Exception("x") } catch (exc Exception) {
+                    let log = () -> Console.WriteLine(exc.Message)
+                    log()
+                }
+            }
+
+            func Main() {
+                DoWork()
+            }
+            """;
+
+        Assert.Equal("x\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_LambdaReadsCaughtVariable_FromFreeFunction_Runs()
+    {
+        // The catch/lambda pair lives in a plain (non-Main) free function
+        // invoked from Main — the shape closest to a real library call site.
+        var source = """
+            package Probe2329Free
+            import System
+
+            func RunIt() {
+                try {
+                    throw Exception("free-func")
+                } catch (exc Exception) {
+                    let log = () -> Console.WriteLine(exc.Message)
+                    log()
+                }
+            }
+
+            func Main() {
+                RunIt()
+            }
+            """;
+
+        Assert.Equal("free-func\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_LambdaReadsCaughtVariable_FromInstanceMethod_Runs()
+    {
+        // The catch/lambda pair lives inside a class instance method.
+        var source = """
+            package Probe2329Inst
+            import System
+
+            open class Worker {
+                func Run() {
+                    try {
+                        throw Exception("inst-method")
+                    } catch (exc Exception) {
+                        let log = () -> Console.WriteLine(exc.Message)
+                        log()
+                    }
+                }
+            }
+
+            func Main() {
+                let w = Worker()
+                w.Run()
+            }
+            """;
+
+        Assert.Equal("inst-method\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_LambdaReadAndDerivedWriteOfCaughtVariable_Runs()
+    {
+        // "Read/write" of the caught variable: the catch variable itself is
+        // read-only (like C#'s implicitly-read-only exception variable), so
+        // the write half is expressed as writing a value *derived from* the
+        // captured variable's read into another captured local — exercising
+        // both a box read (exc.Message) and a box write (total) sharing the
+        // same catch-entry-seeded box in one lambda body.
+        var source = """
+            package Probe2329RW
+            import System
+
+            func Main() {
+                var total = 0
+                try {
+                    throw Exception("rw")
+                } catch (exc Exception) {
+                    let record = () -> {
+                        total = total + exc.Message.Length
+                    }
+                    record()
+                    record()
+                }
+                Console.WriteLine(total)
+            }
+            """;
+
+        // "rw".Length == 2, invoked twice via the same shared box: 4.
+        Assert.Equal("4\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_TwoLambdasShareCaughtVariableBox_Runs()
+    {
+        // Two distinct lambdas captured from the same catch clause must
+        // observe the same underlying box (shared-cell semantics), not two
+        // independently-snapshotted copies.
+        var source = """
+            package Probe2329Shared
+            import System
+
+            func Main() {
+                try {
+                    throw Exception("shared")
+                } catch (exc Exception) {
+                    let a = () -> exc.Message
+                    let b = () -> exc.Message.Length
+                    Console.WriteLine(a())
+                    Console.WriteLine(b())
+                }
+            }
+            """;
+
+        Assert.Equal("shared\n6\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_OahuLoggingLogShape_Runs()
+    {
+        // The exact real-world Oahu shape from the issue:
+        //   catch (Exception exc) { Logging.Log(1, this, () => exc.Summary()); }
+        // Modeled with a local Log helper (same argument shape: a level, a
+        // `this`-typed source, and a trailing closure capturing `exc`) since
+        // Oahu itself must not be modified/referenced from this repo.
+        var source = """
+            package Probe2329Oahu
+            import System
+
+            func Log(level int32, source object, f (() -> string)) {
+                Console.WriteLine(level.ToString() + ":" + source.ToString() + ":" + f())
+            }
+
+            open class Worker {
+                func Run() {
+                    try {
+                        throw Exception("oahu-shape")
+                    } catch (exc Exception) {
+                        Log(1, this, () -> exc.Message)
+                    }
+                }
+            }
+
+            func Main() {
+                let w = Worker()
+                w.Run()
+            }
+            """;
+
+        Assert.Equal("1:Probe2329Oahu.Worker:oahu-shape\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_Issue1437ScenarioRemainsGreen_Runs()
+    {
+        // #1437 fixed the inverse shape: a try/catch declared *inside* a
+        // lambda body. That capture-analysis fix must remain unaffected by
+        // this issue's CaptureBoxingRewriter generalization.
+        var source = """
+            package Probe2329Regress1437
+            import System
+
+            func Main() {
+                let f = func () {
+                    try {
+                        throw Exception("boom1437regress")
+                    } catch (ex Exception) {
+                        Console.WriteLine("caught: " + ex.Message)
+                    }
+                }
+                f()
+            }
+            """;
+
+        Assert.Equal("caught: boom1437regress\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_PatternSwitchStatementArmVariableCapturedByLambda_Runs()
+    {
+        // Audit finding: a pattern-switch *statement* arm's type-pattern
+        // variable has the identical declaration-less-capture gap as a catch
+        // variable — its value is written directly into its ordinary slot by
+        // EmitTypePattern, with no BoundVariableDeclaration anywhere.
+        var source = """
+            package Probe2329PatternStmt
+            import System
+
+            func Classify(o object) {
+                switch o {
+                    case s is string {
+                        let log = () -> Console.WriteLine("str:" + s)
+                        log()
+                    }
+                    default {
+                        Console.WriteLine("other")
+                    }
+                }
+            }
+
+            func Main() {
+                Classify("hello2329")
+            }
+            """;
+
+        Assert.Equal("str:hello2329\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_SwitchExpressionArmVariableCapturedByReturnedLambda_Runs()
+    {
+        // Audit finding: a switch-*expression* arm's type-pattern variable
+        // captured by a lambda that is itself the arm's result (returned out
+        // of the enclosing function) — the arm has no statement body to seed
+        // a box into, only a Result expression, so the fix wraps it in a
+        // BoundBlockExpression.
+        var source = """
+            package Probe2329PatternExpr
+            import System
+
+            func Classify(o object) (() -> string) {
+                return switch o {
+                    case s is string: () -> "str:" + s
+                    default: () -> "other"
+                }
+            }
+
+            func Main() {
+                let f = Classify("hello2329b")
+                Console.WriteLine(f())
+            }
+            """;
+
+        Assert.Equal("str:hello2329b\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_SelectReceiveBindVariableCapturedByLambda_Runs()
+    {
+        // Audit finding: a `select` receive-bind arm variable has the same
+        // gap — its value is written into its ordinary slot via the
+        // channel's TryRead out-argument, with no declaration node.
+        var source = """
+            package Probe2329Select
+            import System
+            import Gsharp.Extensions.Go
+
+            func Main() {
+                let ch = make(chan int32, 1)
+                ch <- 7
+                select {
+                case let v = <-ch {
+                    let log = () -> Console.WriteLine(v)
+                    log()
+                }
+                }
+            }
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2329_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2329CatchCaptureBoxingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2329CatchCaptureBoxingEmitTests.cs
@@ -52,8 +52,16 @@ namespace GSharp.Compiler.Tests.Emit;
 /// share one variable cell for the whole loop, not a fresh cell per
 /// iteration — a `for x in collection` foreach loop remains intentionally
 /// un-boxed, since its per-iteration-fresh variable already matches C#
-/// foreach semantics). An unsafe <c>fixed</c> pointer/pinned local capture
-/// remains a separate, deferred gap — see the repository notes.
+/// foreach semantics). An unsafe <c>fixed</c> pointer/pinned local capture was
+/// also audited: rather than box a raw unmanaged pointer past the lifetime of
+/// its pin (unsafe — the pin is released when the enclosing <c>fixed</c>
+/// block exits), the fix rejects the escape at binding time with a dedicated
+/// diagnostic (GS9008); see
+/// <c>Issue2329FixedPointerCaptureEscapeTests</c> in Core.Tests for the
+/// focused binder-level coverage, and
+/// <see cref="EndToEnd_FixedPointerCapturedInLambda_ReportsGS9008NotGS9998"/>
+/// / <see cref="EndToEnd_FixedNonCapturingUsageStillCompilesAndRuns"/> below
+/// for full-pipeline (<c>gsc</c> CLI) coverage.
 /// </para>
 /// Each test compiles, IL-verifies (inside <see cref="CompileAndRun"/>), and
 /// runs. Every package name is unique so the process-wide
@@ -314,6 +322,102 @@ public class Issue2329CatchCaptureBoxingEmitTests
     }
 
     [Fact]
+    public void EndToEnd_FixedPointerCapturedInLambda_ReportsGS9008NotGS9998()
+    {
+        // Completes the deferred audit item: a nested lambda capturing a
+        // `fixed`-pinned pointer variable is a reachable "declaration-less
+        // capture" gap identical in shape to the catch/pattern-switch/select
+        // gaps fixed above (CaptureBoxingRewriter has no allocation/seed path
+        // for a BoundFixedStatement pointer variable). Unlike those, boxing a
+        // raw unmanaged pointer past its pin's lifetime would be unsafe, so
+        // the fix rejects the escape at binding time (GS9008) instead of
+        // lowering/emitting it. Verifies the FULL gsc CLI pipeline: no
+        // GS9998, no unhandled exception, and a nonzero exit with exactly
+        // the expected diagnostic.
+        var source = """
+            package Probe2329FixedEscape
+            import System
+
+            unsafe func run() {
+                var buf = []uint8{uint8(1), uint8(2), uint8(3)}
+                fixed pD *uint8 = buf {
+                    let log = () -> Console.WriteLine(int32(pD[0]))
+                    log()
+                }
+            }
+
+            func Main() {
+                run()
+            }
+            """;
+
+        var (exitCode, stdout, _) = CompileOnly(source);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS9008", stdout);
+        Assert.DoesNotContain("GS9998", stdout);
+        Assert.DoesNotContain("InvalidOperationException", stdout);
+    }
+
+    [Fact]
+    public void EndToEnd_FixedNonCapturingUsageStillCompilesAndRuns()
+    {
+        // The allowed case must remain unaffected by the escape check: using
+        // the fixed pointer only within the fixed block itself (not from a
+        // nested closure) compiles and runs exactly as before.
+        var source = """
+            package Probe2329FixedOk
+            import System
+
+            unsafe func run() {
+                var buf = []uint8{uint8(65), uint8(66), uint8(67)}
+                fixed pD *uint8 = buf {
+                    pD[0] = uint8(90)
+                }
+                Console.WriteLine(int32(buf[0]))
+            }
+
+            func Main() {
+                run()
+            }
+            """;
+
+        Assert.Equal("90\n", CompileAndRun(source, FixedIlVerifyIgnored));
+    }
+
+    [Fact]
+    public void EndToEnd_LambdaInsideFixedCapturesOtherOuterVariable_Runs()
+    {
+        // A lambda declared inside a `fixed` block that captures a
+        // *different*, ordinary (non-pointer) outer local must still box
+        // normally — GS9008 is specific to the fixed-pointer variable, not
+        // to every capture that happens to occur inside a `fixed` block.
+        var source = """
+            package Probe2329FixedOtherCap
+            import System
+
+            unsafe func run() {
+                var buf = []uint8{uint8(1), uint8(2), uint8(3)}
+                var total = 0
+                fixed pD *uint8 = buf {
+                    pD[0] = uint8(9)
+                    let log = () -> {
+                        total = total + 1
+                    }
+                    log()
+                    log()
+                }
+                Console.WriteLine(total)
+            }
+
+            func Main() {
+                run()
+            }
+            """;
+
+        Assert.Equal("2\n", CompileAndRun(source, FixedIlVerifyIgnored));
+    }
+
+    [Fact]
     public void EndToEnd_SelectReceiveBindVariableCapturedByLambda_Runs()
     {
         // Audit finding: a `select` receive-bind arm variable has the same
@@ -339,7 +443,69 @@ public class Issue2329CatchCaptureBoxingEmitTests
         Assert.Equal("7\n", CompileAndRun(source));
     }
 
-    private static string CompileAndRun(string source)
+    /// <summary>
+    /// Compiles source that is expected to fail binding (a diagnostic, not a
+    /// crash) and returns the process exit code plus captured stdout/stderr,
+    /// without running the (nonexistent) output assembly.
+    /// </summary>
+    private static (int ExitCode, string Stdout, string Stderr) CompileOnly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2329_fail_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            return (compileExit, stdoutWriter.ToString(), stderrWriter.ToString());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    // Issue #1026 / ADR-0125: pinning a buffer and dereferencing an unmanaged
+    // pointer is unverifiable by design. Reused here (rather than duplicated)
+    // for the two `fixed`-statement tests above, which need the same
+    // ignoredErrorCodes as Issue1026FixedEmitTests.
+    private static readonly string[] FixedIlVerifyIgnored =
+    {
+        "Unverifiable",
+        "UnmanagedPointer",
+        "StackUnexpected",
+        "StackByRef",
+        "ExpectedPtr",
+        "StackUnexpectedArrayType",
+        "ExpectedNumericType",
+    };
+
+    private static string CompileAndRun(string source, string[] ilVerifyIgnoredErrorCodes = null)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_2329_exe_").FullName;
         try
@@ -377,7 +543,7 @@ public class Issue2329CatchCaptureBoxingEmitTests
                 compileExit == 0,
                 $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
 
-            IlVerifier.Verify(dllPath);
+            IlVerifier.Verify(dllPath, null, ilVerifyIgnoredErrorCodes);
 
             var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
             if (!File.Exists(rtConfig))

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2329FixedPointerCaptureEscapeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2329FixedPointerCaptureEscapeTests.cs
@@ -1,0 +1,184 @@
+// <copyright file="Issue2329FixedPointerCaptureEscapeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2329 (deferred audit item) / ADR-0125: a <c>fixed</c> statement's
+/// unmanaged <c>*T</c> pointer variable (<c>PointerTypeSymbol</c>, distinct
+/// from the ordinary <c>*T</c>/<c>&amp;</c>/<c>ByRefTypeSymbol</c> "managed
+/// pointer" already guarded by GS9004/GS9006 — see
+/// <c>RefSafeEscapeTests</c>) was reachably captured by a nested closure with
+/// no diagnostic at all: <c>LambdaBinder</c>'s capture-escape checks covered
+/// by-ref-like (<c>ref struct</c>) and <c>ByRefTypeSymbol</c> locals, but not
+/// <c>PointerTypeSymbol</c> locals. The capture then flowed unchecked into
+/// <c>CaptureBoxingRewriter</c>, which has no allocation/seed path for a
+/// <c>fixed</c> pointer variable (it, like a catch-clause variable, is
+/// "declaration-less" — bound directly by <c>BoundFixedStatement</c>, not a
+/// <c>BoundVariableDeclaration</c>) — crashing emit with
+/// <c>GS9998: Variable has no local slot</c>.
+/// <para>
+/// Rather than implement an unsafe lowering that boxes a raw unmanaged
+/// pointer past the lifetime of its pin (the pinned handle is released when
+/// the enclosing <c>fixed</c> block exits, so any closure invoked after that
+/// point — or, for a heap-escaping closure, at an arbitrary later time —
+/// would dereference a pointer that is no longer guaranteed pinned/valid),
+/// the fix rejects the escape during binding: <c>LambdaBinder</c> now
+/// reports <c>GS9008</c> for any <c>PointerTypeSymbol</c> variable found in a
+/// function-literal's captured-variable set, before lowering/emission ever
+/// runs. This mirrors the existing GS9004 rejection for by-ref-like/managed
+/// pointer captures, just for an additional variable kind.
+/// </para>
+/// These tests bind (but do not lower/emit) source directly via
+/// <see cref="GSharp.Core.CodeAnalysis.Binding.Binder.BindProgram"/>, the
+/// same lightweight pattern <c>RefSafeEscapeTests</c> uses for GS9004/GS9006.
+/// </summary>
+public class Issue2329FixedPointerCaptureEscapeTests
+{
+    [Fact]
+    public void FixedPointer_ReadCapturedInLambda_Reports_GS9008_NotGS9998()
+    {
+        // The reachable gap from the audit: a lambda declared inside a
+        // `fixed` block reads the pinned pointer variable.
+        var source = """
+            package P
+            unsafe func run() {
+                var buf = []uint8{uint8(1), uint8(2), uint8(3)}
+                fixed pD *uint8 = buf {
+                    var f = func() uint8 { return pD[0] }
+                }
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS9008");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9998");
+    }
+
+    [Fact]
+    public void FixedPointer_WriteCapturedInLambda_Reports_GS9008()
+    {
+        // Issue #567/#618-style write-only capture: the LHS of an assignment
+        // is a use that must also be checked (mirrors the existing GS9004
+        // by-ref write-capture coverage).
+        var source = """
+            package P
+            unsafe func run() {
+                var buf = []uint8{uint8(1), uint8(2), uint8(3)}
+                fixed pD *uint8 = buf {
+                    var f = func() { pD[0] = uint8(9) }
+                }
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS9008");
+    }
+
+    [Fact]
+    public void FixedPointer_CapturedInLetBoundLambda_Reports_GS9008()
+    {
+        // The `let name = func() {...}` local-function-style spelling goes
+        // through the same BindFunctionLiteral path as an anonymous lambda —
+        // confirm it is covered too.
+        var source = """
+            package P
+            unsafe func run() {
+                var buf = []uint8{uint8(1), uint8(2), uint8(3)}
+                fixed pD *uint8 = buf {
+                    let log = func() uint8 { return pD[0] }
+                }
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS9008");
+    }
+
+    [Fact]
+    public void FixedPointer_NonCapturingUsage_IsLegal()
+    {
+        // The overwhelmingly common case — using the pointer only inside the
+        // `fixed` block itself, never inside a nested closure — must remain
+        // unaffected.
+        var source = """
+            package P
+            unsafe func run() {
+                var buf = []uint8{uint8(1), uint8(2), uint8(3)}
+                fixed pD *uint8 = buf {
+                    pD[0] = uint8(9)
+                }
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9008");
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
+    }
+
+    [Fact]
+    public void FixedPointer_NestedInsideLambdaBody_NotCapturedOutward_IsLegal()
+    {
+        // The inverse (#1437-analogous) shape: the ENTIRE `fixed` statement —
+        // pin, pointer variable, and all uses — is declared inside the lambda
+        // body. The pointer variable is local to that body, not captured
+        // from an enclosing scope, so no GS9008 applies.
+        var source = """
+            package P
+            unsafe func run() {
+                var f = func() uint8 {
+                    var buf = []uint8{uint8(1), uint8(2), uint8(3)}
+                    fixed pD *uint8 = buf {
+                        return pD[0]
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9008");
+    }
+
+    [Fact]
+    public void NonPointerLocal_CapturedInLambdaInsideFixedBlock_IsLegal()
+    {
+        // A lambda inside a `fixed` block that captures a different,
+        // ordinary (non-pointer) outer local must still box normally — the
+        // GS9008 rejection is specific to the pointer variable itself.
+        var source = """
+            package P
+            unsafe func run() {
+                var buf = []uint8{uint8(1), uint8(2), uint8(3)}
+                var total = 0
+                fixed pD *uint8 = buf {
+                    pD[0] = uint8(9)
+                    var f = func() { total = total + 1 }
+                }
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9008");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9998");
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var program = GSharp.Core.CodeAnalysis.Binding.Binder.BindProgram(compilation.GlobalScope, compilation.References);
+        return tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(program.Diagnostics)
+            .ToImmutableArray();
+    }
+}


### PR DESCRIPTION
Closes #2329

## Root cause
`LambdaBinder`'s `CapturedVariableCollector` correctly detects a `catch`-clause variable captured by a nested lambda, but `CaptureBoxingRewriter` only allocated/seeded capture boxes at a `BoundVariableDeclaration` (ordinary `var n = e` locals) or at an inline `out var x` address-of site (#1453). A catch variable's runtime value is written directly into its ordinary local slot by `MethodBodyEmitter.EmitCatchClauses`'s `stloc`, with no declaration node anywhere in the tree, so its box was never constructed or seeded — crashing emit with `GS9998: Variable 'exc' has no local slot`.

## Fix
Generalized (not an emitter patch), in `src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs`:
- Added `RewriteTryStatement`: when a catch-clause variable is captured, prepends a box-construct + box-seed-from-original-variable pair at the start of the (rewritten) catch body — mirroring the existing captured-parameter prologue, but scoped to the catch handler instead of function entry. The original variable symbol is untouched, so the emitter's existing direct-slot store keeps working; reads/writes (including from multiple lambdas) go through the shared box.

## Audit of adjacent local-introducing constructs (per issue request)
Reused the exact list `LambdaBinder.CapturedVariableCollector` special-cases for its `declared` set:
- **Pattern-switch statement arm** (`case x is T { ... }`) and **switch-expression arm** (`case x is T: expr`) type-pattern variable — same declaration-less gap (`EmitTypePattern` stores directly into the arm variable's slot). **Fixed** via `RewritePatternSwitchStatement` / `RewriteSwitchExpression`. Switch-expression arms have only a `Result` expression (no statement body), so the seed is injected via a `BoundBlockExpression` wrap (or folded into an existing one from a prior rewrite).
- **Select-statement receive-bind arm variable** (`case let v = <-ch { ... }`, `Gsharp.Extensions.Go`) — identical gap (the arm variable shares its slot with the channel's `TryRead` out-argument). **Fixed** via `RewriteSelectStatement`.
- **`for i in a...b` (ellipsis) loop variable** — audited, **not a bug**: `Lowerer` desugars it into a real `BoundVariableDeclaration` during binding, before `CaptureBoxingRewriter` runs, so it already goes through the existing box path (and correctly shares one box across the whole loop, matching C-style `for`-loop capture semantics — verified empirically).
- **`for x in collection` (foreach) key/value** — audited, confirmed already intentionally excluded from boxing (per-iteration-fresh semantics is correct as-is); no change.
- **`fixed` pinned/pointer variable** (unmanaged `*T` bound by a `fixed` statement, ADR-0125) — audited, **reachable gap, now fixed** (see below). Unlike the other constructs, it is *not* boxed — boxing a raw unmanaged pointer past the lifetime of its pin would be unsafe, since the pinned handle is released when the enclosing `fixed` block exits. Instead the capture is **rejected at binding time** with a new diagnostic, `GS9008`, mirroring the existing `GS0219`/`GS9004` by-ref-like/managed-pointer capture rejections. `LambdaBinder`'s two capture-escape check sites now also reject any `PointerTypeSymbol` local found in a function literal's captured-variable set, before lowering/emission ever runs — so the previous `GS9998` crash for `fixed pD *uint8 = buf { let f = () -> pD[0] }` is now a clean `GS9008: Unmanaged pointer 'pD' from a fixed statement cannot be captured by a closure; the pin is released when the enclosing fixed block exits.` Non-capturing `fixed` usage, and a lambda declared *inside* a `fixed` block that captures a *different* (non-pointer) outer variable, are both unaffected and continue to compile/box/run exactly as before.

## Tests
- `test/Compiler.Tests/Emit/Issue2329CatchCaptureBoxingEmitTests.cs` (13 tests, each compiles, IL-verifies, and runs end-to-end):
  - Minimal repro from the issue (member access on captured catch variable).
  - Catch/lambda in a free function and in a class instance method.
  - Read + derived-write of the captured catch variable through the shared box.
  - Two lambdas sharing the same captured catch-variable box.
  - The exact Oahu `Logging.Log(level, this, () => exc.Summary())` shape (instance method + `this` + trailing closure over the catch variable) — modeled locally, **Oahu itself is not modified or referenced**.
  - #1437 regression (try/catch declared *inside* a lambda body) remains green.
  - Pattern-switch statement arm and switch-expression arm variable capture by a nested lambda.
  - Select receive-bind arm variable capture by a nested lambda.
  - Fixed-pointer capture is rejected end-to-end via the full `gsc` CLI with `GS9008` (never `GS9998`, never an unhandled exception).
  - Non-capturing `fixed` usage still compiles and runs correctly end-to-end.
  - A lambda inside a `fixed` block capturing a different (non-pointer) outer variable still boxes/runs correctly across multiple invocations.
- `test/Core.Tests/CodeAnalysis/Binding/Issue2329FixedPointerCaptureEscapeTests.cs` (6 tests, binder-level, mirroring `RefSafeEscapeTests`' GS9004/GS9006 style):
  - Read capture, write-only capture, and `let`-bound-lambda capture of a fixed pointer all report `GS9008` (and never `GS9998`).
  - Non-capturing `fixed` usage is legal (no diagnostic).
  - A `fixed` statement fully nested inside a lambda body is legal (the pointer is local to that body, not captured from an enclosing scope).
  - A lambda inside a `fixed` block capturing a different, non-pointer outer local is legal (unaffected boxing).

## Verification
- `dotnet build src/Compiler/Compiler.csproj -c Release` — 0 warnings/errors.
- Full `Core.Tests`: **5986 passed**, 1 skipped (pre-existing `RegenerateBaseline` skip), 0 failed.
- Full `Compiler.Tests`: **2827 passed**, 0 failed (includes all new Issue2329 tests plus the existing Issue1437/Issue1453/Issue523 capture-boxing and Issue1026/Issue1035/Issue1043 fixed-statement suites, all green).

## No deferred work
All audited constructs (catch, pattern-switch statement/expression, select, `fixed` pointer, for-ellipsis, foreach) have been fixed, confirmed correct, or confirmed intentional, with tests. Nothing from the original audit remains open.

## Unrelated issue discovered during investigation (not fixed here, out of scope)
While constructing the Oahu-shape test in the previous commit on this branch, an apparent "static func with a multi-statement body fails to parse" issue was suspected. On further isolated investigation for this update, that suspicion **does not hold up as originally stated** — GSharp has no `static` modifier keyword on individual members or classes at all (confirmed via the parser/lexer: there is no `StaticKeyword` token, and `static` is simply an unrecognized identifier in a member-declaration position). Static/shared members are expressed via a `shared { ... }` block inside a class, e.g.:
```
open class Logging {
    shared {
        func Log(level int32, msg string) {
            Console.WriteLine(level)
            Console.WriteLine(msg)
        }
    }
}
```
This compiles and runs correctly regardless of statement count (verified both 1-statement and 2-statement bodies). Feeding the literal (unsupported) keyword `static` directly before `class`/`func` — e.g. `static class Logging { static func Log(...) { ...two statements... } }` — produces a long cascade of confusing diagnostics (`GS0288` "Field declarations require a `var`/`let`/`const` keyword", then a chain of `GS0005`/`GS0102`/`GS0113` as the parser's error recovery reinterprets each subsequent token as a field/type clause). This reproduces **identically for a single-statement body** and for a bare (non-`open`) `class` too — i.e., it is not actually specific to multi-statement bodies or to any particular class modifier, contrary to the earlier description. So there is no parsing defect tied to statement count; the only legitimate follow-up (not filed, not fixed here, purely a diagnostics-quality/UX observation) would be that the parser's error recovery for the unsupported `static` keyword is noisy/confusing rather than emitting one clear "`static` is not a modifier here; did you mean a `shared { }` block?" diagnostic.

Minimal repro (produces the cascade described above, on unmodified `main` and on this branch alike):
```
package P
import System

class Logging {
    static func Log(level int32) {
        Console.WriteLine(level)
    }
}
```
