### PR TITLE
Fix expression-tree comparison operator factory overload selection (#2373)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/EmitContext.cs
+++ b/src/Core/CodeAnalysis/Emit/EmitContext.cs
@@ -206,6 +206,23 @@ internal sealed class EmitContext
     public Type CoreRuntimeTypeHandleType { get; set; }
 
     /// <summary>
+    /// Gets or sets the BCL <see cref="System.RuntimeMethodHandle"/> type
+    /// resolved from the target framework's <see cref="References"/>.
+    /// Issue #2373: backs emission of a <see cref="System.Reflection.MethodInfo"/>
+    /// runtime constant (<c>ldtoken method ; call
+    /// MethodBase.GetMethodFromHandle</c>) for expression-tree lowering's CLR
+    /// operator-method arguments.
+    /// </summary>
+    public Type CoreRuntimeMethodHandleType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the BCL <see cref="System.Reflection.MethodBase"/> type
+    /// resolved from the target framework's <see cref="References"/>. See
+    /// <see cref="CoreRuntimeMethodHandleType"/>.
+    /// </summary>
+    public Type CoreMethodBaseType { get; set; }
+
+    /// <summary>
     /// Gets or sets the BCL <see cref="Enum"/> type resolved from the target
     /// framework's <see cref="References"/>.
     /// </summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -643,10 +643,52 @@ internal sealed partial class MethodBodyEmitter
             case decimal m:
                 this.EmitDecimalLiteral(m);
                 break;
+            case MethodInfo method:
+                // Issue #2373: expression-tree lowering (ExpressionTreeLowerer)
+                // passes a CLR operator/user MethodInfo as a literal-typed
+                // argument to Expression factories (Expression.Equal(l, r,
+                // liftToNull, method), Expression.Add(l, r, method), the
+                // string-concat Add(l, r, method) overload, ...). A MethodInfo
+                // cannot be embedded as a metadata constant directly; rebuild
+                // it at run time the same way the C# compiler does: `ldtoken
+                // method [, ldtoken declaringType] ; call
+                // MethodBase.GetMethodFromHandle(...) ; castclass MethodInfo`.
+                this.EmitMethodInfoLiteral(method);
+                break;
             default:
                 throw new NotSupportedException(
                     $"Literal of CLR type '{literal.Value?.GetType()}' is not yet supported.");
         }
+    }
+
+    private void EmitMethodInfoLiteral(MethodInfo method)
+    {
+        this.il.OpCode(ILOpCode.Ldtoken);
+        this.il.Token(this.outer.GetMethodEntityHandle(method));
+
+        // The CLR requires the 2-arg GetMethodFromHandle(RuntimeMethodHandle,
+        // RuntimeTypeHandle) overload whenever the declaring type is a
+        // generic instantiation (e.g. a user operator on `Money<Currency>`);
+        // the 1-arg overload throws ArgumentException at run time for those.
+        // A generic-type-DEFINITION declaring type never occurs here because
+        // operator methods are only ever reached through a closed (fully
+        // substituted) receiver type.
+        if (method.DeclaringType is { IsGenericType: true } declaringType)
+        {
+            this.il.OpCode(ILOpCode.Ldtoken);
+            this.il.Token(this.outer.GetTypeReference(declaringType));
+            this.il.Call(this.outer.wellKnown.GetMethodFromHandleWithDeclaringTypeReference());
+        }
+        else
+        {
+            this.il.Call(this.outer.wellKnown.GetMethodFromHandleReference());
+        }
+
+        // GetMethodFromHandle returns MethodBase; every caller of this helper
+        // needs the more specific MethodInfo (constructors never reach here —
+        // Stream C only resolves public static operator methods).
+        this.il.OpCode(ILOpCode.Castclass);
+        this.il.Token(this.outer.GetTypeReference(typeof(MethodInfo)));
     }
 
     // ADR-0044 decimal literal lowering. IL has no `ldc.decimal`, so each

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -879,6 +879,15 @@ internal sealed class ReflectionMetadataEmitter
         this.emitCtx.CoreValueType = this.ResolveCoreType("System.ValueType", typeof(System.ValueType));
         this.emitCtx.CoreSystemType = this.ResolveCoreType("System.Type", typeof(System.Type));
         this.emitCtx.CoreRuntimeTypeHandleType = this.ResolveCoreType("System.RuntimeTypeHandle", typeof(System.RuntimeTypeHandle));
+
+        // Issue #2373: needed to materialise a runtime MethodInfo for a CLR
+        // operator method (op_Equality, op_Addition, ...) passed as an
+        // Expression factory argument (Expression.Equal(l, r, liftToNull,
+        // method), Expression.Add(l, r, method), ...) — see
+        // WellKnownReferences.GetMethodFromHandleReference /
+        // GetMethodFromHandleWithDeclaringTypeReference.
+        this.emitCtx.CoreRuntimeMethodHandleType = this.ResolveCoreType("System.RuntimeMethodHandle", typeof(System.RuntimeMethodHandle));
+        this.emitCtx.CoreMethodBaseType = this.ResolveCoreType("System.Reflection.MethodBase", typeof(System.Reflection.MethodBase));
         this.emitCtx.CoreEnumType = this.ResolveCoreType("System.Enum", typeof(System.Enum));
         // ADR-0059 / issue #255: cache the base type and `IntPtr` parameter
         // type for user-declared named delegate emission.

--- a/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
+++ b/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
@@ -847,6 +847,36 @@ internal sealed class WellKnownReferences
         return this.getMethodReference(method);
     }
 
+    public MemberReferenceHandle GetMethodFromHandleReference()
+    {
+        // System.Reflection.MethodBase::GetMethodFromHandle(RuntimeMethodHandle)
+        // — issue #2373: reconstructs a runtime MethodInfo for a CLR operator
+        // method (op_Equality, op_Addition, ...) from an `ldtoken` value, used
+        // when the method's declaring type is not a generic-type
+        // instantiation. See GetMethodFromHandleWithDeclaringTypeReference for
+        // the generic-declaring-type overload the CLR requires instead.
+        var method = this.emitCtx.CoreMethodBaseType.GetMethod(
+            "GetMethodFromHandle",
+            new[] { this.emitCtx.CoreRuntimeMethodHandleType })
+            ?? throw new InvalidOperationException("MethodBase.GetMethodFromHandle(RuntimeMethodHandle) is not resolvable from the supplied references.");
+        return this.getMethodReference(method);
+    }
+
+    public MemberReferenceHandle GetMethodFromHandleWithDeclaringTypeReference()
+    {
+        // System.Reflection.MethodBase::GetMethodFromHandle(RuntimeMethodHandle,
+        // RuntimeTypeHandle) — issue #2373: required (instead of the 1-arg
+        // overload) whenever the method's declaring type is itself a generic
+        // instantiation (e.g. a user-defined `operator ==` on `Money<T>`
+        // closed over a concrete `T`); the CLR throws at run time if the
+        // 1-arg overload is used for such a method.
+        var method = this.emitCtx.CoreMethodBaseType.GetMethod(
+            "GetMethodFromHandle",
+            new[] { this.emitCtx.CoreRuntimeMethodHandleType, this.emitCtx.CoreRuntimeTypeHandleType })
+            ?? throw new InvalidOperationException("MethodBase.GetMethodFromHandle(RuntimeMethodHandle, RuntimeTypeHandle) is not resolvable from the supplied references.");
+        return this.getMethodReference(method);
+    }
+
     public MemberReferenceHandle GetArrayCopyReference()
     {
         // System.Array::Copy(Array, Array, Int32) — used to implement append(slice, element).

--- a/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
@@ -191,6 +191,22 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
         typeof(string),
         typeof(BindingFlags));
 
+    // Issue #2373: unlike the arithmetic/bitwise/shift/logical factories,
+    // System.Linq.Expressions.Expression's six relational/equality factories
+    // (Equal/NotEqual/LessThan/LessThanOrEqual/GreaterThan/GreaterThanOrEqual)
+    // do NOT expose a 3-arg (Expression, Expression, MethodInfo) overload —
+    // only a 4-arg (Expression, Expression, bool liftToNull, MethodInfo)
+    // overload exists. See BuildClrBinaryOperatorExpression.
+    private static readonly HashSet<string> ComparisonFactoryMethodNames = new(StringComparer.Ordinal)
+    {
+        nameof(System.Linq.Expressions.Expression.Equal),
+        nameof(System.Linq.Expressions.Expression.NotEqual),
+        nameof(System.Linq.Expressions.Expression.LessThan),
+        nameof(System.Linq.Expressions.Expression.LessThanOrEqual),
+        nameof(System.Linq.Expressions.Expression.GreaterThan),
+        nameof(System.Linq.Expressions.Expression.GreaterThanOrEqual),
+    };
+
     private int counter;
 
     public static BoundProgram Lower(BoundProgram program)
@@ -892,6 +908,41 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
             _ => throw new NotSupportedException($"Unsupported CLR binary operator token '{expression.OperatorKind}'."),
         };
 
+        var leftExpr = UpcastToExpression(this.TranslateExpression(expression.Left, parameterMap));
+        var rightExpr = UpcastToExpression(this.TranslateExpression(expression.Right, parameterMap));
+        var resultType = TypeSymbol.FromClrType(typeof(System.Linq.Expressions.BinaryExpression));
+
+        // Issue #2373: unlike the arithmetic/bitwise/shift/logical factories,
+        // the six relational/equality factories do NOT expose a 3-arg
+        // (Expression, Expression, MethodInfo) overload — only a 4-arg
+        // (Expression, Expression, bool liftToNull, MethodInfo) overload
+        // exists. Roslyn itself always passes `liftToNull: false` for C#'s
+        // built-in and user-defined `==`/`!=`/`<`/`<=`/`>`/`>=` operators
+        // (confirmed empirically): `IsLifted` becomes true automatically
+        // from nullable operand types, but the *result* of a comparison is
+        // never itself a nullable/lifted bool, so `liftToNull` is always
+        // `false` here, both for nullable and non-nullable operands.
+        if (ComparisonFactoryMethodNames.Contains(methodName))
+        {
+            var comparisonFactory = GetRequiredMethod(
+                typeof(System.Linq.Expressions.Expression),
+                methodName,
+                typeof(System.Linq.Expressions.Expression),
+                typeof(System.Linq.Expressions.Expression),
+                typeof(bool),
+                typeof(MethodInfo));
+
+            return new BoundClrStaticCallExpression(
+                expression.Syntax,
+                comparisonFactory,
+                resultType,
+                ImmutableArray.Create<BoundExpression>(
+                    leftExpr,
+                    rightExpr,
+                    new BoundLiteralExpression(null, false, TypeSymbol.Bool),
+                    BuildMethodInfoConstant(expression.Method)));
+        }
+
         var factory = GetRequiredMethod(
             typeof(System.Linq.Expressions.Expression),
             methodName,
@@ -902,10 +953,10 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
         return new BoundClrStaticCallExpression(
             expression.Syntax,
             factory,
-            TypeSymbol.FromClrType(typeof(System.Linq.Expressions.BinaryExpression)),
+            resultType,
             ImmutableArray.Create<BoundExpression>(
-                UpcastToExpression(this.TranslateExpression(expression.Left, parameterMap)),
-                UpcastToExpression(this.TranslateExpression(expression.Right, parameterMap)),
+                leftExpr,
+                rightExpr,
                 BuildMethodInfoConstant(expression.Method)));
     }
 

--- a/test/Compiler.Tests/Emit/Issue2373ExpressionTreeClrComparisonEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2373ExpressionTreeClrComparisonEmitTests.cs
@@ -1,0 +1,291 @@
+// <copyright file="Issue2373ExpressionTreeClrComparisonEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.Loader;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2373 — real-assembly, IL-verification and runtime-execution level
+/// regression coverage for <c>ExpressionTreeLowerer.BuildClrBinaryOperatorExpression</c>'s
+/// comparison-factory overload-selection bug. Before the fix, lowering any
+/// comparison (<c>==</c>/<c>!=</c>/<c>&lt;</c>/<c>&lt;=</c>/<c>&gt;</c>/<c>&gt;=</c>)
+/// whose operand type resolved through Stream C (a CLR operator method found
+/// on the operand's own type, rather than G#'s built-in operator table or a
+/// same-compilation user operator) crashed with GS9998 because it requested a
+/// non-existent 3-arg <see cref="Expression"/> factory overload — the six
+/// relational/equality factories only expose a 4-arg
+/// <c>(Expression, Expression, bool liftToNull, MethodInfo)</c> overload.
+/// Getting the lowering call to succeed was only half the fix: an entirely
+/// separate, equally pre-existing emitter gap (fixed alongside this one)
+/// meant the resulting <see cref="MethodInfo"/> literal argument could never
+/// actually be EMITTED — <c>MethodBodyEmitter.EmitLiteral</c> had no case for
+/// a <see cref="MethodInfo"/>-valued <c>BoundLiteralExpression</c>, so even a
+/// CORRECTLY-selected overload (e.g. any arithmetic CLR operator, which
+/// already had the right 3-arg overload) crashed at emission time with
+/// <c>NotSupportedException: Literal of CLR type 'RuntimeMethodInfo' is not
+/// yet supported.</c> Both defects had to be fixed for a real two-assembly,
+/// IL-verified, runtime-executed CLR comparison operator to work at all —
+/// these tests exercise the full, corrected pipeline end to end.
+/// </summary>
+public class Issue2373ExpressionTreeClrComparisonEmitTests
+{
+    [Theory]
+    [InlineData("==", true)]
+    [InlineData("!=", false)]
+    [InlineData("<", false)]
+    [InlineData("<=", true)]
+    [InlineData(">", false)]
+    [InlineData(">=", true)]
+    public void TimeSpanComparison_IlVerifiesAndRunsCorrectly(string op, bool expected)
+    {
+        // TimeSpan is the canonical Stream C example named in
+        // ClrOperatorResolution's own doc comments ("TimeSpan + TimeSpan").
+        // Both operands are equal TimeSpans, so every operator's expected
+        // boolean result is fixed regardless of which two equal values are
+        // used.
+        var source = $$"""
+            package Demo
+            import System
+            import System.Linq.Expressions
+
+            func Predicate() Expression[Func[TimeSpan, bool]] {
+                let other = TimeSpan.FromSeconds(5)
+                return (t TimeSpan) -> t {{op}} other
+            }
+            """;
+
+        var (asm, ctx) = CompileToAssembly(source, "TimeSpan_" + op.GetHashCode());
+        try
+        {
+            var run = GetProgramMethod(asm, "Predicate");
+            var expr = run.Invoke(null, null);
+            var lambda = Assert.IsAssignableFrom<LambdaExpression>(expr);
+
+            var binary = Assert.IsAssignableFrom<BinaryExpression>(lambda.Body);
+            Assert.NotNull(binary.Method);
+            Assert.Equal("System.TimeSpan", binary.Method!.DeclaringType!.FullName);
+            Assert.False(binary.IsLiftedToNull);
+
+            var compiled = (Func<TimeSpan, bool>)lambda.Compile();
+            Assert.Equal(expected, compiled(TimeSpan.FromSeconds(5)));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void TimeSpanArithmetic_SiblingAudit_StillIlVerifiesAndRuns()
+    {
+        // Sibling-audit regression: the arithmetic (3-arg factory) CLR
+        // operator path must be unaffected by the comparison-only overload
+        // fix, but WAS affected by the separate MethodInfo-literal emission
+        // gap fixed alongside it — this is real end-to-end proof that gap is
+        // closed for the pre-existing (non-comparison) CLR operator paths.
+        var source = """
+            package Demo
+            import System
+            import System.Linq.Expressions
+
+            func Sum() Expression[Func[TimeSpan, TimeSpan, TimeSpan]] {
+                return (a TimeSpan, b TimeSpan) -> a + b
+            }
+            """;
+
+        var (asm, ctx) = CompileToAssembly(source, nameof(TimeSpanArithmetic_SiblingAudit_StillIlVerifiesAndRuns));
+        try
+        {
+            var run = GetProgramMethod(asm, "Sum");
+            var expr = run.Invoke(null, null);
+            var lambda = Assert.IsAssignableFrom<LambdaExpression>(expr);
+            var compiled = (Func<TimeSpan, TimeSpan, TimeSpan>)lambda.Compile();
+            Assert.Equal(TimeSpan.FromSeconds(8), compiled(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(3)));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Theory]
+    [InlineData("==", false)]
+    [InlineData("!=", true)]
+    [InlineData("<", true)]
+    [InlineData("<=", true)]
+    [InlineData(">", false)]
+    [InlineData(">=", false)]
+    public void ImportedAsinStrongTypedId_AllSixOperators_IlVerifiesAndRunsCorrectly(string op, bool expected)
+    {
+        // Issue #2373's actual shape, end to end: a REAL, separately
+        // C#-compiled ("imported", exactly like Oahu.Diagnostics/EF Core)
+        // strongly-typed-ID struct wrapping a `string` (the common EF Core
+        // "Asin"-style key pattern), consumed through
+        // `Expression<Func<Book, bool>>` comparing an imported entity's
+        // property against a caller-supplied value of the same imported
+        // type. "aaa" < "bbb" for every ordinal-ordering operator below.
+        var libraryPath = EmitCSharpLibrary(
+            nameof(ImportedAsinStrongTypedId_AllSixOperators_IlVerifiesAndRunsCorrectly) + "_" + op.GetHashCode(),
+            """
+            namespace Lib
+            {
+                public readonly struct Asin
+                {
+                    public string Value { get; }
+                    public Asin(string value) => Value = value;
+                    public static bool operator ==(Asin a, Asin b) => a.Value == b.Value;
+                    public static bool operator !=(Asin a, Asin b) => a.Value != b.Value;
+                    public static bool operator <(Asin a, Asin b) => string.CompareOrdinal(a.Value, b.Value) < 0;
+                    public static bool operator <=(Asin a, Asin b) => string.CompareOrdinal(a.Value, b.Value) <= 0;
+                    public static bool operator >(Asin a, Asin b) => string.CompareOrdinal(a.Value, b.Value) > 0;
+                    public static bool operator >=(Asin a, Asin b) => string.CompareOrdinal(a.Value, b.Value) >= 0;
+                    public override bool Equals(object obj) => obj is Asin o && o.Value == Value;
+                    public override int GetHashCode() => Value?.GetHashCode() ?? 0;
+                }
+
+                public class Book
+                {
+                    public Asin Asin { get; set; }
+                }
+            }
+            """);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        var consumerAssemblyName = "Issue2373Emit.Consumer." + op.GetHashCode();
+        var consumerPath = Path.Combine(LibraryDirectory(), consumerAssemblyName + ".dll");
+        var consumer = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(
+                $$"""
+                package Demo
+                import Lib
+                import System
+                import System.Linq.Expressions
+
+                func Predicate(asin Asin) Expression[Func[Book, bool]] {
+                    return (b Book) -> b.Asin {{op}} asin
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var peStream = File.Create(consumerPath))
+        {
+            var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: consumerAssemblyName);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
+
+        var loadContext = new AssemblyLoadContext(consumerAssemblyName, isCollectible: true);
+        try
+        {
+            var libraryAsm = loadContext.LoadFromAssemblyPath(libraryPath);
+            loadContext.Resolving += (ctx, name) => name.Name == libraryAsm.GetName().Name ? libraryAsm : null;
+            var consumerAsm = loadContext.LoadFromAssemblyPath(consumerPath);
+
+            var asinType = libraryAsm.GetTypes().Single(t => t.Name == "Asin");
+            var bookType = libraryAsm.GetTypes().Single(t => t.Name == "Book");
+
+            var run = GetProgramMethod(consumerAsm, "Predicate");
+            var asinA = Activator.CreateInstance(asinType, "aaa");
+            var asinB = Activator.CreateInstance(asinType, "bbb");
+
+            var expr = run.Invoke(null, new[] { asinB });
+            var lambda = Assert.IsAssignableFrom<LambdaExpression>(expr);
+            var compiled = lambda.Compile();
+
+            var book = Activator.CreateInstance(bookType);
+            bookType.GetProperty("Asin")!.SetValue(book, asinA);
+
+            var invoked = compiled.DynamicInvoke(book);
+            Assert.Equal(expected, invoked);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static MethodInfo GetProgramMethod(Assembly asm, string name)
+    {
+        var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+        Assert.NotNull(programType);
+        var method = programType!.GetMethod(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return method!;
+    }
+
+    private static (Assembly asm, AssemblyLoadContext ctx) CompileToAssembly(string source, string contextName)
+    {
+        var libraryDir = LibraryDirectory();
+        var assemblyPath = Path.Combine(libraryDir, "Issue2373Emit." + contextName + ".dll");
+        var compilation = new GsCompilation(GsSyntaxTree.Parse(SourceText.From(source))) { IsLibrary = true };
+
+        using (var peStream = File.Create(assemblyPath))
+        {
+            var result = compilation.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2373Emit." + contextName);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        IlVerifier.Verify(assemblyPath);
+
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        var asm = loadContext.LoadFromAssemblyPath(assemblyPath);
+        return (asm, loadContext);
+    }
+
+    private static string LibraryDirectory()
+    {
+        var dir = Path.Combine(AppContext.BaseDirectory, "Issue2373Emit");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string EmitCSharpLibrary(string caseName, string csharpSource)
+    {
+        var outputDir = Path.Combine(LibraryDirectory(), caseName);
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "CSharpLib2373.dll");
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(csharpSource, new CSharpParseOptions(LanguageVersion.Latest));
+
+        var referencePaths = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+            ?.Split(Path.PathSeparator)
+            ?? Array.Empty<string>();
+
+        var references = referencePaths
+            .Where(File.Exists)
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "CSharpLib2373",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var emitResult = compilation.Emit(peStream);
+            Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+        }
+
+        return libraryPath;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2373ExpressionTreeComparisonOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2373ExpressionTreeComparisonOverloadTests.cs
@@ -1,0 +1,386 @@
+// <copyright file="Issue2373ExpressionTreeComparisonOverloadTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2373: <c>ExpressionTreeLowerer.BuildClrBinaryOperatorExpression</c>
+/// looked up a single 3-arg <c>(Expression, Expression, MethodInfo)</c>
+/// <see cref="System.Linq.Expressions.Expression"/> factory overload for every
+/// CLR-resolved binary operator (Stream C — a binary operator whose LEFT or
+/// RIGHT operand's CLR type owns a public static <c>op_*</c> method, reached
+/// only once G#'s built-in operator table has no arm for the operand types).
+/// That 3-arg overload exists for arithmetic/bitwise/shift/logical factories,
+/// but the six relational/equality factories (<c>Equal</c>/<c>NotEqual</c>/
+/// <c>LessThan</c>/<c>LessThanOrEqual</c>/<c>GreaterThan</c>/
+/// <c>GreaterThanOrEqual</c>) only expose a 4-arg <c>(Expression, Expression,
+/// bool liftToNull, MethodInfo)</c> overload, so reflection returned
+/// <see langword="null"/> and compilation crashed with GS9998
+/// (<see cref="System.InvalidOperationException"/>: "Required method
+/// '...Expression.Equal' is not available.").
+///
+/// Stream C is reached whenever the operand types are NOT covered by G#'s
+/// built-in operator table (only G#'s own primitives, <c>string</c>, and
+/// <c>bool</c> are registered there) — <see cref="System.TimeSpan"/> is the
+/// canonical example (also called out by <c>ClrOperatorResolution</c>'s own
+/// doc comments), and any user-operator-bearing struct/class imported from a
+/// SEPARATE assembly reaches Stream C too, because Stream D (the
+/// same-compilation <c>func (a T) operator ==(b T) bool</c> receiver form)
+/// only matches G#'s own <c>StructSymbol</c>s, not imported types — an
+/// imported type's <c>op_Equality</c> etc. is only found via Stream C's raw
+/// reflection lookup. This is exactly the shape Oahu.Diagnostics hit: an
+/// EF-Core-imported entity's comparison against a value read outside G#'s
+/// built-in table.
+/// </summary>
+public class Issue2373ExpressionTreeComparisonOverloadTests
+{
+    [Theory]
+    [InlineData("==")]
+    [InlineData("!=")]
+    [InlineData("<")]
+    [InlineData("<=")]
+    [InlineData(">")]
+    [InlineData(">=")]
+    public void ClrStructComparison_AllSixOperators_LowersWithoutCrash(string op)
+    {
+        var source = $$"""
+            import System
+            import System.Linq.Expressions
+
+            func Predicate(other TimeSpan) Expression[Func[TimeSpan, bool]] {
+                return (t TimeSpan) -> t {{op}} other
+            }
+            """;
+
+        var result = Compile(source);
+        Assert.True(result.Success, string.Join(System.Environment.NewLine, result.Diagnostics));
+    }
+
+    [Theory]
+    [InlineData("==")]
+    [InlineData("!=")]
+    [InlineData("<")]
+    [InlineData("<=")]
+    [InlineData(">")]
+    [InlineData(">=")]
+    public void ClrStructComparison_NullableLeftOperand_LowersWithoutCrash(string op)
+    {
+        // Nullable/lifted operand coverage: `TimeSpan?` on the left compared
+        // against a non-nullable `TimeSpan` — C#/Roslyn always passes
+        // `liftToNull: false` here (the comparison RESULT is plain `bool`,
+        // never `bool?`), which this fix hard-codes.
+        var source = $$"""
+            import System
+            import System.Linq.Expressions
+
+            func Predicate(t TimeSpan?, other TimeSpan) Expression[Func[bool]] {
+                return () -> t {{op}} other
+            }
+            """;
+
+        var result = Compile(source);
+        Assert.True(result.Success, string.Join(System.Environment.NewLine, result.Diagnostics));
+    }
+
+    [Theory]
+    [InlineData("==")]
+    [InlineData("!=")]
+    [InlineData("<")]
+    [InlineData("<=")]
+    [InlineData(">")]
+    [InlineData(">=")]
+    public void ClrStructComparison_BothOperandsNullable_LowersWithoutCrash(string op)
+    {
+        var source = $$"""
+            import System
+            import System.Linq.Expressions
+
+            func Predicate(t TimeSpan?, other TimeSpan?) Expression[Func[bool]] {
+                return () -> t {{op}} other
+            }
+            """;
+
+        var result = Compile(source);
+        Assert.True(result.Success, string.Join(System.Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void ClrArithmeticAndUnaryFactories_SiblingAudit_StillLowerCorrectly()
+    {
+        // Sibling audit control: arithmetic (3-arg factory) and unary (2-arg
+        // factory) CLR-operator lowering must be unaffected by the
+        // comparison-only fix.
+        var source = """
+            import System
+            import System.Linq.Expressions
+
+            func Sum(other TimeSpan) Expression[Func[TimeSpan, TimeSpan]] {
+                return (t TimeSpan) -> t + other
+            }
+
+            func Difference(other TimeSpan) Expression[Func[TimeSpan, TimeSpan]] {
+                return (t TimeSpan) -> t - other
+            }
+            """;
+
+        var result = Compile(source);
+        Assert.True(result.Success, string.Join(System.Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void SourceDeclaredStructOperator_StreamD_UnaffectedControl()
+    {
+        // Control: a SAME-COMPILATION struct's user `operator ==` binds via
+        // Stream D (BoundUserInstanceCallExpression), never reaching the
+        // CLR-operator lowering path this issue fixes. Must keep working.
+        var source = """
+            import System
+            import System.Linq.Expressions
+
+            struct Vector2 {
+                var X int32
+                var Y int32
+            }
+
+            func (a Vector2) operator ==(b Vector2) bool {
+                return a.X == b.X && a.Y == b.Y
+            }
+
+            func Predicate(other Vector2) Expression[Func[Vector2, bool]] {
+                return (v Vector2) -> v == other
+            }
+            """;
+
+        var result = Compile(source);
+        Assert.True(result.Success, string.Join(System.Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void GenericExpressionTreeDelegate_ClrComparisonOperand_LowersWithoutCrash()
+    {
+        // Generic expression-tree delegate coverage: the lambda itself is
+        // written against a concrete Stream-C-triggering CLR type (TimeSpan,
+        // never an unconstrained type parameter — G# has no operator
+        // constraint syntax, so `t == other` inside an open `T` body is
+        // correctly rejected), but the delegate TYPE flowing through it is
+        // generic (`Expression[Func[T, bool]]`) and gets closed over `T =
+        // TimeSpan` via ordinary generic-method type inference at the call
+        // site — exactly the shape of a generic imported repository/query
+        // method (like EF Core's `MigrationBuilder.CreateTable<TColumns>`)
+        // forwarding a caller-supplied predicate.
+        var source = """
+            import System
+            import System.Linq.Expressions
+
+            class Box[T] {
+                func Filter(predicate Expression[Func[T, bool]]) Expression[Func[T, bool]] {
+                    return predicate
+                }
+            }
+
+            func Run(box Box[TimeSpan], other TimeSpan) Expression[Func[TimeSpan, bool]] {
+                return box.Filter((t TimeSpan) -> t == other)
+            }
+            """;
+
+        var result = Compile(source);
+        Assert.True(result.Success, string.Join(System.Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void ImportedUserDefinedStructOperator_ReachesClrFallback_LowersWithoutCrash()
+    {
+        // Issue #2373's actual shape: a value-type "Asin"-like wrapper
+        // (a common EF-Core "strongly typed ID" pattern) declaring its own
+        // `operator ==`/`!=`/`<`/`<=`/`>`/`>=`, imported from a SEPARATE,
+        // REAL C#-compiled assembly (mirroring Oahu.Diagnostics: a genuine
+        // externally-compiled CLR type, not a G#-authored one — G#'s own
+        // `func (a T) operator` receiver-form methods are not currently
+        // emitted with the CLR-conventional `public static ... op_Equality`
+        // shape, so they cannot participate in Stream C at all; that is a
+        // separate, pre-existing G#-emission gap unrelated to this issue's
+        // Expression-factory overload-selection defect, called out in the
+        // PR description as deferred follow-up work). Stream D's
+        // same-compilation `StructSymbol` check cannot see an imported type
+        // either way, so comparison MUST resolve via Stream C's raw CLR
+        // `op_*` reflection, exactly like Oahu.Diagnostics' imported
+        // `Book.Asin` comparison.
+        var libraryPath = EmitCSharpLibrary(
+            nameof(this.ImportedUserDefinedStructOperator_ReachesClrFallback_LowersWithoutCrash),
+            """
+            namespace Lib
+            {
+                public readonly struct Asin
+                {
+                    public string Value { get; }
+                    public Asin(string value) => Value = value;
+                    public static bool operator ==(Asin a, Asin b) => a.Value == b.Value;
+                    public static bool operator !=(Asin a, Asin b) => a.Value != b.Value;
+                    public static bool operator <(Asin a, Asin b) => string.CompareOrdinal(a.Value, b.Value) < 0;
+                    public static bool operator <=(Asin a, Asin b) => string.CompareOrdinal(a.Value, b.Value) <= 0;
+                    public static bool operator >(Asin a, Asin b) => string.CompareOrdinal(a.Value, b.Value) > 0;
+                    public static bool operator >=(Asin a, Asin b) => string.CompareOrdinal(a.Value, b.Value) >= 0;
+                    public override bool Equals(object obj) => obj is Asin o && o.Value == Value;
+                    public override int GetHashCode() => Value?.GetHashCode() ?? 0;
+                }
+
+                public class Book
+                {
+                    public Asin Asin { get; set; }
+                }
+            }
+            """);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        var consumer = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(
+                """
+                package Demo
+                import Lib
+                import System
+                import System.Linq.Expressions
+
+                func Predicate(asin Asin) Expression[Func[Book, bool]] {
+                    return (b Book) -> b.Asin == asin
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using var consumerStream = new MemoryStream();
+        var consumerResult = consumer.Emit(consumerStream, pdbStream: null, refStream: null, assemblyName: "Issue2373Binder.Consumer");
+        Assert.True(consumerResult.Success, string.Join(System.Environment.NewLine, consumerResult.Diagnostics));
+    }
+
+    [Fact]
+    public void UndefinedOperator_NegativeControl_StillReportsGs0129()
+    {
+        // Negative control: two imported CLR types with no built-in table
+        // arm AND no `op_*` method in common must still fail with GS0129,
+        // not silently succeed or crash differently, after the fix.
+        var source = """
+            import System
+            import System.Linq.Expressions
+
+            func Predicate(g Guid, t TimeSpan) Expression[Func[bool]] {
+                return () -> g == t
+            }
+            """;
+
+        var result = Compile(source);
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0129");
+    }
+
+    [Fact]
+    public void AmbiguousOperator_NegativeControl_StillReportsAmbiguity()
+    {
+        // Negative/ambiguity control: two imported struct types that mutually
+        // implicitly convert to one another, each declaring an `operator ==`
+        // over its own type, produce a genuine tie for Stream C's combined
+        // candidate set — comparing an A against a B needs exactly one
+        // implicit conversion either way, so neither op_Equality(A,A) nor
+        // op_Equality(B,B) is a strictly better match. Must surface the
+        // ambiguous-overload diagnostic (never GS9998, never a silent pick).
+        var libraryPath = EmitCSharpLibrary(
+            nameof(this.AmbiguousOperator_NegativeControl_StillReportsAmbiguity),
+            """
+            namespace Lib
+            {
+                public struct A
+                {
+                    public static bool operator ==(A a, A b) => true;
+                    public static bool operator !=(A a, A b) => false;
+                    public static implicit operator A(B b) => default;
+                    public override bool Equals(object obj) => false;
+                    public override int GetHashCode() => 0;
+                }
+
+                public struct B
+                {
+                    public static bool operator ==(B a, B b) => true;
+                    public static bool operator !=(B a, B b) => false;
+                    public static implicit operator B(A a) => default;
+                    public override bool Equals(object obj) => false;
+                    public override int GetHashCode() => 0;
+                }
+            }
+            """);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        var consumer = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(
+                """
+                package Demo
+                import Lib
+                import System.Linq.Expressions
+
+                func Predicate(a A, b B) Expression[Func[bool]] {
+                    return () -> a == b
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using var consumerStream = new MemoryStream();
+        var consumerResult = consumer.Emit(consumerStream, pdbStream: null, refStream: null, assemblyName: "Issue2373Binder.Ambiguous");
+        Assert.False(consumerResult.Success);
+        Assert.Contains(consumerResult.Diagnostics, d => d.Id == "GS0160");
+    }
+
+    private static (bool Success, System.Collections.Generic.IEnumerable<GSharp.Core.CodeAnalysis.Diagnostic> Diagnostics) Compile(string source)
+    {
+        var compilation = new GsCompilation(GsSyntaxTree.Parse(SourceText.From(source))) { IsLibrary = true };
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2373Binder");
+        return (result.Success, result.Diagnostics.AsEnumerable());
+    }
+
+    private static string EmitCSharpLibrary(string caseName, string csharpSource)
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2373", caseName);
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "CSharpLib2373.dll");
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(csharpSource, new CSharpParseOptions(LanguageVersion.Latest));
+
+        var referencePaths = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+            ?.Split(Path.PathSeparator)
+            ?? Array.Empty<string>();
+
+        var references = referencePaths
+            .Where(File.Exists)
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "CSharpLib2373_" + caseName,
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var emitResult = compilation.Emit(peStream);
+            Assert.True(emitResult.Success, string.Join(System.Environment.NewLine, emitResult.Diagnostics));
+        }
+
+        return libraryPath;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes issue #2373: `gsc` crashed with GS9998 when an `Expression<Func<T, bool>>` expression tree used a comparison operator (`==`, `!=`, `<`, `<=`, `>`, `>=`) on a built-in or user-defined struct — e.g. the reported `Oahu.Diagnostics` `Book.Asin` comparison scenario.

## Root cause

`ExpressionTreeLowerer.BuildClrBinaryOperatorExpression` requested a **non-existent 3-arg** `Expression.Equal/NotEqual/LessThan/LessThanOrEqual/GreaterThan/GreaterThanOrEqual(Expression, Expression, MethodInfo)` factory overload. Unlike the arithmetic/bitwise/shift/logical factories (which correctly use a 3-arg overload) and the unary factories (which correctly use a 2-arg overload), these six comparison factories only expose a **4-arg** `(Expression, Expression, bool liftToNull, MethodInfo)` overload in `System.Linq.Expressions.Expression`.

## Fix

`BuildClrBinaryOperatorExpression` now branches on comparison vs. other binary operator kinds, using the correct 4-arg overload with a literal `liftToNull: false` argument for comparisons. This matches Roslyn's own emission: a comparison's boolean *result* is never itself nullable/lifted, regardless of whether the operands are nullable — `IsLiftedToNull` naturally stays `false` while `IsLifted` reflects the nullable operand types.

### Second, tightly-coupled bug discovered and fixed

While validating the fix end-to-end (real two-assembly compile + ILVerify + runtime execution), a second, entirely separate, **pre-existing** bug was uncovered: `MethodBodyEmitter.EmitLiteral` had no case for a `MethodInfo`-valued `BoundLiteralExpression`. This meant **any** CLR operator (arithmetic *or* comparison) lowered into an expression tree would crash at emission time with `NotSupportedException: Literal of CLR type 'RuntimeMethodInfo' is not yet supported` — independent of, and prior to, the #2373 overload-selection bug. Confirmed pre-existing by reverting the lowerer fix and re-running the arithmetic-only regression test, which failed identically against the original code.

Fixed by adding:
- `EmitContext.CoreRuntimeMethodHandleType` / `CoreMethodBaseType`
- `WellKnownReferences.GetMethodFromHandleReference()` / `GetMethodFromHandleWithDeclaringTypeReference()`
- `MethodBodyEmitter.EmitMethodInfoLiteral`, emitting `ldtoken method [, ldtoken declaringType] ; call MethodBase.GetMethodFromHandle(...) ; castclass MethodInfo` — mirroring the existing `typeof(T)` literal emission pattern.

### Sibling audit

Reviewed all other `Expression` factory-method lookups in `ExpressionTreeLowerer` (arithmetic/bitwise/shift/logical: 3-arg; unary: 2-arg) empirically via reflection against `System.Linq.Expressions.Expression`. Confirmed **no other factory family has a matching overload-selection gap** — only the six comparison factories were affected. No changes made beyond this proven gap.

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue2373ExpressionTreeComparisonOverloadTests.cs` (24 tests, binder/lowering level):
  - All six comparison operators on `TimeSpan` (plain, nullable-left, both-nullable operands).
  - Arithmetic/unary sibling regression (proves no collateral change to already-correct factory families).
  - Source-declared struct operator control (Stream D — same-compilation operator, unaffected by this fix).
  - Generic expression-tree delegate closing a type parameter over `TimeSpan` at the call site (realistic generic-substitution shape).
  - Real C#-authored imported struct operator (mirrors `Oahu.Diagnostics` `Book.Asin`) reaching the CLR-factory fallback path.
  - Negative/ambiguity controls: undefined operator still reports `GS0129`; a genuine ambiguous overload (two real C#-authored mutually-implicitly-convertible structs each declaring `==`) still reports `GS0160`.
- `test/Compiler.Tests/Emit/Issue2373ExpressionTreeClrComparisonEmitTests.cs` (13 tests, real two-assembly compile + ILVerify + runtime execution):
  - `TimeSpan`, all six operators — ILVerify-clean IL, asserts `BinaryExpression.Method`/`IsLiftedToNull`, executes the compiled lambda and asserts the correct boolean result.
  - Arithmetic sibling-audit regression (specifically proves the MethodInfo-emission fix, since arithmetic already had correct overload selection pre-fix but crashed at emission).
  - Real C#-authored imported "Asin" strongly-typed-ID struct (mirroring `Oahu.Diagnostics`/`Book.Asin`), all six operators — ILVerify-clean IL and correct runtime results.

## Deferred / discovered-but-out-of-scope work

While building the "real C#-authored imported operator" test scenario, a **third, separate, pre-existing** gap was discovered: G#-authored user-defined operators (`func (a T) operator ==(b T) bool`) are emitted as **instance methods without `MethodAttributes.SpecialName`**. This means they can never be discovered by `ClrOperatorResolution`'s `BindingFlags.Static` + `IsSpecialName` reflection filter, making G#-authored operators unusable as `==`/etc. from real CLR/C# consumers, or even from Stream C's own CLR-fallback resolution. This is a legitimate, real bug, but it is a distinct emission-shape defect outside #2373's stated scope (`Expression` factory overload selection — "change only proven gaps"). **Recommended as a follow-up issue.**

## Validation

- Full solution build with analyzers enabled (`-warnaserror`): **0 warnings, 0 errors**.
- `Core.Tests`: 6237/6238 passed (1 pre-existing unrelated `[Skip]` baseline-regen test).
- `Compiler.Tests`: 3041/3041 passed.
- `InternalAnalyzers.Tests`: 7/7 passed.
- `Cs2Gs.Tests` (serial full suite, as required): 1387/1387 passed.
- Branch already up to date with latest `origin/main` (`bd990954`).

Closes #2373
