### PR TITLE
Fix struct-constrained generic type-pattern emission (#2335)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -6014,6 +6014,40 @@ internal sealed class OverloadResolver
                 var argLoc = i < parameterSyntax.Length ? parameterSyntax[i].Location : syntax.Identifier.Location;
                 boundArguments[i] = conversions.BindConversion(argLoc, argument, expectedType);
             }
+            else if (argument.Type != expectedType
+                && !(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type)))
+            {
+                // Issue #2335 (audit follow-up): every OTHER implicit
+                // conversion reaches this point already classified
+                // `IsImplicit` by the negation in the very first `if` above
+                // (that branch's `!IsImplicit` guard is what routed
+                // execution past it), yet none of the specific branches
+                // above (delegate/tuple/named-delegate/nullable-lift)
+                // materializes it. Left unconverted, the raw argument would
+                // flow straight to the emitter — which, for a plain
+                // (non-imported) function call, applies NO further implicit
+                // widening/boxing of its own (contrast the CLR-call and
+                // instance/shared/extension-call paths, which always run
+                // their argument through `BindCallArgumentWithRefKind` /
+                // `BindConversion`). The most common manifestation is a
+                // value-type/generic-type-parameter argument passed to an
+                // `object`/interface-typed plain-function parameter (e.g.
+                // `func Show(x object) {…}; Show(42)`): the missing `box`
+                // opcode produces IL ilverify rejects
+                // (`StackUnexpected: found Int32, expected ref 'object'`).
+                // The same gap silently dropped numeric widening
+                // (`int32 → int64`) and other representation-changing
+                // implicit conversions. `parameter.Type` (the UNSUBSTITUTED
+                // declared type) is checked — not `expectedType` — so an
+                // open erased slot in a generic callee (paramType containing
+                // a type parameter of THIS call's own substitution) is still
+                // skipped and left for the emitter's type-erasure boxing at
+                // the call boundary, exactly mirroring the equivalent guard
+                // in `BindUserInstanceCall`'s per-argument loop
+                // (`if (paramType is TypeParameterSymbol) { …; continue; }`).
+                var argLoc = i < parameterSyntax.Length ? parameterSyntax[i].Location : syntax.Identifier.Location;
+                boundArguments[i] = conversions.BindConversion(argLoc, argument, expectedType);
+            }
         }
 
         // Issue #951: any deferred un-typed arrow lambda that did not map to a

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1882,7 +1882,23 @@ internal sealed partial class MethodBodyEmitter
             this.il.Token(this.outer.GetElementTypeToken(underlyingTypeParameter));
         }
 
-        if (ReflectionMetadataEmitter.IsValueTypeSymbol(narrowed)
+        // Issue #2335 (audit follow-up): mirrors the identical generalization
+        // in EmitTypePattern — a bare (ANY-constraint, including fully
+        // unconstrained) `narrowed` TYPE PARAMETER cannot pick between
+        // `unbox.any` and `castclass` from `IsValueTypeSymbol`/`ClrType`
+        // alone, since an unconstrained (or class/interface-constrained) `T`
+        // can still close over a value type at a given instantiation (e.g.
+        // narrowing an `object`-typed variable to `T` inside
+        // `func F[T](x object) { if x is T { return x } }`, closed over
+        // `int32`). `castclass !!T` is invalid/silently-wrong IL for that
+        // closure. Per ECMA-335 III.4.32, `unbox.any` degrades to the exact
+        // `castclass` behavior when the closed type turns out to be a
+        // reference type, so it is the single opcode correct for every
+        // constraint/closure combination — route every bare type-parameter
+        // narrowing target through it, in addition to the concrete
+        // value-type shapes `IsValueTypeSymbol` already recognizes.
+        if (narrowed is TypeParameterSymbol
+            || ReflectionMetadataEmitter.IsValueTypeSymbol(narrowed)
             || (narrowed.ClrType != null && narrowed.ClrType.IsValueType))
         {
             this.il.OpCode(ILOpCode.Unbox_any);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -1375,10 +1375,33 @@ internal sealed partial class MethodBodyEmitter
     /// both. Addressable variables (parameters, locals, globals) load directly;
     /// non-addressable rvalue receivers are spilled to a pre-planned local.
     /// </summary>
+    /// <remarks>
+    /// Issue #2335 (audit follow-up): a NARROWED variable receiver
+    /// (ADR-0069 smart-cast — <c>bve.NarrowedType != null</c>, e.g. <c>if x is
+    /// T { x.ToString() }</c> narrowing an <c>object</c>-typed
+    /// parameter/local to a type-parameter view <c>T</c>) must NOT take the
+    /// fast "own address" path even though it IS a
+    /// <see cref="BoundVariableExpression"/>: the narrowed view still
+    /// physically lives in the wider DECLARED storage slot (e.g. an
+    /// <c>object</c> field/parameter/local), so <c>ldarga</c>/<c>ldloca</c>
+    /// on that slot yields <c>&lt;declared&gt;&amp;</c> (e.g.
+    /// <c>object&amp;</c>) — NOT the <c>!!T&amp;</c> the <c>constrained.</c>
+    /// prefix requires. ilverify rejects the mismatch
+    /// (<c>StackUnexpected</c>), and the wrong pointer shape would
+    /// misinterpret the receiver's bytes at runtime for shared generic code.
+    /// <see cref="SlotPlanner.ReceiverSpillCollector"/> plans a spill slot
+    /// (typed as the NARROWED type, since <c>BoundVariableExpression.Type</c>
+    /// reports <c>NarrowedType ?? Variable.Type</c>) for exactly this case, so
+    /// falling through to the general rvalue-spill path below —
+    /// <see cref="EmitExpression"/> re-materializes the correctly narrowed
+    /// <c>!!T</c> value via <c>EmitNarrowingCastIfNeeded</c> — produces a
+    /// verifiable, correctly-addressed receiver.
+    /// </remarks>
     /// <param name="receiver">The constrained type-parameter receiver expression.</param>
     private void EmitConstrainedTypeParameterReceiver(BoundExpression receiver)
     {
         if (receiver is BoundVariableExpression bve
+            && bve.NarrowedType == null
             && this.TryLoadVariableAddress(bve.Variable))
         {
             return;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
@@ -298,8 +298,25 @@ internal sealed partial class MethodBodyEmitter
         this.il.Branch(ILOpCode.Brfalse, failLabel);
 
         // Bind the narrowed value into Variable.
+        //
+        // Issue #2335 (audit follow-up): a bare (any-constraint) open
+        // TYPE-PARAMETER pattern target — not just the struct/value-type-
+        // constrained shape that motivated this issue — cannot pick between
+        // `unbox.any` and `castclass` from its declared constraint alone: an
+        // UNCONSTRAINED (or class/interface-constrained) `T` may still close
+        // over a value type at a given call site (e.g. `case v is T` inside
+        // `func F[T](value object, fallback T) T`, instantiated as
+        // `F[int32]`), and `castclass !!T` is invalid IL — and silently wrong
+        // at runtime under the JIT's shared generic-code instantiation — for
+        // that closure. Per ECMA-335 III.4.32, `unbox.any` degrades to the
+        // exact `castclass` behavior when the closed type is a reference
+        // type, so it is the single opcode that is correct for every
+        // constraint/closure combination. Route every bare type-parameter
+        // target through it, in addition to the concrete value-type target
+        // shapes `IsValueTypeSymbol` already recognises (struct, enum,
+        // tuple, struct-constrained type parameter, etc.).
         this.il.LoadLocal(scratch);
-        if (ReflectionMetadataEmitter.IsValueTypeSymbol(tp.TargetType))
+        if (ReflectionMetadataEmitter.IsValueTypeSymbol(tp.TargetType) || tp.TargetType is TypeParameterSymbol)
         {
             this.il.OpCode(ILOpCode.Unbox_any);
             this.il.Token(this.outer.GetElementTypeToken(tp.TargetType));

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -11094,6 +11094,24 @@ internal sealed class ReflectionMetadataEmitter
             return true;
         }
 
+        // Issue #2335: a bare (non-nullable) value-type-constrained generic
+        // type parameter (`where T : struct`, optionally combined with an
+        // `Enum`/other constraint) lowers to an unboxed CLR value on the
+        // evaluation stack — the same as `Nullable<T>`'s underlying, which
+        // the arm above already recognises. Without this check, a bare
+        // `TypeParameterSymbol` with `HasValueTypeConstraint` (no
+        // `NullableTypeSymbol` wrapper, and — since it is an open generic
+        // parameter — no `ClrType` at emit time) fell through to `return
+        // false`, misclassifying it as a reference type. Consumers such as
+        // `MethodBodyEmitter.EmitTypePattern` then selected `castclass`
+        // instead of `unbox.any` for a `case enm is TEnum` pattern,
+        // producing IL that ILVerify rejects ("found ref TEnum, expected
+        // value TEnum").
+        if (type is TypeParameterSymbol bareTp && bareTp.HasValueTypeConstraint)
+        {
+            return true;
+        }
+
         if (type?.ClrType != null && type.ClrType.IsValueType)
         {
             return true;

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -945,7 +945,24 @@ internal sealed class SlotPlanner
             // (parameters/locals/globals) are addressable directly; any other
             // shape (an rvalue such as `getX().CompareTo(y)`) must be spilled to
             // a local so its address can be taken.
-            if (node.IsConstrainedTypeParameterCall && node.Receiver is not BoundVariableExpression)
+            //
+            // Issue #2335 (audit follow-up): a NARROWED variable receiver
+            // (ADR-0069 smart-cast — `bve.NarrowedType != null`, e.g. `if x is
+            // T { x.ToString() }` narrowing an `object`-typed parameter/local
+            // to a type-parameter view `T`) is NOT addressable directly either:
+            // the narrowed view still physically lives in the wider DECLARED
+            // storage slot, so taking that slot's own address yields
+            // `<declared>&` (e.g. `object&`), not the `!!T&` the `constrained.`
+            // prefix requires — ilverify rejects the mismatch
+            // (`StackUnexpected`) and, pre-verification, the wrong pointer
+            // shape corrupts the receiver read. Route a narrowed variable
+            // receiver through the same rvalue-spill path as any other
+            // non-addressable receiver shape so the emitter re-materializes
+            // the correctly narrowed `!!T` value (via
+            // `EmitNarrowingCastIfNeeded`) into a fresh scratch local of type
+            // `T` before taking ITS address.
+            if (node.IsConstrainedTypeParameterCall
+                && (node.Receiver is not BoundVariableExpression importedRecvVar || importedRecvVar.NarrowedType != null))
             {
                 this.sink.Add(node.Receiver);
             }
@@ -963,7 +980,12 @@ internal sealed class SlotPlanner
             // address for the `constrained.` prefix. Variable receivers
             // (parameters/locals/globals) are addressable directly; any other shape
             // (an rvalue) must be spilled to a local so its address can be taken.
-            if (node.IsConstrainedTypeParameterCall && node.Receiver is not BoundVariableExpression)
+            //
+            // Issue #2335 (audit follow-up): see the matching narrowed-variable
+            // rationale in VisitImportedInstanceCallExpression above — a
+            // narrowed variable receiver must also be spilled here.
+            if (node.IsConstrainedTypeParameterCall
+                && (node.Receiver is not BoundVariableExpression userRecvVar || userRecvVar.NarrowedType != null))
             {
                 this.sink.Add(node.Receiver);
             }

--- a/test/Compiler.Tests/Emit/Issue2335AdjacentEmitterDefectsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2335AdjacentEmitterDefectsEmitTests.cs
@@ -1,0 +1,540 @@
+// <copyright file="Issue2335AdjacentEmitterDefectsEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2335 follow-up: two ADJACENT, pre-existing emitter defects
+/// discovered while validating the primary struct-constrained
+/// generic-type-pattern fix (<see cref="Issue2335StructConstrainedGenericPatternEmitTests"/>).
+/// Both were tightly coupled to the same type-classification/conversion
+/// machinery audited for that fix, so they are corrected here rather than
+/// merely documented.
+///
+/// <para>
+/// <b>Defect A — narrowed-variable constrained-receiver addressing.</b>
+/// <c>MethodBodyEmitter.EmitConstrainedTypeParameterReceiver</c> (the
+/// <c>constrained.</c>-prefix receiver-address helper backing issue #943 /
+/// #1052 constrained calls, e.g. <c>x.ToString()</c> / <c>x.CompareTo(y)</c>
+/// dispatched through a type-parameter receiver) assumed ANY
+/// <c>BoundVariableExpression</c> receiver is safely addressable via its OWN
+/// declared storage slot (<c>ldarga</c>/<c>ldloca</c>). That is false for a
+/// NARROWED variable read (ADR-0069 smart-cast — <c>if x is T { x.ToString() }</c>
+/// narrowing an <c>object</c>-typed parameter/local to a type-parameter view
+/// <c>T</c>): the narrowed view still physically lives in the wider DECLARED
+/// slot, so taking that slot's address yields <c>object&amp;</c>, not the
+/// <c>!!T&amp;</c> the <c>constrained.</c> prefix requires — ilverify rejects
+/// the mismatch (<c>StackUnexpected</c>). Fixed in
+/// <c>SlotPlanner.ReceiverSpillCollector</c> (plans a spill slot, typed as
+/// the NARROWED type, for a narrowed variable receiver exactly like any other
+/// non-addressable receiver shape) and in
+/// <c>MethodBodyEmitter.EmitConstrainedTypeParameterReceiver</c> (only takes
+/// the fast "own address" path when the variable is NOT narrowed). A closely
+/// related generalization was applied to the shared
+/// <c>EmitNarrowingCastIfNeeded</c> helper (used by narrowed variable/field/
+/// property reads generally, including a plain <c>if x is T { return x }</c>
+/// with no further method call): it previously fell back to <c>castclass</c>
+/// for ANY bare (including fully unconstrained) type-parameter narrowing
+/// target — the identical gap already closed in <c>EmitTypePattern</c> by the
+/// primary #2335 fix — and now universally routes through <c>unbox.any</c>
+/// per the same ECMA-335 III.4.32 justification.
+/// </para>
+///
+/// <para>
+/// <b>Defect B — plain-function-call boxing/widening.</b>
+/// <c>OverloadResolver.BindCallExpression</c>'s per-argument conversion loop
+/// (used for a call to a plain, non-imported, non-instance G# function) had
+/// no fallback case for a general implicit conversion (boxing a value type
+/// into an <c>object</c>/interface parameter, numeric widening, etc.): its
+/// branches covered only the explicit-only/error path and a
+/// value-type-<c>Nullable&lt;T&gt;</c> lift, so any OTHER implicitly-convertible
+/// argument passed through completely unconverted. The emitter applies no
+/// further implicit conversion of its own for a plain call (contrast the
+/// CLR-call and instance/shared/extension-call paths, which always route
+/// through <c>BindCallArgumentWithRefKind</c>/<c>BindConversion</c>), so a
+/// bare value/enum/generic-type-parameter expression passed directly to a
+/// plain function's <c>object</c>-typed parameter (e.g.
+/// <c>func Show(x object) {…}; Show(42)</c>) silently dropped the <c>box</c>
+/// opcode — ilverify: <c>StackUnexpected: found Int32, expected ref
+/// 'object'</c>. Fixed by adding the same general
+/// implicit-conversion-materialization fallback (calling
+/// <c>conversions.BindConversion</c>) already used by every other call-
+/// argument path, guarded to still skip an open/erased type-parameter
+/// target exactly like <c>BindUserInstanceCall</c> does, so generic
+/// erased-slot arguments (e.g. <c>List[T].Add(val)</c>) are left untouched
+/// for the emitter's call-boundary erasure boxing.
+/// </para>
+///
+/// <para>
+/// Every test compiles with <c>gsc</c>, ilverifies the emitted PE, executes
+/// it, and asserts on captured stdout.
+/// </para>
+/// </summary>
+public class Issue2335AdjacentEmitterDefectsEmitTests
+{
+    // ----- Defect A: narrowed-variable constrained-receiver addressing -----
+
+    [Fact]
+    public void NarrowedParameter_ConstrainedObjectMemberCall_UnconstrainedT_ValueClosure()
+    {
+        // The exact repro: an `object`-typed PARAMETER narrowed via `if x is T`
+        // to an UNCONSTRAINED `T`, then a universal object member (`ToString`)
+        // is called directly on the narrowed variable — the receiver is the
+        // SAME BoundVariableExpression instance (`x`), just reporting the
+        // narrowed type `T` (ADR-0069). Pre-fix this emitted `ldarga.s x`
+        // (address of the DECLARED `object` slot) ahead of `constrained. !!T`,
+        // which ilverify rejects.
+        var source = """
+            package i2335adjA1
+            import System
+
+            func Describe[T](x object) string {
+                if x is T {
+                    return x.ToString()!!
+                }
+                return "other"
+            }
+
+            var v object = 42
+            Console.WriteLine(Describe[int32](v))
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NarrowedLocal_ConstrainedObjectMemberCall_UnconstrainedT_ValueClosure()
+    {
+        // Same shape as above, but the narrowed variable is a LOCAL
+        // (`var y object = x`) rather than a parameter — exercises the
+        // `this.locals` branch of `SlotPlanner`/`TryLoadVariableAddress`
+        // rather than the parameter branch.
+        var source = """
+            package i2335adjA2
+            import System
+
+            func Describe[T](x object) string {
+                var y object = x
+                if y is T {
+                    return y.ToString()!!
+                }
+                return "other"
+            }
+
+            var v object = 99
+            Console.WriteLine(Describe[int32](v))
+            """;
+
+        Assert.Equal("99\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NarrowedParameter_ConstrainedInterfaceCall_ClassConstrainedT_ClassClosure()
+    {
+        // A user-interface-constrained type parameter (`T : IShape`) narrows
+        // an `object`-typed parameter and dispatches a USER interface method
+        // (issue #1052's `BoundUserInstanceCallExpression` constrained-call
+        // path, not just the universal-object-member path #1550 covers) on
+        // the narrowed receiver. Closes over a class (`Square`).
+        var source = """
+            package i2335adjA3
+            import System
+
+            interface IShape {
+                func Area() int32;
+            }
+
+            class Square(Side int32) : IShape {
+                func Area() int32 { return Side * Side }
+            }
+
+            func Describe[T IShape](x object) int32 {
+                if x is T {
+                    return x.Area()
+                }
+                return -1
+            }
+
+            var v object = Square(5)
+            Console.WriteLine(Describe[Square](v))
+            """;
+
+        Assert.Equal("25\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NarrowedField_ConstrainedObjectMemberCall_StructConstrainedT_EnumClosure()
+    {
+        // The narrowed receiver is an INSTANCE FIELD read (not a bare
+        // variable) — a struct+Enum-constrained `T` closing over a real CLR
+        // enum (`System.DayOfWeek`), matching the primary #2335 issue's
+        // constraint shape but exercised through the constrained-receiver
+        // addressing path instead of a switch/is type pattern.
+        var source = """
+            package i2335adjA4
+            import System
+
+            class Holder {
+                var Value object = DayOfWeek.Friday
+            }
+
+            func Describe[TEnum Enum struct](h Holder) string {
+                if h.Value is TEnum {
+                    return h.Value.ToString()!!
+                }
+                return "other"
+            }
+
+            var holder = Holder()
+            Console.WriteLine(Describe[DayOfWeek](holder))
+            """;
+
+        Assert.Equal("Friday\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Control_DirectTypeParameterReceiver_NotNarrowed_StillUsesFastAddressPath()
+    {
+        // Regression control: a receiver declared DIRECTLY as the type
+        // parameter (no narrowing involved) must still resolve through the
+        // efficient "own address" fast path — this test only asserts
+        // observable behavior (correctness), the fast-path IL shape itself
+        // was confirmed separately via manual IL inspection during
+        // development.
+        var source = """
+            package i2335adjA5
+            import System
+
+            func Show[T](x T) string { return x.ToString()!! }
+
+            Console.WriteLine(Show[int32](7))
+            Console.WriteLine(Show[string]("hi"))
+            """;
+
+        Assert.Equal("7\nhi\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NarrowedVariable_ReturnedDirectly_UnconstrainedT_ValueClosure_NoMethodCall()
+    {
+        // Exercises the parallel `EmitNarrowingCastIfNeeded` generalization
+        // (no method call at all — the narrowed value is simply returned).
+        // Pre-fix this specific shape (unconstrained T narrowing an `object`
+        // parameter, closed over a value type) fell back to `castclass !!T`,
+        // which is invalid IL for a value-type closure.
+        var source = """
+            package i2335adjA6
+            import System
+
+            func Unwrap[T](x object) T {
+                if x is T {
+                    return x
+                }
+                return default(T)
+            }
+
+            var v object = 123
+            Console.WriteLine(Unwrap[int32](v))
+            """;
+
+        Assert.Equal("123\n", CompileAndRun(source));
+    }
+
+    // ----- Defect B: plain-function-call boxing/widening -----
+
+    [Fact]
+    public void PlainFunctionCall_LiteralArgument_ToObjectParameter_Boxes()
+    {
+        // The issue's minimal repro: a bare int32 LITERAL argument (not a
+        // variable, not a type-parameter value) passed directly to a plain
+        // top-level function's `object`-typed parameter. Pre-fix this
+        // dropped the `box` opcode entirely (ilverify: found Int32, expected
+        // ref 'object').
+        var source = """
+            package i2335adjB1
+            import System
+
+            func Show(x object) string { return x.ToString()!! }
+
+            Console.WriteLine(Show(42))
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void PlainFunctionCall_TypeParameterArgument_ToObjectParameter_Boxes()
+    {
+        // A generic-closure variant: the argument's static type is the
+        // CALLER's own type parameter `T` (not a concrete value type),
+        // passed to another plain top-level function's `object` parameter.
+        var source = """
+            package i2335adjB2
+            import System
+
+            func Consume(o object) string { return o.ToString()!! }
+            func Feed[T](val T) string { return Consume(val) }
+
+            Console.WriteLine(Feed[int32](11))
+            Console.WriteLine(Feed[string]("z"))
+            """;
+
+        Assert.Equal("11\nz\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void PlainFunctionCall_NumericWideningArgument_Widens()
+    {
+        // The same missing-conversion gap also silently dropped a numeric
+        // widening conversion (int32 variable -> int64 parameter), which
+        // ilverify rejects just as strictly as a missing box (exact
+        // primitive-type stack tracking, not implicit-conversion-aware).
+        var source = """
+            package i2335adjB3
+            import System
+
+            func Show(x int64) string { return x.ToString() }
+
+            var v int32 = 42
+            Console.WriteLine(Show(v))
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void PlainFunctionCall_EnumLiteralArgument_ToObjectParameter_Boxes()
+    {
+        // A struct/enum value (not int32) passed directly to a plain
+        // function's `object` parameter — a second concrete value-type
+        // shape distinct from int32, using a real CLR enum.
+        var source = """
+            package i2335adjB4
+            import System
+
+            func Show(x object) string { return x.ToString()!! }
+
+            Console.WriteLine(Show(DayOfWeek.Tuesday))
+            """;
+
+        Assert.Equal("Tuesday\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void PlainFunctionCall_MultipleArguments_EvaluationOrderPreserved_NoDoubleBox()
+    {
+        // Two side-effecting value-type arguments both boxed to `object`
+        // parameters in a single call: confirms (a) evaluation order is
+        // left-to-right despite the inserted conversions, and (b) each
+        // argument is boxed exactly once (a double-box would still print the
+        // same string here, so this is paired with the direct IL check in
+        // PlainFunctionCall_LiteralArgument_ToObjectParameter_Boxes's
+        // development notes; this test locks in the observable behavior).
+        var source = """
+            package i2335adjB5
+            import System
+
+            func Trace(label string, v int32) int32 {
+                Console.WriteLine(label)
+                return v
+            }
+
+            func Combine(a object, b object) string {
+                return a.ToString()!! + "," + b.ToString()!!
+            }
+
+            Console.WriteLine(Combine(Trace("first", 1), Trace("second", 2)))
+            """;
+
+        Assert.Equal("first\nsecond\n1,2\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Control_ReferenceUpcastArgument_PlainFunctionCall_NoRegression()
+    {
+        // Regression control: a derived-class reference passed to a
+        // base-class-typed plain-function parameter needs NO conversion IL
+        // at all (verifiably assignable without a cast) — confirms the new
+        // general conversion fallback does not insert a spurious/incorrect
+        // cast for an already-compatible reference argument.
+        var source = """
+            package i2335adjB6
+            import System
+
+            open class Animal {
+                open func Speak() string { return "..." }
+            }
+
+            class Dog() : Animal {
+                override func Speak() string { return "woof" }
+            }
+
+            func Describe(a Animal) string { return a.Speak() }
+
+            var d = Dog()
+            Console.WriteLine(Describe(d))
+            """;
+
+        Assert.Equal("woof\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Control_GenericErasedSlotArgument_ListAdd_NoSpuriousBoxOrConversion()
+    {
+        // Regression control mirroring issue #1196 / #1540: an argument bound
+        // to an OPEN (erased) type-parameter slot of a generic user function
+        // — both a `List[T].Add(val)` receiver-erased-slot call and a plain
+        // `T -> T` identity return — must NOT be boxed/converted by the new
+        // general fallback; only genuinely concrete-typed parameters (like
+        // `object` above) should materialize a conversion.
+        var source = """
+            package i2335adjB7
+            import System
+            import System.Collections.Generic
+
+            func DoubleViaList[T](val T) []T {
+                var list = List[T]()
+                list.Add(val)
+                list.Add(val)
+                return list.ToArray()
+            }
+
+            func RepeatIt[T](v T) T {
+                return v
+            }
+
+            var arr = DoubleViaList[int32](5)
+            Console.WriteLine(arr.Length)
+            Console.WriteLine(arr[0])
+            Console.WriteLine(RepeatIt[int32](77))
+            """;
+
+        Assert.Equal("2\n5\n77\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source, bool requiresFullBcl = false)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, requiresFullBcl);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(
+        string source,
+        bool requiresFullBcl)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2335_adjacent_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            if (requiresFullBcl)
+            {
+                foreach (var bcl in BclReferences.Value)
+                {
+                    args.Add("/r:" + bcl);
+                }
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var rtConfig = Path.ChangeExtension(outPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Compiler.Tests/Emit/Issue2335StructConstrainedGenericPatternEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2335StructConstrainedGenericPatternEmitTests.cs
@@ -1,0 +1,468 @@
+// <copyright file="Issue2335StructConstrainedGenericPatternEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2335: a switch/<c>is</c> type pattern targeting a bare
+/// value-type-constrained generic parameter (<c>where T : struct</c>,
+/// optionally combined with <c>Enum</c>) emitted the reference-type
+/// <c>castclass</c> path instead of <c>unbox.any</c>, producing IL that
+/// ILVerify rejects (<c>StackUnexpected: found ref T, expected value T</c>)
+/// and that stores a boxed reference into a value-typed pattern-variable
+/// slot.
+///
+/// <para>
+/// <b>Root cause:</b> <c>ReflectionMetadataEmitter.IsValueTypeSymbol</c> — the
+/// single shared predicate every box/unbox emit decision in the compiler
+/// consults (type patterns, conversions, member-access receiver dispatch,
+/// closures, struct/tuple field defaulting, slot planning) — recognized
+/// nullable wrappers over a value-type-constrained type parameter
+/// (<c>T?</c>, issue #806) and several other symbolic value-type shapes, but
+/// not a BARE (non-nullable) <see cref="Symbols.TypeParameterSymbol"/> whose
+/// <see cref="Symbols.TypeParameterSymbol.HasValueTypeConstraint"/> is
+/// <see langword="true"/>. <c>MethodBodyEmitter.EmitTypePattern</c> asks this
+/// predicate to choose between <c>unbox.any</c> (value target) and
+/// <c>castclass</c> (reference target); for a bare struct-constrained target
+/// it wrongly took the reference branch.
+/// </para>
+///
+/// <para>
+/// <b>Fix:</b> <c>IsValueTypeSymbol</c> now recognizes a bare
+/// <see cref="Symbols.TypeParameterSymbol"/> with
+/// <c>HasValueTypeConstraint == true</c> directly (mirroring the existing
+/// <c>Nullable&lt;T&gt;</c>-over-struct-constrained-T arm one level up).
+/// Because every one of the ~40 <c>IsValueTypeSymbol</c> call sites in the
+/// emitter shares this one predicate, the fix applies uniformly across type
+/// patterns, <c>is</c>/narrowing casts, conversions (<c>box</c>/<c>unbox.any</c>
+/// selection), instance-receiver addressing (<c>call</c> vs <c>callvirt</c>),
+/// and struct/tuple default-value field patching — not just
+/// <c>EmitTypePattern</c>.
+/// </para>
+///
+/// <para>
+/// <b>Audit follow-up (adjacent, tightly-coupled gap closed alongside):</b>
+/// <c>EmitTypePattern</c>'s target-side opcode choice previously fell back to
+/// <c>castclass</c> for ANY bare type parameter that <c>IsValueTypeSymbol</c>
+/// did not recognize — including a genuinely UNCONSTRAINED (or class/
+/// interface-constrained) <c>T</c>. Such a <c>T</c> can still close over a
+/// value type at a given instantiation (e.g. <c>case v is T</c> inside
+/// <c>func F[T](value object, fallback T) T</c>, called as <c>F[int32]</c>),
+/// and <c>castclass !!T</c> is invalid IL for that closure — verified here to
+/// have silently produced a WRONG runtime value pre-fix (reading raw stack
+/// bytes as a boxed-reference target instead of unboxing), not merely an
+/// ilverify failure. Per ECMA-335 III.4.32, <c>unbox.any</c> degrades to the
+/// exact <c>castclass</c> behavior when the closed type turns out to be a
+/// reference type, so it is the single opcode that is correct for every
+/// constraint/closure combination; <c>EmitTypePattern</c> now routes every
+/// bare type-parameter pattern target through it.
+/// </para>
+///
+/// <para>
+/// Every test compiles with <c>gsc</c>, IL-verifies the produced PE with
+/// <c>ilverify</c>, then executes it and asserts on captured stdout. Tests
+/// that closed over a value type via an unconstrained/class-constrained
+/// type parameter also assert on the exact numeric/string value (not merely
+/// "it didn't crash"), since the pre-fix bug for that shape was silent value
+/// corruption rather than an IL-verifier rejection.
+/// </para>
+/// </summary>
+public class Issue2335StructConstrainedGenericPatternEmitTests
+{
+    [Fact]
+    public void SwitchCasePattern_StructConstrainedTypeParameter_Int32_MatchesAndUnwraps()
+    {
+        // Test #1 from the issue: `case v is T` with `T : struct`.
+        var source = """
+            package i2335struct
+            import System
+
+            func F[T struct](value object, fallback T) T {
+                switch value {
+                    default { return fallback }
+                    case v is T { return v }
+                }
+            }
+
+            var a object = 42
+            var b object = "nope"
+            Console.WriteLine(F[int32](a, -1))
+            Console.WriteLine(F[int32](b, -1))
+            """;
+
+        Assert.Equal("42\n-1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void SwitchCasePattern_StructAndEnumConstrainedTypeParameter_MatchesAndUnwraps()
+    {
+        // Test #2 from the issue: `T : struct, Enum` — the exact minimal
+        // repro shape from the issue body (`class C[TEnum Enum struct]`).
+        var source = """
+            package i2335enum
+            import System
+
+            class C[TEnum Enum struct]() {
+                func F(value object) string {
+                    switch value {
+                        default { return "other" }
+                        case enm is TEnum { return enm.ToString() }
+                    }
+                }
+            }
+
+            let c = C[DayOfWeek]()
+            Console.WriteLine(c.F(DayOfWeek.Friday))
+            Console.WriteLine(c.F("nope"))
+            """;
+
+        Assert.Equal("Friday\nother\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void SwitchCasePattern_MultiArm_StringInt32EnumDefault_MatchesEachArm()
+    {
+        // Test #3 from the issue: a multi-arm switch mixing a reference-type
+        // arm (string), a primitive value-type arm (int32), a struct+Enum
+        // constrained generic arm (T), and a default arm.
+        var source = """
+            package i2335multiarm
+            import System
+
+            func Describe[T Enum struct](value object) string {
+                switch value {
+                    case s is string { return "string:" + s }
+                    case n is int32 { return "int32:" + n.ToString() }
+                    case enm is T { return "enum:" + enm.ToString() }
+                    default { return "other" }
+                }
+            }
+
+            var a object = "hi"
+            var b object = 7
+            var c object = DayOfWeek.Tuesday
+            var d object = 3.5
+            Console.WriteLine(Describe[DayOfWeek](a))
+            Console.WriteLine(Describe[DayOfWeek](b))
+            Console.WriteLine(Describe[DayOfWeek](c))
+            Console.WriteLine(Describe[DayOfWeek](d))
+            """;
+
+        Assert.Equal("string:hi\nint32:7\nenum:Tuesday\nother\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void IfIsNarrowing_StructAndEnumConstrainedTypeParameter_ReturnsNarrowedValue()
+    {
+        // Test #4 from the issue: `if x is T` narrowing (as opposed to the
+        // switch-statement `case v is T` capture pattern). The narrowed read
+        // of `x` (declared `object`, narrowed to the struct-constrained `T`)
+        // exercises `MethodBodyEmitter.EmitNarrowingCastIfNeeded`, the
+        // sibling consumer of `IsValueTypeSymbol` for `is`-narrowed reads.
+        var source = """
+            package i2335ifis
+            import System
+
+            func Probe[T Enum struct](x object, fallback T) T {
+                if x is T {
+                    return x
+                }
+                return fallback
+            }
+
+            var a object = DayOfWeek.Wednesday
+            var b object = "nope"
+            Console.WriteLine(Probe[DayOfWeek](a, DayOfWeek.Monday).ToString())
+            Console.WriteLine(Probe[DayOfWeek](b, DayOfWeek.Monday).ToString())
+            """;
+
+        Assert.Equal("Wednesday\nMonday\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void SwitchCasePattern_ClassConstrainedTypeParameter_StillUsesCastclass_Control()
+    {
+        // Test #5 (control) from the issue: a class-constrained generic type
+        // parameter target must keep its existing (correct) castclass/
+        // reference-type behavior — the fix must not perturb this path.
+        var source = """
+            package i2335classctrl
+            import System
+
+            open class Animal() {
+                open func Speak() string -> "generic"
+            }
+            class Dog() : Animal() {
+                override func Speak() string -> "Woof"
+            }
+
+            func F[T Animal](value object, fallback T) string {
+                switch value {
+                    default { return "other" }
+                    case v is T { return v.Speak() }
+                }
+            }
+
+            var a object = Dog()
+            var b object = "nope"
+            Console.WriteLine(F[Dog](a, Dog()))
+            Console.WriteLine(F[Dog](b, Dog()))
+            """;
+
+        Assert.Equal("Woof\nother\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void SwitchCasePattern_UnconstrainedTypeParameter_ReferenceClosure_StillWorks_Control()
+    {
+        // Test #5 (control) from the issue: an UNCONSTRAINED type parameter
+        // closed over a reference type must keep working exactly as before.
+        var source = """
+            package i2335unconstrctrl1
+            import System
+
+            func F[T](value object, fallback T) T {
+                switch value {
+                    default { return fallback }
+                    case v is T { return v }
+                }
+            }
+
+            var a object = "hello"
+            Console.WriteLine(F[string](a, "none"))
+            """;
+
+        Assert.Equal("hello\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void SwitchCasePattern_UnconstrainedTypeParameter_ValueClosure_UnboxesCorrectly()
+    {
+        // Audit follow-up (see class remarks): an UNCONSTRAINED type
+        // parameter closed over a VALUE type (`F[int32]`) previously emitted
+        // `castclass !!T` for the pattern target — invalid IL, and (as
+        // verified against pre-fix `main`) silently corrupted the observed
+        // value at runtime rather than merely failing ilverify. Asserting the
+        // exact numeric value (not just successful execution) pins down that
+        // corruption.
+        var source = """
+            package i2335unconstrval
+            import System
+
+            func F[T](value object, fallback T) T {
+                switch value {
+                    default { return fallback }
+                    case v is T { return v }
+                }
+            }
+
+            var a object = 42
+            var b object = "nope"
+            Console.WriteLine(F[int32](a, -1))
+            Console.WriteLine(F[int32](b, -1))
+            """;
+
+        Assert.Equal("42\n-1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void OahuEnumConverterShape_ConvertToStructEnumConstrainedGeneric_MatchesAndConverts()
+    {
+        // Test #6 from the issue: the exact Oahu `EnumConverter<TEnum>` shape
+        // (`open class ... [TEnum Enum struct] : TypeConverter` overriding
+        // `ConvertTo` with `switch value { default {...}; case enm is TEnum
+        // {...} }`), confirmed against the real Oahu.Foundation source during
+        // the migration round that discovered this issue.
+        var source = """
+            package i2335oahuenumconv
+            import System
+            import System.ComponentModel
+            import System.Globalization
+
+            open class EnumConverterX[TEnum Enum struct] : TypeConverter {
+                func ConvertTo(context ITypeDescriptorContext?, culture CultureInfo?, value object?, destinationType Type) object? {
+                    switch value {
+                        default {
+                            return base.ConvertTo(context, culture, value, destinationType)
+                        }
+                        case enm is TEnum {
+                            return enm.ToString()
+                        }
+                    }
+                }
+            }
+
+            let conv = EnumConverterX[DayOfWeek]()
+            Console.WriteLine(conv.ConvertTo(nil, nil, DayOfWeek.Friday, typeof(string)))
+            Console.WriteLine(conv.ConvertTo(nil, nil, "hi", typeof(string)))
+            """;
+
+        Assert.Equal("Friday\nhi\n", CompileAndRun(source, requiresFullBcl: true));
+    }
+
+    [Fact]
+    public void OahuEnumChainConverterShape_TwoTypeParameters_MatchesAndConverts()
+    {
+        // Test #6 from the issue: the exact Oahu `EnumChainConverter<TEnum,
+        // TPunct>` shape — TWO type parameters, the first `Enum, struct`
+        // constrained (the pattern target) and the second class-constrained
+        // with an `init()` constructor constraint, both declared on the same
+        // `TypeConverter`-derived open class as EnumConverter above.
+        var source = """
+            package i2335oahuchainconv
+            import System
+            import System.ComponentModel
+            import System.Globalization
+
+            class Punct() {
+            }
+
+            open class EnumChainConverterX[TEnum Enum struct, TPunct Punct init()] : TypeConverter {
+                func ConvertTo(context ITypeDescriptorContext?, culture CultureInfo?, value object?, destinationType Type) object? {
+                    switch value {
+                        default {
+                            return base.ConvertTo(context, culture, value, destinationType)
+                        }
+                        case enm is TEnum {
+                            return ToDisplayString(enm)
+                        }
+                    }
+                }
+
+                private func ToDisplayString(value TEnum) string -> value.ToString()
+            }
+
+            let conv = EnumChainConverterX[DayOfWeek, Punct]()
+            Console.WriteLine(conv.ConvertTo(nil, nil, DayOfWeek.Saturday, typeof(string)))
+            Console.WriteLine(conv.ConvertTo(nil, nil, "hi", typeof(string)))
+            """;
+
+        Assert.Equal("Saturday\nhi\n", CompileAndRun(source, requiresFullBcl: true));
+    }
+
+    private static string CompileAndRun(string source, bool requiresFullBcl = false)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, requiresFullBcl);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(
+        string source,
+        bool requiresFullBcl)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2335_struct_generic_pattern_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            if (requiresFullBcl)
+            {
+                foreach (var bcl in BclReferences.Value)
+                {
+                    args.Add("/r:" + bcl);
+                }
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var rtConfig = Path.ChangeExtension(outPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}


### PR DESCRIPTION
## Summary

Fixes #2335: `case enm is TEnum` (and any `is`/switch type pattern) targeting a bare struct-constrained generic type parameter (`where TEnum : Enum, struct` or plain `where T : struct`) was emitted as a reference-type test/conversion (`castclass`) instead of a value-type one (`unbox.any`), producing IL that ILVerify rejects: `found ref TEnum, expected value TEnum`.

## Root cause

`ReflectionMetadataEmitter.IsValueTypeSymbol` is the single shared predicate every box/unbox emit decision in the compiler consults (type patterns, `is`/narrowing casts, conversions, member-access receiver dispatch, closures, struct/tuple default-value field patching, slot planning — ~40 call sites). It already recognized `Nullable<T>` wrapping a struct-constrained type parameter (`T?`, #806), and several other symbolic value-type shapes, but **not a bare (non-nullable) `TypeParameterSymbol` with `HasValueTypeConstraint == true`**. Such a symbol has no `ClrType` at emit time (it's an open generic parameter) and isn't wrapped in `NullableTypeSymbol`, so it fell through every existing arm to `return false`, misclassifying it as a reference type.

`MethodBodyEmitter.EmitTypePattern` (the switch/`is` pattern emitter) asks `IsValueTypeSymbol` to choose between `unbox.any` (value target) and `castclass` (reference target) for the pattern's target type; for a bare struct-constrained target it wrongly took the reference branch.

## Fix

- **`ReflectionMetadataEmitter.IsValueTypeSymbol`** (`src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs`): added a direct arm recognizing a bare `TypeParameterSymbol` with `HasValueTypeConstraint == true` as a value type, placed alongside the existing `Nullable<T>`-over-struct-constrained-T arm. Because this is the single shared predicate, the fix applies uniformly to every consumer, not just the switch-pattern symptom.

- **Audit follow-up, adjacent and tightly-coupled** — `MethodBodyEmitter.EmitTypePattern` (`src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs`): this same function's target-side opcode choice *also* fell back to `castclass` for **any** bare type parameter that `IsValueTypeSymbol` didn't recognize — including a genuinely **unconstrained** (or class/interface-constrained) `T`. Such a `T` can still close over a value type at a given instantiation (e.g. `case v is T` inside `func F[T](value object, fallback T) T`, called as `F[int32]`). I verified this was **silently producing a wrong runtime value** pre-fix (reading raw stack bytes as a boxed reference instead of unboxing), not merely an ILVerify rejection. Per ECMA-335 III.4.32, `unbox.any` degrades to exactly the `castclass` behavior when the closed type turns out to be a reference type, so it is the single opcode that is correct for **every** constraint/closure combination. `EmitTypePattern` now routes every bare type-parameter pattern target through `unbox.any` unconditionally.

## Audit of `IsValueTypeSymbol` consumers

Reviewed all ~40 call sites across `ConversionEmitter.cs`, `MethodBodyEmitter.Conversions.cs`, `MethodBodyEmitter.MemberAccess.cs`, `MethodBodyEmitter.Closures.cs`, `MethodBodyEmitter.Operators.cs`, `MethodBodyEmitter.Expressions.cs`, `DataStructSynthesizer.cs`, and `MethodBodyPlanner.cs`:
- Most sites are unaffected — they already special-case `TypeParameterSymbol` explicitly before consulting `IsValueTypeSymbol`, or converge to the same emitted opcode regardless (e.g. `EmitBoxIfNeeded` already boxed bare type parameters via a fallback branch).
- A few sites are a net *improvement* from the widened predicate (e.g. `EmitClrPropertyAccess`'s `call` vs. `callvirt` receiver-dispatch choice), consistent with the precedent set by issue #454.
- Class-constrained and fully unconstrained-reference behavior is unchanged; the existing `T?` nullable-generic handling (#806) is unchanged and still covered by existing tests.

Two adjacent defects surfaced while building the test scenarios required by the issue are now **fully fixed** (not deferred — see below).

## Adjacent defect #1: narrowed-variable constrained-receiver addressing

`MethodBodyEmitter.EmitConstrainedTypeParameterReceiver` (backing `constrained.`-prefixed dispatch for universal-object-member calls like `.ToString()`/`.Equals()`, and user interface-constrained calls, on a type-parameter receiver) assumed ANY `BoundVariableExpression` receiver is addressable via its own declared storage slot (`ldarga`/`ldloca`). A NARROWED variable (ADR-0069 smart-cast — e.g. `object x` narrowed via `if x is T { x.ToString() }`) still physically lives in the wider DECLARED slot, so taking that slot's address yields `object&`, not the `!!T&` the `constrained.` prefix requires — ILVerify rejected the mismatch (`StackUnexpected`). Reproduces identically for constrained and fully unconstrained `T`, so it is unrelated to `IsValueTypeSymbol` classification.

**Fix:**
- `SlotPlanner.ReceiverSpillCollector.VisitImportedInstanceCallExpression`/`VisitUserInstanceCallExpression` (`src/Core/CodeAnalysis/Emit/SlotPlanner.cs`): a narrowed variable receiver (`bve.NarrowedType != null`) of a constrained type-parameter call now also routes into the rvalue-spill sink, exactly like any other non-addressable receiver shape.
- `MethodBodyEmitter.EmitConstrainedTypeParameterReceiver` (`src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs`): only takes the fast "own address" path when the variable is NOT narrowed; a narrowed receiver falls through to the general spill path, which already correctly re-materializes the narrowed value via `EmitNarrowingCastIfNeeded` into a scratch local of the NARROWED (correct) type before its address is taken.
- A tightly-coupled parallel gap in the shared `EmitNarrowingCastIfNeeded` helper (used by narrowed variable/field/property reads generally, e.g. a bare `if x is T { return x }` with no method call at all) is also closed: it fell back to `castclass` for a bare type-parameter narrowing target — the identical gap already fixed in `EmitTypePattern` above. Now unconditionally routes through `unbox.any` for any bare type-parameter target, per the same ECMA-335 III.4.32 justification.
- Verified no regression: a non-narrowed direct-call receiver (`func Show[T](x T) string { return x.ToString() }`) still takes the fast own-address path with no unnecessary spill introduced.

## Adjacent defect #2: plain-function-call boxing/widening

`OverloadResolver.BindCallExpression`'s per-argument conversion loop (used for calls to a plain, non-imported, non-instance G# function) had no fallback branch for a general implicit conversion — only delegate-literal, tuple, named-delegate-target, and nullable-lift cases were handled. Any OTHER implicitly-convertible argument (boxing a value/generic-typed value into an `object`/interface parameter, numeric widening, etc.) passed through completely unconverted, because the emitter applies no further implicit conversion of its own for a plain call (contrast the CLR-call and instance/shared/extension-call paths, which always route arguments through `BindCallArgumentWithRefKind`/`BindConversion`). This silently dropped required `box`/`conv` opcodes — e.g. `func Show(x object) {...}; Show(42)` emitted no `box` before the call, which ILVerify rejected (`StackUnexpected: found Int32, expected ref 'object'`).

**Fix:** Added the same general implicit-conversion-materialization fallback (`conversions.BindConversion`) already used unconditionally by the working `BindUserInstanceCall` and extension-method-call argument-binding paths, guarded to still skip an open/erased type-parameter parameter slot exactly like `BindUserInstanceCall` does (checked against the UNSUBSTITUTED `parameter.Type`, not `expectedType`), so generic erased-slot arguments (e.g. `List[T].Add(val)`, a generic identity-return function) are left untouched for the emitter's call-boundary erasure boxing.

Verified: no double-boxing (exactly one `box` opcode emitted), evaluation order preserved across multiple side-effecting arguments, and no spurious conversion inserted for an already-compatible reference-upcast argument.

## Tests added

`test/Compiler.Tests/Emit/Issue2335StructConstrainedGenericPatternEmitTests.cs` — 9 end-to-end tests (compile with `gsc` → `ilverify` the emitted PE → execute → assert on captured stdout):

1. Struct-constrained switch pattern (`T : struct`, closed over `int32`).
2. Struct + `Enum`-constrained switch pattern (`TEnum : Enum, struct`) — the issue's exact repro, closed over `System.DayOfWeek`.
3. Multi-arm switch (`string` / `int32` / enum / `default` arms) targeting the same struct-constrained parameter.
4. `if x is T` narrowing for a struct-constrained parameter.
5. Class-constrained control (confirms `castclass` path is preserved/unchanged).
6. Unconstrained reference-closure control (confirms behavior unchanged).
7. Unconstrained value-closure test — locks in the `EmitTypePattern` audit-follow-up fix (previously silently wrong at runtime).
8. Exact Oahu `EnumConverter[TEnum Enum struct] : TypeConverter` shape.
9. Exact Oahu `EnumChainConverter[TEnum Enum struct, TPunct Punct init()]` shape (two type parameters, `switch value { default {...}; case enm is TEnum {...} }`).

`test/Compiler.Tests/Emit/Issue2335AdjacentEmitterDefectsEmitTests.cs` — 13 new end-to-end tests for the two adjacent defects:

1. `NarrowedParameter_ConstrainedObjectMemberCall_UnconstrainedT_ValueClosure` — the exact repro (narrowed `object` parameter → `.ToString()`).
2. `NarrowedLocal_ConstrainedObjectMemberCall_UnconstrainedT_ValueClosure` — same shape via a narrowed local instead of a parameter.
3. `NarrowedParameter_ConstrainedInterfaceCall_ClassConstrainedT_ClassClosure` — interface-constrained (`T : IShape`) narrowed receiver dispatching a user interface method, closed over a class.
4. `NarrowedField_ConstrainedObjectMemberCall_StructConstrainedT_EnumClosure` — narrowed INSTANCE FIELD receiver, struct+`Enum`-constrained `T`.
5. `Control_DirectTypeParameterReceiver_NotNarrowed_StillUsesFastAddressPath` — non-narrowed regression control.
6. `NarrowedVariable_ReturnedDirectly_UnconstrainedT_ValueClosure_NoMethodCall` — the `EmitNarrowingCastIfNeeded` audit-follow-up, no method call involved.
7. `PlainFunctionCall_LiteralArgument_ToObjectParameter_Boxes` — the issue's minimal boxing repro.
8. `PlainFunctionCall_TypeParameterArgument_ToObjectParameter_Boxes` — generic-closure variant (function-to-function, `T` argument to `object` parameter).
9. `PlainFunctionCall_NumericWideningArgument_Widens` — `int32` → `int64` widening.
10. `PlainFunctionCall_EnumLiteralArgument_ToObjectParameter_Boxes` — a real CLR enum value boxed to `object`.
11. `PlainFunctionCall_MultipleArguments_EvaluationOrderPreserved_NoDoubleBox` — evaluation-order/no-double-box validation.
12. `Control_ReferenceUpcastArgument_PlainFunctionCall_NoRegression` — reference-upcast no-regression control.
13. `Control_GenericErasedSlotArgument_ListAdd_NoSpuriousBoxOrConversion` — generic erased-slot no-regression control (`List[T].Add`, identity-return generic function).

No changes were made to Oahu itself — the Oahu-shaped tests are self-contained scratch reproductions of the exact generic-class/switch shape, built directly in the test files.

## Validation

- `dotnet build src/Compiler/Compiler.csproj -c Release` — succeeds, 0 warnings/errors.
- `dotnet test test/Compiler.Tests -c Release` (full suite) — **2892 passed, 0 failed** (2879 original + 13 new).
- `dotnet test test/Core.Tests -c Release` (full suite) — **5992 passed, 0 failed, 1 pre-existing unrelated skip** (`RegenerateBaseline`).
- New adjacent-defects test file targeted run — **13/13 passed**.
- Manually confirmed (via scratch `.gs` files, pre-fix vs. post-fix) that every fixed scenario in both the primary fix and the two adjacent defects: (a) fails ILVerify or produces a wrong value before the fix, and (b) compiles, ILVerifies, and runs correctly after the fix.

## Deferred work

None. Both previously-deferred adjacent defects are now fully root-caused and fixed on this branch, with dedicated regression tests and full-suite validation, per follow-up review.

Closes #2335
