### PR TITLE
Fix #2361: allow compatible user ToString override on data class/struct

### DIFF
--- a/docs/adr/0029-data-struct-synthesized-members.md
+++ b/docs/adr/0029-data-struct-synthesized-members.md
@@ -35,7 +35,7 @@ A `data struct Name { F1 T1; F2 T2; … }` declaration emits the same CLR `Value
 Additional rules:
 
 - A `data struct` MUST have at least one field. Diagnostic on the empty form: `'data struct' requires at least one field; use 'struct' instead.`
-- The user **may not** hand-write any of the six synthesized members on a `data struct`. Diagnostic: `Member 'Name.Equals' is synthesized for 'data struct'; remove the declaration.` This avoids the "did the user intend to override the synthesized one?" ambiguity. (Phase 6+ may relax this if a user-visible `partial` story emerges; the present rule is the conservative one.)
+- The user **may not** hand-write any of the six synthesized members on a `data struct`. Diagnostic: `Member 'Name.Equals' is synthesized for 'data struct'; remove the declaration.` This avoids the "did the user intend to override the synthesized one?" ambiguity. (Phase 6+ may relax this if a user-visible `partial` story emerges; the present rule is the conservative one. **Update:** see "Amendment 2026-07-15" below — `ToString` alone is now relaxed under a strict shape-compatibility check.)
 - Field accessibility modifiers (`public` / `internal` / `private` per ADR-0014) are allowed but **the synthesized methods see every field**. A `private` field on a `data struct` is still part of its identity and `ToString`. A user who wants opacity should pick `struct`, not `data struct`. Documented.
 - The `data` keyword is **context-sensitive**: it is only a keyword immediately before `struct` in a top-level type-declaration position; everywhere else it is an ordinary identifier (so users may still name a variable `data`).
 
@@ -71,3 +71,20 @@ Neutral:
 - **Synthesize `IEquatable<Name>` interface implementation explicitly**: deferred. The `Equals(Name)` overload + operator pair already satisfies the C# pattern; emitting the interface adds a TypeRef row and complicates Phase 3 emit for marginal interop benefit. Phase 6's full interface story can revisit.
 - **Skip `Deconstruct` until Phase 4+**: rejected. The cost is one `MethodDef` row per data struct; the benefit is that Phase 4 destructuring becomes a parser-only change.
 - **`ToString` format `{ F1 = v1, F2 = v2 }` (C# record style)**: rejected. The Kotlin form `Name(F1=v1, F2=v2)` matches `Point(X=3, Y=4)` in the README's "GSharp is Go shape" vibe better than the braces.
+
+## Amendment 2026-07-15: `ToString` user-override relaxation (#2361)
+
+Issue #2361 found that `cs2gs` faithfully translates a C# `record`/`record struct` with an explicit `ToString` override into a G# `data class`/`data struct` with an in-body `ToString` method — which the original "no hand-written synthesized members" rule unconditionally rejected with GS0232. Since `cs2gs` cannot omit or rewrite a user's C# override without losing behavior, every migrated record with a custom `ToString` (e.g. `Oahu.Core.ProfileKey`/`ProfileKeyEx`, `Oahu.Cli.Tui.Tokens.SemanticColor`) was unmigratable.
+
+**Relaxation, scoped narrowly to `ToString` only.** The other five synthesized members (`Equals(object)`, `Equals(Name)`, `GetHashCode`, `op_Equality`/`op_Inequality`, `Deconstruct`) remain unconditionally forbidden — hand-writing any of them is still GS0232. A user-declared `ToString` is now permitted, but only if it exactly matches the synthesized member's shape: `public string ToString()`, zero parameters, returns `string`, not `static`/`async`/`unsafe`, no type parameters. A declaration with the name `ToString` that does not match this shape (wrong arity, wrong return type, `async`, generic, non-`public`) is rejected with the new diagnostic **GS0487** ("incompatible `ToString` override") rather than GS0232, since the intent is clearly to override `ToString` but the shape is invalid.
+
+When a compatible user `ToString` is present:
+
+- The synthesizer skips emitting `EmitDataStructToString`; the emitter's row planner (`PlanClassMethods`/`PlanStructMethods`) reserves 6 `MethodDef` rows instead of 7 to keep row-count planning in lockstep.
+- The user's `ToString` reuses the same vtable slot the synthesized version would have used (`ReuseSlot`, not `NewSlot`) — for both `data class` and `data struct` — so polymorphic dispatch through a base-typed reference still resolves to the most-derived override, exactly as if the compiler had synthesized it. `MethodInfoHelpers.RequiresVirtualOnValueType` is bypassed for this case so a `data struct`'s user `ToString` is still marked `Virtual` (data structs' synthesized members are already virtual-callable via `Equals`/`GetHashCode`, so this is consistent).
+- `Final`-ness follows the same rule as the synthesized members (`DataStructSynthesizer.IsDataObjectOverrideFinal`): non-`open` data classes and all data structs still get `Final`; `open` data classes do not, allowing a derived data class to declare its own compatible `ToString` and call `base.ToString()`.
+
+**Deferred/out of scope, not fixed by this amendment:**
+
+- A receiver-clause (`func (p T) ToString() string`) declaration only reaches this new check when `T` is in the *same* package (an "owned type" receiver clause, which already emits a GS0314 warning steering users toward the in-body form). A receiver-clause `ToString` on a genuinely cross-package/imported data type is bound as an ordinary extension function and never reaches the data-type reservation logic at all — consistent with G#'s extension-function design (extension functions cannot participate in virtual dispatch), not a defect.
+- Plain (non-`data`) classes' hand-written `ToString` overrides still always get a new vtable slot unless the G# `override` keyword resolves against a matching base declaration; this pre-existing limitation is unrelated to data types and is not addressed here.

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -1598,7 +1598,14 @@ internal sealed class DeclarationBinder
                     continue;
                 }
 
-                if (structSymbol.IsData && IsDataStructSynthesizedMemberName(methodName))
+                // Issue #2361: a data class/struct's ToString is the one
+                // synthesized-name exception — its exact shape is validated a
+                // few lines below (once the parameter list/return type are
+                // bound), where it either falls through as an ordinary
+                // in-body method (suppressing the synthesized ToString) or is
+                // rejected with the more specific GS0487. The other five
+                // synthesized names stay unconditionally reserved here.
+                if (structSymbol.IsData && IsDataStructSynthesizedMemberName(methodName) && !IsUserOverridableDataMemberName(methodName))
                 {
                     Diagnostics.ReportDataStructSynthesizedMemberConflict(methodSyntax.Identifier.Location, structSymbol.Name, structSymbol.IsClass, methodName);
                     continue;
@@ -1727,6 +1734,22 @@ internal sealed class DeclarationBinder
                     // FunctionSymbol.IsAsync below) so override / shadow matching
                     // compares the async-normalized effective return type.
                     var methodIsAsync = methodSyntax.IsAsync || isAsyncIteratorReturnType(returnType);
+
+                    // Issue #2361: now that the parameter list/return type are
+                    // bound, validate a data class/struct's ToString shape.
+                    // Compatible: fall through as an ordinary in-body method
+                    // (its FunctionSymbol lands in structSymbol.Methods below,
+                    // which both the emitter's method-row planner and
+                    // DataStructSynthesizer.EmitDataStructSynthesizedMembers
+                    // check to suppress the synthesized ToString row/body).
+                    // Incompatible: reject with GS0487 instead of silently
+                    // colliding with (or shadowing) the synthesized member.
+                    if (structSymbol.IsData && methodName == "ToString"
+                        && !IsCompatibleDataToStringOverride(methodSyntax.Parameters.Count, returnType, methodReturnRefKind, methodIsAsync, methodSyntax.IsUnsafe, methodTypeParameters, methodAccessibility))
+                    {
+                        Diagnostics.ReportIncompatibleDataToStringOverride(methodSyntax.Identifier.Location, structSymbol.Name, structSymbol.IsClass);
+                        continue;
+                    }
 
                     // Phase 3.B.3 sub-step 3: open/override validation against
                     // base class chain per ADR-0017.
@@ -6320,9 +6343,21 @@ internal sealed class DeclarationBinder
                     return;
                 }
 
-                if (methodReceiverStruct.IsData && IsDataStructSynthesizedMemberName(methodName))
+                // Issue #2361: same ToString exception as the in-body form
+                // above — a compatible shape falls through as an ordinary
+                // receiver-clause method (suppressing the synthesized
+                // ToString); an incompatible one gets the more specific
+                // GS0487 instead of the blanket GS0232.
+                if (methodReceiverStruct.IsData && IsDataStructSynthesizedMemberName(methodName) && !IsUserOverridableDataMemberName(methodName))
                 {
                     Diagnostics.ReportDataStructSynthesizedMemberConflict(syntax.Identifier.Location, methodReceiverStruct.Name, methodReceiverStruct.IsClass, methodName);
+                    return;
+                }
+
+                if (methodReceiverStruct.IsData && methodName == "ToString"
+                    && !IsCompatibleDataToStringOverride(syntax.Parameters.Count, type, returnRefKind, syntax.IsAsync, syntax.IsUnsafe, typeParameters, accessibility))
+                {
+                    Diagnostics.ReportIncompatibleDataToStringOverride(syntax.Identifier.Location, methodReceiverStruct.Name, methodReceiverStruct.IsClass);
                     return;
                 }
 
@@ -6595,10 +6630,63 @@ internal sealed class DeclarationBinder
     /// names as inline structs (<c>Equals</c>, <c>GetHashCode</c>,
     /// <c>ToString</c>, <c>op_Equality</c>, <c>op_Inequality</c>,
     /// <c>Deconstruct</c>). User code may not hand-write any of them.
+    /// Issue #2361: <c>ToString</c> is the one exception — see
+    /// <see cref="IsUserOverridableDataMemberName"/> and
+    /// <see cref="IsCompatibleDataToStringOverride"/>.
     /// </summary>
     private static bool IsDataStructSynthesizedMemberName(string methodName)
     {
         return IsInlineSynthesizedMemberName(methodName);
+    }
+
+    /// <summary>
+    /// Issue #2361: names in the ADR-0029 synthesized-member set that MAY be
+    /// hand-written on a data class/struct when the declared shape is
+    /// compatible (see <see cref="IsCompatibleDataToStringOverride"/>),
+    /// suppressing/replacing the synthesized member instead of being
+    /// unconditionally rejected. Deliberately narrow today (only
+    /// <c>ToString</c> — a record's display format is the one synthesized
+    /// facet C# lets users override while keeping equality/hash/copy
+    /// compiler-controlled), but factored as its own predicate (rather than
+    /// inlining a literal string compare at each of the three call sites)
+    /// so a future issue can widen the set without touching the call sites
+    /// again.
+    /// </summary>
+    private static bool IsUserOverridableDataMemberName(string methodName)
+    {
+        return methodName == "ToString";
+    }
+
+    /// <summary>
+    /// Issue #2361: a data class/struct's hand-written <c>ToString</c> is
+    /// only allowed to suppress/replace the synthesized one when its shape
+    /// exactly matches what <c>DataStructSynthesizer.EmitDataStructToString</c>
+    /// would have emitted — <c>public string ToString()</c>: zero
+    /// parameters, non-static (the caller only reaches this for the
+    /// instance-method lists, so staticness is never in question here),
+    /// non-generic, non-async, non-unsafe, returning <c>string</c> by value,
+    /// with <c>public</c> accessibility (matching
+    /// <c>DataStructSynthesizer.DataObjectOverrideAttributes</c>'s
+    /// unconditional <c>MethodAttributes.Public</c>). Any other shape keeps
+    /// the name collision but is reported as an incompatible override
+    /// (GS0487) rather than silently accepted.
+    /// </summary>
+    private static bool IsCompatibleDataToStringOverride(
+        int explicitParameterCount,
+        TypeSymbol returnType,
+        RefKind returnRefKind,
+        bool isAsync,
+        bool isUnsafe,
+        ImmutableArray<TypeParameterSymbol> methodTypeParameters,
+        Accessibility accessibility)
+    {
+        return explicitParameterCount == 0
+            && returnType == TypeSymbol.String
+            && returnRefKind == RefKind.None
+            && !isAsync
+            && !isUnsafe
+            && methodTypeParameters.IsDefaultOrEmpty
+            && accessibility == Accessibility.Public;
     }
 
     private bool IsSamePackageNonAggregateReceiver(TypeClauseSyntax receiverSyntax, TypeSymbol receiverType, PackageSymbol package)

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -2418,6 +2418,26 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Issue #2361 / ADR-0029 follow-up: reports that a data class/struct's
+    /// hand-written <c>ToString</c> declaration is incompatible with the slot
+    /// it would need to suppress/replace (<c>public string ToString()</c> —
+    /// zero parameters, non-static, non-generic, non-async, returning
+    /// <c>string</c>). Unlike the other five synthesized names (which are
+    /// always rejected via <see cref="ReportDataStructSynthesizedMemberConflict"/>),
+    /// a <c>ToString</c> declaration gets this more specific diagnostic so the
+    /// message can describe the exact shape it must match.
+    /// </summary>
+    /// <param name="location">The text location of the member name.</param>
+    /// <param name="typeName">The data type name.</param>
+    /// <param name="isClass"><see langword="true"/> when the type is a data class; otherwise a data struct.</param>
+    public void ReportIncompatibleDataToStringOverride(TextLocation location, string typeName, bool isClass)
+    {
+        var kind = isClass ? "class" : "struct";
+        var message = $"Data {kind} '{typeName}' declares 'ToString' with an incompatible shape; a data {kind} may only override ToString as 'public ToString() string' (no parameters, not static, not generic, not async, returning 'string').";
+        Report(location, "GS0487", message);
+    }
+
+    /// <summary>
     /// ADR-0059 / issue #255: reports that a delegate declaration
     /// (<c>type Name = delegate …</c>) was not followed by a <c>func(...)</c>
     /// signature. Named delegates must take the shape

--- a/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
+++ b/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -415,6 +416,26 @@ internal sealed class DataStructSynthesizer
     }
 
     /// <summary>
+    /// Issue #2361: <see langword="true"/> when <paramref name="structSym"/>
+    /// declared a compatible hand-written <c>ToString</c> (the binder only
+    /// ever lets a "ToString"-named method land in
+    /// <see cref="StructSymbol.Methods"/> for an <c>IsData</c> type when its
+    /// shape exactly matches <c>public string ToString()</c> — see
+    /// <c>DeclarationBinder.IsCompatibleDataToStringOverride</c>). Both the
+    /// method-row planner (<c>ReflectionMetadataEmitter.PlanClassMethods</c> /
+    /// <c>PlanStructMethods</c>) and <see cref="EmitDataStructSynthesizedMembers"/>
+    /// call this so the reserved-row count and the emitted member set agree:
+    /// six synthesized rows plus the user's own ToString (emitted through the
+    /// ordinary user-method path) instead of seven synthesized rows.
+    /// </summary>
+    /// <param name="structSym">The data class/struct symbol to check.</param>
+    /// <returns><see langword="true"/> when a compatible user-declared ToString is present.</returns>
+    public static bool HasUserToStringOverride(StructSymbol structSym)
+    {
+        return !structSym.Methods.IsDefaultOrEmpty && structSym.Methods.Any(m => m.Name == "ToString");
+    }
+
+    /// <summary>
     /// Issue #410 / ADR-0029: emits the seven synthesized members for a
     /// <c>data struct</c> type. The MethodDef rows are added in a fixed
     /// order so they align 1:1 with the rows reserved by the method-row
@@ -423,6 +444,14 @@ internal sealed class DataStructSynthesizer
     /// <c>op_Inequality</c>, <c>Deconstruct</c>.
     /// <c>Equals(Name)</c> is emitted first so its MethodDef handle is
     /// available when <c>Equals(object)</c> is emitted.
+    /// Issue #2361: when the type declares a compatible hand-written
+    /// <c>ToString</c> (<see cref="HasUserToStringOverride"/>), the
+    /// synthesized <c>ToString</c> body/row is skipped here — the user's own
+    /// method is emitted through the ordinary user-method path instead,
+    /// taking over that vtable slot (see
+    /// <c>ReflectionMetadataEmitter.EmitFunction</c>'s
+    /// <c>isDataToStringOverride</c> handling for the Virtual/Final
+    /// attributes that make the slot line up with the synthesized siblings).
     /// </summary>
     /// <param name="structSym">The data-struct symbol to emit members for.</param>
     public void EmitDataStructSynthesizedMembers(StructSymbol structSym)
@@ -439,7 +468,17 @@ internal sealed class DataStructSynthesizer
         var equalsTypedHandle = this.EmitDataStructEqualsTyped(structSym);
         this.EmitDataStructEqualsObject(structSym, typeDef, equalsTypedHandle);
         this.EmitDataStructGetHashCode(structSym);
-        this.EmitDataStructToString(structSym);
+
+        // Issue #2361: skip the synthesized ToString body/row when the type
+        // declares a compatible hand-written one — it is emitted through the
+        // ordinary user-method path instead (see EmitClassMethodBodies /
+        // EmitStructMethodBodies), which now reserves only six synthesized
+        // rows for this type (see PlanClassMethods / PlanStructMethods).
+        if (!HasUserToStringOverride(structSym))
+        {
+            this.EmitDataStructToString(structSym);
+        }
+
         this.cache.DataStructOpEqualityHandles[structSym] = this.EmitDataStructEqualityOperator(structSym, isInequality: false);
         this.EmitDataStructEqualityOperator(structSym, isInequality: true);
         this.EmitDataStructDeconstruct(structSym);
@@ -540,12 +579,29 @@ internal sealed class DataStructSynthesizer
     private static MethodAttributes DataObjectOverrideAttributes(StructSymbol structSym)
     {
         var attrs = MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig;
-        if (!structSym.IsClass || (!structSym.IsOpen && !structSym.IsSealedHierarchy))
+        if (IsDataObjectOverrideFinal(structSym))
         {
             attrs |= MethodAttributes.Final;
         }
 
         return attrs;
+    }
+
+    /// <summary>
+    /// Issue #2361: extracted from <see cref="DataObjectOverrideAttributes"/>
+    /// so <c>ReflectionMetadataEmitter.EmitFunction</c> can apply the exact
+    /// same finality rule to a user-declared <c>ToString</c> override on a
+    /// data class/struct (which is emitted through the ordinary user-method
+    /// path, not through this synthesizer) — the vtable-slot lifecycle for
+    /// the "ToString" name must be identical whether the compiler or the
+    /// user wrote the body. See the doc comment on
+    /// <see cref="DataObjectOverrideAttributes"/> for the full rationale.
+    /// </summary>
+    /// <param name="structSym">The data class/struct symbol to check.</param>
+    /// <returns><see langword="true"/> when the slot must be <c>final</c>.</returns>
+    public static bool IsDataObjectOverrideFinal(StructSymbol structSym)
+    {
+        return !structSym.IsClass || (!structSym.IsOpen && !structSym.IsSealedHierarchy);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1663,9 +1663,14 @@ internal sealed class ReflectionMetadataEmitter
             // reservation and EmitClassMethodBodies' matching emit call,
             // which must run in the same relative order (before
             // user-declared methods) so the MethodDef rows line up.
+            // Issue #2361: when the class declares a compatible hand-written
+            // ToString, only six rows are reserved here — the seventh
+            // ("ToString") is instead reserved by the ordinary c.Methods loop
+            // below, matching DataStructSynthesizer.EmitDataStructSynthesizedMembers
+            // skipping the synthesized ToString body in that case.
             if (c.IsData)
             {
-                methodRow += 7;
+                methodRow += DataStructSynthesizer.HasUserToStringOverride(c) ? 6 : 7;
             }
 
             if (!c.Methods.IsDefaultOrEmpty)
@@ -1796,7 +1801,10 @@ internal sealed class ReflectionMetadataEmitter
                 // Issue #410 / ADR-0029: data structs synthesize 7 MethodDef
                 // rows: Equals(object), Equals(Name), GetHashCode, ToString,
                 // op_Equality, op_Inequality, Deconstruct.
-                methodRow += 7;
+                // Issue #2361: only 6 when the struct declares a compatible
+                // hand-written ToString — see the matching class-side comment
+                // in PlanClassMethods above.
+                methodRow += DataStructSynthesizer.HasUserToStringOverride(s) ? 6 : 7;
 
                 // Rubber-duck follow-up to issue #2224: an anonymous-class
                 // literal's synthesized type has no plain fields (only
@@ -5123,6 +5131,22 @@ internal sealed class ReflectionMetadataEmitter
             var receiverStruct = function.ReceiverType as StructSymbol;
             var receiverIsValueType = receiverStruct != null && !receiverStruct.IsClass;
             var receiverIsInterface = function.ReceiverType is InterfaceSymbol;
+
+            // Issue #2361: a user-declared "ToString" on a data class/struct
+            // suppresses the synthesized ToString (see
+            // DataStructSynthesizer.HasUserToStringOverride /
+            // EmitDataStructSynthesizedMembers) and must take over its exact
+            // CLR vtable slot instead of getting a brand-new one — otherwise
+            // polymorphic dispatch through a base-typed reference would still
+            // resolve to System.Object.ToString (or, for a derived data
+            // class, the base's synthesized/user ToString would stop being
+            // re-overridable). The binder only ever lets a "ToString"-named
+            // method reach an IsData type's Methods list when its shape
+            // exactly matches the synthesized one (see
+            // DeclarationBinder.IsCompatibleDataToStringOverride), so no
+            // extra shape check is needed here.
+            bool isDataToStringOverride = receiverStruct != null && receiverStruct.IsData && function.Name == "ToString";
+
             if (receiverIsInterface && function.Accessibility != Accessibility.Private)
             {
                 // ADR-0085 / issue #726: an instance method whose receiver is
@@ -5144,15 +5168,15 @@ internal sealed class ReflectionMetadataEmitter
                 //
                 // Fall through — no further attribute stamping needed.
             }
-            else if (!receiverIsValueType || MethodInfoHelpers.RequiresVirtualOnValueType(function, receiverStruct))
+            else if (isDataToStringOverride || !receiverIsValueType || MethodInfoHelpers.RequiresVirtualOnValueType(function, receiverStruct))
             {
                 methodAttrs |= MethodAttributes.Virtual;
-                if (!function.IsOverride)
+                if (!function.IsOverride && !isDataToStringOverride)
                 {
                     methodAttrs |= MethodAttributes.NewSlot;
                 }
 
-                if (!function.IsOpen)
+                if (isDataToStringOverride ? DataStructSynthesizer.IsDataObjectOverrideFinal(receiverStruct) : !function.IsOpen)
                 {
                     methodAttrs |= MethodAttributes.Final;
                 }

--- a/test/Compiler.Tests/Emit/Issue2361DataToStringOverrideEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2361DataToStringOverrideEmitTests.cs
@@ -1,0 +1,514 @@
+// <copyright file="Issue2361DataToStringOverrideEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2361 / ADR-0029 follow-up: a data class/struct's hand-written
+/// <c>ToString</c> — when its shape exactly matches
+/// <c>public ToString() string</c> — suppresses/replaces the synthesized
+/// ToString instead of being rejected with GS0232. This means:
+/// <list type="bullet">
+/// <item><description><c>DataStructSynthesizer.EmitDataStructSynthesizedMembers</c>
+/// skips <c>EmitDataStructToString</c> and the user's own method (already
+/// present in <c>structSymbol.Methods</c>) is emitted instead — so exactly
+/// ONE <c>ToString()</c> MethodDef exists on the type, not two.</description></item>
+/// <item><description><c>ReflectionMetadataEmitter</c>'s method-row planner
+/// reserves 6 synthesized rows (not 7) when a compatible user ToString is
+/// present.</description></item>
+/// <item><description>The user ToString gets the SAME Virtual/NewSlot/Final
+/// CLR attribute treatment as the other synthesized members — no NewSlot
+/// (so it reuses/participates in the correct vtable slot for TRUE
+/// polymorphic override dispatch through a base-typed reference,
+/// unlike a plain non-data class's hand-written ToString), and Final
+/// driven by the data type's open/sealed-hierarchy status exactly like
+/// <c>DataStructSynthesizer.IsDataObjectOverrideFinal</c>.</description></item>
+/// </list>
+/// These tests exercise the real-world <c>Oahu.Core.ProfileKey</c> /
+/// <c>Oahu.Core.ProfileKeyEx</c> (open data class, derived class chaining
+/// <c>base.ToString()</c>) and <c>Oahu.Cli.Tui.Tokens.SemanticColor</c>
+/// (data struct, expression-bodied ToString) shapes verbatim (field names,
+/// types, and ToString bodies translated 1:1 from the C# source) plus
+/// negative/ambiguity controls for incompatible shapes and the other five
+/// still-forbidden synthesized names.
+/// </summary>
+public class Issue2361DataToStringOverrideEmitTests
+{
+    [Fact]
+    public void DataClass_CompatibleToString_EmitsExactlyOneToStringMethod()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            open data class Point(X int32, Y int32) {
+                func ToString() string -> "custom"
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var point = assembly.GetTypes().Single(t => t.Name == "Point");
+
+        var toStringMethods = point.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.Name == "ToString" && m.GetParameters().Length == 0)
+            .ToArray();
+        Assert.Single(toStringMethods);
+
+        var instance = Activator.CreateInstance(point, 1, 2);
+        Assert.Equal("custom", instance.ToString());
+    }
+
+    [Fact]
+    public void DataStruct_CompatibleToString_EmitsExactlyOneToStringMethod()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            data struct Point {
+                var X int32
+                var Y int32
+
+                func ToString() string -> "custom"
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var point = assembly.GetTypes().Single(t => t.Name == "Point");
+
+        var toStringMethods = point.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.Name == "ToString" && m.GetParameters().Length == 0)
+            .ToArray();
+        Assert.Single(toStringMethods);
+
+        var instance = Activator.CreateInstance(point);
+        Assert.Equal("custom", instance.ToString());
+    }
+
+    [Fact]
+    public void DataClass_Open_CompatibleToString_IsVirtualNotFinalNotNewSlot()
+    {
+        // ADR-0029's own synthesized ToString never sets NewSlot (ReuseSlot
+        // is the CLR default) and is Final only when the type is NOT open —
+        // the user override must get identical treatment so a derived open
+        // data class can re-override it.
+        var source = """
+            package MyLib
+            import System
+
+            open data class Point(X int32, Y int32) {
+                func ToString() string -> "custom"
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var point = assembly.GetTypes().Single(t => t.Name == "Point");
+        var toString = point.GetMethod("ToString", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly, null, Type.EmptyTypes, null);
+
+        Assert.NotNull(toString);
+        Assert.True(toString.IsVirtual);
+        Assert.False(toString.IsFinal);
+        Assert.False((toString.Attributes & MethodAttributes.NewSlot) == MethodAttributes.NewSlot);
+    }
+
+    [Fact]
+    public void DataClass_NotOpen_CompatibleToString_IsFinal()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            data class Point(X int32, Y int32) {
+                func ToString() string -> "custom"
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var point = assembly.GetTypes().Single(t => t.Name == "Point");
+        var toString = point.GetMethod("ToString", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly, null, Type.EmptyTypes, null);
+
+        Assert.NotNull(toString);
+        Assert.True(toString.IsVirtual);
+        Assert.True(toString.IsFinal);
+    }
+
+    [Fact]
+    public void DataStruct_CompatibleToString_IsVirtualAndFinal()
+    {
+        // Structs are never open (no derivation), so the struct ToString
+        // override must be unconditionally Virtual|Final just like the
+        // synthesized one — and MethodInfoHelpers.RequiresVirtualOnValueType
+        // (which would otherwise say "no Virtual needed" for a plain
+        // non-override struct method) must be bypassed for this case.
+        var source = """
+            package MyLib
+            import System
+
+            data struct Point {
+                var X int32
+                var Y int32
+
+                func ToString() string -> "custom"
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var point = assembly.GetTypes().Single(t => t.Name == "Point");
+        var toString = point.GetMethod("ToString", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly, null, Type.EmptyTypes, null);
+
+        Assert.NotNull(toString);
+        Assert.True(toString.IsVirtual);
+        Assert.True(toString.IsFinal);
+    }
+
+    [Fact]
+    public void DataClass_DerivedOverridesToStringAgain_TrulyPolymorphicThroughBaseReference()
+    {
+        // Confirms REAL CLR override dispatch (not merely direct-call
+        // precedence): a base-typed reference to a derived instance must
+        // invoke the derived ToString via callvirt, and the derived
+        // ToString's `base.ToString()` call must reach the base's (also
+        // user-declared) ToString.
+        var source = """
+            package P
+            import System
+
+            open data class Base2361(Name string) {
+                func ToString() string -> "base:" + Name
+            }
+            open data class Derived2361(Name string, Extra string) : Base2361(Name) {
+                func ToString() string -> base.ToString() + ":" + Extra
+            }
+
+            func Main() {
+                let d = Derived2361("n", "x")
+                Console.WriteLine(d.ToString())
+
+                let baseRef Base2361 = d
+                Console.WriteLine(baseRef.ToString())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("base:n:x\nbase:n:x\n", output);
+    }
+
+    [Fact]
+    public void DataClass_ExactOahuProfileKeyProfileKeyEx_Shape_Compiles_Runs_And_Verifies()
+    {
+        // Verbatim translation of Oahu.Core.Records.ProfileKey /
+        // ProfileKeyEx (Oahu.Core/Records.cs):
+        //   public record ProfileKey(uint Id, ERegion Region, string AccountId) : IProfileKey
+        //   {
+        //       public override string ToString() =>
+        //           $"{GetType().Name} {nameof(Id)}={Id}, {nameof(Region)}={Region}, {nameof(AccountId)}=#<...>";
+        //   }
+        //   public record ProfileKeyEx(uint Id, ERegion Region, string AccountName, string AccountId, string DeviceName) :
+        //       ProfileKey(Id, Region, AccountId), IProfileKeyEx
+        //   {
+        //       public override string ToString() =>
+        //           $"{base.ToString()}, {nameof(AccountName)}=..., {nameof(DeviceName)}=...";
+        //   }
+        // (Checksum32 calls dropped — irrelevant to the ToString-override
+        // mechanism under test; field names/nesting/base-chaining kept 1:1.)
+        var source = """
+            package Oahu.Core
+            import System
+
+            enum ERegion {
+                Us,
+                Eu
+            }
+
+            open data class ProfileKey(Id uint32, Region ERegion, AccountId string) {
+                func ToString() string -> "ProfileKey Id=" + Id.ToString() + ", Region=" + Region.ToString() + ", AccountId=" + AccountId
+            }
+
+            open data class ProfileKeyEx(Id uint32, Region ERegion, AccountName string, AccountId string, DeviceName string) : ProfileKey(Id, Region, AccountId) {
+                func ToString() string -> base.ToString() + ", AccountName=" + AccountName + ", DeviceName=" + DeviceName
+            }
+
+            func Main() {
+                let key = ProfileKeyEx(1, ERegion.Us, "acct-name", "acct-id", "device-1")
+                Console.WriteLine(key.ToString())
+
+                let baseKey ProfileKey = key
+                Console.WriteLine(baseKey.ToString())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        const string expected = "ProfileKey Id=1, Region=Us, AccountId=acct-id, AccountName=acct-name, DeviceName=device-1";
+        Assert.Equal(expected + "\n" + expected + "\n", output);
+    }
+
+    [Fact]
+    public void DataStruct_ExactOahuSemanticColor_Shape_Compiles_Runs_And_Verifies()
+    {
+        // Verbatim translation of Oahu.Cli.Tui.Tokens.SemanticColor
+        // (Oahu.Cli.Tui/Tokens/SemanticColor.cs):
+        //   public readonly record struct SemanticColor(Color Value)
+        //   {
+        //       public override string ToString() => Value.ToMarkup();
+        //   }
+        // (`Color`/`ToMarkup` are third-party Spectre.Console types not
+        // available here — substituted with an int32 `Value` field and a
+        // trivial formatting expression; the ToString-override SHAPE
+        // (data struct, single-field primary ctor, expression-bodied
+        // override) is preserved exactly.)
+        var source = """
+            package Oahu.Cli.Tui.Tokens
+            import System
+
+            data struct SemanticColor(Value int32) {
+                func ToString() string -> "#" + Value.ToString()
+            }
+
+            func Main() {
+                let c = SemanticColor(7)
+                Console.WriteLine(c.ToString())
+                Console.WriteLine(c)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("#7\n#7\n", output);
+    }
+
+    [Fact]
+    public void DataClass_IncompatibleToStringShape_WrongReturnType_CompileFails_ReportsGS0487()
+    {
+        var source = """
+            package MyLib
+
+            open data class Point(X int32, Y int32) {
+                func ToString() int32 {
+                    return 0
+                }
+            }
+            """;
+
+        var (exitCode, stdout, stderr) = TryCompile(source);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0487", stdout + stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DataClass_ExplicitEqualsObject_CompileFails_ReportsGS0232_RegressionControl()
+    {
+        var source = """
+            package MyLib
+
+            open data class Point(X int32, Y int32) {
+                func Equals(other any) bool {
+                    return false
+                }
+            }
+            """;
+
+        var (exitCode, stdout, stderr) = TryCompile(source);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0232", stdout + stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DataStruct_EmitsSixSynthesizedMethods_WhenUserToStringPresent()
+    {
+        // Row-planner regression: with a compatible user ToString, ONLY 6
+        // synthesized rows are reserved/emitted (Equals(object), Equals(Name),
+        // GetHashCode, op_Equality, op_Inequality, Deconstruct) — NOT 7 — and
+        // the user's own ToString fills the 7th MethodDef slot. If the row
+        // count/emission order ever drift apart, the assembly fails to load
+        // or ILVerify fails (already exercised implicitly by every other
+        // test in this file via IlVerifier.Verify in CompileToAssembly).
+        var source = """
+            package MyLib
+            import System
+
+            data struct Point {
+                var X int32
+                var Y int32
+
+                func ToString() string -> "custom"
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var point = assembly.GetTypes().Single(t => t.Name == "Point");
+
+        Assert.NotNull(point.GetMethod("Equals", new[] { typeof(object) }));
+        Assert.NotNull(point.GetMethod("Equals", new[] { point }));
+        Assert.NotNull(point.GetMethod("GetHashCode", Type.EmptyTypes));
+        Assert.NotNull(point.GetMethod("op_Equality", new[] { point, point }));
+        Assert.NotNull(point.GetMethod("op_Inequality", new[] { point, point }));
+        Assert.NotNull(point.GetMethod("Deconstruct", BindingFlags.Public | BindingFlags.Instance));
+
+        var equalsTyped = point.GetMethod("Equals", new[] { point });
+        var a = Activator.CreateInstance(point);
+        var b = Activator.CreateInstance(point);
+        point.GetField("X").SetValue(a, 1);
+        point.GetField("Y").SetValue(a, 2);
+        point.GetField("X").SetValue(b, 1);
+        point.GetField("Y").SetValue(b, 2);
+        Assert.Equal(true, equalsTyped.Invoke(a, new[] { b }));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2361_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) TryCompile(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2361_negemit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:library",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            return (compileExit, compileOut.ToString(), compileErr.ToString());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2361_synth_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2361DataToStringOverrideTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2361DataToStringOverrideTests.cs
@@ -1,0 +1,304 @@
+// <copyright file="Issue2361DataToStringOverrideTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2361 / ADR-0029 follow-up: a data class/struct's hand-written
+/// <c>ToString</c> is the one synthesized member (of the six ADR-0029 names)
+/// that may be declared explicitly, PROVIDED its shape exactly matches
+/// <c>public ToString() string</c> (no parameters, not static, not generic,
+/// not async, not unsafe, returning <c>string</c>). A compatible declaration
+/// suppresses/replaces the synthesized ToString instead of being rejected
+/// with GS0232; an incompatible one is rejected with the more specific
+/// GS0487. The other five synthesized names (Equals/GetHashCode/
+/// op_Equality/op_Inequality/Deconstruct) remain unconditionally forbidden —
+/// see <see cref="DataStructTests"/> for that pre-existing coverage, which
+/// this file does not duplicate.
+/// </summary>
+public class Issue2361DataToStringOverrideTests
+{
+    [Fact]
+    public void DataClass_CompatibleToStringOverride_InBody_NoDiagnostics()
+    {
+        var source = @"
+open data class Point(X int32, Y int32) {
+    func ToString() string {
+        return ""custom""
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void DataClass_CompatibleToStringOverride_ExpressionBody_NoDiagnostics()
+    {
+        var source = @"
+open data class Point(X int32, Y int32) {
+    func ToString() string -> ""custom""
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void DataStruct_CompatibleToStringOverride_InBody_NoDiagnostics()
+    {
+        var source = @"
+data struct Point {
+    var X int32
+    var Y int32
+
+    func ToString() string {
+        return ""custom""
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void DataClass_CompatibleToStringOverride_ReceiverClause_NoBlockingDiagnostics()
+    {
+        // ADR-0079 (GS0314) warns when a receiver-clause method targets a
+        // same-package ("owned") type — the canonical form is the in-body
+        // declaration — but it is only a Warning, not a blocking error, so
+        // the receiver-clause code path (DeclarationBinder's
+        // `methodReceiverStruct != null` branch) is still reachable and must
+        // still apply the #2361 ToString exception (not GS0232/GS0487).
+        var source = @"
+open data class Point(X int32, Y int32) {
+}
+
+func (p Point) ToString() string {
+    return ""custom""
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0232" || d.Id == "GS0487");
+    }
+
+    [Fact]
+    public void DataStruct_CompatibleToStringOverride_ReceiverClause_NoBlockingDiagnostics()
+    {
+        var source = @"
+data struct Point {
+    var X int32
+    var Y int32
+}
+
+func (p Point) ToString() string {
+    return ""custom""
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0232" || d.Id == "GS0487");
+    }
+
+    [Fact]
+    public void DataStruct_ToStringWithParameter_ReceiverClause_ReportsGS0487()
+    {
+        var source = @"
+data struct Point {
+    var X int32
+    var Y int32
+}
+
+func (p Point) ToString(format string) string {
+    return format
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0487");
+    }
+
+    [Fact]
+    public void DataClass_SealedNonOpen_CompatibleToStringOverride_NoDiagnostics()
+    {
+        // Not `open` — the sealed/final-slot policy must still let a
+        // compatible ToString through.
+        var source = @"
+data class Point(X int32, Y int32) {
+    func ToString() string -> ""custom""
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void DataClass_DerivedOverridesToStringAgain_NoDiagnostics()
+    {
+        var source = @"
+open data class Base2361(Name string) {
+    func ToString() string -> ""base:"" + Name
+}
+open data class Derived2361(Name string, Extra string) : Base2361(Name) {
+    func ToString() string -> base.ToString() + "":"" + Extra
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void DataClass_ToStringWithParameter_ReportsGS0487()
+    {
+        var source = @"
+open data class Point(X int32, Y int32) {
+    func ToString(format string) string {
+        return format
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        var diagnostic = Assert.Single(result.Diagnostics, d => d.Id == "GS0487");
+        Assert.Contains("Point", diagnostic.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DataClass_ToStringWrongReturnType_ReportsGS0487()
+    {
+        var source = @"
+open data class Point(X int32, Y int32) {
+    func ToString() int32 {
+        return 0
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0487");
+    }
+
+    [Fact]
+    public void DataClass_AsyncToString_ReportsGS0487()
+    {
+        var source = @"
+open data class Point(X int32, Y int32) {
+    async func ToString() string {
+        return ""x""
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0487");
+    }
+
+    [Fact]
+    public void DataClass_GenericToString_ReportsGS0487()
+    {
+        var source = @"
+open data class Point(X int32, Y int32) {
+    func ToString[T]() string {
+        return ""x""
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0487");
+    }
+
+    [Fact]
+    public void DataClass_PrivateToString_ReportsGS0487()
+    {
+        var source = @"
+open data class Point(X int32, Y int32) {
+    private func ToString() string {
+        return ""x""
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0487");
+    }
+
+    [Fact]
+    public void DataClass_ExplicitToString_SharedBlock_StillReportsGS0232()
+    {
+        // A shared/static-block method named ToString can never be an
+        // Object.ToString override — the ToString exception only applies to
+        // instance methods. Statics stay unconditionally forbidden for ALL
+        // six synthesized names.
+        var source = @"
+open data class Point(X int32, Y int32) {
+    shared {
+        func ToString() string {
+            return ""x""
+        }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0232");
+    }
+
+    [Fact]
+    public void DataClass_ExplicitEqualsObject_StillReportsGS0232_RegressionControl()
+    {
+        // Regression control: the ToString exception must not widen to the
+        // other five synthesized names.
+        var source = @"
+open data class Point(X int32, Y int32) {
+    func Equals(other any) bool {
+        return false
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0232");
+    }
+
+    [Fact]
+    public void DataStruct_ExplicitOpEquality_StillReportsGS0232_RegressionControl()
+    {
+        var source = @"
+data struct Point {
+    var X int32
+    var Y int32
+}
+
+func (a Point) operator ==(b Point) bool {
+    return true
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0232");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Root cause

C# `record`/`record struct` declarations may explicitly override `ToString`. `cs2gs` faithfully translates these into a G# `data class`/`data struct` with an in-body `ToString` method — but ADR-0029's "no hand-written synthesized members" rule unconditionally rejected any such declaration with **GS0232**, since the compiler already synthesizes `ToString` for data types. This made any migrated record/record-struct with a custom `ToString` (e.g. `Oahu.Core.ProfileKey`/`ProfileKeyEx`, `Oahu.Cli.Tui.Tokens.SemanticColor`) unmigratable end-to-end.

## Fix

Relax the rule narrowly for `ToString` only — the other five synthesized members (`Equals(object)`, `Equals(Name)`, `GetHashCode`, `op_Equality`/`op_Inequality`, `Deconstruct`) remain unconditionally forbidden (still GS0232).

- **Binder** (`DeclarationBinder.cs`): a user-declared `ToString` is now accepted if its shape exactly matches what the compiler would have synthesized: `public string ToString()`, zero parameters, not `static`/`async`/`unsafe`, no type parameters. A `ToString`-named declaration that doesn't match this shape is now rejected with a new diagnostic, **GS0487** ("incompatible ToString override"), rather than the generic GS0232 — since the intent is clearly to override `ToString`, just with an invalid shape.
- **Emitter** (`DataStructSynthesizer.cs`, `ReflectionMetadataEmitter.cs`): when a compatible user `ToString` is present, the synthesizer skips emitting the synthesized `ToString`, and the emitter keeps the user's method in the *same vtable slot* the synthesized version would have used (`ReuseSlot`, not `NewSlot`) for both `data class` and `data struct` — so polymorphic dispatch through a base-typed reference still resolves to the most-derived override. The MethodDef row planner (`PlanClassMethods`/`PlanStructMethods`) reserves 6 rows instead of 7 to stay in lockstep, and `Final`-ness follows the same open/non-open rule as the synthesized members (open data classes are not final, so a derived data class can declare its own compatible `ToString` and call `base.ToString()`).
- **cs2gs**: confirmed via a translation-unit-level test that **no change is needed**. `cs2gs` already emits the plain in-body `func ToString() string -> ...` form (no `override` keyword) for a translated record's `ToString`, for both a base record overriding `object.ToString` and a derived record overriding the base record's `ToString` — because the override-chain-root detection (`OverridesExternalBaseMethod`) correctly walks back to `object.ToString`, an external/BCL declaration, in both cases.
- **Docs**: added an amendment to `docs/adr/0029-data-struct-synthesized-members.md` documenting the relaxation, its scope, and the deferred findings below.

## Tests

- **16 new binder tests** (`test/Core.Tests/CodeAnalysis/Binding/Issue2361DataToStringOverrideTests.cs`): in-body/expression-body compatible `ToString` (class + struct), receiver-clause compatible `ToString` (same-package), sealed/non-open class, derived-class `base.ToString()` chaining, 5 incompatible-shape negative controls (wrong arity, wrong return type, `async`, generic, non-`public`) each expecting GS0487, shared/static-block `ToString` still GS0232, and regression controls (`Equals`/`op_Equality` still GS0232). **All pass.**
- **11 new emit/runtime tests** (`test/Compiler.Tests/Emit/Issue2361DataToStringOverrideEmitTests.cs`): exactly-one-`ToString`-MethodDef verification, `Virtual`/`NewSlot`/`Final` attribute assertions for open data class / non-open data class / data struct, true polymorphic dispatch through a base reference (compile + run), the **exact real-world `Oahu.Core.ProfileKey`/`ProfileKeyEx` shape** (open data class + derived data class chaining `base.ToString()`, compiled/run/ILVerify'd end-to-end), the **exact real-world `Oahu.Cli.Tui.Tokens.SemanticColor` shape** (data struct with expression-bodied `ToString`), 2 negative compile-failure controls (GS0487 wrong-return-type; GS0232 `Equals` regression), and a row-planner regression check. **All pass.**
- Pre-existing `DataStructTests.cs` (12 tests) and `DataStructSynthesizedMembersTests.cs`/`Issue1136ObjectMemberEmitTests.cs` regression suites confirmed unaffected.

## Full suite results (after incorporating latest origin/main, 170fbb3d)

- Core.Tests: **6161 passed**, 1 skipped (pre-existing baseline-regen test), 0 failed.
- Compiler.Tests: **3005 passed**, 0 failed.
- Cs2Gs.Tests: **1383 passed**, 0 failed.
- InternalAnalyzers.Tests: **7 passed**, 0 failed.
- Full solution build (`dotnet build gsharp.sln -c Debug`, analyzers enabled): **0 warnings, 0 errors**.

## Deferred / out-of-scope findings

- **Receiver-clause on imported/cross-package types**: a receiver-clause (`func (p T) ToString() string`) declaration only reaches the new shape-compatibility check when `T` is in the *same* package (an "owned type" receiver clause, which already emits a GS0314 warning steering users toward the in-body form). A receiver-clause `ToString` on a genuinely cross-package/imported data type is bound as an ordinary extension function and never reaches the data-type reservation logic — consistent with G#'s extension-function design (extension functions cannot participate in virtual dispatch). Not a defect; documented in the ADR amendment.
- **Plain (non-`data`) class `ToString` vtable slots**: a hand-written `ToString` override on a plain (non-`data`) class always gets a *new* vtable slot unless the G# `override` keyword resolves against a matching base declaration — a pre-existing limitation unrelated to data types, not addressed here.
- **Object-initializer syntax for derived data classes** (found during manual scratch validation, unrelated to #2361): `DerivedType{ Field: val }` object-initializer syntax fails with an IL StackUnderflow when `DerivedType` is a data class deriving from another data class via a base-primary-constructor call (`: Base(Field)`); positional constructor-call syntax (`DerivedType(val)`) works fine in the same scenario. Pre-existing, confirmed via `Issue2338GenericPrimaryCtorBaseInitializerEmitTests.cs`, which already avoids object-initializer syntax for this exact case. Recommend a follow-up issue if not already tracked.

Closes #2361.
