### PR TITLE
Fix #2338: self-instantiation-aware field tokens for generic primary-ctor base-initializer stores

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -4659,6 +4659,38 @@ public sealed class Binder
                 : type;
         }
 
+        // Issue #2340 follow-up (sibling to the #1503 branch already present
+        // in StructSymbol.SubstituteTypeForConstruction): a constructed
+        // generic named delegate appearing as a call's parameter or return
+        // type (e.g. `func MakeGetter[T](item T) Getter[T]`) must have its own
+        // type arguments substituted through the call's method-type-argument
+        // map so the bound call surfaces `Getter[int32]` rather than the
+        // still-open `Getter[T]`. Without this branch the binder's computed
+        // call-expression type stayed open over the callee's own type
+        // parameter even though the emitter correctly built a MethodSpec/
+        // MemberRef closed over the concrete argument — the mismatch between
+        // the (wrong, open) declared type of the receiving local/field and
+        // the (correct, closed) value actually produced by the `call`
+        // instruction failed ilverify with `StackUnexpected`.
+        if (type is DelegateTypeSymbol del
+            && del.Definition != null
+            && !ReferenceEquals(del.Definition, del)
+            && !del.TypeArguments.IsDefaultOrEmpty)
+        {
+            var newDelegateArgs = ImmutableArray.CreateBuilder<TypeSymbol>(del.TypeArguments.Length);
+            var delegateChanged = false;
+            foreach (var arg in del.TypeArguments)
+            {
+                var substituted = SubstituteType(arg, substitution, mapClrType);
+                delegateChanged |= !ReferenceEquals(substituted, arg);
+                newDelegateArgs.Add(substituted);
+            }
+
+            return delegateChanged
+                ? DelegateTypeSymbol.Construct(del.Definition, newDelegateArgs.MoveToImmutable())
+                : type;
+        }
+
         if (type is ImportedTypeSymbol it && it.HasTypeParameterArgument)
         {
             // #313: substitute a generic type parameterized by an in-scope type

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -7447,6 +7447,39 @@ internal sealed class DeclarationBinder
                 && TypeArgumentsEquivalent(ia.TypeArguments, ib.TypeArguments, typeParamMap);
         }
 
+        // Issue #2340 follow-up: a named delegate constructed over a
+        // *method-level* generic parameter (e.g. an interface method
+        // `func Make[T](seed T) Getter[T]`) is never covered by the
+        // StructSymbol/InterfaceSymbol branches above, and — unlike the
+        // interface-level generic case — is not fixed by substituting the
+        // interface's own type arguments, because the delegate's type
+        // argument here is the *method's* type parameter, which is only
+        // resolved through `typeParamMap` (built per call by
+        // TryBuildMethodTypeParameterMap). Without this branch,
+        // `Getter[T_interfaceMethod]` and `Getter[T_implMethod]` are two
+        // distinct DelegateTypeSymbol.Construct cache entries (different
+        // TypeParameterSymbol instances as their sole type argument) that
+        // fail the top-level ReferenceEquals check and then fall through to
+        // the ClrType fallback below, which does not apply the
+        // method-type-parameter map and wrongly rejects a genuinely matching
+        // signature with GS0187. Recurses through TypeArgumentsEquivalent
+        // exactly like the StructSymbol/InterfaceSymbol branches so the
+        // typeParamMap substitution applies to each type argument.
+        if (a is DelegateTypeSymbol dta && b is DelegateTypeSymbol dtb)
+        {
+            // Unlike StructSymbol/InterfaceSymbol (whose `Definition` self-
+            // references on the open definition), DelegateTypeSymbol.Definition
+            // is only set on constructed instances (issue #1503) and stays
+            // `null` on the open definition / non-generic delegates — so it
+            // must be normalized to itself before comparing, or two distinct
+            // non-generic (or open-definition) delegate types would both
+            // report `Definition == null` and wrongly compare as equivalent.
+            var defA = dta.Definition ?? dta;
+            var defB = dtb.Definition ?? dtb;
+            return ReferenceEquals(defA, defB)
+                && TypeArgumentsEquivalent(dta.TypeArguments, dtb.TypeArguments, typeParamMap);
+        }
+
         if (a is ImportedTypeSymbol pa && b is ImportedTypeSymbol pb)
         {
             // Constructed imported generics carrying symbolic arguments (e.g.

--- a/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
+++ b/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
@@ -518,11 +518,45 @@ internal sealed class DataStructSynthesizer
     }
 
     /// <summary>
+    /// Issue #2338 follow-up: returns the <see cref="MethodAttributes"/> for a
+    /// synthesized <c>Object</c>-virtual override (<c>Equals(object)</c>,
+    /// <c>GetHashCode()</c>, <c>ToString()</c>) on a data type. A data STRUCT's
+    /// override is always <c>final</c> (structs can't be subclassed anyway,
+    /// and the parser rejects <c>open data struct</c> outright — ADR-0078 /
+    /// GS0309). A data CLASS's override is only <c>final</c> when the class
+    /// itself cannot be further subclassed — mirroring the exact
+    /// <c>!structSym.IsOpen &amp;&amp; !structSym.IsSealedHierarchy</c> condition
+    /// <see cref="TypeDefEmitter"/> uses to decide the TypeDef's own
+    /// <c>TypeAttributes.Sealed</c> flag. An <c>open</c> (or ADR-0078
+    /// <c>sealed class</c> discriminated-union) data class must leave these
+    /// overrides non-final so a further-derived data class can re-override
+    /// them with its own combined field set; marking them unconditionally
+    /// final made loading ANY data-class-extends-data-class hierarchy throw
+    /// <c>TypeLoadException: Declaration referenced in a method
+    /// implementation cannot be a final method</c> the moment the subclass
+    /// tried to override the base's already-final <c>Equals</c>/
+    /// <c>GetHashCode</c>/<c>ToString</c>.
+    /// </summary>
+    private static MethodAttributes DataObjectOverrideAttributes(StructSymbol structSym)
+    {
+        var attrs = MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig;
+        if (!structSym.IsClass || (!structSym.IsOpen && !structSym.IsSealedHierarchy))
+        {
+            attrs |= MethodAttributes.Final;
+        }
+
+        return attrs;
+    }
+
+    /// <summary>
     /// Issue #410 / ADR-0029: emits
     /// <c>public sealed override bool Equals(object other)</c> that performs
     /// <c>other is Name p &amp;&amp; this.Equals(p)</c>. Sealed because struct
     /// methods cannot be overridden in user code anyway, but the metadata
-    /// flag communicates intent.
+    /// flag communicates intent. Issue #2338 follow-up: for an <c>open</c>
+    /// (or ADR-0078 sealed-hierarchy) data CLASS the override is instead left
+    /// non-final via <see cref="DataObjectOverrideAttributes"/> so a further
+    /// derived data class can re-override it.
     /// </summary>
     private void EmitDataStructEqualsObject(StructSymbol structSym, EntityHandle typeDef, MethodDefinitionHandle equalsTypedHandle)
     {
@@ -556,7 +590,7 @@ internal sealed class DataStructSynthesizer
             .Parameters(1, r => r.Type().Boolean(), ps => ps.AddParameter().Type().Object());
 
         this.emitCtx.Metadata.AddMethodDefinition(
-            attributes: MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig,
+            attributes: DataObjectOverrideAttributes(structSym),
             implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
             name: this.emitCtx.Metadata.GetOrAddString("Equals"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sig),
@@ -711,7 +745,7 @@ internal sealed class DataStructSynthesizer
             .Parameters(0, r => r.Type().Int32(), _ => { });
 
         this.emitCtx.Metadata.AddMethodDefinition(
-            attributes: MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig,
+            attributes: DataObjectOverrideAttributes(structSym),
             implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
             name: this.emitCtx.Metadata.GetOrAddString("GetHashCode"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sig),
@@ -784,7 +818,7 @@ internal sealed class DataStructSynthesizer
             .Parameters(0, r => r.Type().String(), _ => { });
 
         this.emitCtx.Metadata.AddMethodDefinition(
-            attributes: MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig,
+            attributes: DataObjectOverrideAttributes(structSym),
             implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
             name: this.emitCtx.Metadata.GetOrAddString("ToString"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sig),

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -292,6 +292,19 @@ internal sealed partial class MethodBodyEmitter
     /// MethodDef handle is supplied directly. Mirrors
     /// <see cref="EmitFunctionLiteral(BoundFunctionLiteralExpression, Type)"/>
     /// but uses a metadata handle instead of a runtime <see cref="Type"/>.
+    /// Issue #2338 follow-up (deferred from the primary-ctor field-token fix):
+    /// when the display class was reified generic over its enclosing type
+    /// parameters (issue #1477 — e.g. a lambda captures a `T`-typed value
+    /// inside a generic containing type/method), the capture-site
+    /// <c>newobj</c>/<c>stfld</c>/<c>ldftn</c> tokens must be MemberRefs
+    /// parented at the CONSTRUCTED closure TypeSpec, exactly like the
+    /// no-named-delegate sibling above already does — a bare
+    /// MethodDef/FieldDef of a member on a generic type is an illegal
+    /// capture-store/delegate-function token (TypeLoadException + ilverify
+    /// StackUnexpected/DelegateCtor). This overload previously always used
+    /// the bare (open) handles unconditionally, so a generic-reified closure
+    /// bound to a named (rather than `Func`/`Action`) delegate type crashed
+    /// the same way primary-ctor field stores did before the #2338 fix.
     /// </summary>
     private void EmitFunctionLiteralToNamedDelegate(BoundFunctionLiteralExpression literal, EntityHandle delegateCtorHandle)
     {
@@ -309,8 +322,13 @@ internal sealed partial class MethodBodyEmitter
                     $"Closure invoke method '{closure.InvokeMethod.Name}' has no emitted MethodDef.");
             }
 
+            var constructedClosure = closure.ConstructedClassSym;
+            var closureIsGeneric = ReflectionMetadataEmitter.IsUserGenericTypeReference(constructedClosure);
+
             this.il.OpCode(ILOpCode.Newobj);
-            this.il.Token(closureCtor);
+            this.il.Token(closureIsGeneric
+                ? this.outer.ResolveUserCtorTokenForDefault(constructedClosure)
+                : closureCtor);
 
             foreach (var captured in literal.CapturedVariables)
             {
@@ -320,7 +338,16 @@ internal sealed partial class MethodBodyEmitter
                         $"Closure for '{literal.Function.Name}' has no field for captured '{captured.Name}'.");
                 }
 
-                if (!this.outer.cache.StructFieldDefs.TryGetValue(field, out var fieldHandle))
+                EntityHandle fieldToken;
+                if (closureIsGeneric)
+                {
+                    fieldToken = this.outer.ResolveFieldToken(constructedClosure, field);
+                }
+                else if (this.outer.cache.StructFieldDefs.TryGetValue(field, out var fieldHandle))
+                {
+                    fieldToken = fieldHandle;
+                }
+                else
                 {
                     throw new InvalidOperationException(
                         $"Closure field '{field.Name}' has no emitted FieldDef.");
@@ -329,11 +356,13 @@ internal sealed partial class MethodBodyEmitter
                 this.il.OpCode(ILOpCode.Dup);
                 this.EmitCapturedVariableLoad(captured);
                 this.il.OpCode(ILOpCode.Stfld);
-                this.il.Token(fieldHandle);
+                this.il.Token(fieldToken);
             }
 
             this.il.OpCode(ILOpCode.Ldftn);
-            this.il.Token(closureInvoke);
+            this.il.Token(closureIsGeneric
+                ? this.outer.ResolveClosureInvokeFtnToken(constructedClosure, closure.ClassSym, closure.InvokeMethod)
+                : closureInvoke);
             this.il.OpCode(ILOpCode.Newobj);
             this.il.Token(delegateCtorHandle);
             return;

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -4657,6 +4657,10 @@ internal sealed class ReflectionMetadataEmitter
         il.Token(baseCtorToken);
 
         // this.<field> = arg; positional 1:1 with same-named fields.
+        // Issue #2338 / ADR-0087 §3 R3: for a generic class the stfld must
+        // reference the field via a MemberRef parented at the
+        // self-instantiation TypeSpec (ResolveFieldToken), not the bare
+        // open FieldDef, or ilverify rejects the constructed receiver.
         for (var i = 0; i < parameters.Length; i++)
         {
             var param = parameters[i];
@@ -4665,10 +4669,7 @@ internal sealed class ReflectionMetadataEmitter
                 throw new InvalidOperationException($"Class '{classSym.Name}' has no field for primary ctor parameter '{param.Name}'.");
             }
 
-            if (!this.cache.StructFieldDefs.TryGetValue(field, out var fieldHandle))
-            {
-                throw new InvalidOperationException($"Class field '{field.Name}' has no emitted FieldDef.");
-            }
+            var fieldHandle = this.ResolveFieldToken(classSym, field);
 
             il.LoadArgument(0);
             il.LoadArgument(i + 1);

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -662,6 +662,24 @@ public sealed class InterfaceSymbol : TypeSymbol
             substMethod.StaticOwnerType = instance;
         }
 
+        // Issue #2340 follow-up: preserve the ORIGINAL method's own
+        // (method-level) generic type parameters, e.g. `func Transform[TOut](...)`
+        // on a generic interface `ITransformer[TIn]`. These type parameters are
+        // never touched by `subst` (which only maps the INTERFACE's own type
+        // parameters, e.g. TIn), so the same TypeParameterSymbol instances
+        // remain valid on the constructed method. Without copying them here,
+        // every constructed generic interface's methods silently lost their
+        // method-level generic arity (defaulting to the empty array), which
+        // made `DeclarationBinder.TryBuildMethodTypeParameterMap` see a bogus
+        // arity mismatch (0 vs. the implementer's real arity) against ANY
+        // otherwise-correct implementation of a generic method on a
+        // constructed generic interface, incorrectly rejecting it before
+        // signature comparison ever ran and misreporting GS0187.
+        if (!m.TypeParameters.IsDefaultOrEmpty)
+        {
+            substMethod.TypeParameters = m.TypeParameters;
+        }
+
         return substMethod;
     }
 
@@ -768,6 +786,61 @@ public sealed class InterfaceSymbol : TypeSymbol
             return changed
                 ? Construct(iface.Definition, substitutedArgs.MoveToImmutable(), mapClrType)
                 : iface;
+        }
+
+        // Issue #2340 follow-up: a member type that is a constructed
+        // struct/class over the interface's own type parameter (e.g. a
+        // generic interface method `func Make() Box[T]`) carries the
+        // definition's type parameters in its arguments, exactly like the
+        // InterfaceSymbol case above. Without this branch a constructed
+        // interface's method kept exposing `Box[T_iface]` instead of
+        // `Box[int32]`, which made GS0187's signature-matching (see
+        // DeclarationBinder.TypeSignaturesEquivalent's StructSymbol branch)
+        // compare an unsubstituted type argument against the implementing
+        // class's closed argument and reject a genuinely correct
+        // implementation. Mirrors StructSymbol.SubstituteTypeForConstruction's
+        // own recursive handling of nested constructed generics.
+        if (type is StructSymbol structType && !structType.TypeArguments.IsDefaultOrEmpty)
+        {
+            var substitutedArgs = ImmutableArray.CreateBuilder<TypeSymbol>(structType.TypeArguments.Length);
+            var changed = false;
+            for (var i = 0; i < structType.TypeArguments.Length; i++)
+            {
+                var substituted = SubstituteType(structType.TypeArguments[i], subst, mapClrType);
+                substitutedArgs.Add(substituted);
+                changed |= !ReferenceEquals(substituted, structType.TypeArguments[i]);
+            }
+
+            return changed
+                ? StructSymbol.Construct(structType.Definition, substitutedArgs.MoveToImmutable(), mapClrType)
+                : structType;
+        }
+
+        // Issue #2340 follow-up (sibling to the #1503 branch already present
+        // in StructSymbol.SubstituteTypeForConstruction, and the matching
+        // Binder.SubstituteType branch added for the call-site defect): a
+        // member type that is a constructed named delegate over the
+        // interface's own type parameter (e.g. `func Make() Getter[T]`) must
+        // have its own type arguments substituted so the constructed
+        // interface exposes `Getter[int32]` rather than the still-open
+        // `Getter[T]`.
+        if (type is DelegateTypeSymbol del
+            && del.Definition != null
+            && !ReferenceEquals(del.Definition, del)
+            && !del.TypeArguments.IsDefaultOrEmpty)
+        {
+            var substitutedArgs = ImmutableArray.CreateBuilder<TypeSymbol>(del.TypeArguments.Length);
+            var changed = false;
+            for (var i = 0; i < del.TypeArguments.Length; i++)
+            {
+                var substituted = SubstituteType(del.TypeArguments[i], subst, mapClrType);
+                substitutedArgs.Add(substituted);
+                changed |= !ReferenceEquals(substituted, del.TypeArguments[i]);
+            }
+
+            return changed
+                ? DelegateTypeSymbol.Construct(del.Definition, substitutedArgs.MoveToImmutable())
+                : del;
         }
 
         // Issue #974: a member type that is a constructed imported generic over

--- a/test/Compiler.Tests/Emit/Issue2338GenericInterfaceDelegateSubstitutionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2338GenericInterfaceDelegateSubstitutionEmitTests.cs
@@ -1,0 +1,409 @@
+// <copyright file="Issue2338GenericInterfaceDelegateSubstitutionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2338 follow-up: the remaining <c>InterfaceSymbol.SubstituteType</c>
+/// gap for generic interface methods/properties whose return or parameter
+/// type is a named delegate (or a plain generic struct/class) constructed
+/// over the interface's own type parameter or the method's own generic
+/// parameter.
+/// <para>
+/// Note: issue #2230 (fixed by PR #2249) covered the IMPORTED-CLR interface
+/// path — a distinct symbol/binding path from the source-interface
+/// (<c>InterfaceSymbol</c>) gap fixed here; the two are not conflated.
+/// </para>
+/// <para>
+/// Root causes (three independent, compounding gaps, all in the
+/// source-interface implementation-matching path):
+/// <list type="number">
+/// <item><c>InterfaceSymbol.SubstituteType</c> (the construction-time member
+/// substitution helper used by <c>TryResolveMembers</c>/<c>SubstituteMethod</c>
+/// when building a CONSTRUCTED generic interface's methods, e.g.
+/// <c>IFactory[int32]</c>) had no case for <c>DelegateTypeSymbol</c> nor
+/// <c>StructSymbol</c>. A constructed interface's method kept exposing the
+/// still-open definition type (e.g. <c>Getter[T]</c> / <c>Box[T]</c>) instead
+/// of the closed instantiation (<c>Getter[int32]</c> / <c>Box[int32]</c>),
+/// which made <c>DeclarationBinder</c>'s interface-implementation signature
+/// matching reject a genuinely correct implementation with a false-negative
+/// <c>GS0187</c> ("does not implement interface method"). The fix mirrors the
+/// existing <c>DelegateTypeSymbol</c>/<c>StructSymbol</c> branches already
+/// present in <c>Binder.SubstituteType</c> and
+/// <c>StructSymbol.SubstituteTypeForConstruction</c>.</item>
+/// <item><c>InterfaceSymbol.SubstituteMethod</c> never copied the original
+/// interface method's own (method-level) generic type parameters onto the
+/// constructed method, so a generic method (e.g. <c>func Transform[TOut](...)</c>)
+/// declared on a CONSTRUCTED generic interface silently lost its arity
+/// (defaulting to none). This made
+/// <c>DeclarationBinder.TryBuildMethodTypeParameterMap</c> see a bogus
+/// interface-vs-implementer arity mismatch and reject the candidate before
+/// signature comparison ever ran — reachable only once gap 1 stopped masking
+/// it. Fixed by copying <c>m.TypeParameters</c> onto the substituted method.</item>
+/// <item><c>DeclarationBinder.TypeSignaturesEquivalent</c> had no case for
+/// <c>DelegateTypeSymbol</c>, so a named delegate constructed over a
+/// METHOD-level generic parameter (not fixed by substituting the interface's
+/// own type arguments, since it is the method's own type parameter that
+/// differs between the interface's declared signature and the implementer's)
+/// still failed to compare as structurally equivalent. Fixed by adding a
+/// <c>DelegateTypeSymbol</c> branch mirroring the existing
+/// <c>StructSymbol</c>/<c>InterfaceSymbol</c> branches (recursing through
+/// <c>TypeArgumentsEquivalent</c> so the method-type-parameter map applies).</item>
+/// </list>
+/// </para>
+/// Negative/control coverage confirms genuine signature mismatches (wrong
+/// type argument, a different named delegate entirely, a real generic-arity
+/// mismatch) are still correctly rejected with <c>GS0187</c> — the fix only
+/// stops FALSE-negative rejections, it does not loosen matching.
+/// <para>See also <c>Issue2338GenericInterfaceDelegateSubstitutionTests</c>
+/// (Core.Tests) for pure-binder-level coverage of the same fixes.</para>
+/// </summary>
+public class Issue2338GenericInterfaceDelegateSubstitutionEmitTests
+{
+    [Fact]
+    public void Facet1_InterfaceLevelGenericDelegateReturn_ValueAndReferenceType_Runs()
+    {
+        var source = """
+            package Cap2338IfaceReturn
+            import System
+
+            type Getter2338IfaceReturn[T any] = delegate func() T
+
+            interface IFactory2338IfaceReturn[T any] {
+                func Make() Getter2338IfaceReturn[T];
+            }
+
+            class ConcreteInt2338IfaceReturn : IFactory2338IfaceReturn[int32] {
+                func Make() Getter2338IfaceReturn[int32] {
+                    return () -> 42
+                }
+            }
+
+            class ConcreteStr2338IfaceReturn : IFactory2338IfaceReturn[string] {
+                func Make() Getter2338IfaceReturn[string] {
+                    return () -> "hi"
+                }
+            }
+
+            func Main() {
+                var ci = ConcreteInt2338IfaceReturn()
+                Console.WriteLine(ci.Make().Invoke())
+                var cs = ConcreteStr2338IfaceReturn()
+                Console.WriteLine(cs.Make().Invoke())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\nhi\n", output);
+    }
+
+    [Fact]
+    public void Facet2_InterfaceLevelGenericDelegateParameter_Runs()
+    {
+        var source = """
+            package Cap2338IfaceParam
+            import System
+
+            type Consumer2338IfaceParam[T any] = delegate func(item T) void
+
+            interface ISink2338IfaceParam[T any] {
+                func Accept(c Consumer2338IfaceParam[T]) void;
+            }
+
+            class ConcreteSink2338IfaceParam : ISink2338IfaceParam[int32] {
+                func Accept(c Consumer2338IfaceParam[int32]) void {
+                    c.Invoke(99)
+                }
+            }
+
+            func Main() {
+                var s = ConcreteSink2338IfaceParam()
+                s.Accept(func(x int32) void {
+                    Console.WriteLine(x)
+                })
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    [Fact]
+    public void Facet3_InterfaceLevelGenericPlainClassReturn_Runs()
+    {
+        var source = """
+            package Cap2338IfaceClass
+            import System
+
+            class Box2338IfaceClass[T any](Value T)
+
+            interface IFactory2338IfaceClass[T any] {
+                func Make() Box2338IfaceClass[T];
+            }
+
+            class Concrete2338IfaceClass : IFactory2338IfaceClass[int32] {
+                func Make() Box2338IfaceClass[int32] {
+                    return Box2338IfaceClass[int32](7)
+                }
+            }
+
+            func Main() {
+                var c = Concrete2338IfaceClass()
+                Console.WriteLine(c.Make().Value)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void Facet4_MethodLevelGenericDelegateOnNonGenericInterface_ValueAndReferenceType_Runs()
+    {
+        var source = """
+            package Cap2338MethodLevel
+            import System
+
+            type Getter2338MethodLevel[T any] = delegate func() T
+
+            interface IFactory2338MethodLevel {
+                func Make[T](seed T) Getter2338MethodLevel[T];
+            }
+
+            class Concrete2338MethodLevel : IFactory2338MethodLevel {
+                func Make[T](seed T) Getter2338MethodLevel[T] {
+                    return () -> seed
+                }
+            }
+
+            func Main() {
+                var c = Concrete2338MethodLevel()
+                Console.WriteLine(c.Make[int32](55).Invoke())
+                Console.WriteLine(c.Make[string]("world").Invoke())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("55\nworld\n", output);
+    }
+
+    [Fact]
+    public void Facet5_CombinedInterfaceAndMethodLevelGenericsOverMultiParamDelegate_Runs()
+    {
+        var source = """
+            package Cap2338Combined
+            import System
+
+            type Combiner2338Combined[A any, B any] = delegate func(item A) B
+
+            interface ITransformer2338Combined[TIn any] {
+                func Transform[TOut](conv Combiner2338Combined[TIn, TOut]) TOut;
+            }
+
+            class Concrete2338Combined : ITransformer2338Combined[int32] {
+                func Transform[TOut](conv Combiner2338Combined[int32, TOut]) TOut {
+                    return conv.Invoke(10)
+                }
+            }
+
+            func Main() {
+                var c = Concrete2338Combined()
+                var result = c.Transform[string](func(x int32) string {
+                    return "n=" + x.ToString()
+                })
+                Console.WriteLine(result)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("n=10\n", output);
+    }
+
+    [Fact]
+    public void Facet6_ContainingTypeGenericClassImplementingGenericInterfaceOverCombinedGenericDelegate_Runs()
+    {
+        // Containing-type generics: the implementing class is itself generic
+        // (class-level TIn is not yet a concrete type at the class
+        // declaration site) combined with a method-level type parameter
+        // (TOut) inside the same delegate signature.
+        var source = """
+            package Cap2338Containing
+            import System
+
+            type Combiner2338Containing[A any, B any] = delegate func(item A) B
+
+            interface ITransformer2338Containing[TIn any] {
+                func Transform[TOut](conv Combiner2338Containing[TIn, TOut]) TOut;
+            }
+
+            class GenericConcrete2338Containing[TIn any](Seed TIn) : ITransformer2338Containing[TIn] {
+                func Transform[TOut](conv Combiner2338Containing[TIn, TOut]) TOut {
+                    return conv.Invoke(Seed)
+                }
+            }
+
+            func Main() {
+                var c = GenericConcrete2338Containing[int32](21)
+                var result = c.Transform[string](func(x int32) string {
+                    return "n=" + x.ToString()
+                })
+                Console.WriteLine(result)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("n=21\n", output);
+    }
+
+    [Fact]
+    public void Facet7_NestedGenericDelegateSignature_Runs()
+    {
+        // The delegate's own type argument is itself a constructed generic
+        // class over the interface's type parameter: Getter[Box[T]].
+        var source = """
+            package Cap2338Nested
+            import System
+
+            class Box2338Nested[T any](Value T)
+            type Getter2338Nested[T any] = delegate func() T
+
+            interface IFactory2338Nested[T any] {
+                func Make() Getter2338Nested[Box2338Nested[T]];
+            }
+
+            class Concrete2338Nested : IFactory2338Nested[int32] {
+                func Make() Getter2338Nested[Box2338Nested[int32]] {
+                    return () -> Box2338Nested[int32](123)
+                }
+            }
+
+            func Main() {
+                var c = Concrete2338Nested()
+                Console.WriteLine(c.Make().Invoke().Value)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("123\n", output);
+    }
+
+    // Non-generic control: confirms the fix does not disturb the
+    // already-correct common (non-generic-interface) case.
+    [Fact]
+    public void Facet8_NonGenericInterfaceControl_Runs()
+    {
+        var source = """
+            package Cap2338Control
+            import System
+
+            type Getter2338Control = delegate func() int32
+
+            interface IFactory2338Control {
+                func Make() Getter2338Control;
+            }
+
+            class Concrete2338Control : IFactory2338Control {
+                func Make() Getter2338Control {
+                    return () -> 13
+                }
+            }
+
+            func Main() {
+                var c = Concrete2338Control()
+                Console.WriteLine(c.Make().Invoke())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("13\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2338_iface_delegate_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2338GenericNamedDelegateCallSiteEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2338GenericNamedDelegateCallSiteEmitTests.cs
@@ -1,0 +1,374 @@
+// <copyright file="Issue2338GenericNamedDelegateCallSiteEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2338 follow-up (root cause of the "generic named-delegate call-site
+/// defect" discovered while testing <c>EmitFunctionLiteralToNamedDelegate</c>):
+/// calling a generic G# user function/method whose parameter or return type is
+/// a NAMED delegate (<c>type Getter[T any] = delegate func() T</c>) constructed
+/// over the callee's OWN type parameter produced a <em>caller-side</em> type
+/// mismatch, independent of any closure/capture.
+/// <para>
+/// Root cause: <c>Binder.SubstituteType</c> — the substitution routine
+/// <see cref="GSharp.Core.CodeAnalysis.Binding.OverloadResolver"/> uses to
+/// compute a generic call's substituted parameter/return types (for source
+/// functions, methods, and extension methods alike, both instance and shared)
+/// — had no case for <c>DelegateTypeSymbol</c>, unlike its sibling
+/// <c>StructSymbol.SubstituteTypeForConstruction</c> which already substitutes
+/// through a constructed named delegate's type arguments (issue #1503). A
+/// call like <c>func MakeGetter[T](item T) Getter[T]</c> therefore bound with
+/// its ORIGINAL (still-open, <c>Getter&lt;T&gt;</c>) return type even when
+/// instantiated over a concrete argument, instead of the substituted
+/// <c>Getter&lt;int32&gt;</c>. The emitter's <c>MethodSpec</c> for the call
+/// itself was always correct (built directly from the substitution
+/// dictionary), so the actual value produced on the stack was the correctly
+/// closed <c>Getter&lt;int32&gt;</c> — but the caller's declared local
+/// variable / subsequent-use type (derived from the wrong, still-open binder
+/// type) disagreed, failing ilverify with <c>StackUnexpected</c> ("found ref
+/// Getter&lt;int32&gt;, expected ref Getter&lt;!!0&gt;") or, in some binding
+/// shapes, rejecting the call outright at compile time with a spurious
+/// <c>GS0155</c> conversion diagnostic.
+/// </para>
+/// <para>
+/// The fix adds a <c>DelegateTypeSymbol</c> branch to
+/// <c>Binder.SubstituteType</c> mirroring the existing
+/// <c>StructSymbol.SubstituteTypeForConstruction</c> branch exactly. Because
+/// <c>Binder.SubstituteType</c> is the single shared primitive threaded
+/// through every generic call-binding path (free functions, instance/shared
+/// methods, and extension methods), the fix applies uniformly without
+/// special-casing any one call shape.
+/// </para>
+/// <list type="bullet">
+/// <item>Facet 1 — RETURN position: a generic free function constructs and
+/// returns a named delegate closed over its own type parameter, for both a
+/// value-type and a reference-type instantiation.</item>
+/// <item>Facet 2 — PARAMETER + ROUND-TRIP: a generic free function takes a
+/// named delegate parameter (closed over its own type parameter) and returns
+/// it unchanged (identity), exercising both the parameter conversion and the
+/// return-type substitution together.</item>
+/// <item>Facet 3 — METHOD-LEVEL generics: a non-generic class's instance
+/// method carries its OWN type parameter and returns a named delegate closed
+/// over it, called for both a value-type and a reference-type instantiation.</item>
+/// <item>Facet 4 — CONTAINING-TYPE generics: a generic class's instance method
+/// (no method-level type parameter of its own) returns a named delegate closed
+/// over the class's type parameter, called on both a value-type and a
+/// reference-type instantiation of the class.</item>
+/// <item>Facet 5 — SHARED (static) method on a generic class returns a named
+/// delegate closed over the class's type parameter.</item>
+/// <item>Facet 6 — CHAINED generic calls: a generic function calls another
+/// generic function and forwards its named-delegate return value, for both a
+/// value-type and a reference-type instantiation.</item>
+/// <item>Facet 7 — multi-type-parameter named delegate: a two-type-parameter
+/// delegate constructed from a lambda argument (parameter-side unification)
+/// and returned (return-side substitution) together.</item>
+/// <item>Facet 8 — non-generic control: a plain function returning a
+/// non-generic named delegate, confirming no regression in the common case.</item>
+/// </list>
+/// Every generic facet faulted (ilverify <c>StackUnexpected</c> or a spurious
+/// <c>GS0155</c> compile error) before the fix and passes (clean ilverify +
+/// correct runtime output) after it; each was independently confirmed against
+/// the reverted fix.
+/// </summary>
+public class Issue2338GenericNamedDelegateCallSiteEmitTests
+{
+    [Fact]
+    public void Facet1_ReturnPosition_GenericFunctionReturnsDelegateOverOwnTypeParam_ValueAndReferenceType_Runs()
+    {
+        var source = """
+            package Cap2338CsReturn
+            import System
+
+            type Getter2338CsReturn[T any] = delegate func() T
+
+            func MakeGetter2338CsReturn[T](item T) Getter2338CsReturn[T] {
+                return () -> item
+            }
+
+            func Main() {
+                var g = MakeGetter2338CsReturn[int32](42)
+                Console.WriteLine(g.Invoke())
+                var gs = MakeGetter2338CsReturn[string]("hi")
+                Console.WriteLine(gs.Invoke())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\nhi\n", output);
+    }
+
+    [Fact]
+    public void Facet2_ParameterAndReturnRoundTrip_GenericFunctionTakesAndReturnsSameDelegateType_Runs()
+    {
+        var source = """
+            package Cap2338CsRoundTrip
+            import System
+
+            type Getter2338CsRoundTrip[T any] = delegate func() T
+
+            func RoundTrip2338Cs[T](g Getter2338CsRoundTrip[T]) Getter2338CsRoundTrip[T] {
+                return g
+            }
+
+            func Main() {
+                var src Getter2338CsRoundTrip[int32] = func() int32 { return 7 }
+                var g = RoundTrip2338Cs[int32](src)
+                Console.WriteLine(g.Invoke())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void Facet3_MethodLevelGenerics_InstanceMethodWithOwnTypeParameter_NonGenericClass_Runs()
+    {
+        var source = """
+            package Cap2338CsMethodLevel
+            import System
+
+            type Getter2338CsMethodLevel[T any] = delegate func() T
+
+            class Utils2338CsMethodLevel {
+                func Wrap[T](item T) Getter2338CsMethodLevel[T] {
+                    return () -> item
+                }
+            }
+
+            func Main() {
+                var u = Utils2338CsMethodLevel()
+                var g = u.Wrap[int32](11)
+                Console.WriteLine(g.Invoke())
+                var gs = u.Wrap[string]("method")
+                Console.WriteLine(gs.Invoke())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("11\nmethod\n", output);
+    }
+
+    [Fact]
+    public void Facet4_ContainingTypeGenerics_InstanceMethodReturnsDelegateOverClassTypeParam_ValueAndReferenceType_Runs()
+    {
+        var source = """
+            package Cap2338CsContainingType
+            import System
+
+            type Getter2338CsContainingType[T any] = delegate func() T
+
+            open class Holder2338CsContainingType[T] {
+                let value T
+                init(value T) { this.value = value }
+                func MakeGetter() Getter2338CsContainingType[T] {
+                    return () -> this.value
+                }
+            }
+
+            func Main() {
+                var hi = Holder2338CsContainingType[int32](42)
+                Console.WriteLine(hi.MakeGetter().Invoke())
+                var hs = Holder2338CsContainingType[string]("abc")
+                Console.WriteLine(hs.MakeGetter().Invoke())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\nabc\n", output);
+    }
+
+    [Fact]
+    public void Facet5_SharedStaticMethod_GenericClass_ReturnsDelegateOverClassTypeParam_Runs()
+    {
+        var source = """
+            package Cap2338CsShared
+            import System
+
+            type Getter2338CsShared[T any] = delegate func() T
+
+            class Factory2338CsShared[T] {
+                shared {
+                    func Make(value T) Getter2338CsShared[T] {
+                        return () -> value
+                    }
+                }
+            }
+
+            func Main() {
+                var g = Factory2338CsShared[int32].Make(99)
+                Console.WriteLine(g.Invoke())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    [Fact]
+    public void Facet6_ChainedGenericCalls_NestedGenericFunctionForwardsDelegateReturn_ValueAndReferenceType_Runs()
+    {
+        var source = """
+            package Cap2338CsChain
+            import System
+
+            type Getter2338CsChain[T any] = delegate func() T
+
+            func MakeGetter2338CsChain[T](item T) Getter2338CsChain[T] {
+                return () -> item
+            }
+
+            func Relay2338CsChain[U](item U) Getter2338CsChain[U] {
+                return MakeGetter2338CsChain[U](item)
+            }
+
+            func Main() {
+                var g = Relay2338CsChain[int32](55)
+                Console.WriteLine(g.Invoke())
+                var gs = Relay2338CsChain[string]("chained")
+                Console.WriteLine(gs.Invoke())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("55\nchained\n", output);
+    }
+
+    [Fact]
+    public void Facet7_MultiTypeParamDelegate_LambdaArgumentUnificationAndReturn_Runs()
+    {
+        var source = """
+            package Cap2338CsMulti
+            import System
+
+            type Conv2338CsMulti[TIn any, TOut any] = delegate func(x TIn) TOut
+
+            func MakeConv2338CsMulti[TIn, TOut](fn (TIn) -> TOut) Conv2338CsMulti[TIn, TOut] {
+                return (x TIn) -> fn(x)
+            }
+
+            func Main() {
+                var c = MakeConv2338CsMulti[int32, string]((x int32) -> "n=" + x.ToString())
+                Console.WriteLine(c.Invoke(7))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("n=7\n", output);
+    }
+
+    // Non-generic control: confirms the fix does not disturb the
+    // already-correct common (non-generic) case.
+    [Fact]
+    public void Facet8_NonGenericControl_PlainFunctionReturnsNonGenericDelegate_Runs()
+    {
+        var source = """
+            package Cap2338CsControl
+            import System
+
+            type Getter2338CsControl = delegate func() int32
+
+            func MakeGetter2338CsControl(item int32) Getter2338CsControl {
+                return () -> item
+            }
+
+            func Main() {
+                var g = MakeGetter2338CsControl(13)
+                Console.WriteLine(g.Invoke())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("13\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2338_callsite_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2338GenericPrimaryCtorBaseInitializerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2338GenericPrimaryCtorBaseInitializerEmitTests.cs
@@ -1,0 +1,310 @@
+// <copyright file="Issue2338GenericPrimaryCtorBaseInitializerEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2338 regression tests: a generic primary-constructor class/data
+/// class with an explicit base initializer
+/// (<c>class Derived[T](...) : Base(args) { }</c>) previously emitted its
+/// own primary-constructor field stores through
+/// <c>EmitClassConstructorWithBaseInitializerBodyBytes</c> using a bare,
+/// open <c>FieldDef</c> token rather than the self-instantiation-aware
+/// <c>ResolveFieldToken(classSym, field)</c> its sibling (no-base-initializer)
+/// scaffold already used. ilverify reported <c>StackUnexpected</c>: "found
+/// ref Derived&lt;T0&gt;, expected ref Derived" at the constructor's
+/// <c>stfld</c> sites — exactly the same generic-self-instantiation drift
+/// previously fixed for auto-properties (issue #989) and field-like events
+/// (issue #1611), but at this distinct primary-constructor-with-base-
+/// initializer call site.
+///
+/// Reproducing and fixing this exposed a second, independent, non-generic
+/// bug in the same code paths: <see cref="GSharp.Core.CodeAnalysis.Emit.DataStructSynthesizer"/>
+/// unconditionally marked the synthesized <c>Equals(object)</c>/
+/// <c>GetHashCode()</c>/<c>ToString()</c> overrides <c>virtual final</c>,
+/// so ANY <c>open data class</c> derived from another <c>open data class</c>
+/// (exactly the shape used by the issue's own minimal repro and by Oahu's
+/// <c>InteractionMessage[T]</c> shape) threw
+/// <c>TypeLoadException: Declaration referenced in a method implementation
+/// cannot be a final method</c> at type-load time — a distinct defect from
+/// the ilverify field-token drift, uncovered only because these tests
+/// exercise the "run" step the issue asked for, not just compile+ilverify.
+/// Both fixes are covered here so the exact repro described in the issue
+/// compiles, verifies, AND runs end-to-end.
+///
+/// All programs compile+ilverify+run via an in-process <c>gsc</c> invocation
+/// followed by a <c>dotnet exec</c> subprocess, mirroring the issue's ask for
+/// "compile + ILVerify + run" coverage. Each test uses a unique package/type
+/// name because the in-process <c>FunctionTypeSymbol</c> cache is name-keyed.
+/// </summary>
+public class Issue2338GenericPrimaryCtorBaseInitializerEmitTests
+{
+    [Fact]
+    public void MinimalRepro_GenericDataClassWithNonGenericBaseInitializer_CompilesVerifiesAndRuns()
+    {
+        // The issue's exact minimal repro.
+        const string source = """
+            package Gh2338Minimal
+            import System
+
+            open data class Base2338Minimal(Name string) { }
+            open data class Derived2338Minimal[T](Name string, Value T) : Base2338Minimal(Name) { }
+
+            func Main() {
+                var d = Derived2338Minimal[int32]("hello", 42)
+                Console.WriteLine(d.Name)
+                Console.WriteLine(d.Value.ToString())
+            }
+            """;
+
+        Assert.Equal("hello\n42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void MultipleAndGenericFields_ConstructedOverReferenceTypeArgument_CompilesVerifiesAndRuns()
+    {
+        // Multiple primary-ctor fields on the derived class, including two
+        // distinct type-parameter-typed fields and a field typed over the
+        // class's own OTHER field, constructed over a reference type
+        // argument (string) rather than a value type.
+        const string source = """
+            package Gh2338MultiField
+            import System
+
+            open data class Base2338MultiField(Id int32, Label string) { }
+            open data class Derived2338MultiField[T, U](Id int32, Label string, First T, Second U) : Base2338MultiField(Id, Label) { }
+
+            func Main() {
+                var d = Derived2338MultiField[string, int32](7, "widget", "alpha", 99)
+                Console.WriteLine(d.Id.ToString())
+                Console.WriteLine(d.Label)
+                Console.WriteLine(d.First)
+                Console.WriteLine(d.Second.ToString())
+            }
+            """;
+
+        Assert.Equal("7\nwidget\nalpha\n99\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void OahuInteractionMessageShape_GenericOverPayload_CompilesVerifiesAndRuns()
+    {
+        // Exact Oahu occurrence shape from the issue:
+        // InteractionMessage<T>(...) : InteractionMessage(Type, Message).
+        const string source = """
+            package Gh2338Interaction
+            import System
+
+            open data class InteractionMessage(Type string, Message string) { }
+            open data class InteractionMessage[T](Type string, Message string, Data T) : InteractionMessage(Type, Message) { }
+
+            func Main() {
+                var m = InteractionMessage[int32]("info", "hello", 99)
+                Console.WriteLine(m.Type)
+                Console.WriteLine(m.Message)
+                Console.WriteLine(m.Data.ToString())
+                Console.WriteLine(m.ToString())
+
+                var m2 = InteractionMessage[int32]("info", "hello", 99)
+                Console.WriteLine((m == m2).ToString())
+                Console.WriteLine(m.Equals(m2).ToString())
+                Console.WriteLine((m.GetHashCode() == m2.GetHashCode()).ToString())
+            }
+            """;
+
+        Assert.Equal(
+            "info\nhello\n99\n"
+            + "InteractionMessage(Type=info, Message=hello, Data=99)\n"
+            + "True\nTrue\nTrue\n",
+            CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NonGenericControl_DataClassWithBaseInitializer_CompilesVerifiesAndRuns()
+    {
+        // Control: the non-generic sibling of the minimal repro must keep
+        // working (it already used the bare FieldDef path correctly, since a
+        // non-generic type's bare FieldDef and self-instantiation token
+        // coincide).
+        const string source = """
+            package Gh2338NonGenericControl
+            import System
+
+            open data class Base2338NonGeneric(Name string) { }
+            open data class Derived2338NonGeneric(Name string, Value int32) : Base2338NonGeneric(Name) { }
+
+            func Main() {
+                var d = Derived2338NonGeneric("hello", 42)
+                Console.WriteLine(d.Name)
+                Console.WriteLine(d.Value.ToString())
+            }
+            """;
+
+        Assert.Equal("hello\n42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NoBaseInitializerControl_GenericDataClass_CompilesVerifiesAndRuns()
+    {
+        // Control: a generic data class primary constructor with NO base
+        // initializer already routed through the correctly-fixed sibling
+        // scaffold (EmitClassConstructorWithBodyBodyBytes) — pin that this
+        // fix didn't disturb it.
+        const string source = """
+            package Gh2338NoBaseInitControl
+            import System
+
+            open data class Standalone2338[T](Name string, Value T) { }
+
+            func Main() {
+                var d = Standalone2338[int32]("hello", 42)
+                Console.WriteLine(d.Name)
+                Console.WriteLine(d.Value.ToString())
+            }
+            """;
+
+        Assert.Equal("hello\n42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NonDataClassControl_GenericClassWithBaseInitializer_CompilesVerifiesAndRuns()
+    {
+        // Control: a plain (non-data) generic open class with a base
+        // initializer never involved DataStructSynthesizer's Equals/GetHashCode/
+        // ToString overrides, isolating that the field-token fix alone (with
+        // no DataStructSynthesizer involvement) is sufficient for this shape.
+        const string source = """
+            package Gh2338NonDataControl
+            import System
+
+            open class Base2338NonData(Name string) { }
+            open class Derived2338NonData[T](Name string, Value T) : Base2338NonData(Name) { }
+
+            func Main() {
+                var d = Derived2338NonData[int32]("hello", 42)
+                Console.WriteLine(d.Name)
+                Console.WriteLine(d.Value.ToString())
+            }
+            """;
+
+        Assert.Equal("hello\n42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DataClassExtendsDataClassControl_NonGeneric_TypeLoadsAndRunsWithoutFinalMethodError()
+    {
+        // Control isolating the second (independent, non-generic) bug this
+        // investigation uncovered: an `open data class` derived from another
+        // `open data class` previously threw TypeLoadException
+        // ("...cannot be a final method") at load time regardless of
+        // generics, because DataStructSynthesizer unconditionally marked
+        // Equals(object)/GetHashCode()/ToString() `virtual final`.
+        const string source = """
+            package Gh2338DataExtendsDataControl
+            import System
+
+            open data class Base2338DataExtendsData(Name string) { }
+            open data class Derived2338DataExtendsData(Name string, Value int32) : Base2338DataExtendsData(Name) { }
+
+            func Main() {
+                var d = Derived2338DataExtendsData("hello", 42)
+                Console.WriteLine(d.Name)
+                Console.WriteLine(d.Value.ToString())
+                Console.WriteLine(d.ToString())
+            }
+            """;
+
+        Assert.Equal(
+            "hello\n42\nDerived2338DataExtendsData(Name=hello, Value=42)\n",
+            CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2338baseinit_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2338NamedDelegateGenericClosureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2338NamedDelegateGenericClosureEmitTests.cs
@@ -1,0 +1,263 @@
+// <copyright file="Issue2338NamedDelegateGenericClosureEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2338 follow-up: <c>EmitFunctionLiteralToNamedDelegate</c> (a lambda
+/// literal converted to a user-declared NAMED delegate type, e.g.
+/// <c>type Getter[T any] = delegate func() T</c>) was missing the same
+/// generic-closure-reification handling that its sibling
+/// <c>EmitFunctionLiteral</c> already had for issue #1477. When the lambda
+/// captured a value whose type referenced an enclosing generic type/method
+/// parameter, the synthesized closure became a "reified" (self-instantiated)
+/// generic type (per <c>ClosureInfo.ConstructedClassSym</c>), but the
+/// named-delegate conversion path still emitted the closure's <c>newobj</c>
+/// ctor, capture-field <c>stfld</c>s, and <c>ldftn Invoke</c> against bare
+/// cached handles instead of resolving self-instantiation-aware tokens via
+/// <c>ResolveUserCtorTokenForDefault</c> / <c>ResolveFieldToken</c> /
+/// <c>ResolveClosureInvokeFtnToken</c>. This produced an open-generic token
+/// (e.g. <c>Closure&lt;!0&gt;</c>) used inside the closure's own constructed
+/// generic body — rejected by ilverify with <c>StackUnexpected</c> (found the
+/// open type where the constructed <c>Closure&lt;T0&gt;</c> was expected) and
+/// <c>DelegateCtor</c> (unrecognized arguments for delegate <c>.ctor</c>), and
+/// a runtime <c>TypeLoadException</c> / <c>BadImageFormatException</c>.
+/// <para>
+/// The fix mirrors <c>EmitFunctionLiteral</c> exactly: check
+/// <c>IsUserGenericTypeReference(closure.ConstructedClassSym)</c> and route
+/// the ctor/field/invoke tokens through the same resolvers used for the
+/// already-correct inferred-delegate-type closure path.
+/// </para>
+/// <list type="bullet">
+/// <item>Facet A — a generic containing class whose instance method captures
+/// <c>this.value</c> (a <c>T</c>-typed field) in a lambda assigned to a named
+/// delegate, invoked for both a value-type and a reference-type
+/// instantiation.</item>
+/// <item>Facet B — a generic FUNCTION (MVAR) whose lambda captures the
+/// function's type-parameter-typed parameter and assigns it to a named
+/// delegate, invoked for both a value-type and reference-type
+/// instantiation.</item>
+/// <item>Facet C — a NESTED generic context: a generic method with its own
+/// additional type parameter declared inside a generic class, where two
+/// lambdas separately capture the class-level type parameter value and the
+/// method-level type parameter value, each assigned to the (differently
+/// instantiated) named delegate.</item>
+/// <item>Facet D — non-generic control: a plain (non-generic) class/function
+/// capturing a local in a lambda assigned to a non-generic named delegate —
+/// confirms no regression in the common, already-correct case.</item>
+/// </list>
+/// All facets faulted (ilverify errors / <c>BadImageFormatException</c> at
+/// runtime) before the fix and pass (clean ilverify + correct runtime output)
+/// after it.
+/// </summary>
+public class Issue2338NamedDelegateGenericClosureEmitTests
+{
+    // Facet A: generic containing class, lambda captures `this.value` (a
+    // T-typed field), assigned to a named delegate, invoked in the same
+    // method — for both a value-type and a reference-type instantiation.
+    [Fact]
+    public void EndToEnd_FacetA_GenericClassCapturesThisField_NamedDelegate_ValueAndReferenceType_Runs()
+    {
+        var source = """
+            package Cap2338NamedA
+            import System
+
+            type Getter2338NamedA[T any] = delegate func() T
+
+            class HolderNamedA2338[T] {
+                let value T
+                init(value T) { this.value = value }
+                func Show() {
+                    var g Getter2338NamedA[T] = () -> this.value
+                    Console.WriteLine(g.Invoke())
+                }
+            }
+
+            func Main() {
+                var hi = HolderNamedA2338[int32](7)
+                hi.Show()
+                var hs = HolderNamedA2338[string]("abc")
+                hs.Show()
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\nabc\n", output);
+    }
+
+    // Facet B: generic FUNCTION (MVAR) whose lambda captures the
+    // type-parameter-typed parameter and assigns it to a named delegate,
+    // invoked inside the same function — for both a value-type and a
+    // reference-type instantiation.
+    [Fact]
+    public void EndToEnd_FacetB_GenericFunctionCapturesTypeParamValue_NamedDelegate_ValueAndReferenceType_Runs()
+    {
+        var source = """
+            package Cap2338NamedB
+            import System
+
+            type Getter2338NamedB[T any] = delegate func() T
+
+            func RunGetter2338NamedB[T](item T) {
+                var g Getter2338NamedB[T] = () -> item
+                Console.WriteLine(g.Invoke())
+            }
+
+            func Main() {
+                RunGetter2338NamedB[int32](42)
+                RunGetter2338NamedB[string]("hi")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\nhi\n", output);
+    }
+
+    // Facet C: nested generic context — a generic method with its own
+    // additional type parameter declared inside a generic class. Two
+    // lambdas separately capture the class-level type-parameter value and
+    // the method-level type-parameter value, each assigned to a
+    // differently-instantiated named delegate.
+    [Fact]
+    public void EndToEnd_FacetC_NestedGenericMethodInGenericClass_NamedDelegate_Runs()
+    {
+        var source = """
+            package Cap2338NamedC
+            import System
+
+            type Getter2338NamedC[T any] = delegate func() T
+
+            class OuterNamedC2338[T] {
+                let outerValue T
+                init(outerValue T) { this.outerValue = outerValue }
+
+                func Combine[U](innerValue U) {
+                    var showOuter Getter2338NamedC[T] = () -> this.outerValue
+                    var showInner Getter2338NamedC[U] = () -> innerValue
+                    Console.WriteLine(showOuter.Invoke())
+                    Console.WriteLine(showInner.Invoke())
+                }
+            }
+
+            func Main() {
+                var o = OuterNamedC2338[int32](10)
+                o.Combine[string]("nested")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("10\nnested\n", output);
+    }
+
+    // Facet D: non-generic control — a plain (non-generic) lambda capturing
+    // a local, assigned to a non-generic named delegate. Confirms the fix
+    // does not disturb the already-correct common case.
+    [Fact]
+    public void EndToEnd_FacetD_NonGenericControl_NamedDelegate_Runs()
+    {
+        var source = """
+            package Cap2338NamedD
+            import System
+
+            type Getter2338NamedD[T any] = delegate func() T
+
+            func Main() {
+                var captured = 99
+                var g Getter2338NamedD[int32] = () -> captured
+                Console.WriteLine(g.Invoke())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2338_named_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2338GenericInterfaceDelegateSubstitutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2338GenericInterfaceDelegateSubstitutionTests.cs
@@ -1,0 +1,256 @@
+// <copyright file="Issue2338GenericInterfaceDelegateSubstitutionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2338 follow-up: <see cref="InterfaceSymbol"/>'s construction-time
+/// substitution helper (<c>InterfaceSymbol.SubstituteType</c>, the sibling of
+/// <see cref="Binder"/>'s own <c>SubstituteType</c> and
+/// <c>StructSymbol.SubstituteTypeForConstruction</c>) had no case for
+/// <see cref="DelegateTypeSymbol"/> (nor <see cref="StructSymbol"/>). A
+/// constructed generic interface's method whose return or parameter type was
+/// a named delegate — or a plain generic struct/class — over the
+/// interface's own type parameter kept exposing the still-open definition
+/// type (e.g. <c>Getter[T]</c> instead of <c>Getter[int32]</c>), which made
+/// signature matching against the implementing class's closed type
+/// incorrectly fail, misreporting a false-negative GS0187 ("does not
+/// implement interface method") for a genuinely correct implementation.
+///
+/// A second, independent gap in the same area: <c>InterfaceSymbol</c>'s
+/// per-method substitution (<c>SubstituteMethod</c>) never copied the
+/// original method's own (method-level) generic type parameters onto the
+/// constructed method, so a constructed generic interface's generic method
+/// silently lost its arity — causing
+/// <c>DeclarationBinder.TryBuildMethodTypeParameterMap</c> to see a bogus
+/// arity mismatch against any implementation, rejecting it before signature
+/// comparison ever ran.
+///
+/// A third, independent gap: <c>DeclarationBinder.TypeSignaturesEquivalent</c>
+/// had no case for <see cref="DelegateTypeSymbol"/>, so a named delegate
+/// constructed over a *method-level* generic parameter (not fixed by
+/// substituting the interface's own type arguments) still failed to compare
+/// as equivalent to the implementer's own delegate instantiation.
+///
+/// All three fixes are exercised together here purely at the binder level
+/// (no emit/ILVerify); see
+/// <c>Issue2338GenericInterfaceDelegateSubstitutionEmitTests</c> for the
+/// compile + ILVerify + run coverage.
+/// </summary>
+public class Issue2338GenericInterfaceDelegateSubstitutionTests
+{
+    [Fact]
+    public void GenericInterfaceReturningNamedDelegateOverOwnTypeParameter_ImplementationBindsCleanly()
+    {
+        const string source = """
+            package t
+            type Getter[T any] = delegate func() T
+            interface IFactory[T any] { func Make() Getter[T]; }
+            class Concrete : IFactory[int32] {
+                func Make() Getter[int32] { return func() int32 { return 42 } }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void GenericInterfaceReturningNamedDelegate_ConstructedInterfaceMethodExposesClosedDelegateType()
+    {
+        const string source = """
+            package t
+            type Getter[T any] = delegate func() T
+            interface IFactory[T any] { func Make() Getter[T]; }
+            class Concrete : IFactory[int32] {
+                func Make() Getter[int32] { return func() int32 { return 42 } }
+            }
+            """;
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var structSymbol = compilation.GlobalScope.Structs.Single(s => s.Name == "Concrete");
+        var constructedIface = structSymbol.Interfaces.Single(i => i.Name.StartsWith("IFactory", System.StringComparison.Ordinal));
+        var imethod = constructedIface.Methods.Single(m => m.Name == "Make");
+
+        // Before the fix this stayed the open `Getter[T]` definition; it must
+        // now be the closed `Getter[int32]` instantiation.
+        var delegateReturn = Assert.IsType<DelegateTypeSymbol>(imethod.Type);
+        Assert.False(delegateReturn.TypeArguments.IsDefaultOrEmpty);
+        Assert.Same(TypeSymbol.Int32, delegateReturn.TypeArguments[0]);
+    }
+
+    [Fact]
+    public void GenericInterfaceAcceptingNamedDelegateOverOwnTypeParameter_ImplementationBindsCleanly()
+    {
+        const string source = """
+            package t
+            type Consumer[T any] = delegate func(item T) void
+            interface ISink[T any] { func Accept(c Consumer[T]) void; }
+            class ConcreteSink : ISink[int32] {
+                func Accept(c Consumer[int32]) void { c.Invoke(1) }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void GenericInterfaceReturningPlainGenericClass_ImplementationBindsCleanly()
+    {
+        const string source = """
+            package t
+            class Box[T any](Value T)
+            interface IFactory[T any] { func Make() Box[T]; }
+            class Concrete : IFactory[int32] {
+                func Make() Box[int32] { return Box[int32](1) }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void NonGenericInterfaceWithMethodLevelGenericReturningNamedDelegate_ImplementationBindsCleanly()
+    {
+        const string source = """
+            package t
+            type Getter[T any] = delegate func() T
+            interface IFactory { func Make[T](seed T) Getter[T]; }
+            class Concrete : IFactory {
+                func Make[T](seed T) Getter[T] { return func() T { return seed } }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void GenericInterfaceMethodOnConstructedInterface_PreservesMethodLevelTypeParameterArity()
+    {
+        const string source = """
+            package t
+            type Combiner[A any, B any] = delegate func(item A) B
+            interface ITransformer[TIn any] { func Transform[TOut](conv Combiner[TIn, TOut]) TOut; }
+            class Concrete : ITransformer[int32] {
+                func Transform[TOut](conv Combiner[int32, TOut]) TOut { return conv.Invoke(1) }
+            }
+            """;
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var structSymbol = compilation.GlobalScope.Structs.Single(s => s.Name == "Concrete");
+        var constructedIface = structSymbol.Interfaces.Single(i => i.Name.StartsWith("ITransformer", System.StringComparison.Ordinal));
+        var imethod = constructedIface.Methods.Single(m => m.Name == "Transform");
+
+        // Before the fix, SubstituteMethod dropped the method's own
+        // (method-level) generic type parameters entirely.
+        Assert.True(imethod.IsGeneric);
+        Assert.Single(imethod.TypeParameters);
+        Assert.Equal("TOut", imethod.TypeParameters[0].Name);
+    }
+
+    [Fact]
+    public void CombinedInterfaceLevelAndMethodLevelGenericsOverMultiParamDelegate_ImplementationBindsCleanly()
+    {
+        const string source = """
+            package t
+            type Combiner[A any, B any] = delegate func(item A) B
+            interface ITransformer[TIn any] { func Transform[TOut](conv Combiner[TIn, TOut]) TOut; }
+            class Concrete : ITransformer[int32] {
+                func Transform[TOut](conv Combiner[int32, TOut]) TOut { return conv.Invoke(1) }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void GenericClassImplementingGenericInterfaceWithCombinedGenericsOverDelegate_BindsCleanly()
+    {
+        // Containing-type generics: the implementing class is itself generic
+        // (class-level TIn, not yet a concrete type at the class declaration)
+        // combined with a method-level type parameter (TOut) inside the same
+        // delegate signature.
+        const string source = """
+            package t
+            type Combiner[A any, B any] = delegate func(item A) B
+            interface ITransformer[TIn any] { func Transform[TOut](conv Combiner[TIn, TOut]) TOut; }
+            class GenericConcrete[TIn any](Seed TIn) : ITransformer[TIn] {
+                func Transform[TOut](conv Combiner[TIn, TOut]) TOut { return conv.Invoke(Seed) }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void NestedGenericDelegateSignature_ImplementationBindsCleanly()
+    {
+        // The delegate's own type argument is itself a constructed generic
+        // class over the interface's type parameter: Getter[Box[T]].
+        const string source = """
+            package t
+            class Box[T any](Value T)
+            type Getter[T any] = delegate func() T
+            interface IFactory[T any] { func Make() Getter[Box[T]]; }
+            class Concrete : IFactory[int32] {
+                func Make() Getter[Box[int32]] { return func() Box[int32] { return Box[int32](1) } }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void MismatchedDelegateTypeArgument_StillReportsGS0187()
+    {
+        const string source = """
+            package t
+            type Getter[T any] = delegate func() T
+            interface IFactory[T any] { func Make() Getter[T]; }
+            class WrongConcrete : IFactory[int32] {
+                func Make() Getter[string] { return func() string { return "oops" } }
+            }
+            """;
+        Assert.Contains(Bind(source), d => d.Id == "GS0187");
+    }
+
+    [Fact]
+    public void DifferentNamedDelegateType_StillReportsGS0187()
+    {
+        const string source = """
+            package t
+            type Getter[T any] = delegate func() T
+            type Setter[T any] = delegate func(value T) void
+            interface IFactory { func Make[T](seed T) Getter[T]; }
+            class WrongConcrete : IFactory {
+                func Make[T](seed T) Setter[T] { return func(value T) void { } }
+            }
+            """;
+        Assert.Contains(Bind(source), d => d.Id == "GS0187");
+    }
+
+    [Fact]
+    public void GenuineMethodLevelArityMismatchOnConstructedInterface_StillReportsGS0187()
+    {
+        const string source = """
+            package t
+            type Combiner[A any, B any] = delegate func(item A) B
+            interface ITransformer[TIn any] { func Transform[TOut](conv Combiner[TIn, TOut]) TOut; }
+            class WrongArity : ITransformer[int32] {
+                func Transform[TOut, TExtra](conv Combiner[int32, TOut]) TOut { return conv.Invoke(1) }
+            }
+            """;
+        Assert.Contains(Bind(source), d => d.Id == "GS0187");
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.GlobalScope.Diagnostics.ToList();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2338. A generic primary-constructor class/data class with an explicit base initializer (`class Derived[T](...) : Base(args)`) emitted its own primary-constructor field stores through a bare, open `FieldDef` token instead of the self-instantiation-aware `ResolveFieldToken(classSym, field)`. ilverify reported:

```
found ref Derived<T0>, expected ref Derived
```

exactly matching the issue and the real Oahu `InteractionMessage<T>(...) : InteractionMessage(Type, Message)` occurrence.

## Root cause & fix

`EmitClassConstructorWithBaseInitializerBodyBytes` in `ReflectionMetadataEmitter.cs` looked up each primary-ctor field's token directly via `cache.StructFieldDefs[field]`. Its sibling scaffold (`EmitClassConstructorWithBodyBodyBytes`, used when there's no explicit base initializer) already called `ResolveFieldToken(classSym, field)`, which emits the correct self-TypeSpec-parented `MemberRef` for a generic type — the exact anti-pattern already fixed for auto-properties (#989) and field-like events (#1611), here recurring at a third, distinct call site.

Fix: route the base-initializer constructor's field stores through `ResolveFieldToken` too.

## Audit of adjacent bare `StructFieldDefs` lookups

Per the issue's ask, audited every other bare `cache.StructFieldDefs` access in constructor/accessor emit paths:

- `MemberDefEmitter` property/event accessor bodies — already generic-aware (`IsUserGenericTypeReference` + `resolveFieldToken`), per #989/#1611.
- `MethodBodyEmitter` field-access/assignment/address emission, struct-literal initializers — already routed through `ResolveFieldToken`/`ResolveFieldReferenceContainer` with an `isGeneric` gate.
- Remaining bare accesses are either existence checks (`ContainsKey`, no token emitted), planning-phase bookkeeping, or explicitly guarded off for generic instantiations already (e.g. `EmitDefaultStructStringFieldPatches`).

No further generic-token-drift call sites were found in this pass.

**Follow-up completed (see PR comment below):** `MethodBodyEmitter.Closures.EmitFunctionLiteralToNamedDelegate` (a lambda-to-named-delegate conversion) was initially found not to apply the same generic-aware ctor/field/ldftn token resolution its sibling `EmitFunctionLiteral` applies for generic-reified display classes (issue #1477). This has since been fixed on this same branch/PR, with dedicated tests and a full audit of adjacent named-delegate emission paths — no deferred work remains.

## Second, independent defect uncovered while testing

Reproducing the issue's literal minimal repro end-to-end (compile + ilverify + **run**) surfaced a second, unrelated, non-generic bug in the same neighborhood: `DataStructSynthesizer` unconditionally marked the synthesized `Equals(object)`/`GetHashCode()`/`ToString()` overrides `virtual final`. Any `open data class` derived from another `open data class` (exactly the issue's own repro shape, and the Oahu `InteractionMessage` shape) threw:

```
TypeLoadException: Declaration referenced in a method implementation cannot be a final method.
```

at type-load time — regardless of generics (reproduces identically with two plain non-generic data classes). Fixed by only marking these overrides `final` when the type can't be further subclassed, mirroring the existing `!structSym.IsOpen && !structSym.IsSealedHierarchy` condition `TypeDefEmitter` already uses to decide `TypeAttributes.Sealed`.

This was necessary to make the issue's own literal repro (and the multi-field/InteractionMessage/data-extends-data test scenarios) actually **run**, not just compile and verify.

## Tests

Added `test/Compiler.Tests/Emit/Issue2338GenericPrimaryCtorBaseInitializerEmitTests.cs` — all compile + ilverify + run end to end:

- `MinimalRepro_GenericDataClassWithNonGenericBaseInitializer_CompilesVerifiesAndRuns` — the issue's exact repro.
- `MultipleAndGenericFields_ConstructedOverReferenceTypeArgument_CompilesVerifiesAndRuns` — multiple fields, two type parameters, constructed over a reference type argument.
- `OahuInteractionMessageShape_GenericOverPayload_CompilesVerifiesAndRuns` — the exact Oahu `InteractionMessage[T]` shape, including `Equals`/`GetHashCode`/`ToString`/`==` round-trips.
- `NonGenericControl_DataClassWithBaseInitializer_CompilesVerifiesAndRuns` — non-generic control.
- `NoBaseInitializerControl_GenericDataClass_CompilesVerifiesAndRuns` — generic primary ctor with no base initializer (already-correct sibling scaffold) control.
- `NonDataClassControl_GenericClassWithBaseInitializer_CompilesVerifiesAndRuns` — plain (non-data) generic class control, isolating the field-token fix from `DataStructSynthesizer`.
- `DataClassExtendsDataClassControl_NonGeneric_TypeLoadsAndRunsWithoutFinalMethodError` — control for the second, independent defect.

Confirmed the fix precisely: reverted the field-token change only and re-ran the minimal repro through `ilverify`, reproducing the exact reported error (`found ref '[Repro]Repro.Derived\`1<T0>'][expected ref '[Repro]Repro.Derived\`1'`) before restoring the fix.

## Validation

- `dotnet build src/Compiler/Compiler.csproj -c Release` — succeeds, 0 warnings/errors.
- Targeted: `Issue2338*`, `Issue989*`, `Issue1611*`, `Issue1617*`, `DataStructInteropTests`, `DataStructSynthesizedMembersTests`, `Issue2228DataClassWithEmitTests` — all pass (63 + 19 = 82 tests across the two filtered runs).
- Full `test/Core.Tests` suite: **5992 passed**, 1 skipped (pre-existing `RegenerateBaseline`), 0 failed.
- Full `test/Compiler.Tests` suite: **2899 passed**, 0 failed.

## Not modified

Oahu was not touched, per instructions.

Closes #2338.

