### PR TITLE
Issue #2350: sound per-local liveness for ref-struct locals in async functions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1251,6 +1251,10 @@ public sealed class Binder
                     // 'ref'-arg unassigned-before-read checks.
                     RefKindDefiniteAssignmentAnalyzer.Analyze(lowered, function, binder.Diagnostics);
 
+                    // Issue #2350: by-ref-like locals are only legal in an
+                    // async function body when never live across an `await`.
+                    RefStructAsyncLivenessAnalyzer.Analyze(lowered, function, binder.Diagnostics);
+
                     return (lowered, binder.Diagnostics.ToImmutableArray());
                 }));
 
@@ -1295,6 +1299,10 @@ public sealed class Binder
                     {
                         binder.Diagnostics.ReportAllPathsMustReturn(method.Declaration.Identifier.Location);
                     }
+
+                    // Issue #2350: by-ref-like locals are only legal in an
+                    // async function body when never live across an `await`.
+                    RefStructAsyncLivenessAnalyzer.Analyze(lowered, method, binder.Diagnostics);
 
                     return (lowered, binder.Diagnostics.ToImmutableArray());
                 }));
@@ -1780,6 +1788,10 @@ public sealed class Binder
                 binder.Diagnostics.ReportAllPathsMustReturn(method.Declaration.Identifier.Location);
             }
 
+            // Issue #2350: by-ref-like locals are only legal in an async
+            // function body when never live across an `await`.
+            RefStructAsyncLivenessAnalyzer.Analyze(lowered, method, binder.Diagnostics);
+
             return (lowered, binder.Diagnostics.ToImmutableArray());
         }));
 
@@ -1823,6 +1835,10 @@ public sealed class Binder
             {
                 binder.Diagnostics.ReportAllPathsMustReturn(bodySyntax.OpenBraceToken.Location);
             }
+
+            // Issue #2350: by-ref-like locals are only legal in an async
+            // function body when never live across an `await`.
+            RefStructAsyncLivenessAnalyzer.Analyze(lowered, accessor, binder.Diagnostics);
 
             return (lowered, binder.Diagnostics.ToImmutableArray());
         }));
@@ -1869,6 +1885,10 @@ public sealed class Binder
                 binder.Diagnostics.ReportAllPathsMustReturn(allPathsReturnLocation.Value);
             }
 
+            // Issue #2350: by-ref-like locals are only legal in an async
+            // function body when never live across an `await`.
+            RefStructAsyncLivenessAnalyzer.Analyze(lowered, member, binder.Diagnostics);
+
             return (lowered, binder.Diagnostics.ToImmutableArray());
         }));
 
@@ -1909,6 +1929,10 @@ public sealed class Binder
             {
                 binder.Diagnostics.ReportAllPathsMustReturn(method.Declaration.Identifier.Location);
             }
+
+            // Issue #2350: by-ref-like locals are only legal in an async
+            // function body when never live across an `await`.
+            RefStructAsyncLivenessAnalyzer.Analyze(lowered, method, binder.Diagnostics);
 
             return (lowered, binder.Diagnostics.ToImmutableArray());
         }));

--- a/src/Core/CodeAnalysis/Binding/RefStructAsyncLivenessAnalyzer.cs
+++ b/src/Core/CodeAnalysis/Binding/RefStructAsyncLivenessAnalyzer.cs
@@ -1,0 +1,672 @@
+// <copyright file="RefStructAsyncLivenessAnalyzer.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Lowering;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2350: replaces the coarse, syntax-only rejection of a by-ref-like
+/// (<c>ref struct</c>) local declared anywhere in an async function (the
+/// original issue #367 rule in <see cref="StatementBinder"/>) with a sound
+/// per-local dataflow analysis. A by-ref-like local is legal in an async
+/// function as long as it is never <em>live</em> across an <c>await</c>
+/// suspension point: <see cref="Lowering.Async.AsyncCaptureWalker"/> never
+/// hoists a by-ref-like local into the generated state machine's fields (the
+/// CLR forbids a by-ref-like field), so such a local is reset to its CLR
+/// default on every fresh <c>MoveNext</c> call. A value that survives a
+/// suspension therefore silently loses its contents unless it can never
+/// actually be observed live across one — which is exactly what this
+/// analyzer proves before allowing the declaration.
+/// <para>
+/// This is a backward ("may be live") dataflow, dual to the forward "must be
+/// assigned" analysis in <see cref="RefKindDefiniteAssignmentAnalyzer"/>,
+/// over the same <see cref="ControlFlowGraph"/> infrastructure: loops are
+/// fully expanded into real graph edges (so a per-iteration local's liveness
+/// is checked correctly across back-edges), while <c>try</c>, <c>select</c>,
+/// <c>scope</c>, <c>fixed</c>, and pattern-<c>switch</c> bodies are opaque to
+/// the outer graph and are recursively re-analyzed here, mirroring
+/// <see cref="RefKindDefiniteAssignmentAnalyzer"/>'s
+/// <c>ProcessTryStatement</c>/<c>ProcessSelectStatement</c>/etc. shape.
+/// </para>
+/// <para>
+/// <c>try</c>/<c>finally</c> gets special "ambient live" treatment: an
+/// exception can transfer control from <em>any</em> point inside a
+/// <c>try</c> body straight to its <c>catch</c> clauses or <c>finally</c>
+/// block, so whatever is live entering those handlers is folded into an
+/// ambient live set applied to every block of the try body — not just its
+/// formal exit — catching the "unsafe finally interaction" case where a
+/// local assigned before an <c>await</c> in the <c>try</c> body is later
+/// read in <c>finally</c>.
+/// </para>
+/// Capture (a closure capturing a by-ref-like variable) and general escape
+/// (returning/storing a by-ref-like value beyond its safe scope) are already
+/// covered by pre-existing, unrelated machinery
+/// (<see cref="LambdaBinder"/>'s unconditional by-ref-like capture rejection
+/// and <see cref="StatementBinder"/>'s ADR-0058 escape-scope tracking) and
+/// are untouched by this analyzer.
+/// </summary>
+internal static class RefStructAsyncLivenessAnalyzer
+{
+    /// <summary>
+    /// Entry point, intended to be called once per bound-and-lowered function
+    /// body (mirroring every call site of
+    /// <see cref="RefKindDefiniteAssignmentAnalyzer.Analyze"/>). Runs the
+    /// liveness analysis over <paramref name="enclosing"/>'s own body (if it
+    /// is async) and, regardless, walks the body looking for nested async
+    /// function-literal expressions (lambdas and local functions) so each one
+    /// gets its own, independently-scoped liveness analysis rooted at its own
+    /// body — a function literal is an opaque leaf to the general bound-tree
+    /// walker (it is a separate lexical/hoisting scope), so it must be found
+    /// and recursed into manually here.
+    /// </summary>
+    /// <param name="body">The bound-and-lowered body of <paramref name="enclosing"/>.</param>
+    /// <param name="enclosing">The function/method/accessor whose body is being checked.</param>
+    /// <param name="diagnostics">The diagnostic bag to report GS0219 violations to.</param>
+    public static void Analyze(BoundBlockStatement body, FunctionSymbol enclosing, DiagnosticBag diagnostics)
+    {
+        if (body == null || enclosing == null || diagnostics == null)
+        {
+            return;
+        }
+
+        if (enclosing.IsAsync)
+        {
+            AnalyzeScope(body, diagnostics);
+        }
+
+        var finder = new AsyncLambdaScopeFinder(diagnostics);
+        finder.VisitStatement(body);
+    }
+
+    /// <summary>
+    /// Runs the full liveness analysis for one async scope (a top-level
+    /// function/method/accessor body, or an async lambda/local-function
+    /// literal's body). Locals declared by a nested (non-async) lambda are
+    /// excluded automatically, since <see cref="ByRefLikeLocalCollector"/>
+    /// does not recurse into function-literal bodies.
+    /// </summary>
+    private static void AnalyzeScope(BoundBlockStatement body, DiagnosticBag diagnostics)
+    {
+        var collector = new ByRefLikeLocalCollector();
+        collector.VisitStatement(body);
+
+        if (collector.Locals.Count == 0)
+        {
+            // No by-ref-like locals declared directly in this async scope —
+            // nothing to check (whether or not it contains nested async
+            // lambdas is handled separately by the caller).
+            return;
+        }
+
+        AnalyzeRegion(body, liveOutOfRegion: new HashSet<VariableSymbol>(), ambientLive: new HashSet<VariableSymbol>(), collector.Locals, diagnostics);
+    }
+
+    /// <summary>
+    /// Runs the backward "may be live" fixpoint over the CFG of
+    /// <paramref name="regionBody"/> (wrapping it in a synthetic block first
+    /// if it isn't already one). <paramref name="liveOutOfRegion"/> seeds
+    /// what's live immediately after the whole region (from the enclosing
+    /// context); <paramref name="ambientLive"/> is unioned into the live-out
+    /// of every block in the region (used to model "an exception can jump
+    /// straight to a catch/finally from anywhere in this try body").
+    /// Returns what's live entering the region (i.e. live-out of its start),
+    /// for the caller to keep propagating backward past the compound
+    /// statement.
+    /// </summary>
+    private static HashSet<VariableSymbol> AnalyzeRegion(
+        BoundStatement regionBody,
+        HashSet<VariableSymbol> liveOutOfRegion,
+        HashSet<VariableSymbol> ambientLive,
+        HashSet<VariableSymbol> interesting,
+        DiagnosticBag diagnostics)
+    {
+        var graph = ControlFlowGraph.Create(AsBlock(regionBody));
+
+        var liveIn = new Dictionary<ControlFlowGraph.BasicBlock, HashSet<VariableSymbol>>();
+        foreach (var b in graph.Blocks)
+        {
+            liveIn[b] = new HashSet<VariableSymbol>();
+        }
+
+        HashSet<VariableSymbol> ComputeLiveOut(ControlFlowGraph.BasicBlock block)
+        {
+            var result = new HashSet<VariableSymbol>(ambientLive);
+            foreach (var branch in block.Outgoing)
+            {
+                result.UnionWith(branch.To.IsEnd ? liveOutOfRegion : liveIn[branch.To]);
+            }
+
+            return result;
+        }
+
+        var changed = true;
+        var safety = 0;
+        while (changed && safety++ < 10000)
+        {
+            changed = false;
+
+            // Iterate in reverse block-list order: for a backward analysis,
+            // later blocks (closer to the region's exit) typically converge
+            // first, so visiting them first each pass reaches the fixpoint in
+            // fewer iterations. Correctness does not depend on this order.
+            for (var i = graph.Blocks.Count - 1; i >= 0; i--)
+            {
+                var block = graph.Blocks[i];
+                if (block.IsStart || block.IsEnd)
+                {
+                    continue;
+                }
+
+                var liveOut = ComputeLiveOut(block);
+                var newLiveIn = SimulateBlockBackward(block, liveOut, interesting, diagnostics: null);
+                if (!SetsEqual(newLiveIn, liveIn[block]))
+                {
+                    liveIn[block] = newLiveIn;
+                    changed = true;
+                }
+            }
+        }
+
+        // Final reporting pass: sets are now stable, so every violation is
+        // detected exactly once, using fully-converged data.
+        if (diagnostics != null)
+        {
+            for (var i = graph.Blocks.Count - 1; i >= 0; i--)
+            {
+                var block = graph.Blocks[i];
+                if (block.IsStart || block.IsEnd)
+                {
+                    continue;
+                }
+
+                var liveOut = ComputeLiveOut(block);
+                SimulateBlockBackward(block, liveOut, interesting, diagnostics);
+            }
+        }
+
+        return ComputeLiveOut(graph.Start);
+    }
+
+    private static BoundBlockStatement AsBlock(BoundStatement statement)
+    {
+        if (statement is BoundBlockStatement block)
+        {
+            return block;
+        }
+
+        var statements = statement == null
+            ? ImmutableArray<BoundStatement>.Empty
+            : ImmutableArray.Create(statement);
+        return new BoundBlockStatement(statement?.Syntax, statements);
+    }
+
+    private static bool SetsEqual(HashSet<VariableSymbol> a, HashSet<VariableSymbol> b)
+    {
+        if (a.Count != b.Count)
+        {
+            return false;
+        }
+
+        foreach (var v in a)
+        {
+            if (!b.Contains(v))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static HashSet<VariableSymbol> SimulateBlockBackward(
+        ControlFlowGraph.BasicBlock block,
+        HashSet<VariableSymbol> liveOut,
+        HashSet<VariableSymbol> interesting,
+        DiagnosticBag diagnostics)
+    {
+        var live = new HashSet<VariableSymbol>(liveOut);
+        for (var i = block.Statements.Count - 1; i >= 0; i--)
+        {
+            ProcessStatementBackward(block.Statements[i], live, interesting, diagnostics);
+        }
+
+        return live;
+    }
+
+    private static void ProcessStatementBackward(
+        BoundStatement statement,
+        HashSet<VariableSymbol> live,
+        HashSet<VariableSymbol> interesting,
+        DiagnosticBag diagnostics)
+    {
+        switch (statement)
+        {
+            case BoundExpressionStatement es:
+                ApplyExpression(es.Expression, live, interesting, diagnostics, statement);
+                break;
+            case BoundVariableDeclaration vd:
+            {
+                var collector = new ReadAndAwaitCollector(interesting);
+                collector.VisitExpression(vd.Initializer);
+
+                var isInteresting = vd.Variable is LocalVariableSymbol && interesting.Contains(vd.Variable);
+                var selfRead = isInteresting && collector.Reads.Contains(vd.Variable);
+                var killTarget = isInteresting && !selfRead ? vd.Variable : null;
+
+                if (collector.ContainsAwait)
+                {
+                    ReportIfUnsafe(live, killTarget, diagnostics, statement);
+                }
+
+                if (killTarget != null)
+                {
+                    live.Remove(killTarget);
+                }
+
+                live.UnionWith(collector.Reads);
+                break;
+            }
+
+            case BoundReturnStatement rs:
+                if (rs.Expression != null)
+                {
+                    ApplyExpression(rs.Expression, live, interesting, diagnostics, statement);
+                }
+
+                break;
+            case BoundThrowStatement th:
+                ApplyExpression(th.Expression, live, interesting, diagnostics, statement);
+                break;
+            case BoundConditionalGotoStatement cgs:
+                ApplyExpression(cgs.Condition, live, interesting, diagnostics, statement);
+                break;
+            case BoundLabelStatement:
+            case BoundGotoStatement:
+                break;
+
+            // Issue #1642 (also relied upon by RefKindDefiniteAssignmentAnalyzer):
+            // these compound statements are opaque to the outer ControlFlowGraph
+            // (a single fall-through statement — see
+            // ControlFlowGraph.BasicBlockBuilder), so their nested bodies must be
+            // recursively analyzed here.
+            case BoundTryStatement tryStmt:
+                ProcessTryBackward(tryStmt, live, interesting, diagnostics);
+                break;
+            case BoundSelectStatement selectStmt:
+                ProcessSelectBackward(selectStmt, live, interesting, diagnostics);
+                break;
+            case BoundScopeStatement scopeStmt:
+            {
+                var entry = AnalyzeRegion(scopeStmt.Body, live, new HashSet<VariableSymbol>(), interesting, diagnostics);
+                live.Clear();
+                live.UnionWith(entry);
+                break;
+            }
+
+            case BoundFixedStatement fixedStmt:
+                ProcessFixedBackward(fixedStmt, live, interesting, diagnostics);
+                break;
+            case BoundPatternSwitchStatement switchStmt:
+                ProcessSwitchBackward(switchStmt, live, interesting, diagnostics);
+                break;
+            default:
+                // Other opaque statement kinds (go/channel-send/await-for-range/
+                // yield) either don't run unconditionally (a loop body may run
+                // zero times, handled at the CFG level for real loops) or are
+                // not reachable here post-lowering (await-for-range is lowered
+                // away before this analysis runs) — no-op is correct/safe: it
+                // never removes a variable from `live`, so it can only ever be
+                // conservative, never unsound.
+                break;
+        }
+    }
+
+    /// <summary>
+    /// try/catch/finally: an exception can transfer control from any point in
+    /// the try body straight into a catch clause or (if uncaught, or on
+    /// normal/exceptional catch completion) into finally. Modeled as an
+    /// "ambient live" set — the union of what's live entering every catch
+    /// clause and the finally block — that is folded into the live-out of
+    /// every block inside the try body (not just its formal exit), so a
+    /// local that's read in `finally` (or a catch) shows up as live at an
+    /// earlier `await` inside `try`, even though normal control flow alone
+    /// would never reach that read from there.
+    /// </summary>
+    private static void ProcessTryBackward(
+        BoundTryStatement tryStmt,
+        HashSet<VariableSymbol> live,
+        HashSet<VariableSymbol> interesting,
+        DiagnosticBag diagnostics)
+    {
+        var afterTry = new HashSet<VariableSymbol>(live);
+
+        var exceptionalEscapeLive = new HashSet<VariableSymbol>();
+
+        HashSet<VariableSymbol> finallyLiveIn = null;
+        if (tryStmt.FinallyBlock != null)
+        {
+            finallyLiveIn = AnalyzeRegion(tryStmt.FinallyBlock, afterTry, new HashSet<VariableSymbol>(), interesting, diagnostics);
+            exceptionalEscapeLive.UnionWith(finallyLiveIn);
+        }
+
+        // Normal completion of the try body (or a catch clause) falls into
+        // finally (if any); otherwise it falls to whatever's after the whole
+        // try statement.
+        var normalFallthrough = finallyLiveIn ?? afterTry;
+
+        foreach (var clause in tryStmt.CatchClauses)
+        {
+            var catchLiveIn = AnalyzeRegion(clause.Body, normalFallthrough, new HashSet<VariableSymbol>(), interesting, diagnostics);
+            if (clause.Variable != null)
+            {
+                catchLiveIn.Remove(clause.Variable);
+            }
+
+            exceptionalEscapeLive.UnionWith(catchLiveIn);
+        }
+
+        // The try body's own normal exit also falls into finally (or after
+        // the statement); the ambient set additionally lets an exception
+        // reach a catch/finally from any interior point.
+        var tryLiveIn = AnalyzeRegion(tryStmt.TryBlock, normalFallthrough, exceptionalEscapeLive, interesting, diagnostics);
+
+        live.Clear();
+        live.UnionWith(tryLiveIn);
+    }
+
+    /// <summary>
+    /// <c>select</c> always blocks until exactly one arm's body runs; each
+    /// arm's channel/value expression is evaluated to decide readiness, so a
+    /// variable read there is live immediately before the whole statement.
+    /// </summary>
+    private static void ProcessSelectBackward(
+        BoundSelectStatement selectStmt,
+        HashSet<VariableSymbol> live,
+        HashSet<VariableSymbol> interesting,
+        DiagnosticBag diagnostics)
+    {
+        var afterSelect = new HashSet<VariableSymbol>(live);
+        var union = new HashSet<VariableSymbol>();
+
+        foreach (var c in selectStmt.Cases)
+        {
+            var caseLiveIn = AnalyzeRegion(c.Body, afterSelect, new HashSet<VariableSymbol>(), interesting, diagnostics);
+            if (c.Variable != null)
+            {
+                caseLiveIn.Remove(c.Variable);
+            }
+
+            union.UnionWith(caseLiveIn);
+
+            if (c.Channel != null)
+            {
+                ApplyExpression(c.Channel, union, interesting, diagnostics, null);
+            }
+
+            if (c.Value != null)
+            {
+                ApplyExpression(c.Value, union, interesting, diagnostics, null);
+            }
+        }
+
+        live.Clear();
+        live.UnionWith(union);
+    }
+
+    /// <summary>The <c>fixed</c> body always runs unconditionally (no
+    /// branching), and its synthetic pinned/pointer/source locals do not
+    /// exist before it, so they're excluded from what flows backward past
+    /// the statement.</summary>
+    private static void ProcessFixedBackward(
+        BoundFixedStatement fixedStmt,
+        HashSet<VariableSymbol> live,
+        HashSet<VariableSymbol> interesting,
+        DiagnosticBag diagnostics)
+    {
+        var bodyLiveIn = AnalyzeRegion(fixedStmt.Body, live, new HashSet<VariableSymbol>(), interesting, diagnostics);
+        bodyLiveIn.Remove(fixedStmt.PinnedVariable);
+        bodyLiveIn.Remove(fixedStmt.PointerVariable);
+        if (fixedStmt.SourceVariable != null)
+        {
+            bodyLiveIn.Remove(fixedStmt.SourceVariable);
+        }
+
+        live.Clear();
+        live.UnionWith(bodyLiveIn);
+        ApplyExpression(fixedStmt.PinnedSource, live, interesting, diagnostics, null);
+    }
+
+    /// <summary>
+    /// A pattern switch, unlike <c>select</c>, can complete having matched no
+    /// arm when there's no exhaustive <c>default</c> — that "nothing matched"
+    /// path must also contribute to what's live before the statement (it
+    /// falls straight through to whatever's live after it).
+    /// </summary>
+    private static void ProcessSwitchBackward(
+        BoundPatternSwitchStatement switchStmt,
+        HashSet<VariableSymbol> live,
+        HashSet<VariableSymbol> interesting,
+        DiagnosticBag diagnostics)
+    {
+        var afterSwitch = new HashSet<VariableSymbol>(live);
+        var union = new HashSet<VariableSymbol>();
+        var hasDefault = false;
+
+        foreach (var arm in switchStmt.Arms)
+        {
+            if (arm.IsDefault)
+            {
+                hasDefault = true;
+            }
+
+            var armLiveIn = AnalyzeRegion(arm.Body, afterSwitch, new HashSet<VariableSymbol>(), interesting, diagnostics);
+            if (arm.Guard != null)
+            {
+                ApplyExpression(arm.Guard, armLiveIn, interesting, diagnostics, null);
+            }
+
+            union.UnionWith(armLiveIn);
+        }
+
+        if (!hasDefault)
+        {
+            union.UnionWith(afterSwitch);
+        }
+
+        live.Clear();
+        live.UnionWith(union);
+        ApplyExpression(switchStmt.Discriminant, live, interesting, diagnostics, null);
+    }
+
+    /// <summary>
+    /// Applies one expression's backward transfer to <paramref name="live"/>:
+    /// if the expression is a top-level assignment to an interesting local
+    /// that is not also read within its own right-hand side (see the
+    /// self-referential-redefinition note below), that local is a "kill" —
+    /// its pre-statement liveness does not depend on what's live after.
+    /// Otherwise every interesting local read anywhere in the expression is
+    /// added to `live`. If the expression contains an `await`, any
+    /// currently-live interesting local (other than a pure kill target of
+    /// this same expression) is reported as unsafe.
+    /// </summary>
+    private static void ApplyExpression(
+        BoundExpression expression,
+        HashSet<VariableSymbol> live,
+        HashSet<VariableSymbol> interesting,
+        DiagnosticBag diagnostics,
+        BoundStatement owningStatement)
+    {
+        if (expression == null)
+        {
+            return;
+        }
+
+        var collector = new ReadAndAwaitCollector(interesting);
+        collector.VisitExpression(expression);
+
+        VariableSymbol killTarget = null;
+        if (expression is BoundAssignmentExpression assign
+            && interesting.Contains(assign.Variable)
+            && !collector.Reads.Contains(assign.Variable))
+        {
+            // Self-referential redefinition (e.g. `span = span.Slice(await
+            // X())`) must NOT be treated as a kill: the pre-statement value
+            // of `span` is read by the statement's own right-hand side, so it
+            // must survive any `await` nested in that same right-hand side
+            // regardless of the read's apparent position relative to the
+            // `await` — evaluation order does not change which value is
+            // live entering the statement.
+            killTarget = assign.Variable;
+        }
+
+        if (collector.ContainsAwait)
+        {
+            ReportIfUnsafe(live, killTarget, diagnostics, owningStatement);
+        }
+
+        if (killTarget != null)
+        {
+            live.Remove(killTarget);
+        }
+
+        live.UnionWith(collector.Reads);
+    }
+
+    private static void ReportIfUnsafe(
+        HashSet<VariableSymbol> live,
+        VariableSymbol excludedSelfKill,
+        DiagnosticBag diagnostics,
+        BoundStatement owningStatement)
+    {
+        if (diagnostics == null)
+        {
+            return;
+        }
+
+        foreach (var v in live)
+        {
+            if (ReferenceEquals(v, excludedSelfKill))
+            {
+                continue;
+            }
+
+            var location = v.DeclaringSyntax?.Location ?? owningStatement?.Syntax?.Location ?? default(TextLocation);
+            diagnostics.ReportByRefLikeEscape(
+                location,
+                v.Type,
+                $"be declared as a local in an async function and remain live across an 'await' suspension point (variable '{v.Name}'); restructure the code so its value is no longer needed after the 'await'");
+        }
+    }
+
+    /// <summary>
+    /// Collects every by-ref-like local declared directly within a scope
+    /// (does not recurse into nested function-literal bodies, since those are
+    /// a separate lexical/hoisting scope with their own, independently
+    /// analyzed liveness — see <see cref="AsyncLambdaScopeFinder"/>).
+    /// </summary>
+    private sealed class ByRefLikeLocalCollector : BoundTreeWalker
+    {
+        public HashSet<VariableSymbol> Locals { get; } = new HashSet<VariableSymbol>();
+
+        protected override void VisitVariableDeclaration(BoundVariableDeclaration node)
+        {
+            if (node.Variable is LocalVariableSymbol local && TypeSymbol.IsByRefLike(local.Type))
+            {
+                Locals.Add(local);
+            }
+
+            base.VisitVariableDeclaration(node);
+        }
+    }
+
+    /// <summary>
+    /// Collects reads (restricted to a fixed "interesting" set of variables)
+    /// and whether an `await` occurs anywhere within one expression subtree.
+    /// Relies on <see cref="BoundTreeWalker"/>'s default recursion for
+    /// everything except assignment targets (correctly not a read) and
+    /// function-literal bodies (a separate scope, opaque by design).
+    /// </summary>
+    private sealed class ReadAndAwaitCollector : BoundTreeWalker
+    {
+        private readonly HashSet<VariableSymbol> interesting;
+
+        public ReadAndAwaitCollector(HashSet<VariableSymbol> interesting)
+        {
+            this.interesting = interesting;
+        }
+
+        public HashSet<VariableSymbol> Reads { get; } = new HashSet<VariableSymbol>();
+
+        public bool ContainsAwait { get; private set; }
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node is BoundVariableExpression variableExpression && interesting.Contains(variableExpression.Variable))
+            {
+                Reads.Add(variableExpression.Variable);
+            }
+
+            base.VisitExpression(node);
+        }
+
+        protected override void VisitAwaitExpression(BoundAwaitExpression node)
+        {
+            ContainsAwait = true;
+            base.VisitAwaitExpression(node);
+        }
+    }
+
+    /// <summary>
+    /// Finds every async function-literal expression (lambda or local
+    /// function) nested anywhere in a bound tree — regardless of whether the
+    /// enclosing scope itself is async — and runs an independent
+    /// <see cref="AnalyzeScope"/> for each one's own body. A function literal
+    /// is an opaque leaf to the base <see cref="BoundTreeWalker"/> (its body
+    /// is a separate lexical scope), so this walker must manually continue
+    /// into <see cref="BoundFunctionLiteralExpression.Body"/> to discover
+    /// further-nested async lambdas/local functions.
+    /// </summary>
+    private sealed class AsyncLambdaScopeFinder : BoundTreeWalker
+    {
+        private readonly DiagnosticBag diagnostics;
+
+        public AsyncLambdaScopeFinder(DiagnosticBag diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node is BoundFunctionLiteralExpression literal)
+            {
+                // Issue #2350: a function-literal body is bound but not
+                // lowered until emit time (see
+                // ReflectionMetadataEmitter/ClosureEmitter, which each call
+                // Lowerer.Lower(literal.Body) independently right before
+                // emitting it) — general control-flow sugar (if/while/`await
+                // for`, etc.) is still in its raw, un-lowered shape here.
+                // Mirror that emit-time pass with a local, throwaway lowering
+                // so ControlFlowGraph sees the same goto/label shape the
+                // emitter eventually will; this does not replace the node's
+                // real Body anywhere.
+                var loweredLambdaBody = (BoundBlockStatement)Lowerer.Lower(literal.Body);
+
+                if (literal.Function != null && literal.Function.IsAsync)
+                {
+                    AnalyzeScope(loweredLambdaBody, diagnostics);
+                }
+
+                VisitStatement(loweredLambdaBody);
+                return;
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+}

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -1418,21 +1418,34 @@ internal sealed class StatementBinder
         }
 
         // Issue #367: a by-ref-like (`ref struct`) local is legal in an ordinary
-        // function, but an async function or an iterator hoists every local into
-        // a heap-allocated state machine, which the CLR forbids for a by-ref-like
-        // type. A top-level (global) variable is emitted as a static field, which
-        // is likewise heap-rooted and forbidden. Reject the declaration in those
+        // function, but an iterator hoists every local into a heap-allocated
+        // state machine, which the CLR forbids for a by-ref-like type. A
+        // top-level (global) variable is emitted as a static field, which is
+        // likewise heap-rooted and forbidden. Reject the declaration in those
         // contexts.
+        //
+        // Issue #2350: an async function's state machine also hoists locals,
+        // but — unlike an iterator — it is legal for a by-ref-like local to
+        // appear there as long as it never needs to survive an `await`
+        // suspension point (the CLR forbids a by-ref-like *field*, but the
+        // async lowering already never hoists such a local into one — see
+        // AsyncCaptureWalker — so it is only unsafe when live across a
+        // suspension). That is a per-local dataflow question this syntax-only
+        // check cannot answer, so the coarse "any by-ref-like local in any
+        // async function" rejection that used to live here has been replaced
+        // by RefStructAsyncLivenessAnalyzer, which runs after lowering (see
+        // its call sites in Binder.cs) and reports ReportByRefLikeEscape only
+        // for a local actually proven live across a suspension (including via
+        // unsafe try/finally interaction).
         if (TypeSymbol.IsByRefLike(variableType))
         {
             if (function == null || function.IsTopLevelEntryPoint)
             {
                 Diagnostics.ReportByRefLikeEscape(syntax.Identifier.Location, variableType, "be declared as a top-level variable (it would be emitted as a heap-rooted static field)");
             }
-            else if (function.IsAsync || isIteratorReturnType(function.Type))
+            else if (!function.IsAsync && isIteratorReturnType(function.Type))
             {
-                var context = function.IsAsync ? "an async function" : "an iterator";
-                Diagnostics.ReportByRefLikeEscape(syntax.Identifier.Location, variableType, $"be declared as a local in {context} (it would be hoisted into the state machine)");
+                Diagnostics.ReportByRefLikeEscape(syntax.Identifier.Location, variableType, "be declared as a local in an iterator (it would be hoisted into the state machine)");
             }
         }
 

--- a/test/Compiler.Tests/Emit/Issue2350AsyncRefStructLivenessEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2350AsyncRefStructLivenessEmitTests.cs
@@ -1,0 +1,213 @@
+// <copyright file="Issue2350AsyncRefStructLivenessEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2350: end-to-end compile+run coverage for
+/// <see cref="Core.CodeAnalysis.Binding.RefStructAsyncLivenessAnalyzer"/>. A
+/// by-ref-like (<c>ref struct</c>) local such as <c>ReadOnlySpan[T]</c> is now
+/// permitted in an async function/lambda as long as it is proven never live
+/// across an <c>await</c> suspension point. These tests force genuine
+/// <c>MoveNext</c> suspension via <c>await Task.Yield()</c> so the correctness
+/// of the underlying async lowering (which never hoists a by-ref-like local
+/// into a state-machine field — see <c>AsyncCaptureWalker</c>) is actually
+/// exercised end to end, not merely accepted by the binder.
+/// </summary>
+public class Issue2350AsyncRefStructLivenessEmitTests
+{
+    [Fact]
+    public void PipelineProbeCheck_PerIterationSpanDeadBeforeAwait_CompilesAndRuns()
+    {
+        const string source = """
+            package i2350pipelineprobe
+            import System
+            import System.Threading.Tasks
+
+            async func PipelineProbeCheck(buffer []byte, probeCount int32) Task[int32] {
+                var total = 0
+                for var i = 0; i < probeCount; i++ {
+                    var probe ReadOnlySpan[byte] = buffer
+                    total = total + probe.Length
+                    await Task.Yield()
+                }
+                return total
+            }
+
+            var data []byte = []byte{1, 2, 3, 4, 5}
+            Console.WriteLine(PipelineProbeCheck(data, 3).Result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("15\n", output);
+    }
+
+    [Fact]
+    public void SpanLocal_ConsumedBeforeAwait_ReusedAcrossMultipleAwaits_CompilesAndRuns()
+    {
+        const string source = """
+            package i2350reuse
+            import System
+            import System.Threading.Tasks
+
+            async func RunAsync(a []int32, b []int32) Task[int32] {
+                var s ReadOnlySpan[int32] = a
+                var first = s.Length
+                await Task.Yield()
+                s = b
+                var second = s.Length
+                await Task.Yield()
+                return first + second
+            }
+
+            var a []int32 = []int32{1, 2, 3}
+            var b []int32 = []int32{10, 20}
+            Console.WriteLine(RunAsync(a, b).Result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n", output);
+    }
+
+    [Fact]
+    public void SpanLocal_ConsumedEntirelyInTry_FinallyAwaitsSeparately_CompilesAndRuns()
+    {
+        const string source = """
+            package i2350tryfinally
+            import System
+            import System.Threading.Tasks
+
+            async func RunAsync(arr []int32) Task[int32] {
+                var total = 0
+                try {
+                    var s ReadOnlySpan[int32] = arr
+                    total = s.Length
+                } finally {
+                    await Task.Yield()
+                }
+                return total
+            }
+
+            var data []int32 = []int32{7, 8, 9, 10}
+            Console.WriteLine(RunAsync(data).Result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("4\n", output);
+    }
+
+    [Fact]
+    public void SpanLocal_InNestedAsyncLambda_DeadBeforeOwnAwait_CompilesAndRuns()
+    {
+        const string source = """
+            package i2350nestedlambda
+            import System
+            import System.Threading.Tasks
+
+            func RunAsync(arr []int32) Task[int32] {
+                var g = async func() int32 {
+                    var s ReadOnlySpan[int32] = arr
+                    var len = s.Length
+                    await Task.Yield()
+                    return len
+                }
+                return g()
+            }
+
+            var data []int32 = []int32{1, 2, 3, 4, 5, 6}
+            Console.WriteLine(RunAsync(data).Result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("6\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2350liveness_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2350AsyncRefStructLivenessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2350AsyncRefStructLivenessTests.cs
@@ -1,0 +1,499 @@
+// <copyright file="Issue2350AsyncRefStructLivenessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2350: <see cref="GSharp.Core.CodeAnalysis.Binding.RefStructAsyncLivenessAnalyzer"/>
+/// replaces the coarse issue-#367 rule ("no by-ref-like local anywhere in an
+/// async function") with sound per-local liveness/control-flow analysis. A
+/// by-ref-like (<c>ref struct</c>) local, such as <c>ReadOnlySpan[T]</c>, is
+/// now permitted in an async function as long as it is never live across an
+/// <c>await</c> suspension point — covering branches, loops (including
+/// per-iteration reuse), multiple awaits, and try/catch/finally, while still
+/// rejecting genuinely unsafe cases (live-across-suspension, capture, and
+/// unsafe finally interaction).
+/// </summary>
+public class Issue2350AsyncRefStructLivenessTests
+{
+    // The exact shape reported against Oahu.Diagnostics.PipelineProbeCheck:
+    // a Span[T] local is scoped to a single loop iteration and is fully
+    // consumed (read) before the loop's own `await`, so its value never
+    // needs to survive a suspension.
+    [Fact]
+    public void PipelineProbeCheck_PerIterationSpanDeadBeforeAwait_IsPermitted()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func PipelineProbeCheck(buffer []byte, probeCount int32) Task[int32] {
+    var total = 0
+    for var i = 0; i < probeCount; i++ {
+        var probe ReadOnlySpan[byte] = buffer
+        total = total + probe.Length
+        await Task.Yield()
+    }
+    return total
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_UsedThenAwaitedWithNoFurtherUse_IsPermitted()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    var len = s.Length
+    await Task.Yield()
+    return len
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_DeclaredThenAwaited_LiveAfterAwait_Reports_GS0219()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    await Task.Yield()
+    return s.Length
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_ReadWithinSameAwaitExpression_Reports_GS0219()
+    {
+        // The read of `s` and the `await` occur in the very same statement's
+        // right-hand side, but `s` is still evaluated (read) before control
+        // suspends only if it appears as an argument that is itself
+        // evaluated before the await; here `s.Length` feeds an async call
+        // whose own await suspends with `s` still needed for the addition
+        // afterward — `s` is live across the suspension.
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func delayAndAdd(n int32) Task[int32] {
+    await Task.Yield()
+    return n
+}
+
+async func f(arr []int32) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    var extra = await delayAndAdd(1)
+    return s.Length + extra
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_DeadOnOneBranchLiveOnOtherAfterAwait_Reports_GS0219()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32, flag bool) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    if flag {
+        await Task.Yield()
+        return s.Length
+    }
+    return 0
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_ConsumedBeforeBranchThatAwaits_IsPermitted()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32, flag bool) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    var len = s.Length
+    if flag {
+        await Task.Yield()
+    }
+    return len
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_ReassignedBetweenTwoAwaits_IsPermitted()
+    {
+        // Sequential reuse: `s` is fully consumed before the first `await`,
+        // then reassigned (a fresh definition kills the earlier value) and
+        // consumed again before the second `await` — safe on both spans of
+        // its lifetime.
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(a []int32, b []int32) Task[int32] {
+    var s ReadOnlySpan[int32] = a
+    var first = s.Length
+    await Task.Yield()
+    s = b
+    var second = s.Length
+    await Task.Yield()
+    return first + second
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_LiveAcrossSecondOfTwoAwaits_Reports_GS0219()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(a []int32) Task[int32] {
+    await Task.Yield()
+    var s ReadOnlySpan[int32] = a
+    await Task.Yield()
+    return s.Length
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_PerIterationLoopWithReuse_ReassignedEachIteration_IsPermitted()
+    {
+        // Every iteration declares (or reuses) `probe` and fully consumes it
+        // before that same iteration's `await` — the loop's own back-edge
+        // must not be mistaken for a cross-suspension liveness path.
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(buffers []int32, count int32) Task[int32] {
+    var total = 0
+    for var i = 0; i < count; i++ {
+        var probe ReadOnlySpan[int32] = buffers
+        total = total + probe.Length
+        await Task.Yield()
+    }
+    return total
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_UsedAfterLoopAwaitOnNextIteration_Reports_GS0219()
+    {
+        // `probe` is declared before the loop, consumed once, then read
+        // again after the loop's `await` on a later logical use — the same
+        // value must survive the suspension, which is unsafe.
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(buffers []int32, count int32) Task[int32] {
+    var probe ReadOnlySpan[int32] = buffers
+    var total = 0
+    for var i = 0; i < count; i++ {
+        await Task.Yield()
+        total = total + probe.Length
+    }
+    return total
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_ConsumedEntirelyWithinTry_NoAwaitInFinally_IsPermitted()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    var total = 0
+    try {
+        var s ReadOnlySpan[int32] = arr
+        total = s.Length
+    } finally {
+        await Task.Yield()
+    }
+    return total
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_AssignedBeforeAwaitInTry_ReadInFinally_Reports_GS0219()
+    {
+        // Unsafe finally interaction: an exception thrown right after the
+        // `await` inside `try` (or the `await` itself faulting) would
+        // transfer control straight to `finally`, where `s` is still read —
+        // `s` must be treated as live across that `await`.
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    var result = 0
+    try {
+        await Task.Yield();
+        result = 1
+    } finally {
+        result = result + s.Length
+    }
+    return result
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_AssignedBeforeAwaitInTry_ReadInCatch_Reports_GS0219()
+    {
+        // Same "unsafe finally interaction" hazard, but via a `catch` clause
+        // instead of `finally`: an exception after the `await` can transfer
+        // straight into `catch`, where `s` is still read.
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    var result = 0
+    try {
+        await Task.Yield();
+        result = 1
+    } catch (e Exception) {
+        result = s.Length
+    }
+    return result
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_DeclaredInCatchConsumedBeforeFinallyAwait_IsPermitted()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    var result = 0
+    try {
+        result = 1
+    } catch (e Exception) {
+        var s ReadOnlySpan[int32] = arr
+        result = s.Length
+    } finally {
+        await Task.Yield()
+    }
+    return result
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    // Negative control: capture of a by-ref-like local by a closure remains
+    // rejected regardless of the async-liveness relaxation — this is
+    // pre-existing, unrelated LambdaBinder machinery (issue #367) that this
+    // fix must not weaken.
+    [Fact]
+    public void SpanLocal_CapturedByClosureInAsyncFunction_StillReports_GS0219()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    var g = func() int32 { return s.Length }
+    await Task.Yield()
+    return g()
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    // Negative control: boxing a by-ref-like value (a general escape,
+    // ADR-0058) remains rejected regardless of async context.
+    [Fact]
+    public void SpanLocal_BoxedToObjectInAsyncFunction_StillReports_GS0219()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[object] {
+    var s ReadOnlySpan[int32] = arr
+    var o object = s
+    await Task.Yield()
+    return o
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_InNestedAsyncLambda_DeadBeforeOwnAwait_IsPermitted()
+    {
+        // The by-ref-like local belongs to the nested async lambda's own
+        // scope, not the (non-async) enclosing function — confirms nested
+        // async function-literal scopes are discovered and independently
+        // analyzed.
+        var source = @"
+import System
+import System.Threading.Tasks
+
+func f(arr []int32) Task[int32] {
+    var g = async func() int32 {
+        var s ReadOnlySpan[int32] = arr
+        var len = s.Length
+        await Task.Yield()
+        return len
+    }
+    return g()
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_InNestedAsyncLambda_LiveAcrossOwnAwait_Reports_GS0219()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+func f(arr []int32) Task[int32] {
+    var g = async func() int32 {
+        var s ReadOnlySpan[int32] = arr
+        await Task.Yield()
+        return s.Length
+    }
+    return g()
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    [Fact]
+    public void SpanLocal_InOuterAsyncFunction_OuterSafeInnerLambdaCaptureStillUnsafe()
+    {
+        // The outer async function's own `s` is dead before its `await`
+        // (safe), but a nested (non-async, ordinary) closure inside it that
+        // captures `s` is still rejected by the pre-existing capture rule —
+        // confirms the two mechanisms compose correctly and independently.
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    var len = s.Length
+    var g = func() int32 { return s.Length }
+    await Task.Yield()
+    return len + g()
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    // Iterators are explicitly out of scope for issue #2350 (the issue's
+    // title and body are scoped to "async functions"); the pre-existing
+    // coarse rejection for a by-ref-like local in an iterator must remain
+    // untouched.
+    [Fact]
+    public void SpanLocal_InIterator_StillReports_GS0219()
+    {
+        var source = @"
+import System
+import System.Collections.Generic
+
+func gen(arr []int32) sequence[int32] {
+    var s ReadOnlySpan[int32] = arr
+    yield s.Length
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0219");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+
+    // Binds declarations and function bodies and returns the resulting
+    // diagnostics without evaluating. Used for constructs (e.g. iterators)
+    // that the interpreter cannot execute but whose binder diagnostics still
+    // apply.
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var program = GSharp.Core.CodeAnalysis.Binding.Binder.BindProgram(compilation.GlobalScope, compilation.References);
+        return tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(program.Diagnostics)
+            .ToImmutableArray();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/RefStructTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefStructTests.cs
@@ -146,8 +146,14 @@ func f(arr []int32) {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
     }
 
+    // Issue #2350: this async function contains no `await` at all, so `s`
+    // is never live across a suspension point — replacing the old coarse
+    // "any by-ref-like local in any async function" rule
+    // (RefStructAsyncLivenessAnalyzer) with sound per-local liveness now
+    // permits it. See Issue2350AsyncRefStructLivenessTests for the full
+    // suite of safe/unsafe liveness scenarios this fix covers.
     [Fact]
-    public void RefStruct_LocalInAsyncFunction_Reports_GS0219()
+    public void RefStruct_LocalInAsyncFunctionWithNoAwait_IsPermitted()
     {
         var source = @"
 import System
@@ -158,7 +164,7 @@ async func f(arr []int32) Task[int32] {
 }
 ";
         var result = Evaluate(source);
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #2350.

Replaces the coarse issue-#367 rule that blanket-rejected any by-ref-like (`ref struct`) local declared anywhere in an async function body (e.g. `ReadOnlySpan<T>`/`Span<T>`) with a sound, per-local control-flow/liveness analysis. A by-ref-like local is now legal in an async function/lambda as long as it is proven never live across an `await` suspension point — matching how the async lowering (`AsyncCaptureWalker`) already never hoists such a local into a state-machine field (the CLR forbids a by-ref-like field, so a value that survives suspension would silently lose its contents; this analyzer proves that can never observably happen instead of banning the declaration outright).

Real-world motivation: `Oahu.Diagnostics.PipelineProbeCheck` declares a `Span<T>` local scoped to a single loop iteration and fully consumed before that iteration's `await` — previously rejected outright even though it's provably safe.

## Fix

- **New `src/Core/CodeAnalysis/Binding/RefStructAsyncLivenessAnalyzer.cs`**: a backward ("may be live") dataflow analysis over the same `ControlFlowGraph` infrastructure used by `RefKindDefiniteAssignmentAnalyzer` (loops are fully expanded into real graph edges so per-iteration liveness across back-edges is checked correctly; `try`/`select`/`scope`/`fixed`/pattern-`switch` bodies — opaque to the outer graph — are recursively re-analyzed).
  - **try/finally "ambient live" handling** (the "unsafe finally interaction" case): an exception can transfer control from any point inside a `try` body straight to its `catch`/`finally`, so whatever is live entering those handlers is folded into an ambient live set applied to every block of the `try` body — not just its formal exit — correctly flagging a local assigned before an `await` in `try` and later read in `finally`/`catch`.
  - **Self-referential redefinition** (`s = s.Slice(await X())`) is handled soundly: the pre-statement value must survive the `await` regardless of apparent left/right ordering.
  - **Nested async lambdas/local functions** are discovered and independently analyzed (each gets its own liveness analysis rooted at its own body — a lambda literal is bound but not lowered until emit time, so this locally re-lowers just for analysis, mirroring what `ReflectionMetadataEmitter`/`ClosureEmitter` already do independently at emit time).
- **`StatementBinder.cs`**: removed the unconditional `function.IsAsync` branch of the by-ref-like local-declaration rejection. The iterator branch is untouched — iterators are explicitly out of scope for #2350 (issue title/body scope to "async functions").
- **`Binder.cs`**: wired `RefStructAsyncLivenessAnalyzer.Analyze` into all bound-body entry points (top-level functions, class methods, interface methods/accessors, struct member/method bodies) so coverage matches the original coarse check's scope exactly.
- **Capture and escape are unaffected**: `LambdaBinder`'s unconditional by-ref-like-capture rejection and `StatementBinder`'s ADR-0058 escape-scope tracking are pre-existing, unrelated machinery that this fix does not touch — confirmed still enforced via negative-control tests.

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue2350AsyncRefStructLivenessTests.cs` (20 tests): safe/unsafe branches, loops with per-iteration reuse and reassignment, multiple awaits, try/catch/finally positive and negative ("unsafe finally interaction" via both `finally` and `catch`), nested async lambda scopes (safe and unsafe), capture/escape negative controls, iterator control (still rejected), and the exact `Oahu.Diagnostics.PipelineProbeCheck` shape from the issue.
- `test/Compiler.Tests/Emit/Issue2350AsyncRefStructLivenessEmitTests.cs` (4 tests): compile+run regressions that force genuine `MoveNext` suspension via `await Task.Yield()`, so correctness is exercised end-to-end at runtime, not just accepted by the binder.
- Updated `RefStructTests.cs`'s now-outdated `RefStruct_LocalInAsyncFunction_Reports_GS0219` test (no `await` at all in that function — now correctly permitted) to `RefStruct_LocalInAsyncFunctionWithNoAwait_IsPermitted`.

## Test results

- Core.Tests: 6062 passed, 0 failed
- Compiler.Tests: 2973 passed, 0 failed
- Cs2Gs.Tests: 1358 passed, 0 failed
- InternalAnalyzers.Tests: 7 passed, 0 failed
- Full solution build (`dotnet build GSharp.sln -c Debug`): 0 warnings, 0 errors

## Deferred work

None. The fix is generalized (not EF/pipeline-specific), reuses existing CFG/liveness infrastructure, and covers all scenarios called out in the issue (branches, loops, multiple awaits, try/catch/finally, per-iteration Span locals, assignment/reuse, captures, and the exact `PipelineProbeCheck` shape).
