### PR TITLE
Fix #2331: async this-capturing nested lambdas fail with GS9998

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncCaptureWalker.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncCaptureWalker.cs
@@ -159,12 +159,110 @@ public static class AsyncCaptureWalker
             return base.RewriteVariableDeclaration(node);
         }
 
+        /// <summary>
+        /// Issue #2331 (deferred half): a parameter or local whose only
+        /// reference anywhere in this async body is inside a nested lambda —
+        /// including a lambda nested inside that lambda — must still
+        /// contribute to the hoist set. Otherwise its value does not survive
+        /// suspension across an intervening <c>await</c>: a resumed
+        /// <c>MoveNext</c> call is a fresh invocation of the same method, so
+        /// any variable that was not hoisted into a state-machine field is
+        /// re-initialized to the CLR default instead of retaining the value
+        /// it held before suspension.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="BoundTreeRewriter"/> intentionally treats a function
+        /// literal as an opaque leaf (its body is a separate lexical scope),
+        /// so without this override the walk above never reaches a variable
+        /// read/written only inside a nested lambda body. Blindly descending
+        /// into <c>node.Body</c> with <em>this</em> walker would be wrong: it
+        /// would also invoke <see cref="RewriteVariableDeclaration"/> for
+        /// locals the lambda itself declares, incorrectly hoisting
+        /// lambda-owned state into the outer async method's state machine
+        /// and breaking the lambda's own lexical scope.
+        /// <para>
+        /// Instead, this reuses the capture metadata the binder already
+        /// computed: <see cref="BoundFunctionLiteralExpression.CapturedVariables"/>
+        /// lists every outer-scope variable the lambda (or any lambda
+        /// transitively nested within it) needs, because
+        /// <c>LambdaBinder.CapturedVariableCollector.RewriteFunctionLiteralExpression</c>
+        /// already propagates a nested literal's own captures up into every
+        /// enclosing literal's list (issue #503) — the exact mechanism
+        /// <see cref="Lowering.CaptureBoxingRewriter"/>'s own capture walker
+        /// relies on for the same reason. <see cref="LambdaCaptureCollector"/>
+        /// additionally recurses defensively (mirroring
+        /// <see cref="Lowering.CaptureBoxingRewriter"/>'s walker) using a
+        /// dedicated helper that itself never records a variable declaration,
+        /// so a lambda's own locals are still never hoisted even if a future
+        /// binder change stops fully flattening the capture list.
+        /// </para>
+        /// </remarks>
+        protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+        {
+            foreach (var captured in LambdaCaptureCollector.Collect(node))
+            {
+                Record(captured);
+            }
+
+            return node;
+        }
+
         private void Record(VariableSymbol variable)
         {
             if (variable is LocalVariableSymbol local && seen.Add(local))
             {
                 orderedLocals.Add(local);
             }
+        }
+    }
+
+    /// <summary>
+    /// Collects the set of outer-scope variables that a lambda literal — or
+    /// any lambda transitively nested inside its body — captures, using only
+    /// the binder-computed <see cref="BoundFunctionLiteralExpression.CapturedVariables"/>
+    /// metadata on each literal it visits (never a lambda's own local
+    /// declarations or parameter reads). Mirrors
+    /// <c>CaptureBoxingRewriter.CaptureWalker</c>'s defensive recursion (see
+    /// #567) for the same reason: the binder already flattens transitive
+    /// captures onto every enclosing literal (#503), so the recursion below
+    /// is normally a no-op, but keeps this collector correct if that
+    /// invariant ever changes.
+    /// </summary>
+    private sealed class LambdaCaptureCollector : BoundTreeRewriter
+    {
+        private readonly HashSet<VariableSymbol> sink = new HashSet<VariableSymbol>();
+
+        /// <summary>Collects the transitive capture set for <paramref name="root"/>.</summary>
+        /// <param name="root">The lambda literal to start from.</param>
+        /// <returns>Every outer-scope variable <paramref name="root"/> or any
+        /// lambda nested within it needs.</returns>
+        public static IReadOnlyCollection<VariableSymbol> Collect(BoundFunctionLiteralExpression root)
+        {
+            var collector = new LambdaCaptureCollector();
+            collector.VisitLiteral(root);
+            return collector.sink;
+        }
+
+        protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+        {
+            VisitLiteral(node);
+            return node;
+        }
+
+        private void VisitLiteral(BoundFunctionLiteralExpression node)
+        {
+            foreach (var captured in node.CapturedVariables)
+            {
+                sink.Add(captured);
+            }
+
+            // Recurse purely to reach any further-nested BoundFunctionLiteralExpression
+            // node (via this class's own RewriteFunctionLiteralExpression override
+            // above). Unlike ReferenceCollector, this walker never overrides
+            // RewriteVariableDeclaration/RewriteVariableExpression/RewriteAssignmentExpression,
+            // so visiting the lambda's own statements cannot record its own
+            // locals or parameters as captures of the enclosing async method.
+            RewriteStatement(node.Body);
         }
     }
 }

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineFieldMap.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineFieldMap.cs
@@ -162,9 +162,21 @@ public sealed class AsyncStateMachineFieldMap
     }
 
     /// <summary>
-    /// Attempts to find the hoisted field for a variable (local or parameter).
-    /// Returns <c>true</c> if the variable is hoisted.
+    /// Attempts to find the hoisted field for a variable (local, parameter,
+    /// or the kickoff method's implicit <c>this</c>). Returns <c>true</c> if
+    /// the variable is hoisted.
     /// </summary>
+    /// <remarks>
+    /// Issue #2331: <c>this</c> is hoisted into <see cref="ThisField"/>
+    /// unconditionally for every instance-method state machine (see
+    /// <see cref="AsyncStateMachineTypeBuilder"/>), but it is intentionally
+    /// kept out of <see cref="parameterFields"/> because it is not an
+    /// ordinary kickoff parameter. Every caller that resolves a hoisted slot
+    /// for a captured variable — including the emitter's closure-construction
+    /// site (<c>EmitCapturedVariableLoad</c>) — must special-case it here so
+    /// there is a single source of truth for "is this variable hoisted",
+    /// rather than duplicating the <c>this</c> check at each call site.
+    /// </remarks>
     /// <param name="variable">The variable to look up.</param>
     /// <param name="field">The hoisted field, if found.</param>
     /// <returns><c>true</c> if the variable is hoisted; otherwise <c>false</c>.</returns>
@@ -172,6 +184,12 @@ public sealed class AsyncStateMachineFieldMap
     {
         if (variable is ParameterSymbol ps)
         {
+            if (ThisField != null && ReferenceEquals(ps, StateMachine.KickoffMethod.ThisParameter))
+            {
+                field = ThisField;
+                return true;
+            }
+
             return parameterFields.TryGetValue(ps, out field);
         }
 

--- a/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
@@ -888,43 +888,11 @@ public static class MoveNextBodyRewriter
 
             private bool TryGetHoistedField(VariableSymbol variable, out FieldSymbol field)
             {
-                field = null;
-                if (variable is ParameterSymbol param)
-                {
-                    // Check if this is the `this` parameter of an instance method.
-                    // The `this` reference is hoisted to the special ThisField.
-                    if (ctx.plan.FieldMap.ThisField != null &&
-                        ReferenceEquals(param, ctx.plan.KickoffMethod.ThisParameter))
-                    {
-                        field = ctx.plan.FieldMap.ThisField;
-                        return true;
-                    }
-
-                    try
-                    {
-                        field = ctx.plan.FieldMap.GetParameterField(param);
-                        return true;
-                    }
-                    catch (KeyNotFoundException)
-                    {
-                        return false;
-                    }
-                }
-
-                if (variable is LocalVariableSymbol)
-                {
-                    try
-                    {
-                        field = ctx.plan.FieldMap.GetLocalField(variable);
-                        return true;
-                    }
-                    catch (KeyNotFoundException)
-                    {
-                        return false;
-                    }
-                }
-
-                return false;
+                // Delegate to the field map's single source of truth (issue
+                // #2331) so `this`, ordinary parameters, and locals resolve
+                // identically here and at the emitter's closure-construction
+                // site (MethodBodyEmitter.Closures.cs' EmitCapturedVariableLoad).
+                return ctx.plan.FieldMap.TryGetHoistedField(variable, out field);
             }
         }
     }

--- a/test/Compiler.Tests/Emit/Issue2331AsyncCaptureHoistEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2331AsyncCaptureHoistEmitTests.cs
@@ -1,0 +1,244 @@
+// <copyright file="Issue2331AsyncCaptureHoistEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2331 (deferred half): <see cref="Core.CodeAnalysis.Lowering.Async.AsyncCaptureWalker"/>'s
+/// reference collector did not recurse into nested lambda bodies, so an
+/// ordinary local or parameter whose only reference anywhere in an async
+/// method was inside a nested lambda could, in principle, be missed by hoist
+/// discovery. In practice <c>CaptureBoxingRewriter</c> (which runs before
+/// state-machine lowering) already forces every boxable captured
+/// local/parameter's box declaration to live at the original outer-scope
+/// declaration site, which independently prevented this from being an
+/// observable runtime bug for ordinary (non-<c>this</c>) captures. This fix
+/// closes the gap at the source: <c>AsyncCaptureWalker.ReferenceCollector</c>
+/// now overrides <c>RewriteFunctionLiteralExpression</c> and records each
+/// lambda literal's own (transitively binder-flattened, issue #503)
+/// <c>CapturedVariables</c> via a dedicated <c>LambdaCaptureCollector</c>
+/// helper, instead of relying implicitly on the boxing side effect. The
+/// helper deliberately never overrides variable-declaration/reference
+/// rewrites, so a lambda's own locally-declared locals are never
+/// accidentally hoisted into the outer async state machine.
+/// </summary>
+/// <remarks>
+/// These tests force genuine `MoveNext` suspension via <c>await Task.Yield()</c>
+/// before the lambda executes, so a value that only survives correctly by
+/// virtue of the state machine's field storage (rather than happening to
+/// still be on the stack because the prior await completed synchronously)
+/// is actually exercised.
+/// </remarks>
+public class Issue2331AsyncCaptureHoistEmitTests
+{
+    [Fact]
+    public void AsyncMethod_LocalDeclaredBeforeAwait_ReferencedOnlyInsideLambdaAfterAwait_Runs()
+    {
+        const string source = """
+            package i2331localafterlambda
+            import System
+            import System.Threading.Tasks
+
+            async func RunAsync() {
+                let x = 42
+                await Task.Yield()
+                await Task.Run(() -> Console.WriteLine(x))
+            }
+
+            RunAsync().Wait()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void AsyncMethod_ParameterReferencedOnlyInsideLambdaAfterAwait_Runs()
+    {
+        const string source = """
+            package i2331paramonlylambda
+            import System
+            import System.Threading.Tasks
+
+            async func RunAsync(value int32) {
+                await Task.Yield()
+                await Task.Run(() -> Console.WriteLine(value))
+            }
+
+            RunAsync(99).Wait()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    [Fact]
+    public void AsyncMethod_DoublyNestedLambda_CapturingOuterLocalAfterAwait_Runs()
+    {
+        const string source = """
+            package i2331doublenestedlocal
+            import System
+            import System.Threading.Tasks
+
+            async func RunAsync() {
+                let x = 14
+                await Task.Yield()
+                await Task.Run(() -> {
+                    let inner = () -> Console.WriteLine(x)
+                    inner()
+                })
+            }
+
+            RunAsync().Wait()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("14\n", output);
+    }
+
+    [Fact]
+    public void AsyncInstanceMethod_MixedThisAndLocalAndParameter_ReferencedOnlyInsideLambdaAfterAwait_Runs()
+    {
+        const string source = """
+            package i2331mixedafterlambda
+            import System
+            import System.Threading.Tasks
+
+            class Worker() {
+                var Value int32 = 3
+                async func RunAsync(extra int32) {
+                    let local = 4
+                    await Task.Yield()
+                    await Task.Run(() -> Console.WriteLine(this.Value + local + extra))
+                }
+            }
+
+            let w = Worker()
+            w.RunAsync(10).Wait()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("17\n", output);
+    }
+
+    [Fact]
+    public void Control_LambdaOwnLocal_NotHoisted_OuterAsyncMethod_StillRunsCorrectly()
+    {
+        // Control: the lambda's own local (`ownLocal`) must not be
+        // incorrectly hoisted into the outer async method's state machine.
+        // If it were misclassified as an outer local needing hoisting, it
+        // would either fail to compile (declared twice) or shadow/alias
+        // across invocations; this proves the computed sum is correct and
+        // stable across two separate calls with different closure state.
+        const string source = """
+            package i2331lambdaownlocalcontrol
+            import System
+            import System.Threading.Tasks
+
+            async func RunAsync(seed int32) int32 {
+                let outer = seed
+                await Task.Yield()
+                let f = () -> {
+                    let ownLocal = 100
+                    return outer + ownLocal
+                }
+                return f()
+            }
+
+            Console.WriteLine(RunAsync(1).Result)
+            Console.WriteLine(RunAsync(2).Result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("101\n102\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2331hoist_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2331AsyncThisLambdaCaptureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2331AsyncThisLambdaCaptureEmitTests.cs
@@ -1,0 +1,291 @@
+// <copyright file="Issue2331AsyncThisLambdaCaptureEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2331: a nested lambda that captures <c>this</c> inside a
+/// <c>Task</c>-returning <c>async func</c> instance method used to fail at
+/// emit with GS9998 <c>InvalidOperationException: Variable 'this' has no
+/// local slot or parameter index in the current method.</c>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Root cause: <see cref="Core.CodeAnalysis.Lowering.Async.AsyncStateMachineFieldMap.TryGetHoistedField"/>
+/// is the single source of truth both the <c>MoveNext</c> body rewriter and
+/// the emitter's closure-construction site (<c>EmitCapturedVariableLoad</c>
+/// in <c>MethodBodyEmitter.Closures.cs</c>) rely on to decide whether a
+/// captured variable resolves to a state-machine field read instead of an
+/// ordinary local/parameter load. <c>this</c> is always hoisted into
+/// <c>ThisField</c> for an instance-method state machine, but that lookup
+/// only special-cased <c>this</c> in the private copy inside
+/// <c>MoveNextBodyRewriter</c>: the public <c>TryGetHoistedField</c> consulted
+/// by the emitter when constructing a captured-`this` closure did not, so the
+/// closure-construction site fell back to treating the kickoff method's
+/// (now-hoisted, slot-less) <c>ThisParameter</c> as an ordinary local/param
+/// load and the emitter's slot lookup threw. Adding the same <c>this</c>
+/// special case to the shared field map closes the gap for every caller at
+/// once — including nested lambdas transitively reachable from the async
+/// body — without touching the emitter's slot-lookup logic itself.
+/// </para>
+/// <para>These tests exercise the five shapes called out by the issue: an
+/// implicit-<c>this</c> instance call, an explicit <c>this.field</c> read, a
+/// lambda that captures both <c>this</c> and an ordinary local, a doubly
+/// nested lambda capturing <c>this</c>, and the exact Oahu
+/// <c>await Task.Run(() =&gt; InstanceMethod())</c> shape. Non-async and
+/// local-only-capture async controls are included to prove the existing
+/// behavior stays green.</para>
+/// </remarks>
+public class Issue2331AsyncThisLambdaCaptureEmitTests
+{
+    [Fact]
+    public void AsyncInstanceMethod_LambdaImplicitThisCapture_InstanceCall_Runs()
+    {
+        // Exact issue repro shape: `await Task.Run(() -> Do())` where `Do()`
+        // is an implicit-`this` instance call inside the nested lambda.
+        const string source = """
+            package i2331implicit
+            import System
+            import System.Threading.Tasks
+
+            class Worker() {
+                async func RunAsync() -> await Task.Run(() -> Do())
+                func Do() { Console.WriteLine("x") }
+            }
+
+            let w = Worker()
+            w.RunAsync().Wait()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("x\n", output);
+    }
+
+    [Fact]
+    public void AsyncInstanceMethod_LambdaExplicitThisField_Runs()
+    {
+        const string source = """
+            package i2331explicit
+            import System
+            import System.Threading.Tasks
+
+            class Worker() {
+                var Value int32 = 41
+                async func RunAsync() -> await Task.Run(() -> Console.WriteLine(this.Value + 1))
+            }
+
+            let w = Worker()
+            w.RunAsync().Wait()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void AsyncInstanceMethod_LambdaMixedThisAndLocalCapture_Runs()
+    {
+        const string source = """
+            package i2331mixed
+            import System
+            import System.Threading.Tasks
+
+            class Worker() {
+                var Value int32 = 10
+                async func RunAsync(extra int32) {
+                    let local = 5
+                    await Task.Run(() -> Console.WriteLine(this.Value + local + extra))
+                }
+            }
+
+            let w = Worker()
+            w.RunAsync(2).Wait()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("17\n", output);
+    }
+
+    [Fact]
+    public void AsyncInstanceMethod_DoublyNestedLambdaCapturingThis_Runs()
+    {
+        const string source = """
+            package i2331doublenested
+            import System
+            import System.Threading.Tasks
+
+            class Worker() {
+                var Value int32 = 100
+                async func RunAsync() {
+                    await Task.Run(() -> {
+                        let inner = () -> Console.WriteLine(this.Value)
+                        inner()
+                    })
+                }
+            }
+
+            let w = Worker()
+            w.RunAsync().Wait()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("100\n", output);
+    }
+
+    [Fact]
+    public void AsyncInstanceMethod_OahuTaskRunCleanupShape_Runs()
+    {
+        // Mirrors the real Oahu occurrence quoted in the issue:
+        //   public async Task CleanupAsync() => await Task.Run(() => Cleanup());
+        const string source = """
+            package i2331oahu
+            import System
+            import System.Threading.Tasks
+
+            class Resource() {
+                async func CleanupAsync() -> await Task.Run(() -> Cleanup())
+                func Cleanup() { Console.WriteLine("cleaned") }
+            }
+
+            let r = Resource()
+            r.CleanupAsync().Wait()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("cleaned\n", output);
+    }
+
+    [Fact]
+    public void Control_NonAsync_LambdaCapturingThis_StillRuns()
+    {
+        // Non-regression control: the same nested-lambda-captures-this shape
+        // outside of async lowering must remain unaffected by this fix.
+        const string source = """
+            package i2331controlsync
+            import System
+
+            class Worker() {
+                func Do() { Console.WriteLine("nonasync") }
+                func RunSync() -> (() -> Do())()
+            }
+
+            let w = Worker()
+            w.RunSync()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("nonasync\n", output);
+    }
+
+    [Fact]
+    public void Control_AsyncMethod_LambdaCapturingOnlyLocal_StillRuns()
+    {
+        // Non-regression control: the pre-existing working case of an async
+        // method whose nested lambda captures only an ordinary local (no
+        // `this` involved at all — including static/free functions).
+        const string source = """
+            package i2331controllocal
+            import System
+            import System.Threading.Tasks
+
+            async func RunAsync() {
+                let local = 7
+                await Task.Run(() -> Console.WriteLine(local))
+            }
+
+            RunAsync().Wait()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2331_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2331AsyncCaptureHoistFieldTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2331AsyncCaptureHoistFieldTests.cs
@@ -1,0 +1,79 @@
+// <copyright file="Issue2331AsyncCaptureHoistFieldTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #2331 (deferred half): proves at the synthesized-type level that an
+/// outer local referenced only inside a nested lambda after an <c>await</c>
+/// is hoisted into the async state machine, while a local declared and used
+/// only inside the lambda's own body is not.
+/// </summary>
+public class Issue2331AsyncCaptureHoistFieldTests
+{
+    [Fact]
+    public void AsyncMethod_OuterLocalUsedOnlyInLambda_IsHoisted_LambdaOwnLocal_IsNot()
+    {
+        const string Source = """
+            package SmHoistFieldTest
+            import System
+            import System.Threading.Tasks
+
+            async func run() int32 {
+                let x = 10
+                await Task.CompletedTask
+                let f = () -> {
+                    let ownLocal = 5
+                    return x + ownLocal
+                }
+                return f()
+            }
+
+            var t = run()
+            t.Wait()
+            Console.WriteLine(t.Result)
+            """;
+
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(Source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.True(result.Success, "Compilation failed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(nameof(AsyncMethod_OuterLocalUsedOnlyInLambda_IsHoisted_LambdaOwnLocal_IsNot), isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var smType = asm.GetTypes().FirstOrDefault(t => t.Name.Contains("<run>d__"));
+            Assert.NotNull(smType);
+
+            var fieldNames = smType!.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Select(f => f.Name)
+                .ToArray();
+
+            // `x` is referenced only inside the nested lambda `f`, after the
+            // `await` — it must still be hoisted as a state-machine field.
+            Assert.Contains(fieldNames, n => n.Contains("x"));
+
+            // `ownLocal` is declared and used only inside `f`'s own body; it
+            // belongs to the lambda's separately-lowered function and must
+            // never appear as a field on the *outer* `run` state machine.
+            Assert.DoesNotContain(fieldNames, n => n.Contains("ownLocal"));
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncCaptureWalkerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncCaptureWalkerTests.cs
@@ -129,4 +129,146 @@ ImmutableArray.Create<BoundStatement>(
         Assert.Single(result.Parameters);
         Assert.Empty(result.Locals);
     }
+
+    // Issue #2331 (deferred half): a local/parameter whose only reference in
+    // the async body is inside a nested lambda must still be discovered so it
+    // gets hoisted; a lambda's own locals must never leak into the outer
+    // hoist set. These tests exercise AsyncCaptureWalker.Analyze directly
+    // (bypassing CaptureBoxingRewriter) so they pin down the walker's own
+    // contract regardless of any other pass that might independently paper
+    // over the gap.
+    private static BoundFunctionLiteralExpression MakeLiteral(
+        BoundBlockStatement body,
+        params VariableSymbol[] capturedVariables)
+    {
+        var function = new FunctionSymbol("<>lambda", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void);
+        var functionType = FunctionTypeSymbol.Get(ImmutableArray<TypeSymbol>.Empty, TypeSymbol.Void);
+        return new BoundFunctionLiteralExpression(
+            null,
+            function,
+            functionType,
+            body,
+            ImmutableArray.Create(capturedVariables));
+    }
+
+    private static BoundBlockStatement EmptyLiteralBody()
+        => new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty);
+
+    [Fact]
+    public void Analyze_LocalCapturedOnlyInsideNestedLambda_IsHoisted()
+    {
+        // `let x = 42; await Helper(); Task.Run(() -> ... x ...)` — the walker
+        // never sees a direct BoundVariableExpression(x) at the outer level;
+        // it must be discovered via the lambda literal's CapturedVariables.
+        var x = new LocalVariableSymbol("x", isReadOnly: false, TypeSymbol.Int32);
+        var literal = MakeLiteral(EmptyLiteralBody(), x);
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(null, x, new BoundLiteralExpression(null, 42)),
+            new BoundExpressionStatement(null, literal)));
+
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
+
+        Assert.Single(result.Locals);
+        Assert.Same(x, result.Locals[0]);
+    }
+
+    [Fact]
+    public void Analyze_ParameterCapturedOnlyInsideNestedLambda_NotDuplicatedIntoLocals()
+    {
+        // Parameters are always hoisted unconditionally (hoist.Parameters is
+        // the kickoff's own parameter list), so a parameter captured only by
+        // a nested lambda must resolve through `result.Parameters`, not leak
+        // a second, redundant entry into `result.Locals`.
+        var p = new ParameterSymbol("value", TypeSymbol.Int32);
+        var literal = MakeLiteral(EmptyLiteralBody(), p);
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, literal)));
+
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray.Create(p));
+
+        Assert.Single(result.Parameters);
+        Assert.Same(p, result.Parameters[0]);
+        Assert.Empty(result.Locals);
+    }
+
+    [Fact]
+    public void Analyze_DoublyNestedLambda_TransitiveCaptureIsHoisted_ButInnerLambdaOwnLocalIsNot()
+    {
+        // Mirrors the binder's own transitive-propagation guarantee (issue
+        // #503): when an inner lambda nested inside an outer lambda captures
+        // an outer-scope variable, the *outer* literal's own
+        // CapturedVariables already lists that variable too. The outer
+        // literal's body also declares its own local (`innerOnly`, standing
+        // in for e.g. `let inner = () -> ...`) that is NOT part of any
+        // CapturedVariables list — it must never be hoisted into the async
+        // method's state machine.
+        var x = new LocalVariableSymbol("x", isReadOnly: false, TypeSymbol.Int32);
+        var innerOnly = new LocalVariableSymbol("innerOnly", isReadOnly: false, TypeSymbol.Int32);
+
+        var innerLiteral = MakeLiteral(EmptyLiteralBody(), x);
+        var outerBody = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(null, innerOnly, new BoundLiteralExpression(null, 1)),
+            new BoundExpressionStatement(null, innerLiteral)));
+        var outerLiteral = MakeLiteral(outerBody, x);
+
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(null, x, new BoundLiteralExpression(null, 7)),
+            new BoundExpressionStatement(null, outerLiteral)));
+
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
+
+        Assert.Single(result.Locals);
+        Assert.Same(x, result.Locals[0]);
+        Assert.DoesNotContain(result.Locals, l => ReferenceEquals(l, innerOnly));
+    }
+
+    [Fact]
+    public void Analyze_MixedThisAndLocalCapture_OnlyLocalIsHoistedAsLocal()
+    {
+        // `this` (an implicit ParameterSymbol capture) and an ordinary local
+        // captured together by the same lambda: the local must be hoisted,
+        // and `this` (a ParameterSymbol) must not be duplicated into Locals —
+        // its hoisting is handled unconditionally elsewhere (ThisField).
+        var thisParam = new ParameterSymbol("this", TypeSymbol.Object);
+        var local = new LocalVariableSymbol("local", isReadOnly: false, TypeSymbol.Int32);
+        var literal = MakeLiteral(EmptyLiteralBody(), thisParam, local);
+
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(null, local, new BoundLiteralExpression(null, 5)),
+            new BoundExpressionStatement(null, literal)));
+
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
+
+        Assert.Single(result.Locals);
+        Assert.Same(local, result.Locals[0]);
+    }
+
+    [Fact]
+    public void Analyze_LambdaOwnLocal_IsNotHoisted_WhenNotCaptured()
+    {
+        // Control: a lambda that declares (and only uses) its own local, with
+        // an empty CapturedVariables list, must never contribute that local
+        // to the outer async method's hoist set — even though the walker now
+        // recurses defensively into nested-lambda bodies to find
+        // further-nested literals.
+        var ownLocal = new LocalVariableSymbol("ownLocal", isReadOnly: false, TypeSymbol.Int32);
+        var literalBody = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundVariableDeclaration(null, ownLocal, new BoundLiteralExpression(null, 3)),
+            new BoundExpressionStatement(null, new BoundVariableExpression(null, ownLocal))));
+        var literal = MakeLiteral(literalBody);
+
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, literal)));
+
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
+
+        Assert.Empty(result.Locals);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #2331. A nested lambda that captures `this` inside a `Task`-returning `async func` instance method (implicitly via an instance call, explicitly via `this.field`, or transitively through a doubly-nested lambda) failed at emit with:

```
error GS9998: InvalidOperationException: Variable 'this' has no local slot or parameter index in the current method.
```

## Root cause

`this` is unconditionally hoisted into `ThisField` for every instance-method async state machine (`AsyncStateMachineTypeBuilder`). Two independent call sites need to know "is this variable hoisted, and to which field":

1. `MoveNextBodyRewriter.InnerRewriter.TryGetHoistedField` (private) — already special-cased `this` correctly.
2. The emitter's closure-construction site, `EmitCapturedVariableLoad` in `MethodBodyEmitter.Closures.cs` — which resolves hoisting through the **public** `AsyncStateMachineFieldMap.TryGetHoistedField` API. That public API only checked ordinary hoisted parameters/locals, not `this`.

So when a lambda is newly constructed inside the (already-rewritten) `MoveNext` body and captures `this`, the closure-construction site fell through to an ordinary variable load of the kickoff method's now-slot-less `ThisParameter`, and the emitter's slot lookup threw. The lambda's *own* `Invoke` body was never the problem — `CaptureRewriter` in `ClosureEmitter.cs` already rewrites captured-variable reads inside the lambda body correctly, independent of async lowering, mirroring the #567 pattern.

## Fix

- `AsyncStateMachineFieldMap.TryGetHoistedField` (the single public API consulted by every caller — the lowering rewriter *and* the emitter) now special-cases the kickoff method's `ThisParameter`, resolving it to `ThisField`, same as the ordinary parameter/local case.
- `MoveNextBodyRewriter`'s private duplicate of this logic is removed; it now delegates to the field map so there is exactly one source of truth, generalized transitively to any nesting depth of lambdas (doubly nested lambdas, mixed `this` + local/parameter capture, etc.) without special-casing any particular call site.
- No change to emitter slot-lookup logic (`SlotPlanner` / `MethodBodyEmitter.MemberAccess.cs`) and no new global cache — exactly as directed.

## Tests

Added `test/Compiler.Tests/Emit/Issue2331AsyncThisLambdaCaptureEmitTests.cs`, each compiling and running the emitted assembly end-to-end:

1. `AsyncInstanceMethod_LambdaImplicitThisCapture_InstanceCall_Runs` — the exact issue repro (`await Task.Run(() -> Do())`).
2. `AsyncInstanceMethod_LambdaExplicitThisField_Runs` — explicit `this.field` read.
3. `AsyncInstanceMethod_LambdaMixedThisAndLocalCapture_Runs` — `this` + local + parameter mixed capture.
4. `AsyncInstanceMethod_DoublyNestedLambdaCapturingThis_Runs` — a lambda nested inside a lambda, both reaching `this`.
5. `AsyncInstanceMethod_OahuTaskRunCleanupShape_Runs` — the exact real-world Oahu shape (`public async Task CleanupAsync() => await Task.Run(() => Cleanup());`).
6. `Control_NonAsync_LambdaCapturingThis_StillRuns` — non-async control stays green.
7. `Control_AsyncMethod_LambdaCapturingOnlyLocal_StillRuns` — pre-existing local-only async capture stays green.

## Validation

- `dotnet build src/Compiler/Compiler.csproj -c Release` — succeeds, 0 warnings/errors.
- Targeted: `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter FullyQualifiedName~Issue2331AsyncThisLambdaCaptureEmitTests` — 7/7 passed.
- Broader async surface: `--filter FullyQualifiedName~Async` on both `Core.Tests` (329/329 passed) and `Compiler.Tests` (147/147 passed).
- Full suites: `Core.Tests` 5986/5987 passed (1 pre-existing unrelated `RegenerateBaseline` skip); `Compiler.Tests` 2834/2834 passed.

## Scope / deferred work

- `Oahu` was not modified, per instructions.
- `AsyncCaptureWalker`'s tree walk (used to decide which *ordinary* locals get hoisted) still does not descend into nested lambda bodies when collecting locals-only-referenced-inside-a-lambda; this is pre-existing and out of scope here since `this` and all kickoff parameters are hoisted unconditionally regardless of that walk, which is what this issue is about. If a future issue surfaces an ordinary local referenced *only* inside a nested lambda failing to hoist correctly across an `await`, that would need a separate transitive-descent fix in `AsyncCaptureWalker`.
