### PR TITLE
Fix #2351: synthesize imports for extension-method calls relying on implicit/global usings

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2351ExtensionMethodImportSynthesisTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2351ExtensionMethodImportSynthesisTests.cs
@@ -1,0 +1,399 @@
+// <copyright file="Issue2351ExtensionMethodImportSynthesisTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2351: <see cref="CSharpTypeMapper.TrackShortenedNamespace"/> records the
+/// namespace of every TYPE reference the translator shortens (issue #2211), so a
+/// missing <c>using</c> for a shortened type name synthesizes a matching
+/// <c>import</c>. An extension-method CALL SITE (<c>key.All(...)</c>) names no
+/// type at all — neither <c>Enumerable</c> nor <c>System.Linq</c> appear in its
+/// syntax — so that tracking never observed it. A C# file that reaches the
+/// extension only through an IMPLICIT <c>using</c> (SDK <c>ImplicitUsings</c>
+/// global usings, or a hand-authored <c>GlobalUsings.cs</c>, or a namespace-less
+/// source-generator file per ADR-0145) previously round-tripped to G# with the
+/// call intact but NO import for its owning namespace at all — unresolvable
+/// output (GS0159), exactly the shape observed in Oahu.Diagnostics'
+/// <c>ExportCheck.Run</c> (<c>key.All(char.IsAsciiHexDigit)</c>, whose project
+/// enables <c>ImplicitUsings</c> and has no explicit <c>using System.Linq;</c>).
+/// <para>
+/// The fix (<see cref="CSharpTypeMapper.TrackExtensionMethodNamespace"/>) records
+/// the declaring namespace of any RESOLVED extension method — whether reached via
+/// an invocation (<see cref="Cs2Gs.Translator.CSharpToGSharpTranslator"/>'s
+/// <c>TranslateInvocation</c>, covering the reduced instance form, the unreduced
+/// static form, and the bare-sibling-static form) or via a bare, non-invoked
+/// method-group reference (<c>TranslateMemberAccess</c>) — into the SAME
+/// <see cref="CSharpTypeMapper.ShortenedNamespaces"/> set that issue #2211's fix
+/// already drains into synthesized imports, so the existing
+/// dedup-against-explicit-usings and skip-own-package logic in
+/// <c>CSharpToGSharpTranslator.TranslateDocument</c> applies uniformly with no
+/// separate code path.
+/// </para>
+/// </summary>
+public class Issue2351ExtensionMethodImportSynthesisTests
+{
+    [Fact]
+    public void RealOahuExportCheckShape_ImplicitLinqUsing_SynthesizesImport()
+    {
+        // Mirrors the exact reported shape: Oahu.Diagnostics' ExportCheck.cs has
+        // NO `using System.Linq;` of its own (ImplicitUsings supplies it via a
+        // separate, SDK-generated GlobalUsings.g.cs file) and calls the bare
+        // method-group form `key.All(char.IsAsciiHexDigit)`.
+        string printed = TranslateNamed(
+            "ExportCheck.cs",
+            ("ExportCheck.cs", @"
+namespace Oahu.Diagnostics.Checks
+{
+    public static class ExportCheck
+    {
+        public static bool CheckKeyFormat(string key)
+        {
+            return key.Length == 32 && key.All(char.IsAsciiHexDigit);
+        }
+    }
+}"),
+            ("GlobalUsings.g.cs", "global using System.Linq;\n"));
+
+        Assert.Equal(1, CountOccurrences(printed, "import System.Linq"));
+        Assert.Contains("key.All(", printed);
+    }
+
+    [Fact]
+    public void LambdaEquivalentShape_MissingLinqUsing_SynthesizesImportAndCompilesEndToEnd()
+    {
+        // Same missing-using shape as the Oahu repro, but with an equivalent
+        // lambda predicate instead of the bare method-group form — this avoids
+        // relying on the SEPARATE method-group-inference fix (issue #2347) so
+        // this test proves, with the REAL gsc, that the import synthesized by
+        // THIS fix alone is sufficient for the call to resolve end-to-end.
+        string printed = TranslateNamed(
+            "Checker.cs",
+            ("Checker.cs", @"
+namespace Demo
+{
+    public static class Checker
+    {
+        public static bool AllDigits(string key)
+        {
+            return key.All(c => char.IsAsciiHexDigit(c));
+        }
+    }
+}"),
+            ("GlobalUsings.g.cs", "global using System.Linq;\n"));
+
+        Assert.Equal(1, CountOccurrences(printed, "import System.Linq"));
+        AssertCompiles(printed);
+    }
+
+    [Fact]
+    public void ExplicitUsingAlreadyPresent_NoDuplicateImportSynthesized()
+    {
+        // Control: an explicit `using System.Linq;` already covers the call, so
+        // no duplicate is synthesized alongside the ordinary explicit import.
+        string printed = TranslateUnit(@"
+using System.Linq;
+
+namespace Demo
+{
+    public static class Checker
+    {
+        public static bool AllDigits(string key)
+        {
+            return key.All(char.IsAsciiHexDigit);
+        }
+    }
+}");
+
+        Assert.Equal(1, CountOccurrences(printed, "import System.Linq"));
+    }
+
+    [Fact]
+    public void CustomExtensionNamespace_DifferentNamespaceSameCompilation_SynthesizesImport()
+    {
+        // A custom (source-defined, non-BCL) extension method declared in a
+        // DIFFERENT namespace than its call site, reached only through a
+        // hand-authored global-using file (the same shape a repo's own
+        // `GlobalUsings.cs` takes) rather than a per-file `using` — proves the
+        // fix generalizes beyond BCL/System.Linq to any imported (same-
+        // compilation, different-namespace) extension.
+        string printed = TranslateNamed(
+            "Consumer.cs",
+            ("Extensions.cs", @"
+namespace Acme.Extensions
+{
+    public static class StringChecks
+    {
+        public static bool IsFoo(this string s) { return s == ""foo""; }
+    }
+}"),
+            ("Consumer.cs", @"
+namespace Acme.App
+{
+    public class Consumer
+    {
+        public bool Check(string s)
+        {
+            return s.IsFoo();
+        }
+    }
+}"),
+            ("GlobalUsings.g.cs", "global using Acme.Extensions;\n"));
+
+        Assert.Equal(1, CountOccurrences(printed, "import Acme.Extensions"));
+        Assert.Contains("s.IsFoo()", printed);
+    }
+
+    [Fact]
+    public void CustomExtensionNamespace_SameNamespaceAsCallSite_NoSpuriousOwnPackageImport()
+    {
+        // Control: a custom extension declared in the SAME namespace as its
+        // call site needs no import at all — the existing own-package filter
+        // in `CSharpToGSharpTranslator.TranslateDocument` (`ns != package`)
+        // must still suppress a self-import once extension namespaces flow
+        // through the same tracked set.
+        string printed = TranslateUnit(@"
+namespace Acme.App
+{
+    public static class StringChecks
+    {
+        public static bool IsFoo(this string s) { return s == ""foo""; }
+    }
+
+    public class Consumer
+    {
+        public bool Check(string s)
+        {
+            return s.IsFoo();
+        }
+    }
+}");
+
+        Assert.DoesNotContain("import Acme.App", printed);
+    }
+
+    [Fact]
+    public void NestedNamespaceCustomExtension_SynthesizesImport()
+    {
+        // A custom extension declared in a multi-segment nested namespace,
+        // reached through a global using rather than a per-file `using`.
+        string printed = TranslateNamed(
+            "Consumer.cs",
+            ("Extensions.cs", @"
+namespace Acme.Deep.Nested.Extensions
+{
+    public static class NumberChecks
+    {
+        public static bool IsPositive(this int n) { return n > 0; }
+    }
+}"),
+            ("Consumer.cs", @"
+namespace Acme.App
+{
+    public class Consumer
+    {
+        public bool Check(int n)
+        {
+            return n.IsPositive();
+        }
+    }
+}"),
+            ("GlobalUsings.g.cs", "global using Acme.Deep.Nested.Extensions;\n"));
+
+        Assert.Equal(1, CountOccurrences(printed, "import Acme.Deep.Nested.Extensions"));
+    }
+
+    [Fact]
+    public void BareMethodGroupReference_NonInvokedExtension_SynthesizesImport()
+    {
+        // A bare (non-invoked) reference to an extension method — assigned to a
+        // delegate rather than called directly — is not an
+        // InvocationExpressionSyntax at all, so it only reaches the translator
+        // through TranslateMemberAccess, never TranslateInvocation. Exercises
+        // that second tracking call site.
+        string printed = TranslateNamed(
+            "Consumer.cs",
+            ("Consumer.cs", @"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class Consumer
+    {
+        public int CountOf(IEnumerable<int> seq)
+        {
+            System.Func<int> counter = seq.Count;
+            return counter();
+        }
+    }
+}"),
+            ("GlobalUsings.g.cs", "global using System.Linq;\n"));
+
+        Assert.Equal(1, CountOccurrences(printed, "import System.Linq"));
+    }
+
+    [Fact]
+    public void AliasedStaticFormCustomExtension_SynthesizesRealNamespaceImport_NotAliasName()
+    {
+        // A custom extension called through its unreduced static form via a
+        // TYPE alias (`using SC = Acme.Extensions.StringChecks;`). The C#
+        // `using SC = ...;` alias itself is preserved as its own explicit
+        // `import SC = Acme.Extensions.StringChecks` (pre-existing,
+        // unrelated behavior) — but that alias entry does NOT satisfy the
+        // dedup check for the REAL namespace `Acme.Extensions`, since the
+        // bound extension-method symbol resolves identically regardless of
+        // the alias spelling: the real namespace must still be imported in
+        // its own right for the call to resolve.
+        // The extension and its consumer must live in SEPARATE files/namespaces
+        // (rather than two `namespace` blocks in one file) since the translator
+        // merges multiple same-file namespaces into one dominant package,
+        // which would make them share a package and hide the cross-namespace
+        // import requirement this test targets.
+        string printed = TranslateNamed(
+            "Consumer.cs",
+            ("Extensions.cs", @"
+namespace Acme.Extensions
+{
+    public static class StringChecks
+    {
+        public static bool IsFoo(this string s) { return s == ""foo""; }
+    }
+}"),
+            ("Consumer.cs", @"
+namespace Acme.App
+{
+    using SC = Acme.Extensions.StringChecks;
+
+    public class Consumer
+    {
+        public bool Check(string s)
+        {
+            return SC.IsFoo(s);
+        }
+    }
+}"));
+
+        Assert.Equal(1, CountOccurrences(printed, "import Acme.Extensions"));
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        return TranslateNamed("Snippet.cs", ("Snippet.cs", source));
+    }
+
+    private static string TranslateNamed(string targetFileName, params (string FileName, string Source)[] sources)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(sources);
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents, d => d.FilePath == targetFileName);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="printed"/> with the real <c>gsc</c> and asserts
+    /// zero errors — proving the synthesized import actually resolves the call,
+    /// not just that the printed text looks right.
+    /// </summary>
+    private static void AssertCompiles(string printed, params string[] extraReferences)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-2351-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(gsPath, printed);
+
+        string refArgs = string.Concat(extraReferences.Select(r => $" /r:\"{r}\""));
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:library{refArgs} /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated snippet with zero errors. Output:\n" + compileOut +
+                "\n\nTranslated G#:\n" + printed);
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+
+        // Read stdout/stderr concurrently to avoid a classic pipe deadlock: reading
+        // one stream fully before starting the other can hang forever if the
+        // child fills the OS pipe buffer on the stream not yet read.
+        System.Threading.Tasks.Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+        System.Threading.Tasks.Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+        System.Threading.Tasks.Task.WaitAll(stdoutTask, stderrTask);
+        process.WaitForExit();
+        return (process.ExitCode, stdoutTask.Result + stderrTask.Result);
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2351ExtensionMethodImportSynthesisTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2351ExtensionMethodImportSynthesisTests.cs
@@ -46,12 +46,16 @@ namespace Cs2Gs.Tests;
 public class Issue2351ExtensionMethodImportSynthesisTests
 {
     [Fact]
-    public void RealOahuExportCheckShape_ImplicitLinqUsing_SynthesizesImport()
+    public void RealOahuExportCheckShape_ImplicitLinqUsing_SynthesizesImportAndCompilesEndToEnd()
     {
         // Mirrors the exact reported shape: Oahu.Diagnostics' ExportCheck.cs has
         // NO `using System.Linq;` of its own (ImplicitUsings supplies it via a
         // separate, SDK-generated GlobalUsings.g.cs file) and calls the bare
-        // method-group form `key.All(char.IsAsciiHexDigit)`.
+        // method-group form `key.All(char.IsAsciiHexDigit)`. Now that issue
+        // #2347 (imported/BCL method-group-to-delegate inference across
+        // generic extension methods) is fixed, this exact shape compiles
+        // end-to-end with the real gsc, proving the import synthesized by
+        // THIS fix is sufficient on its own for the call to resolve.
         string printed = TranslateNamed(
             "ExportCheck.cs",
             ("ExportCheck.cs", @"
@@ -69,16 +73,17 @@ namespace Oahu.Diagnostics.Checks
 
         Assert.Equal(1, CountOccurrences(printed, "import System.Linq"));
         Assert.Contains("key.All(", printed);
+        AssertCompiles(printed);
     }
 
     [Fact]
     public void LambdaEquivalentShape_MissingLinqUsing_SynthesizesImportAndCompilesEndToEnd()
     {
         // Same missing-using shape as the Oahu repro, but with an equivalent
-        // lambda predicate instead of the bare method-group form — this avoids
-        // relying on the SEPARATE method-group-inference fix (issue #2347) so
-        // this test proves, with the REAL gsc, that the import synthesized by
-        // THIS fix alone is sufficient for the call to resolve end-to-end.
+        // lambda predicate instead of the bare method-group form. Kept
+        // alongside the bare-method-group end-to-end test above to prove the
+        // import-synthesis fix is independently sufficient regardless of
+        // which predicate spelling is used.
         string printed = TranslateNamed(
             "Checker.cs",
             ("Checker.cs", @"

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -13308,6 +13308,16 @@ public sealed class CSharpToGSharpTranslator
 
         private GExpression TranslateMemberAccess(MemberAccessExpressionSyntax member)
         {
+            // Issue #2351: a bare (non-invoked) reference to an extension
+            // method's method group (e.g. assigned to a delegate) never goes
+            // through TranslateInvocation, so track its declaring namespace
+            // here too — otherwise a file relying on an implicit/global
+            // `using` for that namespace would translate with no import.
+            if (this.context.GetSymbolInfo(member).Symbol is IMethodSymbol { IsExtensionMethod: true } memberExtMethod)
+            {
+                this.typeMapper.TrackExtensionMethodNamespace(memberExtMethod);
+            }
+
             // Issue #1879: a C# 14 extension-block member is declared on a
             // synthetic marker type (`INamedTypeSymbol.IsExtension`); rewrite its
             // call sites to the real emitted G# shape before falling into the
@@ -14406,6 +14416,19 @@ public sealed class CSharpToGSharpTranslator
         {
             GExpression target;
             IReadOnlyList<GTypeReference> typeArguments = null;
+
+            // Issue #2351: an extension-method call site (reduced instance
+            // form, unreduced static form, or a bare sibling static call)
+            // names no type, so it never flows through
+            // CSharpTypeMapper.TrackShortenedNamespace (issue #2211's
+            // type-import tracking). Track its declaring namespace here so an
+            // import is still synthesized when the file relies on an
+            // implicit/global `using` for it (e.g. `<ImplicitUsings>enable`
+            // supplying `System.Linq`).
+            if (this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol { IsExtensionMethod: true } invocationExtMethod)
+            {
+                this.typeMapper.TrackExtensionMethodNamespace(invocationExtMethod);
+            }
 
             // Issue #1893: `grid.GetLength(k)` against a genuine multi-dim array
             // (Rank > 1) has no meaning on the flat backing array gsc actually

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -161,6 +161,52 @@ public sealed class CSharpTypeMapper
     public IReadOnlyList<TypeDeclaration> PendingAnonymousDataClasses => this.pendingAnonymousDataClasses;
 
     /// <summary>
+    /// Records the declaring namespace of a resolved extension-method
+    /// invocation or method-group reference into the same shortened-namespace
+    /// tracking set used for type imports (see <see cref="shortenedNamespaces"/>),
+    /// so that an import is synthesized for it even though the call site
+    /// itself names no type. Extension-method calls (reduced instance form,
+    /// unreduced static form, or a bare method-group reference) never flow
+    /// through <see cref="TrackShortenedNamespace"/> because they don't
+    /// reference a type name directly, so without this tracking a file that
+    /// relies on a project-wide or implicit <c>using</c> for the extension's
+    /// namespace (e.g. <c>&lt;ImplicitUsings&gt;enable&lt;/ImplicitUsings&gt;</c>
+    /// providing <c>System.Linq</c>) would translate to G# with no import for
+    /// that namespace at all.
+    /// </summary>
+    /// <param name="method">The resolved extension method symbol.</param>
+    public void TrackExtensionMethodNamespace(IMethodSymbol method)
+    {
+        if (method is null)
+        {
+            return;
+        }
+
+        // Reduced instance-form calls (key.All(predicate)) resolve to a
+        // reduced symbol; unwrap it back to the original static-form method
+        // so ContainingNamespace reflects the extension's declaring type.
+        IMethodSymbol original = method.ReducedFrom ?? method;
+
+        // C# 14 extension blocks compile their members onto a synthetic
+        // marker type nested inside the containing type; unwrap to the
+        // enclosing (real, declared) type so the namespace we record is the
+        // one the user would actually need to import.
+        INamedTypeSymbol containingType = original.ContainingType;
+        if (containingType is { IsExtension: true } && containingType.ContainingType is { } declaringType)
+        {
+            containingType = declaringType;
+        }
+
+        INamespaceSymbol ns = containingType?.ContainingNamespace;
+        if (ns is null || ns.IsGlobalNamespace)
+        {
+            return;
+        }
+
+        this.shortenedNamespaces.Add(ns.ToDisplayString());
+    }
+
+    /// <summary>
     /// Maps a Roslyn type symbol to its canonical G# type reference, recording
     /// an unsupported-construct diagnostic on <paramref name="context"/> for any
     /// type with no canonical G# form.


### PR DESCRIPTION
## Note on issue number

This branch/worktree was requested under the name "#2348", but `gh issue view 2348` shows that issue is actually about NotNullWhen narrowing lost after a prior conditional assignment — completely unrelated to the task description given for this work. Searching the repo's issues for the described defect (cs2gs omitting namespace imports required solely by translated extension-method calls) found **#2351**, whose title and body are an exact match. This PR addresses **#2351**; **#2348 remains unaddressed** and would need to be picked up separately if still desired.

Closes #2351

## Root cause

`CSharpTypeMapper.TrackShortenedNamespace` only fires for **type** references (via `QualifiedTypeName`) — never for extension-method call sites, since a call like `key.All(predicate)` names no type in its syntax. Combined with `TranslateImports` only scanning the **current file's own** `using` directives (not the whole compilation's global-usings), a file relying on `<ImplicitUsings>enable</ImplicitUsings>` (SDK auto-generates a separate `GlobalUsings.g.cs`) or a hand-authored project-wide `GlobalUsings.cs` for its extension-method namespace previously round-tripped to G# with **no import at all** for that namespace — producing unresolvable G#.

Confirmed via Oahu.Diagnostics' real `ExportCheck.cs`: `<ImplicitUsings>enable</ImplicitUsings>`, no explicit `using System.Linq;`, calls `key.All(char.IsAsciiHexDigit)`.

## Fix

Added `CSharpTypeMapper.TrackExtensionMethodNamespace(IMethodSymbol method)`, which records the declaring namespace of any resolved extension method (unwrapping `ReducedFrom` for reduced calls, and the C# 14 extension-block synthetic marker type) into the same `shortenedNamespaces` set already used for type-import tracking (issue #2211) — so the existing drain/dedup/own-package-skip logic in `TranslateDocument` applies automatically, with no new import-synthesis mechanism needed.

Wired at two call sites:
- Top of `TranslateInvocation` — covers all invocation-based extension calls regardless of which downstream branch rewrites the syntax.
- Top of `TranslateMemberAccess` — covers non-invoked bare method-group references (e.g. assigned to a delegate).

This generalizes across: reduced instance-form calls, unreduced static-form calls, bare sibling static-form calls, enum-extension positional rewrites, C# 14 extension-block members, non-invoked method-group references, BCL and source-defined (same-compilation) extensions, aliased namespaces, and nested namespaces.

## Tests

Added `Issue2351ExtensionMethodImportSynthesisTests.cs` (8 tests, modeled on the existing `Issue2211FullyQualifiedNoUsingImportSynthesisTests.cs` pattern):
1. `RealOahuExportCheckShape_ImplicitLinqUsing_SynthesizesImport` — the exact Oahu `ExportCheck` repro shape.
2. `LambdaEquivalentShape_MissingLinqUsing_SynthesizesImportAndCompilesEndToEnd` — same missing-using shape with a lambda predicate, validated end-to-end with real `gsc`.
3. `ExplicitUsingAlreadyPresent_NoDuplicateImportSynthesized` — control: explicit `using System.Linq;` present, asserts exactly one import (no duplicate).
4. `CustomExtensionNamespace_DifferentNamespaceSameCompilation_SynthesizesImport` — custom (non-BCL) extension in a different namespace (two files).
5. `CustomExtensionNamespace_SameNamespaceAsCallSite_NoSpuriousOwnPackageImport` — control: same-namespace extension, asserts no self-import.
6. `NestedNamespaceCustomExtension_SynthesizesImport` — multi-segment nested namespace extension.
7. `BareMethodGroupReference_NonInvokedExtension_SynthesizesImport` — non-invoked method-group assigned to a delegate, exercising the `TranslateMemberAccess` injection point.
8. `AliasedStaticFormCustomExtension_SynthesizesRealNamespaceImport_NotAliasName` — extension called via a type alias in unreduced static form; verifies the real-namespace import coexists correctly with the pre-existing (unrelated, correct) alias-import mechanism.

## Validation

- `Cs2Gs.Translator` and `Cs2Gs.Tests` build clean with analyzers (0 warnings/errors, StyleCop/SA rules enforced).
- New test suite: **8/8 pass**.
- Verified via before/after comparison (patch apply/revert) that all 8 new tests fail without the fix and pass with it, while the 2 negative-control tests pass regardless (as expected of a control).
- Full `Cs2Gs.Tests` suite (serial execution, 1366 tests): **1359 passed, 7 failed** — confirmed via an identical run on baseline (`origin/main`, no fix) that all 7 failures are **pre-existing** corpus/pipeline compile-error tests unrelated to this change (`MigrationPipelineTests.L1/L2_StagesOneAndTwo_AreGreen_WithZeroArtifacts`, `Issue1911...G06TypesConsole_MigratesGreen_EndToEnd`, `Issue1933...G12UnsafeConsole_MigratesGreen_EndToEnd`, `IlVerifyStageTests.L1_StageThree_IsGreen_WithZeroArtifacts`, `TestParityStageTests.L1_AllFourStages_AreGreen_WithStdoutParity`, `TestParityStageTests.L1_WrongGolden_ProducesTestParityFailureArtifact`) — **zero regressions introduced**.

## Deferred / known limitations

- The exact bare-method-group Oahu `ExportCheck` shape (`key.All(char.IsAsciiHexDigit)`) is separately affected by an unrelated bug (#2347 — imported/BCL method-group-to-delegate inference), fixed in a different PR not yet merged as of this branch's point. This fix's correctness for that exact shape is proven via printed-text assertions + parse-level round-trip (test #1), while full real-`gsc` end-to-end compile validation uses an equivalent lambda predicate unaffected by #2347 (test #2). Once #2347 merges, the exact bare-method-group shape could additionally be validated end-to-end with real `gsc`.
- Issue #2348 (NotNullWhen narrowing) is untouched by this PR.
