### PR TITLE
Fix #2360: escaping goto in region-scoped ControlFlowGraph crashed async return-in-try/finally

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -455,12 +455,11 @@ public sealed class ControlFlowGraph
                     {
                         case BoundNodeKind.GotoStatement:
                             var gs = (BoundGotoStatement)statement;
-                            var toBlock = blockFromLabel[gs.Label];
-                            Connect(current, toBlock);
+                            Connect(current, ResolveLabelTarget(gs.Label, blockFromLabel, end));
                             break;
                         case BoundNodeKind.ConditionalGotoStatement:
                             var cgs = (BoundConditionalGotoStatement)statement;
-                            var thenBlock = blockFromLabel[cgs.Label];
+                            var thenBlock = ResolveLabelTarget(cgs.Label, blockFromLabel, end);
                             var elseBlock = next;
                             var negatedCondition = Negate(cgs.Condition);
                             var thenCondition = cgs.JumpIfTrue ? cgs.Condition : negatedCondition;
@@ -571,6 +570,48 @@ public sealed class ControlFlowGraph
 
             branches.RemoveAll(branch => removed.Contains(branch.From) || removed.Contains(branch.To));
             blocks.RemoveAll(block => removed.Contains(block));
+        }
+
+        /// <summary>
+        /// Resolves a goto/conditional-goto's target label to the basic block
+        /// that declares it, or <paramref name="end"/> when the label is not
+        /// declared anywhere in the region this graph was built over.
+        /// </summary>
+        /// <remarks>
+        /// <para>Issue #2360: several analyses (<see cref="RefStructAsyncLivenessAnalyzer"/>,
+        /// <see cref="RefKindDefiniteAssignmentAnalyzer"/>) build a fresh, narrowly
+        /// scoped <see cref="ControlFlowGraph"/> over just one nested compound
+        /// statement's body — a <c>try</c>/<c>catch</c>/<c>finally</c> block, a
+        /// <c>select</c> case, a <c>scope</c>, or a <c>fixed</c> body — because the
+        /// outer graph treats those as single opaque statements (issue #1642). A
+        /// <c>goto</c> lexically inside such a region can legitimately target a
+        /// label declared <em>outside</em> it: the async lowering pipeline's
+        /// generalized try/finally-with-return funnel (<see cref="Lowering.Lowerer"/>'s
+        /// <c>RewriteReturnStatement</c>/<c>WrapWithMethodExitEpilogue</c>) rewrites a
+        /// <c>return</c> inside a protected region into exactly this shape — a
+        /// <c>goto</c> to a synthesized exit label placed after the whole
+        /// enclosing statement, i.e. outside the try body's own region. The same
+        /// applies to a user <c>break</c>/<c>continue</c> lowered to a <c>goto</c>
+        /// past a loop that encloses (but is not entirely inside) the region.</para>
+        /// <para>Such a label is, from the narrow region's point of view,
+        /// indistinguishable from any other exit out of the region — exactly like
+        /// a <c>return</c> or <c>throw</c>, which already connect straight to
+        /// <paramref name="end"/> (see the switch above). Routing an unresolved
+        /// label to <paramref name="end"/> keeps every synthesized branch target
+        /// meaningful to the analysis (the region-scoped liveness/assignment
+        /// fixpoint folds in whatever is live/assigned past the region, via each
+        /// analyzer's own <c>liveOutOfRegion</c>/<c>isFunctionBody</c> plumbing)
+        /// instead of throwing <see cref="KeyNotFoundException"/> and crashing the
+        /// compiler (GS9998) the moment a by-ref-like local or an <c>out</c>
+        /// parameter happens to make either analyzer examine the region.</para>
+        /// </remarks>
+        /// <param name="label">The goto/conditional-goto's target label.</param>
+        /// <param name="blockFromLabel">The label-to-block map for this region.</param>
+        /// <param name="end">This graph's end block.</param>
+        /// <returns>The declaring block, or <paramref name="end"/> if the label escapes the region.</returns>
+        private static BasicBlock ResolveLabelTarget(BoundLabel label, Dictionary<BoundLabel, BasicBlock> blockFromLabel, BasicBlock end)
+        {
+            return blockFromLabel.TryGetValue(label, out var block) ? block : end;
         }
 
         private void Connect(BasicBlock from, BasicBlock to, BoundExpression condition = null)

--- a/test/Compiler.Tests/Emit/Issue2360AsyncTryFinallyReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2360AsyncTryFinallyReturnEmitTests.cs
@@ -1,0 +1,302 @@
+// <copyright file="Issue2360AsyncTryFinallyReturnEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2360: end-to-end compile+run coverage for the fix in
+/// <see cref="Core.CodeAnalysis.Binding.ControlFlowGraph.GraphBuilder"/>. An
+/// async function containing both a by-ref-like (<c>ref struct</c>) local —
+/// legalized per-scope by issue #2350's
+/// <see cref="Core.CodeAnalysis.Binding.RefStructAsyncLivenessAnalyzer"/> —
+/// and a <c>return</c> lexically inside a <c>try</c>/<c>finally</c> crashed
+/// the compiler with GS9998 (<c>KeyNotFoundException</c>) instead of binding
+/// and emitting correctly. <c>Lowerer.RewriteReturnStatement</c> rewrites
+/// that <c>return</c> into a store-to-temp + <c>goto</c> targeting a
+/// synthesized method-exit label placed <em>outside</em> the try statement;
+/// <see cref="Core.CodeAnalysis.Binding.RefStructAsyncLivenessAnalyzer"/>
+/// then analyzes the try body in a region-scoped
+/// <see cref="Core.CodeAnalysis.Binding.ControlFlowGraph"/> that never
+/// contains that label. The fix makes an escaping goto target resolve to the
+/// region's end block (like <c>return</c>/<c>throw</c> already do) instead of
+/// throwing. These tests compile and *run* the fixed program, asserting both
+/// the correct return value and that the <c>finally</c> block's side effect
+/// actually executed — not just that binding no longer crashes.
+/// </summary>
+public class Issue2360AsyncTryFinallyReturnEmitTests
+{
+    [Fact]
+    public void PipelineProbeCheck_ExactIssueRepro_ReturnInTryFinally_NoAwait_CompilesRunsAndDisposes()
+    {
+        // The exact minimal repro from issue #2360.
+        const string source = """
+            package i2360exact
+            import System
+            import System.IO
+            import System.Threading.Tasks
+
+            async func PipelineProbeCheck(buffer []byte) Task[int32] {
+                var span ReadOnlySpan[byte] = buffer
+                var len = span.Length
+                var ms = MemoryStream()
+                try {
+                    return len
+                } finally {
+                    ms.Dispose()
+                    Console.WriteLine("disposed")
+                }
+            }
+
+            var data []byte = []byte{1, 2, 3, 4, 5}
+            Console.WriteLine(PipelineProbeCheck(data).Result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("disposed\n5\n", output);
+    }
+
+    [Fact]
+    public void PipelineProbeCheck_ReturnInTryFinally_WithRealAwaitElsewhere_CompilesRunsAndDisposes()
+    {
+        const string source = """
+            package i2360await
+            import System
+            import System.IO
+            import System.Threading.Tasks
+
+            async func PipelineProbeCheck(buffer []byte) Task[int32] {
+                await Task.Yield()
+                var span ReadOnlySpan[byte] = buffer
+                var len = span.Length
+                var ms = MemoryStream()
+                try {
+                    return len
+                } finally {
+                    ms.Dispose()
+                    Console.WriteLine("disposed")
+                }
+            }
+
+            var data []byte = []byte{1, 2, 3, 4, 5, 6, 7}
+            Console.WriteLine(PipelineProbeCheck(data).Result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("disposed\n7\n", output);
+    }
+
+    [Fact]
+    public void UsingLetDesugaredForm_ReturnInsideUsingScope_CompilesRunsAndDisposes()
+    {
+        // `using let` desugars to try/finally with Dispose() in the finally —
+        // this exercises the identical escaping-goto shape via the
+        // higher-level `using let` syntax rather than a hand-written
+        // try/finally.
+        const string source = """
+            package i2360usinglet
+            import System
+            import System.Threading.Tasks
+
+            class Fixture : IDisposable {
+                func Dispose() {
+                    Console.WriteLine("disposed")
+                }
+            }
+
+            async func RunAsync(arr []int32) Task[int32] {
+                var s ReadOnlySpan[int32] = arr
+                var len = s.Length
+                using let f = Fixture{}
+                return len
+            }
+
+            var data []int32 = []int32{1, 2, 3}
+            Console.WriteLine(RunAsync(data).Result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("disposed\n3\n", output);
+    }
+
+    [Fact]
+    public void MultipleReturnsInSeparateTryFinallyBlocks_CompilesAndRuns()
+    {
+        const string source = """
+            package i2360multi
+            import System
+            import System.Threading.Tasks
+
+            async func RunAsync(arr []int32, flag bool) Task[int32] {
+                var s ReadOnlySpan[int32] = arr
+                var len = s.Length
+                if flag {
+                    try {
+                        return len
+                    } finally {
+                        Console.WriteLine("first")
+                    }
+                }
+
+                try {
+                    return len + 100
+                } finally {
+                    Console.WriteLine("second")
+                }
+            }
+
+            var data []int32 = []int32{1, 2, 3, 4}
+            Console.WriteLine(RunAsync(data, true).Result)
+            Console.WriteLine(RunAsync(data, false).Result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("first\n4\nsecond\n104\n", output);
+    }
+
+    [Fact]
+    public void NestedTryFinally_ReturnInInnermostTry_CompilesAndRuns()
+    {
+        const string source = """
+            package i2360nested
+            import System
+            import System.Threading.Tasks
+
+            async func RunAsync(arr []int32) Task[int32] {
+                var s ReadOnlySpan[int32] = arr
+                var len = s.Length
+                try {
+                    try {
+                        return len
+                    } finally {
+                        Console.WriteLine("inner")
+                    }
+                } finally {
+                    Console.WriteLine("outer")
+                }
+            }
+
+            var data []int32 = []int32{1, 2, 3, 4, 5}
+            Console.WriteLine(RunAsync(data).Result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("inner\nouter\n5\n", output);
+    }
+
+    [Fact]
+    public void ReturnInsideTryCatchFinally_NoAwait_CompilesAndRuns()
+    {
+        const string source = """
+            package i2360catch
+            import System
+            import System.Threading.Tasks
+
+            async func RunAsync(arr []int32) Task[int32] {
+                var s ReadOnlySpan[int32] = arr
+                var len = s.Length
+                try {
+                    return len
+                } catch (e Exception) {
+                    return -1
+                } finally {
+                    Console.WriteLine("cleanup")
+                }
+            }
+
+            var data []int32 = []int32{9, 9, 9}
+            Console.WriteLine(RunAsync(data).Result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("cleanup\n3\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2360tryfinally_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/ControlFlowGraphEscapingGotoTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ControlFlowGraphEscapingGotoTests.cs
@@ -1,0 +1,83 @@
+// <copyright file="ControlFlowGraphEscapingGotoTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Focused, binder-analyzer-independent tests for issue #2360's fix in
+/// <see cref="ControlFlowGraph.GraphBuilder"/>: a <c>goto</c> (or conditional
+/// <c>goto</c>) whose target label is not declared anywhere in the
+/// <see cref="BoundBlockStatement"/> passed to <see cref="ControlFlowGraph.Create"/>
+/// must not throw; instead it must be treated exactly like a
+/// <c>return</c>/<c>throw</c> and routed to <see cref="ControlFlowGraph.End"/>.
+/// This is the exact situation <see cref="RefStructAsyncLivenessAnalyzer"/> and
+/// <see cref="RefKindDefiniteAssignmentAnalyzer"/> create when they build a
+/// region-scoped graph for just a try/catch body whose lowered <c>return</c>
+/// has been rewritten into a <c>goto</c> targeting a method-exit label that
+/// lives outside that region (see <c>Lowerer.RewriteReturnStatement</c> /
+/// <c>WrapWithMethodExitEpilogue</c>).
+/// </summary>
+public class ControlFlowGraphEscapingGotoTests
+{
+    [Fact]
+    public void Create_UnconditionalGotoToUndeclaredLabel_DoesNotThrow_AndConnectsToEnd()
+    {
+        var escapingLabel = new BoundLabel("Label1");
+        var body = new BoundBlockStatement(
+            null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundExpressionStatement(null, new BoundLiteralExpression(null, 1)),
+                new BoundGotoStatement(null, escapingLabel)));
+
+        var graph = ControlFlowGraph.Create(body);
+
+        var gotoBlock = graph.Blocks.Single(b => b.Statements.Any(s => s.Kind == BoundNodeKind.GotoStatement));
+        Assert.Contains(graph.End, gotoBlock.Outgoing.Select(branch => branch.To));
+    }
+
+    [Fact]
+    public void Create_ConditionalGotoToUndeclaredLabel_DoesNotThrow_AndConnectsToEnd()
+    {
+        var escapingLabel = new BoundLabel("Label2");
+        var condition = new BoundLiteralExpression(null, true);
+        var body = new BoundBlockStatement(
+            null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundConditionalGotoStatement(null, escapingLabel, condition),
+                new BoundExpressionStatement(null, new BoundLiteralExpression(null, 2))));
+
+        var graph = ControlFlowGraph.Create(body);
+
+        var gotoBlock = graph.Blocks.Single(b => b.Statements.Any(s => s.Kind == BoundNodeKind.ConditionalGotoStatement));
+        Assert.Contains(graph.End, gotoBlock.Outgoing.Select(branch => branch.To));
+    }
+
+    [Fact]
+    public void Create_GotoToDeclaredLabelWithinSameBlock_StillConnectsToThatBlock()
+    {
+        // Control: a goto whose target label *is* present in the region must
+        // keep resolving to that block, not fall through to End — the fix
+        // must not regress the ordinary, in-region goto case.
+        var label = new BoundLabel("L");
+        var body = new BoundBlockStatement(
+            null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundGotoStatement(null, label),
+                new BoundLabelStatement(null, label),
+                new BoundExpressionStatement(null, new BoundLiteralExpression(null, 3))));
+
+        var graph = ControlFlowGraph.Create(body);
+
+        var gotoBlock = graph.Blocks.Single(b => b.Statements.Any(s => s.Kind == BoundNodeKind.GotoStatement));
+        var labelBlock = graph.Blocks.Single(b => b.Statements.Any(s => s.Kind == BoundNodeKind.LabelStatement));
+        Assert.Contains(labelBlock, gotoBlock.Outgoing.Select(branch => branch.To));
+        Assert.DoesNotContain(graph.End, gotoBlock.Outgoing.Select(branch => branch.To));
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2360AsyncTryFinallyReturnLivenessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2360AsyncTryFinallyReturnLivenessTests.cs
@@ -1,0 +1,322 @@
+// <copyright file="Issue2360AsyncTryFinallyReturnLivenessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2360: an async function containing both a by-ref-like (<c>ref
+/// struct</c>) local — legalized per-scope by issue #2350's
+/// <see cref="GSharp.Core.CodeAnalysis.Binding.RefStructAsyncLivenessAnalyzer"/>
+/// — and a <c>return</c> lexically inside a <c>try</c> whose statement has a
+/// <c>finally</c> (or <c>catch</c>) crashed the compiler with GS9998
+/// (<c>KeyNotFoundException: The given key 'Label1' was not present in the
+/// dictionary</c>) instead of binding cleanly.
+/// </summary>
+/// <remarks>
+/// Root cause: <see cref="GSharp.Core.CodeAnalysis.Lowering.Lowerer"/> rewrites
+/// a <c>return</c> lexically inside a protected (try) region into a
+/// store-to-temp + <c>goto</c> to a synthesized method-exit label placed
+/// <em>after</em> the entire lowered try statement (see
+/// <c>Lowerer.RewriteReturnStatement</c>/<c>WrapWithMethodExitEpilogue</c>).
+/// <see cref="GSharp.Core.CodeAnalysis.Binding.RefStructAsyncLivenessAnalyzer"/>'s
+/// <c>ProcessTryBackward</c> then builds a <see cref="GSharp.Core.CodeAnalysis.Binding.ControlFlowGraph"/>
+/// scoped to just the try body's own statements (issue #1642's opaque-compound-
+/// statement pattern, shared with <see cref="GSharp.Core.CodeAnalysis.Binding.RefKindDefiniteAssignmentAnalyzer"/>)
+/// — but the synthesized <c>goto</c>'s target label lives outside that scoped
+/// region, so the old, unguarded <c>blockFromLabel[gs.Label]</c> lookup in
+/// <c>ControlFlowGraph.GraphBuilder.Build</c> threw. The fix makes that lookup
+/// tolerant of an escaping label, routing it to the region's <c>end</c> block
+/// exactly like a <c>return</c>/<c>throw</c> already does — the generalized,
+/// case-agnostic invariant the fix relies on. These tests exercise that fix
+/// purely at the binder level (fast, no emit); see
+/// <c>Issue2360AsyncTryFinallyReturnEmitTests</c> for full compile+run coverage.
+/// </remarks>
+public class Issue2360AsyncTryFinallyReturnLivenessTests
+{
+    // The exact minimal repro from issue #2360: no await anywhere in the
+    // function, so the by-ref-like local is trivially dead across every
+    // suspension point (there are none) — this must bind cleanly with no
+    // GS0219 and, crucially, must not throw GS9998 while doing so.
+    [Fact]
+    public void SpanLocal_ReturnInsideTryFinally_NoAwait_MinimalRepro_IsPermitted()
+    {
+        var source = @"
+import System
+import System.IO
+import System.Threading.Tasks
+
+async func f(arr []byte) Task[int32] {
+    var span ReadOnlySpan[byte] = arr
+    var len = span.Length
+    var ms = MemoryStream()
+    try {
+        return len
+    } finally {
+        ms.Dispose()
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+    }
+
+    // A `finally` with no `catch` — the shape closest to a `using`
+    // desugaring (see Issue2360AsyncTryFinallyReturnEmitTests for the actual
+    // `using let` end-to-end coverage) but expressed directly as try/finally.
+    [Fact]
+    public void SpanLocal_ReturnInsideTryFinally_WithRealAwaitElsewhere_SpanDeadBeforeReturn_IsPermitted()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    await Task.Yield();
+    var s ReadOnlySpan[int32] = arr
+    var len = s.Length
+    try {
+        return len
+    } finally {
+        Console.WriteLine(""cleanup"")
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+    }
+
+    [Fact]
+    public void SpanLocal_ReturnInsideTryCatchFinally_NoAwait_IsPermitted()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    var len = s.Length
+    try {
+        return len
+    } catch (e Exception) {
+        return -1
+    } finally {
+        Console.WriteLine(""cleanup"")
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+    }
+
+    // The escaping-goto shape can arise inside a `catch` clause's own body
+    // just as easily as inside `try` — ProcessTryBackward re-analyzes catch
+    // bodies through the same region-scoped AnalyzeRegion path.
+    [Fact]
+    public void SpanLocal_ReturnInsideCatchClause_NoAwait_IsPermitted()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    var len = s.Length
+    try {
+        DoWork()
+    } catch (e Exception) {
+        return len
+    } finally {
+        Console.WriteLine(""cleanup"")
+    }
+    return 0
+}
+
+func DoWork() {
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+    }
+
+    [Fact]
+    public void SpanLocal_MultipleReturnsInSeparateTryFinallyBlocks_IsPermitted()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32, flag bool) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    var len = s.Length
+    if flag {
+        try {
+            return len
+        } finally {
+            Console.WriteLine(""first"")
+        }
+    }
+
+    try {
+        return len + 1
+    } finally {
+        Console.WriteLine(""second"")
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+    }
+
+    [Fact]
+    public void SpanLocal_NestedTryFinally_ReturnInInnermostTry_IsPermitted()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    var len = s.Length
+    try {
+        try {
+            return len
+        } finally {
+            Console.WriteLine(""inner"")
+        }
+    } finally {
+        Console.WriteLine(""outer"")
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+    }
+
+    [Fact]
+    public void SpanLocal_ReturnInsideNestedTryFinally_AwaitInOutermostFinally_IsPermitted()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    var len = s.Length
+    try {
+        try {
+            return len
+        } finally {
+            Console.WriteLine(""inner"")
+        }
+    } finally {
+        await Task.Yield()
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+    }
+
+    // Negative control #1: the fix must not make the analysis blind to a
+    // genuinely unsafe interior await — `s` is still read in `finally`
+    // *after* an `await` that could resume with an exception in flight, so
+    // this must keep reporting GS0219 exactly as the pre-existing
+    // (non-try-return) unsafe-finally-interaction tests in
+    // Issue2350AsyncRefStructLivenessTests do.
+    [Fact]
+    public void SpanLocal_ReturnInsideTryFinally_LiveAcrossAwaitInFinally_StillReports_GS0219()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    try {
+        return 0
+    } finally {
+        await Task.Yield();
+        Console.WriteLine(s.Length)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    // Negative control #2: `s` is read after an `await` inside the try body
+    // itself, ahead of the funneled return — still unsafe.
+    [Fact]
+    public void SpanLocal_ReturnInsideTryFinally_LiveAcrossAwaitBeforeReturn_StillReports_GS0219()
+    {
+        var source = @"
+import System
+import System.Threading.Tasks
+
+async func f(arr []int32) Task[int32] {
+    var s ReadOnlySpan[int32] = arr
+    try {
+        await Task.Yield();
+        return s.Length
+    } finally {
+        Console.WriteLine(""cleanup"")
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0219");
+    }
+
+    // The exact shape reported against Oahu.Diagnostics.PipelineProbeCheck:
+    // a Span[T] local dies before a try/finally whose try funnels a `return`
+    // out through a resource-cleanup finally, with no await anywhere in the
+    // function.
+    [Fact]
+    public void PipelineProbeCheck_ReturnInsideTryFinally_ExactOahuShape_IsPermitted()
+    {
+        var source = @"
+import System
+import System.IO
+import System.Threading.Tasks
+
+async func PipelineProbeCheck(buffer []byte) Task[int32] {
+    var span ReadOnlySpan[byte] = buffer
+    var probeLength = span.Length
+    var stream = MemoryStream()
+    try {
+        return probeLength
+    } finally {
+        stream.Dispose()
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0219");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS9998");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Closes #2360.

## Root cause

`Lowerer.RewriteReturnStatement` rewrites a `return` lexically inside a protected region (`try`/`catch`/`finally`/`scope`) into a store-to-temp plus a `goto` targeting a synthesized method-exit label appended **outside** the entire enclosing statement (`WrapWithMethodExitEpilogue`). This is a general, async-independent lowering step.

`RefStructAsyncLivenessAnalyzer.ProcessTryBackward` (added in #2350/#2356) builds a `ControlFlowGraph` scoped to just the `try` block's own statements to run its backward liveness simulation. Because the funneled `goto`'s target label lives outside that narrowly-scoped region, the label is absent from the region's label table, and `ControlFlowGraph.GraphBuilder.Build` performed an unguarded `blockFromLabel[gs.Label]` dictionary lookup — throwing `KeyNotFoundException`. `Compilation.cs`'s broad top-level exception handler turned that into the generic `GS9998` diagnostic instead of a clean bind.

This is **not** async-specific or EF/Oahu-specific: `RefKindDefiniteAssignmentAnalyzer` had already worked around this exact architectural gap for its own region-scoped analysis (see its pre-existing `#1642` fail-safe `try`/`catch`), but `RefStructAsyncLivenessAnalyzer` had no such safety net, letting the crash surface as an unhandled exception whenever a by-ref-like async local coexisted with a `return` funneled out of a `try`/`catch`/`finally`.

The issue's own hint attributed this to `AsyncExceptionHandlerRewriter`'s "Pattern C" pending-branch funneling, but Pattern C only activates when the `try`/`catch`/`finally` itself contains an `await`. The minimal repro has none — `AsyncExceptionHandlerRewriter` passes the `try`/`finally` through unchanged. The real defect is in the shared, async-independent `ControlFlowGraph` infrastructure.

## Fix

`src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs`: added a `ResolveLabelTarget` helper used by both the `GotoStatement` and `ConditionalGotoStatement` cases in `GraphBuilder.Build`. An unresolvable label target now routes to the region's `end` block — mirroring how a `return`/`throw` already "leaves" a region-scoped graph — instead of throwing. This transparently fixes **both** `RefStructAsyncLivenessAnalyzer` and `RefKindDefiniteAssignmentAnalyzer` (and any future region-scoped CFG consumer) with no case-specific special-casing, satisfying the generalized-invariant requirement.

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue2360AsyncTryFinallyReturnLivenessTests.cs` (10 binder-level tests): minimal issue repro, real `await` elsewhere, `try`/`catch`/`finally`, return inside `catch`, multiple returns in separate `try`/`finally` blocks, nested `try`/`finally`, nested `try`/`finally` with `await` in the outer `finally`, two **negative controls** proving `GS0219` still correctly fires when a span is genuinely live across an `await`, and the exact Oahu-shaped `PipelineProbeCheck` repro. All 10 were verified to fail with `KeyNotFoundException` against the pre-fix `ControlFlowGraph.cs` and pass against the fix (confirmed by temporarily swapping in the pre-fix file).
- `test/Core.Tests/CodeAnalysis/Binding/ControlFlowGraphEscapingGotoTests.cs` (3 tests): focused, analyzer-independent unit tests directly against `ControlFlowGraph.Create`, proving an escaping unconditional/conditional `goto` resolves to `End` without throwing, plus a control proving an in-region `goto` still resolves to its own label's block.
- `test/Compiler.Tests/Emit/Issue2360AsyncTryFinallyReturnEmitTests.cs` (6 tests): full compile+run coverage — exact issue repro, real-`await` variant, `using let` desugared form, multiple/nested `try`/`finally`, and `try`/`catch`/`finally` — each asserting both the correct return value **and** that the `finally`/`Dispose` side effect actually executed.

## Test results

Full solution build with analyzers enabled: 0 warnings, 0 errors.

| Suite | Passed | Failed |
|---|---|---|
| Core.Tests | 6112 | 0 (1 pre-existing unrelated skip) |
| Compiler.Tests | 2984 | 0 |
| Cs2Gs.Tests | 1383 | 0 |
| InternalAnalyzers.Tests | 7 | 0 |

## Deferred work

`RefKindDefiniteAssignmentAnalyzer`'s pre-existing `#1642` fail-safe `try`/`catch` around its own region-scoped analysis is now redundant in more cases given this fix, but was left in place as an unrelated, pre-existing defensive measure outside this issue's scope — removing it could be a small follow-up cleanup. No other deferred work.
