### PR TITLE
Fix #2347: resolve bare method-group arguments in imported/CLR overload resolution

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -644,7 +644,8 @@ internal sealed class ConversionClassifier
                         rebound = new BoundDefaultExpression(argument.Syntax, defTargetType);
                     }
                 }
-                else if (!parameterType.IsByRef && argument.Type != TypeSymbol.Error)
+                else if (!parameterType.IsByRef
+                    && (argument.Type != TypeSymbol.Error || OverloadResolution.IsUnresolvedMethodGroupArgument(argument)))
                 {
                     // ADR-0087 §3 R5 / issue #765: when the call dispatches
                     // through a constructed CLR generic whose type arguments
@@ -671,8 +672,17 @@ internal sealed class ConversionClassifier
                     // delegate is `Func<Task,object>` and fails ilverify at the
                     // call's `newobj`. Only applied to function-literal arguments
                     // so non-lambda argument coercion is unaffected.
+                    // Issue #2347: an unresolved method group (deferred through
+                    // overload resolution the same way a lambda is deferred, see
+                    // OverloadResolution.IsUnresolvedMethodGroupArgument) needs
+                    // the identical symbolic-target recovery — its resolved
+                    // MethodInfo is picked below against whichever delegate
+                    // target is recovered here, so a generic method whose
+                    // delegate parameter closes over the method's own (still
+                    // open) type argument must see the symbolic shape too.
                     if (substituted == null
-                        && argument is BoundFunctionLiteralExpression)
+                        && (argument is BoundFunctionLiteralExpression
+                            || OverloadResolution.IsUnresolvedMethodGroupArgument(argument)))
                     {
                         substituted = TrySubstituteParameterTypeFromMethodTypeArgs(method, paramIndex, symbolicMethodTypeArgs);
                     }
@@ -784,8 +794,23 @@ internal sealed class ConversionClassifier
                     var isExpressionTreeLiteralTarget = argument is BoundFunctionLiteralExpression
                         && MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(targetType, out _);
 
+                    // Issue #2347: an unresolved method group's natural type is
+                    // the Error sentinel (see
+                    // OverloadResolution.IsUnresolvedMethodGroupArgument), so
+                    // Conversion.Classify below — which deliberately treats
+                    // Error as convertible to nothing, to avoid cascading
+                    // diagnostics — never reports it as convertible to the
+                    // resolved delegate parameter. Route it through
+                    // BindConversion directly instead: that is exactly the
+                    // mechanism (ConversionClassifier.BindClrMethodGroupConversion
+                    // / BindUserMethodGroupConversion) that picks the single
+                    // MethodInfo/function overload matching targetType's
+                    // Invoke signature, the same way it already does for a
+                    // user-defined generic function's method-group argument.
+                    var isUnresolvedMethodGroupTarget = OverloadResolution.IsUnresolvedMethodGroupArgument(argument);
+
                     if (argument.Type != targetType
-                        && (Conversion.Classify(argument.Type, targetType).Exists || isExpressionTreeLiteralTarget)
+                        && (Conversion.Classify(argument.Type, targetType).Exists || isExpressionTreeLiteralTarget || isUnresolvedMethodGroupTarget)
                         && NeedsBindClrParameterConversion(argument.Type, parameterType, substituted))
                     {
                         // Issue #506: the source-argument list may not align with

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -979,8 +979,20 @@ internal sealed partial class ExpressionBinder
 
             if (t == null && boundArguments[i].Type != TypeSymbol.Null)
             {
-                argsAllTyped = false;
-                break;
+                // Issue #2347: an unresolved method group (e.g. a bare BCL
+                // static method passed where a delegate-typed constructor
+                // parameter is expected) carries no CLR type yet — its shape
+                // depends on the constructor overload eventually chosen.
+                // Defer it exactly like an untyped lambda (leave the argTypes
+                // slot null so generic inference/applicability fall back to
+                // the other arguments) instead of aborting resolution
+                // outright; it is resolved against the winning constructor's
+                // parameter type afterwards by BindClrParameterConversions.
+                if (!OverloadResolution.IsUnresolvedMethodGroupArgument(boundArguments[i]))
+                {
+                    argsAllTyped = false;
+                    break;
+                }
             }
 
             if (boundArguments[i].Type is StructSymbol { IsClass: true })
@@ -3662,8 +3674,21 @@ internal sealed partial class ExpressionBinder
                 var t = GetEffectiveArgumentClrTypeForOverloadResolution(arguments[i].Type);
                 if (t == null && arguments[i].Type != TypeSymbol.Null)
                 {
-                    argsAllTyped = false;
-                    break;
+                    // Issue #2347: a bare method group (e.g. a static BCL
+                    // method or another CLR method reference) passed to a
+                    // generic static/instance method has no fixed CLR type
+                    // until the target delegate parameter is known. Defer it
+                    // like an untyped lambda — leave the argTypes slot null
+                    // so applicability/generic inference proceed using the
+                    // other arguments — instead of aborting the whole
+                    // candidate set; it is resolved against the winning
+                    // overload's parameter type afterwards by
+                    // BindClrParameterConversions.
+                    if (!OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
+                    {
+                        argsAllTyped = false;
+                        break;
+                    }
                 }
 
                 if (arguments[i].Type is StructSymbol { IsClass: true })
@@ -4624,7 +4649,14 @@ internal sealed partial class ExpressionBinder
             var t = GetEffectiveArgumentClrTypeForOverloadResolution(arguments[i].Type);
             if (t == null && arguments[i].Type != TypeSymbol.Null)
             {
-                return false;
+                // Issue #2347: defer an unresolved method-group argument (see
+                // TryBindImportedExtensionCall) instead of failing outright;
+                // BindClrParameterConversions resolves it once the candidate
+                // (and its parameter type) is known.
+                if (!OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
+                {
+                    return false;
+                }
             }
 
             if (arguments[i].Type is StructSymbol { IsClass: true })
@@ -4886,11 +4918,24 @@ internal sealed partial class ExpressionBinder
             var t = GetEffectiveArgumentClrTypeForOverloadResolution(arguments[i].Type);
             if (t == null && arguments[i].Type != TypeSymbol.Null)
             {
-                // Issue #833: argument may carry an open TP (e.g. `T`,
-                // `[]T`). Project to an erased shape so resolution can run.
-                if (!MemberLookup.TryProjectErasedClrType(arguments[i].Type, out t))
+                // Issue #2347: a bare method group passed as a generic
+                // extension-method argument (e.g. `key.All(Char.IsAsciiHexDigit)`)
+                // has no fixed CLR type until the extension candidate's target
+                // delegate parameter is known — defer it exactly like an
+                // untyped lambda (leave the argTypes slot null so generic
+                // inference/applicability resolve TSource from the receiver
+                // and the other arguments) instead of failing the whole
+                // extension-call candidate. It is resolved against the
+                // winning candidate's (possibly generic-inferred) parameter
+                // type afterwards by BindClrParameterConversions.
+                if (!OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
                 {
-                    return false;
+                    // Issue #833: argument may carry an open TP (e.g. `T`,
+                    // `[]T`). Project to an erased shape so resolution can run.
+                    if (!MemberLookup.TryProjectErasedClrType(arguments[i].Type, out t))
+                    {
+                        return false;
+                    }
                 }
             }
 
@@ -6404,7 +6449,12 @@ internal sealed partial class ExpressionBinder
             var t = GetEffectiveArgumentClrTypeForOverloadResolution(arguments[i].Type);
             if (t == null && arguments[i].Type != TypeSymbol.Null)
             {
-                return false;
+                // Issue #2347: defer an unresolved method-group argument (see
+                // TryBindImportedExtensionCall) instead of failing outright.
+                if (!OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
+                {
+                    return false;
+                }
             }
 
             argTypes[i] = t;
@@ -6522,7 +6572,12 @@ internal sealed partial class ExpressionBinder
             var t = GetEffectiveArgumentClrTypeForOverloadResolution(arguments[i].Type);
             if (t == null && arguments[i].Type != TypeSymbol.Null)
             {
-                return false;
+                // Issue #2347: defer an unresolved method-group argument (see
+                // TryBindImportedExtensionCall) instead of failing outright.
+                if (!OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
+                {
+                    return false;
+                }
             }
 
             argTypes[i] = t;
@@ -6636,7 +6691,12 @@ internal sealed partial class ExpressionBinder
             var t = GetEffectiveArgumentClrTypeForOverloadResolution(arguments[i].Type);
             if (t == null && arguments[i].Type != TypeSymbol.Null)
             {
-                return false;
+                // Issue #2347: defer an unresolved method-group argument (see
+                // TryBindImportedExtensionCall) instead of failing outright.
+                if (!OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
+                {
+                    return false;
+                }
             }
 
             argTypes[i] = t;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -711,6 +711,32 @@ internal static class OverloadResolution
     }
 
     /// <summary>
+    /// Issue #2347: returns <see langword="true"/> when <paramref name="argument"/>
+    /// is a method-group reference (either a same-compilation user-function
+    /// group or an imported/CLR one) that has not yet been resolved to a single
+    /// concrete method — i.e. its shape depends entirely on the eventual target
+    /// delegate signature, which is not known until overload resolution (and any
+    /// generic type-argument inference) has picked a candidate. Such an argument
+    /// carries <see cref="TypeSymbol.Error"/> as its natural type. Recognising
+    /// this shape lets every CLR call-binding path (constructors, static/instance
+    /// methods, extension methods, constrained interface/object-member calls)
+    /// defer it the same way an untyped arrow lambda is deferred — contributing
+    /// no CLR type to the argument-type vector fed to <see cref="Resolve{T}"/>
+    /// (so generic inference and applicability fall back to the other
+    /// arguments) — and then resolving it against the winning candidate's actual
+    /// parameter type afterwards via <c>ConversionClassifier.BindConversion</c>.
+    /// This is what makes a bare method group (e.g. <c>Char.IsAsciiHexDigit</c>)
+    /// behave like the equivalent lambda when passed to an imported generic
+    /// extension method (e.g. <c>Enumerable.All&lt;TSource&gt;</c>), instead of
+    /// only working for same-compilation generic functions.
+    /// </summary>
+    /// <param name="argument">The bound argument expression to inspect.</param>
+    /// <returns><see langword="true"/> when the argument is an unresolved method group.</returns>
+    public static bool IsUnresolvedMethodGroupArgument(BoundExpression argument) =>
+        argument is BoundMethodGroupExpression { FunctionType: null }
+            || argument is BoundClrMethodGroupExpression { ResolvedMethod: null };
+
+    /// <summary>
     /// Issue #506: returns <see langword="true"/> when <paramref name="parameter"/>
     /// is the trailing <c>params T[]</c> parameter — i.e. carries the
     /// <see cref="ParamArrayAttribute"/> marker and is a single-dimensional

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2347MethodGroupExtensionInferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2347MethodGroupExtensionInferenceTests.cs
@@ -1,0 +1,218 @@
+// <copyright file="Issue2347MethodGroupExtensionInferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2347: a bare imported/BCL method group (e.g. <c>Char.IsAsciiHexDigit</c>)
+/// passed as an argument to an imported <em>generic</em> extension method (e.g.
+/// <c>Enumerable.All&lt;TSource&gt;</c>) failed with GS0159 "Cannot find function
+/// All", while the equivalent lambda (<c>(c) -&gt; Char.IsAsciiHexDigit(c)</c>)
+/// bound fine. The root cause was general, not LINQ-specific: an unresolved
+/// method-group argument (<see cref="GSharp.Core.CodeAnalysis.Binding.BoundClrMethodGroupExpression"/>
+/// / <see cref="GSharp.Core.CodeAnalysis.Binding.BoundMethodGroupExpression"/>
+/// with no fixed <c>MethodInfo</c>/<c>FunctionType</c> yet) carries the
+/// <c>TypeSymbol.Error</c> sentinel as its natural type, and every CLR
+/// call-binding path that builds the argument-type vector for
+/// <c>OverloadResolution.Resolve</c>/<c>TryInferTypeArguments</c> (imported
+/// extension calls, static/instance CLR calls, constructors, constrained
+/// interface/object-member calls) treated that as a hard "argument not typed"
+/// failure — aborting the whole candidate instead of deferring the method
+/// group the same way an untyped arrow lambda is deferred. The fix recognises
+/// this shape everywhere (<c>OverloadResolution.IsUnresolvedMethodGroupArgument</c>),
+/// lets generic inference/applicability proceed using the other arguments (the
+/// receiver, in the LINQ case), and resolves the method group against the
+/// winning candidate's parameter type afterwards via the existing
+/// <c>ConversionClassifier.BindConversion</c> → <c>BindClrMethodGroupConversion</c>
+/// / <c>BindUserMethodGroupConversion</c> machinery — the same mechanism a
+/// <c>var f Func[...] = SomeType.SomeMethod</c> assignment already used.
+/// </summary>
+public class Issue2347MethodGroupExtensionInferenceTests
+{
+    [Fact]
+    public void BareBclMethodGroup_ToImportedGenericExtensionPredicate_ExactOahuShape_Compiles()
+    {
+        // Exact Oahu.Diagnostics ExportCheck shape: a `string` receiver's
+        // `All` (Enumerable.All<char>, an imported GENERIC extension method)
+        // predicate is a bare BCL static method group, not a lambda.
+        // Char.IsAsciiHexDigit itself has two overloads (char, Rune); only the
+        // (char) overload matches the Func[char,bool] the resolved TSource=char
+        // candidate requires, exercising the overload-set/element-type-
+        // inference generalization the issue asked for, not just a single-
+        // overload happy path.
+        var source = @"
+package Repro
+import System
+import System.Linq
+
+func Main() {
+    let key = ""0123456789ABCDEF0123456789ABCDEF""
+    if key.Length != 32 || !key.All(Char.IsAsciiHexDigit) {
+        Console.WriteLine(""bad key"")
+    }
+}
+";
+        AssertCompilesWithoutErrors(source);
+    }
+
+    [Fact]
+    public void EquivalentLambda_ToImportedGenericExtensionPredicate_StillCompiles()
+    {
+        // Control: the pre-existing working form (an explicit lambda wrapping
+        // the same BCL method) must keep compiling unchanged.
+        var source = @"
+package Repro
+import System
+import System.Linq
+
+func Main() {
+    let key = ""0123456789ABCDEF0123456789ABCDEF""
+    if key.Length != 32 || !key.All(func(c char) bool { return Char.IsAsciiHexDigit(c) }) {
+        Console.WriteLine(""bad key"")
+    }
+}
+";
+        AssertCompilesWithoutErrors(source);
+    }
+
+    [Fact]
+    public void BareBclMethodGroup_ToImportedGenericExtension_OnCharListReceiver_Compiles()
+    {
+        // Generalization beyond `string`: the same bare method group against
+        // Enumerable.All<TSource> with TSource inferred from a List[char]
+        // receiver (a different imported generic-collection receiver shape
+        // than the string/ReadOnlySpan-backed IEnumerable<char> above).
+        var source = @"
+package Repro
+import System
+import System.Collections.Generic
+import System.Linq
+
+func Main() {
+    var chars = List[char]()
+    chars.Add('A')
+    chars.Add('1')
+    var allHex = chars.All(Char.IsAsciiHexDigit)
+    Console.WriteLine(allHex)
+}
+";
+        AssertCompilesWithoutErrors(source);
+    }
+
+    [Fact]
+    public void BareBclMethodGroup_ToImportedGenericInstanceMethod_NonExtension_Compiles()
+    {
+        // Generalization beyond LINQ/extension methods: List[T].Find(Predicate[T])
+        // is a genuine (non-extension) GENERIC instance method on an imported
+        // class. This exercises the same argument-type-vector construction
+        // fix through a different call-binding path (instance CLR calls)
+        // than the extension-method path used by All/Where/Select above.
+        var source = @"
+package Repro
+import System
+import System.Collections.Generic
+
+func Main() {
+    var chars = List[char]()
+    chars.Add('x')
+    chars.Add('9')
+    var firstHex = chars.Find(Char.IsAsciiHexDigit)
+    Console.WriteLine(firstHex)
+}
+";
+        AssertCompilesWithoutErrors(source);
+    }
+
+    [Fact]
+    public void BareMethodGroup_WithNoOverloadMatchingInferredDelegate_ReportsDiagnostic()
+    {
+        // Negative/ambiguity control: Console.WriteLine has many overloads but
+        // none returns bool, so none can satisfy the Func[char,bool] that
+        // Enumerable.All<char> requires. The fix must not silently accept an
+        // incompatible method group merely because it is now deferred like a
+        // lambda — BindClrMethodGroupConversion still rejects it and the
+        // existing diagnostic must surface, exactly as it would for an
+        // equivalent lambda whose body does not type-check.
+        var source = @"
+package Repro
+import System
+import System.Linq
+
+func Main() {
+    let key = ""0123456789ABCDEF0123456789ABCDEF""
+    if key.All(Console.WriteLine) {
+        Console.WriteLine(""unreachable"")
+    }
+}
+";
+        var diagnostics = EmitDiagnostics(source, out var success);
+        Assert.False(success, "Expected the incompatible method group to fail to compile.");
+        Assert.Contains(diagnostics, d => d.IsError);
+    }
+
+    [Fact]
+    public void UserDefinedGenericFunction_WithUserDefinedStaticMethodGroupArgument_StillCompiles()
+    {
+        // Control: a same-compilation (source G#) generic function receiving a
+        // same-compilation static method group already worked before this fix
+        // (OverloadResolver.cs's user-function overload resolution already
+        // special-cased unresolved method groups). This guards that the new
+        // imported/CLR-side deferral does not regress or duplicate-handle the
+        // existing source-side path.
+        var source = @"
+package Repro
+import System
+import System.Collections.Generic
+
+func IsHexChar(c char) bool {
+    return Char.IsAsciiHexDigit(c)
+}
+
+func AllOf[T](xs List[T], predicate (T) -> bool) bool {
+    for x in xs {
+        if !predicate(x) {
+            return false
+        }
+    }
+    return true
+}
+
+func Main() {
+    var chars = List[char]()
+    chars.Add('F')
+    chars.Add('2')
+    var allHex = AllOf(chars, IsHexChar)
+    Console.WriteLine(allHex)
+}
+";
+        AssertCompilesWithoutErrors(source);
+    }
+
+    private static void AssertCompilesWithoutErrors(string source)
+    {
+        var diagnostics = EmitDiagnostics(source, out var success);
+        Assert.True(
+            success,
+            "Emit failed:\n" + string.Join("\n", diagnostics.Select(d => d.ToString())));
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
+    }
+
+    private static IReadOnlyList<Diagnostic> EmitDiagnostics(string source, out bool success)
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        success = result.Success;
+        return result.Diagnostics;
+    }
+}


### PR DESCRIPTION
Closes #2347

## Root cause

Two separate overload resolvers exist in gsharp:

- `OverloadResolver.cs` — handles same-compilation/source G# user-function overload resolution. It **already** special-cased unresolved method-group arguments, which is why a user-defined generic function called with a user-defined method group already worked.
- `OverloadResolution.cs` — handles CLR/imported/reflection-based overload resolution (constructors, imported extension methods, static/instance CLR method calls, constrained interface/object-member calls). It had **no** equivalent handling.

When a bare, unresolved method group (e.g. `Char.IsAsciiHexDigit`) is passed as an argument, its natural type is `TypeSymbol.Error` until a target delegate signature is known. Every CLR call-binding path that builds the `Type[] argTypes` vector for `OverloadResolution.Resolve` / `TryInferTypeArguments` treated this `t == null` case as a hard failure and aborted the whole candidate — unlike untyped arrow lambdas, which are deliberately deferred via a `null` argTypes slot and a post-resolution rebind. This is why `key.All(x => Char.IsAsciiHexDigit(x))` worked but `key.All(Char.IsAsciiHexDigit)` failed with `GS0159 Cannot find function All`.

A second, related bug was found mid-fix: even once overload resolution is made to defer correctly, `ConversionClassifier.BindClrParameterConversions`'s final parameter-conversion step explicitly skipped any argument whose `.Type == TypeSymbol.Error`, so the method group would still never actually get resolved/converted against the winning candidate's parameter type.

Neither issue is LINQ-specific — both affect any bare method-group argument passed to any imported/CLR call-binding path, generic or non-generic.

## Fix

- Added `OverloadResolution.IsUnresolvedMethodGroupArgument(BoundExpression)` as a shared detection helper (true for `BoundMethodGroupExpression { FunctionType: null }` or `BoundClrMethodGroupExpression { ResolvedMethod: null }`).
- Updated the 7 CLR call-binding argType-vector-construction sites in `ExpressionBinder.Calls.cs` (constructors, imported extension calls, static/instance CLR calls via `BindAccessorCall`, inherited/base-class instance calls, constrained interface-constraint calls, constrained/interface object-member calls) to defer an unresolved method-group argument (`argTypes[i] = null`) instead of aborting resolution, mirroring the existing lambda treatment.
- Updated `ConversionClassifier.BindClrParameterConversions` to:
  1. Widen the entry guard to allow an unresolved method-group argument through despite its `Error` type.
  2. Extend the existing lambda-only symbolic-target-recovery logic to also cover method groups.
  3. Add a direct `BindConversion` dispatch for unresolved method groups once the final parameter type is known, bypassing the `Conversion.Classify` gate (which never reports `Error` as convertible), so the pre-existing `BindClrMethodGroupConversion` / `BindUserMethodGroupConversion` machinery actually resolves and converts the method group — preserving ambiguity/negative diagnostics automatically, since no changes were needed to that machinery.

## Tests

Added `test/Core.Tests/CodeAnalysis/Binding/Issue2347MethodGroupExtensionInferenceTests.cs` with 6 tests:

1. Exact Oahu.Diagnostics `ExportCheck` shape: `key.All(Char.IsAsciiHexDigit)` on a `string` (the reported repro, and an overload-set-disambiguation case since `Char.IsAsciiHexDigit` has both `(char)` and `(Rune)` overloads).
2. Equivalent-lambda control (must already work, confirms no regression).
3. `List<char>` receiver variant of the same extension call.
4. Non-extension generic instance method (`List<T>.Find(Predicate<T>)`) to prove the fix generalizes beyond extension methods.
5. Negative/ambiguity control: `Console.WriteLine` has no bool-returning overload, so `key.All(Console.WriteLine)`-shaped code must still fail to compile with a diagnostic.
6. Same-compilation user-defined generic function + user-defined method group control, confirming the pre-existing source-side (`OverloadResolver.cs`) path is undisturbed.

Verified via `git stash` comparison that exactly 3 of the 6 tests fail without the fix (with the exact `Cannot find function All`/`Find` diagnostics from the issue), while the lambda-control, negative-diagnostic, and user-defined-function-control tests are unaffected either way.

## Validation

- `Core.csproj` builds clean with GSA analyzers (0 warnings/errors).
- `Core.Tests`: 6042 passed, 0 failed, 1 skipped.
- `InternalAnalyzers.Tests`: 7 passed, 0 failed.
- `Cs2Gs.Tests`: 1111 passed, 3 failed — confirmed via `git stash` comparison against baseline `origin/main` that these 3 failures are pre-existing and unrelated to this change.
- `Compiler.Tests`: 2950 passed, 19 failed — confirmed via `git stash` comparison against baseline `origin/main` that all 19 failures are pre-existing and unrelated to this change; every one reports `Gsharp.Extensions.dll not found in any expected location`, an environmental/build-artifact issue (missing built extensions assembly in the expected probing path), not a binder/logic regression.

## Deferred / out of scope

- The pre-existing 3 `Cs2Gs.Tests` failures and 19 `Compiler.Tests` failures (missing `Gsharp.Extensions.dll`) are unrelated to this fix and are left for separate follow-up, since they reproduce identically on baseline `origin/main` without this change.
