### PR TITLE
Fix #2364: bind implicit conversions for primary-constructor arguments

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -3355,6 +3355,23 @@ internal sealed class OverloadResolver
 
                 hasErrors = true;
             }
+            else
+            {
+                // Issue #2364: the fixed-arity/non-optional primary-constructor
+                // path validated that the argument-to-parameter conversion was
+                // implicit above, but never actually bound it — the emitter
+                // then received the raw, unconverted argument and had no way
+                // to compensate (`MethodBodyEmitter.EmitConstructorCall` just
+                // emits each bound argument as-is). This silently dropped every
+                // non-identity implicit conversion (nullable wrapping, integral/
+                // floating widening, user-defined implicit conversions, etc.)
+                // at a primary-constructor call site, producing unverifiable IL
+                // (ilverify `StackUnexpected`) despite a clean compile. Mirror
+                // the sibling paths that already do this correctly:
+                // `BindExplicitConstructorCallExpression`'s equivalent loop and
+                // the `primaryHasOptional` branch above in this same method.
+                boundArguments[i] = conversions.BindConversion(parameterSyntax[i].Location, argument, parameter.Type);
+            }
         }
 
         if (hasErrors)

--- a/test/Compiler.Tests/Emit/Issue2364PrimaryConstructorConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2364PrimaryConstructorConversionEmitTests.cs
@@ -1,0 +1,362 @@
+// <copyright file="Issue2364PrimaryConstructorConversionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2364: the fixed-arity (non-optional-parameter) argument-binding loop
+/// in <c>OverloadResolver.BindConstructorCallExpressionCore</c> validated that
+/// an argument's conversion to its primary-constructor parameter type was
+/// implicit, but never actually bound/emitted it. The compile succeeded and
+/// diagnostics were clean, but the emitted IL left the raw (unconverted)
+/// argument on the stack where the constructor's signature expected the
+/// converted type — producing unverifiable IL
+/// (<c>System.Reflection.Metadata.BadImageFormatException</c> /
+/// ILVerify <c>StackUnexpected</c>) despite a clean compile.
+///
+/// These tests compile end-to-end, run <c>ilverify</c> on the emitted
+/// assembly, and execute it, for every real-world shape encountered in the
+/// Oahu migration corpus (a <c>switch</c> expression returning primary-ctor
+/// data-class instances built from <c>int32</c> literals into
+/// <c>int32?</c> parameters — the exact <c>ExCodec.ToQuality</c> /
+/// <c>AudioQuality</c> shape) plus generalized coverage of nullable-wrap,
+/// widening, generic, and user-defined conversions, and control cases for the
+/// sibling paths (explicit <c>init(...)</c> ctor, optional-parameter primary
+/// ctor, plain function call) that were already correct before the fix.
+/// </summary>
+public class Issue2364PrimaryConstructorConversionEmitTests
+{
+    [Fact]
+    public void OahuAudioQualityShape_SwitchExpressionOfPrimaryCtorCalls_CompilesVerifiesAndRuns()
+    {
+        // Exact shape of Oahu.Data's ExCodec.ToQuality / AudioQuality
+        // (open data class primary ctor with int32? params, built from int32
+        // literals inside a switch-expression arm).
+        var source = """
+            package AudioQualityShapePkg
+
+            import System
+
+            enum ECodec { Aax2232, Aax2264, Aax4464, Aax44128 }
+
+            open data class AudioQuality(SampleRate int32?, BitRate int32?) {
+            }
+
+            class ExCodec {
+                shared {
+                    func ToQuality(codec ECodec) AudioQuality? {
+                        return switch codec {
+                            case ECodec.Aax2232: AudioQuality(22050, 32)
+                            case ECodec.Aax2264: AudioQuality(22050, 64)
+                            case ECodec.Aax4464: AudioQuality(44100, 64)
+                            case ECodec.Aax44128: AudioQuality(44100, 128)
+                            default: default(AudioQuality?)
+                        }
+                    }
+                }
+            }
+
+            let q = ExCodec.ToQuality(ECodec.Aax2232)!!
+            Console.WriteLine(q.SampleRate)
+            Console.WriteLine(q.BitRate)
+            """;
+
+        Assert.Equal("22050\n32\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExactArityPrimaryCtor_IntLiteralIntoNullableParams_CompilesVerifiesAndRuns()
+    {
+        var source = """
+            package NullableParamsPkg
+
+            import System
+
+            class Plain(SampleRate int32?, BitRate int32?) {
+            }
+
+            let p = Plain(22050, 32)
+            Console.WriteLine(p.SampleRate)
+            Console.WriteLine(p.BitRate)
+            """;
+
+        Assert.Equal("22050\n32\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExactArityPrimaryCtor_IntLiteralIntoWideningParams_CompilesVerifiesAndRuns()
+    {
+        var source = """
+            package WideningParamsPkg
+
+            import System
+
+            class Wide(BigNum int64, Frac double) {
+            }
+
+            let w = Wide(22050, 32)
+            Console.WriteLine(w.BigNum)
+            Console.WriteLine(w.Frac)
+            """;
+
+        Assert.Equal("22050\n32\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExactArityPrimaryCtor_DataClass_CompilesVerifiesAndRuns()
+    {
+        var source = """
+            package DataClassPkg
+
+            import System
+
+            open data class AudioQuality(SampleRate int32?, BitRate int32?) {
+            }
+
+            let q = AudioQuality(22050, 32)
+            Console.WriteLine(q.SampleRate)
+            Console.WriteLine(q.BitRate)
+            """;
+
+        Assert.Equal("22050\n32\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExactArityPrimaryCtor_NonLiteralVariableArgument_CompilesVerifiesAndRuns()
+    {
+        var source = """
+            package NonLiteralArgPkg
+
+            import System
+
+            class Plain(SampleRate int32?, BitRate int32?) {
+            }
+
+            func Make(a int32, b int32) Plain {
+                return Plain(a, b)
+            }
+
+            let p = Make(22050, 32)
+            Console.WriteLine(p.SampleRate)
+            Console.WriteLine(p.BitRate)
+            """;
+
+        Assert.Equal("22050\n32\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExactArityPrimaryCtor_GenericClass_CompilesVerifiesAndRuns()
+    {
+        var source = """
+            package GenericPrimaryCtorPkg
+
+            import System
+
+            class Box[T any](Value T) {
+            }
+
+            let b = Box[int64?](22050)
+            Console.WriteLine(b.Value)
+            """;
+
+        Assert.Equal("22050\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExactArityPrimaryCtor_UserDefinedImplicitConversion_CompilesVerifiesAndRuns()
+    {
+        var source = """
+            package UserDefinedConversionPkg
+
+            import System
+
+            struct Meters {
+                var V int32
+                func operator implicit (v int32) Meters {
+                    return Meters{V: v}
+                }
+            }
+
+            class Holder(Distance Meters) {
+            }
+
+            let h = Holder(5)
+            Console.WriteLine(h.Distance.V)
+            """;
+
+        Assert.Equal("5\n", CompileAndRun(source));
+    }
+
+    // --- Control cases: sibling paths that were already correct and must
+    // remain unaffected by the fix. ---
+
+    [Fact]
+    public void Control_ExplicitInitConstructor_CompilesVerifiesAndRuns()
+    {
+        var source = """
+            package ExplicitCtorControlPkg
+
+            import System
+
+            class Plain {
+                var SampleRate int32?
+                var BitRate int32?
+                init(sampleRate int32?, bitRate int32?) {
+                    this.SampleRate = sampleRate
+                    this.BitRate = bitRate
+                }
+            }
+
+            let p = Plain(22050, 32)
+            Console.WriteLine(p.SampleRate)
+            Console.WriteLine(p.BitRate)
+            """;
+
+        Assert.Equal("22050\n32\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Control_OptionalParameterPrimaryCtor_CompilesVerifiesAndRuns()
+    {
+        var source = """
+            package OptionalParamControlPkg
+
+            import System
+
+            class Plain(SampleRate int32?, BitRate int32? = nil) {
+            }
+
+            let p = Plain(22050, 32)
+            Console.WriteLine(p.SampleRate)
+            Console.WriteLine(p.BitRate)
+            """;
+
+        Assert.Equal("22050\n32\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Control_RegularFunctionCall_CompilesVerifiesAndRuns()
+    {
+        var source = """
+            package RegularCallControlPkg
+
+            import System
+
+            func Foo(x int32?) int32? {
+                return x
+            }
+
+            Console.WriteLine(Foo(5))
+            """;
+
+        Assert.Equal("5\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2364_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2364PrimaryConstructorConversionBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2364PrimaryConstructorConversionBindingTests.cs
@@ -1,0 +1,215 @@
+// <copyright file="Issue2364PrimaryConstructorConversionBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2364: the fixed-arity/non-optional argument-binding loop in
+/// <c>OverloadResolver.BindConstructorCallExpressionCore</c> validated that an
+/// argument's conversion to its primary-constructor parameter type was
+/// implicit, but never bound it — leaving the raw, unconverted argument in the
+/// bound tree. The emitter then had nothing to compensate with, producing
+/// unverifiable IL despite a clean compile.
+///
+/// These tests inspect the BOUND TREE directly (not just diagnostics, and not
+/// via emitted IL) to prove the fix actually threads a real conversion node
+/// through every primary-constructor argument that needs one, while leaving
+/// already-correct sibling paths (explicit <c>init(...)</c> constructors, the
+/// optional-parameter primary-constructor path, and ordinary method/function
+/// calls) unaffected.
+/// </summary>
+public class Issue2364PrimaryConstructorConversionBindingTests
+{
+    [Fact]
+    public void ExactArityPrimaryCtor_IntLiteralIntoNullableParam_BindsConversionExpression()
+    {
+        var source = @"
+class Plain(SampleRate int32?, BitRate int32?) {}
+let p = Plain(22050, 32)
+0
+";
+        var argument = GetFirstConstructorCallArgument(source, "Plain");
+        Assert.IsType<BoundConversionExpression>(argument);
+        Assert.IsType<NullableTypeSymbol>(argument.Type);
+    }
+
+    [Fact]
+    public void ExactArityPrimaryCtor_IntLiteralIntoWideningParams_BindsConversionExpressions()
+    {
+        var source = @"
+class Wide(BigNum int64, Frac double) {}
+let w = Wide(22050, 32)
+0
+";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(result.Diagnostics);
+
+        var call = FindConstructorCall(compilation, "Wide");
+        Assert.NotNull(call);
+        Assert.Equal(2, call.Arguments.Length);
+        Assert.IsType<BoundConversionExpression>(call.Arguments[0]);
+        Assert.Equal(TypeSymbol.Int64, call.Arguments[0].Type);
+        Assert.IsType<BoundConversionExpression>(call.Arguments[1]);
+        Assert.Equal(TypeSymbol.Float64, call.Arguments[1].Type);
+    }
+
+    [Fact]
+    public void ExactArityPrimaryCtor_DataClass_BindsConversionExpression()
+    {
+        var source = @"
+open data class AudioQuality(SampleRate int32?, BitRate int32?) {}
+let q = AudioQuality(22050, 32)
+0
+";
+        var argument = GetFirstConstructorCallArgument(source, "AudioQuality");
+        Assert.IsType<BoundConversionExpression>(argument);
+        Assert.IsType<NullableTypeSymbol>(argument.Type);
+    }
+
+    [Fact]
+    public void ExactArityPrimaryCtor_NonLiteralVariableArgument_BindsConversionExpression()
+    {
+        var source = @"
+class Plain(SampleRate int32?, BitRate int32?) {}
+let a = 22050
+let b = 32
+let p = Plain(a, b)
+0
+";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(result.Diagnostics);
+
+        var call = FindConstructorCall(compilation, "Plain");
+        Assert.NotNull(call);
+        Assert.IsType<BoundConversionExpression>(call.Arguments[0]);
+        Assert.IsType<NullableTypeSymbol>(call.Arguments[0].Type);
+        Assert.IsType<BoundConversionExpression>(call.Arguments[1]);
+        Assert.IsType<NullableTypeSymbol>(call.Arguments[1].Type);
+    }
+
+    [Fact]
+    public void ExactArityPrimaryCtor_UserDefinedImplicitConversion_BindsConversion()
+    {
+        var source = @"
+struct Meters {
+    var V int32
+    func operator implicit (v int32) Meters {
+        return Meters{V: v}
+    }
+}
+class Holder(Distance Meters) {}
+let h = Holder(5)
+0
+";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(result.Diagnostics);
+
+        var call = FindConstructorCall(compilation, "Holder");
+        Assert.NotNull(call);
+        // A user-defined conversion argument does not have to surface as a
+        // BoundConversionExpression wrapper node (the user-defined-conversion
+        // call itself is the converted value), but it MUST no longer be the
+        // raw int32 literal — the argument's static type must match the
+        // parameter type (Meters), proving some conversion step ran.
+        Assert.NotEqual(TypeSymbol.Int32, call.Arguments[0].Type);
+    }
+
+    // --- Control cases: sibling paths that were already correct and must
+    // remain unaffected by the fix. ---
+
+    [Fact]
+    public void Control_ExplicitInitConstructor_AlreadyBindsConversion()
+    {
+        var source = @"
+class Plain {
+    var SampleRate int32?
+    var BitRate int32?
+    init(sampleRate int32?, bitRate int32?) {
+        this.SampleRate = sampleRate
+        this.BitRate = bitRate
+    }
+}
+let p = Plain(22050, 32)
+0
+";
+        var argument = GetFirstConstructorCallArgument(source, "Plain");
+        Assert.IsType<BoundConversionExpression>(argument);
+        Assert.IsType<NullableTypeSymbol>(argument.Type);
+    }
+
+    [Fact]
+    public void Control_OptionalParameterPrimaryCtor_AlreadyBindsConversion()
+    {
+        var source = @"
+class Plain(SampleRate int32?, BitRate int32? = nil) {}
+let p = Plain(22050, 32)
+0
+";
+        var argument = GetFirstConstructorCallArgument(source, "Plain");
+        Assert.IsType<BoundConversionExpression>(argument);
+        Assert.IsType<NullableTypeSymbol>(argument.Type);
+    }
+
+    [Fact]
+    public void Control_RegularFunctionCall_AlreadyBindsConversion()
+    {
+        var source = @"
+func Foo(x int32?) {}
+Foo(5)
+0
+";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(result.Diagnostics);
+
+        var call = compilation.GlobalScope.Statements
+            .OfType<BoundExpressionStatement>()
+            .Select(s => s.Expression)
+            .OfType<BoundCallExpression>()
+            .FirstOrDefault(c => c.Function.Name == "Foo");
+        Assert.NotNull(call);
+        Assert.IsType<BoundConversionExpression>(call.Arguments[0]);
+        Assert.IsType<NullableTypeSymbol>(call.Arguments[0].Type);
+    }
+
+    private static BoundExpression GetFirstConstructorCallArgument(string source, string typeName)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(result.Diagnostics);
+
+        var call = FindConstructorCall(compilation, typeName);
+        Assert.NotNull(call);
+        Assert.True(call.Arguments.Length > 0);
+        return call.Arguments[0];
+    }
+
+    private static BoundConstructorCallExpression FindConstructorCall(Compilation compilation, string typeName)
+    {
+        return compilation.GlobalScope.Statements
+            .OfType<BoundVariableDeclaration>()
+            .Select(s => s.Initializer)
+            .OfType<BoundConstructorCallExpression>()
+            .FirstOrDefault(c => c.StructType.Name == typeName);
+    }
+
+}


### PR DESCRIPTION
## Root cause

`OverloadResolver.BindConstructorCallExpressionCore`'s fixed-arity (non-optional-parameter) argument-binding loop validated that an argument's conversion to its primary-constructor parameter type was *implicit*, but never actually **bound** it via `conversions.BindConversion(...)`. The raw, unconverted argument reached the emitter, which has no compensating logic, producing unverifiable IL (`ilverify` `StackUnexpected`) despite a clean, diagnostic-free compile — whenever a primary-constructor call needed a non-identity implicit conversion (nullable wrapping, integral/floating widening, user-defined implicit conversions, generic substitutions, etc.).

This is not a synthetic corner case: it silently affected real-world code encountered while migrating Oahu, e.g. `ExCodec.ToQuality`'s switch-expression arms building `AudioQuality` (`open data class AudioQuality(SampleRate int32?, BitRate int32?)`) from `int32` literals:

```gs
func ToQuality(codec ECodec) AudioQuality? {
    return switch codec {
        case ECodec.Aax2232: AudioQuality(22050, 32)
        // ...
    }
}
```

## Fix

Added the missing `else` branch in the loop, mirroring the already-correct sibling paths (`BindExplicitConstructorCallExpression`'s equivalent loop, and the `primaryHasOptional` branch earlier in the same method):

```csharp
else
{
    boundArguments[i] = conversions.BindConversion(parameterSyntax[i].Location, argument, parameter.Type);
}
```

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue2364PrimaryConstructorConversionBindingTests.cs` — 8 binder-level tests that inspect the bound tree directly, confirming a real `BoundConversionExpression` now threads through for: `int32` literal into `int32?` param, `int32` literal into `int64`/`double` widening params, a data-class primary ctor, and a non-literal (variable) argument. Plus 3 control tests proving the already-correct sibling paths (explicit `init(...)` ctor, optional-parameter primary ctor, plain function call) remain unaffected.
- `test/Compiler.Tests/Emit/Issue2364PrimaryConstructorConversionEmitTests.cs` — 10 compile + ilverify + execute tests covering the same shapes end-to-end, including the exact Oahu `ExCodec.ToQuality`/`AudioQuality` switch-expression shape, a generic primary-ctor class (`Box[T any](Value T)`), and a user-defined implicit conversion, plus the same 3 control cases.

**Regression-sanity-checked**: reverting the fix (via `git stash`) makes exactly the expected subset of new tests fail with the original `StackUnexpected` shape (e.g. "found Int32, expected Nullable`1<int32>"), while the control tests for already-correct sibling paths keep passing — confirming the tests genuinely exercise the fixed code path and aren't spuriously green.

**Full suite status (all green, 0 analyzer warnings)**:

| Suite | Result |
|---|---|
| Core.Tests | 6107 passed, 1 skipped, 0 failed |
| Compiler.Tests | 2988 passed, 0 failed |
| Cs2Gs.Tests | 1383 passed, 0 failed |
| InternalAnalyzers.Tests | 7 passed, 0 failed |

## Deferred / out of scope

A distinct, unrelated defect (EF Core `Migration` lambda parameter-type erasure in expression trees — emitting `Expression<Func<object,object>>` instead of `Expression<Func<AnonymousTypeN,object>>`, 21 occurrences in the Oahu.Data corpus) was identified during the same investigation but is **not** the subject of this PR; it is a residual gap from already-closed #2224 and will be reported/filed separately.

Closes #2364
