### PR TITLE
Fix #2385: substitute Nullable-wrapped same-compilation user types in imported generic call arguments

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1052,16 +1052,31 @@ internal sealed class ConversionClassifier
         TypeSymbol receiverType,
         ImmutableArray<TypeSymbol> symbolicMethodTypeArgs = default)
     {
+        // Issue #2385: the receiver type-argument gate below previously only
+        // matched a same-compilation user type when it was DIRECTLY a
+        // StructSymbol/InterfaceSymbol/EnumSymbol/DelegateTypeSymbol (or
+        // nested inside another ImportedTypeSymbol). A same-compilation
+        // struct/enum WRAPPED in Nullable<T> (e.g. `List[Point?]` — the
+        // receiver type argument is a NullableTypeSymbol over the struct, not
+        // the struct itself) matched none of those cases, so the gate bailed
+        // out (`return null`) before ever attempting the substitution. The
+        // call then fell back to the erased CLR parameter type (`object`),
+        // misclassifying the argument as a boxing conversion and emitting an
+        // invalid `box`/`ldnull` sequence against a value-type
+        // `Nullable<T>` generic parameter slot (InvalidProgramException at
+        // runtime — see #2385). `TypeSymbol.ContainsSameCompilationUserType`
+        // is the general, already-established predicate for exactly this
+        // shape (it recurses through NullableTypeSymbol/SliceTypeSymbol/
+        // ArrayTypeSymbol/TupleTypeSymbol/nested ImportedTypeSymbol
+        // uniformly — the same predicate reused to fix the analogous #2381
+        // async-return-erasure bug), and is a structural superset of the old
+        // ad hoc list, so replacing it here also generalizes to
+        // same-compilation enums and array/tuple-wrapped shapes used as a
+        // generic type argument.
         if (method == null
             || receiverType is not ImportedTypeSymbol imported
             || imported.TypeArguments.IsDefaultOrEmpty
-            || !imported.TypeArguments.Any(arg =>
-                arg is StructSymbol
-                || arg is InterfaceSymbol
-                || arg is EnumSymbol
-                || arg is DelegateTypeSymbol
-                || (arg is ImportedTypeSymbol nested && nested.HasTypeParameterArgument == false
-                    && !nested.TypeArguments.IsDefaultOrEmpty)))
+            || !imported.TypeArguments.Any(TypeSymbol.ContainsSameCompilationUserType))
         {
             return null;
         }

--- a/test/Compiler.Tests/Emit/Issue2385NullableSameCompilationStructGenericArgEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2385NullableSameCompilationStructGenericArgEmitTests.cs
@@ -1,0 +1,269 @@
+// <copyright file="Issue2385NullableSameCompilationStructGenericArgEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2385 (deferred finding from #2381): an imported generic collection
+/// closed over a <em>nullable same-compilation struct/enum</em> (e.g.
+/// <c>List[Point?]</c>) produced <c>System.InvalidProgramException</c> at
+/// runtime. <see cref="GSharp.Core.CodeAnalysis.Binding.ConversionClassifier
+/// .TrySubstituteParameterTypeFromReceiver"/> recovers the substituted
+/// parameter type for a call on an imported generic receiver (e.g.
+/// <c>List[T].Add(!0)</c>) whose type argument is a same-compilation user
+/// type, so the correct conversion (<c>T -&gt; Nullable&lt;T&gt;</c>) is
+/// bound instead of the erased/boxing shape. Its gate previously only
+/// matched a receiver type argument that was DIRECTLY a
+/// <c>StructSymbol</c>/<c>InterfaceSymbol</c>/<c>EnumSymbol</c>/
+/// <c>DelegateTypeSymbol</c> (or nested <c>ImportedTypeSymbol</c>) — a
+/// <c>NullableTypeSymbol</c> wrapping one of those (the actual shape of
+/// <c>List[Point?]</c>'s type argument) matched none of those cases, so the
+/// whole substitution was skipped and the call fell back to the erased CLR
+/// parameter type (<c>object</c>), misclassifying the argument as boxing.
+/// The emitted <c>box</c>/bare <c>ldnull</c> IL is invalid against what is
+/// actually a value-type <c>Nullable&lt;T&gt;</c> generic parameter slot,
+/// producing <c>InvalidProgramException</c> at runtime (no compile-time
+/// diagnostic — <see cref="IlVerifier"/> is what catches this class of
+/// defect).
+/// <para>
+/// The fix replaces the narrow ad hoc predicate with
+/// <c>TypeSymbol.ContainsSameCompilationUserType</c> — the general,
+/// already-established predicate (reused from the analogous #2381 fix) that
+/// recurses uniformly through <c>NullableTypeSymbol</c> (and
+/// <c>SliceTypeSymbol</c>/<c>ArrayTypeSymbol</c>/<c>TupleTypeSymbol</c>/nested
+/// <c>ImportedTypeSymbol</c>), so it additionally and for-free generalizes to
+/// same-compilation ENUMS wrapped in <c>Nullable&lt;T&gt;</c>.
+/// </para>
+/// </summary>
+public class Issue2385NullableSameCompilationStructGenericArgEmitTests
+{
+    [Fact]
+    public void ListOfNullableUserStruct_AddConcreteAndNil_RunsAndVerifies()
+    {
+        const string source = """
+            package i2385struct
+            import System
+            import System.Collections.Generic
+
+            struct Point2385(X int32, Y int32) { }
+
+            func main() {
+                let list = List[Point2385?]()
+                list.Add(Point2385(1, 2))
+                list.Add(nil)
+                let first = list[0] ?? Point2385(0, 0)
+                let second = list[1] ?? Point2385(-1, -1)
+                Console.WriteLine(list.Count)
+                Console.WriteLine(first.X)
+                Console.WriteLine(second.X)
+            }
+
+            main()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n1\n-1\n", output);
+    }
+
+    [Fact]
+    public void ListOfNullableUserEnum_AddConcreteAndNil_RunsAndVerifies()
+    {
+        const string source = """
+            package i2385enum
+            import System
+            import System.Collections.Generic
+
+            enum Color2385 { Red, Green, Blue }
+
+            func main() {
+                let list = List[Color2385?]()
+                list.Add(Color2385.Blue)
+                list.Add(nil)
+                let first = list[0] ?? Color2385.Red
+                let second = list[1] ?? Color2385.Red
+                Console.WriteLine(list.Count)
+                Console.WriteLine(first)
+                Console.WriteLine(second)
+            }
+
+            main()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n2\n0\n", output);
+    }
+
+    [Fact]
+    public void DictionaryValueNullableUserStruct_IndexerSetAndGet_RunsAndVerifies()
+    {
+        const string source = """
+            package i2385dict
+            import System
+            import System.Collections.Generic
+
+            struct Point2385Dict(X int32, Y int32) { }
+
+            func main() {
+                let dict = Dictionary[string, Point2385Dict?]()
+                dict["a"] = Point2385Dict(3, 4)
+                dict["b"] = nil
+                let a = dict["a"] ?? Point2385Dict(0, 0)
+                let b = dict["b"] ?? Point2385Dict(-1, -1)
+                Console.WriteLine(dict.Count)
+                Console.WriteLine(a.X)
+                Console.WriteLine(b.X)
+            }
+
+            main()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n3\n-1\n", output);
+    }
+
+    [Fact]
+    public void ListOfNonNullableUserStruct_AddConcreteValue_RegressionStillRuns()
+    {
+        // Regression control: the pre-existing (#765) DIRECT (non-nullable)
+        // same-compilation struct type argument must keep working exactly
+        // as before the widened gate.
+        const string source = """
+            package i2385directstruct
+            import System
+            import System.Collections.Generic
+
+            struct Point2385Direct(X int32, Y int32) { }
+
+            func main() {
+                let list = List[Point2385Direct]()
+                list.Add(Point2385Direct(5, 6))
+                Console.WriteLine(list.Count)
+                Console.WriteLine(list[0].X)
+            }
+
+            main()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n5\n", output);
+    }
+
+    [Fact]
+    public void ListOfNullablePrimitive_AddConcreteValueAndNil_RegressionStillRuns()
+    {
+        // Regression control: a BUILT-IN nullable value type (Nullable<int32>)
+        // is unaffected by the widened gate (it never reached
+        // TrySubstituteParameterTypeFromReceiver's same-compilation-only
+        // substitution path in the first place).
+        const string source = """
+            package i2385primitive
+            import System
+            import System.Collections.Generic
+
+            func main() {
+                let list = List[int32?]()
+                list.Add(42)
+                list.Add(nil)
+                let first = list[0] ?? -1
+                let second = list[1] ?? -1
+                Console.WriteLine(list.Count)
+                Console.WriteLine(first)
+                Console.WriteLine(second)
+            }
+
+            main()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n42\n-1\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2385_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2385NullableSameCompilationStructGenericArgTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2385NullableSameCompilationStructGenericArgTests.cs
@@ -1,0 +1,284 @@
+// <copyright file="Issue2385NullableSameCompilationStructGenericArgTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2385: <see cref="ConversionClassifier.TrySubstituteParameterTypeFromReceiver"/>
+/// recovers the substituted parameter type for a call on an imported generic
+/// receiver (e.g. <c>List[T].Add(value)</c>) whose type argument is a
+/// same-compilation user type, so the binder does not misclassify the
+/// argument as a boxing conversion to the erased CLR shape. Its gate,
+/// however, only matched a receiver type argument that was DIRECTLY a
+/// <see cref="StructSymbol"/>/<see cref="InterfaceSymbol"/>/<see cref="EnumSymbol"/>/
+/// <see cref="DelegateTypeSymbol"/> (or a nested <see cref="ImportedTypeSymbol"/>) —
+/// a same-compilation struct/enum WRAPPED in <see cref="NullableTypeSymbol"/>
+/// (e.g. the receiver type argument of <c>List[Point?]</c>) matched none of
+/// those cases, so the gate bailed out (returned <see langword="null"/>)
+/// before ever attempting the substitution. The call then fell back to the
+/// erased CLR parameter type (effectively <c>object</c>), and the argument
+/// was bound as a boxing conversion — emitting an invalid <c>box</c>/<c>ldnull</c>
+/// sequence against what is actually a value-type <c>Nullable&lt;T&gt;</c>
+/// generic parameter slot (<c>InvalidProgramException</c> at runtime).
+/// <para>
+/// The fix replaces the narrow ad hoc list with
+/// <see cref="TypeSymbol.ContainsSameCompilationUserType"/> — the general,
+/// already-established predicate for exactly this shape (it recurses through
+/// <c>NullableTypeSymbol</c>/<c>SliceTypeSymbol</c>/<c>ArrayTypeSymbol</c>/
+/// <c>TupleTypeSymbol</c>/nested <c>ImportedTypeSymbol</c> uniformly), which
+/// is a structural superset of the old list and additionally generalizes to
+/// same-compilation enums wrapped in <c>Nullable&lt;T&gt;</c>.
+/// </para>
+/// <para>
+/// These tests assert directly on the bound
+/// <see cref="BoundImportedInstanceCallExpression.Arguments"/> types (after
+/// argument-conversion rebinding) rather than only on the absence of
+/// diagnostics, since the pre-fix defect compiled without any diagnostic and
+/// only manifested as an <c>InvalidProgramException</c> at runtime.
+/// </para>
+/// </summary>
+public class Issue2385NullableSameCompilationStructGenericArgTests
+{
+    [Fact]
+    public void ListOfNullableUserStruct_AddConcreteValue_ArgumentSubstitutedToNullableOfStruct()
+    {
+        const string source = @"
+package p
+import System.Collections.Generic
+struct Point2385(X int32, Y int32) { }
+func Outer() {
+    let list = List[Point2385?]()
+    list.Add(Point2385(1, 2))
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var call = FindImportedInstanceCall(compilation, "Outer", "Add");
+        Assert.NotNull(call);
+        var argType = Assert.IsType<NullableTypeSymbol>(call.Arguments[0].Type);
+        Assert.Equal("Point2385", argType.UnderlyingType.Name);
+        Assert.NotEqual(typeof(object), argType.UnderlyingType.ClrType);
+    }
+
+    [Fact]
+    public void ListOfNullableUserStruct_AddNil_ArgumentSubstitutedToNullableOfStruct_NotErasedToObject()
+    {
+        const string source = @"
+package p
+import System.Collections.Generic
+struct Point2385Nil(X int32, Y int32) { }
+func Outer() {
+    let list = List[Point2385Nil?]()
+    list.Add(nil)
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var call = FindImportedInstanceCall(compilation, "Outer", "Add");
+        Assert.NotNull(call);
+
+        // The nil argument must be lowered (by the binder) at the recovered
+        // Nullable[Point2385Nil] target, not left/erased at `object` — a
+        // `BoundDefaultExpression` typed `object` is exactly the pre-fix
+        // shape that emitted the invalid `ldnull` against a value-type slot.
+        var argType = Assert.IsType<NullableTypeSymbol>(call.Arguments[0].Type);
+        Assert.Equal("Point2385Nil", argType.UnderlyingType.Name);
+        Assert.IsType<BoundDefaultExpression>(call.Arguments[0]);
+    }
+
+    [Fact]
+    public void ListOfNullableUserEnum_AddConcreteValueAndNil_ArgumentsSubstitutedToNullableOfEnum()
+    {
+        const string source = @"
+package p
+import System.Collections.Generic
+enum Color2385 { Red, Green, Blue }
+func Outer() {
+    let list = List[Color2385?]()
+    list.Add(Color2385.Green)
+    list.Add(nil)
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var calls = FindImportedInstanceCalls(compilation, "Outer", "Add");
+        Assert.Equal(2, calls.Count);
+        foreach (var call in calls)
+        {
+            var argType = Assert.IsType<NullableTypeSymbol>(call.Arguments[0].Type);
+            Assert.Equal("Color2385", argType.UnderlyingType.Name);
+        }
+    }
+
+    [Fact]
+    public void DictionaryValueNullableUserStruct_IndexerSet_ArgumentSubstitutedToNullableOfStruct()
+    {
+        // Coverage: the same-compilation nullable struct occupies the SECOND
+        // (value) type-argument position of a two-argument imported generic
+        // (Dictionary[TKey,TValue]), via a plain indexer assignment
+        // (`d[k] = v`, bound as BoundClrIndexAssignmentExpression). This
+        // path uses the separate `MapErasedIndexerElementType` substitution
+        // helper (issue #968), whose gate (`arg.ClrType == null`) already
+        // covers a NullableTypeSymbol wrapping a same-compilation struct
+        // (NullableTypeSymbol.ClrType delegates to the underlying type,
+        // which is null pre-emit) — so this scenario was NOT part of the
+        // #2385 defect. Kept as a sibling-path regression control alongside
+        // the (buggy, now-fixed) Add(...) call-argument path.
+        const string source = @"
+package p
+import System.Collections.Generic
+struct Point2385Dict(X int32, Y int32) { }
+func Outer() {
+    let dict = Dictionary[string, Point2385Dict?]()
+    dict[""a""] = Point2385Dict(1, 2)
+    dict[""b""] = nil
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        // A plain (non-compound) indexer assignment `d[k] = v` binds to
+        // BoundClrIndexAssignmentExpression, not a named `set_Item` call
+        // node — the emitter later resolves the setter from `Indexer`.
+        var writes = FindIndexAssignments(compilation, "Outer");
+        Assert.Equal(2, writes.Count);
+        foreach (var write in writes)
+        {
+            var argType = Assert.IsType<NullableTypeSymbol>(write.Value.Type);
+            Assert.Equal("Point2385Dict", argType.UnderlyingType.Name);
+        }
+    }
+
+    [Fact]
+    public void ListOfNonNullableUserStruct_AddConcreteValue_RegressionStillSubstitutesDirectly()
+    {
+        // Regression control: the pre-existing (#765) DIRECT (non-nullable)
+        // same-compilation struct type argument must still substitute
+        // correctly — the fix only widens the gate, it must not narrow it.
+        const string source = @"
+package p
+import System.Collections.Generic
+struct Point2385Direct(X int32, Y int32) { }
+func Outer() {
+    let list = List[Point2385Direct]()
+    list.Add(Point2385Direct(1, 2))
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var call = FindImportedInstanceCall(compilation, "Outer", "Add");
+        Assert.NotNull(call);
+
+        // Identity conversion (no Nullable wrapper) — argument type is the
+        // struct itself, not erased to object.
+        var argType = Assert.IsType<StructSymbol>(call.Arguments[0].Type);
+        Assert.Equal("Point2385Direct", argType.Name);
+    }
+
+    [Fact]
+    public void ListOfNullablePrimitive_AddConcreteValueAndNil_RegressionUnaffected()
+    {
+        // Negative control: a BUILT-IN nullable value type (Nullable<int32>)
+        // must keep binding and running exactly as before — this scenario
+        // never reaches TrySubstituteParameterTypeFromReceiver's
+        // same-compilation gate at all (overload resolution here actually
+        // prefers the explicit `IList.Add(object)` interface implementation
+        // over the generic `List<T>.Add(T)` for a bare int32 literal, and
+        // that boxing conversion is unrelated to, and unaffected by, the
+        // #2385 fix). The full compile+run+ILVerify coverage for this
+        // control lives in the Compiler.Tests emit-level counterpart.
+        const string source = @"
+package p
+import System.Collections.Generic
+func Outer() {
+    let list = List[int32?]()
+    list.Add(42)
+    list.Add(nil)
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var calls = FindImportedInstanceCalls(compilation, "Outer", "Add");
+        Assert.Equal(2, calls.Count);
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree) { IsLibrary = true };
+    }
+
+    private static BoundImportedInstanceCallExpression FindImportedInstanceCall(Compilation compilation, string functionName, string methodName)
+        => FindImportedInstanceCalls(compilation, functionName, methodName).FirstOrDefault();
+
+    private static List<BoundImportedInstanceCallExpression> FindImportedInstanceCalls(Compilation compilation, string functionName, string methodName)
+    {
+        var fn = compilation.BoundProgram.Functions.Keys.Single(f => f.Name == functionName);
+        var body = compilation.BoundProgram.Functions[fn];
+        var collector = new ImportedInstanceCallCollector(methodName);
+        collector.Visit(body);
+        return collector.Collected;
+    }
+
+    private static List<BoundClrIndexAssignmentExpression> FindIndexAssignments(Compilation compilation, string functionName)
+    {
+        var fn = compilation.BoundProgram.Functions.Keys.Single(f => f.Name == functionName);
+        var body = compilation.BoundProgram.Functions[fn];
+        var collector = new ClrIndexAssignmentCollector();
+        collector.Visit(body);
+        return collector.Collected;
+    }
+
+    private sealed class ImportedInstanceCallCollector : BoundTreeWalker
+    {
+        private readonly string methodName;
+
+        public ImportedInstanceCallCollector(string methodName)
+        {
+            this.methodName = methodName;
+        }
+
+        public List<BoundImportedInstanceCallExpression> Collected { get; } = new();
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node is BoundImportedInstanceCallExpression call && call.Method.Name == methodName)
+            {
+                Collected.Add(call);
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+
+    private sealed class ClrIndexAssignmentCollector : BoundTreeWalker
+    {
+        public List<BoundClrIndexAssignmentExpression> Collected { get; } = new();
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node is BoundClrIndexAssignmentExpression write)
+            {
+                Collected.Add(write);
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2385 (a deferred follow-up finding from #2381/PR #2384).

`List[T?].Add(value)` — an imported generic collection (`List<T>`) closed over a **nullable same-compilation struct/enum** (e.g. `List[Point?]`) — produced `System.InvalidProgramException` at runtime due to invalid IL: a `box` instruction (or a bare `ldnull`) was emitted against what is actually a value-type `Nullable<T>` generic parameter slot.

## Root cause

`ConversionClassifier.TrySubstituteParameterTypeFromReceiver` recovers the substituted parameter type for a call on an imported generic receiver (e.g. `List[T].Add(!0)`) whose type argument is a same-compilation user type, so the binder binds the *correct* conversion (`T -> Nullable<T>`) instead of misclassifying the argument as boxing to the erased CLR shape (`object`).

Its gate, however, only matched a receiver type argument that was **directly** a `StructSymbol`/`InterfaceSymbol`/`EnumSymbol`/`DelegateTypeSymbol` (or a nested `ImportedTypeSymbol`). A `NullableTypeSymbol` **wrapping** one of those — the actual shape of `List[Point?]`'s type argument — matched none of those cases, so the whole substitution was skipped. The call fell back to the erased CLR parameter type (`object`), and the argument was bound as a boxing conversion, producing invalid IL against the true `Nullable<T>` slot.

This is the same class of narrow-gate defect fixed for the analogous issue #2381 (async `Task<T>` return erasure).

## Fix

Widened the gate in `TrySubstituteParameterTypeFromReceiver` from the ad hoc `StructSymbol || InterfaceSymbol || EnumSymbol || DelegateTypeSymbol || nested-ImportedTypeSymbol` list to `imported.TypeArguments.Any(TypeSymbol.ContainsSameCompilationUserType)` — the same general, already-established predicate reused from the #2381 fix. It recurses uniformly through `NullableTypeSymbol` (and `SliceTypeSymbol`/`ArrayTypeSymbol`/`TupleTypeSymbol`/nested `ImportedTypeSymbol`), so it is a strict superset of the old list and additionally generalizes, for free, to same-compilation **enums** wrapped in `Nullable<T>`.

No emitter changes were needed — `MethodBodyEmitter.Conversions.cs` already has correct, pre-existing infrastructure (issues #504/#814/#571/#1298/#1572) for both `T -> Nullable<T>` (`newobj Nullable<T>::.ctor`) and `nil -> Nullable<T>` (`ldloca; initobj; ldloc`) once the binder passes the right target type.

A sibling substitution path used for **indexer writes** (`MapErasedIndexerElementType`, issue #968) already handled this case correctly — its gate (`arg.ClrType == null`) naturally covers a `NullableTypeSymbol` wrapping a same-compilation struct, since `NullableTypeSymbol.ClrType` delegates to the underlying type's `ClrType` (`null` pre-emit). Only the `Add`-style call-argument path (`TrySubstituteParameterTypeFromReceiver`) had the defect; audited via `grep` to confirm no other site shares the same narrow-list pattern.

## Tests

- **Core.Tests** (`test/Core.Tests/CodeAnalysis/Binding/Issue2385NullableSameCompilationStructGenericArgTests.cs`, 6 tests): binder-level assertions on `BoundImportedInstanceCallExpression`/`BoundClrIndexAssignmentExpression` argument types for `List[T?].Add(concrete)`/`.Add(nil)` with a same-compilation struct and enum, `Dictionary[string, T?]` indexer-set, plus regression controls for the pre-existing non-nullable same-compilation struct (#765) and built-in `List[int32?]`.
- **Compiler.Tests** (`test/Compiler.Tests/Emit/Issue2385NullableSameCompilationStructGenericArgEmitTests.cs`, 5 tests): full compile + `IlVerifier.Verify` + `dotnet exec` runtime coverage for the same struct/enum/Dictionary scenarios plus the same two regression controls.

## Suite results (this branch, after merging latest `origin/main`)

- Core.Tests: 6304 passed, 1 skipped
- Compiler.Tests: 3103 passed
- InternalAnalyzers.Tests: 7 passed
- Cs2Gs.Tests (serialized, `xunit.parallelizeAssembly=false xunit.parallelizeTestCollections=false`): 1410 passed (2 prior test-host crashes on retry were shared-environment resource contention, not product regressions — a clean 3rd run completed all 1410)
- Full solution build with `RunAnalyzersDuringBuild=true` / `TreatWarningsAsErrors=true`: 0 warnings, 0 errors

## Deferred / discovered work

None. Broader coverage (array/tuple-wrapped same-compilation elements as a generic type argument) was reasoned about via `ContainsSameCompilationUserType`'s existing recursive structure but not required to close this issue's reported defect; no new gaps were found while writing the wider test coverage.
