### PR TITLE
Fix target-type inference for untyped lambdas against imported CLR delegates/events

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -211,6 +211,25 @@ internal sealed partial class ExpressionBinder
             return BindExpression(syntax, targetType);
         }
 
+        // Issue #2389: an untyped arrow-lambda RHS (`f = (s, e) -> ...`)
+        // needs its omitted parameter types resolved from the LHS's declared
+        // delegate/function-type shape *before* binding, exactly like a
+        // `let`/`var` declaration initializer already does (StatementBinder)
+        // — otherwise re-assigning a previously-declared delegate-typed
+        // variable/field with an untyped lambda reports GS0304 even though
+        // the identical lambda works fine as the declaration's own
+        // initializer. Reuse the shared delegate-target-type resolver
+        // (issue #889) so this covers native G# function types,
+        // user-declared named delegates, and imported CLR delegates
+        // uniformly; the conversion performed by the caller below still
+        // reshapes the result to the exact target type.
+        if (targetType != null
+            && syntax is LambdaExpressionSyntax lambdaSyntax
+            && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(targetType, out var lambdaTargetFunctionType))
+        {
+            return lambdas.BindLambdaExpression(lambdaSyntax, lambdaTargetFunctionType);
+        }
+
         return BindExpression(syntax);
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -347,7 +347,31 @@ internal sealed partial class ExpressionBinder
             return BindEventSubscriptionHandlerFromBoundAccessor(memberAccess, boundReceiver, targetDelegateType);
         }
 
-        var bound = BindExpression(handlerSyntax);
+        // Issue #2389: an untyped arrow-lambda handler (`Event += (s, e) ->
+        // ...`) must have its omitted parameter types (and, where the body
+        // doesn't already pin one down, its return type) resolved from the
+        // event's declared delegate/function-type shape *before* binding —
+        // mirroring the target-typed lambda inference already applied to
+        // ordinary call arguments and assignments (ADR-0076 / issue #716).
+        // Without this, the fallback `BindExpression(handlerSyntax)` just
+        // below binds the lambda with no target context at all, so any
+        // omitted parameter type reports GS0304 regardless of whether the
+        // event's delegate is a same-compilation function type, a
+        // user-declared named delegate, or an IMPORTED CLR delegate (the
+        // shape reported in #2389 — a typed lambda or a source-defined
+        // delegate shape masked the gap because both already carry/receive
+        // concrete parameter types some other way). Reuse the shared
+        // delegate-target-type resolver (issue #889 /
+        // `MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol`) so this
+        // covers native G# function types, user-declared named delegates,
+        // and imported CLR delegates/events uniformly; the result still
+        // flows through the identical post-bind conversion (issue #2066)
+        // below so the produced literal is reshaped to the event's exact
+        // declared delegate type.
+        var bound = handlerSyntax is LambdaExpressionSyntax lambdaHandlerSyntax
+            && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(targetDelegateType, out var lambdaTargetFunctionType)
+                ? lambdas.BindLambdaExpression(lambdaHandlerSyntax, lambdaTargetFunctionType)
+                : BindExpression(handlerSyntax);
 
         if (bound is BoundClrMethodGroupExpression clrGroup && clrGroup.ResolvedMethod == null)
         {

--- a/test/Compiler.Tests/Emit/Issue2389ImportedDelegateLambdaEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2389ImportedDelegateLambdaEmitTests.cs
@@ -1,0 +1,554 @@
+// <copyright file="Issue2389ImportedDelegateLambdaEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2389: an untyped arrow-lambda handler (<c>Event += (s, e) -&gt;
+/// ...</c>) used against an IMPORTED CLR delegate/event failed target-type
+/// inference with GS0304 ("cannot infer the type of lambda parameter")
+/// even though a typed lambda (<c>(s object, e EventArgs) -&gt; ...</c>) or a
+/// declaration initializer compiled fine. The root cause was that the
+/// shared handler-binding helper (<c>ExpressionBinder.BindEventSubscriptionHandler</c>,
+/// used by both <c>+=</c>/<c>-=</c> event subscription and, via
+/// <c>BindAssignmentRhs</c>, plain <c>=</c> re-assignment) bound the lambda
+/// syntax with no target type at all, rather than resolving the omitted
+/// parameter/return types from the target delegate's shape up front. See
+/// <c>Issue2389ImportedDelegateLambdaInferenceTests</c> (Core.Tests) for the
+/// binder-level (diagnostics-only) coverage of the same fix; this file
+/// exercises the fix end-to-end against a REAL imported sibling CLR
+/// assembly — instance and static events, <c>EventHandler</c> and custom
+/// delegates, zero/one/multiple parameters, inferred parameter and return
+/// types, add/remove symmetry, and negative arity/signature controls —
+/// compiled, run, and ILVerify'd.
+/// </summary>
+public class Issue2389ImportedDelegateLambdaEmitTests
+{
+    private const string CsLib = """
+        using System;
+
+        namespace ProbeRef2389
+        {
+            public delegate void ZeroParamHandler();
+
+            public delegate void OneParamHandler(string message);
+
+            public delegate int ComputeHandler(int a, int b);
+
+            public class Publisher
+            {
+                public event EventHandler Notified;
+
+                public event ZeroParamHandler Ticked;
+
+                public event OneParamHandler Announced;
+
+                public event ComputeHandler Computed;
+
+                public static event EventHandler StaticNotified;
+
+                public static event OneParamHandler StaticAnnounced;
+
+                public void RaiseNotified() => Notified?.Invoke(this, EventArgs.Empty);
+
+                public void RaiseTicked() => Ticked?.Invoke();
+
+                public void RaiseAnnounced(string message) => Announced?.Invoke(message);
+
+                public int RaiseComputed(int a, int b) => Computed != null ? Computed(a, b) : -1;
+
+                public static void RaiseStaticNotified() => StaticNotified?.Invoke(null, EventArgs.Empty);
+
+                public static void RaiseStaticAnnounced(string message) => StaticAnnounced?.Invoke(message);
+            }
+        }
+        """;
+
+    [Fact]
+    public void InstanceEventHandler_UntypedLambda_CompilesRunsAndVerifies()
+    {
+        var gSource = """
+            package Probe2389
+            import System
+            import ProbeRef2389
+
+            var log string = ""
+
+            var p = Publisher()
+            p.Notified += (sender, e) -> {
+                log = log + "N"
+            }
+            p.RaiseNotified()
+            Console.WriteLine(log)
+            """;
+
+        Assert.Equal("N\n", CompileAndRunWithSiblingCs(CsLib, gSource, "ProbeRef2389a"));
+    }
+
+    [Fact]
+    public void InstanceZeroParamCustomDelegate_UntypedLambda_CompilesRunsAndVerifies()
+    {
+        var gSource = """
+            package Probe2389
+            import System
+            import ProbeRef2389
+
+            var log string = ""
+
+            var p = Publisher()
+            p.Ticked += () -> {
+                log = log + "T"
+            }
+            p.RaiseTicked()
+            Console.WriteLine(log)
+            """;
+
+        Assert.Equal("T\n", CompileAndRunWithSiblingCs(CsLib, gSource, "ProbeRef2389b"));
+    }
+
+    [Fact]
+    public void InstanceOneParamCustomDelegate_UntypedLambda_InfersParamTypeAndVerifies()
+    {
+        // The lambda parameter is inferred as `string` (OneParamHandler's
+        // sole parameter type) with no explicit annotation, then used as a
+        // string (string concatenation) to prove the inferred type is
+        // correct, not merely `object`.
+        var gSource = """
+            package Probe2389
+            import System
+            import ProbeRef2389
+
+            var log string = ""
+
+            var p = Publisher()
+            p.Announced += (message) -> {
+                log = log + "[" + message + "]"
+            }
+            p.RaiseAnnounced("hi")
+            Console.WriteLine(log)
+            """;
+
+        Assert.Equal("[hi]\n", CompileAndRunWithSiblingCs(CsLib, gSource, "ProbeRef2389c"));
+    }
+
+    [Fact]
+    public void InstanceMultiParamCustomDelegate_UntypedLambda_InfersParamAndReturnTypesAndVerifies()
+    {
+        // ComputeHandler is `(int32, int32) -> int32` — both parameters AND
+        // the non-void return type are inferred purely from the target
+        // delegate shape.
+        var gSource = """
+            package Probe2389
+            import System
+            import ProbeRef2389
+
+            var p = Publisher()
+            p.Computed += (a, b) -> {
+                return a + b
+            }
+            Console.WriteLine(p.RaiseComputed(2, 3))
+            """;
+
+        Assert.Equal("5\n", CompileAndRunWithSiblingCs(CsLib, gSource, "ProbeRef2389d"));
+    }
+
+    [Fact]
+    public void StaticEventHandler_UntypedLambda_CompilesRunsAndVerifies()
+    {
+        var gSource = """
+            package Probe2389
+            import System
+            import ProbeRef2389
+
+            var log string = ""
+
+            Publisher.StaticNotified += (sender, e) -> {
+                log = log + "S"
+            }
+            Publisher.RaiseStaticNotified()
+            Console.WriteLine(log)
+            """;
+
+        Assert.Equal("S\n", CompileAndRunWithSiblingCs(CsLib, gSource, "ProbeRef2389e"));
+    }
+
+    [Fact]
+    public void StaticOneParamCustomDelegate_UntypedLambda_CompilesRunsAndVerifies()
+    {
+        var gSource = """
+            package Probe2389
+            import System
+            import ProbeRef2389
+
+            var log string = ""
+
+            Publisher.StaticAnnounced += (message) -> {
+                log = log + "A" + message
+            }
+            Publisher.RaiseStaticAnnounced("Y")
+            Console.WriteLine(log)
+            """;
+
+        Assert.Equal("AY\n", CompileAndRunWithSiblingCs(CsLib, gSource, "ProbeRef2389f"));
+    }
+
+    [Fact]
+    public void InstanceEventHandler_UntypedLambda_AddRemoveSymmetry_CompilesRunsAndVerifies()
+    {
+        // Subscribe with a lambda captured into a variable, raise (handler
+        // fires once), unsubscribe the SAME variable, raise again (handler
+        // must not fire a second time) — add/remove symmetry for the
+        // now-target-typed untyped-lambda handler.
+        var gSource = """
+            package Probe2389
+            import System
+            import ProbeRef2389
+
+            var hits int32 = 0
+            var p = Publisher()
+            var handler EventHandler = (sender, e) -> {
+                hits = hits + 1
+            }
+            p.Notified += handler
+            p.RaiseNotified()
+            p.Notified -= handler
+            p.RaiseNotified()
+            Console.WriteLine(hits)
+            """;
+
+        Assert.Equal("1\n", CompileAndRunWithSiblingCs(CsLib, gSource, "ProbeRef2389g"));
+    }
+
+    [Fact]
+    public void MultipleEventsOnSameInstance_UntypedLambdas_CompileRunAndVerifyTogether()
+    {
+        // Full matrix in one program: EventHandler + all three custom
+        // delegate shapes (zero/one/multi-param), instance AND static, in a
+        // single compilation/emit/ILVerify pass.
+        var gSource = """
+            package Probe2389
+            import System
+            import ProbeRef2389
+
+            var log string = ""
+
+            var p = Publisher()
+            p.Notified += (sender, e) -> {
+                log = log + "N"
+            }
+            p.Ticked += () -> {
+                log = log + "T"
+            }
+            p.Announced += (message) -> {
+                log = log + message
+            }
+            p.Computed += (a, b) -> {
+                return a + b
+            }
+
+            Publisher.StaticNotified += (sender, e) -> {
+                log = log + "S"
+            }
+            Publisher.StaticAnnounced += (message) -> {
+                log = log + "A" + message
+            }
+
+            p.RaiseNotified()
+            p.RaiseTicked()
+            p.RaiseAnnounced("X")
+            var sum = p.RaiseComputed(2, 3)
+            Publisher.RaiseStaticNotified()
+            Publisher.RaiseStaticAnnounced("Y")
+
+            Console.WriteLine(log)
+            Console.WriteLine(sum)
+            """;
+
+        Assert.Equal("NTXSAY\n5\n", CompileAndRunWithSiblingCs(CsLib, gSource, "ProbeRef2389h"));
+    }
+
+    [Fact]
+    public void ArityMismatch_UntypedLambda_AgainstImportedCustomDelegate_ReportsDiagnosticNotCrash()
+    {
+        // Negative / invalid-signature control: a one-parameter lambda
+        // cannot satisfy the two-parameter ComputeHandler shape. Must fail
+        // cleanly with the pre-existing diagnostics (GS0304 / GS0155), not
+        // crash the compiler or silently accept the wrong arity.
+        var gSource = """
+            package Probe2389
+            import System
+            import ProbeRef2389
+
+            var p = Publisher()
+            p.Computed += (onlyOne) -> {
+                return onlyOne
+            }
+            """;
+
+        var diagnostics = CompileExpectingErrorsWithSiblingCs(CsLib, gSource, "ProbeRef2389i");
+        Assert.Contains(diagnostics, d => d.Contains("GS0304", StringComparison.Ordinal));
+        Assert.Contains(diagnostics, d => d.Contains("GS0155", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ZeroArityLambda_AgainstTwoParamImportedDelegate_ReportsDiagnosticNotCrash()
+    {
+        var gSource = """
+            package Probe2389
+            import System
+            import ProbeRef2389
+
+            var p = Publisher()
+            p.Notified += () -> {
+                var x = 1
+            }
+            """;
+
+        var diagnostics = CompileExpectingErrorsWithSiblingCs(CsLib, gSource, "ProbeRef2389j");
+        Assert.Contains(diagnostics, d => d.Contains("GS0155", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ExplicitlyMistypedLambdaParameter_AgainstImportedCustomDelegate_ReportsDiagnosticNotCrash()
+    {
+        // Invalid-SIGNATURE control (as opposed to invalid-arity): an
+        // explicitly-typed parameter that disagrees with the target
+        // delegate's parameter type must still be rejected — the
+        // target-typed inference fix must not silently coerce or ignore an
+        // explicit (wrong) annotation.
+        var gSource = """
+            package Probe2389
+            import System
+            import ProbeRef2389
+
+            var p = Publisher()
+            p.Announced += (message int32) -> {
+                var x = message
+            }
+            """;
+
+        var diagnostics = CompileExpectingErrorsWithSiblingCs(CsLib, gSource, "ProbeRef2389k");
+        Assert.Contains(diagnostics, d => d.Contains("GS0155", StringComparison.Ordinal));
+    }
+
+    private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var workDir = CreateWorkDir("issue2389_");
+        try
+        {
+            var siblingDll = BuildCsLibrary(workDir, csSource, siblingName);
+            File.Copy(siblingDll, Path.Combine(workDir, Path.GetFileName(siblingDll)), overwrite: true);
+            return CompileAndRun(gSource, new[] { siblingDll }, workDir);
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    private static List<string> CompileExpectingErrorsWithSiblingCs(string csSource, string gSource, string siblingName)
+    {
+        var workDir = CreateWorkDir("issue2389_err_");
+        try
+        {
+            var siblingDll = BuildCsLibrary(workDir, csSource, siblingName);
+            return CompileExpectingErrors(gSource, new[] { siblingDll }, workDir);
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    private static string CompileAndRun(string source, IReadOnlyCollection<string> references, string workDir)
+    {
+        var srcPath = Path.Combine(workDir, "test.gs");
+        var outPath = Path.Combine(workDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = GscArgs(outPath, "exe", references, srcPath);
+        var (exitCode, diagnostics) = RunCompiler(args);
+        Assert.True(exitCode == 0, diagnostics);
+
+        IlVerifier.Verify(outPath, additionalReferences: references);
+
+        var runtimeConfig = Path.ChangeExtension(outPath, ".runtimeconfig.json");
+        if (!File.Exists(runtimeConfig))
+        {
+            File.WriteAllText(runtimeConfig, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+        }
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workDir,
+        };
+        psi.ArgumentList.Add("exec");
+        psi.ArgumentList.Add("--runtimeconfig");
+        psi.ArgumentList.Add(runtimeConfig);
+        psi.ArgumentList.Add(outPath);
+
+        using var proc = Process.Start(psi) ?? throw new InvalidOperationException("failed to start dotnet exec");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(proc.ExitCode == 0, $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n");
+    }
+
+    private static List<string> CompileExpectingErrors(string source, IReadOnlyCollection<string> references, string workDir)
+    {
+        var srcPath = Path.Combine(workDir, "test.gs");
+        var outPath = Path.Combine(workDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var (exitCode, diagnostics) = RunCompiler(GscArgs(outPath, "exe", references, srcPath));
+        Assert.True(exitCode != 0, "expected gsc to report errors but it succeeded");
+        return diagnostics.Split('\n', StringSplitOptions.RemoveEmptyEntries).ToList();
+    }
+
+    private static string[] GscArgs(string outPath, string target, IReadOnlyCollection<string> references, string srcPath)
+    {
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+        foreach (var reference in references.Concat(TrustedPlatformAssemblies()))
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        args.Add(srcPath);
+        return args.ToArray();
+    }
+
+    private static (int ExitCode, string Diagnostics) RunCompiler(string[] args)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousErr = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return (Program.Main(args), stdout.ToString() + stderr);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousErr);
+        }
+    }
+
+    private static string BuildCsLibrary(string workDir, string source, string assemblyName)
+    {
+        var csDir = Path.Combine(workDir, "csref");
+        Directory.CreateDirectory(csDir);
+        File.WriteAllText(Path.Combine(csDir, "Lib.cs"), source);
+        File.WriteAllText(Path.Combine(csDir, "Lib.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Library</OutputType>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <LangVersion>latest</LangVersion>
+                <NoWarn>1591;SA1649;SA1518;SA1516;SA1122;SA1201;CS8618</NoWarn>
+                <RunAnalyzers>false</RunAnalyzers>
+                <AssemblyName>{assemblyName}</AssemblyName>
+                <RootNamespace>{assemblyName}</RootNamespace>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        RunDotnet(csDir, "restore");
+        var outDir = Path.Combine(csDir, "out");
+        RunDotnet(csDir, "build", "-c", "Release", "--nologo", "--no-restore", "-o", outDir);
+
+        var dll = Path.Combine(outDir, assemblyName + ".dll");
+        Assert.True(File.Exists(dll), $"sibling assembly not found at {dll}");
+        return dll;
+    }
+
+    private static void RunDotnet(string workingDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDir,
+        };
+        foreach (var arg in args)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        using var proc = Process.Start(psi) ?? throw new InvalidOperationException($"failed to start dotnet {string.Join(" ", args)}");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(120_000), $"dotnet {args[0]} timed out");
+        Assert.True(proc.ExitCode == 0, $"dotnet {string.Join(" ", args)} failed ({proc.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    private static string CreateWorkDir(string prefix)
+    {
+        var root = Path.Combine(Environment.CurrentDirectory, "TestArtifacts");
+        Directory.CreateDirectory(root);
+        var path = Path.Combine(root, prefix + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2389ImportedDelegateLambdaInferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2389ImportedDelegateLambdaInferenceTests.cs
@@ -1,0 +1,374 @@
+// <copyright file="Issue2389ImportedDelegateLambdaInferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2389: an untyped arrow-lambda handler (<c>Event += (s, e) -&gt;
+/// ...</c>) used against an IMPORTED CLR delegate/event failed target-type
+/// inference (GS0304 "cannot infer the type of lambda parameter") because
+/// <see cref="ExpressionBinder"/>'s shared <c>BindEventSubscriptionHandler</c>
+/// helper (for <c>+=</c>/<c>-=</c>) and <c>BindAssignmentRhs</c> helper (for
+/// simple <c>=</c> re-assignment) bound the lambda syntax with
+/// <c>BindExpression(handlerSyntax)</c> — no target type at all — before
+/// falling back to a post-bind conversion that only reshapes an
+/// ALREADY-typed literal. A typed lambda (<c>(s object, e EventArgs) -&gt;
+/// ...</c>) or a declaration initializer (<c>var f EventHandler = (s, e)
+/// -&gt; ...</c>, which threads the target type through a different path)
+/// masked the gap. Both helpers now resolve the omitted parameter (and,
+/// where the body doesn't already pin one down, return) types from the
+/// target delegate/function-type shape via the shared
+/// <see cref="MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol"/>
+/// resolver (issue #889) — covering native G# function types, user-declared
+/// named delegates, and imported CLR delegates/events uniformly. See
+/// <c>Issue2389ImportedDelegateLambdaEmitTests</c> for the compile/run/
+/// ILVerify coverage against a sibling CLR assembly.
+/// </summary>
+public class Issue2389ImportedDelegateLambdaInferenceTests
+{
+    [Fact]
+    public void InstanceImportedClrEvent_UntypedLambda_AddAssign_Binds()
+    {
+        const string source = """
+            package p
+            import System
+
+            var domain = AppDomain.CurrentDomain
+            domain.ProcessExit += (sender, e) -> {
+                var x = sender
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void InstanceImportedClrEvent_UntypedLambda_AddThenRemove_Binds()
+    {
+        // Add/remove symmetry: both operators must resolve the same
+        // target-typed inference against the event's declared delegate.
+        const string source = """
+            package p
+            import System
+
+            var domain = AppDomain.CurrentDomain
+            domain.ProcessExit += (sender, e) -> {
+                var x = sender
+            }
+            domain.ProcessExit -= (sender, e) -> {
+                var y = sender
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void StaticImportedClrEvent_UntypedLambda_TwoParamCustomDelegate_Binds()
+    {
+        // Console.CancelKeyPress is a STATIC imported CLR event whose
+        // delegate (ConsoleCancelEventHandler) is a custom (non-EventHandler)
+        // named delegate — covers the "custom delegate" + "static" cells of
+        // the matrix at the binder level.
+        const string source = """
+            package p
+            import System
+
+            Console.CancelKeyPress += (sender, e) -> {
+                var x = sender
+            }
+            Console.CancelKeyPress -= (sender, e) -> {
+                var y = sender
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void InstanceImportedClrEvent_ZeroParamLambda_Binds()
+    {
+        // Zero-parameter cell of the matrix: System.Threading.ThreadStart is
+        // a zero-arg imported CLR delegate; exercised here as a plain
+        // (non-event) re-assignment target since the BCL has no zero-arg
+        // *event* in common use — the shared resolver does not care whether
+        // the target is an event or a plain variable/field slot.
+        const string source = """
+            package p
+            import System.Threading
+
+            var t ThreadStart
+            t = () -> {
+                var x = 1
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void SourceDefinedFunctionTypeEvent_UntypedLambda_Binds()
+    {
+        // The same helper drives source-defined (non-CLR) function-type
+        // events too — this guards the SHARED root, not just the
+        // imported-CLR repro.
+        const string source = """
+            package p
+
+            class Inner {
+                event Changed (int32, string) -> void
+            }
+
+            var i = Inner()
+            i.Changed += (a, b) -> {
+                var x = a
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void UserDeclaredNamedClrEventType_UntypedLambda_Binds()
+    {
+        // A user-declared event whose TYPE is an imported CLR named delegate
+        // (System.EventHandler) rather than a native G# function type or the
+        // event living on an imported class — the middle ground between
+        // "imported CLR event" and "source-defined delegate shape".
+        const string source = """
+            package p
+            import System
+
+            class Inner {
+                public event Changed EventHandler
+            }
+
+            var i = Inner()
+            i.Changed += (sender, e) -> {
+                var x = sender
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void InterfaceTypedReceiver_ImportedNamedDelegateEvent_UntypedLambda_Binds()
+    {
+        const string source = """
+            package p
+            import System
+
+            interface IHub {
+                event Msg EventHandler
+            }
+
+            class Hub : IHub {
+                public event Msg EventHandler
+            }
+
+            func Use(h IHub) {
+                h.Msg += (sender, e) -> {
+                    var x = sender
+                }
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void PlainReassignment_ImportedClrDelegateTypedVariable_UntypedLambda_Binds()
+    {
+        // Simple `=` re-assignment (not an event `+=`/`-=`) of a
+        // previously-declared imported-CLR-delegate-typed variable. This is
+        // the second call site routed through the same shared helper
+        // (`BindAssignmentRhs`) — the declaration initializer already
+        // threaded the target type through a different path, which is
+        // exactly why the gap on RE-assignment was masked.
+        const string source = """
+            package p
+            import System
+
+            var f EventHandler
+            f = (sender, e) -> {
+                var x = sender
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void InstanceFieldReassignment_ImportedClrDelegateTypedField_UntypedLambda_Binds()
+    {
+        const string source = """
+            package p
+            import System
+
+            class Holder {
+                var Handler EventHandler
+            }
+
+            var h = Holder()
+            h.Handler = (sender, e) -> {
+                var x = sender
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void InferredParameterAndReturnType_GenericImportedClrDelegate_UntypedLambda_Binds()
+    {
+        // System.Predicate<T> is a generic imported CLR delegate with a
+        // single inferred parameter type AND a non-void inferred return
+        // type (bool) — covers "inferred parameter and return types where
+        // applicable" for a plain (non-event) assignment target.
+        const string source = """
+            package p
+            import System
+
+            var p Predicate[int32]
+            p = (x) -> {
+                return x > 0
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void MultiParamInferredReturnType_ImportedClrDelegate_UntypedLambda_Binds()
+    {
+        // System.Comparison<T> is a two-parameter imported CLR delegate with
+        // a non-void (int32) inferred return type.
+        const string source = """
+            package p
+            import System
+
+            var c Comparison[int32]
+            c = (a, b) -> {
+                return a - b
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void TypedLambdaAndMethodGroupHandlers_StillBindAlongsideUntypedFix()
+    {
+        // Regression guard: the pre-existing typed-lambda and method-group
+        // handler shapes (the ones that already "worked" per the issue
+        // description) must keep binding cleanly once the untyped path is
+        // fixed.
+        const string source = """
+            package p
+            import System
+
+            func OnExit(sender object, e EventArgs) { }
+
+            var domain = AppDomain.CurrentDomain
+            domain.ProcessExit += (sender object, e EventArgs) -> {
+                var x = sender
+            }
+            domain.ProcessExit += OnExit
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void ArityMismatch_ImportedClrEvent_UntypedLambda_ReportsGS0304NotCrash()
+    {
+        // Negative/invalid-signature control: an untyped lambda whose arity
+        // does not match the target delegate's must still fail cleanly with
+        // the existing "cannot infer" diagnostic (and the standard
+        // conversion-failure diagnostic), not crash or silently mis-bind.
+        const string source = """
+            package p
+            import System
+
+            var domain = AppDomain.CurrentDomain
+            domain.ProcessExit += (onlyOneParam) -> {
+                var x = onlyOneParam
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0304");
+        Assert.Contains(diagnostics, d => d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void ArityMismatch_PlainReassignment_UntypedLambda_ReportsGS0304NotCrash()
+    {
+        const string source = """
+            package p
+            import System
+
+            var f EventHandler
+            f = (onlyOneParam) -> {
+                var x = onlyOneParam
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0304");
+        Assert.Contains(diagnostics, d => d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void AmbiguousZeroArityLambda_AgainstTwoParamEvent_ReportsGS0304NotCrash()
+    {
+        // A zero-parameter lambda against a two-parameter delegate is an
+        // equally invalid (not merely "ambiguous") shape; confirm it still
+        // reports cleanly rather than binding an incorrect arity.
+        const string source = """
+            package p
+            import System
+
+            Console.CancelKeyPress += () -> {
+                var x = 1
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0155");
+    }
+
+    private static ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}


### PR DESCRIPTION
## Problem

An untyped arrow-lambda (e.g. `(sender, e) -> {...}`) used with `+=` against an imported CLR delegate/event failed target-type inference with GS0304, even though a typed lambda (`(sender object, e EventArgs) -> ...`) or a source-defined delegate shape worked fine. The same gap also affected plain `=` re-assignment of a previously-declared delegate-typed variable/field, even though the identical lambda works as a declaration initializer.

Closes #2389.

## Root cause

Two binder entry points bound the lambda via the generic, target-type-less `BindExpression` path before falling back to a post-bind conversion:

- `BindEventSubscriptionHandler` (`src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs`) — handles `+=`/`-=` event subscription (despite the file name, this is where event-subscription binding lives after the PR #2404 file split).
- `BindAssignmentRhs` (`src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs`) — the shared RHS binder for plain `=` assignment, used by bare variable assignment, member-field/property assignment, and inherited-CLR-instance-member bare writes.

`LambdaBinder.BindLambdaExpression` only infers an omitted parameter type from a target function type when a matching-arity target is supplied *before* binding. Since neither caller passed one, the lambda's own binding failed before any later conversion had a chance to reshape it — no post-bind conversion can retroactively fix an already-failed bind.

## Fix

In both binders, when the RHS/handler is a `LambdaExpressionSyntax` and the target delegate/event/variable type resolves to a function-type shape via the existing shared helper `MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol` (issue #889), bind the lambda through `LambdaBinder.BindLambdaExpression` with that target type instead of the generic `BindExpression`. This uniformly covers native G# function types, user-declared named delegates, and imported CLR delegates/events, reusing the existing delegate-target-resolution infrastructure (already used for call-argument lambda inference) rather than duplicating it. The pre-existing post-bind conversion logic (issue #2066) is left untouched and still applies to the result.

Fixing the single shared `BindAssignmentRhs` helper transparently also fixes plain re-assignment through member-field/property writes and inherited-CLR-instance-member bare writes, since they all route through it.

**Intentionally out of scope:** static field/property write paths (`Type.Field = value` for imported CLR classes / user structs / interfaces) call `BindExpression` directly and bypass `BindAssignmentRhs` entirely — this is a separate, pre-existing target-typing gap (it also affects `if`/`switch` expressions, not just lambdas) and is not part of the same inference helper this issue is scoped to, so it was left unchanged.

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue2389ImportedDelegateLambdaInferenceTests.cs` (new, 15 tests): binder-level diagnostics covering instance/static imported CLR events, add/remove symmetry, source-defined function-type events, user-declared named-CLR-delegate events, interface-typed receivers, plain variable/field re-assignment, inferred parameter/return types via generic BCL delegates (`Predicate<T>`, `Comparison<T>`), typed-lambda/method-group regression guards, and arity-mismatch negative controls (still correctly report GS0304/GS0155).
- `test/Compiler.Tests/Emit/Issue2389ImportedDelegateLambdaEmitTests.cs` (new, 11 tests): compile/run/ILVerify tests against a minimal sibling C# assembly (`ProbeRef2389`) exposing custom delegates (zero/one/two-param, inferred return) and instance/static events, covering add/remove symmetry end-to-end plus negative ambiguity/invalid-signature controls.

## Validation

- `test/Core.Tests`: 6340 passed, 0 failed.
- `test/Compiler.Tests`: 3141 passed, 0 failed (full suite, including sibling-assembly-dependent tests after building `src/Sdk/Gsharp.Extensions`).
- `test/InternalAnalyzers.Tests`: 7 passed, 0 failed.
- `tools/cs2gs/Cs2Gs.Tests`: 1423 passed, 0 failed, run serialized with `RunConfiguration.DisableParallelization=true`.

No Oahu-specific fixtures were modified.
