### PR TITLE
Fix #2381: preserve same-compilation types through async Task<T> return erasure

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -893,6 +893,18 @@ internal sealed class LambdaBinder
             package: literal.Function.Package);
         adapterFunction.IsAsync = literal.Function.IsAsync;
 
+        // Issue #2381: propagate the original literal's lexical enclosing
+        // type so a capturing adapter is nested inside the SAME user type as
+        // the literal it replaces (see the closure-nesting rule in
+        // ClosureEmitter.SynthesizeClosures, issue #1335). Without this the
+        // adapter's synthesized FunctionSymbol reports a null
+        // LexicalEnclosingType, so the emitted closure class falls back to a
+        // top-level placement outside the enclosing type's accessibility
+        // domain — an adapter that (like the original literal) reads a
+        // `private`/`protected` member of that type then produces an
+        // unverifiable FieldAccess/MethodAccess IL site.
+        adapterFunction.LexicalEnclosingType = literal.Function.LexicalEnclosingType;
+
         var body = (BoundBlockStatement)new ErasedFunctionLiteralAdapterRewriter(replacementMap, adapterResultType)
             .RewriteStatement(literal.Body);
 
@@ -945,55 +957,57 @@ internal sealed class LambdaBinder
             return element;
         }
 
+        // Issue #1785 / #2026 / #2232 / #2381: a same-compilation user type
+        // anywhere in the element's structure — a bare struct/enum/interface/
+        // delegate, a nullable wrapping one, a tuple element, an array/slice
+        // element (`[]DiagnosticCheck`, `[N]DiagnosticCheck`), or an imported
+        // generic type argument (`List[DiagnosticCheck]`,
+        // `Dictionary[string,DiagnosticCheck]`, arbitrarily nested) — must
+        // route through the symbolic Task<T> construction below rather than
+        // the ordinary reflection-based `taskOpen.MakeGenericType(element.
+        // ClrType)` path further down. Two distinct CLR-type shapes trigger
+        // this, both signalling "not really closed yet":
+        //   - a genuinely null ClrType (bare struct/enum/interface/tuple/
+        //     array/slice — `SliceTypeSymbol`/`ArrayTypeSymbol`'s CLR shape is
+        //     computed ONCE, at construction, as `elementType.ClrType?.
+        //     MakeArrayType()`, so it stays null forever once captured before
+        //     the element's TypeBuilder closes);
+        //   - a NON-null but OBJECT-ERASED ClrType (an imported generic like
+        //     `List<>` closed over a still-building same-compilation argument
+        //     resolves via reflection to `List<object>`, since imported
+        //     generics do not report a null ClrType the way same-compilation
+        //     types do).
+        // `ContainsSameCompilationUserType` (recursing through nullable/
+        // array/slice/tuple/imported-generic wrappers via `GetWrappedTypes`)
+        // and the emitter's `ArgIsSymbolicUserDefined` (the same recursive
+        // shape, reused so the async function's OBSERVABLE return type used
+        // for lambda/delegate target typing — e.g. `Task.Run(() ->
+        // RunAsync())`'s `TResult` inference — matches the REAL closed
+        // generic the kickoff method's CLR signature carries after emission)
+        // together detect both shapes regardless of which one `element.
+        // ClrType` happens to report. A still-OPEN generic type parameter
+        // (e.g. the caller's own `U` substituted in for a generic async
+        // callee's declared return type, or a constructed generic like
+        // `Box[U]`) is handled by the sibling `ContainsTypeParameter` check.
+        if ((TypeSymbol.ContainsSameCompilationUserType(element)
+            || GSharp.Core.CodeAnalysis.Emit.ReflectionMetadataEmitter.ArgIsSymbolicUserDefined(element)
+            || TypeSymbol.ContainsTypeParameter(element))
+            && Scope.References.TryResolveType(wrapperOpenName, out var symbolicTaskOpen))
+        {
+            // Issue #502 / #320: a user-defined async result type has no CLR
+            // Type yet, so close Task<T> over an object placeholder for
+            // reflection/member lookup while preserving the symbolic result
+            // type for emit-time metadata encoding.
+            var erasedTask = symbolicTaskOpen.MakeGenericType(Scope.References.MapClrTypeToReferences(typeof(object)));
+            return ImportedTypeSymbol.GetConstructed(
+                erasedTask,
+                symbolicTaskOpen,
+                ImmutableArray.Create(element));
+        }
+
         var clr = element.ClrType;
         if (clr == null)
         {
-            // Issue #1785: a nullable same-compilation user type
-            // (`UserStruct?`/`UserEnum?`/`UserClass?`) also has a null ClrType
-            // (its NullableTypeSymbol wraps the struct/enum/class's null
-            // ClrType), so it must widen to `Task<T?>` the same way a bare
-            // user struct/enum/class does below. Symbol-based detection (not
-            // ClrType.IsValueType, which is null for in-flight user types) is
-            // required. Reference-type nullables (`UserClass?`) are included
-            // too — their CLR shape is identical to the bare class, but the
-            // wrapping NullableTypeSymbol still reports a null ClrType and
-            // previously fell through unwrapped, leaving the async function's
-            // observable return type as the bare element instead of
-            // `Task<T?>` (e.g. "Cannot find member Result" at the call site).
-            //
-            // Issue #2026: a still-OPEN generic type parameter (e.g. the
-            // caller's own `U` substituted in for a generic async callee's
-            // declared return type) likewise reports a null ClrType — it is
-            // not yet closed over a concrete CLR type. Route it (and any
-            // type that structurally references a type parameter, e.g. a
-            // constructed generic like `Box[U]`) through the same symbolic
-            // Task<T> construction so the call-site observable return type
-            // stays `Task[U]` instead of silently dropping the Task wrapper.
-            // Issue #2232: a tuple type `(..., UserType, ...)` whose CLR backing
-            // is null because at least one element is a still-in-flight user
-            // type (`TupleTypeSymbol.BuildClrType` returns null unless every
-            // element resolves to a CLR type) must likewise route through the
-            // symbolic Task<T> construction. Otherwise an `async func F() (bool,
-            // UserType)` silently drops its Task wrapper here, so `await F()`
-            // sees the bare tuple and fails with GS0133 "cannot be awaited"
-            // (cascading GS0125 on any deconstructed bindings). A nullable
-            // tuple (`(bool, UserType)?`) is handled the same way.
-            if ((element is StructSymbol or InterfaceSymbol or EnumSymbol or TupleTypeSymbol
-                || (element is NullableTypeSymbol nullableUserVt && nullableUserVt.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol or TupleTypeSymbol)
-                || TypeSymbol.ContainsTypeParameter(element))
-                && Scope.References.TryResolveType(wrapperOpenName, out var symbolicTaskOpen))
-            {
-                // Issue #502 / #320: a user-defined async result type has no CLR
-                // Type yet, so close Task<T> over an object placeholder for
-                // reflection/member lookup while preserving the symbolic result
-                // type for emit-time metadata encoding.
-                var erasedTask = symbolicTaskOpen.MakeGenericType(Scope.References.MapClrTypeToReferences(typeof(object)));
-                return ImportedTypeSymbol.GetConstructed(
-                    erasedTask,
-                    symbolicTaskOpen,
-                    ImmutableArray.Create(element));
-            }
-
             return element;
         }
 

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -11098,9 +11098,16 @@ internal sealed class ReflectionMetadataEmitter
     // ClrType.IsValueType, which is null for in-flight user types — so the
     // kickoff method's real Task<T?> return type is closed over the emitted
     // Nullable<UserT> instead of falling back to the erased Task<object>.
+    // Issue #2381: generalized to reuse ArgIsSymbolicUserDefined so an
+    // imported generic collection closed over a same-compilation argument
+    // (`List[DiagnosticCheck]`, `Dictionary[string, DiagnosticCheck]`,
+    // `List[List[DiagnosticCheck]]`, arrays/slices of a user type, a
+    // nullable-wrapped user value type held as a type argument, …) routes
+    // through the same symbolic Task<T> construction as the bare
+    // struct/interface/enum/type-parameter case, instead of trusting the
+    // erased CLR type cached on the constructed ImportedTypeSymbol.
     private static bool IsAsyncUserDefinedResultType(TypeSymbol type)
-        => type is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol
-        || (type is NullableTypeSymbol nullableUserVt && nullableUserVt.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol);
+        => ArgIsSymbolicUserDefined(type);
 
     /// <summary>
     /// ADR-0122 §9 / issue #1035: builds a standalone method signature for a
@@ -11291,7 +11298,15 @@ internal sealed class ReflectionMetadataEmitter
     // <c>List[List[MyGs]]</c> receiver is recognised even though its
     // outer argument is an <see cref="ImportedTypeSymbol"/> rather than a
     // direct user-defined symbol.
-    private static bool ArgIsSymbolicUserDefined(TypeSymbol arg)
+    // Issue #2381: widened from `private` to `internal` so
+    // AsyncStateMachineTypeBuilder can reuse this exact same-compilation /
+    // type-parameter detection to decide when an async kickoff's Task<T> /
+    // AsyncTaskMethodBuilder<T> / builder-field type must be constructed
+    // symbolically (ImportedTypeSymbol.GetConstructed) rather than via a
+    // reflection-resolved (and, for a same-compilation argument, object-
+    // erased) CLR type — instead of re-deriving an equivalent but separately
+    // maintained predicate.
+    internal static bool ArgIsSymbolicUserDefined(TypeSymbol arg)
     {
         if (arg is StructSymbol or InterfaceSymbol or EnumSymbol or DelegateTypeSymbol)
         {

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Emit;
 using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Lowering.Async;
@@ -115,8 +116,17 @@ public static class AsyncStateMachineTypeBuilder
         sm.StateField = stateField;
 
         var builderFieldType = TypeSymbol.FromClrType(builderInfo.BuilderType);
-        if ((kickoff.Type is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol
-                || (kickoff.Type is NullableTypeSymbol nullableUserVt3 && nullableUserVt3.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol))
+
+        // Issue #2381: widened from a bare struct/interface/enum/type-
+        // parameter kickoff-type check to `ArgIsSymbolicUserDefined` (shared
+        // with the emitter's call-site/return-type symbolic-encoding gate)
+        // so an imported generic closed over a same-compilation argument
+        // (`List[DiagnosticCheck]`, `Dictionary[string, DiagnosticCheck]`,
+        // nested/array/nullable shapes, …) ALSO gets its builder field type
+        // rebuilt as a symbolic constructed generic instead of the
+        // reflection-resolved (and, for such an argument, object-erased)
+        // `builderInfo.BuilderType`.
+        if (ReflectionMetadataEmitter.ArgIsSymbolicUserDefined(kickoff.Type)
             && builderInfo.BuilderType is { IsConstructedGenericType: true } builderClrType)
         {
             builderFieldType = ImportedTypeSymbol.GetConstructed(
@@ -234,7 +244,18 @@ public static class AsyncStateMachineTypeBuilder
         }
         else
         {
-            inner = kickoff.Type?.ClrType;
+            // Issue #2381: an imported generic type closed over a
+            // same-compilation TypeBuilder-backed argument (e.g.
+            // `List[DiagnosticCheck]`, `Dictionary[string, DiagnosticCheck]`,
+            // `List[List[DiagnosticCheck]]`) caches an object-erased
+            // `ClrType` (`List<object>`) from binding time, before the
+            // argument's own CLR type existed. Reconstruct the true closed
+            // shape from the CURRENT state of the type arguments so the
+            // async builder / kickoff signature carry the real generic
+            // instantiation instead of the erased approximation.
+            inner = kickoff.Type is ImportedTypeSymbol importedKickoffType
+                ? importedKickoffType.ReifyClosedClrType()
+                : kickoff.Type?.ClrType;
             if (inner == null)
             {
                 // Issue #1785: a nullable same-compilation user value type
@@ -255,8 +276,17 @@ public static class AsyncStateMachineTypeBuilder
                 // open type parameter afterward (see the `builderFieldType`
                 // override in `Build` and `ResultTypeSymbol`), so the emitted
                 // IL still carries `!!0`/`!0`, not `object`.
-                if (kickoff.Type is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol
-                    || (kickoff.Type is NullableTypeSymbol nullableUserVt2 && nullableUserVt2.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol))
+                // open type parameter afterward (see the `builderFieldType`
+                // override in `Build` and `ResultTypeSymbol`), so the emitted
+                // IL still carries `!!0`/`!0`, not `object`.
+                //
+                // Issue #2381: widened to the shared `ArgIsSymbolicUserDefined`
+                // predicate so an array/slice of a same-compilation user type
+                // (`[N]DiagnosticCheck` / `[]DiagnosticCheck` — whose eagerly-
+                // cached `ClrType` is null when the element had no CLR type
+                // yet) reaches the same erase-then-re-widen treatment instead
+                // of aborting async state-machine synthesis outright.
+                if (ReflectionMetadataEmitter.ArgIsSymbolicUserDefined(kickoff.Type))
                 {
                     inner = references.MapClrTypeToReferences(typeof(object));
                 }

--- a/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
@@ -133,6 +133,81 @@ public sealed class ImportedTypeSymbol : TypeSymbol
         return new ImportedTypeSymbol(name, erasedClosedType, openDefinition, typeArguments);
     }
 
+    /// <summary>
+    /// Issue #2381: recursively reconstructs the TRUE closed CLR type for
+    /// this constructed generic, recomputing every type argument's CLR type
+    /// from its CURRENT state rather than trusting the cached (possibly
+    /// erased) <see cref="TypeSymbol.ClrType"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>A constructed <see cref="ImportedTypeSymbol"/> closed over a
+    /// same-compilation class/struct argument (e.g. <c>List[DiagnosticCheck]</c>)
+    /// caches an object-erased shape (<c>List&lt;object&gt;</c>) because, at
+    /// the time <see cref="GetConstructed"/> ran during binding, the
+    /// argument's own CLR type (its emitted <c>TypeBuilder</c>) did not exist
+    /// yet — see <see cref="HasSubstitutableTypeArgument"/>. That erased
+    /// shape is safe for member/index/conversion resolution during binding,
+    /// but is wrong for final metadata (method signatures, generic builder
+    /// instantiation, field types) once the argument's real CLR type is
+    /// available.</para>
+    /// <para>This walks <see cref="OpenDefinition"/> + <see cref="TypeArguments"/>
+    /// and rebuilds the closed type via <see cref="Type.MakeGenericType"/>
+    /// using each argument's CURRENT CLR type, recursing into nested
+    /// constructed generics (e.g. <c>List[List[UserClass]]</c>,
+    /// <c>Dictionary[string, UserClass]</c>) so every level reflects its
+    /// real closed shape. Value-typed nullable arguments are projected
+    /// through <see cref="NullableLifting.GetEffectiveClrType"/> so they
+    /// close over <c>Nullable&lt;T&gt;</c> rather than the bare value type.</para>
+    /// <para>Falls back to the cached (possibly erased) <see cref="TypeSymbol.ClrType"/>
+    /// when reification is not possible: an in-scope type parameter argument
+    /// (<see cref="HasTypeParameterArgument"/>) has no concrete CLR type to
+    /// close over; a nested argument's own CLR type is still unavailable; or
+    /// <see cref="Type.MakeGenericType"/> legitimately rejects the
+    /// reconstructed arguments (CLR generic constraints).</para>
+    /// </remarks>
+    /// <returns>The reconstructed closed CLR type, or the cached (possibly erased) <see cref="TypeSymbol.ClrType"/> when reification is not possible.</returns>
+    public Type ReifyClosedClrType()
+    {
+        if (OpenDefinition == null || TypeArguments.IsDefaultOrEmpty || HasTypeParameterArgument)
+        {
+            return ClrType;
+        }
+
+        var args = new Type[TypeArguments.Length];
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = TypeArguments[i];
+            var argClr = arg switch
+            {
+                ImportedTypeSymbol nestedImported => nestedImported.ReifyClosedClrType(),
+                NullableTypeSymbol => NullableLifting.GetEffectiveClrType(arg),
+                _ => arg?.ClrType,
+            };
+
+            if (argClr == null)
+            {
+                // Some argument still lacks a concrete CLR type (e.g. its own
+                // TypeBuilder has not been created yet); degrade to the
+                // cached erased shape rather than fail outright.
+                return ClrType;
+            }
+
+            args[i] = argClr;
+        }
+
+        try
+        {
+            return OpenDefinition.MakeGenericType(args);
+        }
+        catch (ArgumentException)
+        {
+            // MakeGenericType can legitimately reject the reconstructed
+            // arguments for CLR generic-constraint reasons; degrade to the
+            // erased shape instead of throwing.
+            return ClrType;
+        }
+    }
+
     /// <inheritdoc/>
     public override DocumentationComment GetDocumentation()
     {

--- a/test/Compiler.Tests/Emit/Issue2381AsyncGenericCollectionReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2381AsyncGenericCollectionReturnEmitTests.cs
@@ -1,0 +1,472 @@
+// <copyright file="Issue2381AsyncGenericCollectionReturnEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2381: an async G# method returning a closed generic collection over
+/// a same-compilation type (e.g. <c>List[UserClass]</c>,
+/// <c>Dictionary[string,UserClass]</c>) was emitted as
+/// <c>Task&lt;Collection&lt;object&gt;&gt;</c> /
+/// <c>AsyncTaskMethodBuilder&lt;Collection&lt;object&gt;&gt;</c> even though
+/// locals and the declared source return type use the real class, producing
+/// unverifiable IL at any caller that observes the real element type.
+/// <para>
+/// Root cause and fix span TWO independent sites, both trusting an
+/// object-erased <see cref="GSharp.Core.CodeAnalysis.Symbols.ImportedTypeSymbol.ClrType"/>
+/// instead of reconstructing the true closed shape from the OPEN generic
+/// definition plus the symbolic type arguments:
+/// <list type="number">
+/// <item><description><c>AsyncStateMachineTypeBuilder.ResolveAsyncReturnClrType</c>
+/// (and its <c>builderFieldType</c> computation in <c>Build()</c>) drove the
+/// async state machine's <c>Task&lt;T&gt;</c> / <c>AsyncTaskMethodBuilder&lt;T&gt;</c>
+/// / <c>SetResult</c> / kickoff-return metadata off the erased
+/// <c>kickoff.Type?.ClrType</c>. Generalized to route through the SAME
+/// symbolic-encoding gate <c>ReflectionMetadataEmitter.ArgIsSymbolicUserDefined</c>
+/// already used by <c>EncodeAsyncReturnType</c>'s Task-construction path for
+/// #1785/#2030's gap1 (bare struct/interface/enum/type-parameter shapes) —
+/// widened here to also recognize an <c>ImportedTypeSymbol</c> closed over a
+/// same-compilation argument (recursively, so <c>List[List[UserClass]]</c>,
+/// <c>Dictionary[string,UserClass]</c>, arrays and nullables of a
+/// same-compilation element all match).</description></item>
+/// <item><description><c>LambdaBinder.WrapAsTask</c> — which computes the
+/// async function/lambda's OBSERVABLE <c>Task&lt;T&gt;</c> return type used
+/// for binder-side call/delegate-target-typing (e.g. inferring
+/// <c>Task.Run&lt;TResult&gt;(Func&lt;Task&lt;TResult&gt;&gt;)</c>'s
+/// <c>TResult</c> for the <c>() -&gt; RunAsync()</c> lambda) — only recognized a
+/// null <c>element.ClrType</c> (the bare struct/enum/tuple/type-parameter
+/// shapes from #1785/#2026/#2232) as "not really closed yet". An imported
+/// generic like <c>List&lt;&gt;</c> closed over a same-compilation argument
+/// reports a NON-null but object-erased <c>ClrType</c>
+/// (<c>List&lt;object&gt;</c>), so it fell through to the ordinary
+/// reflection-based <c>Task&lt;T&gt;</c> construction and silently produced an
+/// erased <c>Task&lt;List&lt;object&gt;&gt;</c> observable type. Generalized
+/// the same-compilation detection to <c>TypeSymbol.ContainsSameCompilationUserType</c>
+/// (which already recurses through array/slice/nullable/tuple/imported-generic
+/// wrappers) OR'd with the emitter's <c>ArgIsSymbolicUserDefined</c>, checked
+/// BEFORE the null-ClrType branch so it also catches the erased-but-non-null
+/// shape. This also generalizes the pre-existing null-ClrType branch to
+/// arrays/slices of a same-compilation element (<c>[]UserClass</c>), which had
+/// the SAME gap (an array/slice's ClrType is computed once, at construction,
+/// as <c>elementType.ClrType?.MakeArrayType()</c>, and previously matched none
+/// of the hand-listed wrapper kinds).</description></item>
+/// </list>
+/// A third, narrower gap was found and fixed along the way:
+/// <c>LambdaBinder.CreateErasedFunctionLiteralAdapter</c> (the adapter
+/// synthesized when a lambda's own bound function type doesn't match its
+/// target delegate shape — here, the <c>() -&gt; RunAsync()</c> lambda passed to
+/// <c>Task.Run</c>) never propagated the original literal's
+/// <c>LexicalEnclosingType</c> onto the adapter's synthesized
+/// <see cref="GSharp.Core.CodeAnalysis.Symbols.FunctionSymbol"/>. Per the
+/// #1335 closure-nesting rule, a capturing closure must be nested inside its
+/// lexically enclosing user type to share its CLR accessibility domain; an
+/// adapter with a null <c>LexicalEnclosingType</c> fell back to a top-level
+/// placement, so an adapter closure that reads a <c>private</c>/<c>protected</c>
+/// member of the enclosing type (as this repro's implicit <c>this.RunAsync()</c>
+/// call does) produced an unverifiable <c>MethodAccess</c> IL site.
+/// </para>
+/// </summary>
+public class Issue2381AsyncGenericCollectionReturnEmitTests
+{
+    [Fact]
+    public void ListOfUserClass_ExactIssueRepro_CompilesAndRuns()
+    {
+        // Exact minimal repro from the issue body.
+        var source = """
+            package issue2381list
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class DiagnosticCheck2381 {}
+
+            class ExportCheck2381 {
+                private async func RunAsync() List[DiagnosticCheck2381] {
+                    let results = List[DiagnosticCheck2381]()
+                    results.Add(DiagnosticCheck2381())
+                    await Task.Delay(1)
+                    return results
+                }
+
+                func Run() List[DiagnosticCheck2381] -> Task.Run(() -> RunAsync()).GetAwaiter().GetResult()
+            }
+
+            var c = ExportCheck2381()
+            var r = c.Run()
+            Console.WriteLine(r.Count)
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void NestedListOfUserClass_CompilesAndRuns()
+    {
+        // Coverage: nested imported generics — List[List[UserClass]] — must
+        // recurse the symbolic reconstruction through both generic layers.
+        var source = """
+            package issue2381nested
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class DiagnosticCheckNested {}
+
+            class ExportCheckNested {
+                private async func RunAsync() List[List[DiagnosticCheckNested]] {
+                    let inner = List[DiagnosticCheckNested]()
+                    inner.Add(DiagnosticCheckNested())
+                    let outer = List[List[DiagnosticCheckNested]]()
+                    outer.Add(inner)
+                    await Task.Delay(1)
+                    return outer
+                }
+
+                func Run() List[List[DiagnosticCheckNested]] -> Task.Run(() -> RunAsync()).GetAwaiter().GetResult()
+            }
+
+            var c = ExportCheckNested()
+            var r = c.Run()
+            Console.WriteLine(r.Count)
+            Console.WriteLine(r[0].Count)
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("1\n1\n", output);
+    }
+
+    [Fact]
+    public void DictionaryOfStringToUserClass_CompilesAndRuns()
+    {
+        // Coverage: Dictionary<string, UserClass> — a two-argument imported
+        // generic where only the SECOND argument is same-compilation.
+        var source = """
+            package issue2381dict
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class DiagnosticCheckDict {}
+
+            class ExportCheckDict {
+                private async func RunAsync() Dictionary[string, DiagnosticCheckDict] {
+                    let results = Dictionary[string, DiagnosticCheckDict]()
+                    results["a"] = DiagnosticCheckDict()
+                    await Task.Delay(1)
+                    return results
+                }
+
+                func Run() Dictionary[string, DiagnosticCheckDict] -> Task.Run(() -> RunAsync()).GetAwaiter().GetResult()
+            }
+
+            var c = ExportCheckDict()
+            var r = c.Run()
+            Console.WriteLine(r.Count)
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void ArrayOfUserClass_CompilesAndRuns()
+    {
+        // Coverage: a slice/array of a same-compilation class. Unlike
+        // List<>/Dictionary<> (imported generics whose erasure surfaces as a
+        // non-null but object-erased ClrType), a slice/array's ClrType is
+        // computed ONCE at construction as `elementType.ClrType?.
+        // MakeArrayType()` and stays genuinely null forever once captured
+        // before the element's TypeBuilder closes — a distinct shape that
+        // needed its own generalization in the null-ClrType branch.
+        var source = """
+            package issue2381arr
+            import System
+            import System.Threading.Tasks
+
+            class DiagnosticCheckArr {}
+
+            class ExportCheckArr {
+                private async func RunAsync() []DiagnosticCheckArr {
+                    let results = []DiagnosticCheckArr{DiagnosticCheckArr(), DiagnosticCheckArr()}
+                    await Task.Delay(1)
+                    return results
+                }
+
+                func Run() []DiagnosticCheckArr -> Task.Run(() -> RunAsync()).GetAwaiter().GetResult()
+            }
+
+            var c = ExportCheckArr()
+            var r = c.Run()
+            Console.WriteLine(r.Length)
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void ListOfValueTypeStruct_CompilesAndRuns()
+    {
+        // Coverage: a same-compilation VALUE type (struct) element, not a
+        // class — ArgIsSymbolicUserDefined/ContainsSameCompilationUserType
+        // must recognize StructSymbol arguments identically to class
+        // (StructSymbol-backed) arguments.
+        var source = """
+            package issue2381vt
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            struct Point2381(X int32, Y int32) { }
+
+            class ExportCheckVt {
+                private async func RunAsync() List[Point2381] {
+                    let results = List[Point2381]()
+                    results.Add(Point2381(1, 2))
+                    results.Add(Point2381(3, 4))
+                    await Task.Delay(1)
+                    return results
+                }
+
+                func Run() List[Point2381] -> Task.Run(() -> RunAsync()).GetAwaiter().GetResult()
+            }
+
+            var c = ExportCheckVt()
+            var r = c.Run()
+            Console.WriteLine(r.Count)
+            Console.WriteLine(r[0].X)
+            Console.WriteLine(r[1].Y)
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("2\n1\n4\n", output);
+    }
+
+    [Fact]
+    public void GenericAsyncMethodReturningListOfInferredUserType_CompilesAndRuns()
+    {
+        // Control: a GENERIC async method (its own method type parameter,
+        // #2030's shape) whose return is ALSO an imported generic collection
+        // over that type parameter (#2381's shape) — both generalizations
+        // must compose when T is inferred as a same-compilation class at the
+        // call site.
+        var source = """
+            package issue2381generic
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class DiagnosticCheckGeneric {}
+
+            async func WrapAsync2381[T](v T) List[T] {
+                let results = List[T]()
+                results.Add(v)
+                await Task.Delay(1)
+                return results
+            }
+
+            func RunGeneric() List[DiagnosticCheckGeneric] -> Task.Run(() -> WrapAsync2381(DiagnosticCheckGeneric())).GetAwaiter().GetResult()
+
+            var r = RunGeneric()
+            Console.WriteLine(r.Count)
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void ListOfPrimitive_ControlUnaffected()
+    {
+        // Negative control: a collection over a BUILT-IN (non-same-compilation)
+        // element type must keep taking the ordinary reflection-based Task<T>
+        // path unaffected by the new same-compilation detection — no
+        // behavior change for the common case.
+        var source = """
+            package issue2381prim
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class ExportCheckPrim {
+                private async func RunAsync() List[int32] {
+                    let results = List[int32]()
+                    results.Add(1)
+                    results.Add(2)
+                    await Task.Delay(1)
+                    return results
+                }
+
+                func Run() List[int32] -> Task.Run(() -> RunAsync()).GetAwaiter().GetResult()
+            }
+
+            var c = ExportCheckPrim()
+            var r = c.Run()
+            Console.WriteLine(r.Count)
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void ListOfUserClass_MetadataReturnTypeIsClosedOverRealClass()
+    {
+        // Metadata assertion: reflect over the emitted kickoff method and
+        // async state machine builder field to confirm the CLR signature is
+        // truly closed over the real user class (List<DiagnosticCheckMeta>),
+        // not List<object>.
+        var source = """
+            package issue2381meta
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class DiagnosticCheckMeta {}
+
+            class ExportCheckMeta {
+                async func RunAsync() List[DiagnosticCheckMeta] {
+                    let results = List[DiagnosticCheckMeta]()
+                    results.Add(DiagnosticCheckMeta())
+                    await Task.Delay(1)
+                    return results
+                }
+            }
+            """;
+
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2381_meta_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var compileExit = CompileQuiet(srcPath, outPath, out var stdout, out var stderr);
+            Assert.True(compileExit == 0, $"gsc failed:\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            IlVerifier.Verify(outPath);
+
+            var asm = Assembly.LoadFrom(outPath);
+            var exportType = asm.GetType("issue2381meta.ExportCheckMeta", throwOnError: true)!;
+            var runAsync = exportType.GetMethod("RunAsync", BindingFlags.Public | BindingFlags.Instance)!;
+
+            var returnType = runAsync.ReturnType;
+            Assert.True(returnType.IsGenericType);
+            Assert.Equal("Task`1", returnType.Name);
+
+            var taskArg = returnType.GetGenericArguments()[0];
+            Assert.True(taskArg.IsGenericType);
+            Assert.Equal("List`1", taskArg.Name);
+
+            var listArg = taskArg.GetGenericArguments()[0];
+            Assert.Equal("DiagnosticCheckMeta", listArg.Name);
+            Assert.NotEqual(typeof(object), listArg);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static int CompileQuiet(string srcPath, string outPath, out string stdout, out string stderr)
+    {
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        stdout = compileOut.ToString();
+        stderr = compileErr.ToString();
+        return compileExit;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2381_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var compileExit = CompileQuiet(srcPath, outPath, out var stdout, out var stderr);
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            IlVerifier.Verify(outPath);
+            Assert.True(File.Exists(outPath), $"expected emitted assembly at {outPath}");
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdoutRun = proc!.StandardOutput.ReadToEnd();
+            var stderrRun = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdoutRun}\nstderr:\n{stderrRun}");
+
+            return stdoutRun.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2381AsyncGenericCollectionTaskWrapTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2381AsyncGenericCollectionTaskWrapTests.cs
@@ -1,0 +1,278 @@
+// <copyright file="Issue2381AsyncGenericCollectionTaskWrapTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2381: <see cref="LambdaBinder.WrapAsTask"/> previously only routed
+/// a NULL-<see cref="TypeSymbol.ClrType"/> element (bare same-compilation
+/// struct/interface/enum/tuple, or a type-parameter-containing type — issues
+/// #1785/#2026/#2232) through the symbolic <c>Task&lt;T&gt;</c> construction
+/// that preserves the real element identity for downstream (emit-time and
+/// call-site delegate-target-typing) consumers. An imported generic
+/// collection closed over a same-compilation argument (e.g.
+/// <c>List[UserClass]</c>) reports a NON-null but object-erased ClrType
+/// (<c>List&lt;object&gt;</c>) and a same-compilation array/slice element
+/// (e.g. <c>[]UserClass</c>) reports a genuinely null ClrType that matched
+/// none of the old hand-listed wrapper kinds — both silently fell through to
+/// either the ordinary erased-reflection <c>Task&lt;T&gt;</c> construction or
+/// (for the array/slice case) no Task-wrapping at all.
+/// <para>
+/// Mirroring <c>Issue2026GenericAsyncTaskWrapTests</c>'s pattern: a same-
+/// compilation <see cref="FunctionSymbol.Type"/> holds the DECLARED
+/// (unwrapped) inner result type — <c>WrapAsTask</c>'s widened, Task-wrapped
+/// "observable" type is instead computed at each call site (a
+/// <see cref="BoundCallExpression"/> invoking the async function). These
+/// tests therefore bind a small caller around each async repro and assert on
+/// the CALL EXPRESSION's <c>.Type</c>, exactly like the #2026 suite.
+/// </para>
+/// </summary>
+public class Issue2381AsyncGenericCollectionTaskWrapTests
+{
+    [Fact]
+    public void AsyncFunctionReturningListOfUserClass_CallSiteObservedAsSymbolicTaskOfListOfUserClass()
+    {
+        const string source = @"
+package p
+import System.Collections.Generic
+class DiagnosticCheck2381Wrap {}
+async func RunAsync() List[DiagnosticCheck2381Wrap] {
+    let results = List[DiagnosticCheck2381Wrap]()
+    return results
+}
+func Outer() {
+    var r = RunAsync()
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var call = FindCall(compilation, "Outer", "RunAsync");
+        AssertIsTaskOfCollectionOfUserType(call.Type, "List", "DiagnosticCheck2381Wrap");
+    }
+
+    [Fact]
+    public void AsyncFunctionReturningDictionaryOfStringToUserClass_CallSiteObservedAsSymbolicTaskOfDictionary()
+    {
+        const string source = @"
+package p
+import System.Collections.Generic
+class DiagnosticCheck2381Dict {}
+async func RunAsync() Dictionary[string, DiagnosticCheck2381Dict] {
+    let results = Dictionary[string, DiagnosticCheck2381Dict]()
+    return results
+}
+func Outer() {
+    var r = RunAsync()
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var call = FindCall(compilation, "Outer", "RunAsync");
+        var task = Assert.IsType<ImportedTypeSymbol>(call.Type);
+        Assert.True(task.ClrType.IsGenericType && task.ClrType.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.Task<>));
+        Assert.Single(task.TypeArguments);
+
+        var dict = Assert.IsType<ImportedTypeSymbol>(task.TypeArguments[0]);
+        Assert.Equal(2, dict.TypeArguments.Length);
+        Assert.Equal("string", dict.TypeArguments[0].Name);
+        Assert.Equal("DiagnosticCheck2381Dict", dict.TypeArguments[1].Name);
+        Assert.NotEqual(typeof(object), dict.TypeArguments[1].ClrType);
+    }
+
+    [Fact]
+    public void AsyncFunctionReturningNestedListOfListOfUserClass_CallSiteObservedAsSymbolicTaskThroughBothLayers()
+    {
+        const string source = @"
+package p
+import System.Collections.Generic
+class DiagnosticCheck2381Nested {}
+async func RunAsync() List[List[DiagnosticCheck2381Nested]] {
+    let results = List[List[DiagnosticCheck2381Nested]]()
+    return results
+}
+func Outer() {
+    var r = RunAsync()
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var call = FindCall(compilation, "Outer", "RunAsync");
+        var task = Assert.IsType<ImportedTypeSymbol>(call.Type);
+        var outerList = Assert.IsType<ImportedTypeSymbol>(task.TypeArguments[0]);
+        var innerList = Assert.IsType<ImportedTypeSymbol>(outerList.TypeArguments[0]);
+        Assert.Equal("DiagnosticCheck2381Nested", innerList.TypeArguments[0].Name);
+    }
+
+    [Fact]
+    public void AsyncFunctionReturningArrayOfUserClass_CallSiteObservedAsSymbolicTaskOfArray()
+    {
+        // Coverage: array/slice element — a distinct null-ClrType shape from
+        // the imported-generic (List/Dictionary) case above, since
+        // SliceTypeSymbol/ArrayTypeSymbol compute their ClrType once, at
+        // construction, as `elementType.ClrType?.MakeArrayType()`.
+        const string source = @"
+package p
+class DiagnosticCheck2381Arr {}
+async func RunAsync() []DiagnosticCheck2381Arr {
+    let results = []DiagnosticCheck2381Arr{}
+    return results
+}
+func Outer() {
+    var r = RunAsync()
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var call = FindCall(compilation, "Outer", "RunAsync");
+        var task = Assert.IsType<ImportedTypeSymbol>(call.Type);
+        Assert.True(task.ClrType.IsGenericType && task.ClrType.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.Task<>));
+        Assert.Single(task.TypeArguments);
+
+        var arr = Assert.IsType<SliceTypeSymbol>(task.TypeArguments[0]);
+        Assert.Equal("DiagnosticCheck2381Arr", arr.ElementType.Name);
+    }
+
+    [Fact]
+    public void AsyncFunctionReturningListOfValueTypeStruct_CallSiteObservedAsSymbolicTaskOfListOfStruct()
+    {
+        // Coverage: same-compilation VALUE type (struct) element, not class.
+        const string source = @"
+package p
+import System.Collections.Generic
+struct Point2381Wrap(X int32) { }
+async func RunAsync() List[Point2381Wrap] {
+    let results = List[Point2381Wrap]()
+    return results
+}
+func Outer() {
+    var r = RunAsync()
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var call = FindCall(compilation, "Outer", "RunAsync");
+        AssertIsTaskOfCollectionOfUserType(call.Type, "List", "Point2381Wrap");
+    }
+
+    [Fact]
+    public void AsyncFunctionReturningListOfPrimitive_CallSiteRegressionUsesOrdinaryReflectionTask()
+    {
+        // Negative control: a collection over a BUILT-IN element type must
+        // keep the ordinary (non-symbolic) reflection-based Task<T>
+        // construction — the real, already-closed CLR Task<List<int32>>,
+        // not a GetConstructed symbolic wrapper — matching pre-#2381
+        // behavior exactly.
+        const string source = @"
+package p
+import System.Collections.Generic
+async func RunAsync() List[int32] {
+    let results = List[int32]()
+    return results
+}
+func Outer() {
+    var r = RunAsync()
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var call = FindCall(compilation, "Outer", "RunAsync");
+        var task = Assert.IsType<ImportedTypeSymbol>(call.Type);
+        Assert.True(task.ClrType.IsGenericType && task.ClrType.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.Task<>));
+
+        var listClrType = task.ClrType.GetGenericArguments()[0];
+        Assert.True(listClrType.IsGenericType && listClrType.GetGenericTypeDefinition() == typeof(System.Collections.Generic.List<>));
+        Assert.Equal(typeof(int), listClrType.GetGenericArguments()[0]);
+    }
+
+    [Fact]
+    public void AsyncFunctionReturningNonGenericUserClass_CallSiteRegressionStillWrapsSymbolically()
+    {
+        // Regression: the pre-existing #1785/#2026 bare same-compilation
+        // class/struct shape (no surrounding collection) must still route
+        // through the symbolic Task<T> construction exactly as before.
+        const string source = @"
+package p
+class DiagnosticCheck2381Bare {}
+async func RunAsync() DiagnosticCheck2381Bare {
+    return DiagnosticCheck2381Bare()
+}
+func Outer() {
+    var r = RunAsync()
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var call = FindCall(compilation, "Outer", "RunAsync");
+        var task = Assert.IsType<ImportedTypeSymbol>(call.Type);
+        Assert.Single(task.TypeArguments);
+        Assert.Equal("DiagnosticCheck2381Bare", task.TypeArguments[0].Name);
+    }
+
+    private static void AssertIsTaskOfCollectionOfUserType(TypeSymbol type, string collectionOpenName, string expectedElementName)
+    {
+        var task = Assert.IsType<ImportedTypeSymbol>(type);
+        Assert.True(task.ClrType.IsGenericType && task.ClrType.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.Task<>));
+        Assert.Single(task.TypeArguments);
+
+        var collection = Assert.IsType<ImportedTypeSymbol>(task.TypeArguments[0]);
+        Assert.Equal(collectionOpenName, collection.OpenDefinition.Name.Split('`')[0]);
+        Assert.Single(collection.TypeArguments);
+        Assert.Equal(expectedElementName, collection.TypeArguments[0].Name);
+        Assert.NotEqual(typeof(object), collection.TypeArguments[0].ClrType);
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree) { IsLibrary = true };
+    }
+
+    private static BoundCallExpression FindCall(Compilation compilation, string functionName, string callName)
+    {
+        var fn = compilation.BoundProgram.Functions.Keys.Single(f => f.Name == functionName);
+        var body = compilation.BoundProgram.Functions[fn];
+        var collector = new CallCollector(callName);
+        collector.Visit(body);
+        return collector.Collected.FirstOrDefault();
+    }
+
+    private sealed class CallCollector : BoundTreeWalker
+    {
+        private readonly string callName;
+
+        public CallCollector(string callName)
+        {
+            this.callName = callName;
+        }
+
+        public List<BoundCallExpression> Collected { get; } = new();
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node is BoundCallExpression call && call.Function.Name == callName)
+            {
+                Collected.Add(call);
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+}


### PR DESCRIPTION
## Root cause

`AsyncStateMachineTypeBuilder.ResolveAsyncReturnClrType` trusted `kickoff.Type?.ClrType` for the async return CLR type. This is object-erased for imported generics closed over same-compilation type arguments (e.g. `List[UserClass]` reports `List<object>`), because `AsyncStateMachineRewriter.Rewrite` runs during **lowering**, before `EmitAssembly` creates any user-class `TypeBuilder`s — so same-compilation `ClrType`s are genuinely `null`/erased at that point. This is the same "erase-for-member-resolution, then re-widen via symbolic type construction for final metadata" pattern established for #1785/#2030, generalized here to also cover imported generic **collections** closed over same-compilation elements (`List<UserClass>`, `Dictionary<string, UserClass>`, arrays/slices, nested collections).

The exact repro (EF Core-style `MigrationBuilder`/`Task.Run` over `List[DiagnosticCheck]`) produced unverifiable IL — mismatched `MoveNext`/`SetResult`/`RunAsync` return-type metadata (`List<object>` instead of `List<DiagnosticCheck>`).

## Fix (3 sites, all reusing existing symbolic-Task infrastructure — no EF-specific or collection-specific special casing)

1. **`ReflectionMetadataEmitter.ArgIsSymbolicUserDefined`** widened from `private` to `internal static` and reused by `AsyncStateMachineTypeBuilder.Build()`/`ResolveAsyncReturnClrType()` to recognize erased-but-symbolic imported generics, not just bare same-compilation struct/interface/enum types.
2. **`LambdaBinder.WrapAsTask`** (computes the async function's *observable* `Task<T>` return type used at call sites and for `Task.Run`-style delegate target typing) generalized into a single unified branch keyed on `TypeSymbol.ContainsSameCompilationUserType(element) || ArgIsSymbolicUserDefined(element) || ContainsTypeParameter(element)`. This is a structural superset of the old narrow struct/enum/tuple/null-ClrType check — it also fixes a **previously silent, wrong-behavior bug**: same-compilation elements nested inside arrays/slices (whose `ClrType` is computed once, at construction, and stays null forever) were not being Task-wrapped at all under the old code (no compile error — just wrong runtime behavior).
3. **`LambdaBinder.CreateErasedFunctionLiteralAdapter`** now propagates `literal.Function.LexicalEnclosingType` onto the synthesized adapter `FunctionSymbol`. Without this, `ClosureEmitter`'s nesting rule silently skipped nesting an adapter-wrapped lambda's closure inside its enclosing type, producing a top-level closure class that violated CLR private-member accessibility (`ILVerify [MethodAccess]` error at runtime).

## Tests

- `test/Compiler.Tests/Emit/Issue2381AsyncGenericCollectionReturnEmitTests.cs` — 8 end-to-end compile+run(+ILVerify+reflection) tests: exact issue repro (`List[UserClass]`), nested `List<List<UserClass>>`, `Dictionary<string,UserClass>`, array of `UserClass`, `List` of value-type struct, generic async method control, primitive-`List` negative control, and a metadata/reflection assertion on the emitted `RunAsync` return type.
- `test/Core.Tests/CodeAnalysis/Binding/Issue2381AsyncGenericCollectionTaskWrapTests.cs` — 7 binder-level tests (modeled on `Issue2026GenericAsyncTaskWrapTests`) asserting the call-site `BoundCallExpression.Type` is correctly Task-wrapped for `List`/`Dictionary`/nested-`List`/array/struct-`List` cases, plus primitive-`List` and bare-class regression controls.

## Validation

- Solution build: **0 warnings / 0 errors** with `RunAnalyzersDuringBuild=true` and `TreatWarningsAsErrors=true`.
- `Core.Tests`: 6298 passed.
- `Compiler.Tests`: 3098 passed.
- `InternalAnalyzers.Tests`: 7 passed.
- `Cs2Gs.Tests` (serialized, `xunit.parallelizeAssembly=false xunit.parallelizeTestCollections=false`): 1410 passed.

## Deferred / discovered work (out of scope for this fix — recommend filing separately)

While manually verifying coverage scenarios, discovered a **pre-existing, unrelated** bug: `List[T?].Add(structValue)` — a `List` of a **nullable** same-compilation struct — produces `InvalidProgramException` at runtime due to invalid IL (`ldnull` pushed for a value-type `Nullable<T>` generic parameter slot instead of properly constructing a `Nullable<T>` value). Confirmed via a plain **synchronous** repro with no async/Task involvement whatsoever that this is a distinct root cause, unrelated to #2381's async return-erasure defect. Excluded nullable-struct-in-collection scenarios from this PR's test suite (uses non-nullable struct elements only); recommend filing as a separate issue.

Closes #2381
