### PR TITLE
Fix #2382: translate native C# top-level statements to G# top-level program code

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2382TopLevelStatementsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2382TopLevelStatementsTranslationTests.cs
@@ -1,0 +1,512 @@
+// <copyright file="Issue2382TopLevelStatementsTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2382: cs2gs translates native C# top-level statements
+/// (<c>GlobalStatementSyntax</c> — no enclosing class/method syntax at all, as
+/// opposed to an explicit <c>Main</c> method hoisted by
+/// <c>CSharpToGSharpTranslator.DeclarationVisitor.TranslateEntryType</c>,
+/// which issue #1904's tests already cover) directly to G# native top-level
+/// statements (ADR-0066): the implicit <c>args</c> binding, top-level
+/// <c>await</c>, a top-level <c>return</c>, ordinary declarations/control
+/// flow, and top-level local functions — hoisted to a genuine top-level
+/// <c>func</c> sibling when capture-free (unlocking unrestricted forward/
+/// mutual reference, unlike a <c>let</c> binding) or kept as an ordered
+/// <c>let</c> binding when a sibling top-level local (or the implicit
+/// <c>args</c>) is captured.
+/// <para>
+/// The Oahu trigger is <c>tools/Oahu.Diagnostics/Program.cs</c>: top-level
+/// statements that reference <c>args</c>, a top-level <c>await</c> + a
+/// top-level <c>return</c> of an awaited call, and a trailing
+/// <c>static void RenderPretty(DiagnosticReport report)</c> local function
+/// with no captures. <see cref="TopLevelStatements_AsyncAwaitWithIntReturn_MatchesOahuDiagnosticsShape"/>
+/// models that exact combined shape (generalized to an async, int-returning
+/// hoisted helper for a stronger regression) end-to-end through the real
+/// <c>gsc</c>.
+/// </para>
+/// </summary>
+public class Issue2382TopLevelStatementsTranslationTests
+{
+    [Fact]
+    public void SimpleSyncProgram_LowersToTopLevelStatements()
+    {
+        string printed = Render(@"
+using System;
+
+Console.WriteLine(""hello"");
+");
+
+        Assert.Contains("Console.WriteLine(\"hello\")", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("func Main", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("class Program", printed, StringComparison.Ordinal);
+        AssertRoundTripParses(printed);
+
+        (int exit, string stdout) = CompileAndRunProgram(printed);
+        Assert.Equal(0, exit);
+        Assert.Equal("hello", stdout.Trim());
+    }
+
+    [Fact]
+    public void ReturnInt_LowersToTopLevelReturn()
+    {
+        string printed = Render(@"
+return 42;
+");
+
+        Assert.Contains("return 42", printed, StringComparison.Ordinal);
+        AssertRoundTripParses(printed);
+
+        (int exit, _) = CompileAndRunProgram(printed);
+        Assert.Equal(42, exit);
+    }
+
+    [Fact]
+    public void ImplicitArgs_UsesArgsIdentifierDirectly()
+    {
+        string printed = Render(@"
+using System;
+
+Console.WriteLine(args.Length);
+");
+
+        Assert.Contains("args.Length", printed, StringComparison.Ordinal);
+        AssertRoundTripParses(printed);
+
+        (int exit, string stdout) = CompileAndRunProgram(printed);
+        Assert.Equal(0, exit);
+        Assert.Equal("0", stdout.Trim());
+    }
+
+    [Fact]
+    public void TopLevelAwait_LowersToTopLevelAwaitStatement()
+    {
+        string printed = Render(@"
+using System;
+using System.Threading.Tasks;
+
+await Task.Delay(1);
+Console.WriteLine(""done"");
+");
+
+        Assert.Contains("await Task.Delay(1)", printed, StringComparison.Ordinal);
+        AssertRoundTripParses(printed);
+
+        (int exit, string stdout) = CompileAndRunProgram(printed);
+        Assert.Equal(0, exit);
+        Assert.Equal("done", stdout.Trim());
+    }
+
+    [Fact]
+    public void AsyncAwaitWithIntReturn_MatchesOahuDiagnosticsShape()
+    {
+        // Models the exact combined Oahu.Diagnostics/Program.cs shape: a
+        // top-level `await`, a top-level `return` of an awaited call — called
+        // BEFORE its own declaration (mirrors `RenderPretty` appearing after
+        // its call site) — through a `static` (therefore always capture-free,
+        // issue #2382) async top-level local function.
+        string printed = Render(@"
+using System;
+using System.Threading.Tasks;
+
+Console.WriteLine(""before"");
+await Task.Delay(1);
+return await ComputeAsync();
+
+static async Task<int> ComputeAsync()
+{
+    await Task.Delay(1);
+    return 5;
+}
+");
+
+        // The static local function must be hoisted to a genuine sibling
+        // top-level `func` (forward-referenceable), never a `let` binding.
+        Assert.DoesNotContain("let ComputeAsync", printed, StringComparison.Ordinal);
+        Assert.Contains("async func ComputeAsync()", printed, StringComparison.Ordinal);
+        Assert.Contains("await Task.Delay(1)", printed, StringComparison.Ordinal);
+        Assert.Contains("return await ComputeAsync()", printed, StringComparison.Ordinal);
+        AssertRoundTripParses(printed);
+
+        (int exit, string stdout) = CompileAndRunProgram(printed);
+        Assert.Equal(5, exit);
+        Assert.Equal("before", stdout.Trim());
+    }
+
+    [Fact]
+    public void CaptureFreeStaticLocalFunction_HoistsToTopLevelFuncNotLetBinding()
+    {
+        // Mirrors Oahu.Diagnostics' trailing `static void RenderPretty(...)`:
+        // called before its own textual declaration, referencing only its own
+        // parameter (no sibling top-level local, no `args`).
+        string printed = Render(@"
+using System;
+
+Greet(""world"");
+
+static void Greet(string name)
+{
+    Console.WriteLine($""Hello, {name}!"");
+}
+");
+
+        Assert.DoesNotContain("let Greet", printed, StringComparison.Ordinal);
+        Assert.Contains("func Greet(name string)", printed, StringComparison.Ordinal);
+        AssertRoundTripParses(printed);
+
+        (int exit, string stdout) = CompileAndRunProgram(printed);
+        Assert.Equal(0, exit);
+        Assert.Equal("Hello, world!", stdout.Trim());
+    }
+
+    [Fact]
+    public void NonStaticButActuallyCaptureFreeLocalFunction_IsAlsoHoisted()
+    {
+        // Exercises the body-walk branch of `IsTopLevelLocalFunctionCaptureFree`
+        // (not just the `static`-modifier fast path): a NON-static local
+        // function that nonetheless references no sibling top-level local and
+        // no `args` must still be hoisted to a top-level `func`.
+        string printed = Render(@"
+using System;
+
+Console.WriteLine(Square(6));
+
+int Square(int n) => n * n;
+");
+
+        Assert.DoesNotContain("let Square", printed, StringComparison.Ordinal);
+        Assert.Contains("func Square(n int32)", printed, StringComparison.Ordinal);
+        AssertRoundTripParses(printed);
+
+        (int exit, string stdout) = CompileAndRunProgram(printed);
+        Assert.Equal(0, exit);
+        Assert.Equal("36", stdout.Trim());
+    }
+
+    [Fact]
+    public void MutuallyReferencingCaptureFreeLocalFunctions_HoistToIndependentlyOrderedFuncs()
+    {
+        // Two `static` top-level local functions calling EACH OTHER — true
+        // mutual/forward reference that a `let` binding could never support
+        // (see Cs2Gs.Tests.LocalFunctionHoistTranslationTests.
+        // Issue2231MutualRecursionRemainsUnsupportedByGscLetBindings). Hoisting
+        // to genuine top-level `func`s (pre-declared in binding scope
+        // regardless of textual order, ADR-0066) fixes this for the
+        // capture-free case.
+        string printed = Render(@"
+using System;
+
+Console.WriteLine(IsEven(4));
+
+static bool IsEven(int n) => n == 0 || IsOdd(n - 1);
+
+static bool IsOdd(int n) => n != 0 && IsEven(n - 1);
+");
+
+        Assert.DoesNotContain("let IsEven", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("let IsOdd", printed, StringComparison.Ordinal);
+        Assert.Contains("func IsEven(n int32)", printed, StringComparison.Ordinal);
+        Assert.Contains("func IsOdd(n int32)", printed, StringComparison.Ordinal);
+        AssertRoundTripParses(printed);
+
+        (int exit, string stdout) = CompileAndRunProgram(printed);
+        Assert.Equal(0, exit);
+        Assert.Equal("True", stdout.Trim());
+    }
+
+    [Fact]
+    public void CapturingLocalFunction_StaysOrderedLetBinding()
+    {
+        // `Greet` reads `greeting`, a sibling top-level local — it must NOT be
+        // hoisted to an independent top-level `func` (it has no implicit
+        // access to a sibling top-level statement's local from there); it
+        // keeps the pre-existing ordered `let`-binding closure form.
+        string printed = Render(@"
+using System;
+
+var greeting = ""hello"";
+
+void Greet()
+{
+    Console.WriteLine(greeting);
+}
+
+Greet();
+");
+
+        Assert.Contains("let Greet", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("func Greet(", printed, StringComparison.Ordinal);
+        AssertRoundTripParses(printed);
+
+        (int exit, string stdout) = CompileAndRunProgram(printed);
+        Assert.Equal(0, exit);
+        Assert.Equal("hello", stdout.Trim());
+    }
+
+    [Fact]
+    public void CapturingLocalFunctionCalledBeforeDeclaration_HoistsOrderedLetBindingAboveUse()
+    {
+        // Generalizes issue #2231's existing in-method-body hoist test to the
+        // top-level-statement sequence: `Helper` is used before its textual
+        // declaration and captures `seed` (a sibling top-level local) — the
+        // `let Helper` binding must land above the use but below `let seed`.
+        string printed = Render(@"
+using System;
+
+int seed = 5;
+int result = Helper();
+
+int Helper()
+{
+    return seed + 1;
+}
+
+Console.WriteLine(result);
+");
+
+        int seedIndex = printed.IndexOf("let seed", StringComparison.Ordinal);
+        int declIndex = printed.IndexOf("let Helper", StringComparison.Ordinal);
+        int useIndex = printed.IndexOf("Helper()", StringComparison.Ordinal);
+        Assert.True(seedIndex >= 0 && declIndex >= 0 && useIndex >= 0, "All three should be present.\n" + printed);
+        Assert.True(seedIndex < declIndex, "`let Helper` must not be hoisted above `let seed`.\n" + printed);
+        Assert.True(declIndex < useIndex, "`let Helper` must still be hoisted above its first use.\n" + printed);
+        AssertRoundTripParses(printed);
+
+        (int exit, string stdout) = CompileAndRunProgram(printed);
+        Assert.Equal(0, exit);
+        Assert.Equal("6", stdout.Trim());
+    }
+
+    [Fact]
+    public void GenericCaptureFreeLocalFunction_HoistsToTopLevelGenericFunc()
+    {
+        string printed = Render(@"
+using System;
+
+Console.WriteLine(Identity(42));
+
+static T Identity<T>(T value) => value;
+");
+
+        Assert.DoesNotContain("let Identity", printed, StringComparison.Ordinal);
+        Assert.Contains("Identity[T]", printed, StringComparison.Ordinal);
+        AssertRoundTripParses(printed);
+
+        (int exit, string stdout) = CompileAndRunProgram(printed);
+        Assert.Equal(0, exit);
+        Assert.Equal("42", stdout.Trim());
+    }
+
+    [Fact]
+    public void MixedWithExplicitMain_TopLevelStatementsWinAsEntryPoint()
+    {
+        // ADR-0066 D6 / C# CS7022 (a warning, not an error): a compilation
+        // with BOTH top-level statements and an explicit Main-shaped method
+        // anywhere still compiles — the synthesized top-level entry point
+        // wins and the explicit method becomes an ordinary, never-invoked
+        // static method. cs2gs must not double-hoist or crash on this shape.
+        string printed = Render(
+            @"
+using System;
+
+Console.WriteLine(""top-level ran"");
+
+static class OtherEntry
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine(""explicit Main ran"");
+    }
+}
+",
+            allowNonInfoDiagnostics: true);
+
+        Assert.Contains("Console.WriteLine(\"top-level ran\")", printed, StringComparison.Ordinal);
+        Assert.Contains("Main", printed, StringComparison.Ordinal);
+        AssertRoundTripParses(printed);
+
+        (int exit, string stdout) = CompileAndRunProgram(printed);
+        Assert.Equal(0, exit);
+
+        // Only the top-level statement runs; the explicit (now-orphaned)
+        // `OtherEntry.Main` is never invoked by anything.
+        Assert.Equal("top-level ran", stdout.Trim());
+    }
+
+    [Fact]
+    public void MultipleFiles_CoexistsWithNamespaceTypeDeclaredInAnotherFile()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[]
+            {
+                ("Program.cs", @"
+using System;
+using Demo;
+
+Console.WriteLine(Greeter.Greet(""Ada""));
+"),
+                ("Greeter.cs", @"
+namespace Demo
+{
+    public static class Greeter
+    {
+        public static string Greet(string name) => $""Hi, {name}"";
+    }
+}
+"),
+            },
+            outputKind: OutputKind.ConsoleApplication);
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline multi-file source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(2, project.Documents.Count);
+
+        var translator = new CSharpToGSharpTranslator();
+        var printedFiles = new System.Collections.Generic.List<string>();
+        foreach (LoadedDocument document in project.Documents)
+        {
+            var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+            CompilationUnit unit = translator.TranslateDocument(document, context);
+            Assert.DoesNotContain(context.Diagnostics, d => d.Severity != TranslationSeverity.Info);
+            printedFiles.Add(GSharpPrinter.Print(unit));
+        }
+
+        string programPrinted = printedFiles[0];
+        string greeterPrinted = printedFiles[1];
+        Assert.Contains("Console.WriteLine(Greeter.Greet(\"Ada\"))", programPrinted, StringComparison.Ordinal);
+        Assert.Contains("class Greeter", greeterPrinted, StringComparison.Ordinal);
+
+        foreach (string printed in printedFiles)
+        {
+            AssertRoundTripParses(printed);
+        }
+
+        (int exit, string stdout) = CompileAndRunProgram(printedFiles.ToArray());
+        Assert.Equal(0, exit);
+        Assert.Equal("Hi, Ada", stdout.Trim());
+    }
+
+    private static void AssertRoundTripParses(string printed)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+    }
+
+    private static string Render(string source, bool allowNonInfoDiagnostics = false)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Program.cs", source) },
+            outputKind: OutputKind.ConsoleApplication);
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        if (!allowNonInfoDiagnostics)
+        {
+            // The top-level-statements hoist itself always logs an Info
+            // diagnostic (issue #2382, mirroring T3/ADR-0115 §B.1) — only
+            // reject a genuine Warning/Unsupported here.
+            Assert.DoesNotContain(context.Diagnostics, d => d.Severity != TranslationSeverity.Info);
+        }
+
+        return GSharpPrinter.Print(unit);
+    }
+
+    /// <summary>
+    /// Compiles a translated top-level G# PROGRAM (already includes its own
+    /// entry statements — unlike <c>LocalFunctionHoistTranslationTests
+    /// .CompileAndRun</c>, no extra call expression needs to be appended)
+    /// with the real <c>gsc</c> and runs it, returning the process exit code
+    /// and captured stdout+stderr.
+    /// </summary>
+    private static (int Exit, string Stdout) CompileAndRunProgram(params string[] printedFiles)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-2382-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        var gsPaths = new System.Collections.Generic.List<string>();
+        for (int i = 0; i < printedFiles.Length; i++)
+        {
+            string gsPath = Path.Combine(workDir, $"Program{i}.gs");
+            File.WriteAllText(gsPath, printedFiles[i]);
+            gsPaths.Add(gsPath);
+        }
+
+        string dllPath = Path.Combine(workDir, "Program.dll");
+        string quotedSources = string.Join(" ", gsPaths.Select(p => $"\"{p}\""));
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{dllPath}\" {quotedSources}");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated top-level program with zero errors. Output:\n" + compileOut +
+                "\n\nTranslated G#:\n" + string.Join("\n---\n", printedFiles));
+
+        return RunDotnet($"\"{dllPath}\"");
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Cs2Gs.Translator;
 
@@ -230,10 +231,43 @@ public sealed class CSharpToGSharpTranslator
         var typeMapper = new CSharpTypeMapper(anonymousTypeRegistry);
         var visitor = new DeclarationVisitor(context, typeMapper, openBases, staticUsingTargets, entryPoint, partialTypeParts, this.preservePartialParts, this.markMergedTypePartial);
 
+        // Issue #2382: a NATIVE C# top-level-statements program (`GlobalStatementSyntax`
+        // members directly under the compilation unit — no enclosing class/method
+        // syntax at all, unlike the explicit-`Main` case handled by `entryType`
+        // below) is recognized by its synthesized entry point's declaring syntax
+        // reference pointing at THIS file's `CompilationUnitSyntax` itself, rather
+        // than at any real method/type declaration. At most one file in a
+        // compilation may contribute top-level statements (ADR-0066 D1 / CS8802),
+        // so this only ever matches one document.
+        List<GlobalStatementSyntax> globalStatements = root.Members.OfType<GlobalStatementSyntax>().ToList();
+        bool hasNativeTopLevelStatements = globalStatements.Count > 0
+            && entryPoint != null
+            && entryPoint.DeclaringSyntaxReferences.Length > 0
+            && entryPoint.DeclaringSyntaxReferences[0].SyntaxTree == root.SyntaxTree
+            && entryPoint.DeclaringSyntaxReferences[0].GetSyntax() is CompilationUnitSyntax;
+
         var members = new List<GNode>();
         var trailingStatements = new List<GNode>();
+
+        if (hasNativeTopLevelStatements)
+        {
+            (IReadOnlyList<GNode> hoistedFuncs, IReadOnlyList<GNode> entryStatements) =
+                visitor.TranslateTopLevelProgram(globalStatements, entryPoint);
+            members.AddRange(hoistedFuncs);
+            trailingStatements.AddRange(entryStatements);
+        }
+
         foreach (MemberDeclarationSyntax member in EnumerateTopLevelDeclarations(root))
         {
+            if (member is GlobalStatementSyntax)
+            {
+                // Already handled in a single pass above (native top-level
+                // statements are not visited one-by-one like an ordinary member —
+                // the whole sequence is translated together so the local-function
+                // capture/hoist analysis can see every sibling statement).
+                continue;
+            }
+
             if (entryType != null
                 && member is TypeDeclarationSyntax typeDecl
                 && context.GetDeclaredSymbol(member) is INamedTypeSymbol declaredType
@@ -1153,6 +1187,93 @@ public sealed class CSharpToGSharpTranslator
             return (funcs, statements);
         }
 
+        /// <summary>
+        /// Issue #2382: translates a native C# top-level-statements program
+        /// (Roslyn's <c>GlobalStatementSyntax</c> members, with no enclosing
+        /// class/method syntax at all — as opposed to <see cref="TranslateEntryType"/>,
+        /// which hoists an EXPLICIT <c>Main</c> method's body) directly to G#
+        /// top-level statements. G# already has native top-level-statement
+        /// support (ADR-0066) with the exact same shape: an implicit <c>args</c>
+        /// binding, top-level <c>await</c>, and a top-level <c>return</c> —
+        /// so the translation is a straight statement-by-statement mapping
+        /// through the SAME <see cref="TranslateStatement"/>/
+        /// <see cref="HoistCallBeforeDeclLocalFunctions(BlockSyntax)"/> seams a
+        /// method body uses, not a second parallel statement translator.
+        /// <para>
+        /// A top-level local function that captures no sibling top-level local
+        /// (and does not read the implicit <c>args</c> parameter) is hoisted
+        /// OUT to its own top-level G# <c>func</c> sibling declaration (see
+        /// <see cref="TranslateTopLevelLocalFunctionAsFunc"/>) — G# funcs are
+        /// pre-declared in binding scope regardless of textual order (ADR-0066),
+        /// so this also gives such a local function unrestricted forward-
+        /// reference support, unlike the ordered `let`-binding fallback used for
+        /// a genuinely capturing local function (which keeps the existing
+        /// call-before-decl hoist behavior, issue #2231).
+        /// </para>
+        /// </summary>
+        /// <param name="globalStatements">Every top-level <c>GlobalStatementSyntax</c> in this file, in source order.</param>
+        /// <param name="entryPoint">The synthesized top-level-statements entry-point method symbol.</param>
+        /// <returns>The hoisted top-level funcs (capture-free local functions) and the entry's top-level statements.</returns>
+        public (IReadOnlyList<GNode> Funcs, IReadOnlyList<GNode> Statements) TranslateTopLevelProgram(
+            IReadOnlyList<GlobalStatementSyntax> globalStatements,
+            IMethodSymbol entryPoint)
+        {
+            this.context.Report(new TranslationDiagnostic(
+                nameof(SyntaxKind.GlobalStatement),
+                "C# native top-level statements are translated directly to G# top-level statements (ADR-0066): a capture-free top-level local function is hoisted to a sibling top-level 'func', and a capturing one keeps its ordered 'let' binding among the statements (issue #2382).",
+                globalStatements[0].GetLocation(),
+                TranslationSeverity.Info));
+
+            List<StatementSyntax> flatStatements = globalStatements.Select(gs => gs.Statement).ToList();
+            TextSpan enclosingSpan = TextSpan.FromBounds(flatStatements[0].SpanStart, flatStatements[^1].Span.End);
+            IReadOnlyList<StatementSyntax> ordered = this.HoistCallBeforeDeclLocalFunctions(flatStatements, enclosingSpan);
+
+            // Issue #1904 (mirrored here): the synthesized top-level entry
+            // point's own implicit parameter is always literally named "args"
+            // (there is no C# source spelling to rename it from — unlike an
+            // explicit `Main(string[] arguments)` — since the parameter is not
+            // written by hand at all), but the rename guard is kept for
+            // defense-in-depth in case a future Roslyn version ever changes
+            // that assumption.
+            IParameterSymbol argsParameter = entryPoint.Parameters.FirstOrDefault();
+            bool renamedArgs = argsParameter != null && argsParameter.Name != "args";
+            if (renamedArgs)
+            {
+                this.patternBindings[argsParameter] = new IdentifierExpression("args");
+            }
+
+            var funcs = new List<GNode>();
+            var statements = new List<GNode>();
+            try
+            {
+                foreach (StatementSyntax statement in ordered)
+                {
+                    if (statement is LocalFunctionStatementSyntax localFunction
+                        && this.context.GetDeclaredSymbol(localFunction) is IMethodSymbol localSymbol
+                        && this.IsTopLevelLocalFunctionCaptureFree(localFunction, argsParameter, enclosingSpan))
+                    {
+                        GMember hoisted = this.TranslateTopLevelLocalFunctionAsFunc(localFunction, localSymbol);
+                        if (hoisted != null)
+                        {
+                            funcs.Add(hoisted);
+                            continue;
+                        }
+                    }
+
+                    statements.AddRange(this.TranslateStatement(statement));
+                }
+            }
+            finally
+            {
+                if (renamedArgs)
+                {
+                    this.patternBindings.Remove(argsParameter);
+                }
+            }
+
+            return (funcs, statements);
+        }
+
         // The set of hard G# keywords (Cs2Gs.Compiler SyntaxFacts.GetKeywordKind).
         // A C# identifier that collides with one of these cannot be emitted bare; it
         // is suffixed with `_` consistently at every declaration and reference site.
@@ -1177,6 +1298,96 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return GSharpReservedWords.Contains(name) ? name + "_" : name;
+        }
+
+        // Issue #2382: whether `localFunction` — declared among the top-level
+        // statements — captures NOTHING from its top-level-statement siblings
+        // (no sibling local, no reference to the implicit `args` parameter).
+        // Such a local function can be hoisted to a genuine, independently
+        // orderable top-level `func` (see <see cref="TranslateTopLevelLocalFunctionAsFunc"/>);
+        // one that DOES capture a sibling must stay an in-place, ordered `let`
+        // binding (the existing <see cref="HoistCallBeforeDeclLocalFunctions(BlockSyntax)"/>
+        // forward-reference reordering already handles that case exactly like
+        // an ordinary method body's captured local function).
+        private bool IsTopLevelLocalFunctionCaptureFree(
+            LocalFunctionStatementSyntax localFunction, IParameterSymbol argsParameter, TextSpan enclosingSpan)
+        {
+            // A `static` local function can never capture in C# (CS8421) — the
+            // language guarantees this shape is already capture-free, so no
+            // body walk is needed.
+            if (localFunction.Modifiers.Any(SyntaxKind.StaticKeyword))
+            {
+                return true;
+            }
+
+            foreach (IdentifierNameSyntax id in localFunction.DescendantNodes().OfType<IdentifierNameSyntax>())
+            {
+                ISymbol symbol = this.context.GetSymbolInfo(id).Symbol;
+
+                if (argsParameter != null && SymbolEqualityComparer.Default.Equals(symbol, argsParameter))
+                {
+                    // References the entry point's own implicit `args` — a
+                    // hoisted top-level `func` is a sibling declaration with no
+                    // implicit access to it, so this must stay an in-place
+                    // closure instead.
+                    return false;
+                }
+
+                if (symbol is not ILocalSymbol local)
+                {
+                    continue;
+                }
+
+                foreach (SyntaxReference reference in local.DeclaringSyntaxReferences)
+                {
+                    SyntaxNode declaration = reference.GetSyntax();
+                    if (localFunction.Span.Contains(declaration.Span))
+                    {
+                        // Its own local (recursion, a nested block, ...) — fine.
+                        continue;
+                    }
+
+                    if (enclosingSpan.Contains(declaration.Span))
+                    {
+                        // Captures a sibling top-level statement's local.
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        // Issue #2382: translates a CAPTURE-FREE top-level local function into
+        // its own top-level G# `func` sibling declaration — reusing the exact
+        // same parameter/return-type/type-parameter mapping and the same
+        // <see cref="TranslateBody"/> seam an ordinary method or the sibling
+        // static methods of an explicit `Main`'s enclosing class already use
+        // (<see cref="TranslateEntryType"/>), rather than the `let`-bound
+        // function-LITERAL form <see cref="TranslateLocalFunction"/> emits for
+        // an in-place/capturing local function.
+        private GMember TranslateTopLevelLocalFunctionAsFunc(LocalFunctionStatementSyntax localFunction, IMethodSymbol symbol)
+        {
+            bool isAsync = localFunction.Modifiers.Any(m => m.IsKind(SyntaxKind.AsyncKeyword));
+            List<Parameter> parameters = this.MapParameters(symbol, localFunction.ParameterList, skipFirst: false);
+            GTypeReference returnType = this.MapDelegateLikeReturnType(symbol, isAsync, localFunction.ReturnType.GetLocation());
+            List<TypeParameter> typeParameters = this.MapMethodTypeParameters(symbol);
+            BlockStatement body = this.TranslateBody(localFunction, $"top-level local function '{localFunction.Identifier.Text}'");
+
+            // A genuine top-level `func` declaration (unlike the function-LITERAL
+            // form a non-hoisted local function lowers to) DOES support G#'s
+            // native `ref` return modifier (ADR-0060/issue #490), so hoisting
+            // incidentally lifts the "ref-returning local function has no
+            // canonical form" gap (issue #1900) that still applies to a
+            // captured/non-hoisted local function.
+            return new MethodDeclaration(
+                SanitizeIdentifier(localFunction.Identifier.Text),
+                parameters,
+                returnType,
+                body,
+                typeParameters,
+                isAsync: isAsync,
+                isRefReturn: symbol.ReturnsByRef);
         }
 
         /// <summary>
@@ -5793,6 +6004,29 @@ public sealed class CSharpToGSharpTranslator
                     }
 
                     break;
+
+                // Issue #2382: a capture-free top-level local function is hoisted
+                // to a genuine top-level `func` (see
+                // <see cref="TranslateTopLevelLocalFunctionAsFunc"/>), which
+                // routes its body through this SAME seam (rather than the
+                // `let`-bound function-literal path <see cref="TranslateLocalFunction"/>
+                // uses for an in-place/captured local function) so a hoisted
+                // local function's body gets identical spill/parameter-shadow/
+                // unsafe handling to an ordinary method's.
+                case LocalFunctionStatementSyntax localFunction:
+                    if (localFunction.Body != null)
+                    {
+                        return this.TranslateBlock(localFunction.Body);
+                    }
+
+                    if (localFunction.ExpressionBody != null)
+                    {
+                        bool returnsVoidLocal =
+                            (this.context.GetDeclaredSymbol(localFunction) as IMethodSymbol)?.ReturnsVoid ?? false;
+                        return this.WrapExpressionBody(localFunction.ExpressionBody.Expression, returnsVoidLocal);
+                    }
+
+                    break;
             }
 
             // No recognizable body; emit an empty parseable block.
@@ -5858,9 +6092,19 @@ public sealed class CSharpToGSharpTranslator
         // than the last sibling local it captures by closure, since G# `let`
         // bindings require captured locals to already be in scope at the
         // binding point (issue #2231).
-        private IReadOnlyList<StatementSyntax> HoistCallBeforeDeclLocalFunctions(BlockSyntax block)
+        private IReadOnlyList<StatementSyntax> HoistCallBeforeDeclLocalFunctions(BlockSyntax block) =>
+            this.HoistCallBeforeDeclLocalFunctions(block.Statements, block.Span);
+
+        // Issue #2382: the C# top-level-statements entry point has no enclosing
+        // `BlockSyntax` (its statements are sibling `GlobalStatementSyntax`
+        // members directly under the compilation unit — see
+        // <see cref="TranslateTopLevelProgram"/>), so the hoist algorithm is
+        // generalized to any flat statement sequence plus the `TextSpan` that
+        // bounds "sibling of this sequence" (a real block's own span, or the
+        // union span of every top-level statement for the synthesized entry).
+        private IReadOnlyList<StatementSyntax> HoistCallBeforeDeclLocalFunctions(
+            IReadOnlyList<StatementSyntax> statements, TextSpan enclosingSpan)
         {
-            SyntaxList<StatementSyntax> statements = block.Statements;
             var localFunctions = statements.OfType<LocalFunctionStatementSyntax>().ToList();
             if (localFunctions.Count == 0)
             {
@@ -5871,7 +6115,7 @@ public sealed class CSharpToGSharpTranslator
             var toHoist = new List<(LocalFunctionStatementSyntax Function, int DeclIndex, int? AnchorIndex)>();
             foreach (LocalFunctionStatementSyntax localFunction in localFunctions)
             {
-                int declIndex = statements.IndexOf(localFunction);
+                int declIndex = IndexOfReference(statements, localFunction);
                 if (this.context.GetDeclaredSymbol(localFunction) is not IMethodSymbol funcSymbol)
                 {
                     continue;
@@ -5899,7 +6143,7 @@ public sealed class CSharpToGSharpTranslator
                     continue;
                 }
 
-                int? barrierIndex = this.SiblingCaptureBarrierIndex(localFunction, block, statements);
+                int? barrierIndex = this.SiblingCaptureBarrierIndex(localFunction, enclosingSpan, statements);
                 int anchorIndex = barrierIndex.HasValue ? barrierIndex.Value + 1 : 0;
                 if (anchorIndex > firstUseIndex)
                 {
@@ -5934,6 +6178,22 @@ public sealed class CSharpToGSharpTranslator
             return reordered;
         }
 
+        // `SyntaxList<T>`/`List<T>` both expose `IndexOf`, but the generalized
+        // `IReadOnlyList<StatementSyntax>` overload above does not — this finds
+        // the same (reference-identity) index for either concrete backing store.
+        private static int IndexOfReference(IReadOnlyList<StatementSyntax> statements, StatementSyntax target)
+        {
+            for (int i = 0; i < statements.Count; i++)
+            {
+                if (ReferenceEquals(statements[i], target))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
         // Returns the index (within `statements`) of the last statement that
         // declares a local variable captured by `localFunction` from the
         // enclosing block — the `let` binding must not be hoisted above this
@@ -5942,7 +6202,7 @@ public sealed class CSharpToGSharpTranslator
         // function's own locals/parameters don't count — those remain in scope
         // at the front of the block).
         private int? SiblingCaptureBarrierIndex(
-            LocalFunctionStatementSyntax localFunction, BlockSyntax block, SyntaxList<StatementSyntax> statements)
+            LocalFunctionStatementSyntax localFunction, TextSpan enclosingSpan, IReadOnlyList<StatementSyntax> statements)
         {
             int? barrier = null;
             foreach (IdentifierNameSyntax id in localFunction.DescendantNodes().OfType<IdentifierNameSyntax>())
@@ -5964,7 +6224,7 @@ public sealed class CSharpToGSharpTranslator
 
                     // Not a sibling of this block (e.g. an outer-scope local) —
                     // already in scope wherever the `let` binding lands.
-                    if (!block.Span.Contains(declaration.Span))
+                    if (!enclosingSpan.Contains(declaration.Span))
                     {
                         continue;
                     }


### PR DESCRIPTION
Closes #2382.

## Problem

cs2gs already hoisted an **explicit** `Main` method into a G# top-level
program (`DeclarationVisitor.TranslateEntryType`), but native Roslyn
**top-level statements** — `GlobalStatementSyntax` members with no
enclosing type/method syntax at all, the default shape for a modern
`Program.cs` such as `tools/Oahu.Diagnostics/Program.cs` in Oahu — were
entirely unsupported. They fell through `DeclarationVisitor.DefaultVisit`
and were silently dropped with an "Unsupported" gate diagnostic, so any
such file (and the whole app, in `--via-sdk` mode) failed to translate.

## Root cause

For a native top-level-statements file, Roslyn's synthesized `<Main>$`
entry-point method's (and its synthesized `Program` type's)
`DeclaringSyntaxReferences` both point at the file's own
`CompilationUnitSyntax` — not at any real `MethodDeclarationSyntax`/
`TypeDeclarationSyntax`. The existing `TranslateEntryType`-triggering
check (`member is TypeDeclarationSyntax typeDecl && ... == entryType`)
therefore never fires for this shape at all.

## Fix

- `DeclarationVisitor.TranslateTopLevelProgram` — a new counterpart to
  `TranslateEntryType`, invoked once per file when
  `entryPoint.DeclaringSyntaxReferences[0].SyntaxTree == root.SyntaxTree`
  and its syntax `is CompilationUnitSyntax` (i.e. genuine top-level
  statements). It covers:
  - the implicit `args string[]` parameter (always literally named
    `args`, since there's no source spelling to rename from);
  - top-level `await`/`return` (Roslyn synthesizes the async
    `Task`/`Task<int>` entry-point shape transparently — no special
    handling needed beyond ordinary `await`/`return` statement
    translation);
  - ordinary global variable/expression statements and control flow,
    reusing `TranslateStatement` unchanged;
  - top-level local functions, split by whether they capture anything
    from their top-level-statement siblings:
    - A `static` local function (CS8421 guarantees no captures) or any
      other local function whose body references neither the implicit
      `args` parameter nor a sibling top-level local
      (`IsTopLevelLocalFunctionCaptureFree`) is hoisted to a genuine
      top-level G# `func` sibling (`TranslateTopLevelLocalFunctionAsFunc`,
      reusing `MapParameters`/`MapMethodTypeParameters`/
      `MapDelegateLikeReturnType`/`TranslateBody` — the same machinery
      `TranslateEntryType`'s sibling static methods and
      `TranslateLocalFunction`'s lambdas already use). Because G# `func`s
      are pre-declared in scope regardless of textual order (ADR-0066),
      this correctly and automatically supports forward references and
      even **mutual recursion** between top-level local functions —
      neither of which a `let` binding could ever support (see
      `LocalFunctionHoistTranslationTests.Issue2231MutualRecursionRemainsUnsupportedByGscLetBindings`).
    - A local function that DOES capture a sibling top-level local (or
      `args`) is left exactly as before: an in-place, ordered `let`
      binding via the unchanged `TranslateLocalFunction`, reusing the
      existing `HoistCallBeforeDeclLocalFunctions` forward-reference
      reordering (now generalized to accept any flat statement list plus
      an enclosing `TextSpan`, not just a real `BlockSyntax`, so it also
      applies at top-level-statement scope with zero behavior change for
      its pre-existing method/constructor/accessor-body callers).
- `TranslateBodyCore` gained a `LocalFunctionStatementSyntax` case so the
  new hoisted-func path can route a local function's body through the
  same `TranslateBody`/`WithParameterShadows` seam an ordinary method
  gets (`WithParameterShadows`'s switch already anticipated this exact
  case — it was dead code until now). This has **no effect** on the
  pre-existing `TranslateLocalFunction` path, which never calls
  `TranslateBody`/`TranslateBodyCore`.
- Mixed native top-level statements + an explicit `Main`-shaped method in
  the same file (C# `CS7022`, a warning, not an error) needs no special
  casing: the top-level statements simply win as the real entry point
  (the detection matches only the synthesized `<Main>$`), and the
  leftover explicit method becomes an ordinary, never-invoked member —
  exactly mirroring real C#/CLR semantics.

## Tests

`tools/cs2gs/Cs2Gs.Tests/Issue2382TopLevelStatementsTranslationTests.cs`
— 13 new tests, each asserting translate + round-trip-parse + a real
`gsc` compile-and-run:

- simple sync top-level program
- `return int`
- implicit `args`
- top-level `await`
- the exact combined Oahu.Diagnostics shape (`await` + `return` of an
  awaited call, through a hoisted **async** local function called
  *before* its own declaration)
- a capture-free `static` local function hoisted and called before its
  declaration (`RenderPretty`-style)
- a **non-static but actually capture-free** local function (exercises
  the body-walk branch of `IsTopLevelLocalFunctionCaptureFree`, not just
  the `static`-modifier fast path)
- two mutually-referencing capture-free local functions (proving true
  forward/mutual reference works, unlike `let`)
- a capturing local function staying an in-place `let` binding
- a capturing local function called before its declaration (hoisted
  `let` ordering, generalizing the existing #2231 test to top-level-
  statement scope)
- a generic capture-free local function
- the mixed explicit-`Main` scenario
- multi-file coexistence (top-level statements in one file, an ordinary
  namespaced type in another, compiled together with `gsc`)

**Verified against the real trigger**: `cs2gs migrate --app
Oahu.Diagnostics` against the actual Oahu repository now reports
`translate=PASS`, `compile=PASS` for `tools/Oahu.Diagnostics` (previously
this app could not be translated at all). The emitted `Program.gs`'s
`RenderPretty` local function is correctly hoisted to a top-level `func`,
not a `let` binding.

## Full suite results

- `Core.Tests`: 6291/6291 passed (1 pre-existing skip)
- `Compiler.Tests`: 3090/3090 passed
- `InternalAnalyzers.Tests`: 7/7 passed
- `Cs2Gs.Tests` (serialized, `RunConfiguration.DisableParallelization=true`): 1423/1423 passed (1410 baseline + 13 new)

## Deferred / discovered but out of scope

The same `cs2gs migrate --app Oahu.Diagnostics` real-repo run surfaces
10 pre-existing `ilverify` failures that are **unrelated to top-level-
statement translation itself** (translate and compile both fully pass —
this is a downstream, post-compile IL-verification concern):

1. **6× `StackUnexpected`** in the pre-existing `Checks/*.cs` classes
   (e.g. `Oahu.Diagnostics.Checks.ExportCheck::Run` — a generic
   covariance/collection-initializer mismatch, `List<object>` found where
   `List<DiagnosticCheck>` was expected). Not touched by this PR.
2. **2× `FieldAccess` + 2× `MethodAccess`** ("Field/Method is not
   visible"): the synthesized `<Main>$`, the hoisted `RenderPretty` func,
   and a top-level lambda end up emitted as members of the **wrong
   package's** synthesized `<Program>` static-holder type
   (`Oahu.Diagnostics.Checks` instead of the correct `Default` package,
   since `Program.cs`'s top-level statements have no C# namespace). This
   looks like a `gsc` **emitter**-side defect (not a cs2gs translation
   defect) in how the per-package `<Program>` container is resolved when
   multiple packages in a large multi-file compilation each need one. I
   attempted several isolated 2-file `gsc`-only repros (package-less
   top-level file + a second real package; adding lambdas; adding async
   methods with captured-variable box classes) and could **not**
   reproduce the misplacement in isolation — it appears to need the
   fuller real 11-file, multi-package project shape to pin down further.
   Filing this as a separate issue (with the artifacts gathered) is
   recommended as a follow-up; it does not block this PR since translate
   and compile — the actual scope of #2382 — both fully succeed.
