### PR TITLE
Fix #2365: preserve substituted user types through imported generic Expression<>/Func<> parameters

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -976,14 +976,38 @@ internal sealed class ConversionClassifier
         }
 
         var openParamType = openParams[paramIndex].ParameterType;
-        if (openParamType.IsGenericParameter
-            && openParamType.DeclaringMethod == null
-            && openParamType.GenericParameterPosition < imported.TypeArguments.Length)
+        if (openParamType.IsByRef)
         {
-            return imported.TypeArguments[openParamType.GenericParameterPosition];
+            openParamType = openParamType.GetElementType();
         }
 
-        return null;
+        if (openParamType == null)
+        {
+            return null;
+        }
+
+        // Issue #2365: the bare-slot check above only covers a parameter whose
+        // OWN type IS the declaring type's generic parameter directly (`!0` of
+        // `List[T].Add(!0)`). A parameter that merely MENTIONS that type
+        // parameter nested inside a constructed generic — e.g.
+        // `Expression<Func<TColumns,object>>` on
+        // `CreateTableBuilder[TColumns].PrimaryKey` — falls through unhandled,
+        // so the closed CLR shape (`Expression<Func<object,object>>`) is used
+        // as the conversion target, erasing the lambda's expression-tree
+        // delegate to `object` even though the earlier delegate-rebind step
+        // (see `TryBuildSymbolicDelegateTargetForMethodParam`) already
+        // recovered the correct symbolic literal shape. Recover the full
+        // substituted shape via the same general recursive projection used by
+        // the method-type-argument sibling below
+        // (<see cref="TrySubstituteParameterTypeFromMethodTypeArgs"/>), which
+        // already understands arrays, tuples, nullable, and arbitrarily nested
+        // constructed generics (delegates, `Expression&lt;&gt;`, ...).
+        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openParamType, openDef, imported.TypeArguments);
+        return mapped != null
+            && mapped != TypeSymbol.Error
+            && (TypeSymbol.ContainsTypeParameter(mapped) || TypeSymbol.ContainsSameCompilationUserType(mapped))
+            ? mapped
+            : null;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2135,6 +2135,24 @@ internal sealed partial class ExpressionBinder
     /// generic parameters.
     /// </summary>
     private static bool TryResolveOpenStaticMethod(Type openDefinition, MethodInfo closedMethod, out MethodInfo openMethod)
+        => TryResolveOpenMethodByToken(openDefinition, closedMethod, BindingFlags.Static, out openMethod);
+
+    /// <summary>
+    /// Issue #2365: instance-method sibling of <see cref="TryResolveOpenStaticMethod"/>.
+    /// Resolves the open generic <em>type</em> definition's INSTANCE method
+    /// corresponding to <paramref name="closedMethod"/> (a non-generic instance
+    /// method reflected off a constructed generic receiver, e.g.
+    /// <c>CreateTableBuilder&lt;object&gt;.PrimaryKey</c>) by metadata-token
+    /// identity, yielding the open shape (e.g. <c>CreateTableBuilder&lt;&gt;.PrimaryKey</c>)
+    /// whose parameter types are stated in terms of the type's own open generic
+    /// parameters. This lets a delegate/expression-tree parameter that closes
+    /// over the DECLARING TYPE's type parameter (rather than a method-level one)
+    /// recover its symbolic shape even though the method itself is not generic.
+    /// </summary>
+    private static bool TryResolveOpenInstanceMethod(Type openDefinition, MethodInfo closedMethod, out MethodInfo openMethod)
+        => TryResolveOpenMethodByToken(openDefinition, closedMethod, BindingFlags.Instance, out openMethod);
+
+    private static bool TryResolveOpenMethodByToken(Type openDefinition, MethodInfo closedMethod, BindingFlags kindFlag, out MethodInfo openMethod)
     {
         openMethod = null;
         if (openDefinition == null || closedMethod == null)
@@ -2144,7 +2162,7 @@ internal sealed partial class ExpressionBinder
 
         try
         {
-            foreach (var candidate in openDefinition.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+            foreach (var candidate in openDefinition.GetMethods(kindFlag | BindingFlags.Public | BindingFlags.NonPublic))
             {
                 if (candidate.MetadataToken == closedMethod.MetadataToken && candidate.Module == closedMethod.Module)
                 {
@@ -2181,7 +2199,16 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var invoke = openParameterType.GetMethodSafe("Invoke");
+        // Issue #2365: an `Expression<TDelegate>` parameter is not itself a
+        // delegate (it exposes no `Invoke`), so unwrap it to the wrapped open
+        // delegate type first, mirroring the identical unwrap in the
+        // method-parameter sibling <see cref="TryBuildSymbolicDelegateTargetForMethodParam"/>.
+        if (MemberLookup.TryGetExpressionTreeDelegateType(openParameterType, out var unwrappedParameterType))
+        {
+            openParameterType = unwrappedParameterType;
+        }
+
+        var invoke = openParameterType?.GetMethodSafe("Invoke");
         if (invoke == null)
         {
             return false;
@@ -2202,20 +2229,29 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
-    /// Issue #1512: builds a symbolic <see cref="FunctionTypeSymbol"/> for a
-    /// lambda argument bound to a generic CLR/imported method whose delegate
-    /// parameter mentions a method type parameter (e.g.
-    /// <c>Task.ContinueWith&lt;TResult&gt;(Func&lt;Task,TResult&gt;)</c>). The
-    /// CLOSED method's parameter is type-erased (<c>Func&lt;Task,object&gt;</c>),
+    /// Issue #1512 / #2365: builds a symbolic <see cref="FunctionTypeSymbol"/> for
+    /// a lambda argument bound to a CLR/imported method whose delegate (or
+    /// <c>Expression&lt;TDelegate&gt;</c>-wrapped delegate) parameter mentions a
+    /// generic type parameter — either a METHOD-level one (e.g.
+    /// <c>Task.ContinueWith&lt;TResult&gt;(Func&lt;Task,TResult&gt;)</c>, #1512) or
+    /// the DECLARING TYPE's own type parameter closed over by a symbolic
+    /// receiver on a non-generic method (e.g.
+    /// <c>CreateTableBuilder&lt;TColumns&gt;.PrimaryKey(Expression&lt;Func&lt;TColumns,object&gt;&gt;)</c>,
+    /// #2365). The CLOSED method's parameter is type-erased
+    /// (<c>Expression&lt;Func&lt;object,object&gt;&gt;</c> / <c>Func&lt;Task,object&gt;</c>),
     /// which would force the lambda's bound function type — and therefore its
-    /// synthesized return — to <c>object</c>, so the delegate emits as
-    /// <c>Func&lt;Task,object&gt;</c> instead of <c>Func&lt;Task,T&gt;</c>. This
-    /// recovers the real shape by substituting the inferred symbolic method type
-    /// arguments (and any receiver-level type arguments) through the OPEN
-    /// method's delegate parameter via <see cref="MemberLookup.MapOpenClrTypeToSymbolic(Type, Type, ImmutableArray{TypeSymbol}, MethodInfo, ImmutableArray{TypeSymbol})"/>.
-    /// Returns <see langword="false"/> (deferring to the erased target) when the
-    /// parameter is not a delegate, the method is not generic, or no recovered
-    /// position contains a type parameter / same-compilation user type.
+    /// synthesized return/parameter shape — to <c>object</c>, producing an
+    /// unverifiable delegate. This recovers the real shape by substituting the
+    /// inferred symbolic method type arguments AND/OR the receiver's symbolic
+    /// type arguments through the OPEN method's delegate parameter via
+    /// <see cref="MemberLookup.MapOpenClrTypeToSymbolic(Type, Type, ImmutableArray{TypeSymbol}, MethodInfo, ImmutableArray{TypeSymbol})"/>,
+    /// unwrapping an <c>Expression&lt;TDelegate&gt;</c> parameter shape to its
+    /// inner delegate first so both direct-delegate and expression-tree targets
+    /// share the same recovery path. Returns <see langword="false"/> (deferring
+    /// to the erased target) when neither the method nor the receiver carries a
+    /// symbolic type argument, the parameter is not a delegate/expression-tree
+    /// shape, or no recovered position contains a type parameter /
+    /// same-compilation user type.
     /// </summary>
     private static bool TryBuildSymbolicDelegateTargetForMethodParam(
         MethodInfo closedMethod,
@@ -2225,11 +2261,29 @@ internal sealed partial class ExpressionBinder
         out FunctionTypeSymbol target)
     {
         target = null;
-        if (closedMethod == null
-            || !closedMethod.IsGenericMethod
-            || symbolicMethodTypeArgs.IsDefaultOrEmpty
-            || !symbolicMethodTypeArgs.Any(s => s != null
-                && (TypeSymbol.ContainsTypeParameter(s) || TypeSymbol.ContainsSameCompilationUserType(s))))
+        if (closedMethod == null)
+        {
+            return false;
+        }
+
+        var methodHasSymbolicArgs = closedMethod.IsGenericMethod
+            && !symbolicMethodTypeArgs.IsDefaultOrEmpty
+            && symbolicMethodTypeArgs.Any(s => s != null
+                && (TypeSymbol.ContainsTypeParameter(s) || TypeSymbol.ContainsSameCompilationUserType(s)));
+
+        Type receiverOpenDef = null;
+        ImmutableArray<TypeSymbol> receiverTypeArgs = default;
+        if (receiverType is ImportedTypeSymbol imp && imp.OpenDefinition != null && !imp.TypeArguments.IsDefaultOrEmpty)
+        {
+            receiverOpenDef = imp.OpenDefinition;
+            receiverTypeArgs = imp.TypeArguments;
+        }
+
+        var receiverHasSymbolicArgs = receiverOpenDef != null
+            && receiverTypeArgs.Any(s => s != null
+                && (TypeSymbol.ContainsTypeParameter(s) || TypeSymbol.ContainsSameCompilationUserType(s)));
+
+        if (!methodHasSymbolicArgs && !receiverHasSymbolicArgs)
         {
             return false;
         }
@@ -2238,7 +2292,26 @@ internal sealed partial class ExpressionBinder
         ParameterInfo[] openParams;
         try
         {
-            openMethod = closedMethod.IsGenericMethodDefinition ? closedMethod : closedMethod.GetGenericMethodDefinition();
+            if (closedMethod.IsGenericMethod)
+            {
+                openMethod = closedMethod.IsGenericMethodDefinition ? closedMethod : closedMethod.GetGenericMethodDefinition();
+            }
+            else if (receiverOpenDef != null && !closedMethod.IsStatic
+                && TryResolveOpenInstanceMethod(receiverOpenDef, closedMethod, out var resolvedOpenMethod))
+            {
+                // Issue #2365: the method itself has no generic parameters of
+                // its own — TColumns belongs to the DECLARING TYPE
+                // (`CreateTableBuilder[TColumns]`) — so recover the open shape
+                // from the receiver's open type definition rather than from
+                // `GetGenericMethodDefinition()` (which only applies to
+                // method-level generics).
+                openMethod = resolvedOpenMethod;
+            }
+            else
+            {
+                return false;
+            }
+
             openParams = openMethod.GetParameters();
         }
         catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
@@ -2252,18 +2325,22 @@ internal sealed partial class ExpressionBinder
         }
 
         var openParamType = openParams[paramIndex].ParameterType;
+
+        // Issue #2365: an `Expression<TDelegate>` parameter is not itself a
+        // delegate (it exposes no `Invoke`), so unwrap it to the wrapped open
+        // delegate type first. Both a direct delegate parameter and an
+        // expression-tree-wrapped one recover through the identical
+        // substitution path below; the caller compares the result against the
+        // literal's own (unwrapped) delegate function type either way.
+        if (MemberLookup.TryGetExpressionTreeDelegateType(openParamType, out var unwrappedOpenDelegate))
+        {
+            openParamType = unwrappedOpenDelegate;
+        }
+
         var invoke = openParamType?.GetMethodSafe("Invoke");
         if (invoke == null)
         {
             return false;
-        }
-
-        Type receiverOpenDef = null;
-        ImmutableArray<TypeSymbol> receiverTypeArgs = default;
-        if (receiverType is ImportedTypeSymbol imp && imp.OpenDefinition != null && !imp.TypeArguments.IsDefaultOrEmpty)
-        {
-            receiverOpenDef = imp.OpenDefinition;
-            receiverTypeArgs = imp.TypeArguments;
         }
 
         var invokeParameters = invoke.GetParameters();

--- a/test/Compiler.Tests/Emit/Issue2365ExpressionTreeGenericSubstitutionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2365ExpressionTreeGenericSubstitutionEmitTests.cs
@@ -1,0 +1,295 @@
+// <copyright file="Issue2365ExpressionTreeGenericSubstitutionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2365 — real-assembly, IL-verification-level regression coverage. Binding alone never
+/// reported an error for the reported bug (<see cref="GSharp.Core.Tests.CodeAnalysis.Binding.Issue2365ExpressionTreeGenericSubstitutionTests"/>
+/// covers the binder/diagnostics surface); the actual defect only manifests in the EMITTED
+/// assembly, where an imported generic method's <c>Expression&lt;Func&lt;TColumns,object&gt;&gt;</c>
+/// parameter — closed over the DECLARING TYPE's own type parameter via a symbolic receiver — was
+/// erased all the way down to <c>Expression&lt;Func&lt;object,object&gt;&gt;</c>, which ILVerify
+/// rejects (<c>StackUnexpected</c>) and which a real runtime <see cref="LambdaExpression"/>
+/// inspection reveals as <see cref="LambdaExpression.Parameters"/>[0].Type == <see cref="object"/>
+/// instead of the real closed-over type. These tests emit a real two-assembly (imported
+/// library + consumer) pair to disk, ILVerify the consumer, then load and invoke it to assert the
+/// runtime <see cref="LambdaExpression"/> shape is exactly right.
+/// </summary>
+public class Issue2365ExpressionTreeGenericSubstitutionEmitTests
+{
+    [Fact]
+    public void PrimaryKeyExpressionParameter_PreservesClosedOverClassType_IlVerifiesAndRunsCorrectly()
+    {
+        var (libraryPath, consumerPath, consumerAssemblyName) = CompileLibraryAndConsumer(
+            """
+            package Demo
+            import Lib
+            import System
+
+            data class Cols(Id string)
+
+            func Run(migrationBuilder MigrationBuilder) CreateTableBuilder[Cols] {
+                return migrationBuilder.CreateTable("Accounts", (table ColumnsBuilder) -> Cols{Id: table.Column("id")}, "dbo", (table CreateTableBuilder[Cols]) -> {
+                    table.PrimaryKey("PK_Accounts", (x Cols) -> x.Id)
+                })
+            }
+            """,
+            nameof(PrimaryKeyExpressionParameter_PreservesClosedOverClassType_IlVerifiesAndRunsCorrectly));
+
+        // Real ILVerify pass is the direct regression check for the reported "Oahu.Data" 21-mismatch
+        // StackUnexpected failure: before the fix, this assembly failed ILVerify with
+        // "found ref 'Expression<Func<object,object>>' expected ref 'Expression<Func<Cols,object>>'".
+        IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
+
+        var (libraryAsm, consumerAsm, loadContext) = LoadLibraryAndConsumer(libraryPath, consumerPath, consumerAssemblyName);
+        try
+        {
+            var colsType = consumerAsm.GetTypes().Single(t => t.Name == "Cols");
+            var migrationBuilderType = libraryAsm.GetTypes().Single(t => t.Name == "MigrationBuilder");
+            var migrationBuilder = Activator.CreateInstance(migrationBuilderType);
+
+            var run = GetProgramMethod(consumerAsm, "Run");
+            var tableBuilder = run.Invoke(null, new[] { migrationBuilder });
+            Assert.NotNull(tableBuilder);
+
+            var getCapturedExpr = tableBuilder!.GetType().GetMethod("GetCapturedExpr", BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(getCapturedExpr);
+            var capturedExpr = getCapturedExpr!.Invoke(tableBuilder, null);
+
+            var lambda = Assert.IsAssignableFrom<LambdaExpression>(capturedExpr);
+            Assert.NotEqual(typeof(object), lambda.Parameters[0].Type);
+            Assert.Equal(colsType, lambda.Parameters[0].Type);
+
+            var compiled = lambda.Compile();
+            var colsInstance = Activator.CreateInstance(colsType, "abc-123");
+            var invoked = compiled.DynamicInvoke(colsInstance);
+            Assert.Equal("abc-123", invoked);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    [Fact]
+    public void PrimaryKeyExpressionParameter_StructTypeArgument_IlVerifiesAndRunsCorrectly()
+    {
+        var (libraryPath, consumerPath, consumerAssemblyName) = CompileLibraryAndConsumer(
+            """
+            package Demo
+            import Lib
+            import System
+
+            data struct StructCols(Id string)
+
+            func Run(migrationBuilder MigrationBuilder) CreateTableBuilder[StructCols] {
+                return migrationBuilder.CreateTable("Accounts", (table ColumnsBuilder) -> StructCols{Id: table.Column("id")}, "dbo", (table CreateTableBuilder[StructCols]) -> {
+                    table.PrimaryKey("PK_Accounts", (x StructCols) -> x.Id)
+                })
+            }
+            """,
+            nameof(PrimaryKeyExpressionParameter_StructTypeArgument_IlVerifiesAndRunsCorrectly));
+
+        IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
+
+        var (libraryAsm, consumerAsm, loadContext) = LoadLibraryAndConsumer(libraryPath, consumerPath, consumerAssemblyName);
+        try
+        {
+            var structColsType = consumerAsm.GetTypes().Single(t => t.Name == "StructCols");
+            var migrationBuilderType = libraryAsm.GetTypes().Single(t => t.Name == "MigrationBuilder");
+            var migrationBuilder = Activator.CreateInstance(migrationBuilderType);
+
+            var run = GetProgramMethod(consumerAsm, "Run");
+            var tableBuilder = run.Invoke(null, new[] { migrationBuilder });
+            Assert.NotNull(tableBuilder);
+
+            var getCapturedExpr = tableBuilder!.GetType().GetMethod("GetCapturedExpr", BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(getCapturedExpr);
+            var capturedExpr = getCapturedExpr!.Invoke(tableBuilder, null);
+
+            var lambda = Assert.IsAssignableFrom<LambdaExpression>(capturedExpr);
+            Assert.NotEqual(typeof(object), lambda.Parameters[0].Type);
+            Assert.Equal(structColsType, lambda.Parameters[0].Type);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    /// <summary>
+    /// Issue #2224 follow-up at the runtime level: unlike the original #2224 test (a single-assembly,
+    /// directly-annotated-parameter anonymous-class expression tree), this exercises the SAME kind of
+    /// "class-shaped value flowing through an expression tree" guarantee (member/property shape must
+    /// survive, not erase to <c>object</c>) for a class whose identity is only established via an
+    /// IMPORTED generic method's symbolic receiver substitution — the #2365 code path.
+    /// </summary>
+    [Fact]
+    public void Issue2224Followup_MultiPropertyClassThroughImportedGenericExpressionTree_PreservesMemberShape()
+    {
+        var (libraryPath, consumerPath, consumerAssemblyName) = CompileLibraryAndConsumer(
+            """
+            package Demo
+            import Lib
+            import System
+
+            data class Cols(Id string, Name string)
+
+            func Run(migrationBuilder MigrationBuilder) CreateTableBuilder[Cols] {
+                return migrationBuilder.CreateTable("Accounts", (table ColumnsBuilder) -> Cols{Id: table.Column("id"), Name: table.Column("name")}, "dbo", (table CreateTableBuilder[Cols]) -> {
+                    table.PrimaryKey("PK_Accounts", (x Cols) -> x.Id)
+                })
+            }
+            """,
+            nameof(Issue2224Followup_MultiPropertyClassThroughImportedGenericExpressionTree_PreservesMemberShape));
+
+        IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
+
+        var (libraryAsm, consumerAsm, loadContext) = LoadLibraryAndConsumer(libraryPath, consumerPath, consumerAssemblyName);
+        try
+        {
+            var colsType = consumerAsm.GetTypes().Single(t => t.Name == "Cols");
+            var migrationBuilderType = libraryAsm.GetTypes().Single(t => t.Name == "MigrationBuilder");
+            var migrationBuilder = Activator.CreateInstance(migrationBuilderType);
+
+            var run = GetProgramMethod(consumerAsm, "Run");
+            var tableBuilder = run.Invoke(null, new[] { migrationBuilder });
+            var getCapturedExpr = tableBuilder!.GetType().GetMethod("GetCapturedExpr", BindingFlags.Public | BindingFlags.Instance);
+            var capturedExpr = getCapturedExpr!.Invoke(tableBuilder, null);
+
+            var lambda = Assert.IsAssignableFrom<LambdaExpression>(capturedExpr);
+            Assert.Equal(colsType, lambda.Parameters[0].Type);
+
+            // The body reaches a MemberExpression over the real Cols.Id property (not `object`-typed
+            // reflection member access), matching the property-shape preservation goal of #2224.
+            var body = lambda.Body;
+            while (body is UnaryExpression unary && (body.NodeType == ExpressionType.Convert || body.NodeType == ExpressionType.ConvertChecked))
+            {
+                body = unary.Operand;
+            }
+
+            // `data class` primary-constructor members reify as real fields (not auto-properties);
+            // either way, the member's DECLARING TYPE must be the real `Cols` type, not `object`.
+            var member = Assert.IsAssignableFrom<MemberExpression>(body);
+            Assert.Equal(colsType, member.Member.DeclaringType);
+            Assert.Equal("Id", member.Member.Name);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static MethodInfo GetProgramMethod(Assembly asm, string name)
+    {
+        var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+        Assert.NotNull(programType);
+        var method = programType!.GetMethod(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return method!;
+    }
+
+    private static string LibraryDirectory()
+    {
+        var dir = Path.Combine(AppContext.BaseDirectory, "Issue2365Emit");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string EmitSharedLibrary()
+    {
+        var libraryPath = Path.Combine(LibraryDirectory(), "Issue2365Emit.Library.dll");
+        if (File.Exists(libraryPath))
+        {
+            return libraryPath;
+        }
+
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Lib
+                import System
+                import System.Linq.Expressions
+
+                class ColumnsBuilder {
+                    func Column(name string) string { return name }
+                }
+
+                class CreateTableBuilder[TColumns] {
+                    private var capturedExpr Expression[Func[TColumns, object]]
+
+                    func PrimaryKey(name string, columns Expression[Func[TColumns, object]]) CreateTableBuilder[TColumns] {
+                        capturedExpr = columns
+                        return this
+                    }
+
+                    func GetCapturedExpr() Expression[Func[TColumns, object]] {
+                        return capturedExpr
+                    }
+                }
+
+                class MigrationBuilder {
+                    func CreateTable[TColumns](name string, columns Func[ColumnsBuilder, TColumns], schema string, constraints Action[CreateTableBuilder[TColumns]]) CreateTableBuilder[TColumns] {
+                        var builder = CreateTableBuilder[TColumns]{}
+                        constraints(builder)
+                        return builder
+                    }
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using var peStream = File.Create(libraryPath);
+        var result = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2365Emit.Library");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return libraryPath;
+    }
+
+    private static (string LibraryPath, string ConsumerPath, string ConsumerAssemblyName) CompileLibraryAndConsumer(string consumerSource, string testName)
+    {
+        var libraryPath = EmitSharedLibrary();
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        var consumerAssemblyName = "Issue2365Emit.Consumer." + testName;
+        var consumerPath = Path.Combine(LibraryDirectory(), consumerAssemblyName + ".dll");
+
+        var consumer = new Compilation(resolver, SyntaxTree.Parse(SourceText.From(consumerSource)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var peStream = File.Create(consumerPath))
+        {
+            var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: consumerAssemblyName);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        return (libraryPath, consumerPath, consumerAssemblyName);
+    }
+
+    private static (Assembly LibraryAssembly, Assembly ConsumerAssembly, AssemblyLoadContext LoadContext) LoadLibraryAndConsumer(
+        string libraryPath, string consumerPath, string consumerAssemblyName)
+    {
+        var loadContext = new AssemblyLoadContext(consumerAssemblyName, isCollectible: true);
+        var libraryAsm = loadContext.LoadFromAssemblyPath(libraryPath);
+        loadContext.Resolving += (ctx, name) =>
+            name.Name == libraryAsm.GetName().Name ? libraryAsm : null;
+        var consumerAsm = loadContext.LoadFromAssemblyPath(consumerPath);
+        return (libraryAsm, consumerAsm, loadContext);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2365ExpressionTreeGenericSubstitutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2365ExpressionTreeGenericSubstitutionTests.cs
@@ -1,0 +1,511 @@
+// <copyright file="Issue2365ExpressionTreeGenericSubstitutionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2365: an imported generic method whose delegate/expression-tree parameter closes over
+/// the DECLARING TYPE's own type parameter via a symbolic receiver (e.g. EF Core's
+/// <c>CreateTableBuilder&lt;TColumns&gt;.PrimaryKey(string, Expression&lt;Func&lt;TColumns,object&gt;&gt;)</c>)
+/// erased the lambda's target type all the way down to <c>Expression&lt;Func&lt;object,object&gt;&gt;</c>,
+/// producing an unverifiable assembly (ILVerify <c>StackUnexpected</c>: found
+/// <c>Expression&lt;Func&lt;object,object&gt;&gt;</c>, expected
+/// <c>Expression&lt;Func&lt;TColumns,object&gt;&gt;</c>) even though binding itself reported no error.
+///
+/// Root cause (two compounding, EF-agnostic defects, both fixed):
+/// <list type="number">
+/// <item><description>
+/// <c>ExpressionBinder.Calls.TryBuildSymbolicDelegateTargetForMethodParam</c> (used to rebind a lambda
+/// LITERAL's own function type before it is checked against a parameter) only recovered a symbolic
+/// delegate target when the METHOD ITSELF was generic (issue #1512's
+/// <c>Task.ContinueWith&lt;TResult&gt;</c> shape). A NON-generic method whose delegate parameter mentions
+/// the DECLARING TYPE's type parameter through a symbolic RECEIVER (our case) fell through untouched.
+/// It also never unwrapped an <c>Expression&lt;TDelegate&gt;</c> parameter (which has no <c>Invoke</c>
+/// method) before probing for one, so even the ALREADY-supported method-generic case would have failed
+/// for an <c>Expression&lt;&gt;</c>-wrapped parameter.
+/// </description></item>
+/// <item><description>
+/// <c>ConversionClassifier.TrySubstituteParameterTypeFromReceiver</c> (used for the actual
+/// argument-to-parameter CONVERSION, downstream of and independent from the lambda-literal rebind above)
+/// only substituted a parameter type that WAS DIRECTLY the receiver's generic parameter slot, with no
+/// recursion into nested constructed generics such as <c>Expression&lt;Func&lt;TColumns,object&gt;&gt;</c>.
+/// Its sibling, <c>TrySubstituteParameterTypeFromMethodTypeArgs</c> (the method-type-argument
+/// equivalent), had already been generalized to the fully recursive
+/// <c>MemberLookup.MapOpenClrTypeToSymbolic</c> — the receiver-level sibling was simply never updated to
+/// match, so even after (1) recovered the correct symbolic delegate shape for the lambda LITERAL, the
+/// subsequent conversion of that literal to the declared <c>Expression&lt;Func&lt;TColumns,object&gt;&gt;</c>
+/// parameter type re-erased it back down to the CLR-closed, type-argument-less shape.
+/// </description></item>
+/// </list>
+/// Both fixes reuse the existing, EF-agnostic <c>MemberLookup.MapOpenClrTypeToSymbolic</c> substitution
+/// engine (already used by every other staged/deferred lambda and generic-substitution path in the
+/// binder) — there is no anonymous-type or EF-specific special case anywhere in the fix.
+/// </summary>
+public class Issue2365ExpressionTreeGenericSubstitutionTests
+{
+    [Fact]
+    public void ImportedInstanceMethod_ExpressionParameterClosedOverReceiverTypeArgument_Binds()
+    {
+        // The exact reported shape: PrimaryKey is a NON-generic instance method on
+        // CreateTableBuilder[TColumns]; its Expression[Func[TColumns,object]] parameter closes purely
+        // through the symbolic RECEIVER (the `table` parameter's own declared type), not through any
+        // method-level type argument.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            data class Cols(Id string)
+
+            func Run(migrationBuilder MigrationBuilder) {
+                migrationBuilder.CreateTable("Accounts", (table ColumnsBuilder) -> Cols{Id: table.Column("id")}, "dbo", (table CreateTableBuilder[Cols]) -> {
+                    table.PrimaryKey("PK_Accounts", (x Cols) -> x.Id)
+                })
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void ImportedInstanceMethod_StructTypeArgument_Binds()
+    {
+        // Value-type (struct) TColumns control: the substitution must also work when the closed-over
+        // type is a data struct, not just a reference type.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            data struct StructCols(Id string)
+
+            func Run(migrationBuilder MigrationBuilder) {
+                migrationBuilder.CreateTable("Accounts", (table ColumnsBuilder) -> StructCols{Id: table.Column("id")}, "dbo", (table CreateTableBuilder[StructCols]) -> {
+                    table.PrimaryKey("PK_Accounts", (x StructCols) -> x.Id)
+                })
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void ImportedInstanceMethod_ExplicitOuterTypeArguments_Binds()
+    {
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            data class Cols(Id string)
+
+            func Run(migrationBuilder MigrationBuilder) {
+                migrationBuilder.CreateTable[Cols]("Accounts", (table ColumnsBuilder) -> Cols{Id: table.Column("id")}, "dbo", (table CreateTableBuilder[Cols]) -> {
+                    table.PrimaryKey("PK_Accounts", (x Cols) -> x.Id)
+                })
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void ImportedInstanceMethod_MultipleLambdaParameters_Binds()
+    {
+        // Parameter-SHAPE coverage: the Expression's own delegate has TWO parameters of TColumns
+        // (Func[TColumns, TColumns, object]), not just one.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            data class Cols(Id string)
+
+            func Run(migrationBuilder MigrationBuilder) {
+                migrationBuilder.CreateTable("Accounts", (table ColumnsBuilder) -> Cols{Id: table.Column("id")}, "dbo", (table CreateTableBuilder[Cols]) -> {
+                    table.PrimaryKeyComposite("PK_Accounts", (a Cols, b Cols) -> a.Id)
+                })
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void ImportedInstanceMethod_ExpressionParameterNotInFirstPosition_Binds()
+    {
+        // Parameter-POSITION coverage: the Expression[] argument is the SECOND of three parameters,
+        // not the delegate-target-establishing first one.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            data class Cols(Id string)
+
+            func Run(migrationBuilder MigrationBuilder) {
+                migrationBuilder.CreateTable("Accounts", (table ColumnsBuilder) -> Cols{Id: table.Column("id")}, "dbo", (table CreateTableBuilder[Cols]) -> {
+                    table.IndexOn(true, (x Cols) -> x.Id, "IX_Accounts")
+                })
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void ImportedInstanceMethod_DirectActionShape_NotWrappedInExpression_Binds()
+    {
+        // Confirms the receiver-symbolic generalization (defect 1's gate fix) applies to a plain
+        // Action[TColumns] delegate too, not only Expression[Func[TColumns,object]] shapes.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            data class Cols(Id string)
+
+            func Run(migrationBuilder MigrationBuilder) {
+                migrationBuilder.CreateTable("Accounts", (table ColumnsBuilder) -> Cols{Id: table.Column("id")}, "dbo", (table CreateTableBuilder[Cols]) -> {
+                    table.ForEachColumn((x Cols) -> { })
+                })
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void ImportedInstanceMethod_NestedGenericComposition_Binds()
+    {
+        // TColumns appears nested inside another constructed generic
+        // (Expression[Func[Wrapper[TColumns], object]]), exercising the recursive substitution path in
+        // MemberLookup.MapOpenClrTypeToSymbolic beyond a single top-level type-parameter slot.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            data class Cols(Id string)
+
+            func Run(migrationBuilder MigrationBuilder) {
+                migrationBuilder.CreateTable("Accounts", (table ColumnsBuilder) -> Cols{Id: table.Column("id")}, "dbo", (table CreateTableBuilder[Cols]) -> {
+                    table.NestedSelector((w Wrapper[Cols]) -> w)
+                })
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void ImportedGenericConstructor_ExplicitTypeArgumentWithExpressionParameter_Binds()
+    {
+        // Sibling code path (issue #1502's constructor-lambda recovery, generalized by #2365):
+        // an imported generic type's CONSTRUCTOR takes an Expression[]-wrapped parameter closing over
+        // the type's own type argument, exercising ExpressionBinder.Calls.TryBuildSymbolicDelegateTarget
+        // / TryResolveSymbolicDelegateTargetForCtor, which had the identical missing Expression[] unwrap
+        // as defect 1's method-parameter sibling.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            data class Cols(Id string)
+
+            func Run() {
+                var holder = ExpressionHolder[Cols]((c Cols) -> c.Id)
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void SourceOnlyGenericMethod_ExpressionParameterClosedOverReceiverTypeArgument_AlreadyBinds()
+    {
+        // Control: a PURELY source-declared (non-imported) generic class with an Expression[]-shaped
+        // method closing over its own type parameter through a symbolic receiver, entirely inside the
+        // CONSUMER source (no CLR reflection / ImportedTypeSymbol involved at all). This exercises a
+        // different (purely symbolic) substitution path and is expected to already work; it guards
+        // against a regression in that path from the imported-method-focused fix above.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+            import System
+            import System.Linq.Expressions
+
+            data class Cols(Id string)
+
+            class LocalBox[T] {
+                func Select(selector Expression[Func[T, object]]) Expression[Func[T, object]] { return selector }
+            }
+
+            func Run() {
+                var box = LocalBox[Cols]{}
+                var expr = box.Select((c Cols) -> c.Id)
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void Issue2224Followup_ImportedGenericExpressionTree_ClosesOverNamedClass_Binds()
+    {
+        // Issue #2224 follow-up: the original #2224 regression validated that an anonymous-class
+        // literal used INSIDE an expression tree lowers with correct PropertyInfo `NewExpression.Members`
+        // (see Issue2224AnonymousClassExpressionTreeMembersTests, unmodified and still passing). This is
+        // the #2365-specific follow-up: the SAME kind of class-shaped value, when it is the TColumns of
+        // an IMPORTED generic method's Expression[Func[TColumns,object]] parameter (rather than a
+        // directly-annotated source parameter type), must likewise preserve the real class shape all the
+        // way through — not erase to `object` — so that member/property recognition downstream (e.g. an
+        // EF-style reflection-based key-shape reader) keeps working. See also the runtime-level
+        // regression coverage in Issue2365ExpressionTreeGenericSubstitutionEmitTests.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            data class Cols(Id string, Name string)
+
+            func Run(migrationBuilder MigrationBuilder) {
+                migrationBuilder.CreateTable("Accounts", (table ColumnsBuilder) -> Cols{Id: table.Column("id"), Name: table.Column("name")}, "dbo", (table CreateTableBuilder[Cols]) -> {
+                    table.PrimaryKey("PK_Accounts", (x Cols) -> x.Id)
+                    table.Annotation("Sqlite:Autoincrement", true)
+                })
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void NegativeControl_ArityMismatchOnExpressionParameter_StillFailsWithDiagnostic()
+    {
+        // The Expression parameter's own delegate declares zero lambda parameters where the
+        // receiver-closed shape requires exactly one — the generalized substitution must not silently
+        // accept an incompatible lambda shape.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            data class Cols(Id string)
+
+            func Run(migrationBuilder MigrationBuilder) {
+                migrationBuilder.CreateTable("Accounts", (table ColumnsBuilder) -> Cols{Id: table.Column("id")}, "dbo", (table CreateTableBuilder[Cols]) -> {
+                    table.PrimaryKey("PK_Accounts", () -> "unrelated")
+                })
+            }
+            """,
+            expectSuccess: false);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void NegativeControl_UnknownMemberOnReceiverStillFailsWithDiagnostic()
+    {
+        // Sanity control: an unrelated/nonexistent member call on the same symbolic receiver must not
+        // be swallowed by the generalized substitution recovery — it should still fail to resolve.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            data class Cols(Id string)
+
+            func Run(migrationBuilder MigrationBuilder) {
+                migrationBuilder.CreateTable("Accounts", (table ColumnsBuilder) -> Cols{Id: table.Column("id")}, "dbo", (table CreateTableBuilder[Cols]) -> {
+                    table.NoSuchMethod("PK_Accounts", (x Cols) -> x.Id)
+                })
+            }
+            """,
+            expectSuccess: false);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void NegativeControl_ArityMismatchOnCompositeExpressionParameter_StillFailsWithDiagnostic()
+    {
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            data class Cols(Id string)
+
+            func Run(migrationBuilder MigrationBuilder) {
+                migrationBuilder.CreateTable("Accounts", (table ColumnsBuilder) -> Cols{Id: table.Column("id")}, "dbo", (table CreateTableBuilder[Cols]) -> {
+                    table.PrimaryKeyComposite("PK_Accounts", (a Cols) -> a.Id)
+                })
+            }
+            """,
+            expectSuccess: false);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void AmbiguityControl_OverloadedByArityStillRanksToExactMatch()
+    {
+        // Overload-ranking coverage: PrimaryKey and PrimaryKeyWithUnique share the same receiver-closed
+        // Expression[Func[TColumns,object]] SHAPE but differ in arity/extra leading parameter; the
+        // generalized substitution must not cause the wrong overload (or an ambiguous result) to be
+        // picked for either call.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            data class Cols(Id string)
+
+            func Run(migrationBuilder MigrationBuilder) {
+                migrationBuilder.CreateTable("Accounts", (table ColumnsBuilder) -> Cols{Id: table.Column("id")}, "dbo", (table CreateTableBuilder[Cols]) -> {
+                    table.PrimaryKey("PK_Accounts", (x Cols) -> x.Id)
+                    table.PrimaryKeyWithUnique("PK_Accounts2", true, (x Cols) -> x.Id)
+                })
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    /// <summary>
+    /// Synthetic reconstruction of the reported Oahu.Data migration regression: a generic
+    /// <c>CreateTable&lt;TColumns&gt;(name, columns, schema, constraints)</c> call whose constraints
+    /// lambda invokes BOTH the fluent, self-returning <c>Annotation</c> call (issue #2345's shape) AND
+    /// the expression-tree-parameter <c>PrimaryKey</c> call (issue #2365's shape) together, matching the
+    /// real-world file's combined usage.
+    /// </summary>
+    [Fact]
+    public void OahuDataStyleMigrationRegression_AnnotationAndPrimaryKeyTogether_Binds()
+    {
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            data class Cols(Id string, Name string)
+
+            func Up(migrationBuilder MigrationBuilder) {
+                migrationBuilder.CreateTable(
+                    "Accounts",
+                    (table ColumnsBuilder) -> Cols{
+                        Id: table.Column("id"),
+                        Name: table.Column("name"),
+                    },
+                    "dbo",
+                    (table CreateTableBuilder[Cols]) -> {
+                        table.Annotation("Sqlite:Autoincrement", true)
+                        table.PrimaryKey("PK_Accounts", (x Cols) -> x.Id)
+                    })
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    private static void AssertBindsCleanly(EmitResult result)
+    {
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0159");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static EmitResult CompileAgainstLibrary(string consumerSource, bool expectSuccess = true)
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2365");
+        Directory.CreateDirectory(outputDir);
+
+        var libraryPath = Path.Combine(outputDir, "Issue2365.Library.dll");
+        EmitLibraryAssembly(libraryPath);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+
+        var consumer = new Compilation(resolver, SyntaxTree.Parse(SourceText.From(consumerSource)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2365.Consumer." + Guid.NewGuid().ToString("N"));
+
+        _ = expectSuccess;
+        return result;
+    }
+
+    private static void EmitLibraryAssembly(string libraryPath)
+    {
+        if (File.Exists(libraryPath))
+        {
+            // Reused across [Fact]s in this class; each test compiles a distinct consumer assembly
+            // against the same cached library, mirroring Issue2142's / Issue2345's pattern.
+            return;
+        }
+
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Lib
+                import System
+                import System.Linq.Expressions
+
+                class ColumnsBuilder {
+                    func Column(name string) string { return name }
+                }
+
+                class Wrapper[T] {
+                }
+
+                class CreateTableBuilder[TColumns] {
+                    func Annotation(name string, value object) CreateTableBuilder[TColumns] { return CreateTableBuilder[TColumns]{} }
+
+                    func PrimaryKey(name string, columns Expression[Func[TColumns, object]]) CreateTableBuilder[TColumns] { return CreateTableBuilder[TColumns]{} }
+
+                    func PrimaryKeyWithUnique(name string, isUnique bool, columns Expression[Func[TColumns, object]]) CreateTableBuilder[TColumns] { return CreateTableBuilder[TColumns]{} }
+
+                    func PrimaryKeyComposite(name string, columns Expression[Func[TColumns, TColumns, object]]) CreateTableBuilder[TColumns] { return CreateTableBuilder[TColumns]{} }
+
+                    func IndexOn(isUnique bool, columns Expression[Func[TColumns, object]], name string) CreateTableBuilder[TColumns] { return CreateTableBuilder[TColumns]{} }
+
+                    func ForEachColumn(visit Action[TColumns]) CreateTableBuilder[TColumns] { return CreateTableBuilder[TColumns]{} }
+
+                    func NestedSelector(columns Expression[Func[Wrapper[TColumns], object]]) CreateTableBuilder[TColumns] { return CreateTableBuilder[TColumns]{} }
+                }
+
+                class MigrationBuilder {
+                    func CreateTable[TColumns](name string, columns Func[ColumnsBuilder, TColumns], schema string, constraints Action[CreateTableBuilder[TColumns]]) TColumns {
+                        return columns(ColumnsBuilder{})
+                    }
+
+                    func CreateTable[TColumns](name string, columns Func[ColumnsBuilder, TColumns]) TColumns {
+                        return columns(ColumnsBuilder{})
+                    }
+                }
+
+                class ExpressionHolder[T] {
+                    var Value Expression[Func[T, object]]
+                    init(value Expression[Func[T, object]]) { Value = value }
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using var peStream = File.Create(libraryPath);
+        var result = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2365.Library");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+}


### PR DESCRIPTION
Closes #2365

## Summary

Imported generic methods whose `Expression<Func<TDelegate>>` (or `Func<...>`/`Action<...>`) parameter closes over the DECLARING TYPE's type parameter (rather than the method's own generic parameter) silently erased the closed-over type to `object` during emission. This produced 21 ILVerify `StackUnexpected` mismatches in the real Oahu.Data EF Core migration corpus, where `MigrationBuilder.CreateTable<TColumns>(...).PrimaryKey(Expression<Func<TColumns,object>>)` emitted `Expression<Func<object,object>>` instead of `Expression<Func<Cols,object>>`.

Binding always succeeded (no GS0159/diagnostic) — this is a pure emission/IL-shape defect, not a binder failure, which made it easy to miss with binder-only tests.

## Root cause (three compounding, EF-agnostic defects)

All three live in the general imported-generic-substitution/delegate-recovery machinery in `src/Core/CodeAnalysis/Binding/`, and none contain EF-specific or anonymous-type-specific logic:

1. **`ExpressionBinder.Calls.TryBuildSymbolicDelegateTargetForMethodParam`** only recovered a symbolic delegate target when the METHOD itself had symbolic (open) generic arguments (the #1512 `Task.ContinueWith<TResult>` shape). It never considered the case where the delegate parameter's symbolic type comes from the RECEIVER's (declaring type's) type argument, and never unwrapped `Expression<TDelegate>` (which has no `Invoke` method) before probing for a delegate shape.
2. **`ConversionClassifier.TrySubstituteParameterTypeFromReceiver`** only substituted a parameter type that WAS DIRECTLY the receiver's generic parameter slot (e.g. `TColumns column`), with no recursion into nested constructed generics like `Expression<Func<TColumns,object>>`. Its sibling, `TrySubstituteParameterTypeFromMethodTypeArgs`, already used the fully recursive `MemberLookup.MapOpenClrTypeToSymbolic` — this fix brings `TrySubstituteParameterTypeFromReceiver` in line with that same recursive engine instead of inventing new substitution logic.
3. **`ExpressionBinder.Calls.TryBuildSymbolicDelegateTarget`** (the static-call/constructor sibling used for #1330/#1502 shapes) had the identical missing `Expression<TDelegate>` unwrap as (1) — fixed for consistency and generality, since it shares the same underlying delegate-shape-probing code path.

## Fix

- Generalized the gate in `TryBuildSymbolicDelegateTargetForMethodParam` to `methodHasSymbolicArgs || receiverHasSymbolicArgs`, and added an `Expression<TDelegate>` unwrap (via `MemberLookup.TryGetExpressionTreeDelegateType`) before probing for `Invoke`.
- Rewrote `TrySubstituteParameterTypeFromReceiver` to recursively map the parameter's open CLR type back to its symbolic equivalent via `MemberLookup.MapOpenClrTypeToSymbolic`, matching the existing method-type-args sibling.
- Applied the same `Expression<TDelegate>` unwrap fix to `TryBuildSymbolicDelegateTarget`.

No EF-specific or anonymous-type-specific code was added anywhere — the fix is purely in the general substitution/delegate-recovery engine (`MemberLookup.MapOpenClrTypeToSymbolic` was already fully recursive and reused as-is).

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue2365ExpressionTreeGenericSubstitutionTests.cs` (15 tests) — binder/diagnostics-level coverage: exact bug repro, struct type argument, explicit outer type args, multiple lambda parameters, non-first `Expression<>` parameter position, direct `Action<>` shape, nested generic composition, imported-generic-CONSTRUCTOR sibling scenario, source-only (non-imported) generic method control, #2224-follow-up scenario, negative/ambiguity controls (arity mismatch, unknown method), and an Oahu.Data-style combined regression.
- `test/Compiler.Tests/Emit/Issue2365ExpressionTreeGenericSubstitutionEmitTests.cs` (3 tests) — REAL two-assembly (imported library + consumer) tests using `IlVerifier.Verify()` (actual ILVerify invocation) plus `AssemblyLoadContext`-based runtime invocation to inspect the actual emitted `LambdaExpression.Parameters[0].Type`. Covers class `TColumns`, struct `TColumns`, and an #2224-follow-up member-shape-preservation scenario.
  - **Empirically verified these are effective regression guards**: reverting the fix (via `git checkout --`, not stash) causes all 3 emit tests to fail with the exact reported ILVerify `StackUnexpected` error; restoring the fix makes them pass again. The binder-level tests were confirmed to pass regardless of the fix (since binding always succeeded) — they remain valuable for shape/negative-control coverage but are not the primary regression guard.

## Test results (post-merge with latest `origin/main`, incorporating the #2360 fix)

- `Core.Tests`: 6145 passed, 0 failed, 1 skipped (baseline regen, expected)
- `Compiler.Tests`: 2994 passed, 0 failed
- `Cs2Gs.Tests`: 1383 passed, 0 failed
- `InternalAnalyzers.Tests`: 7 passed, 0 failed
- Full solution build with analyzers: 0 warnings, 0 errors

## Deferred / out-of-scope work discovered during investigation

Three pre-existing gaps were discovered while authoring tests, confirmed unrelated to and unaffected by this fix, and left unfixed as out of scope for #2365:

1. **Parser gap**: `static func Wrap[T](...)` (a static method with its own method-level generic type parameter) fails to parse with cascading syntax errors. Non-static generic methods and static non-generic methods each work individually; only the combination fails.
2. **Chained-call lambda inference gap**: unannotated (inferred) lambda parameters in a method chain where the receiver's generic type argument was itself inferred from an earlier call (e.g. `.CreateTable(...).PrimaryKey("PK", (x) -> x.Id)`) fail with "Cannot find member Id" — a distinct pre-existing lambda-parameter-type-inference limitation for chained calls.
3. **Lambda parameter type-checking leniency**: a lambda argument with an explicitly-declared WRONG parameter type is unexpectedly accepted by the binder with no diagnostic, independent of this fix.

None of these affect the reported #2365 defect or its fix; they are documented here for future work.
