### PR TITLE
Fix #2403: user callable wins over colliding CLR type in call position

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
@@ -147,6 +147,98 @@ internal sealed partial class OverloadResolver
         return new BoundCallExpression(null, method, convertedArgs.MoveToImmutable());
     }
 
+    /// <summary>
+    /// Issue #2403: whether <paramref name="syntax"/>'s unqualified callee name
+    /// could resolve to a genuine user-defined callable — a same-compilation
+    /// free/extension <see cref="FunctionSymbol"/> reachable through
+    /// <see cref="Scope"/>, or an implicit-<c>this</c> instance/static sibling
+    /// method (including a private one) on the enclosing struct/class or
+    /// interface body — checked BEFORE the CLR constructor/conversion
+    /// fallbacks a few lines below in <see cref="BindCallExpression"/> run. A
+    /// same-named imported CLR type (e.g. <c>System.Net.Http.HttpClient</c>)
+    /// must not shadow a colliding user method in call position, mirroring how
+    /// a same-named source method always wins over an imported CLR type in
+    /// C#.
+    /// </summary>
+    /// <remarks>
+    /// Only the EXISTENCE of a same-named candidate is checked here — not full
+    /// overload applicability (argument count/types). That is intentional:
+    /// when this returns <see langword="true"/>, <see cref="BindCallExpression"/>
+    /// simply skips the CLR early-return paths and falls through to its
+    /// ordinary implicit-<c>this</c> / symbol-lookup call-binding logic further
+    /// down, which already performs full overload selection via
+    /// <see cref="SelectUnifiedInstanceStaticOverload"/> / <see cref="SelectInstanceOverloadOrReport"/>
+    /// / <see cref="SelectBestUserOverload"/> and reports the correct
+    /// diagnostic (wrong-argument-count, ambiguity, ...) against the genuine
+    /// user candidate — so no overload-resolution logic is duplicated here.
+    /// When no such candidate exists, this returns <see langword="false"/> and
+    /// the CLR paths run exactly as before, so genuine constructor/conversion
+    /// calls (e.g. `StringBuilder(16)`) are unaffected.
+    /// </remarks>
+    private bool HasUserCallableCandidate(CallExpressionSyntax syntax)
+    {
+        var name = syntax.Identifier.Text;
+
+        // A same-compilation free function or extension function (extension
+        // functions are flattened into the global function table — issue
+        // #1103) is directly visible through the scope's symbol table.
+        if (Scope.TryLookupSymbol(name) is FunctionSymbol)
+        {
+            return true;
+        }
+
+        // Issue #1159: the implicit `this` an unqualified instance-member
+        // reference would bind against (mirrors GetEffectiveThisParameter's
+        // callers below).
+        var effThis = GetEffectiveThisParameter();
+        if (effThis?.Type is StructSymbol receiverStruct)
+        {
+            // Issue #1147: an unqualified call inside an instance method
+            // resolves against the COMBINED instance + static (`shared`)
+            // overload set of the enclosing type — mirror that union here.
+            if (!TypeMemberModel.GetMethods(receiverStruct, name, MemberQuery.Instance(MemberKinds.Method)).IsDefaultOrEmpty
+                || !TypeMemberModel.GetMethods(receiverStruct, name, MemberQuery.Static(MemberKinds.Method)).IsDefaultOrEmpty)
+            {
+                return true;
+            }
+        }
+        else if (effThis?.Type is InterfaceSymbol receiverIface)
+        {
+            // ADR-0085 / ADR-0090: implicit `this` inside an interface default
+            // method body also sees the interface's own private helpers.
+            if (!TypeMemberModel.GetMethods(receiverIface, name, MemberQuery.Instance(MemberKinds.Method)).IsDefaultOrEmpty
+                || receiverIface.GetPrivateMethods(name).Length > 0)
+            {
+                return true;
+            }
+        }
+
+        if (getCurrentFunction()?.ThisParameter == null)
+        {
+            // ADR-0089 / ADR-0090: implicit static-self dispatch inside a
+            // static-virtual or private-static interface helper body.
+            if (getCurrentFunction()?.StaticOwnerType is InterfaceSymbol staticIface)
+            {
+                if (!TypeMemberModel.GetMethods(staticIface, name, MemberQuery.Static(MemberKinds.Method)).IsDefaultOrEmpty
+                    || staticIface.GetStaticPrivateMethods(name).Length > 0)
+                {
+                    return true;
+                }
+            }
+            else if (getCurrentFunction()?.StaticOwnerType is StructSymbol staticStruct)
+            {
+                // Issue #1585: implicit static-self dispatch inside a
+                // `shared` method body of a user struct/class.
+                if (!TypeMemberModel.GetMethods(staticStruct, name, MemberQuery.Static(MemberKinds.Method)).IsDefaultOrEmpty)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     public BoundExpression BindCallExpression(CallExpressionSyntax syntax)
     {
         // Issue #2185: an indirect invocation whose callee is an arbitrary
@@ -181,13 +273,24 @@ internal sealed partial class OverloadResolver
             }
         }
 
+        // Issue #2403: a resolvable user-defined callable (same-compilation
+        // free/extension function, or an implicit-`this` instance/static
+        // sibling method) with this name takes precedence over ALL THREE CLR
+        // constructor/conversion fallback paths below, mirroring how a
+        // same-named source method always shadows a colliding imported CLR
+        // type (e.g. `System.Net.Http.HttpClient`) in call position. Computed
+        // once and reused by all three gates; see HasUserCallableCandidate's
+        // remarks for why only existence (not full overload applicability) is
+        // checked here.
+        var hasUserCallable = HasUserCallableCandidate(syntax);
+
         // Phase 4-exit: prefer CLR class instantiation over the single-arg
         // conversion-call hijack below, so that `StringBuilder(16)` resolves
         // to a CLR ctor rather than `conversions.BindConversion(int → StringBuilder)`.
         // Also handles closed-generic imports (`List[int]()`,
         // `Dictionary[string, int]()`). Interpreter-only — resolves a
         // ConstructorInfo and emits BoundClrConstructorCallExpression.
-        if (tryBindClrConstructorCall(syntax, out var clrCtorCall))
+        if (!hasUserCallable && tryBindClrConstructorCall(syntax, out var clrCtorCall))
         {
             return clrCtorCall;
         }
@@ -203,7 +306,7 @@ internal sealed partial class OverloadResolver
             ? syntax.TypeArgumentList.Arguments.Count
             : -1;
 
-        if (syntax.Arguments.Count == 1 && lookupTypeWithArity(syntax.Identifier.Text, ctorPreferredArity) is TypeSymbol type)
+        if (!hasUserCallable && syntax.Arguments.Count == 1 && lookupTypeWithArity(syntax.Identifier.Text, ctorPreferredArity) is TypeSymbol type)
         {
             // Issue #663: when the call carries a `?` token (e.g. `string?(x)`),
             // wrap the resolved type in NullableTypeSymbol so the conversion
@@ -243,7 +346,8 @@ internal sealed partial class OverloadResolver
         // Issue #1069: a value struct (e.g. a `data struct`) declaring a
         // primary constructor is also positionally constructible —
         // `Entry(1, 2)` lowers to a struct literal initializing its fields.
-        if (lookupTypeWithArity(syntax.Identifier.Text, ctorPreferredArity) is StructSymbol classType
+        if (!hasUserCallable
+            && lookupTypeWithArity(syntax.Identifier.Text, ctorPreferredArity) is StructSymbol classType
             && (classType.IsClass || classType.IsInline || classType.HasPrimaryConstructor))
         {
             return BindConstructorCallExpression(syntax, classType);

--- a/test/Compiler.Tests/Emit/Issue2403MethodCallVsImportedTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2403MethodCallVsImportedTypeEmitTests.cs
@@ -1,0 +1,213 @@
+// <copyright file="Issue2403MethodCallVsImportedTypeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2403: compiled (gsc emit + IL verify + execute) coverage for the
+/// call-vs-imported-type precedence fix in
+/// <see cref="GSharp.Core.CodeAnalysis.Binding.OverloadResolver.BindCallExpression"/>.
+/// A user/same-compilation method (or implicit-<c>this</c> instance method)
+/// whose name collides with an imported CLR type (e.g.
+/// <c>System.Net.Http.HttpClient</c>) must be preferred over that type's
+/// constructor/conversion fallbacks — both at bind time and in the emitted IL
+/// that actually runs.
+/// </summary>
+public class Issue2403MethodCallVsImportedTypeEmitTests
+{
+    [Fact]
+    public void PrivateInstanceMethod_ClassArgument_ImportedClrTypeCollision_CompilesAndRuns()
+    {
+        var source = """
+            package p
+            import System
+            import System.Text
+
+            class Profile { var Name string }
+
+            class Service {
+                private func StringBuilder(profile Profile) string {
+                    return "user:" + profile.Name
+                }
+
+                func Run(profile Profile) string {
+                    return StringBuilder(profile)
+                }
+            }
+
+            var svc = Service{}
+            Console.WriteLine(svc.Run(Profile{Name: "abc"}))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("user:abc\n", output);
+    }
+
+    [Fact]
+    public void MultiArgument_ImportedClrTypeCollision_CompilesAndRuns()
+    {
+        // Control: StringBuilder also has a two-argument constructor
+        // (`StringBuilder(string, int32)`); a two-argument user method with
+        // the same name must still win at the emitted-IL level.
+        var source = """
+            package p
+            import System
+            import System.Text
+
+            class Profile { var Name string }
+
+            class Service {
+                private func StringBuilder(a Profile, b Profile) string {
+                    return a.Name + "-" + b.Name
+                }
+
+                func Run(a Profile, b Profile) string {
+                    return StringBuilder(a, b)
+                }
+            }
+
+            var svc = Service{}
+            Console.WriteLine(svc.Run(Profile{Name: "x"}, Profile{Name: "y"}))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("x-y\n", output);
+    }
+
+    [Fact]
+    public void ExactOahuCoreShape_AuthorizeHttpClient_CompilesAndRuns()
+    {
+        // The exact Oahu.Core Authorize shape: `import System.Net.Http`
+        // brings the CLR `HttpClient` type into scope; `Authorize` declares a
+        // private instance method named `HttpClient` taking an `IProfile` and
+        // returning a nullable `IProfile`, invoked across four call sites
+        // through implicit `this`.
+        var source = """
+            package p
+            import System
+            import System.Net.Http
+
+            interface IProfile {
+                prop Authorization string { get; }
+            }
+
+            class Profile : IProfile {
+                prop Authorization string { get; set; }
+            }
+
+            class Authorize {
+                private func HttpClient(profile IProfile) IProfile? {
+                    return profile
+                }
+
+                func Run(a IProfile, b IProfile, c IProfile, d IProfile) IProfile? {
+                    let x = HttpClient(a)
+                    let y = HttpClient(b)
+                    let z = HttpClient(c)
+                    return HttpClient(d)
+                }
+            }
+
+            var auth = Authorize{}
+            var p = Profile{Authorization: "tok"}
+            var result = auth.Run(p, p, p, p)
+            Console.WriteLine(result?.Authorization)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("tok\n", output);
+    }
+
+    [Fact]
+    public void GenuineConstructorControl_NoUserMethod_StillConstructsClrTypeAndRuns()
+    {
+        // Guardrail: with no colliding user method, `StringBuilder(16)` must
+        // still emit and run as the real CLR constructor call.
+        var source = """
+            package p
+            import System
+            import System.Text
+
+            var sb = StringBuilder(16)
+            Console.WriteLine(sb.Capacity)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("16\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2403_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2403MethodCallVsImportedTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2403MethodCallVsImportedTypeTests.cs
@@ -1,0 +1,378 @@
+// <copyright file="Issue2403MethodCallVsImportedTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2403: in call position, a user/same-compilation method (or implicit-
+/// <c>this</c> instance method) whose name collides with an IMPORTED CLR type
+/// used to lose to that type's constructor/conversion fallbacks in
+/// <see cref="OverloadResolver.BindCallExpression"/>. The three CLR early-return
+/// paths — <c>tryBindClrConstructorCall</c> (real CLR constructor overload
+/// resolution), the single-argument conversion-call hijack, and the
+/// <c>ClassName(args)</c> primary-constructor path — all ran BEFORE the
+/// implicit-<c>this</c> / free-function symbol lookup further down, so a
+/// colliding CLR type won unconditionally. Found while rerunning Oahu.Core
+/// after #2394: <c>Authorize.HttpClient(IProfile)</c> is a real private
+/// instance method, but calls such as <c>HttpClient(profile)</c> (through
+/// implicit <c>this</c>) bound to the imported <c>System.Net.Http.HttpClient</c>
+/// construction/conversion instead, producing GS0155/GS0490 and subsequent
+/// missing-member errors.
+///
+/// The fix gates all three CLR early-return paths on
+/// <c>OverloadResolver.HasUserCallableCandidate</c>: when a same-name user
+/// callable (free/extension function, or implicit-<c>this</c> instance/static
+/// sibling method — public or private) exists, the CLR paths are skipped and
+/// binding falls through to the ordinary call-binding logic, which performs
+/// full overload selection and reports the correct diagnostic. When no such
+/// candidate exists, the CLR paths run exactly as before, so genuine
+/// constructor/conversion calls are unaffected.
+/// </summary>
+public class Issue2403MethodCallVsImportedTypeTests
+{
+    [Fact]
+    public void PrivateInstanceMethod_ClassArgument_ImportedClrTypeCollision_ResolvesToUserMethod()
+    {
+        // Minimal repro shape from the issue: `import System.Text` brings the
+        // CLR `StringBuilder` type into scope; `Service` also declares a
+        // PRIVATE instance method named `StringBuilder` taking a class
+        // argument and returning a different local type. The implicit-`this`
+        // call must resolve to the private sibling method, not the CLR ctor.
+        var source = """
+            package p
+            import System.Text
+
+            class Profile { var Name string }
+            class Result { var Value string }
+
+            class Service {
+                private func StringBuilder(profile Profile) Result {
+                    return Result{ Value: profile.Name }
+                }
+
+                func Run(profile Profile) Result {
+                    return StringBuilder(profile)
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void PublicInstanceMethod_ClassArgument_ImportedClrTypeCollision_ResolvesToUserMethod()
+    {
+        var source = """
+            package p
+            import System.Text
+
+            class Profile { var Name string }
+            class Result { var Value string }
+
+            class Service {
+                func StringBuilder(profile Profile) Result {
+                    return Result{ Value: profile.Name }
+                }
+
+                func Run(profile Profile) Result {
+                    return StringBuilder(profile)
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void PrimitiveArgument_ImportedClrTypeCollision_ResolvesToUserMethod()
+    {
+        // A primitive (int32) argument, rather than a class argument.
+        var source = """
+            package p
+            import System.Text
+
+            class Service {
+                func StringBuilder(count int32) int32 {
+                    return count * 2
+                }
+
+                func Run(count int32) int32 {
+                    return StringBuilder(count)
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void NullableReturn_ImportedClrTypeCollision_ResolvesToUserMethod()
+    {
+        var source = """
+            package p
+            import System.Text
+
+            class Profile { var Name string }
+            class Result { var Value string }
+
+            class Service {
+                private func StringBuilder(profile Profile) Result? {
+                    return nil
+                }
+
+                func Run(profile Profile) Result? {
+                    return StringBuilder(profile)
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ZeroArgument_ImportedClrTypeCollision_ResolvesToUserMethod()
+    {
+        // Control: StringBuilder has a public parameterless constructor, so a
+        // zero-argument call is the shape most likely to still be hijacked by
+        // the CLR ctor fallback if the fix were incomplete.
+        var source = """
+            package p
+            import System.Text
+
+            class Result { var Value string }
+
+            class Service {
+                func StringBuilder() Result {
+                    return Result{ Value: "user" }
+                }
+
+                func Run() Result {
+                    return StringBuilder()
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void MultiArgument_ImportedClrTypeCollision_ResolvesToUserMethod()
+    {
+        // Control: StringBuilder also has a two-argument constructor
+        // (`StringBuilder(string, int32)`), so a two-argument call is another
+        // shape the CLR ctor fallback could hijack.
+        var source = """
+            package p
+            import System.Text
+
+            class Profile { var Name string }
+            class Result { var Value string }
+
+            class Service {
+                private func StringBuilder(a Profile, b Profile) Result {
+                    return Result{ Value: a.Name + b.Name }
+                }
+
+                func Run(a Profile, b Profile) Result {
+                    return StringBuilder(a, b)
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void StaticSelfContext_ImportedClrTypeCollision_ResolvesToUserStaticMethod()
+    {
+        // Issue #1585 static-self dispatch: an unqualified call inside a
+        // `shared` method body must also prefer a same-named `shared` sibling
+        // over the colliding imported CLR type.
+        var source = """
+            package p
+            import System.Text
+
+            class Profile { var Name string }
+            class Result { var Value string }
+
+            class Service {
+                shared {
+                    func StringBuilder(profile Profile) Result {
+                        return Result{ Value: profile.Name }
+                    }
+
+                    func Run(profile Profile) Result {
+                        return StringBuilder(profile)
+                    }
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void InterfaceDefaultMethod_ImportedClrTypeCollision_ResolvesToUserMethod()
+    {
+        // ADR-0085 / ADR-0090 implicit `this` inside an interface default
+        // method body must also prefer the sibling default method over the
+        // colliding imported CLR type.
+        var source = """
+            package p
+            import System.Text
+
+            class Profile { var Name string }
+            class Result { var Value string }
+
+            interface IService {
+                func StringBuilder(profile Profile) Result {
+                    return Result{ Value: profile.Name }
+                }
+
+                func Run(profile Profile) Result {
+                    return StringBuilder(profile)
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void GenuineConstructorControl_NoUserMethod_StillConstructsClrType()
+    {
+        // Guardrail: with NO colliding user method anywhere, `StringBuilder(16)`
+        // must still resolve to the real CLR constructor (the whole point of
+        // the "Phase 4-exit" comment in BindCallExpression).
+        var source = """
+            package p
+            import System.Text
+
+            class Owner {
+                func Run() int32 {
+                    let sb = StringBuilder(16)
+                    return sb.Capacity
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void GenuineUserClassConstructorControl_NoCollidingFunction_StillConstructs()
+    {
+        // Guardrail: an ordinary user class's own primary-constructor call
+        // (`ClassName(args)`, Phase 3.B.3 sub-step 2 path) must still work when
+        // there is no same-named callable to prefer.
+        var source = """
+            package p
+
+            class Point(X int32, Y int32) {
+            }
+
+            class Owner {
+                func Run() int32 {
+                    let p = Point(1, 2)
+                    return p.X
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void WrongArgumentCount_UserMethodStillReportsDiagnostic_NotConstructionFallback()
+    {
+        // Guardrail: a genuinely wrong-arity call to the colliding user method
+        // must still be rejected (mirroring ordinary user-function behavior),
+        // not silently reinterpreted through the CLR construction/conversion
+        // fallback because HasUserCallableCandidate only checks existence, not
+        // arity.
+        var source = """
+            package p
+            import System.Text
+
+            class Profile { var Name string }
+            class Result { var Value string }
+
+            class Service {
+                private func StringBuilder(profile Profile) Result {
+                    return Result{ Value: profile.Name }
+                }
+
+                func Run() Result {
+                    return StringBuilder()
+                }
+            }
+            """;
+
+        Assert.NotEmpty(Bind(source));
+    }
+
+    [Fact]
+    public void ExactOahuCoreShape_AuthorizeHttpClient_ResolvesToUserMethod()
+    {
+        // The exact Oahu.Core Authorize shape from the issue: `import
+        // System.Net.Http` brings the CLR `HttpClient` type into scope;
+        // `Authorize` declares a PRIVATE instance method named `HttpClient`
+        // taking an `IProfile` and returning a nullable `IProfile`. Four call
+        // sites through implicit `this` (mirroring the four Authorize call
+        // sites the issue references) must all resolve to the user method.
+        var source = """
+            package p
+            import System.Net.Http
+
+            interface IProfile {
+                prop Authorization string { get; }
+            }
+
+            class Profile : IProfile {
+                prop Authorization string { get; set; }
+            }
+
+            class Authorize {
+                private func HttpClient(profile IProfile) IProfile? {
+                    return profile
+                }
+
+                func Run(a IProfile, b IProfile, c IProfile, d IProfile) IProfile? {
+                    let x = HttpClient(a)
+                    let y = HttpClient(b)
+                    let z = HttpClient(c)
+                    return HttpClient(d)
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any())
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}

--- a/test/Interpreter.Tests/Issue2403MethodCallVsImportedTypeInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2403MethodCallVsImportedTypeInterpreterTests.cs
@@ -1,0 +1,181 @@
+// <copyright file="Issue2403MethodCallVsImportedTypeInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2403: runtime (tree-walking interpreter) parity for the
+/// call-vs-imported-type precedence fix in
+/// <c>OverloadResolver.BindCallExpression</c>. These tests execute (not just
+/// bind) call sites where a user method name collides with an imported CLR
+/// type, confirming the interpreter actually dispatches to the user method's
+/// body (observable via its return value) rather than constructing/converting
+/// the CLR type.
+/// </summary>
+public class Issue2403MethodCallVsImportedTypeInterpreterTests
+{
+    [Fact]
+    public void PrivateInstanceMethod_ClassArgument_ImportedClrTypeCollision_ExecutesUserMethod()
+    {
+        var source = """
+            import System.Text
+
+            class Profile {
+                var Name string
+            }
+
+            class Service {
+                private func StringBuilder(profile Profile) string {
+                    return "user:" + profile.Name
+                }
+
+                func Run(profile Profile) string {
+                    return StringBuilder(profile)
+                }
+            }
+
+            var svc = Service{}
+            svc.Run(Profile{Name: "abc"})
+            """;
+
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("user:abc", output);
+    }
+
+    [Fact]
+    public void ZeroArgument_ImportedClrTypeCollision_ExecutesUserMethod()
+    {
+        var source = """
+            import System.Text
+
+            class Service {
+                func StringBuilder() string {
+                    return "user-zero-arg"
+                }
+
+                func Run() string {
+                    return StringBuilder()
+                }
+            }
+
+            var svc = Service{}
+            svc.Run()
+            """;
+
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("user-zero-arg", output);
+    }
+
+    [Fact]
+    public void MultiArgument_ImportedClrTypeCollision_ExecutesUserMethod()
+    {
+        var source = """
+            import System.Text
+
+            class Profile {
+                var Name string
+            }
+
+            class Service {
+                private func StringBuilder(a Profile, b Profile) string {
+                    return a.Name + "-" + b.Name
+                }
+
+                func Run(a Profile, b Profile) string {
+                    return StringBuilder(a, b)
+                }
+            }
+
+            var svc = Service{}
+            svc.Run(Profile{Name: "x"}, Profile{Name: "y"})
+            """;
+
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("x-y", output);
+    }
+
+    [Fact]
+    public void GenuineConstructorControl_NoUserMethod_StillConstructsClrTypeAtRuntime()
+    {
+        // Guardrail: with no colliding user method, `StringBuilder(16)` must
+        // still construct the real CLR StringBuilder at runtime.
+        var source = """
+            import System.Text
+
+            let sb = StringBuilder(16)
+            sb.Capacity
+            """;
+
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("16", output);
+    }
+
+    [Fact]
+    public void ExactOahuCoreShape_AuthorizeHttpClient_ExecutesUserMethodAtRuntime()
+    {
+        // The exact Oahu.Core Authorize shape: a private instance method named
+        // `HttpClient` colliding with the imported `System.Net.Http.HttpClient`
+        // CLR type, invoked through implicit `this` across four call sites,
+        // returning a nullable `IProfile`.
+        var source = """
+            import System.Net.Http
+
+            interface IProfile {
+                prop Authorization string { get; }
+            }
+
+            class Profile : IProfile {
+                prop Authorization string { get; set; }
+            }
+
+            class Authorize {
+                private func HttpClient(profile IProfile) IProfile? {
+                    return profile
+                }
+
+                func Run(a IProfile, b IProfile, c IProfile, d IProfile) IProfile? {
+                    let x = HttpClient(a)
+                    let y = HttpClient(b)
+                    let z = HttpClient(c)
+                    return HttpClient(d)
+                }
+            }
+
+            var auth = Authorize{}
+            var p = Profile{Authorization: "tok"}
+            var result = auth.Run(p, p, p, p)
+            result?.Authorization
+            """;
+
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("tok", output);
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString();
+    }
+}


### PR DESCRIPTION
## Problem

In call position, `OverloadResolver.BindCallExpression` ran three CLR constructor/conversion fallback paths — real CLR constructor binding (`tryBindClrConstructorCall`), the single-argument conversion-call hijack (`conversions.BindConversion`), and the `ClassName(args)` primary-constructor path — **before** ever considering a same-named same-compilation callable. A user/same-compilation method (including a private instance method reachable through implicit `this`) whose name collides with an imported CLR type therefore always lost.

In `Oahu.Core`, `Authorize` declares a private instance method `HttpClient(profile IProfile) IProfile?`. Because `import System.Net.Http` brings the CLR `HttpClient` type into scope, all four `HttpClient(profile)` call sites inside `Authorize` were being routed into the CLR conversion-call hijack instead of the user's method, producing GS0155/GS0490 plus cascading missing-member errors.

## Fix

Added `HasUserCallableCandidate` — a cheap **existence-only** check (not full overload resolution) for a same-named:
- same-compilation free/extension `FunctionSymbol` visible through `Scope`, or
- implicit-`this` instance/static sibling method (including private) on the enclosing struct/class or interface, including static-self dispatch inside `shared`/interface-static bodies.

Computed once near the top of `BindCallExpression` and used to gate all three CLR early-return paths (`!hasUserCallable && ...`). When a candidate exists, control falls through to the existing implicit-`this`/symbol-lookup call-binding logic, which already performs full overload selection (`SelectUnifiedInstanceStaticOverload` / `SelectInstanceOverloadOrReport` / `SelectBestUserOverload`) and reports the correct diagnostics — so no overload-resolution logic is duplicated. When no candidate exists, the CLR paths run exactly as before, preserving genuine constructor/conversion calls (e.g. `StringBuilder(16)`).

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue2403MethodCallVsImportedTypeTests.cs` — 12 binder tests: private/public instance method collision, primitive/class arguments, nullable return, zero/multi-arg controls, static-self context, interface default-method visibility, genuine CLR ctor control (`StringBuilder(16)`), genuine user-class ctor control, a wrong-argument-count guardrail, and the exact Oahu.Core `Authorize.HttpClient(IProfile)` shape with all 4 call sites. **Verified 8 of the 12 fail without the fix** (sanity-checked by temporarily reverting the fix and re-running).
- `test/Interpreter.Tests/Issue2403MethodCallVsImportedTypeInterpreterTests.cs` — 5 runtime/REPL tests.
- `test/Compiler.Tests/Emit/Issue2403MethodCallVsImportedTypeEmitTests.cs` — 4 full compile+ilverify+execute tests.

All 21 new tests pass.

## Full suite results

| Suite | Result |
| --- | --- |
| `Core.Tests` | 6337 passed, 1 skipped (pre-existing), 0 failed |
| `Compiler.Tests` | 3134 passed, 0 failed |
| `InternalAnalyzers.Tests` | 7 passed, 0 failed |
| `Interpreter.Tests` | 425 passed, 0 failed |
| `Cs2Gs.Tests` (serialized, `RunConfiguration.DisableParallelization=true`) | 1423 passed, 0 failed |

## Oahu.Core migration re-run (read-only checkout)

Re-ran the real `cs2gs migrate` pipeline against a read-only local checkout of `Oahu.Core` (no edits, no PR against the Oahu repo), comparing the SDK-based compile stage before/after the fix with a freshly rebuilt/repacked `Gsharp.NET.Sdk` package and cleared NuGet cache (needed because the SDK compile path restores by pinned package version, which otherwise silently serves a stale cached build):

- **Compile-error artifact count: 48 → 47.**
- The removed error is exactly `GS0155: Cannot convert type 'Profile?' to 'System.Net.Http.HttpClient'.` at `Authorize.gs:45` — the `Authorize.HttpClient(profile)` call site from this issue.
- Full diagnostic diff (by `id` + `file` + `line` + `message`) confirms **zero regressions**: no new or changed diagnostics anywhere else in the 47 remaining artifacts.

**Next independent blocker:** the largest remaining cluster is `GS0157: Cannot find type Oahu. Are you missing an import?` (plus its cascading `GS0158` member-not-found errors), concentrated in `AaxExporter.gs` and `BookLibrary.gs`. This is a cross-project type-resolution gap — `Oahu.Core` references types (e.g. `Book`) declared in sibling `Oahu.*` projects that aren't part of this single-project corpus run — unrelated to #2403.

Fixes #2403