### PR TITLE
Fix #2349: if/else inside lambda block bound as void statement in mid-body position

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -10503,23 +10503,42 @@ public class Parser
         return ParseStatement();
     }
 
-    // Issue #669 / ADR-0128 / issue #1172: lookahead to determine whether an
-    // `if` at the current position is a value-producing if-EXPRESSION rather
-    // than a void if-STATEMENT inside a block expression (e.g. an arrow-lambda
-    // `-> { ... }` body, an if-expression then/else block, or a standalone
-    // block expression).
+    // Issue #669 / ADR-0128 / issue #1172 / issue #2349: lookahead to
+    // determine whether an `if` at the current position is a value-producing
+    // if-EXPRESSION rather than a void if-STATEMENT inside a block expression
+    // (e.g. an arrow-lambda `-> { ... }` body, an if-expression then/else
+    // block, or a standalone block expression).
     //
-    // The disambiguation rule (ADR-0128 / issue #1172): an `if`/`else if`
-    // chain is a value-producing if-expression ONLY when the chain terminates
-    // in a plain `else { ... }` branch — only then does every code path yield
-    // a value (matching the binder's BindIfExpression, which requires a
-    // non-null ElseExpression). A chain that ends without a plain final `else`
-    // (no `else` at all, or a trailing `else if` with nothing after) has a
-    // path with no value and is therefore parsed as a void if-statement. This
-    // brings block-bodied arrow lambdas to parity with func literals: a
-    // non-trailing `if`/`else if` chain without a final `else` becomes a void
-    // statement, and a trailing one yields a void (Action-like) lambda instead
-    // of being rejected with GS0276/GS0124.
+    // The disambiguation rule (ADR-0128 / issue #1172, refined by issue
+    // #2349) has TWO independent requirements — both must hold for the `if`
+    // to be treated as a value-producing if-expression:
+    //
+    //   1. SHAPE: the `if`/`else if` chain terminates in a plain
+    //      `else { ... }` branch — only then does every code path yield a
+    //      value (matching the binder's BindIfExpression, which requires a
+    //      non-null ElseExpression). A chain that ends without a plain final
+    //      `else` (no `else` at all, or a trailing `else if` with nothing
+    //      after) has a path with no value.
+    //
+    //   2. POSITION: the chain is the LAST item in its enclosing block
+    //      expression (i.e. immediately followed by that block's closing
+    //      `}`), so it is actually eligible to become the block's trailing
+    //      value-producing expression. Issue #2349: a mid-body `if`/`else`
+    //      (more statements follow inside the same block) can never be used
+    //      as a value — its result, if any, is always discarded — so it must
+    //      be parsed as a void if-STATEMENT regardless of shape. Requiring
+    //      value-producing THEN/ELSE arms for such an `if` was wrong: the
+    //      arms are free to end in ordinary void statements (a method call,
+    //      an assignment, …), and forcing them through the value-requiring
+    //      block-expression binder produced a spurious GS0124 ("Expression
+    //      must have a value") even though the `if` was never used as a
+    //      value in the first place.
+    //
+    // This brings block-bodied arrow lambdas to parity with func literals: a
+    // non-trailing `if`/`else if` chain (with or without a final `else`)
+    // becomes a void statement, and only a trailing, else-terminated one
+    // yields a value (or, for a void-typed lambda body, a void (Action-like)
+    // lambda) instead of being rejected with GS0276/GS0124.
     //
     // We perform look-ahead only (no token consumption): we walk every link of
     // the `if`/`else if` chain. For each link we scan forward to its then-block
@@ -10528,7 +10547,9 @@ public class Parser
     // handles nested blocks). After the matching `}` we inspect what follows:
     //   * not `else`                -> void if-statement (return false);
     //   * `else if`                 -> continue walking from that inner `if`;
-    //   * plain `else { ... }`      -> value-producing if-expression (return true).
+    //   * plain `else { ... }`      -> scan that final else-block to its own
+    //                                  matching close brace, then require
+    //                                  requirement 2 (tail position) above.
     private bool LooksLikeIfExpression()
     {
         // `i` is the offset of the `if` keyword for the current chain link.
@@ -10633,9 +10654,49 @@ public class Parser
                 continue;
             }
 
-            // Plain final `else { ... }`: the chain terminates in an else, so
-            // every path yields a value -> value-producing if-expression.
-            return true;
+            // Plain final `else { ... }`: shape requirement satisfied (every
+            // path yields a value). Issue #2349: also require the POSITION
+            // requirement — this chain must be the last item in its
+            // enclosing block expression, i.e. immediately followed by that
+            // block's closing `}`, or it can never actually be used as a
+            // value and must be a void if-statement instead. Scan the final
+            // else-block to its own matching close brace to find that
+            // position.
+            var elseBraceDepth = 0;
+            var m = j + 2;
+            while (true)
+            {
+                if (m > LookaheadMaxScan)
+                {
+                    return false;
+                }
+
+                var k = Peek(m).Kind;
+                if (k == SyntaxKind.EndOfFileToken)
+                {
+                    return false;
+                }
+
+                if (k == SyntaxKind.OpenBraceToken)
+                {
+                    elseBraceDepth++;
+                }
+                else if (k == SyntaxKind.CloseBraceToken)
+                {
+                    elseBraceDepth--;
+                    if (elseBraceDepth == 0)
+                    {
+                        break;
+                    }
+                }
+
+                m++;
+            }
+
+            // `m` is now at the final else-block's matching close brace.
+            // Value-producing only when immediately followed by the
+            // enclosing block expression's own closing brace (tail position).
+            return Peek(m + 1).Kind == SyntaxKind.CloseBraceToken;
         }
     }
 

--- a/test/Compiler.Tests/Emit/Issue2349LambdaIfStatementEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2349LambdaIfStatementEmitTests.cs
@@ -1,0 +1,304 @@
+// <copyright file="Issue2349LambdaIfStatementEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2349 — end-to-end compile+run coverage (real <c>gsc</c> pipeline,
+/// not the tree-walking interpreter) for a mid-body <c>if</c>/<c>else</c>
+/// inside a lambda block body. The parser previously misclassified such a
+/// construct as a value-producing if-EXPRESSION purely from its shape (does
+/// the chain terminate in a plain <c>else</c>?), without regard to whether
+/// it was actually used as a value. A mid-body if/else can never be used as
+/// a value — more statements follow it in the same block — so its arms are
+/// free to end in ordinary void statements (an assignment, a method call),
+/// which produced a spurious GS0124 ("Expression must have a value") at
+/// compile time. These tests confirm the fix compiles AND runs correctly
+/// end-to-end (verifiable IL, correct runtime output) for sync/async
+/// lambdas, nested blocks, and the exact Oahu.Diagnostics
+/// <c>rootCmd.SetAction</c> shape.
+/// </summary>
+public class Issue2349LambdaIfStatementEmitTests
+{
+    [Fact]
+    public void EndToEnd_MidBodyIfElse_AssignmentArms_RunsCorrectly()
+    {
+        var source = """
+            package P2349Basic
+            import System
+            func Main() {
+                let f = (doExport bool) -> {
+                    var report = ""
+                    if doExport {
+                        report = "export"
+                    } else {
+                        report = "run"
+                    }
+                    Console.WriteLine(report)
+                }
+                f(true)
+                f(false)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("export\nrun\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_MidBodyElseIfChain_RunsCorrectly()
+    {
+        var source = """
+            package P2349ElseIf
+            import System
+            func Main() {
+                let classify = (n int32) -> {
+                    if n > 0 {
+                        Console.WriteLine("p")
+                    } else if n < 0 {
+                        Console.WriteLine("n")
+                    } else {
+                        Console.WriteLine("z")
+                    }
+                    Console.WriteLine("done")
+                }
+                classify(5)
+                classify(-5)
+                classify(0)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("p\ndone\nn\ndone\nz\ndone\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NestedMidBodyIfElse_RunsCorrectly()
+    {
+        var source = """
+            package P2349Nested
+            import System
+            func Main() {
+                let f = (a bool, b bool) -> {
+                    if a {
+                        if b {
+                            Console.WriteLine("ab")
+                        } else {
+                            Console.WriteLine("a")
+                        }
+                        Console.WriteLine("after-inner")
+                    } else {
+                        Console.WriteLine("none")
+                    }
+                    Console.WriteLine("done")
+                }
+                f(true, true)
+                f(true, false)
+                f(false, false)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("ab\nafter-inner\ndone\na\nafter-inner\ndone\nnone\ndone\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_AsyncLambda_MidBodyIfElse_RunsCorrectly()
+    {
+        var source = """
+            package P2349Async
+            import System
+            import System.Threading.Tasks
+            func Main() {
+                let f = async (ok bool) -> {
+                    if ok {
+                        Console.WriteLine("y")
+                    } else {
+                        Console.WriteLine("n")
+                    }
+                    await Task.CompletedTask
+                }
+                f(true).Wait()
+                f(false).Wait()
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("y\nn\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_TailIfElse_StillValueProducing_Unaffected()
+    {
+        // Control: tail-position if/else remains a value-producing
+        // if-expression and must still compile and run correctly.
+        var source = """
+            package P2349Tail
+            import System
+            func Main() {
+                let f = (cond bool) -> {
+                    if cond { 1 } else { 2 }
+                }
+                Console.WriteLine(f(true))
+                Console.WriteLine(f(false))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n2\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ExactOahuDiagnosticsShape_TwoMidBodyIfElseBlocks_ThenReturn_RunsCorrectly()
+    {
+        // The exact real-world shape from tools/Oahu.Diagnostics/Program.cs:
+        // an async lambda (`rootCmd.SetAction(async (parse, ct) => { ... })`)
+        // with two independent mid-body if/else blocks (each assigning a
+        // result variable), followed by further statements and a final
+        // `return` with an integer value.
+        var source = """
+            package P2349Oahu
+            import System
+            import System.Threading.Tasks
+            func Main() {
+                let handler = async (doExport bool, useJson bool) -> {
+                    var report = ""
+                    if doExport {
+                        report = "export"
+                    } else {
+                        report = "run"
+                    }
+
+                    if useJson {
+                        Console.WriteLine("json: " + report)
+                    } else {
+                        Console.WriteLine("pretty: " + report)
+                    }
+
+                    await Task.CompletedTask
+                    return 0
+                }
+                Console.WriteLine(handler(true, false).Result)
+                Console.WriteLine(handler(false, true).Result)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("pretty: export\n0\njson: run\n0\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_OrdinaryFunction_MidBodyIfElse_ControlUnaffected()
+    {
+        // Control: ordinary (non-lambda) functions were never affected —
+        // must continue to compile and run correctly.
+        var source = """
+            package P2349Ordinary
+            import System
+            func F(cond bool) {
+                if cond {
+                    Console.WriteLine("a")
+                } else {
+                    Console.WriteLine("b")
+                }
+                Console.WriteLine("c")
+            }
+            func Main() {
+                F(true)
+                F(false)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("a\nc\nb\nc\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2349_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2349LambdaIfStatementBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2349LambdaIfStatementBinderTests.cs
@@ -1,0 +1,259 @@
+// <copyright file="Issue2349LambdaIfStatementBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2349 — binder-level coverage for the parser fix in
+/// <c>Issue2349LambdaIfStatementParserTests</c>: a mid-body if/else
+/// (terminated by a plain <c>else</c>) inside a lambda block body must bind
+/// cleanly as a void if-STATEMENT, without the spurious GS0124 ("Expression
+/// must have a value") that resulted from misclassifying it as a
+/// value-producing if-EXPRESSION. Covers sync/async lambdas, nested blocks,
+/// multiple mid-body if/else constructs, and the exact Oahu.Diagnostics
+/// <c>rootCmd.SetAction</c> async-lambda shape (two independent mid-body
+/// if/else blocks assigning/branching on a result, followed by a final
+/// return), plus ordinary-function and tail-if-expression controls.
+/// </summary>
+public class Issue2349LambdaIfStatementBinderTests
+{
+    [Fact]
+    public void MidBodyIfElse_VoidArms_NoGS0124()
+    {
+        var result = Evaluate(@"
+let f = (cond bool) -> {
+    if cond {
+        Console.WriteLine(""a"")
+    } else {
+        Console.WriteLine(""b"")
+    }
+    Console.WriteLine(""c"")
+}
+");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0124");
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void MidBodyIfElse_AssignmentArms_NoGS0124()
+    {
+        // Exact Oahu shape facet: both arms are assignment statements to an
+        // already-declared local, not calls.
+        var result = Evaluate(@"
+let f = (doExport bool) -> {
+    var report = """"
+    if doExport {
+        report = ""export""
+    } else {
+        report = ""run""
+    }
+    Console.WriteLine(report)
+}
+");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0124");
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void MidBodyElseIfChain_VoidArms_NoGS0124()
+    {
+        var result = Evaluate(@"
+let f = (n int32) -> {
+    if n > 0 {
+        Console.WriteLine(""p"")
+    } else if n < 0 {
+        Console.WriteLine(""n"")
+    } else {
+        Console.WriteLine(""z"")
+    }
+    Console.WriteLine(""done"")
+}
+");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0124");
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ExactOahuDiagnosticsShape_TwoMidBodyIfElseBlocks_ThenReturn_NoGS0124()
+    {
+        // The exact real-world shape from tools/Oahu.Diagnostics/Program.cs:
+        // an async lambda (`rootCmd.SetAction(async (parse, ct) => { ... })`)
+        // with two independent mid-body if/else blocks (each assigning a
+        // result variable), followed by further statements and a final
+        // `return` with an integer value.
+        var result = Evaluate(@"
+let handler = async (doExport bool, useJson bool) -> {
+    var report = """"
+    if doExport {
+        report = ""export""
+    } else {
+        report = ""run""
+    }
+
+    if useJson {
+        Console.WriteLine(""json: "" + report)
+    } else {
+        Console.WriteLine(""pretty: "" + report)
+    }
+
+    await Task.CompletedTask
+    return 0
+}
+");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0124");
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void NestedMidBodyIfElse_InsideOuterIfsThenBlock_NoGS0124()
+    {
+        var result = Evaluate(@"
+let f = (a bool, b bool) -> {
+    if a {
+        if b {
+            Console.WriteLine(""ab"")
+        } else {
+            Console.WriteLine(""a"")
+        }
+        Console.WriteLine(""after-inner"")
+    } else {
+        Console.WriteLine(""none"")
+    }
+    Console.WriteLine(""done"")
+}
+");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0124");
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void AsyncLambda_MidBodyIfElse_NoGS0124()
+    {
+        var result = Evaluate(@"
+let f = async (ok bool) -> {
+    if ok {
+        Console.WriteLine(""y"")
+    } else {
+        Console.WriteLine(""n"")
+    }
+    await Task.CompletedTask
+}
+");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0124");
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void SingleIdentifierArrowLambda_MidBodyIfElse_NoGS0124()
+    {
+        // Issue #932 single-identifier arrow-lambda shorthand `x -> { ... }`
+        // shares the same block-expression parse path. A target type is
+        // needed for the parameter to infer its type.
+        var result = Evaluate(@"
+let f Action[bool] = cond -> {
+    if cond {
+        Console.WriteLine(""y"")
+    } else {
+        Console.WriteLine(""n"")
+    }
+    Console.WriteLine(""done"")
+}
+");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0124");
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void TailIfElse_StillValueProducing_ControlUnaffected()
+    {
+        // Control: a tail-position if/else (last item of the block) is still
+        // a value-producing if-expression, unaffected by the fix.
+        var result = Evaluate(@"
+let f = (cond bool) -> {
+    if cond { 1 } else { 2 }
+}
+Console.WriteLine(f(true))
+");
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void OrdinaryFunction_MidBodyIfElse_ControlAlreadyWorks()
+    {
+        // Control: ordinary (non-lambda) functions parse their bodies via
+        // ParseBlockStatement, never the block-expression if-expression
+        // heuristic — mid-body if/else already worked there before this fix
+        // and must continue to.
+        var result = Evaluate(@"
+func F(cond bool) {
+    if cond {
+        Console.WriteLine(""a"")
+    } else {
+        Console.WriteLine(""b"")
+    }
+    Console.WriteLine(""c"")
+}
+");
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void LocalFunction_MidBodyIfElse_ControlAlreadyWorks()
+    {
+        // Control: a "local function" in G# is a lambda bound to a `let`
+        // inside another function's body (no separate declaration syntax).
+        // It shares the exact same block-expression parse path as any other
+        // lambda and must be fixed identically.
+        var result = Evaluate(@"
+func Outer(cond bool) {
+    let Inner = (c bool) -> {
+        if c {
+            Console.WriteLine(""a"")
+        } else {
+            Console.WriteLine(""b"")
+        }
+        Console.WriteLine(""c"")
+    }
+    Inner(cond)
+}
+");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0124");
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void MidBodyIfWithoutElse_StillWorks_Regression()
+    {
+        // Regression guard: an if/else-if chain WITHOUT a terminating plain
+        // else was already a void if-statement regardless of position
+        // (issue #1172) — must remain unaffected.
+        var result = Evaluate(@"
+let f = () -> {
+    if true {
+        Console.WriteLine(""a"")
+    }
+    Console.WriteLine(""b"")
+}
+");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0124");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0276");
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var prelude = "import System\nimport System.Threading.Tasks\n";
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(prelude + source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue2349LambdaIfStatementParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue2349LambdaIfStatementParserTests.cs
@@ -1,0 +1,246 @@
+// <copyright file="Issue2349LambdaIfStatementParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #2349 — <c>LooksLikeIfExpression</c> (ADR-0128 / issue #1172) decided
+/// whether an <c>if</c>/<c>else if</c> chain inside a block expression (an
+/// arrow-lambda body, or an if-expression arm) was a value-producing
+/// if-EXPRESSION purely from its SHAPE: does the chain terminate in a plain
+/// <c>else { ... }</c>? That answers whether every code path yields A value,
+/// but not whether the construct is actually USED as a value. A mid-body
+/// if/else (more statements follow it in the same block) can never be used
+/// as a value — its result, if any, is always discarded — so it must be a
+/// void if-STATEMENT regardless of shape. Requiring value-producing arms
+/// for such a mid-body if/else was wrong: the arms are free to end in
+/// ordinary void statements (an assignment, a method call, …), and forcing
+/// them through the value-requiring block-expression binder produced a
+/// spurious GS0124 ("Expression must have a value") even though the if/else
+/// was never used as a value.
+///
+/// The fix adds a POSITION requirement alongside the existing SHAPE
+/// requirement: an else-terminated chain is a value-producing if-expression
+/// ONLY when it is also the LAST item in its enclosing block expression
+/// (i.e. immediately followed by that block's closing <c>}</c>). These
+/// parser-level tests pin the resulting <see cref="IfStatementSyntax"/> vs
+/// <see cref="IfExpressionSyntax"/> AST shape directly.
+/// </summary>
+public class Issue2349LambdaIfStatementParserTests
+{
+    [Fact]
+    public void MidBodyIfElse_WithPlainElse_ParsesAsIfStatement_NotIfExpression()
+    {
+        // The exact bug shape: an else-terminated if/else in the MIDDLE of a
+        // lambda block body (more statements follow) must parse as a void
+        // IfStatementSyntax, not an IfExpressionSyntax, even though its shape
+        // (plain terminal `else { ... }`) would otherwise qualify it as a
+        // value-producing if-expression at the block's tail.
+        const string source = """
+            package P
+            import System
+            let f = () -> {
+                if true {
+                    Console.Write("a")
+                } else {
+                    Console.Write("b")
+                }
+                Console.Write("c")
+            }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var lambda = FindFirst<LambdaExpressionSyntax>(tree);
+        var block = Assert.IsType<BlockExpressionSyntax>(lambda.Body);
+
+        // Two statements: the if/else (now a plain IfStatementSyntax) and the
+        // final `Console.Write("c")`, which becomes the block's trailing
+        // value-producing expression (lifted out of Statements).
+        Assert.Single(block.Statements);
+        Assert.IsType<IfStatementSyntax>(block.Statements[0]);
+        Assert.Null(Walk(tree.Root).OfType<IfExpressionSyntax>().FirstOrDefault());
+    }
+
+    [Fact]
+    public void TailIfElse_WithPlainElse_StillParsesAsIfExpression()
+    {
+        // Control: when the else-terminated if/else IS the last item in the
+        // block (tail position), it is still a value-producing if-expression
+        // — unaffected by the fix.
+        const string source = """
+            package P
+            let f = () -> {
+                if true { 1 } else { 2 }
+            }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        Assert.NotNull(FindFirst<IfExpressionSyntax>(tree));
+    }
+
+    [Fact]
+    public void MidBodyElseIfChain_WithPlainFinalElse_ParsesAsIfStatement()
+    {
+        // Same rule for a longer `else if` chain: mid-body use forces the
+        // void if-statement form regardless of the chain's shape.
+        const string source = """
+            package P
+            import System
+            let f = (n int32) -> {
+                if n > 0 {
+                    Console.Write("p")
+                } else if n < 0 {
+                    Console.Write("n")
+                } else {
+                    Console.Write("z")
+                }
+                Console.Write("done")
+            }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var lambda = FindFirst<LambdaExpressionSyntax>(tree);
+        var block = Assert.IsType<BlockExpressionSyntax>(lambda.Body);
+        Assert.Single(block.Statements);
+        Assert.IsType<IfStatementSyntax>(block.Statements[0]);
+        Assert.Empty(Walk(tree.Root).OfType<IfExpressionSyntax>());
+    }
+
+    [Fact]
+    public void TwoMidBodyIfElseBlocks_ThenTrailingReturn_BothParseAsIfStatements()
+    {
+        // The exact real-world shape (Oahu.Diagnostics `rootCmd.SetAction`
+        // async lambda): TWO independent mid-body if/else constructs,
+        // followed by further statements and a final return. Neither if/else
+        // is in tail position, so both must be void if-statements.
+        const string source = """
+            package P
+            import System
+            let f = (doExport bool, useJson bool) -> {
+                var report = ""
+                if doExport {
+                    report = "export"
+                } else {
+                    report = "run"
+                }
+
+                if useJson {
+                    Console.WriteLine("json: " + report)
+                } else {
+                    Console.WriteLine("pretty: " + report)
+                }
+
+                return 0
+            }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var ifStatements = Walk(tree.Root).OfType<IfStatementSyntax>().ToList();
+        Assert.Equal(2, ifStatements.Count);
+        Assert.Empty(Walk(tree.Root).OfType<IfExpressionSyntax>());
+    }
+
+    [Fact]
+    public void MidBodyIfElse_NestedInsideAnotherIfsThenBlock_ParsesAsIfStatement()
+    {
+        // Nested blocks: a mid-body if/else inside the then-block of an
+        // OUTER if/else (itself mid-body) must also parse as a void
+        // if-statement.
+        const string source = """
+            package P
+            import System
+            let f = (a bool, b bool) -> {
+                if a {
+                    if b {
+                        Console.Write("ab")
+                    } else {
+                        Console.Write("a")
+                    }
+                    Console.Write("after-inner")
+                } else {
+                    Console.Write("none")
+                }
+                Console.Write("done")
+            }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        Assert.Empty(Walk(tree.Root).OfType<IfExpressionSyntax>());
+    }
+
+    [Fact]
+    public void AsyncLambda_MidBodyIfElse_ParsesAsIfStatement()
+    {
+        // Async lambdas use the same block-expression parse path — the fix
+        // must apply identically.
+        const string source = """
+            package P
+            import System
+            import System.Threading.Tasks
+            let f = async () -> {
+                var ok = true
+                if ok {
+                    Console.Write("y")
+                } else {
+                    Console.Write("n")
+                }
+                await Task.CompletedTask
+            }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        Assert.Empty(Walk(tree.Root).OfType<IfExpressionSyntax>());
+    }
+
+    [Fact]
+    public void MidBodyIfWithoutElse_StillParsesAsIfStatement_Unaffected()
+    {
+        // Regression guard: an if/else-if chain WITHOUT a terminating plain
+        // else was already a void if-statement regardless of position
+        // (issue #1172) — the position check must not change that.
+        const string source = """
+            package P
+            import System
+            let f = () -> {
+                if true {
+                    Console.Write("a")
+                }
+                Console.Write("b")
+            }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        Assert.Empty(Walk(tree.Root).OfType<IfExpressionSyntax>());
+    }
+
+    private static T FindFirst<T>(SyntaxTree tree)
+        where T : SyntaxNode
+    {
+        return Walk(tree.Root).OfType<T>().First();
+    }
+
+    private static IEnumerable<SyntaxNode> Walk(SyntaxNode node)
+    {
+        yield return node;
+        foreach (var c in node.GetChildren())
+        {
+            if (c is SyntaxNode sn)
+            {
+                foreach (var d in Walk(sn))
+                {
+                    yield return d;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Root cause

`Parser.LooksLikeIfExpression()` (the ADR-0128/#1172 heuristic used inside `ParseBlockExpression()`/`ParseBlockExpressionItem()`) decided whether a bare `if` inside a block-expression — arrow-lambda bodies, if-expression then/else arms — should parse as a value-producing `IfExpressionSyntax` vs. a void `IfStatementSyntax` based **purely on SHAPE**: whether the `if`/`else if` chain terminates in a plain final `else { ... }`. It had **no regard for the construct's POSITION** within its enclosing block.

A mid-body if/else (more statements follow it) can never legally be used as a value, so its arms are free to end in ordinary void statements (assignment, method call). But `BindIfExpression`/`BindBlockExpressionValue` unconditionally requires if-expression arm blocks to yield a non-void value (`BindExpression(..., canBeVoid: false)`). Misclassifying a mid-body if/else as an `IfExpressionSyntax` therefore produced spurious `GS0124: Expression must have a value.` diagnostics.

Ordinary functions and func-literals are structurally immune: their bodies parse via `ParseBlockStatement()` → `ParseStatement()`, which unconditionally treats any `if` as `IfStatementSyntax` and never invokes `LooksLikeIfExpression` — matching the issue's observation that "ordinary functions work". Only arrow-lambda bodies and if-expression arm blocks go through `ParseBlockExpression()`, and recursively, so does any nested `if` inside those arms (relative to *its own* enclosing block).

Real-world repro: `tools/Oahu.Diagnostics/Program.cs`'s `rootCmd.SetAction(async (parse, ct) => { ... if (doExport) {...} else {...} ... if (useJson) {...} else {...} ... return report.HasErrors ? 1 : 0; })` — an async lambda with two independent mid-body if/else assignment blocks.

## Fix

`LooksLikeIfExpression()` now requires **both**:
1. **SHAPE** (unchanged): the `if`/`else if` chain terminates in a plain final `else { ... }`.
2. **POSITION** (new): that if/else construct must be the **last item** in its enclosing block — i.e., eligible to become the block's trailing value.

After locating the chain-terminating else-block, the scan walks to its own matching closing brace (reusing the existing brace-depth-counting technique already used for then-blocks), then only classifies the construct as a value-producing if-expression when the very next token is the enclosing block's own closing `}`. Otherwise, it unconditionally parses as a void if-statement, regardless of shape.

This preserves every legitimate tail-position if-expression while correctly treating mid-body if/else as a statement. The added scan reuses the pre-existing `LookaheadMaxScan` cap, so the `Issue1607` pathological-input perf guards are unaffected (unbalanced-brace inputs already bail out in the prior shape scan before reaching the new code).

## Verification

Verified end-to-end against the real Oahu.Diagnostics shape via the `gsc` CLI: confirmed the exact `GS0124` failure without the fix, and correct compile+run behavior with it (via patch revert/restore, not `git stash`).

## Tests added

- `test/Core.Tests/CodeAnalysis/Syntax/Issue2349LambdaIfStatementParserTests.cs` (7): pins `IfStatementSyntax` vs `IfExpressionSyntax` AST shape for mid-body vs. tail if/else, else-if chains, two-sibling mid-body constructs (Oahu shape), nested blocks, async lambdas, and the pre-existing if-without-else regression guard.
- `test/Core.Tests/CodeAnalysis/Binding/Issue2349LambdaIfStatementBinderTests.cs` (12): bind-only diagnostic checks (no `GS0124`) for the same shapes, plus ordinary-function and local-function (`let`-bound lambda) controls.
- `test/Compiler.Tests/Emit/Issue2349LambdaIfStatementEmitTests.cs` (7): real `gsc` compile+run verification (IL-verify + `dotnet exec`) for mid-body if/else, else-if chains, nested blocks, async lambdas, tail-if-expression and ordinary-function controls, and the exact Oahu.Diagnostics async-lambda shape.

Confirmed via patch revert/restore that 12/18 of the new Core.Tests fail without the fix (exact `GS0124` messages), and pass again once restored.

## Validation

- `dotnet build GSharp.sln -c Debug -warnaserror`: 0 warnings, 0 errors
- `Core.Tests`: 6117 passed, 1 skipped (pre-existing `RegenerateBaseline`)
- `Compiler.Tests`: 2985 passed
- `Cs2Gs.Tests`: 1383 passed
- `InternalAnalyzers.Tests`: 7 passed
- Merged latest `origin/main` (through #2352) into this branch; rebuilt clean and re-ran the affected/targeted suites after each merge.

## Deferred / out-of-scope observation (not a blocker for this fix)

While writing binder-level tests, I found a **separate, pre-existing, unrelated** interpreter gap: `BoundTreeRewriter`/`Lowerer` has no case for `BoundLambdaExpression`, so a lambda's/local-function's body is never passed through the standard if-statement-to-goto lowering pass before the tree-interpreting `Compilation.Evaluate()` executes it. Invoking (not just declaring) a lambda containing a raw `BoundIfStatement` via `Evaluate()` throws `EvaluatorException: "Unexpected node IfStatement"`. This reproduces even for the pre-existing if-without-else case and is **not specific to #2349** — no prior test happened to actually call such a lambda from `Evaluate()`. It does **not** affect the real `gsc` compile+run pipeline (verified via this PR's own compile+run emit tests, which do invoke such lambdas and produce correct output). Left as-is; may be worth a follow-up issue if `Evaluate()`-based lambda invocation semantics matter for other work.

Closes #2349
