### PR TITLE
Fix #2375: delegate/expression-tree return-type erasure for same-compilation types

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -601,23 +601,35 @@ public sealed class Conversion
         // `(int32) -> int64` slot) — mirroring C#'s implicit numeric conversion
         // of a lambda body to an expected delegate return type.
         if (from is FunctionTypeSymbol fnFrom && to is FunctionTypeSymbol fnTo
-            && fnFrom.Arity == fnTo.Arity
-            && (fnFrom.ReturnType == fnTo.ReturnType || ReturnTypeWidens(fnFrom.ReturnType, fnTo.ReturnType)))
+            && IsFunctionShapeAssignable(fnFrom, fnTo))
         {
-            var sameShape = true;
-            for (var i = 0; i < fnFrom.Arity; i++)
-            {
-                if (fnFrom.ParameterTypes[i] != fnTo.ParameterTypes[i])
-                {
-                    sameShape = false;
-                    break;
-                }
-            }
+            return Conversion.Implicit;
+        }
 
-            if (sameShape)
-            {
-                return Conversion.Implicit;
-            }
+        // Issue #2375: a constructed CLR delegate (`Func`/`Action`/named
+        // delegate) closed over one or more same-compilation classes/structs
+        // reports a type-erased (widened to `object`) `Invoke` signature via
+        // plain CLR reflection on `to.ClrType` — the real backing type may
+        // still be an in-flight `TypeBuilder` (#313/#939), and separately a
+        // same-compilation parameter/return TypeSymbol has no `ClrType` at
+        // all until emit. Both defeat the purely-reflective
+        // `IsFunctionToDelegateConvertible` check below even though the
+        // shapes are, symbolically, an exact match. When the target's
+        // symbolic `FunctionTypeSymbol` shape can be recovered without
+        // reflection (via `MemberLookup.TryGetDelegateFunctionTypeFromSymbol`,
+        // which substitutes the delegate's own open generic definition against
+        // its recorded symbolic type arguments instead of reflecting on the
+        // possibly-erased `ClrType`), compare structurally against THAT
+        // shape first — this is a strict generalization of the
+        // `fnFrom`/`fnTo` check just above, not an EF- or class-specific
+        // special case, and simply widens which delegate targets can be
+        // resolved without depending on reflection over `ClrType`.
+        if (from is FunctionTypeSymbol fnFromSymbolic
+            && to is not FunctionTypeSymbol
+            && MemberLookup.TryGetDelegateFunctionTypeFromSymbol(to, out var toFnSymbolic)
+            && IsFunctionShapeAssignable(fnFromSymbolic, toFnSymbolic))
+        {
+            return Conversion.Implicit;
         }
 
         // Issue #295: a GSharp function value (a `func` literal or any
@@ -1843,6 +1855,35 @@ public sealed class Conversion
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Issue #2375: structural (symbol-identity-based) shape comparison
+    /// shared by the plain <see cref="FunctionTypeSymbol"/>-to-<see cref="FunctionTypeSymbol"/>
+    /// conversion check and the symbolically-resolved delegate-target check —
+    /// this is safe to use even when one or both sides wrap a same-compilation
+    /// type with no (or an erased) CLR backing.
+    /// </summary>
+    /// <param name="from">The source function-type shape.</param>
+    /// <param name="to">The target function-type shape.</param>
+    /// <returns><see langword="true"/> when the shapes are assignment-compatible.</returns>
+    private static bool IsFunctionShapeAssignable(FunctionTypeSymbol from, FunctionTypeSymbol to)
+    {
+        if (from == null || to == null || from.Arity != to.Arity
+            || !(from.ReturnType == to.ReturnType || ReturnTypeWidens(from.ReturnType, to.ReturnType)))
+        {
+            return false;
+        }
+
+        for (var i = 0; i < from.Arity; i++)
+        {
+            if (from.ParameterTypes[i] != to.ParameterTypes[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -735,7 +735,7 @@ internal sealed class ConversionClassifier
                     // vector so the default lowers against the real type
                     // parameter and emits the verifiable `ldloca; initobj; ldloc`
                     // slot shape uniformly for ref and value instantiations.
-                    var defSubstituted = TrySubstituteParameterTypeFromReceiver(method, paramIndex, receiverType)
+                    var defSubstituted = TrySubstituteParameterTypeFromReceiver(method, paramIndex, receiverType, symbolicMethodTypeArgs)
                         ?? TrySubstituteParameterTypeFromMethodTypeArgs(method, paramIndex, symbolicMethodTypeArgs);
                     var defTargetType = defSubstituted ?? TypeSymbol.FromClrType(parameterType);
                     if (defTargetType != null && defTargetType != TypeSymbol.Error)
@@ -760,7 +760,7 @@ internal sealed class ConversionClassifier
                     // verifier-rejecting `box T → !0 expected value` IL
                     // sequence at the call site).
                     var substituted = TrySubstituteParameterTypeFromReceiver(
-                        method, paramIndex, receiverType);
+                        method, paramIndex, receiverType, symbolicMethodTypeArgs);
 
                     // Issue #1512: a lambda argument bound to a generic method's
                     // delegate parameter (e.g. `Func<Task,TResult>`) must convert
@@ -1030,11 +1030,27 @@ internal sealed class ConversionClassifier
     /// <param name="method">The resolved CLR method (may be null).</param>
     /// <param name="paramIndex">Zero-based index into the method's parameter list.</param>
     /// <param name="receiverType">The receiver's bound type symbol.</param>
+    /// <param name="symbolicMethodTypeArgs">Issue #2375: the symbolic method
+    /// type-argument vector (e.g. <c>[Conversion]</c> for
+    /// <c>Builder[Book].HasOneRequired[Conversion](...)</c>), threaded through
+    /// alongside the receiver's own <c>TypeArguments</c> so a parameter type
+    /// that mentions BOTH the declaring generic type's parameter (<c>TEntity</c>)
+    /// AND the method's own type parameter (<c>TRelated</c>) — e.g.
+    /// <c>Expression&lt;Func&lt;TEntity,TRelated&gt;&gt;</c> — is substituted in
+    /// a single pass. Without this, a method-level generic parameter whose
+    /// <see cref="Type.GenericParameterPosition"/> coincides with the
+    /// receiver's own type-parameter position (both commonly <c>0</c> for a
+    /// single-type-parameter type and a single-method-type-parameter method)
+    /// was previously left as an unresolved open <c>!!0</c> reference (or,
+    /// before the companion fix, silently and incorrectly matched against the
+    /// receiver's own argument). May be default/empty when the method is
+    /// non-generic or its type arguments could not be recovered.</param>
     /// <returns>The substituted target symbol or <see langword="null"/>.</returns>
     public static TypeSymbol TrySubstituteParameterTypeFromReceiver(
         MethodInfo method,
         int paramIndex,
-        TypeSymbol receiverType)
+        TypeSymbol receiverType,
+        ImmutableArray<TypeSymbol> symbolicMethodTypeArgs = default)
     {
         if (method == null
             || receiverType is not ImportedTypeSymbol imported
@@ -1106,7 +1122,14 @@ internal sealed class ConversionClassifier
         // (<see cref="TrySubstituteParameterTypeFromMethodTypeArgs"/>), which
         // already understands arrays, tuples, nullable, and arbitrarily nested
         // constructed generics (delegates, `Expression&lt;&gt;`, ...).
-        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openParamType, openDef, imported.TypeArguments);
+        //
+        // Issue #2375: pass `openMethod`/`symbolicMethodTypeArgs` alongside the
+        // receiver's own `openDef`/`imported.TypeArguments` so a parameter type
+        // that mentions the method's OWN generic parameter (e.g. `TRelated` in
+        // `Expression<Func<TEntity,TRelated>>`) is substituted in the SAME pass
+        // as the receiver's `TEntity` — rather than only ever substituting one
+        // or the other depending on which happens to be tried first.
+        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openParamType, openDef, imported.TypeArguments, openMethod, symbolicMethodTypeArgs);
         return mapped != null
             && mapped != TypeSymbol.Error
             && (TypeSymbol.ContainsTypeParameter(mapped) || TypeSymbol.ContainsSameCompilationUserType(mapped))

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -783,7 +783,26 @@ internal sealed class MemberLookup
         {
             // Type-level parameter (declared on a generic type): map through
             // the receiver/container's symbolic TypeArguments.
-            var declaring = openClr.DeclaringType;
+            //
+            // Issue #2375 follow-up: `Type.DeclaringType` for a *method*-level
+            // generic parameter (e.g. `TRelated` of `Builder<TEntity>
+            // .HasOneRequired<TRelated>(...)`) returns the METHOD's declaring
+            // type (`Builder<TEntity>`), not `null` — only `DeclaringMethod`
+            // distinguishes a method-level parameter from a type-level one.
+            // Because a single-type-parameter type and a single-method-type-
+            // parameter method both report `GenericParameterPosition == 0`,
+            // this branch — guarded only by `DeclaringType`/`openDefinition`
+            // matching — previously matched `TRelated` too and returned
+            // `typeArguments[0]` (the receiver's `TEntity` argument, e.g.
+            // `Book`) instead of falling through to the method-level branch
+            // below. That silently substituted the wrong closed type for a
+            // deferred lambda's `Expression<Func<TEntity,TRelated>>`
+            // conversion target, producing invalid IL (`Func<Book,Book>`
+            // instead of `Func<Book,Conversion>`) that ILVerify rejected as
+            // `StackUnexpected`. Require `IsGenericTypeParameter` (equivalently
+            // `DeclaringMethod == null`) so a method-level parameter always
+            // falls through to its own (method-scoped) substitution below.
+            var declaring = openClr.IsGenericTypeParameter ? openClr.DeclaringType : null;
             if (declaring != null && openDefinition != null && !typeArguments.IsDefaultOrEmpty)
             {
                 var declaringDef = declaring.IsGenericTypeDefinition ? declaring : (declaring.IsGenericType ? declaring.GetGenericTypeDefinition() : declaring);
@@ -797,9 +816,12 @@ internal sealed class MemberLookup
                 }
             }
 
-            // Issue #833: method-level parameter (declared on a generic method).
-            // The CLR reports DeclaringMethod != null and DeclaringType == null
-            // for these; substitute via the parallel method-type-args slot.
+            // Issue #833: method-level parameter (declared on a generic
+            // method). `DeclaringMethod` is the only reliable discriminator —
+            // `DeclaringType` is set for these too (to the method's own
+            // declaring type, issue #2375 follow-up above) — so substitute via
+            // the parallel method-type-args slot whenever `DeclaringMethod` is
+            // present, regardless of `DeclaringType`.
             if (openClr.DeclaringMethod != null && !methodTypeArguments.IsDefaultOrEmpty)
             {
                 if (openMethodDefinition == null
@@ -1009,11 +1031,6 @@ internal sealed class MemberLookup
         }
 
         var openMethod = closed.IsGenericMethodDefinition ? closed : closed.GetGenericMethodDefinition();
-        var openReturn = openMethod.ReturnType;
-        if (openReturn == null || openReturn.IsSameAs(typeof(void)))
-        {
-            return null;
-        }
 
         Type receiverOpenDef = null;
         ImmutableArray<TypeSymbol> receiverTypeArgs = default;
@@ -1021,6 +1038,33 @@ internal sealed class MemberLookup
         {
             receiverOpenDef = imp.OpenDefinition;
             receiverTypeArgs = imp.TypeArguments;
+
+            // Issue #2375: `closed.GetGenericMethodDefinition()` only opens the
+            // METHOD's own generic parameters — it leaves the DECLARING TYPE's
+            // type arguments exactly as closed on `closed` (e.g. `object` when
+            // the receiver's own type argument was erased during overload
+            // resolution). For an instance method whose return type references
+            // BOTH a method-level parameter (e.g. `TRelated`) and the
+            // declaring type's own parameter (e.g. `TEntity`, as in
+            // `Builder<TEntity>.WithOne<TRelated>() : DependentBuilder<TRelated,
+            // TEntity>`), this left the second slot permanently erased to
+            // `object` even though the method-level slot recovered correctly.
+            // Re-resolve the truly-open method (both type- and method-level
+            // parameters unbound) from the receiver's OWN open declaring type by
+            // metadata-token match — the same recovery already used by
+            // `ExpressionBinder.Calls.TryGetOpenInstanceMethod` /
+            // `ResolveInstanceReturnTypeFromReceiver`.
+            var reopened = TryGetOpenMethodOnDeclaringType(receiverOpenDef, openMethod);
+            if (reopened != null)
+            {
+                openMethod = reopened;
+            }
+        }
+
+        var openReturn = openMethod.ReturnType;
+        if (openReturn == null || openReturn.IsSameAs(typeof(void)))
+        {
+            return null;
         }
 
         var mapped = MapOpenClrTypeToSymbolic(openReturn, receiverOpenDef, receiverTypeArgs, openMethod, symbolicMethodTypeArgs);
@@ -1350,6 +1394,34 @@ internal sealed class MemberLookup
             case DelegateTypeSymbol del:
                 functionType = del.EquivalentFunctionType;
                 return functionType != null;
+
+            // Issue #2375: a constructed `Func`/`Action`/named-delegate
+            // `ImportedTypeSymbol` closed over a same-compilation class or
+            // struct (e.g. `Func[Book, Conversion]`) carries a deliberately
+            // type-erased closed CLR shape in `ClrType` (#313/#939: the
+            // same-compilation argument is projected onto `object` because
+            // the real CLR type may not exist yet — it can still be a
+            // `TypeBuilder`). Reflecting on `ClrType` via
+            // `TryGetDelegateFunctionType(Type, ...)` below therefore widens
+            // that argument to `object`. When the symbolic
+            // `OpenDefinition`/`TypeArguments` shape (#313 construction) is
+            // available and every argument is fully resolved (no leftover
+            // open <see cref="TypeParameterSymbol"/>), build the
+            // `FunctionTypeSymbol` directly from that symbolic shape instead,
+            // preserving the real argument types. Falls through to the
+            // reflection-based path below for anything that isn't a simple
+            // `Invoke(...)` shape mapping directly onto the delegate's own
+            // generic parameters (e.g. an Invoke signature that nests a type
+            // parameter inside another generic), and for genuinely-open
+            // generic parameters (still-unresolved method type parameters),
+            // which keep their existing (deliberate) `object`-widening
+            // behavior unchanged.
+            case ImportedTypeSymbol imported
+                when imported.OpenDefinition != null
+                    && !imported.TypeArguments.IsDefaultOrEmpty
+                    && !imported.TypeArguments.Any(TypeSymbol.ContainsTypeParameter)
+                    && TryGetDelegateFunctionTypeFromOpenDefinition(imported.OpenDefinition, imported.TypeArguments, out functionType):
+                return true;
             default:
                 return type.ClrType != null && TryGetDelegateFunctionType(type.ClrType, out functionType);
         }
@@ -2422,6 +2494,120 @@ internal sealed class MemberLookup
     /// </summary>
     internal static void ClearCache() => methodsIncludingSelfAndInterfacesCache = new ConditionalWeakTable<Type, System.Collections.Concurrent.ConcurrentDictionary<string, IReadOnlyList<MethodInfo>>>();
 
+    /// <summary>
+    /// Issue #2375: builds the <see cref="FunctionTypeSymbol"/> shape of a
+    /// constructed delegate (<c>Func`N</c>/<c>Action`N</c>/a named delegate)
+    /// directly from its open CLR generic definition and the symbolic type
+    /// arguments it was constructed with (<see cref="ImportedTypeSymbol.OpenDefinition"/>
+    /// / <see cref="ImportedTypeSymbol.TypeArguments"/>), instead of
+    /// reflecting over the (possibly type-erased) closed
+    /// <see cref="TypeSymbol.ClrType"/>. A delegate's <c>Invoke</c> method
+    /// parameters/return map 1:1 onto the delegate type's own open generic
+    /// parameters by position (verified: <c>typeof(Func&lt;,&gt;).GetMethod("Invoke")</c>'s
+    /// parameter/return <see cref="Type"/> instances are reference-equal to
+    /// <c>typeof(Func&lt;,&gt;).GetGenericArguments()</c>), so this only needs to
+    /// substitute each such open-parameter slot with the corresponding entry
+    /// in <paramref name="typeArguments"/>. Returns <see langword="false"/>
+    /// (letting the caller fall back to the reflection-based
+    /// <see cref="TryGetDelegateFunctionType(Type, out FunctionTypeSymbol)"/>)
+    /// for any Invoke slot that is NOT directly one of the delegate's own
+    /// generic parameters (e.g. a named delegate whose Invoke signature nests
+    /// a type parameter inside another generic, such as <c>List&lt;T&gt;</c>) —
+    /// an intentionally conservative scope covering the overwhelmingly common
+    /// <c>Func</c>/<c>Action</c>/simple-named-delegate shape without
+    /// attempting general type substitution.
+    /// </summary>
+    /// <param name="openDefinition">The delegate's open CLR generic definition (e.g. <c>typeof(Func&lt;,&gt;)</c>).</param>
+    /// <param name="typeArguments">The symbolic type arguments the delegate was constructed with.</param>
+    /// <param name="functionType">The matching function-type symbol, on success.</param>
+    /// <returns><see langword="true"/> when every Invoke parameter/return slot could be mapped symbolically.</returns>
+    private static bool TryGetDelegateFunctionTypeFromOpenDefinition(Type openDefinition, ImmutableArray<TypeSymbol> typeArguments, out FunctionTypeSymbol functionType)
+    {
+        functionType = null;
+        if (openDefinition == null
+            || typeArguments.IsDefaultOrEmpty
+            || !openDefinition.IsGenericTypeDefinition
+            || (!ClrTypeUtilities.IsDelegateType(openDefinition)
+                && !string.Equals(openDefinition.BaseType?.FullName, "System.MulticastDelegate", StringComparison.Ordinal)
+                && !(openDefinition.FullName?.StartsWith("System.Func`", StringComparison.Ordinal) == true)
+                && !(openDefinition.FullName?.StartsWith("System.Action`", StringComparison.Ordinal) == true)))
+        {
+            return false;
+        }
+
+        var openGenericParams = openDefinition.GetGenericArguments();
+        if (openGenericParams.Length != typeArguments.Length)
+        {
+            return false;
+        }
+
+        MethodInfo invoke;
+        try
+        {
+            invoke = openDefinition.GetMethod("Invoke");
+        }
+        catch (Exception ex) when (ex is AmbiguousMatchException || ex is NotSupportedException)
+        {
+            return false;
+        }
+
+        if (invoke == null)
+        {
+            return false;
+        }
+
+        static bool TryMapSlot(Type invokeSlotType, Type openDefinitionForSlot, ImmutableArray<TypeSymbol> args, out TypeSymbol mapped)
+        {
+            if (invokeSlotType.IsGenericParameter
+                && ClrTypeUtilities.IsSameAs(invokeSlotType.DeclaringType, openDefinitionForSlot)
+                && invokeSlotType.GenericParameterPosition >= 0
+                && invokeSlotType.GenericParameterPosition < args.Length)
+            {
+                mapped = args[invokeSlotType.GenericParameterPosition];
+                return mapped != null;
+            }
+
+            mapped = null;
+            return false;
+        }
+
+        var parameters = invoke.GetParameters();
+        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(parameters.Length);
+        var variadicBuilder = ImmutableArray.CreateBuilder<bool>(parameters.Length);
+        var anyVariadic = false;
+        foreach (var parameter in parameters)
+        {
+            if (!TryMapSlot(parameter.ParameterType, openDefinition, typeArguments, out var mappedParam))
+            {
+                return false;
+            }
+
+            parameterTypes.Add(mappedParam);
+
+            // ADR-0102 follow-up / issue #818: mirror TryGetDelegateFunctionType's
+            // variadic-flag handling so a params-shaped named delegate keeps
+            // its call-site pack/pass-through behavior through this path too.
+            var paramArray = parameter.GetCustomAttributesData()
+                .Any(a => string.Equals(a.AttributeType.FullName, "System.ParamArrayAttribute", StringComparison.Ordinal));
+            variadicBuilder.Add(paramArray);
+            anyVariadic |= paramArray;
+        }
+
+        TypeSymbol returnType;
+        if (invoke.ReturnType.IsSameAs(typeof(void)))
+        {
+            returnType = TypeSymbol.Void;
+        }
+        else if (!TryMapSlot(invoke.ReturnType, openDefinition, typeArguments, out returnType))
+        {
+            return false;
+        }
+
+        var variadicFlags = anyVariadic ? variadicBuilder.ToImmutable() : default;
+        functionType = FunctionTypeSymbol.Get(parameterTypes.ToImmutable(), variadicFlags, returnType);
+        return true;
+    }
+
     private bool IsVisibleImportedMethod(MethodBase method)
         => method.IsPublic || (method.IsAssembly && this.binderCtx.References.CanAccessInternalMembers(method.DeclaringType?.Assembly));
 
@@ -2843,6 +3029,54 @@ internal sealed class MemberLookup
         return false;
     }
 
+    /// <summary>
+    /// Issue #2375: locates the counterpart of <paramref name="genericMethod"/>
+    /// (a method already opened at its OWN generic-method-parameter level, e.g.
+    /// via <c>MethodInfo.GetGenericMethodDefinition()</c>) on
+    /// <paramref name="openDeclaringType"/> — the receiver's fully open
+    /// declaring type (all of ITS OWN type parameters unbound too). This
+    /// matters because <c>GetGenericMethodDefinition()</c> only opens the
+    /// method's own type parameters; if the method's DECLARING type was
+    /// already closed (e.g. erased to <c>object</c> by overload resolution),
+    /// the declaring type's arguments remain closed on the result, silently
+    /// corrupting any reference to the declaring type's own type parameter
+    /// inside the method's signature (e.g. a return type like
+    /// <c>DependentBuilder&lt;TRelated, TEntity&gt;</c> would keep `TEntity`
+    /// erased to `object` even after re-opening `TRelated`). Match is by
+    /// metadata token + module, which is stable for methods on a constructed
+    /// generic type.
+    /// </summary>
+    /// <param name="openDeclaringType">The receiver's open generic type definition.</param>
+    /// <param name="genericMethod">The method to re-project onto <paramref name="openDeclaringType"/>.</param>
+    /// <returns>The fully open method, or <see langword="null"/> when no match is found.</returns>
+    private static MethodInfo TryGetOpenMethodOnDeclaringType(Type openDeclaringType, MethodInfo genericMethod)
+    {
+        if (openDeclaringType == null || genericMethod == null)
+        {
+            return null;
+        }
+
+        if (ClrTypeUtilities.AreSame(genericMethod.DeclaringType, openDeclaringType))
+        {
+            return genericMethod;
+        }
+
+        var token = genericMethod.MetadataToken;
+        var module = genericMethod.Module;
+        const BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+        foreach (var candidate in openDeclaringType.GetMethods(bindingFlags))
+        {
+            if (candidate.MetadataToken == token && ReferenceEquals(candidate.Module, module))
+            {
+                return candidate.IsGenericMethodDefinition || !candidate.IsGenericMethod
+                    ? candidate
+                    : candidate.GetGenericMethodDefinition();
+            }
+        }
+
+        return null;
+    }
+
     private static void UnifyForMethodTypeArgs(Type openClr, TypeSymbol actual, MethodInfo openMethod, TypeSymbol[] result)
     {
         if (openClr == null || actual == null)
@@ -2911,6 +3145,30 @@ internal sealed class MemberLookup
                     UnifyForMethodTypeArgs(openArgs[j], imp.TypeArguments[j], openMethod, result);
                 }
 
+                return;
+            }
+
+            // Issue #2375: open formal is `Expression<TDelegate>` and actual is a
+            // G# arrow/lambda (FunctionTypeSymbol) — i.e. a deferred lambda
+            // argument being matched against an expression-tree-wrapped
+            // parameter such as `HasOne<TRelated>(Expression<Func<TEntity,
+            // TRelated>>)`. A lambda literal's bound type is always its bare
+            // `FunctionTypeSymbol` shape (Expression<> wrapping only happens via
+            // a later argument CONVERSION, never as the lambda's own natural
+            // type), so without this unwrap the outer `openArgs.Length == 1`
+            // (Expression`1's own single type argument, the `Func<...>` shape)
+            // never matches the FunctionTypeSymbol pattern below (which expects
+            // `openArgs.Length` to equal the delegate's own parameter/return
+            // arity). Unwrapping one level lets the existing #1334 pattern unify
+            // the inner `Func<TEntity, TRelated>` shape against the lambda's
+            // parameter/return types directly, recovering `TRelated` for a
+            // fully-inferred call (no explicit type argument) whose only
+            // occurrence is the delegate's return position.
+            if (openArgs.Length == 1
+                && actual is FunctionTypeSymbol
+                && string.Equals(openDef.FullName, "System.Linq.Expressions.Expression`1", StringComparison.Ordinal))
+            {
+                UnifyForMethodTypeArgs(openArgs[0], actual, openMethod, result);
                 return;
             }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -1234,6 +1234,26 @@ internal static class OverloadResolution
                     return false;
                 }
 
+                // Issue #2375: mirror UnifyForInference's #2142 unwrap — a
+                // deferred lambda slot whose delegate parameter is
+                // `Expression<TDelegate>` (e.g. `HasOne<TRelated>(Expression<Func<TEntity, TRelated>>)`)
+                // has no `Invoke` method of its own; unwrap to `TDelegate`
+                // first so this closes the lambda's parameter types instead
+                // of unconditionally bailing out for every expression-tree
+                // deferred lambda parameter.
+                if (delegateType.IsGenericType
+                    && !delegateType.IsGenericTypeDefinition
+                    && string.Equals(delegateType.GetGenericTypeDefinition().FullName, "System.Linq.Expressions.Expression`1", StringComparison.Ordinal))
+                {
+                    var expressionArgs = delegateType.GetGenericArguments();
+                    if (expressionArgs.Length != 1)
+                    {
+                        return false;
+                    }
+
+                    delegateType = expressionArgs[0];
+                }
+
                 invoke = delegateType.GetMethodSafe("Invoke");
                 if (invoke is null)
                 {

--- a/test/Compiler.Tests/Emit/Issue2375ExpressionTreeMethodTypeArgumentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2375ExpressionTreeMethodTypeArgumentEmitTests.cs
@@ -1,0 +1,340 @@
+// <copyright file="Issue2375ExpressionTreeMethodTypeArgumentEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2375 — real-assembly, IL-verification and runtime-level regression coverage. Binding alone
+/// never reported an error for the reported bug (see the binder/diagnostics-level companion
+/// <see cref="GSharp.Core.Tests.CodeAnalysis.Binding.Issue2375ExpressionTreeMethodTypeArgumentTests"/>);
+/// the actual defect only manifested in the EMITTED assembly (ILVerify <c>StackUnexpected</c>) and, more
+/// subtly, in the runtime shape of the produced <see cref="LambdaExpression"/> (whose parameter/return
+/// types were the wrong same-compilation type, or <see cref="object"/>, instead of the real generic
+/// method type argument). These tests emit a real two-assembly (imported library + consumer) pair to
+/// disk, ILVerify the consumer, then load and invoke it to assert the runtime expression-tree shape is
+/// exactly right — mirroring the real Oahu EF Core navigation-chain regression
+/// (<c>HasOne(e => e.Conversion).WithOne(e => e.Book).HasForeignKey(e => e.BookId)</c>).
+/// </summary>
+public class Issue2375ExpressionTreeMethodTypeArgumentEmitTests
+{
+    [Fact]
+    public void ExplicitMethodTypeArgument_IlVerifiesAndPreservesReturnType()
+    {
+        var (libraryPath, consumerPath, consumerAssemblyName) = CompileLibraryAndConsumer(
+            """
+            package Demo
+            import Lib
+            import System
+            import System.Linq.Expressions
+
+            class Book { }
+            class Conversion { }
+
+            func Run(b Builder[Book]) Expression[Func[Book, Conversion]] {
+                b.HasOneRequired[Conversion]((e Book) -> Conversion{})
+                return b.GetLastNav[Conversion]()
+            }
+            """,
+            nameof(ExplicitMethodTypeArgument_IlVerifiesAndPreservesReturnType));
+
+        IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
+
+        var (_, consumerAsm, loadContext) = LoadLibraryAndConsumer(libraryPath, consumerPath, consumerAssemblyName);
+        try
+        {
+            var bookType = consumerAsm.GetTypes().Single(t => t.Name == "Book");
+            var conversionType = consumerAsm.GetTypes().Single(t => t.Name == "Conversion");
+            var run = GetProgramMethod(consumerAsm, "Run");
+
+            var builderType = run.GetParameters()[0].ParameterType;
+            var builder = Activator.CreateInstance(builderType);
+            var capturedExpr = run.Invoke(null, new[] { builder });
+
+            var lambda = Assert.IsAssignableFrom<LambdaExpression>(capturedExpr);
+            Assert.Equal(bookType, lambda.Parameters[0].Type);
+            Assert.Equal(conversionType, lambda.ReturnType);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    [Fact]
+    public void InferredMethodTypeArgument_IlVerifiesAndPreservesReturnType()
+    {
+        // No explicit [TRelated] — the method type argument is recovered purely from the deferred
+        // lambda's own bound return type (defect 3 in the class-level remarks).
+        var (libraryPath, consumerPath, consumerAssemblyName) = CompileLibraryAndConsumer(
+            """
+            package Demo
+            import Lib
+            import System
+            import System.Linq.Expressions
+
+            class Book { var Conversion Conversion }
+            class Conversion { }
+
+            func Run(b Builder[Book]) Expression[Func[Book, Conversion]] {
+                b.HasOne((e Book) -> e.Conversion)
+                return b.GetLastNav[Conversion]()
+            }
+            """,
+            nameof(InferredMethodTypeArgument_IlVerifiesAndPreservesReturnType));
+
+        IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
+
+        var (_, consumerAsm, loadContext) = LoadLibraryAndConsumer(libraryPath, consumerPath, consumerAssemblyName);
+        try
+        {
+            var bookType = consumerAsm.GetTypes().Single(t => t.Name == "Book");
+            var conversionType = consumerAsm.GetTypes().Single(t => t.Name == "Conversion");
+            var run = GetProgramMethod(consumerAsm, "Run");
+
+            var builderType = run.GetParameters()[0].ParameterType;
+            var builder = Activator.CreateInstance(builderType);
+            var capturedExpr = run.Invoke(null, new[] { builder });
+
+            var lambda = Assert.IsAssignableFrom<LambdaExpression>(capturedExpr);
+
+            // Defect 1's exact reported symptom: before the fix this was `Book` (the RECEIVER's own
+            // TEntity), not `Conversion`.
+            Assert.NotEqual(bookType, lambda.ReturnType);
+            Assert.Equal(bookType, lambda.Parameters[0].Type);
+            Assert.Equal(conversionType, lambda.ReturnType);
+
+            var compiled = lambda.Compile();
+            var conversionInstance = Activator.CreateInstance(conversionType);
+            var bookInstance = Activator.CreateInstance(bookType);
+            bookType.GetField("Conversion")!.SetValue(bookInstance, conversionInstance);
+            var invoked = compiled.DynamicInvoke(bookInstance);
+            Assert.Same(conversionInstance, invoked);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    [Fact]
+    public void NavigationChain_InferredThroughout_IlVerifiesAndRunsCorrectly()
+    {
+        // The exact reported Oahu EF navigation-chain shape end to end: HasOne(...).WithOne(...)
+        // .HasForeignKey(...), fully inferred, real assembly, real ILVerify, real runtime invocation.
+        var (libraryPath, consumerPath, consumerAssemblyName) = CompileLibraryAndConsumer(
+            """
+            package Demo
+            import Lib
+            import System
+
+            class Book { var Conversion Conversion }
+            class Conversion {
+                var BookId int32
+                var Book Book
+            }
+
+            func Run(b Builder[Book]) {
+                b.HasOne((e Book) -> e.Conversion)
+                    .WithOne((e Conversion) -> e.Book)
+                    .HasForeignKey((e Conversion) -> e.BookId)
+            }
+            """,
+            nameof(NavigationChain_InferredThroughout_IlVerifiesAndRunsCorrectly));
+
+        // Real ILVerify pass is the direct regression check for the reported Oahu.Data StackUnexpected
+        // failure across the full navigation chain (not just a single call).
+        IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
+
+        var (_, consumerAsm, loadContext) = LoadLibraryAndConsumer(libraryPath, consumerPath, consumerAssemblyName);
+        try
+        {
+            var run = GetProgramMethod(consumerAsm, "Run");
+            var builderType = run.GetParameters()[0].ParameterType;
+            var builder = Activator.CreateInstance(builderType);
+
+            // Must not throw (no invalid-cast / no unresolved-generic-token runtime failure).
+            run.Invoke(null, new[] { builder });
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    [Fact]
+    public void DirectPlainFuncTarget_NoImportedLibrary_IlVerifiesAndRunsCorrectly()
+    {
+        // Defect 5 (Conversion.cs): a lambda converting directly to a PLAIN (non-Expression-wrapped)
+        // constructed `Func[TEntity,TRelated]` local-variable target, with NO imported library and NO
+        // generic method call involved at all. This isolates the standalone
+        // `Conversion.IsFunctionShapeAssignable` / delegate-target reflection path from every
+        // generic-method-substitution defect covered by the other tests in this class — single
+        // assembly, real emit, real ILVerify, real runtime invocation.
+        var source = """
+            package Demo
+
+            class Conversion { var Id int32 }
+            class Book {
+                var Id int32
+                var Conversion Conversion
+            }
+
+            func Run(b Book) Conversion {
+                var f Func[Book, Conversion] = (e Book) -> e.Conversion
+                return f(b)
+            }
+            """;
+
+        var dir = LibraryDirectory();
+        var consumerPath = Path.Combine(dir, "Issue2375Emit.DirectPlainFuncTarget.dll");
+        var consumerAssemblyName = "Issue2375Emit.DirectPlainFuncTarget";
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var peStream = File.Create(consumerPath))
+        {
+            var result = compilation.Emit(peStream, pdbStream: null, refStream: null, assemblyName: consumerAssemblyName);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        IlVerifier.Verify(consumerPath);
+
+        var loadContext = new AssemblyLoadContext(consumerAssemblyName, isCollectible: true);
+        try
+        {
+            var consumerAsm = loadContext.LoadFromAssemblyPath(consumerPath);
+            var bookType = consumerAsm.GetTypes().Single(t => t.Name == "Book");
+            var conversionType = consumerAsm.GetTypes().Single(t => t.Name == "Conversion");
+            var run = GetProgramMethod(consumerAsm, "Run");
+
+            var conversionInstance = Activator.CreateInstance(conversionType);
+            var bookInstance = Activator.CreateInstance(bookType);
+            bookType.GetField("Conversion")!.SetValue(bookInstance, conversionInstance);
+
+            var invoked = run.Invoke(null, new[] { bookInstance });
+            Assert.Same(conversionInstance, invoked);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static MethodInfo GetProgramMethod(Assembly asm, string name)
+    {
+        var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+        Assert.NotNull(programType);
+        var method = programType!.GetMethod(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return method!;
+    }
+
+    private static string LibraryDirectory()
+    {
+        var dir = Path.Combine(AppContext.BaseDirectory, "Issue2375Emit");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string EmitSharedLibrary()
+    {
+        var libraryPath = Path.Combine(LibraryDirectory(), "Issue2375Emit.Library.dll");
+        if (File.Exists(libraryPath))
+        {
+            return libraryPath;
+        }
+
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Lib
+                import System
+                import System.Linq.Expressions
+
+                class Builder[TEntity] {
+                    private var lastNav object
+
+                    func HasOneRequired[TRelated](nav Expression[Func[TEntity, TRelated]]) Builder[TRelated] {
+                        lastNav = nav
+                        return Builder[TRelated]{}
+                    }
+
+                    func HasOne[TRelated](nav Expression[Func[TEntity, TRelated]]) Builder[TRelated] {
+                        lastNav = nav
+                        return Builder[TRelated]{}
+                    }
+
+                    func WithOne[TRelated](nav Expression[Func[TEntity, TRelated]]) DependentBuilder[TRelated, TEntity] {
+                        return DependentBuilder[TRelated, TEntity]{}
+                    }
+
+                    func GetLastNav[TRelated]() Expression[Func[TEntity, TRelated]] {
+                        return lastNav as Expression[Func[TEntity, TRelated]]
+                    }
+                }
+
+                class DependentBuilder[TPrincipal, TDependent] {
+                    func HasForeignKey[TDependentEntity](fk Expression[Func[TDependentEntity, object]]) DependentBuilder[TPrincipal, TDependent] {
+                        return this
+                    }
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using var peStream = File.Create(libraryPath);
+        var result = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2375Emit.Library");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return libraryPath;
+    }
+
+    private static (string LibraryPath, string ConsumerPath, string ConsumerAssemblyName) CompileLibraryAndConsumer(string consumerSource, string testName)
+    {
+        var libraryPath = EmitSharedLibrary();
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        var consumerAssemblyName = "Issue2375Emit.Consumer." + testName;
+        var consumerPath = Path.Combine(LibraryDirectory(), consumerAssemblyName + ".dll");
+
+        var consumer = new Compilation(resolver, SyntaxTree.Parse(SourceText.From(consumerSource)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var peStream = File.Create(consumerPath))
+        {
+            var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: consumerAssemblyName);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        return (libraryPath, consumerPath, consumerAssemblyName);
+    }
+
+    private static (Assembly LibraryAssembly, Assembly ConsumerAssembly, AssemblyLoadContext LoadContext) LoadLibraryAndConsumer(
+        string libraryPath, string consumerPath, string consumerAssemblyName)
+    {
+        var loadContext = new AssemblyLoadContext(consumerAssemblyName, isCollectible: true);
+        var libraryAsm = loadContext.LoadFromAssemblyPath(libraryPath);
+        loadContext.Resolving += (ctx, name) =>
+            name.Name == libraryAsm.GetName().Name ? libraryAsm : null;
+        var consumerAsm = loadContext.LoadFromAssemblyPath(consumerPath);
+        return (libraryAsm, consumerAsm, loadContext);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2375ExpressionTreeMethodTypeArgumentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2375ExpressionTreeMethodTypeArgumentTests.cs
@@ -1,0 +1,477 @@
+// <copyright file="Issue2375ExpressionTreeMethodTypeArgumentTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2375: an imported generic INSTANCE method whose expression-tree parameter's delegate
+/// closes over the METHOD's OWN generic type parameter (not merely the declaring type's, which
+/// #2365 already covers) — e.g. EF Core's
+/// <c>EntityTypeBuilder&lt;TEntity&gt;.HasOne&lt;TRelated&gt;(Expression&lt;Func&lt;TEntity,TRelated&gt;&gt;)</c>
+/// — erased the METHOD-level type parameter's occurrences to the wrong type (the RECEIVER's own type
+/// argument) or to <c>object</c>, producing an unverifiable assembly (ILVerify <c>StackUnexpected</c>)
+/// even though binding itself reported no error.
+///
+/// Root causes (three independent, EF-agnostic defects in the shared CLR-import substitution engine,
+/// all fixed; see also the emit/ILVerify-level companion
+/// <c>GSharp.Compiler.Tests.Emit.Issue2375ExpressionTreeMethodTypeArgumentEmitTests</c>):
+/// <list type="number">
+/// <item><description>
+/// <c>MemberLookup.MapOpenClrTypeToSymbolic</c>'s TYPE-level-parameter branch keyed a recovered generic
+/// parameter purely by <c>GenericParameterPosition</c> plus <c>DeclaringType</c> — but a METHOD-level CLR
+/// <see cref="Type"/> ALSO reports its enclosing type as <c>DeclaringType</c> (contrary to a previously
+/// incorrect assumption), so a method type parameter whose position coincidentally collided with the
+/// declaring type's own parameter position (both commonly position 0) was misidentified as the type-level
+/// parameter and substituted with the RECEIVER's type argument instead of the method's own — corrupting
+/// BOTH occurrences of the delegate's parameter/return types to the receiver's entity type (e.g.
+/// <c>Expression&lt;Func&lt;Book,Book&gt;&gt;</c> instead of <c>Expression&lt;Func&lt;Book,Conversion&gt;&gt;</c>).
+/// Fixed by requiring <c>IsGenericTypeParameter</c> before taking the type-level substitution path.
+/// </description></item>
+/// <item><description>
+/// Even once (1) correctly routed a method-level parameter to the method-level substitution branch, the
+/// CALLER — <c>ConversionClassifier.TrySubstituteParameterTypeFromReceiver</c> (used to convert the bound
+/// argument to the declared parameter type) — invoked the 3-argument overload of
+/// <c>MapOpenClrTypeToSymbolic</c>, which hard-codes empty method type arguments; the method's own already-
+/// resolved symbolic type arguments (known to the caller) were never threaded through, so the method-level
+/// branch had nothing to substitute with. Fixed by adding an optional <c>symbolicMethodTypeArgs</c>
+/// parameter to <c>TrySubstituteParameterTypeFromReceiver</c>, unifying type-level and method-level
+/// substitution into the single 5-argument overload (mirroring the sibling
+/// <c>TrySubstituteParameterTypeFromMethodTypeArgs</c>, which already did this correctly).
+/// </description></item>
+/// <item><description>
+/// For a FULLY INFERRED call (no explicit method type argument, e.g. <c>.HasOne(e -&gt; e.Conversion)</c>),
+/// the method type argument must itself be recovered by unifying the delegate's return position against
+/// the deferred lambda's own natural (bound) return type. <c>MemberLookup.UnifyForMethodTypeArgs</c>
+/// already had this unification for a BARE <c>Func&lt;...&gt;</c>-shaped open parameter (issue #1334), but
+/// never unwrapped an <c>Expression&lt;TDelegate&gt;</c> wrapper first — since a lambda literal's bound
+/// type is always its bare <c>FunctionTypeSymbol</c> shape (the <c>Expression&lt;&gt;</c> wrapping only
+/// happens via the later argument CONVERSION, never as the lambda's own natural type), the outer arity
+/// check against <c>Expression&lt;TDelegate&gt;</c>'s own single type argument always failed, so the method
+/// type argument was never inferred at all for this shape. Fixed by unwrapping one <c>Expression&lt;&gt;</c>
+/// level before applying the existing #1334 pattern.
+/// </description></item>
+/// <item><description>
+/// A fourth, RETURN-TYPE-specific defect (only reachable once (1)-(3) let the method's own type argument
+/// resolve correctly) affects <c>MemberLookup.ResolveCallReturnTypeFromSymbolicTypeArgs</c>: it derived the
+/// call's "open" method via <c>MethodInfo.GetGenericMethodDefinition()</c>, which only re-opens the
+/// METHOD's own generic parameters — it leaves the DECLARING TYPE's type arguments exactly as already
+/// closed on the selected candidate (e.g. erased to <c>object</c> during overload resolution). For a
+/// return type that references BOTH a method-level parameter and the declaring type's own parameter (e.g.
+/// <c>Builder&lt;TEntity&gt;.WithOne&lt;TRelated&gt;() : DependentBuilder&lt;TRelated,TEntity&gt;</c>), this
+/// left the declaring-type slot permanently erased to <c>object</c> in the call's bound return type even
+/// after the method-level slot recovered correctly — breaking any FURTHER chained call against that
+/// result (the exact EF <c>.HasOne(...).WithOne(...).HasForeignKey(...)</c> navigation-chain shape). Fixed
+/// by re-resolving the truly-open method from the receiver's own open declaring type by metadata-token
+/// match (mirroring the existing <c>ExpressionBinder.Calls.TryGetOpenInstanceMethod</c> /
+/// <c>ResolveInstanceReturnTypeFromReceiver</c> recovery) before substituting.
+/// </description></item>
+/// <item><description>
+/// A fifth, independently-reachable defect covers the issue's own LITERAL minimal repro — a lambda
+/// converting directly to a plain (non-<c>Expression</c>-wrapped) constructed delegate type closed over
+/// same-compilation classes, e.g. <c>var f Func[Book, Conversion] = (e Book) -&gt; e.Conversion</c>, with
+/// NO imported generic method involved at all. <c>Conversion.IsFunctionToDelegateConvertible</c> — the
+/// general "does a func value convert to this CLR delegate type" check used by
+/// <c>Conversion.ClassifyCore</c> — resolved the delegate's <c>Invoke</c> signature purely via CLR
+/// reflection on the target's (possibly type-erased, per #313/#939) <c>ClrType</c>, AND compared each
+/// resolved slot against the SOURCE function's OWN <c>TypeSymbol.ClrType</c> — which is null for any
+/// same-compilation class/struct parameter or return type during binding (its real CLR type is only
+/// materialized at emit time via <c>TypeBuilder</c>). Both defeat the purely-reflective path even when the
+/// two shapes are, symbolically, an exact match. Fixed by adding a new structural (non-reflective) check —
+/// <c>Conversion.IsFunctionShapeAssignable</c>, factored out of the pre-existing bare
+/// <c>FunctionTypeSymbol</c>-to-<c>FunctionTypeSymbol</c> comparison — that first tries to recover the
+/// target's symbolic <c>FunctionTypeSymbol</c> shape via the already-EF-agnostic
+/// <c>MemberLookup.TryGetDelegateFunctionTypeFromSymbol</c> (the same helper defect (1)-(3) already rely
+/// on) and compares purely by <c>TypeSymbol</c> identity, falling back to the original reflective
+/// <c>IsFunctionToDelegateConvertible</c> path only when no symbolic shape can be recovered (e.g. a
+/// genuinely still-open generic parameter, or a delegate type with no recorded open-definition/type-argument
+/// linkage).
+/// </description></item>
+/// </list>
+/// All four fixes reuse the existing, EF-agnostic <c>MemberLookup.MapOpenClrTypeToSymbolic</c>
+/// substitution engine — there is no anonymous-type, EF-specific, or Oahu-specific special case anywhere
+/// in any of the fixes.
+/// </summary>
+public class Issue2375ExpressionTreeMethodTypeArgumentTests
+{
+    [Fact]
+    public void ImportedGenericInstanceMethod_ExplicitMethodTypeArgument_ExpressionReturnPosition_Binds()
+    {
+        // The explicit-type-argument shape: HasOneRequired[TRelated] is called with TRelated supplied
+        // explicitly, so the method's own type argument is never inferred at all — this isolates
+        // defects (1) and (2) (the erasure/collision + missing method-type-arg threading) from
+        // defect (3) (inference from a deferred lambda body).
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            class Book { }
+            class Conversion { }
+
+            func Run(b Builder[Book]) {
+                b.HasOneRequired[Conversion]((e Book) -> Conversion{})
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void ImportedGenericInstanceMethod_InferredMethodTypeArgument_ExpressionReturnPosition_Binds()
+    {
+        // The real Oahu shape: no explicit type argument at all — TRelated must be recovered purely by
+        // unifying the delegate's return slot against the deferred lambda's own inferred return type
+        // (defect 3).
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            class Book { var Conversion Conversion }
+            class Conversion { }
+
+            func Run(b Builder[Book]) {
+                b.HasOne((e Book) -> e.Conversion)
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void ImportedGenericInstanceMethod_NavigationChain_InferredThroughout_Binds()
+    {
+        // The exact reported Oahu EF navigation chain shape: HasOne(...).WithOne(...).HasForeignKey(...),
+        // every method-type-argument fully inferred, exercising both the method-level-parameter
+        // substitution (defects 1-3) AND the chained-call return-type substitution (defect 4) together —
+        // WithOne's return type `DependentBuilder[TRelated, TEntity]` mixes a method-level slot
+        // (TRelated, from the lambda) with the declaring type's own slot (TEntity, from the receiver),
+        // and the immediately following `.HasForeignKey(...)` call requires that return type to be
+        // correctly resolved (not erased to `object`) to bind at all.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            class Book { var Conversion Conversion }
+            class Conversion {
+                var BookId int32
+                var Book Book
+            }
+
+            func Run(b Builder[Book]) {
+                b.HasOne((e Book) -> e.Conversion)
+                    .WithOne((e Conversion) -> e.Book)
+                    .HasForeignKey((e Conversion) -> e.BookId)
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void ImportedGenericInstanceMethod_StructRelatedType_Binds()
+    {
+        // Value-type (struct) TRelated control: the method-level substitution must also work when the
+        // inferred/explicit type is a data struct, not just a reference type.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            class Book { var Conversion StructConversion }
+            data struct StructConversion(Id int32)
+
+            func Run(b Builder[Book]) {
+                b.HasOne((e Book) -> e.Conversion)
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void ImportedGenericInstanceMethod_NullableReturn_Binds()
+    {
+        // Nullable-reference-typed TRelated control: the navigation property itself is nullable — the
+        // substitution must not lose or corrupt the nullable annotation on the recovered type argument.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            class Book { var Conversion Conversion? }
+            class Conversion { }
+
+            func Run(b Builder[Book]) {
+                b.HasOne((e Book) -> e.Conversion)
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void ImportedGenericInstanceMethod_ValueTypeReturn_Binds()
+    {
+        // Primitive/value-type (non-struct) TRelated control: the delegate's return position closes
+        // over int32 rather than a same-compilation user type.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            class Book { var Age int32 }
+
+            func Run(b Builder[Book]) {
+                b.HasOne((e Book) -> e.Age)
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void ImportedGenericInstanceMethod_GenericMethodCalledOnGenericReceiver_OpenControl_Binds()
+    {
+        // Genuinely-open-generic non-regression control: HasOne is called from INSIDE another generic
+        // function, so neither TEntity (the receiver's own type argument) nor TRelated (the method's
+        // own, here inferred from a still-open TEntity-typed lambda parameter) is closed at the call
+        // site — both remain in-scope G# type parameters. This must keep working exactly as before
+        // (issue #313/#671's open in-scope type parameter substitution), unaffected by the #2375 fixes.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            class Related { }
+
+            func Attach[TEntity](b Builder[TEntity], pick Func[TEntity, Related]) {
+                b.HasOne((e TEntity) -> pick(e))
+            }
+            """);
+
+        AssertBindsCleanly(result);
+    }
+
+    [Fact]
+    public void NegativeControl_ArityMismatchOnMethodTypeArgumentExpression_StillFailsWithDiagnostic()
+    {
+        // The lambda supplied for the Expression[Func[TEntity,TRelated]] parameter declares zero
+        // parameters where the shape requires exactly one — the generalized method-level substitution
+        // must not silently accept an incompatible lambda shape.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            class Book { }
+            class Conversion { }
+
+            func Run(b Builder[Book]) {
+                b.HasOne(() -> Conversion{})
+            }
+            """,
+            expectSuccess: false);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void NegativeControl_UnknownMemberOnChainedResult_StillFailsWithDiagnostic()
+    {
+        // Sanity control: an unrelated/nonexistent member call on the CHAINED result of a fully-inferred
+        // call must not be swallowed by the generalized substitution — it should still fail to resolve.
+        var result = CompileAgainstLibrary(
+            """
+            package Demo
+            import Lib
+
+            class Book { var Conversion Conversion }
+            class Conversion { }
+
+            func Run(b Builder[Book]) {
+                b.HasOne((e Book) -> e.Conversion).NoSuchMethod()
+            }
+            """,
+            expectSuccess: false);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void DirectPlainFuncTarget_LiteralIssueRepro_NoImportedGenericMethod_Binds()
+    {
+        // The issue's own literal minimal repro (defect 5): a lambda converts directly to a
+        // PLAIN (non-Expression-wrapped) constructed `Func[TEntity,TRelated]` local-variable target,
+        // with NO imported library, NO generic method call, and NO Expression<> wrapper involved at
+        // all — isolating the standalone `Conversion.IsFunctionToDelegateConvertible` reflection gap
+        // from every generic-method-substitution defect (1)-(4) above.
+        var result = CompileSingle(
+            """
+            package Demo
+
+            class Conversion { var Id int32 }
+            class Book {
+                var Id int32
+                var Conversion Conversion
+            }
+
+            func Main() {
+                var f Func[Book, Conversion] = (e Book) -> e.Conversion
+            }
+            """);
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void DirectPlainFuncTarget_StructRelatedType_Binds()
+    {
+        // Value-type (struct) control for the direct plain-Func target shape.
+        var result = CompileSingle(
+            """
+            package Demo
+
+            data struct StructConversion(Id int32)
+            class Book {
+                var Conversion StructConversion
+            }
+
+            func Main() {
+                var f Func[Book, StructConversion] = (e Book) -> e.Conversion
+            }
+            """);
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void DirectActionTarget_SameCompilationParameterType_Binds()
+    {
+        // Sibling control: `Action[TEntity]` (void-returning) closed over a same-compilation class
+        // parameter must also bind via the same non-reflective structural path — the defect was not
+        // return-type-specific; the source lambda's OWN parameter TypeSymbol has no ClrType either.
+        var result = CompileSingle(
+            """
+            package Demo
+
+            class Book { var Id int32 }
+
+            func Main() {
+                var a Action[Book] = (e Book) -> { }
+            }
+            """);
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void DirectPlainFuncTarget_GenuinelyOpenGenericControl_StillWidensToObject()
+    {
+        // Non-regression control: when the delegate is STILL genuinely open (called from inside
+        // another generic function, T unresolved at this call site), the pre-existing (deliberate)
+        // object-widening behavior for the truly-unresolved slot must be unaffected by this fix —
+        // `MemberLookup.TryGetDelegateFunctionTypeFromSymbol`'s `ImportedTypeSymbol` branch explicitly
+        // excludes any type argument that still contains an open type parameter, falling back to the
+        // original reflective path.
+        var result = CompileSingle(
+            """
+            package Demo
+
+            func Wrap[T](pick Func[T, object]) Func[T, object] {
+                return pick
+            }
+            """);
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static void AssertBindsCleanly(EmitResult result)
+    {
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0159");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static EmitResult CompileSingle(string source)
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source))) { IsLibrary = true };
+        using var peStream = new MemoryStream();
+        return compilation.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2375.Direct." + Guid.NewGuid().ToString("N"));
+    }
+
+    private static EmitResult CompileAgainstLibrary(string consumerSource, bool expectSuccess = true)
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2375");
+        Directory.CreateDirectory(outputDir);
+
+        var libraryPath = Path.Combine(outputDir, "Issue2375.Library.dll");
+        EmitLibraryAssembly(libraryPath);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+
+        var consumer = new Compilation(resolver, SyntaxTree.Parse(SourceText.From(consumerSource)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2375.Consumer." + Guid.NewGuid().ToString("N"));
+
+        _ = expectSuccess;
+        return result;
+    }
+
+    private static void EmitLibraryAssembly(string libraryPath)
+    {
+        if (File.Exists(libraryPath))
+        {
+            // Reused across [Fact]s in this class; each test compiles a distinct consumer assembly
+            // against the same cached library, mirroring Issue2365's pattern.
+            return;
+        }
+
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Lib
+                import System
+                import System.Linq.Expressions
+
+                class Builder[TEntity] {
+                    func HasOneRequired[TRelated](nav Expression[Func[TEntity, TRelated]]) Builder[TRelated] {
+                        return Builder[TRelated]{}
+                    }
+
+                    func HasOne[TRelated](nav Expression[Func[TEntity, TRelated]]) Builder[TRelated] {
+                        return Builder[TRelated]{}
+                    }
+
+                    func WithOne[TRelated](nav Expression[Func[TEntity, TRelated]]) DependentBuilder[TRelated, TEntity] {
+                        return DependentBuilder[TRelated, TEntity]{}
+                    }
+                }
+
+                class DependentBuilder[TPrincipal, TDependent] {
+                    func HasForeignKey[TDependentEntity](fk Expression[Func[TDependentEntity, object]]) DependentBuilder[TPrincipal, TDependent] {
+                        return this
+                    }
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using var peStream = File.Create(libraryPath);
+        var result = library.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Issue2375.Library");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes gsc erasing or misresolving same-compilation `TRelated`/`TEntity` types when a lambda is converted to a plain `Func`/`Action` delegate, an `Expression<Func<...>>` tree, or a method-type-argument-inferred delegate target — the pattern that surfaces in the EF `HasOne(...).WithOne(...).HasForeignKey(...)` navigation chain from #2375, as well as the issue's own literal minimal repro:

```gsharp
var f Func[Book, Conversion] = (e Book) -> e.Conversion
```

Closes #2375.

## Root causes and fixes

All in `src/Core/CodeAnalysis/Binding/`:

1. **`MemberLookup.TryGetDelegateFunctionTypeFromSymbol`**: added the `ImportedTypeSymbol` case plus a new `TryGetDelegateFunctionTypeFromOpenDefinition` helper, so a same-compilation `TypeBuilder`-backed closed generic type used as a delegate's `Invoke` parameter/return is preserved instead of collapsing to its open generic definition/`object`.
2. **`OverloadResolution.TryInferDeferredLambdaParameterTypes`**: added the symmetric `Expression<TDelegate>` unwrap so deferred lambda parameter inference sees through the expression-tree wrapper the same way the direct-delegate path already did.
3. **`MemberLookup.MapOpenClrTypeToSymbolic`**: added an `IsGenericTypeParameter` guard on the type-level branch, preventing an open generic parameter from being misidentified as declaring-type-level when it is actually method-level (`Type.DeclaringType` is non-null for both).
4. **`ConversionClassifier.TrySubstituteParameterTypeFromReceiver`**: threaded a new `symbolicMethodTypeArgs` parameter so parameter-type substitution can use the symbolic (non-erased) method type arguments recovered by fix 6, instead of only the receiver's type arguments.
5. **`MemberLookup.UnifyForMethodTypeArgs`**: added an `Expression<TDelegate>` unwrap before the existing `FunctionTypeSymbol` pattern match, fixing the fully-inferred method-type-argument case (no explicit `<TRelated>`) which previously fell through to erasure.
6. **`MemberLookup.TryGetOpenMethodOnDeclaringType`** (new): a `MetadataToken`-based re-projection used from `ResolveCallReturnTypeFromSymbolicTypeArgs` to recover the declaring type's own open generic parameters, since `MethodInfo.GetGenericMethodDefinition()` only re-opens a method's own generic parameters, not its declaring type's. Fixes return-type erasure across chained calls (e.g. `.WithOne(...).HasForeignKey(...)`).
7. **`Conversion.cs`**: extracted a shared `IsFunctionShapeAssignable` structural comparison helper from the existing `FunctionTypeSymbol`-to-`FunctionTypeSymbol` conversion check, and added a new check for converting a lambda's bound `FunctionTypeSymbol` to a real CLR delegate type (not another `FunctionTypeSymbol`). Recovers the target delegate's symbolic shape via `TryGetDelegateFunctionTypeFromSymbol` (fix 1) when the target's `ClrType`-based reflection would otherwise erase/be unavailable (in-flight `TypeBuilder` or same-compilation type). This directly fixes the issue's own literal minimal repro above.

An initial attempt at an additional fix in `ExpressionBinder.Calls.cs` (`TryMapDeferredLambdaTargetsSymbolic` unwrap) was implemented and then proven unnecessary via A/B testing (revert + full targeted test run) and removed — fixes 1, 2, 5, and 6 already cover that code path.

## Test coverage

`test/Core.Tests/CodeAnalysis/Binding/Issue2375ExpressionTreeMethodTypeArgumentTests.cs` (13 binder-level tests) and `test/Compiler.Tests/Emit/Issue2375ExpressionTreeMethodTypeArgumentEmitTests.cs` (4 emit-level ILVerify + runtime tests) cover:

- Direct `Func<Book,Conversion>` literal repro (source/imported, class/struct related types), no imported library, no generic method involved.
- Explicit and inferred custom `HasOne<TRelated>(Expression<Func<TEntity,TRelated>>)` method-type-argument scenarios.
- The exact EF navigation chain: `HasOne(...).WithOne(...).HasForeignKey(...)`.
- Nullable/reference/value return types, and a genuinely open generic control proving the fix does not over-apply to real open type parameters.
- Runtime execution + ILVerify for all emit-level scenarios.

## Validation

Full suite results on this branch (rebased onto `origin/main` @ `f8261164`):

| Suite | Result |
|---|---|
| Core.Tests | 6250 passed, 1 skipped (intentional), 6251 total |
| Compiler.Tests | 3065 passed, 0 failed, 3065 total |
| Cs2Gs.Tests (serialized, `RunConfiguration.DisableParallelization=true`) | 1410/1410 |
| InternalAnalyzers.Tests | 7/7 |
| Full solution build | 0 warnings, 0 errors |

## Deferred / out of scope

None for this issue's scope. During investigation, no other unrelated pre-existing bugs were found that needed to be called out.
