### PR TITLE
Fix #2412: preserve oblivious-nullability taint across project references

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -14,6 +14,7 @@ using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Cs2Gs.Pipeline;
 
@@ -84,6 +85,18 @@ public sealed class TranslateStage : IMigrationStage
                 DeclaredProjectItems.Read(context.App.ProjectPath, "PackageReference")));
         context.ProjectReferences.AddRange(
             DeclaredProjectItems.Read(context.App.ProjectPath, "ProjectReference"));
+
+        // Issue #2412: every project's own `Compilation` in this run (app +
+        // every transitively-referenced sibling), so `TranslationContext.
+        // ResolveDeclaringCompilation` can redirect a whole-program fact query
+        // (e.g. `ObliviousNullabilityAnalyzer`'s oblivious-taint fixpoint) for a
+        // symbol declared in a REFERENCED sibling project back to that
+        // sibling's OWN compilation — the one whose syntax trees actually
+        // contain the tainting evidence — instead of always the current
+        // document's own project compilation, which never sees it.
+        IReadOnlyList<CSharpCompilation> siblingCompilations = projects
+            .Select(p => p.Compilation)
+            .ToList();
 
         // Translate the app itself (index 0) plus its transitively referenced
         // sibling projects (Refs #914). Sibling G# is emitted so the app's uses
@@ -185,7 +198,8 @@ public sealed class TranslateStage : IMigrationStage
                 var translationContext = new TranslationContext(
                     currentProject.Compilation,
                     document.SemanticModel,
-                    document.FilePath);
+                    document.FilePath,
+                    siblingCompilations);
 
                 CompilationUnit unit = translator.TranslateDocument(document, translationContext);
                 string printed = GSharpPrinter.Print(unit);

--- a/tools/cs2gs/Cs2Gs.ProjectLoading/CSharpProjectLoader.cs
+++ b/tools/cs2gs/Cs2Gs.ProjectLoading/CSharpProjectLoader.cs
@@ -191,8 +191,16 @@ public static class CSharpProjectLoader
 
         var workspaceFailures = new List<Diagnostic>();
         using var workspace = MSBuildWorkspace.Create();
-        workspace.LoadMetadataForReferencedProjects = true;
 
+        // Issue #2412: unlike LoadProjectAsync, this loader's entire purpose is
+        // to load referenced projects as their own bound source Projects so their
+        // syntax is available to callers (e.g. cross-project oblivious-nullability
+        // taint analysis, Refs #914). Setting LoadMetadataForReferencedProjects
+        // makes MSBuildWorkspace collapse same-solution ProjectReferences into
+        // pure metadata references instead of Solution.Projects entries, which
+        // silently empties root.ProjectReferences/TransitiveCSharpProjectReferences
+        // below and degrades this call to loading only the primary project — do
+        // not set it here.
         Project project = await workspace.OpenProjectAsync(fullPath, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 

--- a/tools/cs2gs/Cs2Gs.Tests/CSharpProjectLoaderDiagnosticsTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/CSharpProjectLoaderDiagnosticsTests.cs
@@ -306,6 +306,100 @@ namespace Sample
             d => d.FilePath.Replace('\\', '/').EndsWith("Lib/IWidget.cs", StringComparison.Ordinal));
     }
 
+    /// <summary>
+    /// Issue #2412 regression guard: on a fresh, never-restored/never-built
+    /// sibling project (the shape <see cref="LoadProjectWithReferencesAsync_IncludesReferencedSiblingProject"/>
+    /// exercises), MSBuildWorkspace cannot resolve a prebuilt output assembly
+    /// for the <c>ProjectReference</c>, so it always keeps the sibling as a
+    /// source <see cref="Project"/> in the solution regardless of the
+    /// <c>LoadMetadataForReferencedProjects</c> setting — that test alone would
+    /// NOT have caught this bug. Once the sibling has actually been restored
+    /// and built (its real-world state — e.g. any already-built solution like
+    /// Oahu.Core referencing Oahu.Data/Oahu.Foundation/Oahu.Decrypt), a
+    /// prebuilt <c>bin/</c> output exists for MSBuildWorkspace to substitute,
+    /// and setting <c>LoadMetadataForReferencedProjects = true</c> makes it
+    /// collapse the sibling <c>ProjectReference</c> into a pure metadata
+    /// reference — dropping it from <c>Solution.Projects</c> entirely and
+    /// silently degrading <see cref="CSharpProjectLoader.LoadProjectWithReferencesAsync"/>
+    /// to returning only the primary project. This regressed cross-project
+    /// oblivious-nullability taint analysis (Refs #914's sibling-source
+    /// requirement) because the sibling's source was never available to
+    /// analyze. <see cref="CSharpProjectLoader.LoadProjectWithReferencesAsync"/>
+    /// must not set that flag.
+    /// </summary>
+    [Fact]
+    public async Task LoadProjectWithReferencesAsync_IncludesReferencedSiblingProject_WhenSiblingIsPrebuilt()
+    {
+        string root = NewScratchDir("with-prebuilt-reference");
+        File.WriteAllText(Path.Combine(root, "Directory.Build.props"), "<Project></Project>");
+
+        string libDir = Path.Combine(root, "Lib");
+        Directory.CreateDirectory(libDir);
+        string libProjectPath = Path.Combine(libDir, "Lib.csproj");
+        File.WriteAllText(libProjectPath, @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+");
+        File.WriteAllText(
+            Path.Combine(libDir, "IWidget.cs"),
+            "namespace Lib { public interface IWidget { int Value { get; } } }");
+
+        string appDir = Path.Combine(root, "App");
+        Directory.CreateDirectory(appDir);
+        File.WriteAllText(Path.Combine(appDir, "App.csproj"), @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include=""..\Lib\Lib.csproj"" />
+  </ItemGroup>
+</Project>
+");
+        File.WriteAllText(
+            Path.Combine(appDir, "Widget.cs"),
+            "namespace App { public class Widget : Lib.IWidget { public int Value => 42; } }");
+
+        // Reproduce the real-world precondition (Refs #2412): the sibling has
+        // already been restored and built, so a prebuilt output assembly
+        // exists on disk for MSBuildWorkspace to (incorrectly, if the buggy
+        // flag were set) substitute in place of the source Project.
+        RunDotnetBuild(libProjectPath);
+
+        System.Collections.Generic.IReadOnlyList<LoadedCSharpProject> projects =
+            await CSharpProjectLoader.LoadProjectWithReferencesAsync(Path.Combine(appDir, "App.csproj"));
+
+        Assert.True(
+            projects.Count >= 2,
+            "Expected the app project plus its prebuilt referenced sibling as a source project.");
+        Assert.Contains(
+            projects[0].Documents,
+            d => d.FilePath.Replace('\\', '/').EndsWith("App/Widget.cs", StringComparison.Ordinal));
+        Assert.Contains(
+            projects.Skip(1).SelectMany(p => p.Documents),
+            d => d.FilePath.Replace('\\', '/').EndsWith("Lib/IWidget.cs", StringComparison.Ordinal));
+    }
+
+    private static void RunDotnetBuild(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", $"build \"{projectPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using Process process = Process.Start(startInfo);
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(
+            process.ExitCode == 0,
+            $"Prerequisite `dotnet build` failed (exit {process.ExitCode}); cannot exercise the prebuilt-sibling path.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
     private static string NewScratchDir(string label)
     {
         string root = Path.Combine(AppContext.BaseDirectory, "loader-tests", label, Guid.NewGuid().ToString("N"));

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2412CrossProjectObliviousNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2412CrossProjectObliviousNullabilityTranslationTests.cs
@@ -1,0 +1,597 @@
+// <copyright file="Issue2412CrossProjectObliviousNullabilityTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #2412: <see cref="ObliviousNullabilityAnalyzer"/>'s
+/// whole-program taint fixpoint (issues #2113/#2157/#2167/#2259/#2285) is
+/// scoped to ONE <see cref="CSharpCompilation"/>, but
+/// <c>CSharpProjectLoader.LoadProjectWithReferencesAsync</c> (used by every
+/// app with a <c>ProjectReference</c>) loads the app and each transitively
+/// referenced sibling project as SEPARATE compilations linked only by ordinary
+/// project/metadata references. A downstream project's translator asking
+/// whether a symbol DECLARED IN a referenced sibling is null-tainted used to
+/// walk only its own (downstream) compilation's syntax trees — which never
+/// contain the sibling's tainting evidence — and always answer "no", so the
+/// `!!` forgiveness <see cref="CSharpToGSharpTranslator"/> already emits
+/// correctly for the intra-project case (issue #914) never fired across a
+/// project boundary. This is the exact shape of the real-world Oahu.Core
+/// <c>AaxExporter.ExportChapters</c> diagnostic (GS0156 on <c>book.Asin</c>,
+/// a member declared in Oahu.Data and correctly promoted there, consumed
+/// bare in Oahu.Core).
+/// <para>
+/// <b>Fix</b>: <c>TranslateStage</c> now threads every loaded project's own
+/// <see cref="CSharpCompilation"/> (the app plus its transitive
+/// <c>ProjectReference</c> closure) into every <see cref="TranslationContext"/>
+/// it creates (<see cref="TranslationContext.SiblingCompilations"/>).
+/// <see cref="CSharpToGSharpTranslator"/>'s single promotion choke point
+/// (<c>ShouldPromoteToNullableReference</c>) now calls a new three-argument
+/// <see cref="ObliviousNullabilityAnalyzer.IsTainted(CSharpCompilation, ISymbol, IReadOnlyList{CSharpCompilation})"/>
+/// overload that tries the current compilation first (byte-identical to the
+/// existing two-argument overload — every single-compilation caller passes no
+/// sibling set) and then, only if that reports untainted, each sibling's OWN
+/// cached taint result in turn — a symbol tainted in ANY ONE known project's
+/// own analysis is a single global fact, since interface-implementation edges
+/// (issue #2285) can record taint for a symbol declared in a THIRD project
+/// entirely (the real Oahu shape: the tainting <c>?.</c> evidence and the
+/// interface edge both live in Oahu.Data, but the promoted symbol,
+/// <c>IBookMeta.Asin</c>, is declared in Oahu.Foundation).
+/// </para>
+/// <para>
+/// Object-initializer assignment sinks already routed through
+/// <c>ShouldPromoteToNullableReference</c> via <c>ForgiveObjectInitializerValue</c>
+/// / <c>IsNullablePromotedValue</c>, so the three-argument overload alone
+/// covers them. RETURN and ARGUMENT positions route instead through
+/// <c>ReceiverNeedsNullForgiveness</c>, whose general (declared-nullable,
+/// flow-narrowed) branch gates on Roslyn's <c>NullableFlowState.NotNull</c> —
+/// never reported in an oblivious compilation — so that method needed one
+/// additional, narrowly-scoped branch: when a value read resolves to a
+/// field/property/method DECLARED IN A DIFFERENT ASSEMBLY than the current
+/// compilation's own AND that sibling's own analysis proves it tainted,
+/// assert <c>!!</c> directly, bypassing the flow-state gate. This is disjoint
+/// from every existing intra-project branch (all of which require the SAME
+/// assembly), so no existing single-compilation behavior changes.
+/// </para>
+/// </summary>
+public class Issue2412CrossProjectObliviousNullabilityTranslationTests
+{
+    // ---- Issue's own minimal LibA/LibB repro -------------------------------
+
+    private const string LibBSource = @"
+namespace LibB
+{
+    public interface IFoo
+    {
+        string Name { get; }
+    }
+
+    public class Impl : IFoo
+    {
+        public Impl Other { get; set; }
+        public string Name => Other?.Name;
+    }
+}";
+
+    [Fact]
+    public void CrossProject_ObjectInitializerAssignment_FromReferencedInterfaceMember_InsertsForgiveness()
+    {
+        const string LibASource = @"
+using LibB;
+
+namespace LibA
+{
+    public class Target
+    {
+        public string Name { get; set; }
+    }
+
+    public class Consumer
+    {
+        public Target Make(IFoo foo) => new Target { Name = foo.Name };
+    }
+}";
+
+        (string printedB, string printedA) = TranslateTwoProjects(LibBSource, LibASource);
+
+        // LibB's own translation is unaffected: `IFoo.Name`/`Impl.Name` are
+        // still promoted to `string?` purely from LibB's own `Other?.Name`
+        // evidence (issue #914/#2285), independent of any sibling.
+        // LibA's `Target.Name` is Target's OWN declared property, assigned
+        // (not read) from the tainted `foo.Name` — it must stay non-nullable
+        // `string` (issue #2412's own worked example: the fix must not
+        // repaint an unrelated declaration's own type). Only the read of the
+        // cross-project-tainted `foo.Name` at the consumption site gets `!!`
+        // forgiveness.
+        Assert.Contains("prop Name string", Compact(printedA));
+        Assert.DoesNotContain("prop Name string?", Compact(printedA));
+        Assert.Contains("Target{Name: foo.Name!!}", Compact(printedA));
+    }
+
+    [Fact]
+    public void CrossProject_ReturnPosition_FromReferencedInterfaceMember_InsertsForgiveness()
+    {
+        const string LibASource = @"
+using LibB;
+
+namespace LibA
+{
+    public class Consumer
+    {
+        public string GetName(IFoo foo)
+        {
+            return foo.Name;
+        }
+    }
+}";
+
+        (_, string printedA) = TranslateTwoProjects(LibBSource, LibASource);
+
+        Assert.Contains("return foo.Name!!", Compact(printedA));
+    }
+
+    [Fact]
+    public void CrossProject_MethodArgumentPosition_FromReferencedInterfaceMember_InsertsForgiveness()
+    {
+        const string LibASource = @"
+using LibB;
+
+namespace LibA
+{
+    public class Sink
+    {
+        public void Accept(string s) { }
+    }
+
+    public class Consumer
+    {
+        public void Run(IFoo foo, Sink sink)
+        {
+            sink.Accept(foo.Name);
+        }
+    }
+}";
+
+        (_, string printedA) = TranslateTwoProjects(LibBSource, LibASource);
+
+        Assert.Contains("sink.Accept(foo.Name!!)", Compact(printedA));
+    }
+
+    [Fact]
+    public void CrossProject_FieldTarget_FromReferencedInterfaceMember_InsertsForgiveness()
+    {
+        const string LibASource = @"
+using LibB;
+
+namespace LibA
+{
+    public class Holder
+    {
+        public string Name;
+    }
+
+    public class Consumer
+    {
+        public Holder Make(IFoo foo) => new Holder { Name = foo.Name };
+    }
+}";
+
+        (_, string printedA) = TranslateTwoProjects(LibBSource, LibASource);
+
+        Assert.Contains("Holder{Name: foo.Name!!}", Compact(printedA));
+    }
+
+    // ---- Negative controls --------------------------------------------------
+
+    [Fact]
+    public void CrossProject_UnrelatedUntaintedSiblingMember_StaysNonNullable_NoSpuriousForgiveness()
+    {
+        // `Plain.Label` has NO direct or transitive taint evidence anywhere in
+        // LibB — the fix must not over-promote every cross-project symbol, only
+        // ones the sibling's own analysis actually proved tainted.
+        const string libB = @"
+namespace LibB
+{
+    public interface IFoo
+    {
+        string Name { get; }
+    }
+
+    public class Impl : IFoo
+    {
+        public Impl Other { get; set; }
+        public string Name => Other?.Name;
+    }
+
+    public class Plain
+    {
+        public string Label => ""fixed"";
+    }
+}";
+
+        const string libA = @"
+using LibB;
+
+namespace LibA
+{
+    public class Target
+    {
+        public string Name { get; set; }
+    }
+
+    public class Consumer
+    {
+        public Target Make(Plain plain) => new Target { Name = plain.Label };
+    }
+}";
+
+        (string printedB, string printedA) = TranslateTwoProjects(libB, libA);
+
+        Assert.Contains("prop Label string -> \"fixed\"", printedB);
+        Assert.DoesNotContain("prop Label string? ", printedB);
+        Assert.Contains("Target{Name: plain.Label}", Compact(printedA));
+        Assert.DoesNotContain("plain.Label!!", printedA);
+    }
+
+    [Fact]
+    public void CrossProject_NullableEnabledSiblingProject_Unaffected()
+    {
+        // A nullable-ENABLED sibling's OWN declared annotation drives promotion
+        // (independent of ObliviousNullabilityAnalyzer, which never runs for an
+        // enabled compilation) — the cross-project wiring must not perturb that
+        // existing, already-correct path: a non-null `string` member stays a
+        // bare, non-`!!` read downstream, and a genuinely nullable `string?`
+        // member (real annotation, not taint) is read with the SAME forgiveness
+        // an intra-project nullable-enabled reference would already get.
+        const string libB = @"
+#nullable enable
+namespace LibB
+{
+    public class Enabled
+    {
+        public string NonNull => ""x"";
+
+        public string? Nullable => null;
+    }
+}";
+
+        const string libA = @"
+using LibB;
+
+namespace LibA
+{
+    public class Target
+    {
+        public string A { get; set; }
+        public string B { get; set; }
+    }
+
+    public class Consumer
+    {
+        public Target Make(Enabled e) => new Target { A = e.NonNull, B = e.Nullable! };
+    }
+}";
+
+        (string printedB, string printedA) = TranslateTwoProjects(libB, libA, obliviousB: false);
+
+        // `NonNull` is a plain, genuinely non-nullable `string` — no `!!`.
+        // `Nullable` is a genuinely `string?`-annotated property (not
+        // taint-promoted) — the ALREADY-correct nullable-enabled path
+        // (independent of this fix) inserts `!!` from its own declared
+        // annotation, and the cross-project wiring must not disturb that.
+        Assert.Contains("Target{A: e.NonNull, B: e.Nullable!!}", Compact(printedA));
+    }
+
+    [Fact]
+    public void CrossProject_SameSimpleMemberNameInTwoSiblings_DoesNotCrossContaminate()
+    {
+        // Issue requirement: "multiple projects declaring same simple symbol
+        // names". LibC's `Impl.Name`/`IFoo.Name` shape mirrors LibB's exactly
+        // (same simple names, same shape) but carries NO tainting evidence, so
+        // it must stay non-nullable even though the CONSUMER references both
+        // siblings' same-named symbol side by side. Assembly/symbol identity
+        // (not name) must disambiguate the two.
+        const string libC = @"
+namespace LibC
+{
+    public interface IFoo
+    {
+        string Name { get; }
+    }
+
+    public class Impl : IFoo
+    {
+        public string Name => ""fixed-c"";
+    }
+}";
+
+        LoadedCSharpProject projectB = LoadOblivious(LibBSource, "LibB");
+        LoadedCSharpProject projectC = LoadOblivious(libC, "LibC");
+
+        const string libA = @"
+using B = LibB;
+using C = LibC;
+
+namespace LibA
+{
+    public class TargetB
+    {
+        public string Name { get; set; }
+    }
+
+    public class TargetC
+    {
+        public string Name { get; set; }
+    }
+
+    public class Consumer
+    {
+        public TargetB MakeB(B.IFoo foo) => new TargetB { Name = foo.Name };
+
+        public TargetC MakeC(C.IFoo foo) => new TargetC { Name = foo.Name };
+    }
+}";
+
+        LoadedCSharpProject projectA = LoadOblivious(
+            libA,
+            "LibA",
+            new MetadataReference[] { projectB.Compilation.ToMetadataReference(), projectC.Compilation.ToMetadataReference() });
+
+        var siblings = new[] { projectA.Compilation, projectB.Compilation, projectC.Compilation };
+        string printedC = TranslateProject(projectC, siblings);
+        string printedA = TranslateProject(projectA, siblings);
+
+        Assert.Contains("prop Name string {", printedC);
+        Assert.DoesNotContain("prop Name string? {", printedC);
+
+        Assert.Contains("TargetB{Name: foo.Name!!}", Compact(printedA));
+        Assert.Contains("TargetC{Name: foo.Name}", Compact(printedA));
+        Assert.DoesNotContain("TargetC{Name: foo.Name!!}", Compact(printedA));
+    }
+
+    // ---- Transitive (three-project) chain: the real Oahu shape -------------
+
+    [Fact]
+    public void CrossProject_TransitiveThreeProjects_InterfaceMemberDeclaredInThirdProject_InsertsForgiveness()
+    {
+        // Mirrors Oahu exactly: `IBookMeta.Asin` (LibFoundation) is get-only and
+        // carries NO evidence of its own; `Conversion.Asin` (LibData) is the
+        // ONLY `?.`-seeded evidence, and LibData's OWN interface-implementation
+        // edges (issue #2285) are what promote `IBookMeta.Asin` — a symbol
+        // declared in a THIRD project — inside LibData's own taint fixpoint.
+        // LibCore (the consumer) references LibData directly and LibFoundation
+        // transitively; it must still insert `!!` for `book.Asin`.
+        const string libFoundation = @"
+namespace LibFoundation
+{
+    public interface IBookMeta
+    {
+        string Asin { get; }
+    }
+}";
+
+        const string libData = @"
+using LibFoundation;
+
+namespace LibData
+{
+    public interface IBookCommon : IBookMeta
+    {
+    }
+
+    public class BookMetaHolder
+    {
+        public IBookMeta BookMeta { get; set; }
+    }
+
+    public class Conversion : IBookCommon
+    {
+        public BookMetaHolder Holder { get; set; }
+
+        public string Asin => Holder?.BookMeta?.Asin;
+    }
+}";
+
+        LoadedCSharpProject projectFoundation = LoadOblivious(libFoundation, "LibFoundation");
+        LoadedCSharpProject projectData = LoadOblivious(
+            libData, "LibData", new MetadataReference[] { projectFoundation.Compilation.ToMetadataReference() });
+
+        const string libCore = @"
+using LibData;
+using LibFoundation;
+
+namespace LibCore
+{
+    public class ContentReference
+    {
+        public string Asin { get; set; }
+    }
+
+    public class AaxExporter
+    {
+        public ContentReference Export(IBookCommon book) => new ContentReference { Asin = book.Asin };
+    }
+}";
+
+        LoadedCSharpProject projectCore = LoadOblivious(
+            libCore,
+            "LibCore",
+            new MetadataReference[]
+            {
+                projectData.Compilation.ToMetadataReference(),
+                projectFoundation.Compilation.ToMetadataReference(),
+            });
+
+        var siblings = new[] { projectCore.Compilation, projectData.Compilation, projectFoundation.Compilation };
+        string printedData = TranslateProject(projectData, siblings);
+        string printedCore = TranslateProject(projectCore, siblings);
+
+        // LibData's own standalone translation already promotes both endpoints
+        // (issue #2285) — the interface member declared in Foundation AND its
+        // own implementing property.
+        Assert.Contains("prop Asin string? ->", printedData);
+
+        // The regression: LibCore inserts the forgiveness for the Foundation-
+        // declared interface member, whose only evidence lives in LibData.
+        Assert.Contains("ContentReference{Asin: book.Asin!!}", Compact(printedCore));
+    }
+
+    // ---- Determinism / caching ----------------------------------------------
+
+    [Fact]
+    public void CrossProject_RepeatedTranslation_IsDeterministicAndConsistent()
+    {
+        const string LibASource = @"
+using LibB;
+
+namespace LibA
+{
+    public class Target
+    {
+        public string Name { get; set; }
+    }
+
+    public class Consumer
+    {
+        public Target Make(IFoo foo) => new Target { Name = foo.Name };
+    }
+}";
+
+        LoadedCSharpProject projectB = LoadOblivious(LibBSource, "LibB");
+        LoadedCSharpProject projectA = LoadOblivious(
+            LibASource, "LibA", new MetadataReference[] { projectB.Compilation.ToMetadataReference() });
+        var siblings = new[] { projectA.Compilation, projectB.Compilation };
+
+        // Two INDEPENDENT translator instances (as every real pipeline stage
+        // creates one per project) over the SAME loaded projects must agree —
+        // the fix must not depend on incidental ordering of which project gets
+        // translated (and therefore cached) first.
+        string firstPrintedA = TranslateProject(projectA, siblings);
+        string firstPrintedB = TranslateProject(projectB, siblings);
+        string secondPrintedB = TranslateProject(projectB, siblings);
+        string secondPrintedA = TranslateProject(projectA, siblings);
+
+        Assert.Equal(firstPrintedA, secondPrintedA);
+        Assert.Equal(firstPrintedB, secondPrintedB);
+        Assert.Contains("Target{Name: foo.Name!!}", Compact(firstPrintedA));
+        Assert.Contains("Target{Name: foo.Name!!}", Compact(secondPrintedA));
+    }
+
+    // ---- Helpers -------------------------------------------------------------
+
+    private static (string PrintedB, string PrintedA) TranslateTwoProjects(
+        string sourceB, string sourceA, bool obliviousB = true)
+    {
+        LoadedCSharpProject projectB = obliviousB
+            ? LoadOblivious(sourceB, "LibB")
+            : LoadEnabled(sourceB, "LibB");
+        LoadedCSharpProject projectA = LoadOblivious(
+            sourceA, "LibA", new MetadataReference[] { projectB.Compilation.ToMetadataReference() });
+
+        var siblings = new[] { projectA.Compilation, projectB.Compilation };
+        string printedB = TranslateProject(projectB, siblings);
+        string printedA = TranslateProject(projectA, siblings);
+        return (printedB, printedA);
+    }
+
+    private static LoadedCSharpProject LoadOblivious(
+        string source, string assemblyName, IReadOnlyList<MetadataReference> extraReferences = null)
+    {
+        LoadedCSharpProject project = LoadWithReferences(source, assemblyName, extraReferences);
+        Assert.Equal(NullableContextOptions.Disable, project.Compilation.Options.NullableContextOptions);
+        return project;
+    }
+
+    private static LoadedCSharpProject LoadEnabled(
+        string source, string assemblyName, IReadOnlyList<MetadataReference> extraReferences = null)
+    {
+        // `CSharpProjectLoader.LoadInMemory` always builds a compilation with
+        // DEFAULT `CSharpCompilationOptions` (`NullableContextOptions.Disable`)
+        // — a `#nullable enable` PRAGMA inside the source only changes each
+        // file's own per-tree annotation context, never the compilation-level
+        // option `ObliviousNullabilityAnalyzer.IsTainted` gates on to decide
+        // whether a compilation participates in taint analysis at all. A
+        // genuinely nullable-ENABLED sibling compilation (for the negative
+        // control proving the cross-project wiring does not perturb the
+        // already-correct nullable-annotation-driven path) must instead be
+        // built directly with `WithNullableContextOptions(Enable)`.
+        IReadOnlyList<MetadataReference> references = extraReferences is null
+            ? CSharpProjectLoader.RuntimeReferences()
+            : CSharpProjectLoader.RuntimeReferences().Concat(extraReferences).ToList();
+
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source, new CSharpParseOptions(LanguageVersion.Latest), path: assemblyName + ".cs");
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { tree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+
+        var diagnostics = compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
+        Assert.True(diagnostics.Count == 0, $"{assemblyName} should bind with no C# errors: " + string.Join(Environment.NewLine, diagnostics));
+
+        var document = new LoadedDocument(assemblyName + ".cs", tree, compilation.GetSemanticModel(tree));
+        var project = new LoadedCSharpProject(compilation, new[] { document }, Array.Empty<Diagnostic>());
+        Assert.NotEqual(NullableContextOptions.Disable, project.Compilation.Options.NullableContextOptions);
+        return project;
+    }
+
+    private static LoadedCSharpProject LoadWithReferences(
+        string source, string assemblyName, IReadOnlyList<MetadataReference> extraReferences)
+    {
+        IReadOnlyList<MetadataReference> references = extraReferences is null
+            ? CSharpProjectLoader.RuntimeReferences()
+            : CSharpProjectLoader.RuntimeReferences().Concat(extraReferences).ToList();
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { (assemblyName + ".cs", source) }, references, assemblyName);
+        Assert.True(
+            project.BoundWithoutErrors,
+            $"{assemblyName} should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        return project;
+    }
+
+    private static string TranslateProject(
+        LoadedCSharpProject project, IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        var translator = new CSharpToGSharpTranslator();
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation, document.SemanticModel, document.FilePath, siblingCompilations);
+        CompilationUnit unit = translator.TranslateDocument(document, context);
+        return PrintAndValidate(unit);
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    // Collapses incidental whitespace/newlines around composite-literal braces
+    // so an assertion on `Target{Name: foo.Name!!}` is not sensitive to the
+    // printer's exact line-wrapping.
+    private static string Compact(string printed) =>
+        string.Join(" ", printed.Split(
+            new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries));
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -833,6 +833,31 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
+            // Issue #2412: a VALUE-position read (`return foo.Name;`,
+            // `sink.Accept(foo.Name)`) of a field/property/parameter/local/method
+            // declared in a REFERENCED SIBLING project (a separate
+            // `CSharpCompilation`, loaded by `CSharpProjectLoader.
+            // LoadProjectWithReferencesAsync`) that the sibling's OWN whole-
+            // program taint fixpoint proved null-tainted. Unlike a same-project
+            // tainted value — whose consuming property/method/local is itself
+            // promoted to `T?` by THIS compilation's own `Compute()` edge walk
+            // (issue #2167), so the value flows `T? -> T?` and needs no `!!` —
+            // a foreign symbol can never seed an edge in this compilation's own
+            // fixpoint (the tainting evidence lives only in the sibling's
+            // syntax), so the consuming declaration's OWN type is never promoted
+            // and the mismatch must be bridged here, at the read, instead. Gated
+            // to a symbol whose `ContainingAssembly` differs from this
+            // compilation's own assembly so every intra-project case (handled by
+            // the existing promotion path above) is completely untouched.
+            ISymbol foreignCandidate = this.context.GetSymbolInfo(recv).Symbol;
+            if (this.IsObliviousCompilation()
+                && foreignCandidate is IFieldSymbol or IPropertySymbol or IParameterSymbol or ILocalSymbol or IMethodSymbol
+                && !SymbolEqualityComparer.Default.Equals(foreignCandidate.ContainingAssembly, this.context.Compilation.Assembly)
+                && this.ShouldPromoteToNullableReference(foreignCandidate))
+            {
+                return true;
+            }
+
             // Flow analysis must have proven the receiver non-null at this site.
             if (this.context.GetTypeInfo(recv).Nullability.FlowState != NullableFlowState.NotNull)
             {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -525,7 +525,22 @@ public sealed partial class CSharpToGSharpTranslator
             // generated `var settings T? = …` locals already rely on it — and
             // `Cast[T]`/`typeof(T)`/`T()` NAME positions are unaffected because
             // they reference `T`, not the promoted symbol.
-            if (ObliviousNullabilityAnalyzer.IsTainted(this.context.Compilation, symbol))
+            //
+            // Issue #2412: the taint fixpoint only walks ONE compilation's own
+            // syntax trees, so a symbol whose ONLY tainting evidence lives in a
+            // REFERENCED sibling project (loaded as its own separate
+            // `CSharpCompilation` by `CSharpProjectLoader.
+            // LoadProjectWithReferencesAsync`) — whether the symbol is declared
+            // there directly, or is declared here/in a third project but only
+            // gets wired into taint via a sibling's own interface-implementation
+            // edges (issue #2285) — must also be checked against every sibling's
+            // OWN cached result, not just `this.context.Compilation`'s (the
+            // downstream consumer's translation unit, whose syntax never
+            // contains that evidence). `this.context.SiblingCompilations` is
+            // `null` for every existing single-compilation caller, so this
+            // overload reduces to the exact prior single-compilation check —
+            // a pure additive fix for the cross-project case.
+            if (ObliviousNullabilityAnalyzer.IsTainted(this.context.Compilation, symbol, this.context.SiblingCompilations))
             {
                 return true;
             }

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -105,6 +105,196 @@ internal static class ObliviousNullabilityAnalyzer
         return Cache.GetValue(compilation, Compute).Tainted.Contains(Canonical(symbol));
     }
 
+    /// <summary>
+    /// Issue #2412: cross-project overload of <see cref="IsTainted(CSharpCompilation, ISymbol)"/>.
+    /// <paramref name="compilation"/>'s own whole-program taint fixpoint only
+    /// walks ITS OWN syntax trees, so it never sees a referenced sibling
+    /// project's tainting evidence — even for a symbol DECLARED in
+    /// <paramref name="compilation"/> itself, when that evidence is an
+    /// interface-implementation edge (issue #2285) recorded only inside a
+    /// sibling project's own fixpoint (the sibling's own source types are the
+    /// ones implementing the interface). This tries <paramref name="compilation"/>
+    /// first (byte-identical to the two-argument overload for every existing,
+    /// single-compilation caller — an empty or <see langword="null"/>
+    /// <paramref name="siblingCompilations"/> reduces to exactly that), then
+    /// each of <paramref name="siblingCompilations"/> in the supplied
+    /// (deterministic) order, returning <see langword="true"/> on the first
+    /// compilation whose OWN cached <see cref="Compute"/> result proves the
+    /// symbol tainted. A symbol declared in — or seeded/propagated from — ANY
+    /// ONE known project's own source is a single global fact once true, so
+    /// this is a plain existential OR: each candidate's result is computed
+    /// (and cached, same <see cref="Cache"/>) independently and exactly once
+    /// regardless of how many times this overload is called, keeping repeated
+    /// per-document queries within one run, and across a project translated
+    /// both standalone and as a sibling, consistent and cheap.
+    /// <para>
+    /// Deliberately scoped to <paramref name="symbol"/> ITSELF (plus its
+    /// remapped counterpart in each sibling) — never a same-compilation
+    /// backward walk through <paramref name="compilation"/>'s own assignment
+    /// edges to some OTHER, indirectly-connected declaration. Issue #2412's
+    /// own worked example is explicit that the fix must insert `!!`
+    /// forgiveness AT THE CONSUMPTION SITE while leaving the consuming
+    /// project's OWN declarations (e.g. an object-initializer target
+    /// property) untouched — confirmed empirically: even a fully MERGED
+    /// single-compilation version of the exact LibA/LibB repro promotes the
+    /// object-initializer TARGET property's own declared type too (the
+    /// existing, pre-#2412 edge-based fixpoint already treats "declaration
+    /// type is the join of every direct assignment" uniformly for locals,
+    /// fields, AND properties alike) — a broader, transitively-propagating
+    /// design here would branch further from that minimal, explicitly-scoped
+    /// request than necessary, and would let ONE cross-project call site's
+    /// taint silently repaint an unrelated declaration's own type everywhere
+    /// else it is used in the consuming project.
+    /// </para>
+    /// </summary>
+    /// <param name="compilation">The compilation of the translation unit asking about <paramref name="symbol"/>.</param>
+    /// <param name="symbol">The declaration symbol to test.</param>
+    /// <param name="siblingCompilations">
+    /// Every other project's own compilation loaded in the same migration run
+    /// (<see cref="TranslationContext.SiblingCompilations"/>), or
+    /// <see langword="null"/> when none is known.
+    /// </param>
+    /// <returns><see langword="true"/> when any known compilation's own analysis proves the symbol null-tainted.</returns>
+    public static bool IsTainted(
+        CSharpCompilation compilation,
+        ISymbol symbol,
+        IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        if (IsTainted(compilation, symbol))
+        {
+            return true;
+        }
+
+        if (symbol == null || siblingCompilations == null)
+        {
+            return false;
+        }
+
+        foreach (CSharpCompilation sibling in siblingCompilations)
+        {
+            if (sibling == null || ReferenceEquals(sibling, compilation))
+            {
+                continue;
+            }
+
+            // A symbol resolved through one compilation's semantic model and
+            // the "same" declaration resolved directly in the compilation that
+            // actually owns it are NOT `SymbolEqualityComparer.Default`-equal
+            // across two independently-bound `CSharpCompilation`s linked only
+            // by a `CompilationReference` (confirmed empirically: two separate
+            // `CSharpCompilation.Create` calls each mint their own distinct
+            // `IAssemblySymbol` wrapper for the "same" referenced assembly, so
+            // even `ContainingAssembly` differs) — this is true of the exact
+            // `LoadProjectWithReferencesAsync` shape too (a separate
+            // `BuildLoadedProjectAsync`/`GetCompilationAsync` call per project).
+            // So `IsTainted(sibling, symbol)` alone would only ever match a
+            // symbol whose OWN declaring compilation happens to be `sibling`
+            // itself — remap `symbol` to ITS OWN symbol in `sibling`'s symbol
+            // table (by stable metadata identity: containing type's fully
+            // qualified metadata name + member name/arity, not object/CLR
+            // symbol identity) and test that remapped symbol against
+            // `sibling`'s own cached result instead.
+            ISymbol remapped = RemapToCompilation(sibling, symbol);
+            if (remapped != null && IsTainted(sibling, remapped))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Finds the symbol in <paramref name="targetCompilation"/>'s own symbol
+    /// table that is the "same" declaration as <paramref name="symbol"/>,
+    /// which may have been resolved through an entirely different
+    /// <see cref="CSharpCompilation"/>. Matching is by stable metadata
+    /// identity (containing type's fully qualified metadata name plus member
+    /// name/kind/arity), never by <see cref="SymbolEqualityComparer"/> or CLR
+    /// object identity, since those do not hold across independently bound
+    /// compilations (see the long comment on the calling overload). Returns
+    /// <see langword="null"/> when no matching declaration exists in
+    /// <paramref name="targetCompilation"/> (e.g. `symbol` is unrelated to it).
+    /// </summary>
+    private static ISymbol RemapToCompilation(Compilation targetCompilation, ISymbol symbol)
+    {
+        if (symbol is IParameterSymbol parameter)
+        {
+            ISymbol remappedOwner = RemapMemberOwner(targetCompilation, parameter.ContainingSymbol);
+            return remappedOwner switch
+            {
+                IMethodSymbol method when parameter.Ordinal < method.Parameters.Length =>
+                    method.Parameters[parameter.Ordinal],
+                IPropertySymbol indexer when parameter.Ordinal < indexer.Parameters.Length =>
+                    indexer.Parameters[parameter.Ordinal],
+                _ => null,
+            };
+        }
+
+        return RemapMemberOwner(targetCompilation, symbol);
+    }
+
+    /// <summary>
+    /// Remaps a field/property/method/local-owning member symbol (everything
+    /// <see cref="RemapToCompilation"/> handles other than parameters
+    /// themselves) into <paramref name="targetCompilation"/>'s own symbol
+    /// table by metadata name. Locals have no stable cross-compilation
+    /// identity (they only ever make sense within the one method body/one
+    /// compilation that declares them), so they intentionally fall through to
+    /// <see langword="null"/> here.
+    /// </summary>
+    private static ISymbol RemapMemberOwner(Compilation targetCompilation, ISymbol symbol)
+    {
+        if (symbol == null)
+        {
+            return null;
+        }
+
+        INamedTypeSymbol containingType = symbol.ContainingType;
+        if (containingType == null)
+        {
+            return null;
+        }
+
+        INamedTypeSymbol remappedType = targetCompilation.GetTypeByMetadataName(MetadataTypeName(containingType));
+        if (remappedType == null)
+        {
+            return null;
+        }
+
+        if (symbol is IMethodSymbol method)
+        {
+            return remappedType.GetMembers(method.Name)
+                .OfType<IMethodSymbol>()
+                .FirstOrDefault(candidate =>
+                    candidate.IsStatic == method.IsStatic &&
+                    candidate.Parameters.Length == method.Parameters.Length &&
+                    candidate.TypeParameters.Length == method.TypeParameters.Length);
+        }
+
+        return remappedType.GetMembers(symbol.Name).FirstOrDefault(candidate => candidate.Kind == symbol.Kind);
+    }
+
+    /// <summary>
+    /// Builds the CLR metadata name (e.g. <c>Outer+Inner`1</c> within its
+    /// namespace) that <see cref="Compilation.GetTypeByMetadataName"/> expects,
+    /// walking outward through nested-type containment so nested types (which
+    /// <c>MetadataName</c> alone does not capture) are found too.
+    /// </summary>
+    private static string MetadataTypeName(INamedTypeSymbol type)
+    {
+        var parts = new List<string>();
+        for (INamedTypeSymbol current = type; current != null; current = current.ContainingType)
+        {
+            parts.Insert(0, current.MetadataName);
+        }
+
+        string nested = string.Join("+", parts);
+        return type.ContainingNamespace is { IsGlobalNamespace: false } ns
+            ? ns.ToDisplayString() + "." + nested
+            : nested;
+    }
+
     private static TaintResult Compute(Compilation compilation)
     {
         var tainted = new HashSet<ISymbol>(SymbolEqualityComparer.Default);

--- a/tools/cs2gs/Cs2Gs.Translator/TranslationContext.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/TranslationContext.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Cs2Gs.Translator.Coverage;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -32,21 +33,60 @@ public sealed class TranslationContext
     // avoids re-creating a `SemanticModel` per member for the same tree.
     private readonly Dictionary<SyntaxTree, SemanticModel> modelsByTree = new Dictionary<SyntaxTree, SemanticModel>();
 
+    // Issue #2412: every project's own `Compilation` loaded alongside this one
+    // in the same migration run (the app plus every transitively-referenced
+    // sibling project — see `TranslateStage`), consulted by
+    // `ObliviousNullabilityAnalyzer.IsTainted`'s multi-compilation overload
+    // when a symbol's own compilation (`Compilation`) reports it untainted.
+    // Null (default, and every existing single-compilation caller) means "no
+    // sibling set is known", so only `Compilation` is ever consulted — the
+    // exact prior behavior.
+    private readonly IReadOnlyList<CSharpCompilation> siblingCompilations;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="TranslationContext"/> class.
     /// </summary>
     /// <param name="compilation">The owning C# compilation.</param>
     /// <param name="semanticModel">The active semantic model for the file being translated.</param>
     /// <param name="filePath">The originating file path, used to tag diagnostics.</param>
-    public TranslationContext(CSharpCompilation compilation, SemanticModel semanticModel, string filePath)
+    /// <param name="siblingCompilations">
+    /// Issue #2412: every project's own <see cref="CSharpCompilation"/> loaded
+    /// alongside <paramref name="compilation"/> in the same migration run (the
+    /// app plus its transitively-referenced sibling projects). A whole-program
+    /// fact computed only from one compilation's own syntax trees (e.g.
+    /// <see cref="Translator.ObliviousNullabilityAnalyzer"/>'s taint fixpoint)
+    /// can be TRUE in a sibling project's own result for a symbol this
+    /// compilation cannot prove tainted on its own — not only because the
+    /// symbol is declared there, but also because that sibling's own
+    /// interface-implementation edges (issue #2285) can record taint for a
+    /// symbol declared in a THIRD project (an interface member implemented by
+    /// one of the sibling's own types). Pass <see langword="null"/> (default)
+    /// for a single-compilation translation (in-memory tests, <c>CompileViaSdk</c>,
+    /// a project with no references) — only <paramref name="compilation"/> is
+    /// then ever consulted, the exact prior behavior.
+    /// </param>
+    public TranslationContext(
+        CSharpCompilation compilation,
+        SemanticModel semanticModel,
+        string filePath,
+        IReadOnlyList<CSharpCompilation> siblingCompilations = null)
     {
         this.Compilation = compilation ?? throw new ArgumentNullException(nameof(compilation));
         this.SemanticModel = semanticModel ?? throw new ArgumentNullException(nameof(semanticModel));
         this.FilePath = filePath;
+        this.siblingCompilations = siblingCompilations;
     }
 
     /// <summary>Gets the owning C# compilation.</summary>
     public CSharpCompilation Compilation { get; }
+
+    /// <summary>
+    /// Gets every project's own <see cref="CSharpCompilation"/> loaded
+    /// alongside <see cref="Compilation"/> in the same migration run (issue
+    /// #2412), or <see langword="null"/> when no sibling set is known (a
+    /// single-compilation translation).
+    /// </summary>
+    public IReadOnlyList<CSharpCompilation> SiblingCompilations => this.siblingCompilations;
 
     /// <summary>Gets the active semantic model for the file being translated.</summary>
     public SemanticModel SemanticModel { get; private set; }


### PR DESCRIPTION
Fixes #2412.

## Problem

cs2gs's `ObliviousNullabilityAnalyzer` correctly promotes oblivious-nullability taint within a single `CSharpCompilation`, but lost that information whenever a downstream project consumed a member declared in a referenced sibling project, because `CSharpProjectLoader` loaded each project reference as its own separate `CSharpCompilation` with no shared taint state.

Exact Oahu symptom (read-only repro, not modified/PR'd): `corpus_Oahu.Core/AaxExporter.gs:44:41` — `GS0156: Cannot convert type 'string?' to 'string'`. `Conversion.Asin` (declared in `Oahu.Data`, seeded by a `?.`-chain) is oblivious-nullable, but `Oahu.Core`'s `AaxExporter.ExportChapters` never emitted the required `!!` when reading `book.Asin`.

## Root cause (two parts)

1. **`CSharpProjectLoader.LoadProjectWithReferencesAsync` set `MSBuildWorkspace.LoadMetadataForReferencedProjects = true`.** That flag makes MSBuildWorkspace collapse same-solution `ProjectReference`s into pure metadata references once the referenced project has a prebuilt output assembly on disk — the normal state of any already-built solution (e.g. `Oahu.Core` referencing `Oahu.Data`/`Oahu.Foundation`/`Oahu.Decrypt`). This silently emptied `Solution.Projects`/`ProjectReferences`, degrading the loader to returning only the primary project. Sibling source was therefore never available for cross-project analysis against any real-world, previously-built solution — the in-memory synthetic tests never exercised this path and so never caught it. Fix: stop setting that flag here (`LoadProjectAsync`, the single-project loader, is unaffected and still sets it intentionally).
2. **`ObliviousNullabilityAnalyzer`'s taint fixpoint (`Compute()`) is scoped per-`CSharpCompilation`.** Added a minimal cross-compilation `IsTainted` overload: given a symbol resolved in the consuming compilation, remap it by metadata identity (containing type + name + arity) into each sibling compilation and ask that sibling's own `Compute()` whether *its* view of the symbol is tainted — reusing each project's already-computed, cached fixpoint instead of re-analyzing foreign syntax or introducing global mutable state. `TranslateStage` now threads every loaded project's compilation through `TranslationContext` as `SiblingCompilations`.
3. A second, narrower gap: `ReceiverNeedsNullForgiveness` (the return-statement/argument-position sink) gates its general branch on Roslyn's `NullableFlowState.NotNull`, a state Roslyn never reports in an oblivious (nullable-disabled) compilation — so the new cross-project check was unreachable for those two positions even though the object-initializer sink (a different function) was already covered by the `IsTainted` overload alone. Added a branch gated strictly on `ContainingAssembly` mismatch (every intra-project path is untouched) that fires for a foreign, cross-project-tainted symbol read in return/argument position.

## Verification against the real Oahu.Core corpus (read-only)

The emitted `AaxExporter.gs` now contains `book.Asin!!` and `book.Sku!!`; the original `GS0156` at `AaxExporter.gs:44:41` is gone.

Fixing the loader also activates, for the first time on a real prebuilt solution, the already-designed (but never functioning) sibling-translation feature from #914 (`TranslateStage` always intended to translate+emit referenced projects' G# too, so an app's uses of sibling types resolve at compile time). That surfaces a large, separate body of pre-existing translator/compiler gaps in `Oahu.Data`/`Oahu.Foundation`/`Oahu.Decrypt` that were previously invisible (masked because `Oahu.Core` was always compiled against those siblings' precise, prebuilt CLR metadata instead of their, currently much less complete, G# translations).

Net effect on `corpus/Oahu.Core`'s own gate: compile-error artifact count moved from the round-17 baseline of **47** to **91** — not a regression in this fix (every new artifact is attributed to `Oahu.Core`'s own files per the existing `IsFromReferencedProject` triage rule, and the target `GS0156` is confirmed fixed), but a newly-exposed, **independent next blocker**: cross-project extension-method / member resolution against sibling-*translated* G# (e.g. `IEnumerable<T>.IsNullOrEmpty()`, declared in `Oahu.Foundation`'s `ExtensionsVarious.cs`, resolves fine against the sibling's prebuilt DLL metadata but not against its translated G#). That gap is unrelated to oblivious-nullability taint and is left unfixed here — reported for the next round of work, per instructions not to fix it in this PR.

## Tests

- Added `Issue2412CrossProjectObliviousNullabilityTranslationTests` (9 cases): object-initializer/return/argument/field sinks, a transitive three-project chain matching the exact Oahu `AaxExporter`/`Conversion.Asin` shape, negative controls (nullable-enabled sibling, unrelated/untainted member), same-simple-name disambiguation across two siblings, and translation-cache determinism.
- Added a `CSharpProjectLoaderDiagnosticsTests` regression case that pre-builds a sibling project before loading, reproducing the real MSBuildWorkspace metadata-collapse condition the synthetic `LoadInMemory`-based tests could not exercise.

## Test results

Full serialized `Cs2Gs.Tests` (`MSBUILDDISABLENODEREUSE=1`, `RunConfiguration.DisableParallelization=true`): **1433/1433 passing**.
