### PR TITLE
Fix #2337: correct extends/base-ctor tokens for nested sibling inheritance under generic outers

### DIFF
--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -454,12 +454,16 @@ internal sealed class TypeDefEmitter
                 // System.Attribute, regardless of any other resolution.
                 baseType = this.wellKnown.GetSystemAttributeTypeRef();
             }
-            else if (structSym.BaseClass != null && !structSym.BaseClass.TypeArguments.IsDefaultOrEmpty)
+            else if (structSym.BaseClass != null && ReflectionMetadataEmitter.IsUserGenericTypeReference(structSym.BaseClass))
             {
                 // Issue #1055: the base is a CONSTRUCTED generic user class
                 // (e.g. `Derived : Base[int32]`). Reference it via a TypeSpec
                 // naming the generic instantiation so the runtime sees the
                 // correct base subobject layout, vtable slots and type identity.
+                // Issue #2337: also covers a nested sibling base that only
+                // carries the enclosing generic's reified TypeParameters (no
+                // own TypeArguments) — it must resolve to the base's
+                // self-instantiation TypeSpec, not the bare open TypeDef.
                 baseType = this.getUserStructTypeSpec(structSym.BaseClass);
             }
             else if (structSym.BaseClass != null && this.cache.StructTypeDefs.TryGetValue(structSym.BaseClass, out var baseHandle))
@@ -609,9 +613,11 @@ internal sealed class TypeDefEmitter
             }
 
             typeAttrs = classAttrs;
-            if (structSym.BaseClass != null && !structSym.BaseClass.TypeArguments.IsDefaultOrEmpty)
+            if (structSym.BaseClass != null && ReflectionMetadataEmitter.IsUserGenericTypeReference(structSym.BaseClass))
             {
                 // Issue #1055: nested class extending a constructed generic base.
+                // Issue #2337: also covers a nested sibling base carrying only
+                // the enclosing generic's reified TypeParameters.
                 baseType = this.getUserStructTypeSpec(structSym.BaseClass);
             }
             else if (structSym.BaseClass != null && this.cache.StructTypeDefs.TryGetValue(structSym.BaseClass, out var baseHandle))
@@ -1697,7 +1703,11 @@ internal sealed class TypeDefEmitter
         // MethodDef is keyed by the open definition, so resolve a MemberRef
         // parented at the constructed base's TypeSpec instead of falling back to
         // System.Object (which would chain past the real base subobject).
-        if (classSym.BaseClass != null && !classSym.BaseClass.TypeArguments.IsDefaultOrEmpty)
+        // Issue #2337: also covers a nested sibling base that only carries the
+        // enclosing generic's reified TypeParameters (implicit generic arity,
+        // no own TypeArguments) — it likewise needs a TypeSpec-parented
+        // MemberRef, not the bare base ctor MethodDef.
+        if (classSym.BaseClass != null && ReflectionMetadataEmitter.IsUserGenericTypeReference(classSym.BaseClass))
         {
             return this.resolveConstructedBaseCtorToken(classSym.BaseClass);
         }
@@ -1781,10 +1791,13 @@ internal sealed class TypeDefEmitter
         // is invalid for a generic type. Emit a MemberRef parented at the
         // constructed base's TypeSpec for the selected ctor (primary or explicit
         // `init(...)`), mirroring the parameter-less #1055 path.
+        // Issue #2337: a nested sibling base carrying only the enclosing
+        // generic's reified TypeParameters (no own TypeArguments) requires the
+        // same TypeSpec-parented MemberRef treatment.
         var constructedGenericBase =
-            (classSym.BaseClass != null && !classSym.BaseClass.TypeArguments.IsDefaultOrEmpty)
+            (classSym.BaseClass != null && ReflectionMetadataEmitter.IsUserGenericTypeReference(classSym.BaseClass))
                 ? classSym.BaseClass
-                : ((gsharpBase != null && !gsharpBase.TypeArguments.IsDefaultOrEmpty) ? gsharpBase : null);
+                : ((gsharpBase != null && ReflectionMetadataEmitter.IsUserGenericTypeReference(gsharpBase)) ? gsharpBase : null);
         if (constructedGenericBase != null)
         {
             return this.resolveConstructedBaseExplicitCtorToken(constructedGenericBase, init.GSharpConstructor);

--- a/test/Compiler.Tests/Emit/Issue2337NestedGenericInheritanceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2337NestedGenericInheritanceEmitTests.cs
@@ -1,0 +1,337 @@
+// <copyright file="Issue2337NestedGenericInheritanceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2337 — a nested class that implicitly inherits the generic arity of
+/// its enclosing generic type (e.g. <c>class Mid : Base { }</c> nested inside
+/// <c>class Outer[T]</c>) carries the enclosing generic's reified
+/// <see cref="GSharp.Core.CodeAnalysis.Symbols.StructSymbol.TypeParameters"/>
+/// while its own <see cref="GSharp.Core.CodeAnalysis.Symbols.StructSymbol.TypeArguments"/>
+/// stays empty. <see cref="GSharp.Core.CodeAnalysis.Emit.TypeDefEmitter"/>'s
+/// four <c>extends</c>/base-constructor token gates previously routed a base
+/// through the self-instantiation TypeSpec ONLY when <c>TypeArguments</c> was
+/// non-empty (issue #1055's explicitly-constructed-base case), so a nested
+/// sibling base fell through to the bare open TypeDef/base-ctor MethodDef.
+/// ILVerify then rejects the emitted assembly with a
+/// <c>found ref Derived&lt;T0&gt;, expected ref Base&lt;T0&gt;</c>
+/// <c>StackUnexpected</c> error wherever the mismatched token surfaces on the
+/// stack (e.g. a <c>callvirt</c> dispatch through a base-typed reference).
+/// <para>
+/// The fix widens all four gates to
+/// <c>ReflectionMetadataEmitter.IsUserGenericTypeReference(baseClass)</c> — the
+/// existing shared predicate (already used elsewhere in
+/// <c>TypeDefEmitter</c>/<c>ReflectionMetadataEmitter</c> for the identical
+/// "does this reference need a TypeSpec instead of a bare TypeDef" question) —
+/// which is <see langword="true"/> when EITHER <c>TypeArguments</c> is
+/// non-empty (a constructed base, #1055) OR the base's own
+/// <c>TypeParameters</c> is non-empty (an open definition — including a nested
+/// sibling reified over its enclosing generic's parameters, #2337). Using one
+/// shared predicate at all four sites prevents them drifting out of sync
+/// again.
+/// </para>
+/// Each test uses a UNIQUE package/type name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed and not cleared between
+/// tests.
+/// </summary>
+public class Issue2337NestedGenericInheritanceEmitTests
+{
+    [Fact]
+    public void EndToEnd_ThreeLevelNestedSiblingInheritance_UnderGenericOuter_VerifiesAndRuns()
+    {
+        // The exact issue repro shape (Base / Mid : Base / Leaf : Mid, all
+        // nested inside a generic Outer[T]), surfaced through a callvirt
+        // dispatch on a Base-typed reference — the precise scenario that
+        // reported `found ref Leaf<T0>, expected ref Base<T0>` pre-fix.
+        var source = """
+            package Issue2337ThreeLevel
+            import System
+
+            class Outer2337a[T] {
+                open class Base2337a {
+                    open func Speak() string { return "base" }
+                }
+                open class Mid2337a : Base2337a { }
+                open class Leaf2337a : Mid2337a {
+                    override func Speak() string { return "leaf" }
+                }
+
+                func MakeLeaf() Base2337a {
+                    return Leaf2337a()
+                }
+            }
+
+            func Main() {
+                var o = Outer2337a[int32]()
+                var b = o.MakeLeaf()
+                Console.WriteLine(b.Speak())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("leaf\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_DirectNestedSiblingBaseCall_SkipsMidLevel_VerifiesAndRuns()
+    {
+        // Leaf calls `base.Speak()` (its direct base is Mid, which does not
+        // declare Speak, so the call resolves up through to Base). The
+        // non-virtual `call` instruction's declaring-type token must be the
+        // self-instantiation TypeSpec too, not the bare TypeDef.
+        var source = """
+            package Issue2337DirectCall
+            import System
+
+            class Outer2337b[T] {
+                open class Base2337b {
+                    open func Speak() string { return "base" }
+                }
+                open class Mid2337b : Base2337b { }
+                class Leaf2337b : Mid2337b {
+                    override func Speak() string { return "leaf->" + base.Speak() }
+                }
+
+                func MakeLeaf() Base2337b {
+                    return Leaf2337b()
+                }
+            }
+
+            func Main() {
+                var o = Outer2337b[int32]()
+                var b = o.MakeLeaf()
+                Console.WriteLine(b.Speak())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("leaf->base\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NestedSiblingBaseConstructorChaining_UnderGenericOuter_VerifiesAndRuns()
+    {
+        // Explicit `init(...) : base(...)` chaining across all three nested
+        // sibling levels (GetBaseInitializerCtorToken, private helper #4)
+        // must also route through the self-instantiation TypeSpec.
+        var source = """
+            package Issue2337CtorChain
+            import System
+
+            class Outer2337c[T] {
+                open class Base2337c {
+                    var Value int32
+                    init(v int32) { Value = v }
+                }
+                open class Mid2337c : Base2337c {
+                    init(v int32) : base(v) { }
+                }
+                class Leaf2337c : Mid2337c {
+                    init(v int32) : base(v) { }
+                }
+
+                func MakeLeaf(v int32) Base2337c {
+                    return Leaf2337c(v)
+                }
+            }
+
+            func Main() {
+                var o = Outer2337c[int32]()
+                var b = o.MakeLeaf(42)
+                Console.WriteLine(b.Value)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ExplicitConstructedBase_Issue1055Control_StillVerifiesAndRuns()
+    {
+        // Control: issue #1055's ORIGINAL case — a base explicitly constructed
+        // with concrete type arguments (TypeArguments non-empty, TypeParameters
+        // empty on the reference) — must remain routed through the same
+        // self-instantiation/constructed-base TypeSpec helpers after widening
+        // the gate to the shared IsUserGenericTypeReference predicate.
+        var source = """
+            package Issue2337Ctrl1055
+            import System
+
+            open class Base2337Ctrl1055[TIn, TOut] {
+                open func Transform(x TIn) TOut;
+            }
+            class Derived2337Ctrl1055 : Base2337Ctrl1055[int32, int32] {
+                override func Transform(x int32) int32 { return x + 1 }
+            }
+
+            func Main() {
+                let b Base2337Ctrl1055[int32, int32] = Derived2337Ctrl1055()
+                Console.WriteLine(b.Transform(41))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NonGenericNestedSiblingInheritance_ControlStillVerifiesAndRuns()
+    {
+        // Control: the SAME three-level nested sibling shape, but the
+        // enclosing type is NON-generic — neither TypeArguments nor
+        // TypeParameters is ever populated on the base reference, so this path
+        // was never affected by the bug and must remain clean after the fix.
+        var source = """
+            package Issue2337NonGenericCtrl
+            import System
+
+            class Outer2337Ctrl {
+                open class Base2337Ctrl {
+                    open func Speak() string { return "base" }
+                }
+                open class Mid2337Ctrl : Base2337Ctrl { }
+                class Leaf2337Ctrl : Mid2337Ctrl {
+                    override func Speak() string { return "leaf" }
+                }
+            }
+
+            func Main() {
+                let b Outer2337Ctrl.Base2337Ctrl = Outer2337Ctrl.Leaf2337Ctrl()
+                Console.WriteLine(b.Speak())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("leaf\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_OahuTreeDecompositionShape_BaseCustomToStringCustomFormatString_VerifiesAndRuns()
+    {
+        // The real Oahu occurrence that discovered this bug: a
+        // TreeDecomposition[T]-shaped generic outer with a nested
+        // Base / CustomToString : Base / CustomFormatString : CustomToString
+        // sibling family, where the leaf override calls up through
+        // `base.Describe()` and is dispatched through a Base-typed reference.
+        var source = """
+            package Oahu.Aux.Diagnostics
+            import System
+
+            class TreeDecomposition2337[T] {
+                open class Base2337Oahu {
+                    open func Describe() string { return "base" }
+                }
+                open class CustomToString2337 : Base2337Oahu {
+                    open override func Describe() string { return "custom-to-string" }
+                }
+                class CustomFormatString2337 : CustomToString2337 {
+                    override func Describe() string { return "custom-format-string:" + base.Describe() }
+                }
+
+                func MakeFormatString() Base2337Oahu {
+                    return CustomFormatString2337()
+                }
+            }
+
+            func Main() {
+                var td = TreeDecomposition2337[int32]()
+                var b = td.MakeFormatString()
+                System.Console.WriteLine(b.Describe())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("custom-format-string:custom-to-string\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2337_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2337 — closes #2337.

`TypeDefEmitter`'s four `extends`/base-constructor token gates only checked `BaseClass.TypeArguments` to decide whether a base needed the self-instantiation/constructed `TypeSpec` instead of the bare open `TypeDef`. A nested class that implicitly inherits its enclosing generic type's arity (e.g. `class Mid : Base` nested inside `class Outer[T]`) carries the reified `TypeParameters` on the base symbol while `TypeArguments` stays empty, so these gates fell through to the bare `TypeDef`/base-ctor `MethodDef`. ILVerify then rejected the emitted assembly wherever the mismatched token surfaced on the stack:

```
found ref Leaf<T0>, expected ref Base<T0>
```

## Fix

Widened all four gates in `src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs` to the existing shared `ReflectionMetadataEmitter.IsUserGenericTypeReference` predicate (already used elsewhere in the emitter for the identical "does this reference need a TypeSpec instead of a bare TypeDef" question), which returns `true` when EITHER:
- `TypeArguments` is non-empty (issue #1055's explicitly-constructed-base case), OR
- the base's own `TypeParameters` is non-empty (an open definition, including a nested sibling reified over its enclosing generic's parameters — issue #2337's case).

Sites fixed:
1. `EmitStructTypeDef` — top-level class `extends` clause.
2. `EmitNestedStructTypeDef` — nested class `extends` clause.
3. `GetBaseCtorToken` — default (parameter-less) base-ctor chaining token.
4. `GetBaseInitializerCtorToken` — explicit `init(...) : base(...)` chaining token.

Using one shared predicate at all four sites (instead of four independently-drifting `!TypeArguments.IsDefaultOrEmpty` checks) prevents them from drifting out of sync again, per the issue's request.

No changes were made to Oahu.

## Tests

Added `test/Compiler.Tests/Emit/Issue2337NestedGenericInheritanceEmitTests.cs` (compile + ILVerify + run, end-to-end):
- `EndToEnd_ThreeLevelNestedSiblingInheritance_UnderGenericOuter_VerifiesAndRuns` — the exact issue repro shape (`Base`/`Mid : Base`/`Leaf : Mid` nested inside a generic `Outer[T]`), dispatched through a `callvirt` on a base-typed reference.
- `EndToEnd_DirectNestedSiblingBaseCall_SkipsMidLevel_VerifiesAndRuns` — `Leaf` calls `base.Speak()`, resolving up through `Mid` to `Base`.
- `EndToEnd_NestedSiblingBaseConstructorChaining_UnderGenericOuter_VerifiesAndRuns` — explicit `init(...) : base(...)` chaining across all three nested sibling levels (exercises site 4).
- `EndToEnd_ExplicitConstructedBase_Issue1055Control_StillVerifiesAndRuns` — issue #1055's original explicitly-constructed-base case, as a regression control.
- `EndToEnd_NonGenericNestedSiblingInheritance_ControlStillVerifiesAndRuns` — the same three-level nested-sibling shape under a *non-generic* enclosing type, as a regression control.
- `EndToEnd_OahuTreeDecompositionShape_BaseCustomToStringCustomFormatString_VerifiesAndRuns` — the real Oahu `TreeDecomposition[T]` `Base`/`CustomToString`/`CustomFormatString` shape that discovered the bug.

Verified 4 of the 6 new tests fail with the exact ILVerify error from the issue when run against the pre-fix compiler (confirmed by temporarily stashing the fix and rebuilding), and all 6 pass after the fix. The 2 controls pass both before and after, confirming no regression risk and no false positives.

## Validation

- `dotnet build src/Compiler/Compiler.csproj -c Release` — succeeds, 0 warnings/errors.
- Targeted: `Issue2337`, `Issue1055`, `Issue1465`, `Issue1467`, `Issue1493`, `Issue1060`, `Issue1521`, `Issue1537`, `Issue1069`, `Issue1254` filters — 59/59 passed.
- Full `test/Core.Tests` — 5992 passed, 1 skipped (pre-existing baseline-regen skip), 0 failed.
- Full `test/Compiler.Tests` — 2898 passed, 0 failed.

## Deferred work

None identified — all four affected token sites are now covered by the shared predicate and by regression tests, and the fix reuses existing, already-tested TypeSpec/MemberRef resolution helpers (`GetUserStructTypeSpec`, `ResolveConstructedBaseParameterlessCtorToken`, `ResolveConstructedBaseExplicitCtorToken`) rather than introducing new emission logic.
