### PR TITLE
Add safe structural projections

### DIFF
--- a/docs/adr/0148-safe-structural-projections.md
+++ b/docs/adr/0148-safe-structural-projections.md
@@ -1,0 +1,363 @@
+# ADR-0148: Safe structural projections and object-spread mapping
+
+- **Status**: Accepted
+- **Date**: 2026-07-15
+- **Phase**: Phase 3.B (OO surface) follow-on
+- **Related**: ADR-0051 (properties and auto-properties), ADR-0100 (target-typed `default`), ADR-0112 (unified member resolution), ADR-0117 (object and collection initializers), ADR-0146 (anonymous-object literals)
+- **Implementation**: `StructuralProjectionPlanner` and projection lowering in `ConversionClassifier`; object-spread parsing/binding in `Parser` and `ExpressionBinder.Literals`
+
+## Context
+
+G# supports named class and struct literals, anonymous `object { ... }` and
+`data object { ... }` values, ordinary implicit conversions, and target-typed
+function arguments. It does not yet provide a safe way to project one object
+shape into another unrelated concrete type.
+
+This leaves routine application boundaries verbose. Domain models, persistence
+entities, transport DTOs, view models, and anonymous query results often carry
+the same public data under distinct nominal types. Developers must currently
+copy each member manually or introduce a mapping library and its runtime
+configuration.
+
+The language can remove that boilerplate because both shapes are known at
+compile time. However, structural projection must not be implemented as a raw
+copy of the target's storage. Such a copy could bypass constructors, setters,
+visibility, readonly state, and other invariants. Reusing a source expression
+for every projected member could also evaluate calls or other side effects more
+than once.
+
+This ADR distinguishes a **structural projection** from a cast or reference
+conversion:
+
+- A cast or nominal conversion preserves or adapts the existing value.
+- A structural projection constructs a new target value from readable source
+  members.
+- Interface adaptation forwards behavior and identity rather than constructing
+  a concrete value; it is a separate feature.
+
+Both anonymous synthesized source types and explicitly declared source types
+participate. Projection is entirely compile-time and does not use runtime
+reflection or mapping profiles.
+
+## Decision
+
+### A. Strict implicit structural projection
+
+An expression of source type `S` is implicitly projectable to an unrelated
+concrete target type `T` when the compiler can build one complete, unambiguous,
+safe projection plan.
+
+```gsharp
+data class PersonDto(Name string, Age int32)
+
+let dto PersonDto = source
+send(source) // `send` accepts PersonDto
+```
+
+The same rule applies when `source` has an anonymous synthesized type:
+
+```gsharp
+data class PersonDto(Name string, Age int32)
+
+let dto PersonDto = object {
+    let Name = "Ada"
+    let Age = 37
+}
+
+let dataDto PersonDto = data object {
+    let Name = "Grace"
+    let Age = 40
+}
+```
+
+It also applies to explicitly declared source classes and structs:
+
+```gsharp
+class PersonEntity {
+    var Name string
+    var Age int32
+    var PersistenceVersion int64
+}
+
+data class PersonDto(Name string, Age int32)
+
+let entity = PersonEntity{
+    Name: "Ada",
+    Age: 37,
+    PersistenceVersion: 12
+}
+
+// The extra PersistenceVersion source member is ignored.
+let dto PersonDto = entity
+```
+
+Implicit projection is **strict on the destination** and permits width
+subtyping on the source:
+
+- Every required target construction slot must be supplied.
+- Every automatically writable target member in the selected construction path
+  must have a compatible source member.
+- Extra source members are ignored.
+- A missing, ambiguous, inaccessible, or incompatibly typed member makes the
+  implicit projection unavailable and produces a targeted diagnostic when the
+  conversion is required.
+
+This strictness prevents an implicit conversion from silently leaving visible
+destination state at a default value.
+
+### B. Explicit object-spread projection
+
+A named target literal may contain one object-spread source, written
+`...expression`, followed by explicit member initializers:
+
+```gsharp
+let dto = PersonDto{
+    ...entity,
+    Name: entity.DisplayName,
+    Age: int32(entity.Years)
+}
+```
+
+The spread must be the first entry and may appear at most once. Explicit
+initializers win over same-named spread members. They provide ordinary G#
+expressions for renaming, flattening, calculation, explicit conversion, nested
+projection, or intentional defaulting:
+
+```gsharp
+data class AddressDto(City string)
+data class CustomerDto(Name string, Address AddressDto, LoyaltyPoints int32)
+
+let dto = CustomerDto{
+    ...customer,
+    Name: customer.Profile.DisplayName,
+    Address: AddressDto{ ...customer.PostalAddress },
+    LoyaltyPoints: default
+}
+```
+
+Unlike implicit projection, explicit spread may be partial for writable members:
+unmatched optional fields and settable properties retain the target type's
+ordinary constructor, initializer, or default value. Required constructor
+inputs must still be supplied by the spread or by an explicit initializer.
+
+No separate ignore, rename, resolver, converter, reverse-map, or profile syntax
+is introduced. Explicit target initializers already express those operations.
+
+### C. Automatic mapping surface
+
+Automatic discovery considers only members that form a public data and
+construction contract.
+
+Eligible source members are:
+
+- public readable instance fields; and
+- public readable, non-indexed instance properties.
+
+Eligible target slots are:
+
+- parameters of the selected public construction path;
+- public mutable instance fields; and
+- public non-indexed instance properties with an `init` or `set` accessor.
+
+The following never participate automatically:
+
+- private, protected, or internal members;
+- compiler-generated backing fields;
+- static members;
+- constants, readonly fields, events, indexers, or methods;
+- get-only target properties that are not supplied through a constructor; and
+- members available only because the projection occurs inside their declaring
+  type.
+
+Automatic projection therefore never gains privilege from the lexical binding
+context. Explicit member expressions continue to follow ordinary G#
+accessibility rules, allowing a type's own code to access its private state
+deliberately without making that state discoverable by the mapper.
+
+For example, the private field is neither required nor writable by projection:
+
+```gsharp
+class Account {
+    var Name string
+    private var PasswordHash string
+}
+
+data class AccountView(Name string)
+
+let view AccountView = account
+```
+
+A constructor may initialize private target state internally. That is safe
+because the constructor remains the type's declared invariant boundary.
+
+### D. Construction paths
+
+A projection constructs the target through its normal public surface:
+
+1. A declared primary/data constructor is used when its required parameters can
+   be satisfied unambiguously.
+2. Otherwise, a public parameterless constructor or the normal zero-value
+   construction for a value type is used, followed by ordinary public field and
+   property initialization.
+3. An abstract target or a type with no safe public construction path is not
+   structurally projectable.
+
+The compiler must not initialize non-public fields directly, invoke private
+setters, or manufacture a value that ordinary source code could not construct
+through the selected public path.
+
+Source and target member names match exactly and case-sensitively. Member values
+must have an existing implicit conversion to their target slot. A caller that
+wants narrowing or another explicit conversion writes it in an explicit target
+initializer.
+
+Structural projection is not recursively applied to member values in the first
+implementation. Nested objects and collections use explicit projection or
+ordinary sequence operations. Recursive projection can be considered later
+with cycle detection and separate overload-resolution analysis.
+
+### E. Evaluation and side effects
+
+Projection has an exact single-evaluation contract:
+
+- The source expression is evaluated exactly once and captured in a synthetic
+  local before any projected member is read.
+- Every selected source field or property getter is evaluated at most once.
+- Anonymous-object member initializer expressions are evaluated exactly once in
+  lexical order, including initializers for extra members ignored by width
+  subtyping.
+- Explicit target initializer expressions are evaluated exactly once in lexical
+  order.
+- Target constructors, setters, and public field writes retain their ordinary
+  language semantics.
+
+Conceptually, a named-source projection lowers as follows:
+
+```gsharp
+let sourceTemp = sourceExpression
+let targetTemp = Target(
+    Name: sourceTemp.Name,
+    Age: sourceTemp.Age
+)
+targetTemp
+```
+
+The actual lowering may use existing bound block, synthetic-local, constructor,
+field-assignment, and property-assignment nodes. It must not duplicate the
+original source expression in generated member-access nodes.
+
+### F. Conversion and overload precedence
+
+Structural projection is considered only after identity, nominal inheritance,
+built-in representation-preserving conversions, and applicable user-defined
+conversions.
+
+For overload resolution it is weaker than those conversions. If two overloads
+are applicable only through different structural projections and neither has a
+better non-structural conversion, the call is ambiguous. The compiler does not
+rank candidates by counting matching members or by guessing which shape is
+closer.
+
+Implicit projection is unavailable for `ref`, `out`, or `in` arguments because
+it creates a distinct target value rather than an alias to the source storage.
+
+### G. Compiler architecture
+
+One context-aware structural-projection planner is the source of truth for:
+
+- conversion applicability;
+- overload candidate validation;
+- detailed missing/ambiguous/incompatible-member diagnostics; and
+- bound-tree lowering.
+
+The planner operates on source and target member models plus the current
+projection mode (strict implicit or explicit spread). It must not be represented
+only by a type-pair conversion singleton: construction choice, accessibility,
+explicit overrides, and evaluation capture are part of the plan.
+
+User-defined member lookup reuses `TypeMemberModel`; imported CLR lookup reuses
+the existing public-member helpers behind `MemberLookup`. Target writes route
+through the same accessibility and writability checks as ordinary named target
+literals and object initializers.
+
+Lowering reuses existing constructors, `BoundBlockExpression`, synthetic
+locals, and normal field/property assignment nodes. No projection-specific
+runtime library or emitter path is required.
+
+### H. Interface targets are separate
+
+This ADR does not structurally project to an interface. A concrete target is
+constructed; an interface has no construction shape. Making an unrelated value
+act as an interface requires a forwarding adapter and decisions about identity,
+mutation, equality, method dispatch, and allocation.
+
+Anonymous objects continue to implement interfaces explicitly:
+
+```gsharp
+let listener MouseListener = object : MouseListener {
+    func onClick() { Console.WriteLine("clicked") }
+}
+```
+
+Structural interface adapters may be proposed separately with explicit syntax.
+
+## Consequences
+
+Positive:
+
+- Anonymous object literals and explicitly typed objects share one safe,
+  compile-time projection model.
+- Common DTO and view-model mapping becomes a normal assignment or argument
+  conversion.
+- Object spread provides local, visible control without runtime profiles or
+  reflection.
+- Constructors and public setters retain responsibility for target invariants.
+- Private storage cannot be discovered or overwritten automatically.
+- Single-evaluation rules make side effects deterministic.
+- Existing binder and lowering machinery can implement the feature without a
+  mapping runtime or bespoke emitter.
+
+Negative:
+
+- Implicit projection can allocate and invoke public getters, constructors, and
+  setters; diagnostics and documentation must make the value-producing nature
+  clear.
+- Exact-name matching intentionally does not provide convention-based
+  flattening or case-insensitive matching.
+- Strict destination coverage may reject mappings that a permissive runtime
+  mapper would accept; explicit spread is the escape hatch.
+- Interface adaptation, recursive mapping, and collection mapping remain
+  explicit or deferred.
+
+## Alternatives considered
+
+### Raw field-to-field reconstruction
+
+Rejected. Enumerating target storage bypasses visibility, constructors, setters,
+readonly state, and invariants. A projection must use only the target's normal
+construction surface.
+
+### Runtime AutoMapper-style profiles
+
+Rejected as the language primitive. Runtime reflection and global mapping
+configuration add startup work, trimming/AOT concerns, delayed failures, and
+configuration that is distant from the conversion site. Libraries remain free
+to provide that model when dynamic mapping is genuinely required.
+
+### Anonymous-object sources only
+
+Rejected. Anonymous query results are important, but explicitly declared
+entities, DTOs, structs, and imported CLR objects have the same shape-mapping
+need. The safety rules are based on public contracts, not whether the source
+type has a name.
+
+### Implicit partial mapping
+
+Rejected. Silently defaulting unmatched visible target state makes ordinary
+assignment too permissive. Strict implicit projection plus explicit partial
+spread keeps the zero-ceremony path safe and the controlled path concise.
+
+### Implicit structural interface conformance
+
+Rejected from this ADR. Forwarding behavior is an adapter problem rather than a
+concrete-value projection and requires separate identity and mutation semantics.

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -34,16 +34,32 @@ public sealed class Conversion
     /// </summary>
     public static readonly Conversion Explicit = new Conversion(exists: true, isIdentity: false, isImplicit: false);
 
+    /// <summary>
+    /// ADR-0148: a safe structural projection that constructs a new concrete
+    /// target through its public constructor/member surface.
+    /// </summary>
+    public static readonly Conversion StructuralProjection = new Conversion(
+        exists: true,
+        isIdentity: false,
+        isImplicit: true,
+        isStructuralProjection: true);
+
     // Issue #1482: the implicit numeric-widening lattice and the numeric
     // primitive set now live in the single authoritative
     // `NumericWideningLattice` helper. Conversion classification and overload
     // "better conversion" ranking both query that one table so they cannot
     // drift apart (they previously disagreed about native-int widening).
     private Conversion(bool exists, bool isIdentity, bool isImplicit)
+        : this(exists, isIdentity, isImplicit, isStructuralProjection: false)
+    {
+    }
+
+    private Conversion(bool exists, bool isIdentity, bool isImplicit, bool isStructuralProjection)
     {
         Exists = exists;
         IsIdentity = isIdentity;
         IsImplicit = isImplicit;
+        IsStructuralProjection = isStructuralProjection;
     }
 
     /// <summary>
@@ -61,6 +77,9 @@ public sealed class Conversion
     /// </summary>
     public bool IsImplicit { get; }
 
+    /// <summary>Gets a value indicating whether this conversion constructs a target through ADR-0148 structural projection.</summary>
+    public bool IsStructuralProjection { get; }
+
     /// <summary>
     /// Gets a value indicating whether the conversion is explicit or not.
     /// </summary>
@@ -73,6 +92,24 @@ public sealed class Conversion
     /// <param name="to">To type.</param>
     /// <returns>The conversion mapping between the two types.</returns>
     public static Conversion Classify(TypeSymbol from, TypeSymbol to)
+        => ClassifyCore(from, to, allowStructuralProjection: true);
+
+    /// <summary>
+    /// Classifies only pre-ADR-0148 conversions. Projection planning uses this
+    /// to keep member conversion non-recursive.
+    /// </summary>
+    /// <param name="from">The source type.</param>
+    /// <param name="to">The target type.</param>
+    /// <returns>The non-structural conversion.</returns>
+    internal static Conversion ClassifyNonStructural(TypeSymbol from, TypeSymbol to)
+        => ClassifyCore(from, to, allowStructuralProjection: false);
+
+    /// <summary>Classifies a conversion, optionally including structural projection.</summary>
+    /// <param name="from">The source type.</param>
+    /// <param name="to">The target type.</param>
+    /// <param name="allowStructuralProjection">Whether structural projection is eligible.</param>
+    /// <returns>The classified conversion.</returns>
+    internal static Conversion ClassifyCore(TypeSymbol from, TypeSymbol to, bool allowStructuralProjection)
     {
         if (from == to)
         {
@@ -1085,6 +1122,11 @@ public sealed class Conversion
             && ClrTypeUtilities.IsAssignableByName(to.ClrType, from.ClrType))
         {
             return Conversion.Implicit;
+        }
+
+        if (allowStructuralProjection && StructuralProjectionPlanner.CanProject(from, to))
+        {
+            return Conversion.StructuralProjection;
         }
 
         return Conversion.None;

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -252,6 +252,57 @@ internal sealed class ConversionClassifier
         return BindConversion(syntax.Location, expression, type, allowExplicit);
     }
 
+    /// <summary>Binds an explicit ADR-0148 spread projection.</summary>
+    /// <param name="diagnosticLocation">The source location for conversion diagnostics.</param>
+    /// <param name="expression">The spread source.</param>
+    /// <param name="targetType">The concrete target type.</param>
+    /// <param name="strict">Whether every writable target slot must be covered.</param>
+    /// <param name="explicitValues">Explicit target values keyed by exact member name.</param>
+    /// <param name="explicitOrder">Explicit member names in lexical evaluation order.</param>
+    /// <returns>The lowered projection expression.</returns>
+    public BoundExpression BindStructuralProjection(
+        TextLocation diagnosticLocation,
+        BoundExpression expression,
+        TypeSymbol targetType,
+        bool strict,
+        IReadOnlyDictionary<string, BoundExpression> explicitValues,
+        ImmutableArray<string> explicitOrder)
+        => BindStructuralProjectionCore(
+            diagnosticLocation,
+            expression,
+            targetType,
+            strict,
+            explicitValues,
+            explicitOrder);
+
+    /// <summary>Checks whether an implicit user conversion should outrank structural projection.</summary>
+    /// <param name="sourceType">The source type.</param>
+    /// <param name="targetType">The target type.</param>
+    /// <returns><see langword="true"/> when a symbolic or CLR conversion operator applies.</returns>
+    public bool HasUserDefinedImplicitConversion(TypeSymbol sourceType, TypeSymbol targetType)
+        => HasUserDefinedImplicitConversionForTypes(sourceType, targetType);
+
+    /// <summary>Checks the symbolic and CLR implicit conversion operators for a type pair.</summary>
+    /// <param name="sourceType">The source type.</param>
+    /// <param name="targetType">The target type.</param>
+    /// <returns><see langword="true"/> when an implicit conversion operator applies.</returns>
+    public static bool HasUserDefinedImplicitConversionForTypes(TypeSymbol sourceType, TypeSymbol targetType)
+    {
+        if (TryResolveUserDefinedSymbolConversion(sourceType, targetType, allowExplicit: false, out _))
+        {
+            return true;
+        }
+
+        return sourceType?.ClrType != null
+            && targetType?.ClrType != null
+            && ClrOperatorResolution.TryResolveConversion(
+                sourceType.ClrType,
+                targetType.ClrType,
+                allowExplicit: false,
+                out _,
+                out _);
+    }
+
     /// <summary>
     /// Core <c>BindConversion</c> overload: classifies the conversion from
     /// <paramref name="expression"/>'s static type to <paramref name="type"/>,
@@ -471,7 +522,25 @@ internal sealed class ConversionClassifier
 
             if (expression.Type != TypeSymbol.Error && type != TypeSymbol.Error)
             {
-                Diagnostics.ReportCannotConvert(diagnosticLocation, expression.Type, type);
+                if (!StructuralProjectionPlanner.TryCreate(
+                    expression.Type,
+                    type,
+                    strict: true,
+                    explicitMemberNames: null,
+                    out _,
+                    out var projectionFailure)
+                    && !string.IsNullOrEmpty(projectionFailure))
+                {
+                    Diagnostics.ReportStructuralProjectionFailure(
+                        diagnosticLocation,
+                        expression.Type,
+                        type,
+                        projectionFailure);
+                }
+                else
+                {
+                    Diagnostics.ReportCannotConvert(diagnosticLocation, expression.Type, type);
+                }
             }
 
             return new BoundErrorExpression(null);
@@ -485,6 +554,36 @@ internal sealed class ConversionClassifier
         if (conversion.IsIdentity)
         {
             return expression;
+        }
+
+        if (conversion.IsStructuralProjection)
+        {
+            if (TryResolveUserDefinedSymbolConversion(expression.Type, type, allowExplicit, out var projectionUserConvOp))
+            {
+                var converted = projectionUserConvOp.Parameters.Length == 1
+                    ? BindConversion(diagnosticLocation, expression, projectionUserConvOp.Parameters[0].Type, allowExplicit)
+                    : expression;
+                return new BoundCallExpression(null, projectionUserConvOp, ImmutableArray.Create(converted));
+            }
+
+            if (expression.Type?.ClrType != null && type?.ClrType != null
+                && ClrOperatorResolution.TryResolveConversion(
+                    expression.Type.ClrType,
+                    type.ClrType,
+                    allowExplicit,
+                    out var projectionConvMethod,
+                    out _))
+            {
+                return new BoundClrConversionCallExpression(null, expression, projectionConvMethod, type);
+            }
+
+            return BindStructuralProjectionCore(
+                diagnosticLocation,
+                expression,
+                type,
+                strict: true,
+                explicitValues: null,
+                explicitOrder: default);
         }
 
         // Issue #367: a by-ref-like (`ref struct`) value boxes when converted to
@@ -823,7 +922,12 @@ internal sealed class ConversionClassifier
                         var location = call != null && sourceIndex >= 0 && sourceIndex < call.Arguments.Count
                             ? call.Arguments[sourceIndex].Location
                             : call?.Location ?? default;
-                        rebound = BindConversion(location, argument, targetType, allowExplicit: true);
+                        var parameterConversion = Conversion.Classify(argument.Type, targetType);
+                        rebound = BindConversion(
+                            location,
+                            argument,
+                            targetType,
+                            allowExplicit: !parameterConversion.IsStructuralProjection);
                     }
                     else if (argument.Type != targetType
                         && TryApplyUserDefinedImplicitArgumentConversion(argument, targetType, out var udcArg))
@@ -2284,5 +2388,287 @@ internal sealed class ConversionClassifier
             expression.Syntax,
             ImmutableArray.Create<BoundStatement>(declaration),
             rebuilt);
+    }
+
+    private BoundExpression BindStructuralProjectionCore(
+        TextLocation diagnosticLocation,
+        BoundExpression expression,
+        TypeSymbol targetType,
+        bool strict,
+        IReadOnlyDictionary<string, BoundExpression> explicitValues,
+        ImmutableArray<string> explicitOrder)
+    {
+        var explicitNames = explicitValues == null
+            ? null
+            : new HashSet<string>(explicitValues.Keys, StringComparer.Ordinal);
+        if (!StructuralProjectionPlanner.TryCreate(
+            expression.Type,
+            targetType,
+            strict,
+            explicitNames,
+            out var plan,
+            out var failure))
+        {
+            if (expression.Type != TypeSymbol.Error && targetType != TypeSymbol.Error)
+            {
+                if (!string.IsNullOrEmpty(failure))
+                {
+                    Diagnostics.ReportStructuralProjectionFailure(
+                        diagnosticLocation,
+                        expression.Type,
+                        targetType,
+                        failure);
+                }
+                else
+                {
+                    Diagnostics.ReportCannotConvert(diagnosticLocation, expression.Type, targetType);
+                }
+            }
+
+            return new BoundErrorExpression(expression.Syntax);
+        }
+
+        var sourceTemp = new LocalVariableSymbol(
+            $"<projectionSource{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
+            isReadOnly: true,
+            expression.Type);
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        statements.Add(new BoundVariableDeclaration(expression.Syntax, sourceTemp, expression));
+
+        Dictionary<string, BoundExpression> explicitReads = null;
+        if (explicitValues != null)
+        {
+            explicitReads = new Dictionary<string, BoundExpression>(StringComparer.Ordinal);
+            foreach (var name in explicitOrder)
+            {
+                if (!explicitValues.TryGetValue(name, out var value) || explicitReads.ContainsKey(name))
+                {
+                    continue;
+                }
+
+                var explicitTemp = new LocalVariableSymbol(
+                    $"<projectionOverride{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
+                    isReadOnly: true,
+                    value.Type);
+                statements.Add(new BoundVariableDeclaration(value.Syntax, explicitTemp, value));
+                explicitReads.Add(name, new BoundVariableExpression(value.Syntax, explicitTemp));
+            }
+        }
+
+        var constructorArguments = ImmutableArray.CreateBuilder<BoundExpression>(plan.ConstructorSlots.Length);
+        foreach (var slot in plan.ConstructorSlots)
+        {
+            constructorArguments.Add(BindStructuralProjectionSlot(
+                diagnosticLocation,
+                expression.Syntax,
+                sourceTemp,
+                slot,
+                explicitReads));
+        }
+
+        if (plan.Construction.Kind == StructuralProjectionConstructionKind.UserDefault
+            && !plan.Construction.UserType.IsClass)
+        {
+            var initializers = ImmutableArray.CreateBuilder<BoundFieldInitializer>(plan.InitializerSlots.Length);
+            var initializedFields = new HashSet<FieldSymbol>();
+            foreach (var slot in plan.InitializerSlots)
+            {
+                var value = BindStructuralProjectionSlot(
+                    diagnosticLocation,
+                    expression.Syntax,
+                    sourceTemp,
+                    slot,
+                    explicitReads);
+                initializers.Add(slot.TargetField != null
+                    ? new BoundFieldInitializer(slot.TargetField, value)
+                    : new BoundFieldInitializer(slot.TargetProperty, value));
+                if (slot.TargetField != null)
+                {
+                    initializedFields.Add(slot.TargetField);
+                }
+                else if (slot.TargetProperty?.BackingField != null)
+                {
+                    initializedFields.Add(slot.TargetProperty.BackingField);
+                }
+            }
+
+            foreach (var field in plan.Construction.UserType.Fields)
+            {
+                if (initializedFields.Contains(field))
+                {
+                    continue;
+                }
+
+                if (TryGetStructuralProjectionFieldInitializer(
+                    plan.Construction.UserType,
+                    field,
+                    out var initializer))
+                {
+                    initializers.Add(new BoundFieldInitializer(field, initializer));
+                }
+                else if (field.Type == TypeSymbol.String)
+                {
+                    initializers.Add(new BoundFieldInitializer(
+                        field,
+                        new BoundLiteralExpression(expression.Syntax, string.Empty, TypeSymbol.String)));
+                }
+            }
+
+            var literal = new BoundStructLiteralExpression(expression.Syntax, plan.Construction.UserType, initializers.ToImmutable());
+            return new BoundBlockExpression(expression.Syntax, statements.ToImmutable(), literal);
+        }
+
+        BoundExpression construction = plan.Construction.Kind switch
+        {
+            StructuralProjectionConstructionKind.UserDefault => new BoundConstructorCallExpression(
+                expression.Syntax,
+                plan.Construction.UserType,
+                ImmutableArray<BoundExpression>.Empty),
+            StructuralProjectionConstructionKind.UserPrimary => new BoundConstructorCallExpression(
+                expression.Syntax,
+                plan.Construction.UserType,
+                constructorArguments.ToImmutable()),
+            StructuralProjectionConstructionKind.UserExplicit => new BoundConstructorCallExpression(
+                expression.Syntax,
+                plan.Construction.UserType,
+                constructorArguments.ToImmutable(),
+                plan.Construction.UserConstructor),
+            StructuralProjectionConstructionKind.ClrConstructor => new BoundClrConstructorCallExpression(
+                expression.Syntax,
+                targetType.ClrType,
+                plan.Construction.ClrConstructor,
+                constructorArguments.ToImmutable(),
+                targetType),
+            StructuralProjectionConstructionKind.ClrDefaultValue => new BoundDefaultExpression(expression.Syntax, targetType),
+            _ => throw new InvalidOperationException("Unsupported structural projection construction."),
+        };
+
+        if (plan.InitializerSlots.IsDefaultOrEmpty)
+        {
+            return new BoundBlockExpression(expression.Syntax, statements.ToImmutable(), construction);
+        }
+
+        var targetTemp = new LocalVariableSymbol(
+            $"<projectionTarget{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
+            isReadOnly: false,
+            targetType);
+        statements.Add(new BoundVariableDeclaration(expression.Syntax, targetTemp, construction));
+        foreach (var slot in plan.InitializerSlots)
+        {
+            var receiver = new BoundVariableExpression(expression.Syntax, targetTemp);
+            var value = BindStructuralProjectionSlot(
+                diagnosticLocation,
+                expression.Syntax,
+                sourceTemp,
+                slot,
+                explicitReads);
+            BoundExpression assignment;
+            if (slot.TargetField != null)
+            {
+                assignment = new BoundFieldAssignmentExpression(
+                    expression.Syntax,
+                    targetTemp,
+                    slot.TargetDeclaringType,
+                    slot.TargetField,
+                    value);
+            }
+            else if (slot.TargetProperty != null)
+            {
+                assignment = new BoundPropertyAssignmentExpression(
+                    expression.Syntax,
+                    receiver,
+                    slot.TargetDeclaringType,
+                    slot.TargetProperty,
+                    value);
+            }
+            else
+            {
+                assignment = new BoundClrPropertyAssignmentExpression(
+                    expression.Syntax,
+                    receiver,
+                    slot.TargetClrMember,
+                    value,
+                    slot.TargetType);
+            }
+
+            statements.Add(new BoundExpressionStatement(expression.Syntax, assignment));
+        }
+
+        return new BoundBlockExpression(
+            expression.Syntax,
+            statements.ToImmutable(),
+            new BoundVariableExpression(expression.Syntax, targetTemp));
+    }
+
+    private static bool TryGetStructuralProjectionFieldInitializer(
+        StructSymbol type,
+        FieldSymbol field,
+        out BoundExpression initializer)
+    {
+        if (type.InstanceFieldInitializers.TryGetValue(field, out initializer))
+        {
+            return true;
+        }
+
+        if (type.Definition != null)
+        {
+            foreach (var candidate in type.Definition.InstanceFieldInitializers)
+            {
+                if (string.Equals(candidate.Key.Name, field.Name, StringComparison.Ordinal))
+                {
+                    initializer = candidate.Value;
+                    return true;
+                }
+            }
+        }
+
+        initializer = null;
+        return false;
+    }
+
+    private BoundExpression BindStructuralProjectionSlot(
+        TextLocation diagnosticLocation,
+        SyntaxNode syntax,
+        VariableSymbol sourceTemp,
+        StructuralProjectionSlot slot,
+        IReadOnlyDictionary<string, BoundExpression> explicitReads)
+    {
+        if (slot.Source == null)
+        {
+            if (explicitReads != null && explicitReads.TryGetValue(slot.Name, out var explicitRead))
+            {
+                return explicitRead;
+            }
+
+            if (slot.UserDefaultParameter != null)
+            {
+                return OverloadResolver.CreateOptionalUserDefaultArgument(slot.UserDefaultParameter);
+            }
+
+            if (slot.ClrDefaultParameter != null)
+            {
+                return CreateOptionalDefaultArgument(slot.ClrDefaultParameter);
+            }
+
+            throw new InvalidOperationException($"Structural projection slot '{slot.Name}' has no value.");
+        }
+
+        var source = slot.Source;
+        var receiver = new BoundVariableExpression(syntax, sourceTemp);
+        BoundExpression read;
+        if (source.Field != null)
+        {
+            read = new BoundFieldAccessExpression(syntax, receiver, source.DeclaringType, source.Field);
+        }
+        else if (source.Property != null)
+        {
+            read = new BoundPropertyAccessExpression(syntax, receiver, source.DeclaringType, source.Property);
+        }
+        else
+        {
+            read = new BoundClrPropertyAccessExpression(syntax, receiver, source.ClrMember, source.Type);
+        }
+
+        return BindConversion(diagnosticLocation, read, slot.TargetType);
     }
 }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -7959,7 +7959,8 @@ internal sealed class DeclarationBinder
                 ctors,
                 argTypes,
                 interpolatedStringArgs: interpolatedStringArgs,
-                constantNarrowingArgumentCheck: ExpressionBinder.MakeConstantNarrowingArgumentCheck(boundArguments));
+                constantNarrowingArgumentCheck: ExpressionBinder.MakeConstantNarrowingArgumentCheck(boundArguments),
+                structuralProjectionArgumentCheck: ExpressionBinder.MakeStructuralProjectionArgumentCheck(boundArguments));
             switch (resolution.Outcome)
             {
                 case OverloadResolution.ResolutionOutcome.Resolved:

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1024,7 +1024,8 @@ internal sealed partial class ExpressionBinder
                 interpolatedStringArgs: ComputeInterpolatedStringArgFlags(syntax.Arguments, boundArguments.Count),
                 argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
                 supplementaryInterfaceCheck: supplementaryInterfaceCheck,
-                constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(boundArguments));
+                constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(boundArguments),
+                structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(boundArguments));
             switch (resolution.Outcome)
             {
                 case OverloadResolution.ResolutionOutcome.Resolved:
@@ -3938,7 +3939,8 @@ internal sealed partial class ExpressionBinder
                     ComputeInterpolatedStringArgFlags(ce.Arguments, arguments.Length),
                     argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
                     supplementaryInterfaceCheck: supplementaryInterfaceCheck,
-                    constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments));
+                    constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
+                    structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments));
                 switch (resolution.Outcome)
                 {
                     case OverloadResolution.ResolutionOutcome.Resolved:
@@ -4904,7 +4906,8 @@ internal sealed partial class ExpressionBinder
             ComputeInterpolatedStringArgFlags(ce.Arguments, arguments.Length),
             argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
-            constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments));
+            constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
+            structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments));
 
         switch (resolution.Outcome)
         {
@@ -5220,7 +5223,8 @@ internal sealed partial class ExpressionBinder
             ComputeInterpolatedStringArgFlags(ce.Arguments, argTypes.Length, receiverArgCount: 1),
             argumentNames: extensionArgumentNames,
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
-            constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments, argumentOffset: 1));
+            constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments, argumentOffset: 1),
+            structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments, argumentOffset: 1));
 
         switch (resolution.Outcome)
         {
@@ -6694,7 +6698,8 @@ internal sealed partial class ExpressionBinder
             scope.References.MapClrTypeToReferences,
             interpolatedStringArgs,
             argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
-            constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments));
+            constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
+            structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments));
         if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
         {
             return false;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -908,6 +908,11 @@ internal sealed partial class ExpressionBinder
         StructSymbol resolvedDefinition,
         ImmutableArray<TypeSymbol> enclosingTypeArguments = default)
     {
+        if (syntax.SpreadExpression != null)
+        {
+            return BindStructuralSpreadLiteral(syntax, resolvedDefinition, enclosingTypeArguments);
+        }
+
         var typeName = syntax.TypeIdentifier.Text;
 
         StructSymbol structSymbol = null;
@@ -1252,6 +1257,121 @@ internal sealed partial class ExpressionBinder
 
         var litResult = new BoundVariableExpression(syntax, litTemp);
         return new BoundBlockExpression(syntax, bracedStatements.ToImmutable(), litResult);
+    }
+
+    private BoundExpression BindStructuralSpreadLiteral(
+        StructLiteralExpressionSyntax syntax,
+        StructSymbol resolvedDefinition,
+        ImmutableArray<TypeSymbol> enclosingTypeArguments)
+    {
+        var emptyTargetSyntax = new StructLiteralExpressionSyntax(
+            syntax.SyntaxTree,
+            syntax.TypeIdentifier,
+            syntax.OpenBraceToken,
+            spreadToken: null,
+            spreadExpression: null,
+            spreadSeparatorToken: null,
+            new SeparatedSyntaxList<FieldInitializerSyntax>(ImmutableArray<SyntaxNode>.Empty),
+            syntax.CloseBraceToken)
+        {
+            TypeArgumentList = syntax.TypeArgumentList,
+        };
+
+        var boundTarget = BindStructLiteralExpression(emptyTargetSyntax, resolvedDefinition, enclosingTypeArguments);
+        var source = BindExpression(syntax.SpreadExpression);
+        if (boundTarget is BoundErrorExpression)
+        {
+            foreach (var initializer in syntax.Initializers)
+            {
+                _ = BindExpression(initializer.Value);
+            }
+
+            return new BoundErrorExpression(syntax);
+        }
+
+        var explicitNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var initializer in syntax.Initializers)
+        {
+            explicitNames.Add(initializer.FieldIdentifier.Text);
+        }
+
+        if (!StructuralProjectionPlanner.TryCreate(
+            source.Type,
+            boundTarget.Type,
+            strict: false,
+            explicitNames,
+            out var plan,
+            out _))
+        {
+            var failedValues = new Dictionary<string, BoundExpression>(StringComparer.Ordinal);
+            var failedOrder = ImmutableArray.CreateBuilder<string>(syntax.Initializers.Count);
+            foreach (var initializer in syntax.Initializers)
+            {
+                failedValues[initializer.FieldIdentifier.Text] = BindExpression(initializer.Value);
+                failedOrder.Add(initializer.FieldIdentifier.Text);
+            }
+
+            return conversions.BindStructuralProjection(
+                syntax.SpreadExpression.Location,
+                source,
+                boundTarget.Type,
+                strict: false,
+                explicitValues: failedValues,
+                explicitOrder: failedOrder.ToImmutable());
+        }
+
+        var slotTypes = new Dictionary<string, TypeSymbol>(StringComparer.Ordinal);
+        foreach (var slot in plan.ConstructorSlots.Concat(plan.InitializerSlots))
+        {
+            slotTypes[slot.Name] = slot.TargetType;
+        }
+
+        var values = new Dictionary<string, BoundExpression>(StringComparer.Ordinal);
+        var order = ImmutableArray.CreateBuilder<string>(syntax.Initializers.Count);
+        foreach (var initializer in syntax.Initializers)
+        {
+            var name = initializer.FieldIdentifier.Text;
+            if (values.ContainsKey(name))
+            {
+                Diagnostics.ReportSymbolAlreadyDeclared(initializer.FieldIdentifier.Location, name);
+                _ = BindExpression(initializer.Value);
+                continue;
+            }
+
+            if (!slotTypes.TryGetValue(name, out var slotType))
+            {
+                _ = BindExpression(initializer.Value);
+                Diagnostics.ReportStructuralProjectionFailure(
+                    initializer.FieldIdentifier.Location,
+                    source.Type,
+                    boundTarget.Type,
+                    $"Explicit initializer '{name}' does not name a public construction or writable member slot.");
+                continue;
+            }
+
+            if (initializer.Value is CollectionInitializerExpressionSyntax { Target: null } collection)
+            {
+                BindCollectionElementsForDiagnostics(collection);
+                Diagnostics.ReportStructuralProjectionFailure(
+                    initializer.FieldIdentifier.Location,
+                    source.Type,
+                    boundTarget.Type,
+                    $"Explicit projection initializer '{name}' requires an expression value.");
+                continue;
+            }
+
+            var value = BindExpression(initializer.Value);
+            values.Add(name, conversions.BindConversion(initializer.Value.Location, value, slotType));
+            order.Add(name);
+        }
+
+        return conversions.BindStructuralProjection(
+            syntax.SpreadExpression.Location,
+            source,
+            boundTarget.Type,
+            strict: false,
+            explicitValues: values,
+            explicitOrder: order.ToImmutable());
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -2095,4 +2095,33 @@ internal sealed partial class ExpressionBinder
             return IsImplicitConstantNarrowingArgument(boundArguments[argIndex], TypeSymbol.FromClrType(clrParameterType));
         };
     }
+
+    // ADR-0148: imported overload resolution works on CLR Type surrogates and
+    // cannot see a G# argument's symbolic public shape. Supply that context as
+    // a call-local applicability callback; by-ref parameters remain excluded.
+    internal static Func<int, System.Type, bool> MakeStructuralProjectionArgumentCheck(
+        IReadOnlyList<BoundExpression> boundArguments,
+        int argumentOffset = 0)
+    {
+        if (boundArguments == null)
+        {
+            return null;
+        }
+
+        return (index, clrParameterType) =>
+        {
+            var argIndex = index - argumentOffset;
+            if (argIndex < 0
+                || argIndex >= boundArguments.Count
+                || clrParameterType == null
+                || clrParameterType.IsByRef)
+            {
+                return false;
+            }
+
+            return StructuralProjectionPlanner.CanProject(
+                boundArguments[argIndex].Type,
+                TypeSymbol.FromClrType(clrParameterType));
+        };
+    }
 }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -174,6 +174,12 @@ internal static class OverloadResolution
         /// so an exact identity or widening match always wins when applicable.
         /// </summary>
         ConstantNarrowing = 13,
+
+        /// <summary>
+        /// ADR-0148 structural projection. Ranked worse than every nominal,
+        /// built-in, and user-defined implicit conversion.
+        /// </summary>
+        StructuralProjection = 14,
     }
 
     /// <summary>
@@ -644,7 +650,11 @@ internal static class OverloadResolution
     /// this call's candidates. Threaded as a parameter for the same reentrancy/
     /// concurrency reason as <paramref name="supplementaryInterfaceCheck"/>.
     /// </param>
-    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null)
+    /// <param name="structuralProjectionArgumentCheck">
+    /// Optional binder callback that recognizes an argument's symbolic object
+    /// shape as projectable to a candidate CLR parameter type.
+    /// </param>
+    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null)
         where T : MethodBase
     {
         var applicable = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)>();
@@ -668,7 +678,7 @@ internal static class OverloadResolution
             // rest.
             try
             {
-                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck);
+                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck, structuralProjectionArgumentCheck);
             }
             catch (Exception ex) when (IsMetadataLoadFailure(ex))
             {
@@ -687,7 +697,7 @@ internal static class OverloadResolution
             {
                 try
                 {
-                    EvaluateExpandedParamsCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck);
+                    EvaluateExpandedParamsCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck, structuralProjectionArgumentCheck);
                 }
                 catch (Exception ex) when (IsMetadataLoadFailure(ex))
                 {
@@ -2045,7 +2055,7 @@ internal static class OverloadResolution
     /// so the per-candidate work can be guarded against reflection load
     /// failures (issue #321) without disturbing the surrounding control flow.
     /// </summary>
-    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null)
+    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null)
         where T : MethodBase
     {
         {
@@ -2268,6 +2278,11 @@ internal static class OverloadResolution
                         // correctly-typed literal before emit.
                         conv = ImplicitConversionKind.ConstantNarrowing;
                     }
+                    else if (structuralProjectionArgumentCheck != null
+                        && structuralProjectionArgumentCheck(i, paramTypes[i]))
+                    {
+                        conv = ImplicitConversionKind.StructuralProjection;
+                    }
                     else
                     {
                         ok = false;
@@ -2298,7 +2313,7 @@ internal static class OverloadResolution
     /// applicability check in <see cref="EvaluateCandidate"/> but rewrites the
     /// trailing parameter type to the element type for ranking purposes.
     /// </summary>
-    private static void EvaluateExpandedParamsCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null)
+    private static void EvaluateExpandedParamsCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null)
         where T : MethodBase
     {
         T candidate = rawCandidate;
@@ -2486,7 +2501,15 @@ internal static class OverloadResolution
             var conv = ClassifyImplicit(target, argTypes[i], supplementaryInterfaceCheck);
             if (conv == ImplicitConversionKind.None)
             {
-                return;
+                if (structuralProjectionArgumentCheck != null
+                    && structuralProjectionArgumentCheck(i, target))
+                {
+                    conv = ImplicitConversionKind.StructuralProjection;
+                }
+                else
+                {
+                    return;
+                }
             }
 
             conversions[i] = conv;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -1530,7 +1530,7 @@ internal sealed class OverloadResolver
     /// separately, but they still rank strictly better than the numeric/
     /// delegate special cases ranked worse below.
     /// </summary>
-    private static OverloadResolution.ImplicitConversionKind ClassifyUserArgumentConversionKind(TypeSymbol argType, TypeSymbol paramType)
+    private OverloadResolution.ImplicitConversionKind ClassifyUserArgumentConversionKind(TypeSymbol argType, TypeSymbol paramType)
     {
         if (argType == null || paramType == null)
         {
@@ -1540,6 +1540,13 @@ internal sealed class OverloadResolver
         if (argType == paramType)
         {
             return OverloadResolution.ImplicitConversionKind.Identity;
+        }
+
+        if (Conversion.Classify(argType, paramType).IsStructuralProjection)
+        {
+            return conversions.HasUserDefinedImplicitConversion(argType, paramType)
+                ? OverloadResolution.ImplicitConversionKind.UserDefinedImplicit
+                : OverloadResolution.ImplicitConversionKind.StructuralProjection;
         }
 
         if (paramType is NullableTypeSymbol nullableParam && argType == nullableParam.UnderlyingType)

--- a/src/Core/CodeAnalysis/Binding/SmartCastStability.cs
+++ b/src/Core/CodeAnalysis/Binding/SmartCastStability.cs
@@ -272,10 +272,9 @@ internal static class SmartCastStability
         // Issue #1636: a candidate distinct from the declared type is a genuine
         // subtype narrowing when it implicitly converts to the declared type
         // (candidate → declared): every candidate value is already usable as
-        // declared. `Conversion.Classify` encodes the full class/interface/
-        // base-type lattice (class → base class, class → implemented interface,
-        // interface → base interface, struct → interface, etc.).
-        var toDeclared = Conversion.Classify(candidate, declared);
+        // declared. Structural projection constructs a new value and therefore
+        // is not a runtime subtype relation; exclude it from type-test narrowing.
+        var toDeclared = Conversion.ClassifyNonStructural(candidate, declared);
         if (toDeclared.Exists && toDeclared.IsImplicit)
         {
             return true;

--- a/src/Core/CodeAnalysis/Binding/StructuralProjectionPlan.cs
+++ b/src/Core/CodeAnalysis/Binding/StructuralProjectionPlan.cs
@@ -1,0 +1,772 @@
+// <copyright file="StructuralProjectionPlan.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+internal enum StructuralProjectionConstructionKind
+{
+    /// <summary>Default construction of a user type.</summary>
+    UserDefault,
+
+    /// <summary>Primary construction of a user type.</summary>
+    UserPrimary,
+
+    /// <summary>Explicit construction of a user type.</summary>
+    UserExplicit,
+
+    /// <summary>Default initialization of a CLR value type.</summary>
+    ClrDefaultValue,
+
+    /// <summary>Public CLR constructor invocation.</summary>
+    ClrConstructor,
+}
+
+/// <summary>
+/// ADR-0148 compile-time plan for constructing one concrete object shape from
+/// another through public readable/writable members.
+/// </summary>
+internal sealed class StructuralProjectionPlan
+{
+    public StructuralProjectionPlan(
+        TypeSymbol sourceType,
+        TypeSymbol targetType,
+        StructuralProjectionConstruction construction,
+        ImmutableArray<StructuralProjectionSlot> constructorSlots,
+        ImmutableArray<StructuralProjectionSlot> initializerSlots)
+    {
+        SourceType = sourceType;
+        TargetType = targetType;
+        Construction = construction;
+        ConstructorSlots = constructorSlots;
+        InitializerSlots = initializerSlots;
+    }
+
+    public TypeSymbol SourceType { get; }
+
+    public TypeSymbol TargetType { get; }
+
+    public StructuralProjectionConstruction Construction { get; }
+
+    public ImmutableArray<StructuralProjectionSlot> ConstructorSlots { get; }
+
+    public ImmutableArray<StructuralProjectionSlot> InitializerSlots { get; }
+}
+
+internal sealed class StructuralProjectionConstruction
+{
+    public StructuralProjectionConstruction(
+        StructuralProjectionConstructionKind kind,
+        StructSymbol userType = null,
+        ConstructorSymbol userConstructor = null,
+        ConstructorInfo clrConstructor = null)
+    {
+        Kind = kind;
+        UserType = userType;
+        UserConstructor = userConstructor;
+        ClrConstructor = clrConstructor;
+    }
+
+    public StructuralProjectionConstructionKind Kind { get; }
+
+    public StructSymbol UserType { get; }
+
+    public ConstructorSymbol UserConstructor { get; }
+
+    public ConstructorInfo ClrConstructor { get; }
+}
+
+internal sealed class StructuralProjectionSlot
+{
+    public StructuralProjectionSlot(
+        string name,
+        TypeSymbol targetType,
+        StructuralProjectionSourceMember source,
+        FieldSymbol targetField = null,
+        StructSymbol targetDeclaringType = null,
+        PropertySymbol targetProperty = null,
+        MemberInfo targetClrMember = null,
+        ParameterSymbol userDefaultParameter = null,
+        ParameterInfo clrDefaultParameter = null)
+    {
+        Name = name;
+        TargetType = targetType;
+        Source = source;
+        TargetField = targetField;
+        TargetDeclaringType = targetDeclaringType;
+        TargetProperty = targetProperty;
+        TargetClrMember = targetClrMember;
+        UserDefaultParameter = userDefaultParameter;
+        ClrDefaultParameter = clrDefaultParameter;
+    }
+
+    public string Name { get; }
+
+    public TypeSymbol TargetType { get; }
+
+    /// <summary>
+    /// Gets the selected source member, or <see langword="null"/> when an
+    /// explicit target-literal initializer supplies this slot.
+    /// </summary>
+    public StructuralProjectionSourceMember Source { get; }
+
+    public FieldSymbol TargetField { get; }
+
+    public StructSymbol TargetDeclaringType { get; }
+
+    public PropertySymbol TargetProperty { get; }
+
+    public MemberInfo TargetClrMember { get; }
+
+    public ParameterSymbol UserDefaultParameter { get; }
+
+    public ParameterInfo ClrDefaultParameter { get; }
+}
+
+internal sealed class StructuralProjectionSourceMember
+{
+    public StructuralProjectionSourceMember(
+        string name,
+        TypeSymbol type,
+        FieldSymbol field = null,
+        StructSymbol declaringType = null,
+        PropertySymbol property = null,
+        MemberInfo clrMember = null)
+    {
+        Name = name;
+        Type = type;
+        Field = field;
+        DeclaringType = declaringType;
+        Property = property;
+        ClrMember = clrMember;
+    }
+
+    public string Name { get; }
+
+    public TypeSymbol Type { get; }
+
+    public FieldSymbol Field { get; }
+
+    public StructSymbol DeclaringType { get; }
+
+    public PropertySymbol Property { get; }
+
+    public MemberInfo ClrMember { get; }
+}
+
+internal static class StructuralProjectionPlanner
+{
+    private const BindingFlags PublicInstance = BindingFlags.Public | BindingFlags.Instance;
+
+    public static bool CanProject(TypeSymbol source, TypeSymbol target)
+        => TryCreate(source, target, strict: true, explicitMemberNames: null, out _, out _);
+
+    public static bool TryCreate(
+        TypeSymbol source,
+        TypeSymbol target,
+        bool strict,
+        ISet<string> explicitMemberNames,
+        out StructuralProjectionPlan plan,
+        out string failure)
+    {
+        plan = null;
+        failure = null;
+
+        if (source == null || target == null
+            || source == TypeSymbol.Error || target == TypeSymbol.Error
+            || !IsProjectionObjectType(source)
+            || !IsProjectionObjectType(target)
+            || target is InterfaceSymbol
+            || target is TypeParameterSymbol)
+        {
+            return false;
+        }
+
+        var sourceMembers = CollectSourceMembers(source);
+        if (sourceMembers.Count == 0)
+        {
+            if (source is StructSymbol sourceStruct
+                && (sourceStruct.Fields.Any(f => !f.IsStatic && !f.IsConst)
+                    || sourceStruct.Properties.Any(p => !p.IsStatic && !p.IsIndexer)))
+            {
+                failure = $"Source type '{source}' does not provide any public readable instance members.";
+            }
+
+            return false;
+        }
+
+        return target is StructSymbol userTarget
+            ? TryCreateUserTargetPlan(source, userTarget, sourceMembers, strict, explicitMemberNames, out plan, out failure)
+            : TryCreateClrTargetPlan(source, target, sourceMembers, strict, explicitMemberNames, out plan, out failure);
+    }
+
+    private static bool TryCreateUserTargetPlan(
+        TypeSymbol source,
+        StructSymbol target,
+        Dictionary<string, StructuralProjectionSourceMember> sourceMembers,
+        bool strict,
+        ISet<string> explicitNames,
+        out StructuralProjectionPlan plan,
+        out string failure)
+    {
+        plan = null;
+        failure = null;
+        if (target.IsAbstract || target.IsGenericDefinition)
+        {
+            return false;
+        }
+
+        var construction = SelectUserConstruction(target, sourceMembers, explicitNames, out var parameters, out failure);
+        if (construction == null)
+        {
+            return false;
+        }
+
+        var constructorSlots = ImmutableArray.CreateBuilder<StructuralProjectionSlot>(parameters.Length);
+        var constructorNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (parameter, parameterType) in parameters)
+        {
+            constructorNames.Add(parameter.Name);
+            if (explicitNames?.Contains(parameter.Name) != true
+                && !sourceMembers.ContainsKey(parameter.Name)
+                && parameter.HasExplicitDefaultValue)
+            {
+                constructorSlots.Add(new StructuralProjectionSlot(
+                    parameter.Name,
+                    parameterType,
+                    source: null,
+                    userDefaultParameter: parameter));
+                continue;
+            }
+
+            if (!TryCreateSlot(parameter.Name, parameterType, sourceMembers, explicitNames, required: true, out var slot, out failure))
+            {
+                return false;
+            }
+
+            constructorSlots.Add(slot);
+        }
+
+        var initializerSlots = ImmutableArray.CreateBuilder<StructuralProjectionSlot>();
+        var targetNames = new HashSet<string>(constructorNames, StringComparer.Ordinal);
+        for (var current = target; current != null; current = current.BaseClass)
+        {
+            foreach (var field in current.Fields)
+            {
+                if (field.Accessibility != Accessibility.Public
+                    || field.IsStatic || field.IsConst || field.IsReadOnly
+                    || !targetNames.Add(field.Name))
+                {
+                    continue;
+                }
+
+                if (!TryCreateSlot(field.Name, field.Type, sourceMembers, explicitNames, strict, out var slot, out failure))
+                {
+                    return false;
+                }
+
+                if (slot != null)
+                {
+                    initializerSlots.Add(new StructuralProjectionSlot(
+                        slot.Name,
+                        slot.TargetType,
+                        slot.Source,
+                        targetField: field,
+                        targetDeclaringType: current));
+                }
+            }
+
+            foreach (var property in current.Properties)
+            {
+                if (property.Accessibility != Accessibility.Public
+                    || property.IsStatic || property.IsIndexer || !property.HasSetter
+                    || !targetNames.Add(property.Name))
+                {
+                    continue;
+                }
+
+                if (!TryCreateSlot(property.Name, property.Type, sourceMembers, explicitNames, strict, out var slot, out failure))
+                {
+                    return false;
+                }
+
+                if (slot != null)
+                {
+                    initializerSlots.Add(new StructuralProjectionSlot(
+                        slot.Name,
+                        slot.TargetType,
+                        slot.Source,
+                        targetDeclaringType: current,
+                        targetProperty: property));
+                }
+            }
+        }
+
+        plan = new StructuralProjectionPlan(
+            source,
+            target,
+            construction,
+            constructorSlots.ToImmutable(),
+            initializerSlots.ToImmutable());
+        return HasMappedSlot(plan, explicitNames);
+    }
+
+    private static StructuralProjectionConstruction SelectUserConstruction(
+        StructSymbol target,
+        Dictionary<string, StructuralProjectionSourceMember> sourceMembers,
+        ISet<string> explicitNames,
+        out ImmutableArray<(ParameterSymbol Parameter, TypeSymbol Type)> parameters,
+        out string failure)
+    {
+        failure = null;
+        if (target.HasPrimaryConstructor)
+        {
+            parameters = target.PrimaryConstructorParameters
+                .Select(parameter => (parameter, parameter.Type))
+                .ToImmutableArray();
+            return new StructuralProjectionConstruction(StructuralProjectionConstructionKind.UserPrimary, userType: target);
+        }
+
+        var explicitConstructors = target.EffectiveExplicitConstructors;
+        if (!explicitConstructors.IsDefaultOrEmpty)
+        {
+            ConstructorSymbol selected = null;
+            foreach (var candidate in explicitConstructors)
+            {
+                if (candidate.Function.Accessibility != Accessibility.Public
+                    || !ParametersCanBeSupplied(
+                        candidate.Parameters,
+                        target.GetConstructorParameterTypesForConstruction(candidate),
+                        sourceMembers,
+                        explicitNames))
+                {
+                    continue;
+                }
+
+                if (selected != null)
+                {
+                    parameters = ImmutableArray<(ParameterSymbol, TypeSymbol)>.Empty;
+                    failure = $"Type '{target}' has more than one applicable public constructor.";
+                    return null;
+                }
+
+                selected = candidate;
+            }
+
+            if (selected == null)
+            {
+                parameters = ImmutableArray<(ParameterSymbol, TypeSymbol)>.Empty;
+                failure = $"Type '{target}' has no applicable public constructor.";
+                return null;
+            }
+
+            var selectedTypes = target.GetConstructorParameterTypesForConstruction(selected);
+            var selectedParameters = ImmutableArray.CreateBuilder<(ParameterSymbol, TypeSymbol)>(selected.Parameters.Length);
+            for (var i = 0; i < selected.Parameters.Length; i++)
+            {
+                selectedParameters.Add((selected.Parameters[i], selectedTypes[i]));
+            }
+
+            parameters = selectedParameters.ToImmutable();
+            return new StructuralProjectionConstruction(
+                StructuralProjectionConstructionKind.UserExplicit,
+                userType: target,
+                userConstructor: selected);
+        }
+
+        parameters = ImmutableArray<(ParameterSymbol, TypeSymbol)>.Empty;
+        return new StructuralProjectionConstruction(StructuralProjectionConstructionKind.UserDefault, userType: target);
+    }
+
+    private static bool TryCreateClrTargetPlan(
+        TypeSymbol source,
+        TypeSymbol target,
+        Dictionary<string, StructuralProjectionSourceMember> sourceMembers,
+        bool strict,
+        ISet<string> explicitNames,
+        out StructuralProjectionPlan plan,
+        out string failure)
+    {
+        plan = null;
+        failure = null;
+        var clrType = target.ClrType;
+        if (clrType == null || clrType.IsInterface || clrType.IsAbstract || clrType.ContainsGenericParameters)
+        {
+            return false;
+        }
+
+        ConstructorInfo constructor = null;
+        ParameterInfo[] constructorParameters = Array.Empty<ParameterInfo>();
+        var constructors = ClrTypeUtilities.SafeGetConstructors(clrType, PublicInstance);
+        if (!clrType.IsValueType)
+        {
+            constructor = constructors.FirstOrDefault(c => c.GetParameters().Length == 0);
+            if (constructor == null)
+            {
+                foreach (var candidate in constructors)
+                {
+                    var candidateParameters = candidate.GetParameters();
+                    if (!ParametersCanBeSupplied(candidateParameters, sourceMembers, explicitNames))
+                    {
+                        continue;
+                    }
+
+                    if (constructor != null)
+                    {
+                        failure = $"Type '{target}' has more than one applicable public constructor.";
+                        return false;
+                    }
+
+                    constructor = candidate;
+                    constructorParameters = candidateParameters;
+                }
+            }
+        }
+        else
+        {
+            constructor = constructors.FirstOrDefault(c => c.GetParameters().Length == 0);
+            if (constructor == null)
+            {
+                foreach (var candidate in constructors)
+                {
+                    var candidateParameters = candidate.GetParameters();
+                    if (!ParametersCanBeSupplied(candidateParameters, sourceMembers, explicitNames))
+                    {
+                        continue;
+                    }
+
+                    if (constructor != null)
+                    {
+                        failure = $"Type '{target}' has more than one applicable public constructor.";
+                        return false;
+                    }
+
+                    constructor = candidate;
+                    constructorParameters = candidateParameters;
+                }
+            }
+        }
+
+        if (!clrType.IsValueType && constructor == null)
+        {
+            failure = $"Type '{target}' has no applicable public constructor.";
+            return false;
+        }
+
+        if (constructor != null && constructorParameters.Length == 0)
+        {
+            constructorParameters = constructor.GetParameters();
+        }
+
+        var constructorSlots = ImmutableArray.CreateBuilder<StructuralProjectionSlot>(constructorParameters.Length);
+        var targetNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var parameter in constructorParameters)
+        {
+            var parameterName = parameter.Name;
+            var parameterType = TypeSymbol.FromClrType(parameter.ParameterType);
+            targetNames.Add(parameterName);
+            if (explicitNames?.Contains(parameterName) != true
+                && !sourceMembers.ContainsKey(parameterName)
+                && parameter.IsOptional)
+            {
+                constructorSlots.Add(new StructuralProjectionSlot(
+                    parameterName,
+                    parameterType,
+                    source: null,
+                    clrDefaultParameter: parameter));
+                continue;
+            }
+
+            if (!TryCreateSlot(parameterName, parameterType, sourceMembers, explicitNames, required: true, out var slot, out failure))
+            {
+                return false;
+            }
+
+            constructorSlots.Add(slot);
+        }
+
+        var initializerSlots = ImmutableArray.CreateBuilder<StructuralProjectionSlot>();
+        foreach (var property in ClrTypeUtilities.SafeGetProperties(clrType, PublicInstance))
+        {
+            var setter = property.GetSetMethod(nonPublic: false);
+            if (property.GetIndexParameters().Length != 0 || setter == null || !targetNames.Add(property.Name))
+            {
+                continue;
+            }
+
+            var propertyType = TypeSymbol.FromClrType(property.PropertyType);
+            if (!TryCreateSlot(property.Name, propertyType, sourceMembers, explicitNames, strict, out var slot, out failure))
+            {
+                return false;
+            }
+
+            if (slot != null)
+            {
+                initializerSlots.Add(new StructuralProjectionSlot(
+                    slot.Name,
+                    slot.TargetType,
+                    slot.Source,
+                    targetClrMember: property));
+            }
+        }
+
+        foreach (var field in ClrTypeUtilities.SafeGetFields(clrType, PublicInstance))
+        {
+            if (field.IsStatic || field.IsLiteral || field.IsInitOnly || !targetNames.Add(field.Name))
+            {
+                continue;
+            }
+
+            var fieldType = TypeSymbol.FromClrType(field.FieldType);
+            if (!TryCreateSlot(field.Name, fieldType, sourceMembers, explicitNames, strict, out var slot, out failure))
+            {
+                return false;
+            }
+
+            if (slot != null)
+            {
+                initializerSlots.Add(new StructuralProjectionSlot(
+                    slot.Name,
+                    slot.TargetType,
+                    slot.Source,
+                    targetClrMember: field));
+            }
+        }
+
+        var constructionKind = constructor != null
+            ? StructuralProjectionConstructionKind.ClrConstructor
+            : StructuralProjectionConstructionKind.ClrDefaultValue;
+        plan = new StructuralProjectionPlan(
+            source,
+            target,
+            new StructuralProjectionConstruction(constructionKind, clrConstructor: constructor),
+            constructorSlots.ToImmutable(),
+            initializerSlots.ToImmutable());
+        return HasMappedSlot(plan, explicitNames);
+    }
+
+    private static bool TryCreateSlot(
+        string name,
+        TypeSymbol targetType,
+        Dictionary<string, StructuralProjectionSourceMember> sourceMembers,
+        ISet<string> explicitNames,
+        bool required,
+        out StructuralProjectionSlot slot,
+        out string failure)
+    {
+        failure = null;
+        if (explicitNames?.Contains(name) == true)
+        {
+            slot = new StructuralProjectionSlot(name, targetType, source: null);
+            return true;
+        }
+
+        if (!sourceMembers.TryGetValue(name, out var sourceMember))
+        {
+            slot = null;
+            if (required)
+            {
+                failure = $"Source type does not provide public readable member '{name}'.";
+                return false;
+            }
+
+            return true;
+        }
+
+        if (!HasImplicitMemberConversion(sourceMember.Type, targetType))
+        {
+            slot = null;
+            failure = $"Source member '{name}' of type '{sourceMember.Type}' is not implicitly convertible to '{targetType}'.";
+            return false;
+        }
+
+        slot = new StructuralProjectionSlot(name, targetType, sourceMember);
+        return true;
+    }
+
+    private static bool ParametersCanBeSupplied(
+        ImmutableArray<ParameterSymbol> parameters,
+        ImmutableArray<TypeSymbol> parameterTypes,
+        Dictionary<string, StructuralProjectionSourceMember> sourceMembers,
+        ISet<string> explicitNames)
+    {
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var parameter = parameters[i];
+            if (string.IsNullOrEmpty(parameter.Name))
+            {
+                return false;
+            }
+
+            if (explicitNames?.Contains(parameter.Name) == true)
+            {
+                continue;
+            }
+
+            if (!sourceMembers.TryGetValue(parameter.Name, out var source)
+                || !HasImplicitMemberConversion(source.Type, parameterTypes[i]))
+            {
+                if (!parameter.HasExplicitDefaultValue)
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ParametersCanBeSupplied(
+        ParameterInfo[] parameters,
+        Dictionary<string, StructuralProjectionSourceMember> sourceMembers,
+        ISet<string> explicitNames)
+    {
+        foreach (var parameter in parameters)
+        {
+            if (string.IsNullOrEmpty(parameter.Name))
+            {
+                return false;
+            }
+
+            if (explicitNames?.Contains(parameter.Name) == true)
+            {
+                continue;
+            }
+
+            var targetType = TypeSymbol.FromClrType(parameter.ParameterType);
+            if (!sourceMembers.TryGetValue(parameter.Name, out var source)
+                || !HasImplicitMemberConversion(source.Type, targetType))
+            {
+                if (!parameter.IsOptional)
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static bool HasImplicitMemberConversion(TypeSymbol source, TypeSymbol target)
+    {
+        var conversion = Conversion.ClassifyNonStructural(source, target);
+        return conversion.IsImplicit
+            || ConversionClassifier.HasUserDefinedImplicitConversionForTypes(source, target);
+    }
+
+    private static bool HasMappedSlot(StructuralProjectionPlan plan, ISet<string> explicitNames)
+    {
+        foreach (var slot in plan.ConstructorSlots.Concat(plan.InitializerSlots))
+        {
+            if (slot.Source != null || explicitNames?.Contains(slot.Name) == true)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsProjectionObjectType(TypeSymbol type)
+    {
+        if (type is StructSymbol aggregate)
+        {
+            return !aggregate.IsInline && !aggregate.IsRefStruct;
+        }
+
+        if (type is not ImportedTypeSymbol)
+        {
+            return false;
+        }
+
+        var clrType = type.ClrType;
+        return clrType != null
+            && !clrType.IsSameAs(typeof(object))
+            && !clrType.IsSameAs(typeof(string))
+            && !clrType.IsPrimitive
+            && !clrType.IsEnum
+            && !clrType.IsArray
+            && !clrType.IsPointer
+            && !clrType.IsByRefLike
+            && !ClrTypeUtilities.IsDelegateType(clrType);
+    }
+
+    private static Dictionary<string, StructuralProjectionSourceMember> CollectSourceMembers(TypeSymbol source)
+    {
+        var result = new Dictionary<string, StructuralProjectionSourceMember>(StringComparer.Ordinal);
+        if (source is StructSymbol structSource)
+        {
+            for (var current = structSource; current != null; current = current.BaseClass)
+            {
+                foreach (var property in current.Properties)
+                {
+                    if (property.Accessibility == Accessibility.Public
+                        && property.HasGetter && !property.IsStatic && !property.IsIndexer
+                        && !result.ContainsKey(property.Name))
+                    {
+                        result.Add(property.Name, new StructuralProjectionSourceMember(
+                            property.Name,
+                            property.Type,
+                            declaringType: current,
+                            property: property));
+                    }
+                }
+
+                foreach (var field in current.Fields)
+                {
+                    if (field.Accessibility == Accessibility.Public
+                        && !field.IsStatic && !field.IsConst
+                        && !result.ContainsKey(field.Name))
+                    {
+                        result.Add(field.Name, new StructuralProjectionSourceMember(
+                            field.Name,
+                            field.Type,
+                            field: field,
+                            declaringType: current));
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        var clrType = source.ClrType;
+        if (clrType == null)
+        {
+            return result;
+        }
+
+        foreach (var property in ClrTypeUtilities.SafeGetProperties(clrType, PublicInstance))
+        {
+            if (property.GetIndexParameters().Length == 0
+                && property.GetGetMethod(nonPublic: false) != null
+                && !result.ContainsKey(property.Name))
+            {
+                result.Add(property.Name, new StructuralProjectionSourceMember(
+                    property.Name,
+                    TypeSymbol.FromClrType(property.PropertyType),
+                    clrMember: property));
+            }
+        }
+
+        foreach (var field in ClrTypeUtilities.SafeGetFields(clrType, PublicInstance))
+        {
+            if (!field.IsStatic && !field.IsLiteral && !result.ContainsKey(field.Name))
+            {
+                result.Add(field.Name, new StructuralProjectionSourceMember(
+                    field.Name,
+                    TypeSymbol.FromClrType(field.FieldType),
+                    clrMember: field));
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -930,6 +930,21 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0155", message);
     }
 
+    /// <summary>Reports why a requested structural projection is unsafe or incomplete.</summary>
+    /// <param name="location">The projection source location.</param>
+    /// <param name="fromType">The source type.</param>
+    /// <param name="toType">The target type.</param>
+    /// <param name="reason">The compile-time planning failure.</param>
+    public void ReportStructuralProjectionFailure(
+        TextLocation location,
+        TypeSymbol fromType,
+        TypeSymbol toType,
+        string reason)
+    {
+        var message = $"Cannot project type '{fromType}' to '{toType}': {reason}";
+        Report(location, "GS0490", message);
+    }
+
     /// <summary>
     /// Reports that there's no implicit conversion from one type to the other.
     /// </summary>

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -1624,6 +1624,8 @@ public sealed class Evaluator
             }
         }
 
+        ApplyClassFieldInitializers(sv, node.StructType);
+
         foreach (var init in node.Initializers)
         {
             // Issue #1211: a composite-literal entry may target a settable
@@ -1829,6 +1831,8 @@ public sealed class Evaluator
             }
         }
 
+        ApplyClassFieldInitializers(sv, node.StructType);
+
         // Issue #306: a class declaring an explicit `init(...)` constructor runs
         // its bound body with `this`, the constructor parameters, and the class
         // fields in scope. The base initializer (when GSharp) is forwarded first,
@@ -1951,6 +1955,30 @@ public sealed class Evaluator
         }
 
         return sv;
+    }
+
+    private void ApplyClassFieldInitializers(StructValue value, StructSymbol type)
+    {
+        if (!type.IsClass)
+        {
+            return;
+        }
+
+        var hierarchy = new Stack<StructSymbol>();
+        for (var current = type; current != null; current = current.BaseClass)
+        {
+            hierarchy.Push(current);
+        }
+
+        while (hierarchy.Count > 0)
+        {
+            var current = hierarchy.Pop();
+            var initializerOwner = current.Definition ?? current;
+            foreach (var initializer in initializerOwner.InstanceFieldInitializers)
+            {
+                value.Fields[initializer.Key.Name] = EvaluateExpression(initializer.Value);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -1923,9 +1923,38 @@ public sealed class StructSymbol : TypeSymbol
             foreach (var f in source)
             {
                 var newType = SubstituteTypeForConstruction(f.Type, subst, mapClrType);
-                builder.Add(ReferenceEquals(newType, f.Type)
-                    ? f
-                    : new FieldSymbol(f.Name, newType, f.Accessibility));
+                if (ReferenceEquals(newType, f.Type))
+                {
+                    builder.Add(f);
+                    continue;
+                }
+
+                var substituted = new FieldSymbol(
+                    f.Name,
+                    newType,
+                    f.Accessibility,
+                    f.IsReadOnly,
+                    f.IsStatic,
+                    f.IsConst,
+                    f.IsEventBackingField);
+                if (f.IsConst)
+                {
+                    substituted.SetConstantValue(f.ConstantValue);
+                }
+
+                if (f.ExplicitOffset is int offset)
+                {
+                    substituted.SetExplicitOffset(offset);
+                }
+
+                if (f.IsFixedBuffer)
+                {
+                    substituted.SetFixedBuffer(
+                        SubstituteTypeForConstruction(f.FixedBufferElementType, subst, mapClrType),
+                        f.FixedBufferLength);
+                }
+
+                builder.Add(substituted);
             }
 
             result = builder.MoveToImmutable();

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -9361,9 +9361,17 @@ public class Parser
             }
 
             var openBrace = MatchToken(SyntaxKind.OpenBraceToken);
-            var initializers = ParseStructLiteralInitializers();
+            var (spreadToken, spreadExpression, spreadSeparator, initializers) = ParseStructLiteralInitializers();
             var closeBrace = MatchToken(SyntaxKind.CloseBraceToken);
-            var literal = new StructLiteralExpressionSyntax(syntaxTree, identifier, openBrace, initializers, closeBrace);
+            var literal = new StructLiteralExpressionSyntax(
+                syntaxTree,
+                identifier,
+                openBrace,
+                spreadToken,
+                spreadExpression,
+                spreadSeparator,
+                initializers,
+                closeBrace);
             literal.TypeArgumentList = typeArguments;
             return literal;
         }
@@ -9409,6 +9417,11 @@ public class Parser
     {
         var k1 = Peek(1).Kind;
         if (k1 == SyntaxKind.CloseBraceToken)
+        {
+            return false;
+        }
+
+        if (k1 == SyntaxKind.EllipsisToken)
         {
             return false;
         }
@@ -10731,9 +10744,14 @@ public class Parser
     private bool IsStructLiteralFollowingBrace(int braceOffsetPlusOne)
     {
         // braceOffsetPlusOne is the offset of the token AFTER the '{'. A struct
-        // literal is either empty (`}`) or starts with `Identifier :` (a field init).
+        // literal is empty (`}`), starts with a spread, or starts with `Identifier :`.
         var k0 = Peek(braceOffsetPlusOne).Kind;
         if (k0 == SyntaxKind.CloseBraceToken)
+        {
+            return true;
+        }
+
+        if (k0 == SyntaxKind.EllipsisToken)
         {
             return true;
         }
@@ -10775,13 +10793,39 @@ public class Parser
     {
         var typeIdentifier = MatchToken(SyntaxKind.IdentifierToken);
         var openBrace = MatchToken(SyntaxKind.OpenBraceToken);
-        var initializers = ParseStructLiteralInitializers();
+        var (spreadToken, spreadExpression, spreadSeparator, initializers) = ParseStructLiteralInitializers();
         var closeBrace = MatchToken(SyntaxKind.CloseBraceToken);
-        return new StructLiteralExpressionSyntax(syntaxTree, typeIdentifier, openBrace, initializers, closeBrace);
+        return new StructLiteralExpressionSyntax(
+            syntaxTree,
+            typeIdentifier,
+            openBrace,
+            spreadToken,
+            spreadExpression,
+            spreadSeparator,
+            initializers,
+            closeBrace);
     }
 
-    private SeparatedSyntaxList<FieldInitializerSyntax> ParseStructLiteralInitializers()
+    private (
+        SyntaxToken SpreadToken,
+        ExpressionSyntax SpreadExpression,
+        SyntaxToken SpreadSeparator,
+        SeparatedSyntaxList<FieldInitializerSyntax> Initializers)
+        ParseStructLiteralInitializers()
     {
+        SyntaxToken spreadToken = null;
+        ExpressionSyntax spreadExpression = null;
+        SyntaxToken spreadSeparator = null;
+        if (Current.Kind == SyntaxKind.EllipsisToken)
+        {
+            spreadToken = MatchToken(SyntaxKind.EllipsisToken);
+            spreadExpression = ParseExpression();
+            if (Current.Kind == SyntaxKind.CommaToken)
+            {
+                spreadSeparator = MatchToken(SyntaxKind.CommaToken);
+            }
+        }
+
         var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
         var parseNext = Current.Kind != SyntaxKind.CloseBraceToken;
         while (parseNext &&
@@ -10799,7 +10843,11 @@ public class Parser
             }
         }
 
-        return new SeparatedSyntaxList<FieldInitializerSyntax>(nodesAndSeparators.ToImmutable());
+        return (
+            spreadToken,
+            spreadExpression,
+            spreadSeparator,
+            new SeparatedSyntaxList<FieldInitializerSyntax>(nodesAndSeparators.ToImmutable()));
     }
 
     private FieldInitializerSyntax ParseFieldInitializer()

--- a/src/Core/CodeAnalysis/Syntax/StructLiteralExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/StructLiteralExpressionSyntax.cs
@@ -21,18 +21,27 @@ public sealed class StructLiteralExpressionSyntax : ExpressionSyntax
     /// <param name="syntaxTree">The parent syntax tree.</param>
     /// <param name="typeIdentifier">The struct type identifier.</param>
     /// <param name="openBraceToken">The opening brace.</param>
+    /// <param name="spreadToken">The optional leading ellipsis.</param>
+    /// <param name="spreadExpression">The optional spread source.</param>
+    /// <param name="spreadSeparatorToken">The optional separator after the spread source.</param>
     /// <param name="initializers">The field initializers.</param>
     /// <param name="closeBraceToken">The closing brace.</param>
     public StructLiteralExpressionSyntax(
         SyntaxTree syntaxTree,
         SyntaxToken typeIdentifier,
         SyntaxToken openBraceToken,
+        SyntaxToken spreadToken,
+        ExpressionSyntax spreadExpression,
+        SyntaxToken spreadSeparatorToken,
         SeparatedSyntaxList<FieldInitializerSyntax> initializers,
         SyntaxToken closeBraceToken)
         : base(syntaxTree)
     {
         TypeIdentifier = typeIdentifier;
         OpenBraceToken = openBraceToken;
+        SpreadToken = spreadToken;
+        SpreadExpression = spreadExpression;
+        SpreadSeparatorToken = spreadSeparatorToken;
         Initializers = initializers;
         CloseBraceToken = closeBraceToken;
     }
@@ -45,6 +54,15 @@ public sealed class StructLiteralExpressionSyntax : ExpressionSyntax
 
     /// <summary>Gets the opening brace.</summary>
     public SyntaxToken OpenBraceToken { get; }
+
+    /// <summary>Gets the optional leading <c>...</c> token.</summary>
+    public SyntaxToken SpreadToken { get; }
+
+    /// <summary>Gets the optional source expression whose public shape is projected.</summary>
+    public ExpressionSyntax SpreadExpression { get; }
+
+    /// <summary>Gets the comma separating the spread from explicit overrides, when present.</summary>
+    public SyntaxToken SpreadSeparatorToken { get; }
 
     /// <summary>Gets the field initializers.</summary>
     public SeparatedSyntaxList<FieldInitializerSyntax> Initializers { get; }

--- a/test/Core.Tests/CodeAnalysis/Binding/StructuralProjectionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/StructuralProjectionTests.cs
@@ -1,0 +1,560 @@
+// <copyright file="StructuralProjectionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>Tests ADR-0148 safe structural projections.</summary>
+public class StructuralProjectionTests
+{
+    [Fact]
+    public void NamedSourceAndTargetProduceProjectionPlan()
+    {
+        const string sourceText = @"
+class Source { var Name string var Age int32 var Extra bool }
+class Target { var Name string var Age int64 }
+let source = Source{Name: ""Ada"", Age: 36, Extra: true}
+0
+";
+        var tree = SyntaxTree.Parse(SourceText.From(sourceText));
+        var compilation = new Compilation(tree);
+        _ = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        var sourceType = compilation.GlobalScope.Variables.Single(v => v.Name == "source").Type;
+        var targetType = compilation.GlobalScope.Structs.Single(s => s.Name == "Target");
+
+        var planned = StructuralProjectionPlanner.TryCreate(
+            sourceType,
+            targetType,
+            strict: true,
+            explicitMemberNames: null,
+            out _,
+            out var failure);
+
+        Assert.True(planned, failure);
+    }
+
+    [Fact]
+    public void AnonymousObject_ImplicitlyProjectsToNamedClass()
+    {
+        var result = Evaluate(@"
+class Person { var Name string var Age int64 }
+let person Person = object { let Name = ""Ada""; let Age = 36; let Extra = true }
+person.Name == ""Ada"" && person.Age == 36
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void DataObject_ImplicitlyProjectsToPrimaryConstructor()
+    {
+        var result = Evaluate(@"
+data class Person(Name string, Age int64) {}
+let person Person = data object { let Name = ""Ada""; let Age = 36 }
+person.Name == ""Ada"" && person.Age == 36
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void NamedSource_UsesWidthSubtypingAndCannotWritePrivateTargetField()
+    {
+        var result = Evaluate(@"
+class Source { var Name string var Age int32 var Secret int32 }
+class Target {
+    var Name string
+    var Age int64
+    private var Secret int32 = 91
+    func ReadSecret() int32 -> Secret
+}
+let source = Source{Name: ""Ada"", Age: 36, Secret: 0}
+let target Target = source
+target.ReadSecret()
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(91, result.Value);
+    }
+
+    [Fact]
+    public void ProjectionEvaluatesAllAnonymousInitializersExactlyOnce()
+    {
+        var result = Evaluate(@"
+class Target { var Value int32 }
+func Next(value int32) int32 {
+    effects = effects + 1
+    return value
+}
+var effects = 0
+let target Target = object { let Value = Next(7); let Extra = Next(8) }
+effects * 10 + target.Value
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(27, result.Value);
+    }
+
+    [Fact]
+    public void ProjectionEvaluatesSourceAndSelectedGetterOnce()
+    {
+        var result = Evaluate(@"
+class Source {
+    prop Value int32 {
+        get {
+            reads = reads + 1
+            return 7
+        }
+    }
+}
+class Target { var Value int32 }
+func Make() Source {
+    creates = creates + 1
+    return Source{}
+}
+var creates = 0
+var reads = 0
+let target Target = Make()
+creates * 100 + reads * 10 + target.Value
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(117, result.Value);
+    }
+
+    [Fact]
+    public void MissingRequiredMemberReportsProjectionDiagnostic()
+    {
+        var result = Evaluate(@"
+class Source { var Name string }
+class Target { var Name string var Age int32 }
+let source = Source{Name: ""Ada""}
+let target Target = source
+0
+");
+
+        var diagnostic = Assert.Single(result.Diagnostics, d => d.Id == "GS0490");
+        Assert.Contains("Age", diagnostic.Message);
+    }
+
+    [Fact]
+    public void ExplicitSpreadOverridesSourceMember()
+    {
+        var result = Evaluate(@"
+class Source { var Name string var Age int32 }
+class Target { var Name string var Age int64 }
+let source = Source{Name: ""Ada"", Age: 36}
+let target = Target{ ...source, Age: 42 }
+target.Name == ""Ada"" && target.Age == 42
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void ExplicitSpreadSuppliesPrimaryConstructorAndPreservesPartialDefaults()
+    {
+        var primary = Evaluate(@"
+class Source { var Name string var Age int32 }
+data class Target(Name string, Age int64) {}
+let source = Source{Name: ""Ada"", Age: 36}
+let target = Target{ ...source, Age: 42 }
+target.Name == ""Ada"" && target.Age == 42
+");
+        Assert.Empty(primary.Diagnostics);
+        Assert.Equal(true, primary.Value);
+
+        var partial = Evaluate(@"
+class Source { var Name string }
+class Target { var Name string var Age int32 = 9 }
+let source = Source{Name: ""Ada""}
+let target = Target{ ...source }
+target.Name == ""Ada"" && target.Age == 9
+");
+        Assert.Empty(partial.Diagnostics);
+        Assert.Equal(true, partial.Value);
+
+        var partialStruct = Evaluate(@"
+struct Source { var Name string }
+struct Target { var Name string var Age int32 = 11 }
+let source = Source{Name: ""Ada""}
+let target = Target{ ...source }
+target.Name == ""Ada"" && target.Age == 11
+");
+        Assert.Empty(partialStruct.Diagnostics);
+        Assert.Equal(true, partialStruct.Value);
+    }
+
+    [Fact]
+    public void GenericTargetSpreadParsesAndProjects()
+    {
+        var result = Evaluate(@"
+class Source { var Value int32 }
+class Box[T] { var Value T }
+let source = Source{Value: 7}
+let box = Box[int32]{ ...source }
+box.Value
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void OptionalConstructorInputsRetainTheirDefaults()
+    {
+        var result = Evaluate(@"
+class Source { var Name string }
+data class Target(Name string, Age int32 = 9) {}
+let source = Source{Name: ""Ada""}
+let implicitTarget Target = source
+let explicitTarget = Target{ ...source }
+implicitTarget.Age + explicitTarget.Age
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(18, result.Value);
+    }
+
+    [Fact]
+    public void ExplicitSpreadBindsConstructorOnlyAndConstructedGenericSlots()
+    {
+        var constructorOnly = Evaluate(@"
+class Source { var Other int32 }
+class Target {
+    private var stored int32
+    init(value int32) { stored = value }
+    func Read() int32 { return stored }
+}
+let source = Source{Other: 1}
+let target = Target{ ...source, value: 7 }
+target.Read()
+");
+        Assert.Empty(constructorOnly.Diagnostics);
+        Assert.Equal(7, constructorOnly.Value);
+
+        var generic = Evaluate(@"
+class Source { var value int32 }
+class Box[T] {
+    private var stored T
+    init(value T) { stored = value }
+    func Read() T { return stored }
+}
+let source = Source{value: 9}
+let box = Box[int32]{ ...source }
+box.Read()
+");
+        Assert.Empty(generic.Diagnostics);
+        Assert.Equal(9, generic.Value);
+    }
+
+    [Fact]
+    public void ImportedValueTypeUsesApplicablePublicConstructor()
+    {
+        var result = Evaluate(@"
+import System
+class Source { var ticks int64 }
+let source = Source{ticks: 42L}
+let duration TimeSpan = source
+duration.Ticks
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42L, result.Value);
+    }
+
+    [Fact]
+    public void ProjectedMemberUsesUserDefinedImplicitConversion()
+    {
+        var result = Evaluate(@"
+struct Amount {
+    var Value int32
+    func operator implicit (amount Amount) int64 {
+        return amount.Value
+    }
+}
+class Source { var Number Amount }
+class Target { var Number int64 }
+let source = Source{Number: Amount{Value: 12}}
+let target Target = source
+target.Number
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(12L, result.Value);
+    }
+
+    [Fact]
+    public void ImportedMethodOverloadAcceptsStructuralProjection()
+    {
+        var result = Evaluate(@"
+import System.Net.Http
+class Source { var uriString string }
+func Probe(client HttpClient, source Source) {
+    let pending = client.GetAsync(source)
+}
+0
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void NamedStructProjectsThroughAssignmentReturnAndArgument()
+    {
+        var result = Evaluate(@"
+struct Source { var Name string var Age int32 var Extra bool }
+struct Target { var Name string var Age int64 }
+func Project(source Source) Target { return source }
+func Read(target Target) int64 { return target.Age }
+let source = Source{Name: ""Ada"", Age: 36, Extra: true}
+let assigned Target = source
+Read(Project(source)) + assigned.Age
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(72L, result.Value);
+    }
+
+    [Fact]
+    public void ProjectionWritesPublicInitProperty()
+    {
+        var result = Evaluate(@"
+class Source { var Name string }
+class Target { prop Name string { get; init; } }
+let source = Source{Name: ""Ada""}
+let target Target = source
+target.Name
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Ada", result.Value);
+    }
+
+    [Fact]
+    public void ImportedClrSourceProjectsThroughPublicProperties()
+    {
+        var result = Evaluate(@"
+import System
+class VersionDto { var Major int32 var Minor int32 }
+let version = Version(3, 7)
+let dto VersionDto = version
+dto.Major * 10 + dto.Minor
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(37, result.Value);
+    }
+
+    [Fact]
+    public void AnonymousObjectProjectsToImportedClrTarget()
+    {
+        var result = Evaluate(@"
+import System.Text
+let builder StringBuilder = object { let Capacity = 20; let Length = 0 }
+builder.Capacity >= 20 && builder.Length == 0
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void ExplicitSpreadProjectsToImportedClrTarget()
+    {
+        var result = Evaluate(@"
+import System.Text
+class Source { var Length int32 }
+let source = Source{Length: 0}
+let builder = StringBuilder{ ...source, Capacity: 24 }
+builder.Capacity >= 24 && builder.Length == 0
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void PrivateSourceMemberDoesNotParticipate()
+    {
+        var result = Evaluate(@"
+class Source { private var Age int32 = 36 }
+class Target { var Age int32 }
+let source = Source{}
+let target Target = source
+0
+");
+
+        var diagnostic = Assert.Single(result.Diagnostics, d => d.Id == "GS0490");
+        Assert.Contains("public readable", diagnostic.Message);
+    }
+
+    [Fact]
+    public void ExplicitSpreadCannotWritePrivateTargetStorage()
+    {
+        var result = Evaluate(@"
+class Source { var Value int32 }
+class Target {
+    var Value int32
+    private var Secret int32
+    func Copy(source Source) Target {
+        return Target{ ...source, Secret: 7 }
+    }
+}
+0
+");
+
+        var diagnostic = Assert.Single(result.Diagnostics, d => d.Id == "GS0490");
+        Assert.Contains("public construction or writable member", diagnostic.Message);
+    }
+
+    [Fact]
+    public void ConstructedGenericReadonlyFieldIsNotWritable()
+    {
+        var result = Evaluate(@"
+class Source { var Value int32 }
+class Box[T] { let Value T }
+let source = Source{Value: 7}
+let box Box[int32] = source
+0
+");
+
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ConstructedGenericTargetsPreserveDeclaredFieldInitializers()
+    {
+        var classResult = Evaluate(@"
+class Source { var Value int32 }
+class Box[T] {
+    var Value T
+    private var Marker int32 = 9
+    func ReadMarker() int32 { return Marker }
+}
+let source = Source{Value: 7}
+let box Box[int32] = source
+box.ReadMarker()
+");
+        Assert.Empty(classResult.Diagnostics);
+        Assert.Equal(9, classResult.Value);
+
+        var structResult = Evaluate(@"
+struct Source { var Value int32 }
+struct Box[T] {
+    var Value T
+    private var Marker int32 = 11
+    func ReadMarker() int32 { return Marker }
+}
+let source = Source{Value: 7}
+let box Box[int32] = source
+box.ReadMarker()
+");
+        Assert.Empty(structResult.Diagnostics);
+        Assert.Equal(11, structResult.Value);
+    }
+
+    [Fact]
+    public void ProjectionDoesNotRecursivelyProjectMemberValues()
+    {
+        var result = Evaluate(@"
+class InnerSource { var Value int32 }
+class InnerTarget { var Value int32 }
+class Source { var Inner InnerSource }
+class Target { var Inner InnerTarget }
+let source = Source{Inner: InnerSource{Value: 7}}
+let target Target = source
+0
+");
+
+        var diagnostic = Assert.Single(result.Diagnostics, d => d.Id == "GS0490");
+        Assert.Contains("Inner", diagnostic.Message);
+    }
+
+    [Fact]
+    public void IdentityOverloadOutranksProjection()
+    {
+        var result = Evaluate(@"
+class Source { var Value int32 }
+class Target { var Value int32 }
+func Pick(value Source) int32 { return 1 }
+func Pick(value Target) int32 { return 2 }
+let source = Source{Value: 7}
+Pick(source)
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void UnrelatedProjectionOverloadsRemainAmbiguous()
+    {
+        var result = Evaluate(@"
+class Source { var Value int32 }
+class First { var Value int32 }
+class Second { var Value int32 }
+func Pick(value First) int32 { return 1 }
+func Pick(value Second) int32 { return 2 }
+let source = Source{Value: 7}
+Pick(source)
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0266");
+    }
+
+    [Fact]
+    public void UserDefinedImplicitConversionOutranksProjection()
+    {
+        var result = Evaluate(@"
+struct Target { var Value int32 }
+struct Source {
+    var Value int32
+    func operator implicit (source Source) Target {
+        return Target{Value: 99}
+    }
+}
+let source = Source{Value: 7}
+let target Target = source
+target.Value
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(99, result.Value);
+    }
+
+    [Fact]
+    public void ProjectionIsNotAppliedToRefArgument()
+    {
+        var result = Evaluate(@"
+class Source { var Value int32 }
+class Target { var Value int32 }
+func Touch(ref target Target) {}
+var source = Source{Value: 7}
+Touch(ref source)
+0
+");
+
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/StructuralProjectionEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/StructuralProjectionEmitTests.cs
@@ -1,0 +1,90 @@
+// <copyright file="StructuralProjectionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>Validates emitted ADR-0148 projection behavior.</summary>
+public class StructuralProjectionEmitTests
+{
+    [Fact]
+    public void ProjectionEmitsConstructorSafeSingleEvaluationCode()
+    {
+        var output = CompileAndRun(@"
+import System
+class Source { var Value int32 }
+class Target {
+    var Value int32
+    private var Secret int32 = 91
+    func ReadSecret() int32 { return Secret }
+}
+func Make() Source {
+    creates = creates + 1
+    return Source{Value: 7}
+}
+var creates = 0
+let target Target = Make()
+let changed = Target{ ...target, Value: 9 }
+Console.WriteLine(target.Value)
+Console.WriteLine(changed.Value)
+Console.WriteLine(changed.ReadSecret())
+Console.WriteLine(creates)
+");
+
+        Assert.Equal(
+            "7" + Environment.NewLine
+            + "9" + Environment.NewLine
+            + "91" + Environment.NewLine
+            + "1" + Environment.NewLine,
+            output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        peStream.Position = 0;
+
+        var context = new AssemblyLoadContext("projection-run", isCollectible: true);
+        try
+        {
+            var assembly = context.LoadFromStream(peStream);
+            var programType = assembly.GetTypes().First(t => t.Name == "<Program>");
+            var entry = programType.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            var savedOut = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry.Invoke(
+                    null,
+                    entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(savedOut);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement ADR-0148 safe structural projections for anonymous, named, generic, and CLR object shapes
- add implicit assignment/return/argument projection and explicit `Target{ ...source, overrides }` mapping
- enforce public-only discovery, constructor-safe target creation, single source evaluation, overload ranking, and targeted diagnostics
- cover interpreter and emitted runtime behavior

## Validation
- `dotnet test .\test\Core.Tests\Core.Tests.csproj --filter FullyQualifiedName~StructuralProjection` (30 passed)
- full Core regression suite (6,199 passed, 1 skipped)

Co-authored-by:  khurram-uworx@users.noreply.github.com