### PR TITLE
Fix #2388: sound nullable lifting for imported/same-compilation custom-equality structs

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundClrBinaryOperatorExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrBinaryOperatorExpression.cs
@@ -12,21 +12,48 @@ using GSharp.Core.CodeAnalysis.Syntax;
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
-/// User-defined binary operator on an imported CLR type, resolved to a
-/// public static <see cref="MethodInfo"/> with C#-style operator name
-/// (e.g. <c>op_Addition</c>, <c>op_Equality</c>). Stream C lets GSharp source
-/// write <c>a + b</c> against operator-bearing CLR types such as
-/// <c>TimeSpan</c>, <c>BigInteger</c>, or <c>System.Numerics.Vector2</c>.
+/// User-defined binary operator resolved to a public static operator method,
+/// identified by C#-style operator name (e.g. <c>op_Addition</c>,
+/// <c>op_Equality</c>). Stream C lets GSharp source write <c>a + b</c>
+/// against operator-bearing CLR types such as <c>TimeSpan</c>,
+/// <c>BigInteger</c>, or <c>System.Numerics.Vector2</c>, resolved via
+/// <see cref="Method"/> (a reflection <see cref="MethodInfo"/>).
 /// </summary>
+/// <remarks>
+/// Issue #2388: this node is ALSO reused for the nullable-lifted form of a
+/// same-compilation struct's Stream D user-defined operator (<c>func (a T)
+/// operator ==(b T) bool</c>) when one or both operands are a value-type
+/// <c>Nullable&lt;T&gt;</c> — that scenario has no reflection
+/// <see cref="MethodInfo"/> available at bind time (the declaring struct is
+/// still <see cref="System.Reflection.Emit.TypeBuilder"/>-backed), so
+/// <see cref="Function"/> carries the same-compilation
+/// <see cref="FunctionSymbol"/> instead. Exactly one of <see cref="Method"/>
+/// / <see cref="Function"/> is non-null. Sharing one node type lets the
+/// nullable-lifting machinery in <c>SlotPlanner</c> /
+/// <c>MethodBodyEmitter.Operators</c> (<c>LiftedBinarySlots</c> /
+/// <c>EmitLiftedNullableClrBinary</c>) drive both the imported-CLR-type and
+/// same-compilation-struct cases uniformly.
+/// </remarks>
 public sealed class BoundClrBinaryOperatorExpression : BoundExpression
 {
     public BoundClrBinaryOperatorExpression(SyntaxNode syntax, SyntaxKind operatorKind, BoundExpression left, BoundExpression right, MethodInfo method, TypeSymbol resultType)
+        : this(syntax, operatorKind, left, right, method, null, resultType)
+    {
+    }
+
+    public BoundClrBinaryOperatorExpression(SyntaxNode syntax, SyntaxKind operatorKind, BoundExpression left, BoundExpression right, Symbols.FunctionSymbol function, TypeSymbol resultType)
+        : this(syntax, operatorKind, left, right, null, function, resultType)
+    {
+    }
+
+    private BoundClrBinaryOperatorExpression(SyntaxNode syntax, SyntaxKind operatorKind, BoundExpression left, BoundExpression right, MethodInfo method, Symbols.FunctionSymbol function, TypeSymbol resultType)
         : base(syntax)
     {
         OperatorKind = operatorKind;
         Left = left;
         Right = right;
         Method = method;
+        Function = function;
         Type = resultType;
     }
 
@@ -36,7 +63,16 @@ public sealed class BoundClrBinaryOperatorExpression : BoundExpression
 
     public BoundExpression Right { get; }
 
+    /// <summary>Gets the resolved imported-CLR-type operator method, or <see langword="null"/> when <see cref="Function"/> is used instead.</summary>
     public MethodInfo Method { get; }
+
+    /// <summary>
+    /// Gets the resolved same-compilation struct operator function (issue
+    /// #2388), used for the nullable-lifted Stream D case instead of
+    /// <see cref="Method"/>. <see langword="null"/> for the ordinary
+    /// (imported-CLR-type or non-nullable Stream D) shape.
+    /// </summary>
+    public Symbols.FunctionSymbol Function { get; }
 
     public override TypeSymbol Type { get; }
 

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1708,7 +1708,12 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundClrBinaryOperatorExpression(null, node.OperatorKind, left, right, node.Method, node.Type);
+        // Issue #2388: preserve whichever of Method (imported CLR type) /
+        // Function (nullable-lifted same-compilation struct operator) the
+        // original node carried — exactly one is non-null.
+        return node.Function != null
+            ? new BoundClrBinaryOperatorExpression(null, node.OperatorKind, left, right, node.Function, node.Type)
+            : new BoundClrBinaryOperatorExpression(null, node.OperatorKind, left, right, node.Method, node.Type);
     }
 
     /// <summary>Rewrites a CLR unary operator call (Stream C).</summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -1437,6 +1437,85 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #2388: true for the six comparison operators whose C# lifted
+    /// form always yields a plain (non-nullable) <c>bool</c> — <c>nil == nil</c>
+    /// is true, a HasValue mismatch is false/true, and two present operands
+    /// unwrap and delegate to the underlying operator. Every other
+    /// Stream C/D operator (arithmetic, bitwise) lifts to <c>Nullable&lt;R&gt;</c>
+    /// instead, propagating a "no value" operand as a null result.
+    /// </summary>
+    private static bool IsClrOperatorLiftedToBool(SyntaxKind opKind) => opKind switch
+    {
+        SyntaxKind.EqualsEqualsToken or SyntaxKind.BangEqualsToken
+            or SyntaxKind.LessToken or SyntaxKind.LessOrEqualsToken
+            or SyntaxKind.GreaterToken or SyntaxKind.GreaterOrEqualsToken => true,
+        _ => false,
+    };
+
+    /// <summary>
+    /// Issue #2388: when a Stream C/D binary operator resolves against a
+    /// value-type operand that is (or should be) wrapped in a nullable
+    /// <c>Nullable&lt;T&gt;</c> — either operand is already
+    /// <see cref="NullableTypeSymbol"/>, or the OTHER operand is — lifts both
+    /// operands up to a matching <c>Nullable&lt;T&gt;</c> (mixed-mode: the
+    /// bare non-nullable side is wrapped) and computes the operator's lifted
+    /// result type. Returns <see langword="false"/> when no lifting applies
+    /// (plain non-nullable call site, unchanged behavior).
+    /// </summary>
+    /// <param name="opKind">The operator token.</param>
+    /// <param name="left">The bound left operand; replaced with its <c>Nullable&lt;T&gt;</c>-converted form when lifting applies.</param>
+    /// <param name="right">The bound right operand; replaced with its <c>Nullable&lt;T&gt;</c>-converted form when lifting applies.</param>
+    /// <param name="leftLocation">The left operand's source location (for the wrapping conversion).</param>
+    /// <param name="rightLocation">The right operand's source location (for the wrapping conversion).</param>
+    /// <param name="naturalResultType">The operator's own (non-lifted) result type.</param>
+    /// <param name="liftedResultType">The lifted result type: <c>bool</c> for comparisons, <c>Nullable&lt;naturalResultType&gt;</c> otherwise.</param>
+    /// <returns><see langword="true"/> when lifting applies and <paramref name="left"/>/<paramref name="right"/>/<paramref name="liftedResultType"/> were updated.</returns>
+    private bool TryLiftNullableClrOperatorOperands(
+        SyntaxKind opKind,
+        ref BoundExpression left,
+        ref BoundExpression right,
+        TextLocation leftLocation,
+        TextLocation rightLocation,
+        TypeSymbol naturalResultType,
+        out TypeSymbol liftedResultType)
+    {
+        liftedResultType = null;
+
+        bool leftIsNullableValueType = left.Type is NullableTypeSymbol leftNullable
+            && leftNullable.UnderlyingType?.ClrType is { IsValueType: true };
+        bool rightIsNullableValueType = right.Type is NullableTypeSymbol rightNullable
+            && rightNullable.UnderlyingType?.ClrType is { IsValueType: true };
+
+        // A struct-typed same-compilation operand has no static ClrType, so
+        // the `IsValueType: true` check above never matches it directly —
+        // detect that shape via NullableTypeSymbol alone (any nullable
+        // wrapper) so `MyStruct? == MyStruct?` (Stream D) also lifts.
+        bool leftIsNullableStruct = left.Type is NullableTypeSymbol leftStructNullable
+            && leftStructNullable.UnderlyingType is StructSymbol;
+        bool rightIsNullableStruct = right.Type is NullableTypeSymbol rightStructNullable
+            && rightStructNullable.UnderlyingType is StructSymbol;
+
+        leftIsNullableValueType |= leftIsNullableStruct;
+        rightIsNullableValueType |= rightIsNullableStruct;
+
+        if (!leftIsNullableValueType && !rightIsNullableValueType)
+        {
+            return false;
+        }
+
+        var leftLiftedType = leftIsNullableValueType ? (NullableTypeSymbol)left.Type : NullableTypeSymbol.Get(left.Type);
+        var rightLiftedType = rightIsNullableValueType ? (NullableTypeSymbol)right.Type : NullableTypeSymbol.Get(right.Type);
+
+        left = conversions.BindConversion(leftLocation, left, leftLiftedType);
+        right = conversions.BindConversion(rightLocation, right, rightLiftedType);
+
+        liftedResultType = IsClrOperatorLiftedToBool(opKind)
+            ? (TypeSymbol)TypeSymbol.Bool
+            : NullableTypeSymbol.Get(naturalResultType);
+        return true;
+    }
+
+    /// <summary>
     /// Issue #1554: shared fallback that resolves a binary operator via the
     /// user-defined operator path (Stream D) and then the CLR <c>op_*</c> path
     /// (Stream C), in that order, for both the plain binary expression
@@ -1469,15 +1548,28 @@ internal sealed partial class ExpressionBinder
         // the operator's first formal parameter (Parameters[0], so binary ops
         // have Parameters.Length == 2 regardless of which operand declared
         // the operator).
+        //
+        // Issue #2388: the lookup unwraps a `Nullable<T>` operand to `T` so a
+        // custom-equality struct's operator is found even when compared as
+        // `T? == T?` — without the unwrap, `left.Type is StructSymbol` never
+        // matches a `NullableTypeSymbol` and the comparison fell straight
+        // through to an "operator undefined" diagnostic (GS0129).
         var userOpName = OperatorNames.TryGetBinaryName(opKind);
         if (userOpName != null)
         {
+            var leftStructType = left.Type is NullableTypeSymbol leftNullableForStruct
+                ? leftNullableForStruct.UnderlyingType as StructSymbol
+                : left.Type as StructSymbol;
+            var rightStructType = right.Type is NullableTypeSymbol rightNullableForStruct
+                ? rightNullableForStruct.UnderlyingType as StructSymbol
+                : right.Type as StructSymbol;
+
             FunctionSymbol userOp = null;
-            if (left.Type is StructSymbol leftStruct && TypeMemberModel.TryGetStaticMethodIncludingInherited(leftStruct, userOpName, out var leftOp))
+            if (leftStructType != null && TypeMemberModel.TryGetStaticMethodIncludingInherited(leftStructType, userOpName, out var leftOp))
             {
                 userOp = leftOp;
             }
-            else if (right.Type is StructSymbol rightStruct && TypeMemberModel.TryGetStaticMethodIncludingInherited(rightStruct, userOpName, out var rightOp))
+            else if (rightStructType != null && TypeMemberModel.TryGetStaticMethodIncludingInherited(rightStructType, userOpName, out var rightOp))
             {
                 userOp = rightOp;
             }
@@ -1492,6 +1584,11 @@ internal sealed partial class ExpressionBinder
 
             if (userOp != null && userOp.Parameters.Length == 2)
             {
+                if (TryLiftNullableClrOperatorOperands(opKind, ref left, ref right, leftLocation, rightLocation, userOp.Type, out var liftedResultType))
+                {
+                    return new BoundClrBinaryOperatorExpression(null, opKind, left, right, userOp, liftedResultType);
+                }
+
                 var convertedLeft = conversions.BindConversion(leftLocation, left, userOp.Parameters[0].Type);
                 var convertedRight = conversions.BindConversion(rightLocation, right, userOp.Parameters[1].Type);
                 return new BoundCallExpression(null, userOp, ImmutableArray.Create(convertedLeft, convertedRight));
@@ -1503,6 +1600,27 @@ internal sealed partial class ExpressionBinder
         if ((left.Type?.ClrType != null || right.Type?.ClrType != null)
             && ClrOperatorResolution.TryResolveBinary(opKind, left.Type, right.Type, out var clrMethod, out ambiguous))
         {
+            // Issue #2388: `ClrOperatorResolution` matches on
+            // `TypeSymbol.ClrType`, which for a `NullableTypeSymbol` wrapping
+            // a value type is already the UNDERLYING CLR type (see
+            // `NullableTypeSymbol`'s constructor) — so this lookup "succeeds"
+            // for `DateTime? == DateTime?` too, resolving
+            // `DateTime.op_Equality(DateTime, DateTime)` even though the
+            // bound operands remain `Nullable<DateTime>`-typed. Emitting
+            // `EmitExpression(left); EmitExpression(right); call` then left a
+            // `Nullable<T>` on the stack where the callee expects a bare `T`
+            // — exactly the ilverify `StackUnexpected` this issue reports.
+            // Detect that shape here and lift both operands (mixed-mode: wrap
+            // a bare non-nullable side) so the emitter's lifted-binary slot
+            // machinery (`LiftedBinarySlots` / `EmitLiftedNullableClrBinary`)
+            // spills, HasValue-branches, and unwraps before calling the
+            // resolved method — mirroring exactly how the built-in operator
+            // table already lifts `int32? + int32?` et al.
+            if (TryLiftNullableClrOperatorOperands(opKind, ref left, ref right, leftLocation, rightLocation, TypeSymbol.FromClrType(clrMethod.ReturnType), out var liftedClrResultType))
+            {
+                return new BoundClrBinaryOperatorExpression(null, opKind, left, right, clrMethod, liftedClrResultType);
+            }
+
             return new BoundClrBinaryOperatorExpression(
                 null,
                 opKind,

--- a/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
+++ b/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
@@ -181,6 +181,20 @@ internal sealed class MetadataTokenCache
         = new Dictionary<TypeSymbol, MemberReferenceHandle>();
 
     /// <summary>
+    /// Gets the cache mapping a user-defined value-type underlying
+    /// (<see cref="EnumSymbol"/> or value-kind <see cref="StructSymbol"/>) to
+    /// the <see cref="MemberReferenceHandle"/> for
+    /// <c>System.Nullable`1&lt;T&gt;::get_HasValue()</c> (issue #2388). Mirrors
+    /// <see cref="NullableUserValueTypeGetValueMemberRefs"/>; used to
+    /// HasValue-branch a nullable-lifted Stream C/D custom-operator call
+    /// over a same-compilation struct, where no real CLR
+    /// <see cref="System.Type"/> exists to drive the reflection-based
+    /// <see cref="WellKnownReferences.GetNullableGetHasValueReference"/>.
+    /// </summary>
+    public Dictionary<TypeSymbol, MemberReferenceHandle> NullableUserValueTypeGetHasValueMemberRefs { get; }
+        = new Dictionary<TypeSymbol, MemberReferenceHandle>();
+
+    /// <summary>
     /// Gets the cache mapping a <see cref="FieldInfo"/> to its
     /// <see cref="MemberReferenceHandle"/>.
     /// </summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -1646,15 +1646,292 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitClrBinaryOperator(BoundClrBinaryOperatorExpression op)
     {
+        // Issue #2388: a nullable-lifted call site (either operand
+        // Nullable<T>-wrapped — see TryLiftNullableClrOperatorOperands /
+        // IsLiftedValueTypeClrBinary) was pre-planned into liftedBinarySlots
+        // by SlotPlanner.LiftedBinaryOperatorCollector; falling through to
+        // the naive push-push-call path below would leave a raw
+        // Nullable<T> on the evaluation stack where the resolved operator
+        // expects the bare underlying value — ilverify's StackUnexpected.
+        if (this.liftedBinarySlots.TryGetValue(op, out var liftedSlots))
+        {
+            this.EmitLiftedNullableClrBinary(op, liftedSlots);
+            return;
+        }
+
         // Stream C emit parity: user-defined binary operator on a CLR type.
         // C# operators are public-static methods, so we emit `call` against
         // the resolved MethodInfo with both arguments pushed in source
-        // order.
+        // order. (op.Function is never set on a non-lifted node — the
+        // binder only produces the Function-carrying shape when lifting
+        // applies, so it always has a liftedBinarySlots entry and is
+        // handled above.)
         this.EmitExpression(op.Left);
         this.EmitExpression(op.Right);
         this.il.OpCode(ILOpCode.Call);
         this.il.Token(this.outer.GetMethodReference(op.Method));
         this.EmitErasedObjectReturnWidening(TypeSymbol.FromClrType(op.Method.ReturnType), op.Type);
+    }
+
+    // Issue #2388: mirrors EmitLiftedNullableBinary's HasValue/get_Value
+    // skeleton, but for a Stream C/D custom-operator call
+    // (BoundClrBinaryOperatorExpression) instead of the built-in operator
+    // table. Because ClrOperatorResolution / the Stream D lookup resolve a
+    // SEPARATE method per operator token (op_Equality vs op_Inequality vs
+    // op_LessThan, ...; see OperatorNames.TryGetBinaryName), the resolved
+    // op.Method/op.Function already IS the exact operator the source wrote
+    // — there is no need to compute `!=` by negating `==`, unlike the
+    // built-in table's EmitLiftedEquality. This lets every comparison kind
+    // share one call-shaped "both present" branch that simply invokes the
+    // resolved method/function; only the "not both present" fallback value
+    // differs (per C# §12.4.8's lifted-equality vs lifted-ordering rules).
+    private void EmitLiftedNullableClrBinary(BoundClrBinaryOperatorExpression op, LiftedBinarySlots slots)
+    {
+        var leftNullable = (NullableTypeSymbol)op.Left.Type;
+        var rightNullable = (NullableTypeSymbol)op.Right.Type;
+        var lhsSlot = slots.LhsSlot;
+        var rhsSlot = slots.RhsSlot;
+
+        if (rhsSlot < 0)
+        {
+            throw new InvalidOperationException(
+                $"Lifted CLR/user binary operator '{op.OperatorKind}': RHS slot missing — a nullable-lifted Stream "
+                + "C/D call site never has a `nil` RHS (see SlotPlanner.IsLiftedValueTypeClrBinary); check "
+                + "LiftedBinaryOperatorCollector.");
+        }
+
+        // Spill both operands.
+        this.EmitExpression(op.Left);
+        this.il.StoreLocal(lhsSlot);
+        this.EmitExpression(op.Right);
+        this.il.StoreLocal(rhsSlot);
+
+        bool isEquality = op.OperatorKind == SyntaxKind.EqualsEqualsToken;
+        bool isInequality = op.OperatorKind == SyntaxKind.BangEqualsToken;
+        bool isOrdering = op.OperatorKind is SyntaxKind.LessToken or SyntaxKind.LessOrEqualsToken
+            or SyntaxKind.GreaterToken or SyntaxKind.GreaterOrEqualsToken;
+
+        if (isEquality || isInequality)
+        {
+            // §12.4.8: a HasValue mismatch (exactly one operand null) is
+            // false for == and true for !=; both-null is true for == and
+            // false for !=; both-present delegates to the resolved
+            // operator (already the correct op_Equality / op_Inequality).
+            this.EmitLiftedClrComparison(
+                op,
+                lhsSlot,
+                rhsSlot,
+                leftNullable,
+                rightNullable,
+                mismatchResult: isInequality,
+                bothAbsentResult: !isInequality);
+            return;
+        }
+
+        if (isOrdering)
+        {
+            // Any missing operand makes every ordering comparison false —
+            // there is no "both empty" special case (unlike equality).
+            this.EmitLiftedClrComparison(
+                op,
+                lhsSlot,
+                rhsSlot,
+                leftNullable,
+                rightNullable,
+                mismatchResult: false,
+                bothAbsentResult: false);
+            return;
+        }
+
+        // Arithmetic / bitwise: produces Nullable<R>. The same-compilation
+        // Function-carrying case has no runtime CLR Type for the result
+        // underlying, so constructing Nullable<R> symbolically (mirroring
+        // GetNullableCtorMemberRefForUserValueType) is deferred — reported
+        // as a known limitation. Imported-CLR arithmetic operators
+        // (op.Method, e.g. DateTime.op_Subtraction) are fully supported.
+        if (op.Function != null)
+        {
+            throw new NotSupportedException(
+                $"Lifted same-compilation arithmetic/bitwise operator '{op.OperatorKind}' on "
+                + $"'{op.Function.Name}' is not yet supported (issue #2388 scoped equality/ordering "
+                + "lifting; symbolic Nullable<R> construction for a same-compilation result type is "
+                + "deferred follow-up work).");
+        }
+
+        this.EmitLiftedClrArithmetic(op, lhsSlot, rhsSlot, slots.ResultSlot, leftNullable, rightNullable);
+    }
+
+    // Both-present branch calls the resolved op.Method / op.Function
+    // directly; the not-both-present branches produce a caller-supplied
+    // constant per operator-family rules (see call sites above).
+    private void EmitLiftedClrComparison(
+        BoundClrBinaryOperatorExpression op,
+        int lhsSlot,
+        int rhsSlot,
+        NullableTypeSymbol leftNullable,
+        NullableTypeSymbol rightNullable,
+        bool mismatchResult,
+        bool bothAbsentResult)
+    {
+        var getHasValueLhs = this.GetNullableHasValueRef(leftNullable);
+        var getHasValueRhs = this.GetNullableHasValueRef(rightNullable);
+
+        var flagsAgreeLabel = this.il.DefineLabel();
+        var bothAbsentLabel = this.il.DefineLabel();
+        var end = this.il.DefineLabel();
+
+        // Compare HasValue flags; if they differ the result is the fixed
+        // mismatch value for this operator family.
+        this.il.LoadLocalAddress(lhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getHasValueLhs);
+        this.il.LoadLocalAddress(rhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getHasValueRhs);
+        this.il.Branch(ILOpCode.Beq, flagsAgreeLabel);
+
+        this.il.LoadConstantI4(mismatchResult ? 1 : 0);
+        this.il.Branch(ILOpCode.Br, end);
+
+        // Agreed: either both absent (fixed value) or both present (call
+        // the resolved operator on the unwrapped values).
+        this.il.MarkLabel(flagsAgreeLabel);
+        this.il.LoadLocalAddress(lhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getHasValueLhs);
+        this.il.Branch(ILOpCode.Brfalse, bothAbsentLabel);
+
+        this.EmitUnwrappedNullableValue(lhsSlot, leftNullable);
+        this.EmitUnwrappedNullableValue(rhsSlot, rightNullable);
+        this.EmitCallResolvedClrOrFunctionOperator(op);
+        this.il.Branch(ILOpCode.Br, end);
+
+        this.il.MarkLabel(bothAbsentLabel);
+        this.il.LoadConstantI4(bothAbsentResult ? 1 : 0);
+
+        this.il.MarkLabel(end);
+    }
+
+    private void EmitLiftedClrArithmetic(
+        BoundClrBinaryOperatorExpression op,
+        int lhsSlot,
+        int rhsSlot,
+        int resultSlot,
+        NullableTypeSymbol leftNullable,
+        NullableTypeSymbol rightNullable)
+    {
+        if (resultSlot < 0)
+        {
+            throw new InvalidOperationException(
+                $"Lifted CLR binary operator '{op.OperatorKind}' produces Nullable<R> but no result slot was "
+                + "pre-allocated; check LiftedBinaryOperatorCollector and the prepass in CollectLocalsAndLabels.");
+        }
+
+        var getHasValueLhs = this.GetNullableHasValueRef(leftNullable);
+        var getHasValueRhs = this.GetNullableHasValueRef(rightNullable);
+
+        var resultUnderlyingClr = op.Method.ReturnType;
+        if (!NullableLifting.TryConstructNullable(this.outer.emitCtx.References, resultUnderlyingClr, out var nullableClr))
+        {
+            throw new InvalidOperationException(
+                $"Cannot construct Nullable<{resultUnderlyingClr.FullName}>: System.Nullable`1 is not resolvable in the reference set.");
+        }
+
+        var nullableInnerArg = nullableClr.GetGenericArguments()[0];
+        var ctor = nullableClr.GetConstructor(new[] { nullableInnerArg })
+            ?? throw new InvalidOperationException(
+                $"Nullable<{nullableInnerArg.FullName}> has no single-arg constructor.");
+        var nullableToken = this.outer.GetTypeHandleForMember(nullableClr);
+
+        var nullBranch = this.il.DefineLabel();
+        var end = this.il.DefineLabel();
+
+        this.il.LoadLocalAddress(lhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getHasValueLhs);
+        this.il.LoadLocalAddress(rhsSlot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(getHasValueRhs);
+        this.il.OpCode(ILOpCode.And);
+        this.il.Branch(ILOpCode.Brfalse, nullBranch);
+
+        this.EmitUnwrappedNullableValue(lhsSlot, leftNullable);
+        this.EmitUnwrappedNullableValue(rhsSlot, rightNullable);
+        this.EmitCallResolvedClrOrFunctionOperator(op);
+        this.il.OpCode(ILOpCode.Newobj);
+        this.il.Token(this.outer.GetCtorReference(ctor));
+        this.il.Branch(ILOpCode.Br, end);
+
+        this.il.MarkLabel(nullBranch);
+        this.il.LoadLocalAddress(resultSlot);
+        this.il.OpCode(ILOpCode.Initobj);
+        this.il.Token(nullableToken);
+        this.il.LoadLocal(resultSlot);
+
+        this.il.MarkLabel(end);
+    }
+
+    // Issue #2388: HasValue/Value accessors on Nullable<T> need different
+    // MemberRef construction depending on whether T has a real runtime CLR
+    // Type (imported CLR value type, e.g. DateTime) or is still
+    // TypeBuilder-backed (same-compilation struct/enum) — mirrors the
+    // existing get_Value split already used by the `(v!!)` unwrap operator
+    // (NullableLifting.IsUserValueTypeNullable / RequiresSymbolicNullableGetValue).
+    private MemberReferenceHandle GetNullableHasValueRef(NullableTypeSymbol nullable)
+    {
+        return NullableLifting.IsUserValueTypeNullable(nullable)
+            ? this.outer.GetNullableGetHasValueMemberRefForUserValueType(nullable)
+            : this.outer.wellKnown.GetNullableGetHasValueReference(nullable.UnderlyingType.ClrType);
+    }
+
+    private MemberReferenceHandle GetNullableValueRef(NullableTypeSymbol nullable)
+    {
+        return NullableLifting.IsUserValueTypeNullable(nullable)
+            ? this.outer.GetNullableGetValueMemberRefForUserValueType(nullable)
+            : this.outer.wellKnown.GetNullableGetValueReference(nullable.UnderlyingType.ClrType);
+    }
+
+    private void EmitUnwrappedNullableValue(int slot, NullableTypeSymbol nullable)
+    {
+        this.il.LoadLocalAddress(slot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(this.GetNullableValueRef(nullable));
+    }
+
+    // Dispatches the "both present" call to whichever carrier the node
+    // holds — op.Method (imported CLR type, e.g. DateTime.op_Equality) via
+    // reflection MemberRef, or op.Function (same-compilation struct
+    // operator, e.g. Meters.op_Equality) via the ordinary
+    // FunctionHandles/MethodHandles cache — mirroring the two-cache
+    // fallback used by every other same-compilation call site
+    // (EmitFunctionPointerFromMethod, BoundCallExpression emission).
+    // Generic same-compilation operator functions are out of scope for
+    // this lifted path (deferred follow-up).
+    private void EmitCallResolvedClrOrFunctionOperator(BoundClrBinaryOperatorExpression op)
+    {
+        if (op.Function != null)
+        {
+            if (!this.outer.cache.FunctionHandles.TryGetValue(op.Function, out var fnHandle)
+                && !this.outer.cache.MethodHandles.TryGetValue(op.Function, out fnHandle))
+            {
+                throw new InvalidOperationException(
+                    $"Lifted same-compilation operator '{op.Function.Name}' has no emitted MethodDef.");
+            }
+
+            if (op.Function.IsGeneric && !op.Function.TypeParameters.IsDefaultOrEmpty)
+            {
+                throw new NotSupportedException(
+                    $"Lifted same-compilation operator '{op.Function.Name}' is generic; MethodSpec construction for "
+                    + "a nullable-lifted generic operator call is not yet supported (deferred follow-up).");
+            }
+
+            this.il.OpCode(ILOpCode.Call);
+            this.il.Token(fnHandle);
+            return;
+        }
+
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(this.outer.GetMethodReference(op.Method));
     }
 
     private void EmitClrUnaryOperator(BoundClrUnaryOperatorExpression op)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -94,7 +94,7 @@ internal sealed partial class MethodBodyEmitter
     private readonly Dictionary<BoundBinaryExpression, int> nullableCoalesceSpillSlots;
     private readonly Dictionary<BoundExpression, int> indexAssignmentValueSlots;
     private readonly Dictionary<BoundGoStatement, BoundScopeStatement> goEnclosingScopes;
-    private readonly Dictionary<BoundBinaryExpression, LiftedBinarySlots> liftedBinarySlots;
+    private readonly Dictionary<BoundExpression, LiftedBinarySlots> liftedBinarySlots;
     private readonly ParameterSymbol structThisParameter;
     private readonly Lowering.Async.AsyncStateMachineFieldMap asyncFieldMap;
     private readonly Lowering.Async.AsyncStateMachinePlan asyncPlan;
@@ -153,7 +153,7 @@ internal sealed partial class MethodBodyEmitter
         Dictionary<BoundExpression, int> receiverSpillSlots,
         Dictionary<BoundExpression, int> indexAssignmentValueSlots,
         Dictionary<BoundGoStatement, BoundScopeStatement> goEnclosingScopes,
-        Dictionary<BoundBinaryExpression, LiftedBinarySlots> liftedBinarySlots = null,
+        Dictionary<BoundExpression, LiftedBinarySlots> liftedBinarySlots = null,
         Dictionary<BoundBinaryExpression, int> nullableCoalesceSpillSlots = null,
         ParameterSymbol structThisParameter = null,
         Lowering.Async.AsyncStateMachineFieldMap asyncFieldMap = null,
@@ -181,7 +181,7 @@ internal sealed partial class MethodBodyEmitter
         this.receiverSpillSlots = receiverSpillSlots;
         this.indexAssignmentValueSlots = indexAssignmentValueSlots;
         this.goEnclosingScopes = goEnclosingScopes;
-        this.liftedBinarySlots = liftedBinarySlots ?? new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
+        this.liftedBinarySlots = liftedBinarySlots ?? new Dictionary<BoundExpression, LiftedBinarySlots>();
         this.nullableCoalesceSpillSlots = nullableCoalesceSpillSlots ?? new Dictionary<BoundBinaryExpression, int>();
         this.structThisParameter = structThisParameter;
         this.asyncFieldMap = asyncFieldMap;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -338,7 +338,7 @@ internal sealed class MethodBodyPlanner
         Dictionary<BoundExpression, int> receiverSpillSlots,
         Dictionary<BoundExpression, int> indexAssignmentValueSlots,
         Dictionary<BoundGoStatement, BoundScopeStatement> goEnclosingScopes,
-        Dictionary<BoundBinaryExpression, LiftedBinarySlots> liftedBinarySlots,
+        Dictionary<BoundExpression, LiftedBinarySlots> liftedBinarySlots,
         Dictionary<BoundBinaryExpression, int> nullableCoalesceSpillSlots,
         InstructionEncoder il,
         Dictionary<BoundStackAllocExpression, int> stackAllocResultSlots = null)
@@ -653,11 +653,13 @@ internal sealed class MethodBodyPlanner
         // operators additionally need a Nullable<R>-typed result slot for
         // the null-branch `ldloca; initobj Nullable<R>; ldloc` shape;
         // equality / ordering operators return bool and need no result
-        // slot. The slot bundle is keyed by the BoundBinaryExpression
-        // node and stored in liftedBinarySlots so the emitter can look it
-        // up at lowering time. Skip nodes already owned by other
-        // collectors (NullCoalesce uses receiverSpillSlots) to avoid
-        // double allocation.
+        // slot. The slot bundle is keyed by the lifted expression node
+        // (a BoundBinaryExpression from the built-in operator table, or —
+        // issue #2388 — a BoundClrBinaryOperatorExpression from a
+        // nullable-lifted Stream C/D custom operator) and stored in
+        // liftedBinarySlots so the emitter can look it up at lowering time.
+        // Skip nodes already owned by other collectors (NullCoalesce uses
+        // receiverSpillSlots) to avoid double allocation.
         foreach (var lifted in this.CollectLiftedBinaryOperators(body))
         {
             if (liftedBinarySlots.ContainsKey(lifted))
@@ -665,23 +667,28 @@ internal sealed class MethodBodyPlanner
                 continue;
             }
 
+            var (liftedLeft, liftedRight, liftedType) = DecomposeLiftedBinary(lifted);
+
             var lhsSlot = localTypes.Count;
-            localTypes.Add(lifted.Left.Type);
+            localTypes.Add(liftedLeft.Type);
 
             // `value-type Nullable<T> == nil` / `!= nil` only needs an
             // LHS spill slot; the RHS is the `nil` literal (no temp
-            // required) and the result is bool (no result slot).
+            // required) and the result is bool (no result slot). Issue
+            // #2388: a lifted BoundClrBinaryOperatorExpression never has a
+            // `nil` RHS (see IsLiftedValueTypeClrBinary), so this branch is
+            // only ever taken for the built-in-operator-table shape.
             int rhsSlot = -1;
             int resultSlot = -1;
-            if (lifted.Right.Type != TypeSymbol.Null)
+            if (liftedRight.Type != TypeSymbol.Null)
             {
                 rhsSlot = localTypes.Count;
-                localTypes.Add(lifted.Right.Type);
+                localTypes.Add(liftedRight.Type);
 
-                if (lifted.Type is NullableTypeSymbol)
+                if (liftedType is NullableTypeSymbol)
                 {
                     resultSlot = localTypes.Count;
-                    localTypes.Add(lifted.Type);
+                    localTypes.Add(liftedType);
                 }
             }
 
@@ -1319,12 +1326,29 @@ internal sealed class MethodBodyPlanner
     // operand). Arithmetic / bitwise forms additionally need a
     // Nullable<R>-typed result slot so the null branch can initobj a
     // default Nullable<R> and load it as a value.
-    internal IEnumerable<BoundBinaryExpression> CollectLiftedBinaryOperators(BoundNode root)
+    //
+    // Issue #2388: widened to `BoundExpression` so a nullable-lifted Stream
+    // C/D `BoundClrBinaryOperatorExpression` (custom-equality operator on
+    // `Nullable<T>` operands) shares the same slot bundle as the built-in
+    // operator table's `BoundBinaryExpression` shape.
+    internal IEnumerable<BoundExpression> CollectLiftedBinaryOperators(BoundNode root)
     {
-        var sink = new List<BoundBinaryExpression>();
+        var sink = new List<BoundExpression>();
         this.slotPlanner.CollectLiftedBinaryOperators((BoundStatement)root, sink);
         return sink;
     }
+
+    // Issue #2388: a lifted binary node is either the built-in operator
+    // table's BoundBinaryExpression or a nullable-lifted Stream C/D
+    // BoundClrBinaryOperatorExpression; both shapes expose the same
+    // Left/Right/Type triple the slot allocator needs, but neither shares a
+    // common base-class accessor for Left/Right, so decompose explicitly.
+    private static (BoundExpression Left, BoundExpression Right, TypeSymbol Type) DecomposeLiftedBinary(BoundExpression lifted) => lifted switch
+    {
+        BoundBinaryExpression be => (be.Left, be.Right, be.Type),
+        BoundClrBinaryOperatorExpression ce => (ce.Left, ce.Right, ce.Type),
+        _ => throw new InvalidOperationException($"DecomposeLiftedBinary: unexpected lifted binary node kind '{lifted.Kind}'."),
+    };
 
     internal IEnumerable<BoundConversionExpression> CollectNullableNumericWideningConversions(BoundNode root)
     {

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -3933,7 +3933,7 @@ internal sealed class ReflectionMetadataEmitter
         private readonly Dictionary<BoundStackAllocExpression, int> stackAllocResultSlots = new();
         private readonly Dictionary<BoundExpression, int> indexAssignmentValueSlots = new();
         private readonly Dictionary<BoundGoStatement, BoundScopeStatement> goEnclosingScopes = new();
-        private readonly Dictionary<BoundBinaryExpression, LiftedBinarySlots> liftedBinarySlots = new();
+        private readonly Dictionary<BoundExpression, LiftedBinarySlots> liftedBinarySlots = new();
         private readonly Dictionary<BoundBinaryExpression, int> nullableCoalesceSpillSlots = new();
         private readonly Dictionary<VariableSymbol, object> constValues = new();
 
@@ -10189,6 +10189,54 @@ internal sealed class ReflectionMetadataEmitter
             name: this.emitCtx.Metadata.GetOrAddString("get_Value"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
         this.cache.NullableUserValueTypeGetValueMemberRefs[underlying] = handle;
+        return handle;
+    }
+
+    /// <summary>
+    /// Issue #2388: gets a MemberRef for
+    /// <c>System.Nullable`1&lt;T&gt;::get_HasValue()</c> where <c>T</c> is a
+    /// user-declared value type emitted in this assembly (a value-kind
+    /// <see cref="StructSymbol"/> or an <see cref="EnumSymbol"/>). Mirrors
+    /// <see cref="GetNullableGetValueMemberRefForUserValueType"/> exactly,
+    /// except the getter returns <c>bool</c> instead of <c>!0</c>. Needed to
+    /// HasValue-branch a nullable-lifted Stream C/D custom-operator call
+    /// (e.g. a same-compilation struct's <c>operator ==</c>) over
+    /// <c>Nullable&lt;UserStruct&gt;</c> operands, where no real CLR
+    /// <see cref="System.Type"/> exists at emit time to resolve the
+    /// reflection-based <see cref="WellKnownReferences.GetNullableGetHasValueReference"/>.
+    /// </summary>
+    /// <param name="nullableOfUserVt">A <c>Nullable&lt;T&gt;</c> over a user value type (enum or value struct).</param>
+    /// <returns>The <c>get_HasValue()</c> MemberRef.</returns>
+    internal MemberReferenceHandle GetNullableGetHasValueMemberRefForUserValueType(NullableTypeSymbol nullableOfUserVt)
+    {
+        if (nullableOfUserVt == null || !NullableLifting.RequiresSymbolicNullableGetValue(nullableOfUserVt))
+        {
+            throw new InvalidOperationException(
+                "GetNullableGetHasValueMemberRefForUserValueType requires Nullable<user enum, value struct, or struct-constrained type parameter>.");
+        }
+
+        var underlying = nullableOfUserVt.UnderlyingType;
+        if (this.cache.NullableUserValueTypeGetHasValueMemberRefs.TryGetValue(underlying, out var cached))
+        {
+            return cached;
+        }
+
+        var parentBlob = new BlobBuilder();
+        this.EncodeTypeSymbol(new BlobEncoder(parentBlob).TypeSpecificationSignature(), nullableOfUserVt);
+        var parent = this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(parentBlob));
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                parameterCount: 0,
+                returnType: r => r.Type().Boolean(),
+                parameters: _ => { });
+
+        var handle = this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString("get_HasValue"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        this.cache.NullableUserValueTypeGetHasValueMemberRefs[underlying] = handle;
         return handle;
     }
 

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -178,7 +178,12 @@ internal sealed class SlotPlanner
     public void CollectNullableValueTypeCoalesces(BoundStatement root, List<BoundBinaryExpression> sink)
         => new NullableValueTypeCoalesceCollector(sink).Visit(root);
 
-    public void CollectLiftedBinaryOperators(BoundStatement root, List<BoundBinaryExpression> sink)
+    // Issue #2388: widened from `List<BoundBinaryExpression>` to
+    // `List<BoundExpression>` so the same collector/slot machinery also
+    // catches a nullable-lifted `BoundClrBinaryOperatorExpression` (Stream
+    // C/D custom-equality operators on `Nullable<T>` operands), not just the
+    // built-in operator table's `BoundBinaryExpression` shape.
+    public void CollectLiftedBinaryOperators(BoundStatement root, List<BoundExpression> sink)
         => new LiftedBinaryOperatorCollector(sink).Visit(root);
 
     public void CollectNullableNumericWideningConversions(BoundStatement root, List<BoundConversionExpression> sink)
@@ -1513,9 +1518,9 @@ internal sealed class SlotPlanner
     // per-node slot bundle.
     private sealed class LiftedBinaryOperatorCollector : BoundTreeWalker
     {
-        private readonly List<BoundBinaryExpression> sink;
+        private readonly List<BoundExpression> sink;
 
-        public LiftedBinaryOperatorCollector(List<BoundBinaryExpression> sink)
+        public LiftedBinaryOperatorCollector(List<BoundExpression> sink)
         {
             this.sink = sink;
         }
@@ -1528,6 +1533,40 @@ internal sealed class SlotPlanner
             }
 
             base.VisitBinaryExpression(node);
+        }
+
+        // Issue #2388: a Stream C/D custom-operator call
+        // (BoundClrBinaryOperatorExpression) needs the identical LhsSlot /
+        // RhsSlot spill-and-HasValue-branch treatment as the built-in
+        // operator table's BoundBinaryExpression above when its operands
+        // were nullable-lifted by TryLiftNullableClrOperatorOperands (both
+        // sides converted to a matching Nullable<T>). Sharing the sink /
+        // slot dictionary lets EmitClrBinaryOperator reuse the exact same
+        // LiftedBinarySlots lookup as EmitBinary.
+        protected override void VisitClrBinaryOperatorExpression(BoundClrBinaryOperatorExpression node)
+        {
+            if (IsLiftedValueTypeClrBinary(node))
+            {
+                this.sink.Add(node);
+            }
+
+            base.VisitClrBinaryOperatorExpression(node);
+        }
+
+        private static bool IsLiftedValueTypeClrBinary(BoundClrBinaryOperatorExpression node)
+        {
+            // The binder only ever produces this node with BOTH operands
+            // already Nullable<T>-converted when lifting applies (mixed-mode
+            // wraps the bare side); a plain (non-lifted) Stream C/D call site
+            // never has a NullableTypeSymbol operand at all. Nil comparisons
+            // (`T? == nil`) never reach Stream C/D in the first place — the
+            // built-in IsNullCompare arm binds those directly as a plain
+            // BoundBinaryExpression before Stream C/D is even attempted — so
+            // there is no Form-2 "nil" case to mirror here, unlike
+            // IsLiftedValueTypeBinary above.
+            return node.Left.Type is NullableTypeSymbol left
+                && (left.UnderlyingType?.ClrType is { IsValueType: true } || left.UnderlyingType is StructSymbol)
+                && node.Right.Type is NullableTypeSymbol;
         }
 
         private static bool IsLiftedValueTypeBinary(BoundBinaryExpression node)

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -2382,6 +2382,20 @@ public sealed class Evaluator
 
     private object EvaluateClrBinaryOperatorExpression(BoundClrBinaryOperatorExpression node)
     {
+        // Issue #2388: the nullable-lifted same-compilation struct operator
+        // shape (Function set, Method null) needs the same HasValue-branch
+        // lifting semantics as the IL emitter's EmitLiftedNullableClrBinary;
+        // the tree-walking interpreter does not implement that lifting, so
+        // fail loudly rather than silently invoking the unlifted operator on
+        // a boxed Nullable<T>. The compiled (gsc-emitted) path is unaffected
+        // — this only affects direct BoundTree interpretation via Evaluator.
+        if (node.Function != null)
+        {
+            throw new NotSupportedException(
+                "Evaluator: nullable-lifted same-compilation user operator calls (issue #2388) are not supported by "
+                + "the tree-walking interpreter; compile and run instead.");
+        }
+
         var left = EvaluateExpression(node.Left);
         var right = EvaluateExpression(node.Right);
         return node.Method.Invoke(null, new[] { left, right });

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -502,11 +502,16 @@ public static class SpillSequenceSpiller
                         clrPropAssign.Value,
                         (recv, val) => new BoundClrPropertyAssignmentExpression(null, recv, clrPropAssign.Member, val, clrPropAssign.Type));
                 case BoundClrBinaryOperatorExpression clrBinary:
+                    // Issue #2388: preserve whichever of Method (imported CLR
+                    // type) / Function (nullable-lifted same-compilation
+                    // struct operator) the original node carried.
                     return SpillTwoOperand(
                         clrBinary,
                         clrBinary.Left,
                         clrBinary.Right,
-                        (l, r) => new BoundClrBinaryOperatorExpression(null, clrBinary.OperatorKind, l, r, clrBinary.Method, clrBinary.Type));
+                        (l, r) => clrBinary.Function != null
+                            ? new BoundClrBinaryOperatorExpression(null, clrBinary.OperatorKind, l, r, clrBinary.Function, clrBinary.Type)
+                            : new BoundClrBinaryOperatorExpression(null, clrBinary.OperatorKind, l, r, clrBinary.Method, clrBinary.Type));
                 case BoundClrUnaryOperatorExpression clrUnary:
                     return SpillOneOperand(
                         clrUnary,

--- a/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
@@ -885,6 +885,22 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
         BoundClrBinaryOperatorExpression expression,
         Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
     {
+        // Issue #2388: the nullable-lifted same-compilation struct operator
+        // shape (Function set, Method null) has no reflection MethodInfo
+        // available at lowering time (the declaring struct's operator is
+        // still TypeBuilder-backed) — the `Expression.Equal`/`Expression.Add`
+        // etc. factories all require an actual MethodInfo for a user-defined
+        // operator overload, so this shape cannot yet be lowered into an
+        // expression tree. The imported-CLR-type shape (Method set) is
+        // unaffected: `Expression.Equal(nullableLeft, nullableRight, false,
+        // method)` already performs the Nullable<T> unwrap/lift itself at
+        // expression-tree-compile time, so no change is needed there.
+        if (expression.Method == null)
+        {
+            throw new NotSupportedException(
+                "Expression trees do not yet support a nullable-lifted same-compilation user operator call (issue #2388).");
+        }
+
         var methodName = expression.OperatorKind switch
         {
             SyntaxKind.PlusToken => nameof(System.Linq.Expressions.Expression.Add),

--- a/test/Compiler.Tests/Emit/Issue2388NullableCustomEqualityEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2388NullableCustomEqualityEmitTests.cs
@@ -1,0 +1,520 @@
+// <copyright file="Issue2388NullableCustomEqualityEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2388 — real-assembly, IL-verification and runtime-execution level
+/// regression coverage for <c>Nullable&lt;T&gt;</c> comparisons where the
+/// underlying <c>T</c> has custom equality/ordering. Before the fix,
+/// <c>ClrOperatorResolution</c>'s CLR <c>op_*</c> lookup (Stream C) matched
+/// on <see cref="TypeSymbol.ClrType"/>, which for a
+/// <c>NullableTypeSymbol</c>-wrapped value type is already the UNDERLYING
+/// CLR type (see <c>NullableTypeSymbol</c>'s constructor). So
+/// <c>DateTime? == DateTime?</c> "successfully" resolved
+/// <c>DateTime.op_Equality(DateTime, DateTime)</c> while leaving the bound
+/// operands <c>Nullable&lt;DateTime&gt;</c>-typed, and the emitter naively
+/// pushed both raw <c>Nullable&lt;T&gt;</c> operands and called the resolved
+/// method directly — producing invalid IL (ilverify
+/// <c>StackUnexpected</c>: found <c>Nullable&lt;DateTime&gt;</c>, expected
+/// <c>DateTime</c>). A parallel same-compilation-struct gap (Stream D)
+/// reported a false compile-time GS0129 for <c>T? == T?</c> instead, because
+/// the struct-operator lookup never unwrapped the nullable wrapper before
+/// checking <c>is StructSymbol</c>.
+///
+/// These tests cover both root causes end to end: a real BCL value type with
+/// custom equality (<c>DateTime</c>), a real BCL value type with equality
+/// only (<c>Guid</c>, no ordering operators), a REAL, separately
+/// C#-compiled ("imported") struct with custom equality (mirroring an
+/// EF Core / Oahu-style strongly-typed-ID sibling), and a same-compilation
+/// G# struct's user-defined operator (Stream D), plus negative/regression
+/// controls proving the fix is scoped correctly.
+/// </summary>
+public class Issue2388NullableCustomEqualityEmitTests
+{
+    [Fact]
+    public void DateTimeNullable_Equality_EqualValues_ReturnsTrueAndVerifies()
+    {
+        var source = """
+            package DtEqPkg
+            import System
+
+            let a DateTime? = DateTime(2020, 1, 1)
+            let b DateTime? = DateTime(2020, 1, 1)
+            Console.WriteLine(a == b)
+            """;
+
+        Assert.Equal("True\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DateTimeNullable_Equality_DifferentValues_ReturnsFalse()
+    {
+        var source = """
+            package DtEqNePkg
+            import System
+
+            let a DateTime? = DateTime(2020, 1, 1)
+            let b DateTime? = DateTime(2021, 1, 1)
+            Console.WriteLine(a == b)
+            """;
+
+        Assert.Equal("False\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DateTimeNullable_Inequality_ReturnsExpected()
+    {
+        var source = """
+            package DtNeqPkg
+            import System
+
+            let a DateTime? = DateTime(2020, 1, 1)
+            let b DateTime? = DateTime(2021, 1, 1)
+            let c DateTime? = DateTime(2020, 1, 1)
+            Console.WriteLine(a != b)
+            Console.WriteLine(a != c)
+            """;
+
+        Assert.Equal("True\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DateTimeNullable_HasValueMismatch_EqualityIsFalse_InequalityIsTrue()
+    {
+        var source = """
+            package DtMismatchPkg
+            import System
+
+            let a DateTime? = DateTime(2020, 1, 1)
+            let n DateTime? = nil
+            Console.WriteLine(a == n)
+            Console.WriteLine(n == a)
+            Console.WriteLine(a != n)
+            Console.WriteLine(n != a)
+            """;
+
+        Assert.Equal("False\nFalse\nTrue\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DateTimeNullable_BothNil_EqualityIsTrue_InequalityIsFalse()
+    {
+        var source = """
+            package DtBothNilPkg
+            import System
+
+            let a DateTime? = nil
+            let b DateTime? = nil
+            Console.WriteLine(a == b)
+            Console.WriteLine(a != b)
+            """;
+
+        Assert.Equal("True\nFalse\n", CompileAndRun(source));
+    }
+
+    [Theory]
+    [InlineData("<", true)]
+    [InlineData("<=", true)]
+    [InlineData(">", false)]
+    [InlineData(">=", false)]
+    public void DateTimeNullable_Ordering_AllFourOperators_ReturnsCorrectResult(string op, bool expected)
+    {
+        var source = $$"""
+            package DtOrdPkg
+            import System
+
+            let a DateTime? = DateTime(2020, 1, 1)
+            let b DateTime? = DateTime(2021, 1, 1)
+            Console.WriteLine(a {{op}} b)
+            """;
+
+        Assert.Equal(expected ? "True\n" : "False\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DateTimeNullable_Ordering_AnyMissingOperand_IsFalse()
+    {
+        var source = """
+            package DtOrdNilPkg
+            import System
+
+            let a DateTime? = DateTime(2020, 1, 1)
+            let n DateTime? = nil
+            Console.WriteLine(a < n)
+            Console.WriteLine(n < a)
+            Console.WriteLine(n < n)
+            """;
+
+        Assert.Equal("False\nFalse\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DateTimeNullable_MixedModeAgainstNonNullable_BothOrders_ReturnTrue()
+    {
+        var source = """
+            package DtMixedPkg
+            import System
+
+            let a DateTime? = DateTime(2020, 1, 1)
+            let b DateTime = DateTime(2020, 1, 1)
+            Console.WriteLine(a == b)
+            Console.WriteLine(b == a)
+            """;
+
+        Assert.Equal("True\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GuidNullable_EqualityAndInequality_ReturnCorrectResults()
+    {
+        var source = """
+            package GuidEqPkg
+            import System
+
+            let g1 Guid? = Guid.Empty
+            let g2 Guid? = Guid.Empty
+            let g3 Guid? = nil
+            Console.WriteLine(g1 == g2)
+            Console.WriteLine(g1 == g3)
+            Console.WriteLine(g1 != g3)
+            """;
+
+        Assert.Equal("True\nFalse\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void SameCompilationStruct_NullableEquality_StreamD_ReturnsCorrectResults()
+    {
+        // Directly-related deferred-work control called out by the issue:
+        // a same-compilation struct's user-defined operator (Stream D) is
+        // resolved via TypeMemberModel against the (TypeBuilder-backed,
+        // ClrType-less) StructSymbol — before the fix this reported a
+        // compile-time GS0129 for `Meters? == Meters?` because the lookup
+        // never unwrapped the nullable wrapper.
+        var source = """
+            package MetersEqPkg
+
+            struct Meters(Value float64) {
+            }
+
+            func (a Meters) operator ==(b Meters) bool -> a.Value == b.Value
+            func (a Meters) operator !=(b Meters) bool -> !(a == b)
+
+            let a Meters? = Meters{Value: 1.0}
+            let b Meters? = Meters{Value: 1.0}
+            let c Meters? = Meters{Value: 2.0}
+            let n Meters? = nil
+            Console.WriteLine(a == b)
+            Console.WriteLine(a == c)
+            Console.WriteLine(a != c)
+            Console.WriteLine(a == n)
+            Console.WriteLine(n == n)
+            """;
+
+        Assert.Equal("True\nFalse\nTrue\nFalse\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void SameCompilationStruct_WithoutUserOperator_NullableEquality_StillReportsGS0129()
+    {
+        var (exitCode, stdout, _) = TryCompile("""
+            package PlainNoOpPkg
+
+            struct Plain(Value float64) {
+            }
+
+            func F(a Plain?, b Plain?) bool {
+                return a == b
+            }
+            """);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0129", stdout);
+    }
+
+    [Fact]
+    public void CSharpImportedStructWithCustomEquality_NullableComparison_RunsAndVerifies()
+    {
+        // The issue's explicit "small C# sibling struct" ask: a REAL,
+        // separately C#-compiled struct (mirroring an EF Core / Oahu-style
+        // strongly-typed-ID or value object) with custom `==`/`!=`,
+        // consumed as `Nullable<T>` from G# exactly like the DateTime/Guid
+        // BCL cases above but through the imported-metadata path.
+        var libraryPath = EmitCSharpLibrary(
+            nameof(CSharpImportedStructWithCustomEquality_NullableComparison_RunsAndVerifies),
+            """
+            namespace Lib
+            {
+                public readonly struct Meters
+                {
+                    public double Value { get; }
+                    public Meters(double value) => Value = value;
+                    public static bool operator ==(Meters a, Meters b) => System.Math.Abs(a.Value - b.Value) < 0.0001;
+                    public static bool operator !=(Meters a, Meters b) => !(a == b);
+                    public override bool Equals(object obj) => obj is Meters m && m == this;
+                    public override int GetHashCode() => Value.GetHashCode();
+                }
+            }
+            """);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        var consumerAssemblyName = "Issue2388Emit.Consumer";
+        var consumerPath = Path.Combine(LibraryDirectory(), consumerAssemblyName + ".dll");
+        var consumer = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(
+                """
+                package Demo
+                import Lib
+                import System
+
+                func Eq(a Meters?, b Meters?) bool {
+                    return a == b
+                }
+                func NotEq(a Meters?, b Meters?) bool {
+                    return a != b
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var peStream = File.Create(consumerPath))
+        {
+            var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: consumerAssemblyName);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
+
+        var libraryAsm = Assembly.LoadFrom(libraryPath);
+        var consumerAsm = Assembly.LoadFrom(consumerPath);
+        var metersType = libraryAsm.GetTypes().Single(t => t.Name == "Meters");
+        var programType = consumerAsm.GetTypes().Single(t => t.Name == "<Program>");
+
+        var eqMethod = programType.GetMethod("Eq", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        var neqMethod = programType.GetMethod("NotEq", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(eqMethod);
+        Assert.NotNull(neqMethod);
+
+        var nullableMetersType = typeof(Nullable<>).MakeGenericType(metersType);
+        var m1 = Activator.CreateInstance(metersType, 1.0);
+        var m2 = Activator.CreateInstance(metersType, 1.0);
+        var m3 = Activator.CreateInstance(metersType, 2.0);
+        var n = Activator.CreateInstance(nullableMetersType);
+
+        Assert.Equal(true, eqMethod!.Invoke(null, new[] { WrapNullable(nullableMetersType, m1), WrapNullable(nullableMetersType, m2) }));
+        Assert.Equal(false, eqMethod.Invoke(null, new[] { WrapNullable(nullableMetersType, m1), WrapNullable(nullableMetersType, m3) }));
+        Assert.Equal(false, eqMethod.Invoke(null, new[] { WrapNullable(nullableMetersType, m1), n }));
+        Assert.Equal(true, neqMethod!.Invoke(null, new[] { WrapNullable(nullableMetersType, m1), n }));
+    }
+
+    private static object WrapNullable(Type nullableType, object value)
+    {
+        return Activator.CreateInstance(nullableType, value)!;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2388_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) TryCompile(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2388_neg_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            return (compileExit, compileOut.ToString(), compileErr.ToString());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string LibraryDirectory()
+    {
+        var dir = Path.Combine(AppContext.BaseDirectory, "Issue2388Emit");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string EmitCSharpLibrary(string caseName, string csharpSource)
+    {
+        var outputDir = Path.Combine(LibraryDirectory(), caseName);
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "CSharpLib2388.dll");
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(csharpSource, new CSharpParseOptions(LanguageVersion.Latest));
+
+        var referencePaths = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+            ?.Split(Path.PathSeparator)
+            ?? Array.Empty<string>();
+
+        var references = referencePaths
+            .Where(File.Exists)
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "CSharpLib2388",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var emitResult = compilation.Emit(peStream);
+            Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+        }
+
+        return libraryPath;
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2388NullableCustomEqualityBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2388NullableCustomEqualityBinderTests.cs
@@ -1,0 +1,197 @@
+// <copyright file="Issue2388NullableCustomEqualityBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2388: <c>Nullable&lt;T&gt;</c> comparisons where <c>T</c> is an
+/// imported CLR value type with custom equality (<c>DateTime</c>,
+/// <c>Guid</c>) previously bound "successfully" against
+/// <c>ClrOperatorResolution</c>'s CLR-type match (Stream C) even though the
+/// bound operands stayed <c>Nullable&lt;T&gt;</c>-typed — the CLR type match
+/// only inspects <see cref="TypeSymbol.ClrType"/>, which for
+/// <see cref="NullableTypeSymbol"/> is already the UNDERLYING type. The
+/// resulting <c>BoundClrBinaryOperatorExpression</c> then emitted invalid IL
+/// (ilverify <c>StackUnexpected</c>) at the CALL site, not the BIND site — so
+/// these tests assert the binder produces clean diagnostics for the
+/// nullable-lifted shapes (proving the binder itself now recognizes and
+/// lifts them) while a same-compilation struct WITHOUT a user operator still
+/// correctly reports GS0129 (proving the fix does not make every value type
+/// universally nullable-comparable). Method bodies are bound but never
+/// invoked — this is pure binder coverage, independent of the tree-walking
+/// Evaluator (which does not implement nullable-lifting semantics for the
+/// same-compilation Function-carrying node shape; see
+/// Issue2388NullableCustomEqualityEmitTests for the compiled/run/ILVerify
+/// coverage that exercises the actual lifted comparisons).
+/// </summary>
+public class Issue2388NullableCustomEqualityBinderTests
+{
+    [Fact]
+    public void DateTimeNullable_Equality_BindsClean()
+    {
+        var source = @"
+import System
+func F(a DateTime?, b DateTime?) bool {
+    return a == b
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void DateTimeNullable_Inequality_BindsClean()
+    {
+        var source = @"
+import System
+func F(a DateTime?, b DateTime?) bool {
+    return a != b
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Theory]
+    [InlineData("<")]
+    [InlineData("<=")]
+    [InlineData(">")]
+    [InlineData(">=")]
+    public void DateTimeNullable_Ordering_BindsClean(string op)
+    {
+        var source = $@"
+import System
+func F(a DateTime?, b DateTime?) bool {{
+    return a {op} b
+}}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void DateTimeNullable_MixedModeAgainstNonNullable_BindsClean()
+    {
+        var source = @"
+import System
+func F(a DateTime?, b DateTime) bool {
+    return a == b
+}
+func G(a DateTime, b DateTime?) bool {
+    return a == b
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void DateTimeNullable_AgainstNil_StillBindsCleanViaExistingIsNullCompareArm()
+    {
+        // Not touched by this fix (IsNullCompare fires before Stream C/D is
+        // ever reached) — regression guard proving the new lifting logic
+        // doesn't interfere with it.
+        var source = @"
+import System
+func F(a DateTime?) bool {
+    return a == nil
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void GuidNullable_EqualityAndInequality_BindClean()
+    {
+        var source = @"
+import System
+func F(a Guid?, b Guid?) bool {
+    return a == b
+}
+func G(a Guid?, b Guid?) bool {
+    return a != b
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void SameCompilationStruct_NullableEquality_StreamD_BindsClean()
+    {
+        // Issue #2388 "directly related deferred work" control: a
+        // same-compilation struct's user-defined operator (Stream D) is
+        // resolved via TypeMemberModel against the struct symbol; before
+        // this fix, `T? == T?` never unwrapped the NullableTypeSymbol
+        // before the `is StructSymbol` check and always reported GS0129
+        // even though the struct DOES declare `operator ==`.
+        var source = @"
+struct Meters(Value float64) {
+}
+
+func (a Meters) operator ==(b Meters) bool -> a.Value == b.Value
+func (a Meters) operator !=(b Meters) bool -> !(a == b)
+
+func F(a Meters?, b Meters?) bool {
+    return a == b
+}
+func G(a Meters?, b Meters?) bool {
+    return a != b
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void SameCompilationStruct_WithoutUserOperator_NullableEquality_StillReportsGS0129()
+    {
+        // Negative control: the fix only unwraps NullableTypeSymbol to find
+        // an EXISTING user operator — it must not fabricate equality for a
+        // struct that never declared one.
+        var source = @"
+struct Plain(Value float64) {
+}
+
+func F(a Plain?, b Plain?) bool {
+    return a == b
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0129");
+    }
+
+    [Fact]
+    public void SameCompilationStruct_NonNullableEquality_StillBindsClean_Regression()
+    {
+        // Regression guard: the non-nullable Stream D call path (plain
+        // BoundCallExpression, untouched by this fix) still binds.
+        var source = @"
+struct MetersB(Value float64) {
+}
+
+func (a MetersB) operator ==(b MetersB) bool -> a.Value == b.Value
+
+func F(a MetersB, b MetersB) bool {
+    return a == b
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    private static void AssertNoErrors(EvaluationResult result)
+    {
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2388: `Nullable<T>` comparisons where the underlying CLR struct `T` has custom equality (e.g. `DateTime`, `Guid`, or a same-compilation struct with a user-defined `==`/`!=`) previously emitted invalid IL — ILVerify reported `StackUnexpected` for imported CLR types (Stream C), and same-compilation structs with a genuine custom operator incorrectly hit a false `GS0129` (Stream D), because the nullable wrapper was never unwrapped before operator resolution.

## Root cause

- **Stream C (imported CLR operators):** `NullableTypeSymbol.ClrType` returns the *underlying* (non-nullable) type by design. `ClrOperatorResolution.TryResolveBinary` used this to spuriously match e.g. `DateTime.op_Equality(DateTime, DateTime)` against `Nullable<DateTime>`-typed operands with no lifting awareness — the emitted call sequence pushed two `Nullable<DateTime>` values onto a stack expecting two `DateTime` values, producing `StackUnexpected`.
- **Stream D (same-compilation struct operators):** same-compilation `StructSymbol`s have no CLR `Type` at bind time, so the check `left.Type is StructSymbol` failed whenever `left.Type` was `NullableTypeSymbol`-wrapped, causing a bind failure (`GS0129`) even when the struct legitimately defines a custom `==`/`!=` operator.

## Fix

Generalizes the existing lifted-binary infrastructure — previously scoped only to the built-in operator table (`BoundBinaryExpression` / `liftedBinarySlots` / `LiftedBinaryOperatorCollector`) — to also cover the CLR/user-operator resolution path:

- `BoundClrBinaryOperatorExpression` now optionally carries a `FunctionSymbol` (same-compilation) alongside the existing `MethodInfo` (imported CLR), giving both resolution streams one unified lifted node shape.
- `ExpressionBinder.Operators.cs` unwraps `Nullable<T>` operands before Stream C/D resolution and re-wraps the result, tracking liftedness.
- `SlotPlanner`/`MethodBodyPlanner` widen lifted-binary collection and slot allocation to also visit `BoundClrBinaryOperatorExpression` nodes.
- `MethodBodyEmitter.Operators.cs` emits the `HasValue`-guarded lifted comparison/arithmetic sequence for both imported-CLR and same-compilation operators. All six comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) share one generalized comparison-emission helper, since (unlike the built-in operator table) each operator token resolves to its own distinct CLR operator method name — there's no need to negate `==` to synthesize `!=`.
- `ReflectionMetadataEmitter`/`MetadataTokenCache` gain a `Nullable<UserStruct>::get_HasValue()` MemberRef builder mirroring the existing `get_Value()` helper, needed to check `HasValue` on a same-compilation struct wrapped in `Nullable<T>`.

No EF/Oahu-specific logic — the fix is fully generalized across imported and same-compilation struct operators.

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue2388NullableCustomEqualityBinderTests.cs` — 12 binder-level tests: `DateTime?`/`Guid?` equality, inequality, all four ordering operators, mixed nullable/non-nullable operand order, nil comparisons, a same-compilation custom-operator struct (positive Stream D control), and a struct *without* an operator (negative `GS0129` control).
- `test/Compiler.Tests/Emit/Issue2388NullableCustomEqualityEmitTests.cs` — 15 compile+run+ILVerify tests: all six comparison operators (`[Theory]`), `HasValue`-mismatch and both-nil edge cases, mixed-mode operand order, a same-compilation struct positive control, a `GS0129` negative control, and — per the issue's explicit ask — a **real C#-compiled sibling struct** with custom `==`/`!=` consumed via `Nullable<T>` from G# through `ReferenceResolver`.

## Validation

- `dotnet build GSharp.sln -c Debug`: **0 warnings, 0 errors**.
- `Core.Tests`: 6316 passed, 1 skipped (pre-existing baseline-regen skip), 0 failed.
- `Compiler.Tests`: 3130 passed, 0 failed.
- `InternalAnalyzers.Tests`: 7 passed, 0 failed.
- `Cs2Gs.Tests` (serialized, `xunit.parallelizeAssembly=false xunit.parallelizeTestCollections=false`): 1423 passed, 0 failed (one run hit the known shared-environment "Test host process crashed" flake; retry passed clean).
- Branch incorporates latest `origin/main` at `313bc0f4` (merge, no conflicts) — `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`.

## Deferred work — enumerated as distinct, issue-ready repros/subsystems

None of these are required for #2388 (equality/ordering lifting) and none were fixed here, per scope. Each was independently reproduced against this branch (`GS_DEBUG_STACK=1` for stack traces) so they are ready to be filed as standalone follow-up issues:

1. **Tree-walking interpreter (`Evaluator`) does not lift same-compilation nullable operators.**
   Subsystem: `src/Core/CodeAnalysis/Evaluator.cs` (`EvaluateClrBinaryOperatorExpression`).
   Repro (via `gsi`/`SessionEngine`, not `gsc`):
   ```
   struct Meters(Value float64) {}
   func (a Meters) operator ==(b Meters) bool -> a.Value == b.Value
   var x Meters? = Meters{Value: 1.0}
   var y Meters? = Meters{Value: 1.0}
   var r bool = x == y
   ```
   Currently throws `NotSupportedException: Evaluator: nullable-lifted same-compilation user operator calls (issue #2388) are not supported by the tree-walking interpreter; compile and run instead.` The compiled (gsc-emitted) path is unaffected — only direct BoundTree interpretation hits this.

2. **`ExpressionTreeLowerer` cannot lower same-compilation nullable-lifted operators into `Expression<>` trees.**
   Subsystem: `src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs` (`BuildClrBinaryOperatorExpression`).
   Repro (`gsc`, with `System.Linq.Expressions` referenced):
   ```
   package deferredExprTree
   import System
   import System.Linq.Expressions

   struct Meters(Value float64) {}
   func (a Meters) operator ==(b Meters) bool -> a.Value == b.Value

   func Predicate() Expression[Func[Meters?, Meters?, bool]] {
       return (a Meters?, b Meters?) -> a == b
   }
   ```
   Currently throws `NotSupportedException: Expression trees do not yet support a nullable-lifted same-compilation user operator call (issue #2388).` The imported-CLR (`Method`-set) shape is unaffected: `Expression.Equal(left, right, false, method)` already performs its own lift at expression-tree-compile time.

3. **Same-compilation lifted arithmetic/bitwise operators are unsupported.**
   Subsystem: `src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs` (`EmitLiftedNullableClrBinary` → arithmetic branch).
   Repro (`gsc`):
   ```
   package deferredArith
   struct Meters(Value float64) {}
   func (a Meters) operator +(b Meters) Meters -> Meters{Value: a.Value + b.Value}
   func Main() {
       var a Meters? = Meters{Value: 1.0}
       var b Meters? = Meters{Value: 2.0}
       var c Meters? = a + b
   }
   ```
   Currently throws `NotSupportedException: Lifted same-compilation arithmetic/bitwise operator 'PlusToken' on 'op_Addition' is not yet supported (issue #2388 scoped equality/ordering lifting; symbolic Nullable<R> construction for a same-compilation result type is deferred follow-up work).` Imported-CLR arithmetic operators (e.g. `DateTime.op_Subtraction`) ARE fully supported by this fix.

4. **Generic same-compilation operator functions in the lifted path are unsupported — blocked by an unrelated, pre-existing defect.**
   Subsystem: `src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs` (`EmitCallResolvedClrOrFunctionOperator`, `op.Function.IsGeneric` branch).
   While attempting to reproduce this gap directly, a **separate, pre-existing bug** (unrelated to #2388, confirmed present and unmodified by this PR's diff) was found: declaring a receiver-style operator on a *generic* same-compilation struct crashes the binder with an unhandled `NullReferenceException`, even with no nullable involved at all:
   ```
   struct Box<T>(Value T) {}
   func (a Box<T>) operator ==(b Box<T>) bool -> true
   func Main() {
       var a Box<int32> = Box<int32>{Value: 1}
       var b Box<int32> = Box<int32>{Value: 2}
       var r bool = a == b
   }
   ```
   fails with `GS9998: NullReferenceException` at `DeclarationBinder.BindFunctionDeclaration` (`src/Core/CodeAnalysis/Binding/DeclarationBinder.cs:6821`), fully independent of nullable-lifting. This means the nullable-lifted generic-operator gap (`MethodSpec` construction, guarded by `NotSupportedException` in this PR) cannot even be exercised until that more fundamental generic-receiver-operator binding defect is fixed first. Recommend filing/triaging the `DeclarationBinder` NRE as its own issue before attempting the generic-lifted-operator follow-up.

Closes #2388
