### PR TITLE
Fix #2416: generic extension inference for null-asserted receiver member access

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -4412,20 +4412,46 @@ public sealed class Binder
                 // the array's interface set to find a match for the
                 // parameter's open definition and extract its arguments.
                 var argClr = argumentType?.ClrType;
-                if (argClr != null && argClr.IsArray && pit.OpenDefinition != null)
+                var matched = argClr != null && argClr.IsArray && pit.OpenDefinition != null
+                    ? FindMatchingInterface(argClr, pit.OpenDefinition)
+                    : null;
+                if (matched != null)
                 {
-                    var matched = FindMatchingInterface(argClr, pit.OpenDefinition);
-                    if (matched != null)
+                    var matchedArgs = matched.GetGenericArguments();
+                    if (matchedArgs.Length == pit.TypeArguments.Length)
                     {
-                        var matchedArgs = matched.GetGenericArguments();
-                        if (matchedArgs.Length == pit.TypeArguments.Length)
+                        for (var i = 0; i < pit.TypeArguments.Length; i++)
                         {
-                            for (var i = 0; i < pit.TypeArguments.Length; i++)
-                            {
-                                InferTypeArguments(pit.TypeArguments[i], TypeSymbol.FromClrType(matchedArgs[i]), substitution);
-                            }
+                            InferTypeArguments(pit.TypeArguments[i], TypeSymbol.FromClrType(matchedArgs[i]), substitution);
                         }
                     }
+                }
+                else if ((argumentType is SliceTypeSymbol || argumentType is ArrayTypeSymbol)
+                    && pit.TypeArguments.Length == 1
+                    && IsArrayCompatibleOpenInterface(pit.OpenDefinition))
+                {
+                    // Issue #2416: the reflection-based lookup above requires a
+                    // real CLR `Type` for the slice/array (`argumentType.ClrType`),
+                    // which is null for a same-compilation SOURCE element type
+                    // that has not been emitted yet (e.g. a source `struct`/
+                    // `class` used as `[]Chapter`). A CLR single-dimensional
+                    // array unconditionally implements `IEnumerable<T>`,
+                    // `ICollection<T>`, `IList<T>`, `IReadOnlyCollection<T>`,
+                    // and `IReadOnlyList<T>` with `T` equal to its own element
+                    // type — a guarantee of the CLR array contract, not
+                    // something that needs reflection to confirm. Unify
+                    // symbolically against the slice/array's own
+                    // <see cref="SliceTypeSymbol.ElementType"/> /
+                    // <see cref="ArrayTypeSymbol.ElementType"/> so this generic
+                    // extension/method inference doesn't depend on whether the
+                    // element type has a `ClrType` yet. This keeps working the
+                    // same way regardless of whether the array receiver came
+                    // from a bare member access, a null-asserted chain
+                    // (`x!!.Member`), a nested chain, or a for-loop element.
+                    var elementType = argumentType is SliceTypeSymbol slice
+                        ? slice.ElementType
+                        : ((ArrayTypeSymbol)argumentType).ElementType;
+                    InferTypeArguments(pit.TypeArguments[0], elementType, substitution);
                 }
             }
         }
@@ -4537,6 +4563,28 @@ public sealed class Binder
         }
 
         return null;
+    }
+
+    // Issue #2416: the fixed, closed set of single-type-parameter generic
+    // interfaces that the CLR guarantees every single-dimensional array
+    // (`T[]`) implements, regardless of whether `T` has been emitted yet.
+    // Used to symbolically unify a slice/array argument against an
+    // `IEnumerable[T]`-shaped (or equivalent) generic parameter when the
+    // array's element type has no `ClrType` (still source-only), so
+    // reflection-based interface lookup (<see cref="FindMatchingInterface"/>)
+    // isn't available.
+    private static bool IsArrayCompatibleOpenInterface(Type openDefinition)
+    {
+        if (openDefinition == null || !openDefinition.IsGenericTypeDefinition)
+        {
+            return false;
+        }
+
+        return openDefinition.IsSameAs(typeof(System.Collections.Generic.IEnumerable<>))
+            || openDefinition.IsSameAs(typeof(System.Collections.Generic.ICollection<>))
+            || openDefinition.IsSameAs(typeof(System.Collections.Generic.IList<>))
+            || openDefinition.IsSameAs(typeof(System.Collections.Generic.IReadOnlyCollection<>))
+            || openDefinition.IsSameAs(typeof(System.Collections.Generic.IReadOnlyList<>));
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue2416NullAssertedMemberExtensionInferenceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2416NullAssertedMemberExtensionInferenceEmitTests.cs
@@ -1,0 +1,252 @@
+// <copyright file="Issue2416NullAssertedMemberExtensionInferenceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2416 end-to-end coverage: compile, IL-verify, and run generic
+/// extension calls reached through a null-asserted receiver's member
+/// access (e.g. <c>x!!.Member.Ext()</c>), plus a faithful
+/// Oahu-BookLibrary-shaped repro (<c>ChapterInfo</c>/<c>Chapter</c> with a
+/// recursive <c>[]Chapter</c> and a generic
+/// <c>IEnumerable[T]?.IsNullOrEmpty[T]()</c> extension). The pre-fix
+/// binder's <c>InferTypeArguments</c> could only unify a slice/array
+/// argument against an open CLR interface parameter (like
+/// <c>IEnumerable[T]</c>) by reflecting over the argument's real CLR
+/// <c>Type</c>; for a same-compilation source struct/class element type
+/// that CLR <c>Type</c> doesn't exist pre-emission, so the parameter's
+/// type argument was never inferred and the call failed to bind with
+/// GS0159 "Cannot find function", regardless of whether the receiver was
+/// reached via null-assertion, bare member access, or a for-loop element.
+/// The fix adds a symbolic fallback (slice/array <c>ElementType</c>
+/// unification against the fixed set of CLR-guaranteed
+/// single-type-parameter array interfaces) that needs no CLR
+/// <c>Type</c>, so these calls now bind, emit, verify, and run correctly.
+/// </summary>
+public class Issue2416NullAssertedMemberExtensionInferenceEmitTests
+{
+    [Fact]
+    public void NullAssertedReceiver_ThenMemberAccess_GenericExtension_CompilesAndRuns()
+    {
+        // The originally-reported broken shape: x!!.Member.Ext() where
+        // Ext is a generic extension over an imported open interface
+        // (IEnumerable[T]?) and Member's static type is a slice of a
+        // same-compilation source struct.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            struct Chapter {
+                var Title string
+            }
+
+            struct Book {
+                var Chapters []Chapter
+            }
+
+            func (e IEnumerable[T]?) IsNullOrEmpty[T]() bool {
+                return e == nil || e!!.Count() == 0
+            }
+
+            var book Book? = Book{ Chapters: []Chapter{} }
+            Console.WriteLine(book!!.Chapters.IsNullOrEmpty())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void NullAssertedReceiver_ThenMemberAccess_GenericExtension_NonEmpty_ReturnsFalse()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            struct Chapter {
+                var Title string
+            }
+
+            struct Book {
+                var Chapters []Chapter
+            }
+
+            func (e IEnumerable[T]?) IsNullOrEmpty[T]() bool {
+                return e == nil || e!!.Count() == 0
+            }
+
+            var book Book? = Book{ Chapters: []Chapter{ Chapter{ Title: "One" } } }
+            Console.WriteLine(book!!.Chapters.IsNullOrEmpty())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("False\n", output);
+    }
+
+    [Fact]
+    public void NullAssertedReceiver_ThenMemberAccess_NonGenericExtension_CompilesAndRuns()
+    {
+        // Non-generic extension variant: proves the fix to the generic
+        // inference routine doesn't regress the (unrelated) non-generic
+        // extension-lookup path for the same null-assert-then-member
+        // shape.
+        var source = """
+            package P
+            import System
+
+            struct Chapter {
+                var Title string
+            }
+
+            struct Book {
+                var Chapters []Chapter
+            }
+
+            func (e []Chapter) IsEmpty() bool {
+                return e.Length == 0
+            }
+
+            var book Book? = Book{ Chapters: []Chapter{} }
+            Console.WriteLine(book!!.Chapters.IsEmpty())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void OahuBookLibraryShape_NullAssertedReceiver_NestedChapters_GenericExtension_CompilesAndRuns()
+    {
+        // Faithful Oahu.Core BookLibrary shape: ChapterInfo/Chapter mirror
+        // the real Oahu.Core.Models.LicenseResponse.cs JSON model — each
+        // Chapter recursively carries a []Chapter of nested chapters, and
+        // ChapterInfo carries the top-level []Chapter. The real
+        // Oahu.Foundation extension is reproduced verbatim:
+        //   func (e IEnumerable[T]?) IsNullOrEmpty[T]() bool ->
+        //       e == nil || e!!.Count() == 0
+        // Both the reported-broken chain
+        // (chapterInfo!!.Chapters.IsNullOrEmpty()) and a nested-chapter
+        // variant (reaching a chapter's own nested Chapters through a
+        // for-loop element, mirroring BookLibrary.gs:766) are exercised.
+        var source = """
+            package Core
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            class Chapter {
+                prop Title string
+                prop Chapters []Chapter
+            }
+
+            class ChapterInfo {
+                prop Chapters []Chapter
+            }
+
+            func (e IEnumerable[T]?) IsNullOrEmpty[T]() bool {
+                return e == nil || e!!.Count() == 0
+            }
+
+            func DescribeChapterInfo(info ChapterInfo?) string {
+                if info!!.Chapters.IsNullOrEmpty() {
+                    return "empty"
+                }
+                for chapter in info!!.Chapters {
+                    if !chapter.Chapters.IsNullOrEmpty() {
+                        return "has-nested"
+                    }
+                }
+                return "flat"
+            }
+
+            var leaf = Chapter{ Title: "Leaf", Chapters: []Chapter{} }
+            var nested = Chapter{ Title: "Nested", Chapters: []Chapter{ leaf } }
+            var info = ChapterInfo{ Chapters: []Chapter{ nested } }
+            Console.WriteLine(DescribeChapterInfo(info))
+
+            var emptyInfo = ChapterInfo{ Chapters: []Chapter{} }
+            Console.WriteLine(DescribeChapterInfo(emptyInfo))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("has-nested\nempty\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2416_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2416NullAssertedMemberExtensionInferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2416NullAssertedMemberExtensionInferenceTests.cs
@@ -1,0 +1,425 @@
+// <copyright file="Issue2416NullAssertedMemberExtensionInferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #2416: after #2414 fixed cross-package
+/// SOURCE-declared extension visibility, a generic extension declared over
+/// an imported CLR generic interface parameter (e.g. <c>func (e
+/// IEnumerable[T]?) IsNullOrEmpty[T]() bool</c>, mirroring
+/// Oahu.Foundation's real declaration) still failed with <c>GS0159</c>
+/// ("Cannot find function") whenever the call-site receiver was a
+/// same-compilation, SOURCE-defined element type reached through a
+/// slice/array-typed member access — regardless of whether that member
+/// access was preceded by a null assertion (<c>x!!.Member.Call()</c>), was
+/// a bare chain (<c>x.Member.Call()</c>), or was a for-loop element.
+/// <para>
+/// <b>Root cause</b>: <see cref="Binder.InferTypeArguments"/>'s handling of
+/// an <c>ImportedTypeSymbol</c> parameter constructed over an in-scope type
+/// parameter (the <c>IEnumerable[T]</c> case, #313) only unified a
+/// slice/array argument by REFLECTING over the argument's <c>ClrType</c>
+/// (<see cref="TypeSymbol.ClrType"/>) to find a matching
+/// <c>IEnumerable&lt;T&gt;</c>-shaped interface (#611). A slice/array whose
+/// element is a SOURCE type (a G# <c>class</c>/<c>struct</c> not yet
+/// emitted) has no <c>ClrType</c> at bind time — see
+/// <c>StructSymbol</c>/<c>TypeSymbol.ClrType</c> — so that reflection-based
+/// lookup silently produced nothing and the type parameter was never
+/// inferred, independent of any null assertion in the receiver chain.
+/// </para>
+/// <para>
+/// <b>Fix</b>: <see cref="Binder.InferTypeArguments"/> now also unifies
+/// symbolically — using the slice/array's own <c>ElementType</c> directly,
+/// no <c>ClrType</c> required — whenever the parameter's open CLR
+/// definition is one of the fixed set of single-type-parameter interfaces
+/// every CLR single-dimensional array unconditionally implements
+/// (<c>IEnumerable&lt;T&gt;</c>, <c>ICollection&lt;T&gt;</c>,
+/// <c>IList&lt;T&gt;</c>, <c>IReadOnlyCollection&lt;T&gt;</c>,
+/// <c>IReadOnlyList&lt;T&gt;</c>). This is a general fix to the shared
+/// type-argument substitution routine used by every generic call/extension
+/// site — it does not special-case <c>IsNullOrEmpty</c> or null assertions
+/// in any way, and null-assertion/member-access nullability semantics are
+/// unchanged (the underlying-type computation in
+/// <c>BoundUnaryOperator.Bind</c> for <c>!!</c> is untouched).
+/// </para>
+/// </summary>
+public class Issue2416NullAssertedMemberExtensionInferenceTests
+{
+    private static readonly string ImportedLibraryPath = EmitCSharpLibrary();
+
+    // ---- Faithful Oahu BookLibrary/Chapter shape -------------------------
+
+    private const string ChapterModelSource = """
+        package Core
+        class Chapter {
+            prop Title string
+            prop Chapters []Chapter
+        }
+        class ChapterInfo {
+            prop Chapters []Chapter
+        }
+        """;
+
+    private const string GenericSourceExtension = """
+        package Foundation
+        import System.Collections.Generic
+        import System.Linq
+        func (e IEnumerable[T]?) IsNullOrEmpty[T]() bool { return e == nil || e!!.Count() == 0 }
+        """;
+
+    [Fact]
+    public void Control_DirectNullAssertedReceiver_Generic_Resolves()
+    {
+        // Baseline control from the issue: `x!!.IsNullOrEmpty()` already
+        // resolved before this fix (the receiver IS the `IEnumerable[T]`
+        // argument directly, no member access involved).
+        var diagnostics = BindAndReturnAllDiagnostics(
+            GenericSourceExtension,
+            ChapterModelSource + """
+
+            func Direct(source IEnumerable[Chapter]?) bool { return source!!.IsNullOrEmpty() }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Control_BareMemberAccess_NoNullAssertion_ArrayOfSourceStruct_Resolves()
+    {
+        // The equivalent "bare Member.IsNullOrEmpty()" control from the
+        // issue: no null assertion anywhere in the chain. Pre-fix this
+        // failed too (the array/ClrType gap is unconditional), so this also
+        // regression-covers that this control genuinely resolves now.
+        var diagnostics = BindAndReturnAllDiagnostics(
+            GenericSourceExtension,
+            ChapterModelSource + """
+
+            func Bare(ch Chapter) bool { return ch.Chapters.IsNullOrEmpty() }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Broken_NullAssertedReceiver_ThenMemberAccess_ArrayOfSourceStruct_Resolves()
+    {
+        // The exact reported broken shape: `x!!.Member.IsNullOrEmpty()`.
+        var diagnostics = BindAndReturnAllDiagnostics(
+            GenericSourceExtension,
+            ChapterModelSource + """
+
+            func Chained(source ChapterInfo?) bool { return source!!.Chapters.IsNullOrEmpty() }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Broken_NullAssertedReceiver_ThenForLoopElement_NestedMemberChain_Resolves()
+    {
+        // Mirrors BookLibrary.gs's AddChapters loop: `for ch in
+        // source!!.Chapters { if !ch.Chapters.IsNullOrEmpty() { ... } }` —
+        // both a null-asserted-then-member receiver AND a for-loop element
+        // reaching a second, nested member chain.
+        var diagnostics = BindAndReturnAllDiagnostics(
+            GenericSourceExtension,
+            ChapterModelSource + """
+
+            func Nested(source ChapterInfo?) bool {
+                for ch in source!!.Chapters {
+                    if !ch.Chapters.IsNullOrEmpty() {
+                        return true
+                    }
+                }
+                return false
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void NullableMemberType_NullAssertedReceiver_ThenMemberAccess_Resolves()
+    {
+        // The member itself is nullable (`[]Chapter?`), not just the outer
+        // receiver — covers nullable member types distinctly from the
+        // non-nullable `[]Chapter` member covered above.
+        var diagnostics = BindAndReturnAllDiagnostics(
+            GenericSourceExtension,
+            """
+            package Core
+            class Chapter {
+                prop Title string
+                prop Chapters []Chapter?
+            }
+            func Chained(ch Chapter?) bool { return ch!!.Chapters.IsNullOrEmpty() }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void FieldMember_NullAssertedReceiver_ThenMemberAccess_Resolves()
+    {
+        // A field (`var`) rather than an auto-property (`prop`).
+        var diagnostics = BindAndReturnAllDiagnostics(
+            GenericSourceExtension,
+            """
+            package Core
+            class Chapter {
+                var Title string
+                var Chapters []Chapter
+            }
+            func Chained(ch Chapter?) bool { return ch!!.Chapters.IsNullOrEmpty() }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void MethodReturnMember_NullAssertedReceiver_ThenMemberAccess_Resolves()
+    {
+        // The chain's array-typed step is a METHOD CALL return value, not a
+        // field/property.
+        var diagnostics = BindAndReturnAllDiagnostics(
+            GenericSourceExtension,
+            ChapterModelSource + """
+
+            class Holder {
+                prop Info ChapterInfo
+                func GetChapters() []Chapter { return this.Info.Chapters }
+            }
+            func Chained(h Holder?) bool { return h!!.GetChapters().IsNullOrEmpty() }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void IndexerMember_NullAssertedReceiver_ThenMemberAccess_Resolves()
+    {
+        // The chain's array-typed step is reached through a Dictionary
+        // INDEXER, not a plain field/property/method-return.
+        var diagnostics = BindAndReturnAllDiagnostics(
+            GenericSourceExtension,
+            """
+            package Core
+            import System.Collections.Generic
+            class Chapter {
+                prop Title string
+                prop Chapters []Chapter
+            }
+            class ChapterInfo {
+                prop Chapters []Chapter
+            }
+            class Holder {
+                prop Map Dictionary[string, []Chapter]
+            }
+            func Chained(h Holder?) bool { return h!!.Map["k"].IsNullOrEmpty() }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void NestedTwoLevelMemberChain_NullAssertedReceiver_Resolves()
+    {
+        // `a!!.B.C.IsNullOrEmpty()` — two member-access hops after the null
+        // assertion before reaching the array-typed member.
+        var diagnostics = BindAndReturnAllDiagnostics(
+            GenericSourceExtension,
+            ChapterModelSource + """
+
+            class Wrapper {
+                prop Info ChapterInfo
+            }
+            func Chained(w Wrapper?) bool { return w!!.Info.Chapters.IsNullOrEmpty() }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void NonGenericExtension_NullAssertedReceiver_ThenMemberAccess_Resolves()
+    {
+        // A NON-generic extension declared directly over the slice type
+        // (no type parameter at all) must keep working — proves the fix to
+        // the generic-inference routine doesn't regress (or accidentally
+        // depend on) the non-generic extension-lookup path.
+        var diagnostics = BindAndReturnAllDiagnostics(
+            """
+            package Foundation
+            func (e []?Core.Chapter) IsNullOrEmpty() bool { return e == nil || e!!.Length == 0 }
+            """,
+            ChapterModelSource + """
+
+            func Chained(source ChapterInfo?) bool { return source!!.Chapters.IsNullOrEmpty() }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void ImportedReceiver_CrossAssembly_NullAssertedReceiver_ThenMemberAccess_Resolves()
+    {
+        // Source vs imported receivers: the extension itself comes from a
+        // genuinely separately-compiled CLR assembly (reflection-only via
+        // MetadataLoadContext), reached through `import Lib2416`, exactly
+        // mirroring how Oahu.Core consumes Oahu.Foundation's extension when
+        // Foundation is referenced as a prebuilt assembly rather than
+        // translated G# source. The receiver's element type (`Chapter`) is
+        // still a same-compilation SOURCE type.
+        var diagnostics = BindImported("""
+            package App
+            import Lib2416
+
+            class Chapter {
+                prop Title string
+                prop Chapters []Chapter
+            }
+            class ChapterInfo {
+                prop Chapters []Chapter
+            }
+            func Chained(source ChapterInfo?) bool { return source!!.Chapters.IsNullOrEmpty() }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Negative_InvalidReceiver_NotSequenceCompatible_StillReportsCannotFindFunction()
+    {
+        // Invalid-receiver negative: the member's type is a plain
+        // non-sequence struct (no slice/array, no IEnumerable[T] shape at
+        // all). The fix must NOT broaden acceptance to non-array/slice
+        // receivers — this must keep failing with GS0159.
+        var diagnostics = BindAndReturnAllDiagnostics(
+            GenericSourceExtension,
+            """
+            package Core
+            class Holder {
+                prop Value int32
+            }
+            func Chained(h Holder?) bool { return h!!.Value.IsNullOrEmpty() }
+            """);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void Negative_AmbiguousExtensionOverloads_ThroughNullAssertedMemberChain_StillReportsAmbiguity()
+    {
+        // Ambiguity negative: the SAME package declares two independently
+        // applicable generic extension overloads for the same simple name
+        // over two UNRELATED array-compatible interfaces
+        // (ICollection[T]?/IReadOnlyCollection[T]? — neither extends the
+        // other, so there is no legitimate "more specific" winner). Both
+        // are only reachable for a same-compilation slice-of-source-struct
+        // argument BECAUSE of the #2416 fix (previously neither's
+        // ClrType-based fallback matched at all, so this shape never even
+        // got far enough to be ambiguous). Reaching the receiver through a
+        // null-asserted member chain must still surface a genuine ambiguity
+        // (GS0266) rather than silently picking one of the two tied
+        // candidates.
+        var diagnostics = BindAndReturnAllDiagnostics(
+            """
+            package Foundation
+            import System.Collections.Generic
+            func (e ICollection[T]?) IsNullOrEmpty[T]() bool { return e == nil || e!!.Count == 0 }
+            func (e IReadOnlyCollection[T]?) IsNullOrEmpty[T]() bool { return e == nil || e!!.Count == 0 }
+            """,
+            ChapterModelSource + """
+
+            func Chained(source ChapterInfo?) bool { return source!!.Chapters.IsNullOrEmpty() }
+            """);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0266");
+    }
+
+    private static System.Collections.Generic.IReadOnlyList<GSharp.Core.CodeAnalysis.Diagnostic> BindAndReturnAllDiagnostics(params string[] sources)
+    {
+        var scope = BindSource(sources);
+        var program = Binder.BindProgram(scope);
+        return scope.Diagnostics.Concat(program.Diagnostics).ToList();
+    }
+
+    private static BoundGlobalScope BindSource(params string[] sources)
+    {
+        var trees = sources.Select(s => GsSyntaxTree.Parse(SourceText.From(s))).ToImmutableArray();
+        return Binder.BindGlobalScope(previous: null, trees);
+    }
+
+    private static System.Collections.Generic.IReadOnlyList<GSharp.Core.CodeAnalysis.Diagnostic> BindImported(string source)
+    {
+        using var resolver = ReferenceResolver.WithReferences(new[] { ImportedLibraryPath });
+        var tree = GsSyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GsCompilation(resolver, tree);
+        return tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .ToList();
+    }
+
+    private static string EmitCSharpLibrary()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2416Binding");
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Lib2416.dll");
+
+        const string csharpSource = """
+            #nullable enable
+            using System.Collections.Generic;
+            using System.Linq;
+
+            namespace Lib2416
+            {
+                public static class ExtensionsVarious
+                {
+                    public static bool IsNullOrEmpty<T>(this IEnumerable<T>? source)
+                    {
+                        return source == null || !source.Any();
+                    }
+                }
+            }
+            """;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(csharpSource, new CSharpParseOptions(LanguageVersion.Latest));
+
+        var referencePaths = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+            ?.Split(Path.PathSeparator)
+            ?? Array.Empty<string>();
+
+        var references = referencePaths
+            .Where(File.Exists)
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "Lib2416",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using (var peStream = File.Create(libraryPath))
+        {
+            var emitResult = compilation.Emit(peStream);
+            Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+        }
+
+        return libraryPath;
+    }
+}


### PR DESCRIPTION
Fixes #2416.

## Problem

After #2414 (cross-package generic extension resolution), `gsc` still
reported `GS0159 "Cannot find function"` for chains like
`x!!.Member.IsNullOrEmpty()` in the faithful Oahu.Core shape (e.g.
`BookLibrary.gs:758`/`:766`), even though the direct/null-asserted
control (`x!!.IsNullOrEmpty()`, e.g. `:659`) and an equivalent bare
`Member.IsNullOrEmpty()` (e.g. `:827`) resolved.

## Root cause

`Binder.InferTypeArguments`'s `ImportedTypeSymbol pit` branch handles
generic extensions whose receiver parameter is an *open CLR
interface* (e.g. `IEnumerable[T]?`, the real shape of
`Oahu.Foundation`'s `IsNullOrEmpty[T]()`). To unify a slice/array
argument against that open interface, it reflected over the
argument's real CLR `Type` (`argumentType.ClrType.IsArray` +
`FindMatchingInterface`).

That CLR `Type` is `null` for a same-compilation source `struct`/
`class` element type that hasn't been emitted yet (`TypeSymbol.ClrType`
stays `null` for source types pre-emission) — so the type parameter
was never inferred and the call failed to bind, **regardless of
whether the array receiver arrived via a bare member access, a
null-asserted chain, a nested chain, or a for-loop element.** The
issue's "bare member already works" framing holds only when the
receiver's element type itself has a real CLR type (e.g. an
EF/database entity referenced from a separate, already-built
assembly); it breaks equally for any of those access shapes once the
element type is a same-compilation G# source type — the gap is in
the reflection fallback, not in null-assertion handling specifically.

## Fix

Added a symbolic fallback that needs no `ClrType`: a CLR
single-dimensional array unconditionally implements `IEnumerable<T>`,
`ICollection<T>`, `IList<T>`, `IReadOnlyCollection<T>`, and
`IReadOnlyList<T>` with `T` equal to its own element type — a
guarantee of the CLR array contract, not something reflection needs
to confirm. When the parameter's open definition is one of those
five interfaces, unify directly against the slice/array's own
`ElementType` symbol instead. New helper `IsArrayCompatibleOpenInterface`
sits next to the existing `FindMatchingInterface`, using
`Type.IsSameAs` per this repo's `GSA0002` analyzer rule for
`System.Type` comparisons.

This is a fix to the shared type-propagation/substitution root in
`InferTypeArguments` — not a special case for `IsNullOrEmpty` or for
null-assertion.

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue2416NullAssertedMemberExtensionInferenceTests.cs`
  (13 binder-level cases): direct-null-assert and bare-member
  controls, the reported null-assert-then-member chain, a nested
  for-loop chain, a nullable member type, field/property/
  method-return/indexer member steps, a two-level nested member
  chain, a non-generic-extension control, a cross-assembly (imported)
  receiver control, and two negatives — an invalid receiver and a
  genuine ambiguity between two unrelated array-compatible interfaces
  (`ICollection[T]?`/`IReadOnlyCollection[T]?`, `GS0266`).
- `test/Compiler.Tests/Emit/Issue2416NullAssertedMemberExtensionInferenceEmitTests.cs`
  (4 compile+ILVerify+run cases): the reported chain (empty and
  non-empty), a non-generic-extension variant, and a faithful
  Oahu.Core `BookLibrary`/`Chapter` shape (recursive `[]Chapter`, the
  real `IEnumerable[T]?.IsNullOrEmpty[T]()` extension body) exercised
  through both a null-asserted top-level chain and a nested for-loop
  chain.

All 17 new tests were independently verified to **fail without** the
`Binder.cs` fix (9/13 binder tests, 3/4 emit tests — reversed and
restored via a saved patch, never `git stash`) and pass with it.

## Full validation

- `Core.Tests`: 6369/6370 passing (1 pre-existing, unrelated
  `RegenerateBaseline` skip).
- `Compiler.Tests`: 3146/3146 passing.
- `InternalAnalyzers.Tests`: 7/7 passing.
- `Cs2Gs.Tests`, serialized (`MSBUILDDISABLENODEREUSE=1`,
  `RunConfiguration.DisableParallelization=true`): 1434/1434 passing.

## Oahu.Core migration re-run (read-only, no Oahu edits/PR)

Rebuilt/repacked the SDK, refreshed `.nugs`, and cleared the stale
cached `gsharp.net.sdk/0.3.94-g70fdc2c7c7` NuGet package (same
pre-commit version string as the baseline build, so the global
package cache held stale pre-fix bits under an identical version
key). Re-ran `cs2gs migrate --corpus <Oahu>/src --app
corpus/Oahu.Foundation --app corpus/Oahu.Decrypt --app
corpus/Oahu.Data --app corpus/Oahu.Core`:

- Foundation/Decrypt/Data: unchanged, all green.
- **Oahu.Core: 47/47 compile-stage artifacts, byte-identical
  diagnostic fingerprints before and after this fix — no visible
  change.**

This is disclosed rather than hidden. The generated
`Oahu.Core.gsproj` still compiles Foundation/Decrypt/Data as their
original, prebuilt CLR reference assemblies (`obj/Debug/net10.0/ref/*.dll`)
rather than their translated G# sources, so Oahu.Core's own
`IsNullOrEmpty` call sites already resolved through CLR-imported
reflection lookup before this fix and never exercised the broken
source-to-source path #2416 describes. The fix is confirmed correct
and necessary by the dedicated regression tests above, which
reproduce the true same-compilation-source-struct shape and fail
without it — it simply has no measurable effect on this specific
real-corpus configuration today, because that configuration doesn't
exercise the bug.

### Next independent blocker (identified, not fixed)

The earliest remaining `Oahu.Core` artifact is unchanged:
`corpus_Oahu.Core/AaxExporter.gs:44`, `GS0156`, the `book.Asin`
oblivious-nullability-taint shape (`ContentReference{Asin: book.Asin, ...}`).
This is unrelated to #2416. Notably, it's the same diagnostic
#2412/#2413 (merged) targeted, and it still reproduces identically
in this real-corpus run — suggesting a residual gap between #2413's
cross-project taint fix (which changed the *translate*-stage loader)
and the compile-stage's still-hybrid CLR reference selection. Left
unfixed here, per instructions, and flagged for its own follow-up.

## Scope notes

- No Oahu repo edits or PR (per instructions) — the migration re-run
  above is read-only against the existing local checkout.
- Never used `git stash` for this branch's work (a patch file was
  used instead to reversibly verify tests fail without the fix).
