### PR TITLE
Fix #2389: target-type untyped lambdas against imported delegate/event handlers

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -347,7 +347,31 @@ internal sealed partial class ExpressionBinder
             return BindEventSubscriptionHandlerFromBoundAccessor(memberAccess, boundReceiver, targetDelegateType);
         }
 
-        var bound = BindExpression(handlerSyntax);
+        // Issue #2389: an untyped arrow lambda handler (`Ticked += (count) ->
+        // ...`) omits its parameter type clauses and relies entirely on a
+        // target function type to infer them (ADR-0076 / issue #716). The
+        // plain `BindExpression(handlerSyntax)` fallback below binds with NO
+        // target type at all, so inference fails with GS0304 even though the
+        // event's declared delegate type (`targetDelegateType`) fully
+        // determines the expected parameter/return shape — the same target
+        // shape already threaded into target-typed local declarations
+        // (StatementBinder.Narrowing.cs) and call-argument inference
+        // (OverloadResolver.*). Reuse that established
+        // `TryGetLambdaTargetFunctionTypeFromSymbol` conversion here so the
+        // event's delegate type (whether a user `delegate` alias or a
+        // genuinely imported CLR delegate) fills in the omitted parameter
+        // types before falling through to the same method-group / conversion
+        // handling below that already covers typed lambdas.
+        BoundExpression bound;
+        if (handlerSyntax is LambdaExpressionSyntax lambdaHandler
+            && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(targetDelegateType, out var handlerTargetFnType))
+        {
+            bound = lambdas.BindLambdaExpression(lambdaHandler, handlerTargetFnType);
+        }
+        else
+        {
+            bound = BindExpression(handlerSyntax);
+        }
 
         if (bound is BoundClrMethodGroupExpression clrGroup && clrGroup.ResolvedMethod == null)
         {

--- a/test/Compiler.Tests/Emit/Issue2389ImportedDelegateLambdaEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2389ImportedDelegateLambdaEmitTests.cs
@@ -1,0 +1,382 @@
+// <copyright file="Issue2389ImportedDelegateLambdaEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2389 — real-assembly, IL-verification and runtime-execution level
+/// regression coverage for target-typing an UNTYPED arrow lambda
+/// (<c>(count) -&gt; ...</c>, no parameter type clauses) used with
+/// <c>+=</c>/<c>-=</c> against a genuinely IMPORTED (separately Roslyn-
+/// compiled, real-assembly) CLR delegate/event. Before the fix,
+/// <c>ExpressionBinder.BindEventSubscriptionHandler</c>'s fallback path
+/// bound the handler syntax through the untargeted
+/// <c>BindExpression(handlerSyntax)</c>, which for an arrow lambda dispatches
+/// to <c>LambdaBinder.BindLambdaExpression</c> with NO target function type
+/// — so an omitted parameter type clause always failed with GS0304, even
+/// though the event's declared delegate type fully determines the expected
+/// parameter/return shape. A TYPED lambda (<c>(count int32) -&gt; ...</c>) or
+/// a SOURCE-defined delegate shape (<c>event E (args) -&gt; ret</c>, ADR-0076)
+/// never hit this gap because their parameter types either don't need
+/// inference or are threaded through a different, already target-typed
+/// binder path.
+///
+/// The fix reuses the same <c>MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol</c>
+/// helper already used by target-typed local declarations
+/// (<c>StatementBinder.Narrowing.cs</c>) and call-argument inference
+/// (<c>OverloadResolver.*</c>) to convert the event's delegate type into its
+/// structural <c>FunctionTypeSymbol</c> shape before binding the lambda, so
+/// omitted parameter types are filled in from the delegate's own signature.
+///
+/// These tests exercise the full, corrected pipeline end to end against a
+/// REAL, separately-compiled C# sibling assembly ("genuinely imported",
+/// exactly like a NuGet package or Oahu.* reference) exposing both instance
+/// and static events of a custom delegate shape (0/1/3 parameters, and a
+/// non-void return for inferred-return-type coverage) as well as the
+/// standard BCL <c>EventHandler</c> shape.
+/// </summary>
+public class Issue2389ImportedDelegateLambdaEmitTests
+{
+    [Fact]
+    public void InstanceEvent_CustomOneParamDelegate_UntypedLambda_RunsAndVerifies()
+    {
+        var libraryPath = EmitCSharpLibrary(nameof(InstanceEvent_CustomOneParamDelegate_UntypedLambda_RunsAndVerifies));
+
+        var output = CompileAndRun(
+            libraryPath,
+            """
+            package App
+            import System
+            import Lib2389
+
+            func Main() {
+                let t = Ticker()
+                t.Ticked += (count) -> System.Console.WriteLine("tick ${count}")
+                t.FireTicked(5)
+            }
+            """,
+            nameof(InstanceEvent_CustomOneParamDelegate_UntypedLambda_RunsAndVerifies));
+
+        Assert.Equal("tick 5\n", output);
+    }
+
+    [Fact]
+    public void InstanceEvent_EventHandlerShape_UntypedLambda_RunsAndVerifies()
+    {
+        var libraryPath = EmitCSharpLibrary(nameof(InstanceEvent_EventHandlerShape_UntypedLambda_RunsAndVerifies));
+
+        var output = CompileAndRun(
+            libraryPath,
+            """
+            package App
+            import System
+            import Lib2389
+
+            func Main() {
+                let t = Ticker()
+                t.Changed += (sender, e) -> System.Console.WriteLine("changed")
+                t.FireChanged()
+            }
+            """,
+            nameof(InstanceEvent_EventHandlerShape_UntypedLambda_RunsAndVerifies));
+
+        Assert.Equal("changed\n", output);
+    }
+
+    [Fact]
+    public void InstanceEvent_ZeroParamDelegate_UntypedLambda_RunsAndVerifies()
+    {
+        var libraryPath = EmitCSharpLibrary(nameof(InstanceEvent_ZeroParamDelegate_UntypedLambda_RunsAndVerifies));
+
+        var output = CompileAndRun(
+            libraryPath,
+            """
+            package App
+            import System
+            import Lib2389
+
+            func Main() {
+                let t = Ticker()
+                t.Pulsed += () -> System.Console.WriteLine("pulsed")
+                t.FirePulsed()
+            }
+            """,
+            nameof(InstanceEvent_ZeroParamDelegate_UntypedLambda_RunsAndVerifies));
+
+        Assert.Equal("pulsed\n", output);
+    }
+
+    [Fact]
+    public void InstanceEvent_ThreeParamDelegate_UntypedLambda_RunsAndVerifies()
+    {
+        var libraryPath = EmitCSharpLibrary(nameof(InstanceEvent_ThreeParamDelegate_UntypedLambda_RunsAndVerifies));
+
+        var output = CompileAndRun(
+            libraryPath,
+            """
+            package App
+            import System
+            import Lib2389
+
+            func Main() {
+                let t = Ticker()
+                t.Combined += (a, b, c) -> System.Console.WriteLine("combined ${a} ${b} ${c}")
+                t.FireCombined(1, 2, 3)
+            }
+            """,
+            nameof(InstanceEvent_ThreeParamDelegate_UntypedLambda_RunsAndVerifies));
+
+        Assert.Equal("combined 1 2 3\n", output);
+    }
+
+    [Fact]
+    public void InstanceEvent_NonVoidDelegate_UntypedLambda_InfersReturnType_RunsAndVerifies()
+    {
+        var libraryPath = EmitCSharpLibrary(nameof(InstanceEvent_NonVoidDelegate_UntypedLambda_InfersReturnType_RunsAndVerifies));
+
+        var output = CompileAndRun(
+            libraryPath,
+            """
+            package App
+            import System
+            import Lib2389
+
+            func Main() {
+                let t = Ticker()
+                t.Transforming += (x) -> x * 2
+                let r = t.FireTransforming(10)
+                System.Console.WriteLine("transform ${r}")
+            }
+            """,
+            nameof(InstanceEvent_NonVoidDelegate_UntypedLambda_InfersReturnType_RunsAndVerifies));
+
+        Assert.Equal("transform 20\n", output);
+    }
+
+    [Fact]
+    public void StaticEvent_CustomOneParamDelegate_UntypedLambda_RunsAndVerifies()
+    {
+        var libraryPath = EmitCSharpLibrary(nameof(StaticEvent_CustomOneParamDelegate_UntypedLambda_RunsAndVerifies));
+
+        var output = CompileAndRun(
+            libraryPath,
+            """
+            package App
+            import System
+            import Lib2389
+
+            func Main() {
+                Ticker.StaticTicked += (count) -> System.Console.WriteLine("static tick ${count}")
+                Ticker.FireStaticTicked(9)
+            }
+            """,
+            nameof(StaticEvent_CustomOneParamDelegate_UntypedLambda_RunsAndVerifies));
+
+        Assert.Equal("static tick 9\n", output);
+    }
+
+    [Fact]
+    public void StaticEvent_EventHandlerShape_UntypedLambda_RunsAndVerifies()
+    {
+        var libraryPath = EmitCSharpLibrary(nameof(StaticEvent_EventHandlerShape_UntypedLambda_RunsAndVerifies));
+
+        var output = CompileAndRun(
+            libraryPath,
+            """
+            package App
+            import System
+            import Lib2389
+
+            func Main() {
+                Ticker.StaticChanged += (sender, e) -> System.Console.WriteLine("static changed")
+                Ticker.FireStaticChanged()
+            }
+            """,
+            nameof(StaticEvent_EventHandlerShape_UntypedLambda_RunsAndVerifies));
+
+        Assert.Equal("static changed\n", output);
+    }
+
+    [Fact]
+    public void InstanceEvent_UntypedLambda_AddThenRemove_SymmetricallyBindsAndVerifies()
+    {
+        // Issue #2389 add/remove symmetry: the fix lives in the single
+        // BindEventSubscriptionHandler helper shared by both `+=` (isAdd:
+        // true) and `-=` (isAdd: false) — mirroring the established
+        // symmetry-test convention (see Issue1473FunctionTypeEventEmitTests),
+        // this proves the SAME untyped-lambda inference gap that `+=` hit is
+        // also closed for `-=`, end to end (compile, IL-verify, run).
+        var libraryPath = EmitCSharpLibrary(nameof(InstanceEvent_UntypedLambda_AddThenRemove_SymmetricallyBindsAndVerifies));
+
+        var output = CompileAndRun(
+            libraryPath,
+            """
+            package App
+            import System
+            import Lib2389
+
+            func Main() {
+                let t = Ticker()
+                t.Ticked += (count) -> System.Console.WriteLine("added ${count}")
+                t.FireTicked(1)
+                t.Ticked -= (count) -> System.Console.WriteLine("added ${count}")
+                System.Console.WriteLine("removed-ok")
+            }
+            """,
+            nameof(InstanceEvent_UntypedLambda_AddThenRemove_SymmetricallyBindsAndVerifies));
+
+        Assert.Equal("added 1\nremoved-ok\n", output);
+    }
+
+    private static string EmitCSharpLibrary(string caseName)
+    {
+        var outputDir = Path.Combine(LibraryDirectory(), caseName);
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Lib2389.dll");
+
+        const string csharpSource = """
+            using System;
+
+            namespace Lib2389
+            {
+                public delegate void TickHandler(int count);
+                public delegate int Transformer(int x);
+                public delegate void Combiner(int a, int b, int c);
+                public delegate void Pulse();
+
+                public class Ticker
+                {
+                    public event TickHandler Ticked;
+                    public event EventHandler Changed;
+                    public event Transformer Transforming;
+                    public event Combiner Combined;
+                    public event Pulse Pulsed;
+                    public static event TickHandler StaticTicked;
+                    public static event EventHandler StaticChanged;
+
+                    public void FireTicked(int count) => Ticked?.Invoke(count);
+
+                    public void FireChanged() => Changed?.Invoke(this, EventArgs.Empty);
+
+                    public int FireTransforming(int x) => Transforming != null ? Transforming(x) : -1;
+
+                    public void FireCombined(int a, int b, int c) => Combined?.Invoke(a, b, c);
+
+                    public void FirePulsed() => Pulsed?.Invoke();
+
+                    public static void FireStaticTicked(int count) => StaticTicked?.Invoke(count);
+
+                    public static void FireStaticChanged() => StaticChanged?.Invoke(null, EventArgs.Empty);
+                }
+            }
+            """;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(csharpSource, new CSharpParseOptions(LanguageVersion.Latest));
+
+        var referencePaths = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+            ?.Split(Path.PathSeparator)
+            ?? Array.Empty<string>();
+
+        var references = referencePaths
+            .Where(File.Exists)
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        // ilverify resolves `-r` references by the reference FILE's simple
+        // name (sans extension), not by the assembly's embedded metadata
+        // identity — so the emitted assembly's declared Name must match its
+        // file name ("Lib2389") even though each test case's copy lives in
+        // its own per-case subdirectory to avoid cross-test collisions.
+        var compilation = CSharpCompilation.Create(
+            "Lib2389",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var emitResult = compilation.Emit(peStream);
+            Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+        }
+
+        return libraryPath;
+    }
+
+    private static string CompileAndRun(string libraryPath, string gsharpSource, string caseName)
+    {
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        var assemblyName = "Issue2389Emit.Consumer." + caseName;
+        var consumerPath = Path.Combine(LibraryDirectory(), assemblyName + ".dll");
+        var consumer = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(gsharpSource)));
+
+        using (var peStream = File.Create(consumerPath))
+        {
+            var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: assemblyName);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
+
+        var loadContext = new AssemblyLoadContext(assemblyName, isCollectible: true);
+        try
+        {
+            var libraryLoadContext = new AssemblyLoadContext(assemblyName + "-Lib", isCollectible: true);
+            try
+            {
+                libraryLoadContext.LoadFromAssemblyPath(libraryPath);
+                var libraryAssemblyName = Path.GetFileNameWithoutExtension(libraryPath);
+                loadContext.Resolving += (ctx, name) => string.Equals(name.Name, libraryAssemblyName, StringComparison.Ordinal)
+                    ? libraryLoadContext.LoadFromAssemblyPath(libraryPath)
+                    : null;
+
+                var asm = loadContext.LoadFromAssemblyPath(consumerPath);
+                var entry = asm.EntryPoint;
+                Assert.NotNull(entry);
+
+                var stdout = Console.Out;
+                var captured = new StringWriter();
+                Console.SetOut(captured);
+                try
+                {
+                    entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+                }
+                finally
+                {
+                    Console.SetOut(stdout);
+                }
+
+                return captured.ToString().Replace("\r\n", "\n");
+            }
+            finally
+            {
+                libraryLoadContext.Unload();
+            }
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static string LibraryDirectory()
+    {
+        var dir = Path.Combine(AppContext.BaseDirectory, "Issue2389Emit");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2389ImportedDelegateLambdaEventTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2389ImportedDelegateLambdaEventTests.cs
@@ -1,0 +1,354 @@
+// <copyright file="Issue2389ImportedDelegateLambdaEventTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2389: an UNTYPED arrow lambda (<c>(count) -&gt; ...</c>, no
+/// parameter type clauses) used with <c>+=</c>/<c>-=</c> against a genuinely
+/// IMPORTED (separately-compiled, real-assembly) CLR delegate/event failed
+/// target-type inference with GS0304, even though the event's declared
+/// delegate type fully determines the expected parameter/return shape. A
+/// TYPED lambda or a source-defined delegate shape (ADR-0076 <c>event E
+/// (args) -&gt; ret</c>) never hit the gap.
+///
+/// <c>ExpressionBinder.BindEventSubscriptionHandler</c> is the single shared
+/// helper behind every <c>+=</c>/<c>-=</c> subscription form (bare
+/// implicit-<c>this</c> event, chained/instance receiver, interface event,
+/// and the raw imported-CLR-event path), so fixing it there covers every one
+/// of those contexts uniformly. The fix reuses the same
+/// <c>MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol</c> conversion
+/// already used by target-typed local declarations
+/// (<c>StatementBinder.Narrowing.cs</c>) and call-argument inference
+/// (<c>OverloadResolver.*</c>) to fill in the lambda's omitted parameter
+/// types from the event's delegate signature before binding.
+///
+/// These binder-level tests use a REAL, separately Roslyn-compiled C# sibling
+/// assembly exposing both instance and static events across a range of
+/// custom-delegate shapes (0/1/3 parameters, non-void return) plus the
+/// standard <c>EventHandler</c> shape, and assert on the resulting
+/// <see cref="GSharp.Core.CodeAnalysis.Diagnostic"/> set — including negative
+/// signature/ambiguity controls proving the fix does not silently accept
+/// mismatched shapes.
+/// </summary>
+public class Issue2389ImportedDelegateLambdaEventTests
+{
+    private static readonly string LibraryPath = EmitCSharpLibrary();
+
+    [Fact]
+    public void InstanceEvent_CustomOneParamDelegate_UntypedLambda_Binds()
+    {
+        Assert.Empty(Bind("""
+            package App
+            import Lib2389B
+
+            func Main() {
+                let t = Ticker()
+                t.Ticked += (count) -> { }
+            }
+            """));
+    }
+
+    [Fact]
+    public void InstanceEvent_EventHandlerShape_UntypedLambda_Binds()
+    {
+        Assert.Empty(Bind("""
+            package App
+            import Lib2389B
+
+            func Main() {
+                let t = Ticker()
+                t.Changed += (sender, e) -> { }
+            }
+            """));
+    }
+
+    [Fact]
+    public void InstanceEvent_ZeroParamDelegate_UntypedLambda_Binds()
+    {
+        Assert.Empty(Bind("""
+            package App
+            import Lib2389B
+
+            func Main() {
+                let t = Ticker()
+                t.Pulsed += () -> { }
+            }
+            """));
+    }
+
+    [Fact]
+    public void InstanceEvent_ThreeParamDelegate_UntypedLambda_Binds()
+    {
+        Assert.Empty(Bind("""
+            package App
+            import Lib2389B
+
+            func Main() {
+                let t = Ticker()
+                t.Combined += (a, b, c) -> { }
+            }
+            """));
+    }
+
+    [Fact]
+    public void InstanceEvent_NonVoidDelegate_UntypedLambda_InfersReturnType_Binds()
+    {
+        Assert.Empty(Bind("""
+            package App
+            import Lib2389B
+
+            func Main() {
+                let t = Ticker()
+                t.Transforming += (x) -> x * 2
+            }
+            """));
+    }
+
+    [Fact]
+    public void StaticEvent_CustomOneParamDelegate_UntypedLambda_Binds()
+    {
+        Assert.Empty(Bind("""
+            package App
+            import Lib2389B
+
+            func Main() {
+                Ticker.StaticTicked += (count) -> { }
+            }
+            """));
+    }
+
+    [Fact]
+    public void StaticEvent_EventHandlerShape_UntypedLambda_Binds()
+    {
+        Assert.Empty(Bind("""
+            package App
+            import Lib2389B
+
+            func Main() {
+                Ticker.StaticChanged += (sender, e) -> { }
+            }
+            """));
+    }
+
+    [Fact]
+    public void InstanceEvent_UntypedLambda_AddAndRemove_BothBind()
+    {
+        // Add/remove symmetry: BindEventSubscriptionHandler is the SAME
+        // helper for both `+=` (isAdd: true) and `-=` (isAdd: false) — this
+        // proves the fix applies to both operators, not just `+=`.
+        Assert.Empty(Bind("""
+            package App
+            import Lib2389B
+
+            func Main() {
+                let t = Ticker()
+                t.Ticked += (count) -> { }
+                t.Ticked -= (count) -> { }
+            }
+            """));
+    }
+
+    [Fact]
+    public void TypedLambda_StillBinds_RegressionControl()
+    {
+        // Baseline control: a fully-typed lambda against the same imported
+        // custom delegate must keep working exactly as before the fix.
+        Assert.Empty(Bind("""
+            package App
+            import Lib2389B
+
+            func Main() {
+                let t = Ticker()
+                t.Ticked += (count int32) -> { }
+            }
+            """));
+    }
+
+    [Fact]
+    public void SourceDefinedDelegateShape_UntypedLambda_StillBinds()
+    {
+        // Source-language coverage: an event declared with an ADR-0076
+        // function-type shape (`event E (args) -> ret`) hits the exact same
+        // `BindEventSubscriptionHandler` fallback as an imported CLR
+        // delegate — `targetDelegateType` here is already a
+        // `FunctionTypeSymbol`, which `TryGetLambdaTargetFunctionTypeFromSymbol`
+        // returns as-is. This proves the fix is not special-cased to CLR
+        // reflection lookups; it uniformly threads the target type through
+        // for every delegate-shaped event regardless of where the shape
+        // originates.
+        Assert.Empty(Bind("""
+            package App
+            class Clock {
+                event Ticked (int32) -> void
+            }
+            func Main() {
+                let c = Clock()
+                c.Ticked += (count) -> { }
+            }
+            """));
+    }
+
+    [Fact]
+    public void ArityMismatch_UntypedLambda_ReportsDiagnostic()
+    {
+        // Negative signature control: a 2-parameter untyped lambda against a
+        // 1-parameter delegate must still be rejected — target-typing fills
+        // in parameter TYPES from the delegate's slots, it must not paper
+        // over a genuine arity mismatch. Since the lambda's arity does not
+        // match the target delegate, the target-typing fix does not apply
+        // per-parameter types (the same as it would for a source-defined
+        // delegate mismatch), so the parameters fall back to natural
+        // inference (GS0304) and the overall handler still fails the final
+        // delegate-conversion check (GS0155). What matters here is that the
+        // mismatch is still definitively rejected rather than silently
+        // accepted.
+        var diagnostics = Bind("""
+            package App
+            import Lib2389B
+
+            func Main() {
+                let t = Ticker()
+                t.Ticked += (a, b) -> { }
+            }
+            """);
+
+        Assert.NotEmpty(diagnostics);
+        Assert.Contains(diagnostics, d => d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void ReturnTypeMismatch_UntypedLambda_ReportsDiagnostic()
+    {
+        // Negative signature control: the delegate's non-void return type
+        // (int32) is still enforced — a body producing an incompatible type
+        // (string) must be rejected, not silently widened/accepted.
+        var diagnostics = Bind("""
+            package App
+            import Lib2389B
+
+            func Main() {
+                let t = Ticker()
+                t.Transforming += (x) -> "not an int"
+            }
+            """);
+
+        Assert.NotEmpty(diagnostics);
+    }
+
+    [Fact]
+    public void AmbiguousMethodGroupHandler_ReportsDiagnostic_UnaffectedByFix()
+    {
+        // Negative ambiguity control: two overloads that are each only
+        // implicitly (never exactly) convertible to the target delegate's
+        // `int64` parameter must still be rejected as ambiguous — this path
+        // never touches the untyped-lambda fix (it's a method-group
+        // conversion, not a LambdaExpressionSyntax), so it's a sibling-audit
+        // regression guard proving the fix didn't disturb method-group
+        // handler resolution.
+        var diagnostics = Bind("""
+            package App
+            import Lib2389B
+
+            func Handle(x int32) { }
+            func Handle(x int16) { }
+
+            func Main() {
+                let t = Ticker()
+                t.Widened += Handle
+            }
+            """);
+
+        Assert.NotEmpty(diagnostics);
+    }
+
+    private static System.Collections.Generic.IReadOnlyList<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
+    {
+        using var resolver = ReferenceResolver.WithReferences(new[] { LibraryPath });
+        var tree = GsSyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GsCompilation(resolver, tree);
+
+        // The imported library is loaded reflection-only via a
+        // MetadataLoadContext (see ReferenceResolver.WithReferences), so its
+        // types cannot actually be instantiated/invoked — these tests bind
+        // (and lower) the program to surface every diagnostic, including
+        // ones raised while binding function BODIES (BoundProgram.Diagnostics
+        // — GlobalScope.Diagnostics alone only covers declaration-level
+        // binding), without going through Compilation.Evaluate, which would
+        // try to actually execute the reflection-only Ticker calls.
+        var parseDiagnostics = tree.Diagnostics;
+        return parseDiagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .ToList();
+    }
+
+    private static string EmitCSharpLibrary()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2389Binding");
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Lib2389B.dll");
+
+        const string csharpSource = """
+            using System;
+
+            namespace Lib2389B
+            {
+                public delegate void TickHandler(int count);
+                public delegate int Transformer(int x);
+                public delegate void Combiner(int a, int b, int c);
+                public delegate void Pulse();
+                public delegate void Wide(long v);
+
+                public class Ticker
+                {
+                    public event TickHandler Ticked;
+                    public event EventHandler Changed;
+                    public event Transformer Transforming;
+                    public event Combiner Combined;
+                    public event Pulse Pulsed;
+                    public event Wide Widened;
+                    public static event TickHandler StaticTicked;
+                    public static event EventHandler StaticChanged;
+                }
+            }
+            """;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(csharpSource, new CSharpParseOptions(LanguageVersion.Latest));
+
+        var referencePaths = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+            ?.Split(Path.PathSeparator)
+            ?? Array.Empty<string>();
+
+        var references = referencePaths
+            .Where(File.Exists)
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "Lib2389B",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var emitResult = compilation.Emit(peStream);
+            Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+        }
+
+        return libraryPath;
+    }
+}


### PR DESCRIPTION
Closes #2389.

## Problem

An untyped arrow lambda used with `+=`/`-=` against a genuinely **imported**
(separately-compiled) CLR delegate/event failed target-type inference with
GS0304, even though the event's declared delegate type fully determines the
expected parameter/return shape:

```
package App
import SomeLib

func Main() {
    let t = Ticker()
    t.Ticked += (count) -> { }   // GS0304: cannot infer type of 'count'
}
```

A typed lambda (`(count int32) -> { }`) or a source-defined delegate shape
(ADR-0076 `event E (args) -> ret`) never hit the gap.

## Root cause

`ExpressionBinder.BindEventSubscriptionHandler` in
`src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs` is the single
shared helper behind **every** `+=`/`-=` subscription form — bare
implicit-`this` event, chained/instance receiver, interface event, and the
raw imported-CLR-event path all funnel through it. Its fallback path bound
the handler via a plain `BindExpression(handlerSyntax)`, which for an arrow
lambda dispatches to `LambdaBinder.BindLambdaExpression` with **no target
function type** — so an omitted parameter type clause always failed
inference, even though the event's delegate type is known at that point.

## Fix

When the handler is an untyped `LambdaExpressionSyntax`, resolve the event's
delegate type into a `FunctionTypeSymbol` via the already-established
`MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol` helper — the same
helper already used by target-typed local declarations
(`StatementBinder.Narrowing.cs`) and call-argument inference
(`OverloadResolver.*`) — and bind the lambda through
`LambdaBinder.BindLambdaExpression` with that target type. This correctly
resolves both user source `delegate` types and genuinely imported CLR
delegates (via reflection fallback). The rest of the method (method-group
checks, final delegate-conversion check) is unchanged, so typed-lambda and
method-group handler behavior is completely unaffected.

Because the fix lives in the single shared helper, it uniformly covers every
`+=`/`-=` subscription context without any additional call-site changes.

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue2389ImportedDelegateLambdaEventTests.cs`
  — 13 binder-level facts against a real, separately Roslyn-compiled C#
  sibling assembly: instance/static events across 0/1/3-param,
  `EventHandler`-shaped, and non-void-return delegates; add/remove symmetry;
  typed-lambda and source-defined-delegate-shape regression controls; and
  negative arity-mismatch / return-type-mismatch / method-group-ambiguity
  controls proving the fix doesn't silently paper over genuine mismatches.
- `test/Compiler.Tests/Emit/Issue2389ImportedDelegateLambdaEmitTests.cs` — 8
  full compile → ILVerify → run facts covering the same delegate shapes plus
  add+remove symmetry, executed against a real imported assembly (not just
  reflection-only metadata).

## Audit: imported static field/property assignment

Per the review scope for this issue, I audited the sibling case of a plain
`=` assignment to an imported CLR static field/property whose type is a
delegate and confirmed the same root cause reproduces there too, in a
different binder path (`ExpressionBinder.Assignments.cs`). Since it's an
independent code path with its own leverage/blast radius, I filed it
separately as #2410 rather than expanding this PR's scope.

## Validation performed

- `Core.Tests`: 6350 passed, 1 skipped (baseline regen), 0 failed
- `Compiler.Tests`: 3142 passed, 0 failed
- `InternalAnalyzers.Tests`: 7 passed, 0 failed
- `Sdk.Tests`: 39 passed, 0 failed
- `Cs2Gs.Tests` (serialized, `RunConfiguration.DisableParallelization=true`):
  1423 passed, 0 failed
- SDK packaging smoke test (`e2etests/sdk-e2e.sh`) rebuilt/repacked
  `Gsharp.NET.Sdk`, refreshed `.nugs`, and cleared the matching
  `~/.nuget/packages/gsharp.net.sdk/<version>` cache before validating the
  packaged `gsc` payload end to end.

No changes to Oahu or other repositories.
