### PR TITLE
Fix #2412: load sibling compilations for cross-project taint on the default SDK-backed path

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -40,6 +40,29 @@ public sealed class TranslateStage : IMigrationStage
             throw new ArgumentNullException(nameof(context));
         }
 
+        // Issue #2412 (reopened): this must stay the ORIGINAL CompileViaSdk-gated
+        // loader choice for `projects`/`project` — the values every other part of
+        // this method (PE reference capture, document translation, the generated
+        // `.gsproj`'s <Reference>/<ProjectReference> sets) depends on. `LoadProjectAsync`
+        // sets `LoadMetadataForReferencedProjects = true`, which is why a sibling
+        // ProjectReference shows up in `project.Compilation.References` as a
+        // `PortableExecutableReference` pointing at the sibling's own prebuilt ref
+        // assembly (e.g. `obj/Debug/net10.0/ref/Sibling.dll`) — exactly what the SDK-
+        // backed compile stage needs to resolve sibling types via CLR reference
+        // assemblies (Refs #914) without re-emitting the sibling's own G#.
+        // `LoadProjectWithReferencesAsync` deliberately does NOT set that flag (a
+        // sibling ProjectReference instead becomes a same-workspace `CompilationReference`
+        // to a separately loaded source `Project`), so swapping it in here — as a
+        // prior version of this fix did — silently emptied `project.Compilation`'s
+        // own `PortableExecutableReference` set for every sibling, breaking every
+        // downstream reference/type resolution the app's OWN generated `.gsproj` and
+        // gsc compile depend on (a regression caught by re-running the real Oahu
+        // corpus, not by any in-memory test). Cross-project taint analysis needs only
+        // read-only sibling `CSharpCompilation`s matched by metadata identity (see
+        // `ObliviousNullabilityAnalyzer.RemapToCompilation`), never object/reference
+        // identity with `project.Compilation` — so it is loaded independently below,
+        // via its own isolated `LoadProjectWithReferencesAsync` call/workspace, and
+        // never touches `projects`/`project` or anything derived from them.
         IReadOnlyList<LoadedCSharpProject> projects = context.Options.CompileViaSdk
             ? new[]
             {
@@ -94,12 +117,41 @@ public sealed class TranslateStage : IMigrationStage
         // sibling's OWN compilation — the one whose syntax trees actually
         // contain the tainting evidence — instead of always the current
         // document's own project compilation, which never sees it.
-        IReadOnlyList<CSharpCompilation> siblingCompilations = projects
-            .Select(p => p.Compilation)
-            .ToList();
+        //
+        // Issue #2412 (reopened): under the default SDK-backed path `projects`
+        // above is deliberately kept to the app's own project only (see the
+        // loader comment), so it can no longer double as the sibling list here.
+        // Load the transitive sibling projects a SECOND time, independently,
+        // purely to bind their own compilations for this taint lookup — this
+        // extra MSBuild workspace load only ever feeds `IsTainted`'s read-only,
+        // metadata-identity-based cross-compilation symbol remap (see
+        // `ObliviousNullabilityAnalyzer.RemapToCompilation`), so it is safe for
+        // it to be a wholly separate `Compilation` graph than `project`'s own —
+        // and it never touches `projects`/`project`, PE reference capture, or
+        // anything the generated `.gsproj` depends on.
+        IReadOnlyList<CSharpCompilation> siblingCompilations;
+        if (context.Options.CompileViaSdk)
+        {
+            IReadOnlyList<LoadedCSharpProject> taintOnlyProjects = await CSharpProjectLoader
+                .LoadProjectWithReferencesAsync(context.App.ProjectPath, cancellationToken)
+                .ConfigureAwait(false);
+            siblingCompilations = taintOnlyProjects.Select(p => p.Compilation).ToList();
+        }
+        else
+        {
+            siblingCompilations = projects.Select(p => p.Compilation).ToList();
+        }
 
-        // Translate the app itself (index 0) plus its transitively referenced
-        // sibling projects (Refs #914). Sibling G# is emitted so the app's uses
+        // Translate the app itself (index 0) plus, in the no-via-sdk path,
+        // its transitively referenced sibling projects (Refs #914); under the
+        // default SDK-backed path `projects` above contains only the app
+        // itself, so this loop's `projectIndex > 0` branch never runs there —
+        // a referenced sibling is migrated and compiled as its own,
+        // independent app, linked back in by the Compile stage's rewritten
+        // ProjectReference/prebuilt CLR reference assembly (Refs #914), and
+        // its `Compilation` is already available above via
+        // `siblingCompilations` for cross-project taint resolution. Sibling
+        // G# is emitted here only in the no-via-sdk path, so the app's uses
         // of sibling types resolve at the gsc compile stage; those files are
         // flagged IsFromReferencedProject so the Compile stage attributes errors
         // only to the app's own files (a sibling's own gaps are measured in its

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2412SdkBackedCrossProjectObliviousNullabilityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2412SdkBackedCrossProjectObliviousNullabilityTests.cs
@@ -1,0 +1,381 @@
+// <copyright file="Issue2412SdkBackedCrossProjectObliviousNullabilityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression coverage for issue #2412's reopening: PR #2413 fixed
+/// cross-project oblivious-nullability taint (issue #2412) only for
+/// <c>TranslateStage</c>'s NO-<c>--via-sdk</c> path — its own regression suite
+/// (<see cref="Issue2412CrossProjectObliviousNullabilityTranslationTests"/>)
+/// exercises the translator directly, in-memory, never through the real
+/// pipeline. A fresh, default (<c>--via-sdk</c>, <see cref="PipelineOptions.CompileViaSdk"/>
+/// true) <c>cs2gs migrate</c> on an on-disk, multi-project corpus with a
+/// PREBUILT sibling (the real Oahu.Core precondition — its siblings
+/// Oahu.Data/Oahu.Foundation/Oahu.Decrypt are always already restored and
+/// built) still emitted the bare, un-forgiven read: <c>TranslateStage</c>'s
+/// project-loading step was gated on <c>CompileViaSdk</c> itself, so the
+/// default path only ever loaded the app's OWN project
+/// (<c>CSharpProjectLoader.LoadProjectAsync</c>, no siblings at all) — the
+/// <see cref="Cs2Gs.Translator.TranslationContext.SiblingCompilations"/> list
+/// #2413 introduced was always a single-element list in this path, so the
+/// cross-compilation <c>ObliviousNullabilityAnalyzer.IsTainted</c> overload had
+/// nothing to redirect to. This test exercises the true default pipeline
+/// end-to-end (<see cref="MigrationPipeline"/> with <see cref="TranslateStage"/>
+/// + <see cref="CompileStage"/>, <see cref="PipelineOptions.CompileViaSdk"/>
+/// left at its true default) against a real, on-disk, MSBuild-loaded
+/// multi-project corpus (app + two sibling projects, one already built before
+/// the run) and proves the fix downstream: the emitted G# actually contains the
+/// <c>!!</c> forgiveness and the real <c>dotnet build</c> (via the packed
+/// <c>Gsharp.NET.Sdk</c>) actually succeeds — not just that an in-memory
+/// translator call produces the right string.
+/// </summary>
+public class Issue2412SdkBackedCrossProjectObliviousNullabilityTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_MultiProjectCorpus_PrebuiltSibling_CrossProjectTaint_EmitsForgivenessAndCompiles()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null || repoRoot is null ||
+            GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            // Gated exactly like every other live --via-sdk e2e test in this
+            // suite (e.g. Issue2319AppLocalNbgvPackageReferenceTests): build
+            // GSharp.sln (which also packs Gsharp.NET.Sdk) first.
+            return;
+        }
+
+        string sourceRoot = NewScratchDir("issue2412-via-sdk");
+        (string libProjectPath, string libEnabledProjectPath, string appProjectPath) = WriteFixture(sourceRoot);
+
+        // Issue #2412 (reopened)'s exact real-world precondition: Oahu.Core's
+        // siblings (Oahu.Data/Oahu.Foundation/Oahu.Decrypt) are always already
+        // restored and built by the time Oahu.Core is migrated. Prebuild ONE
+        // sibling directly (outside the pipeline) so MSBuildWorkspace sees a
+        // real prebuilt output assembly on disk for its ProjectReference —
+        // the exact condition #2413's own CSharpProjectLoaderDiagnosticsTests
+        // regression guards at the loader level; this test proves the SAME
+        // precondition does not break the fix end-to-end through the real
+        // default pipeline.
+        RunDotnetBuild(libProjectPath);
+
+        string outputRoot = NewOutputRoot("issue2412-via-sdk");
+        RunResult firstRun = await RunPipeline(outputRoot, sourceRoot, libProjectPath, libEnabledProjectPath, appProjectPath, compiler);
+
+        AppResult firstAppResult = firstRun.Apps.Single(a => a.AppId == "test/App");
+        Assert.True(
+            firstAppResult.Succeeded,
+            "Expected the --via-sdk build to succeed for the App project. Stages: " +
+                string.Join("; ", firstAppResult.Stages.Select(s => s.Stage + "=" + s.Status)));
+
+        string firstConsumerGs = ReadEmittedFile(outputRoot, firstRun.RunId, "test_App", "Consumer.gs");
+        AssertExpectedForgiveness(firstConsumerGs);
+
+        // Issue #2412 (reopened)'s own regression-test requirement: no
+        // dependence on stale caches. Re-run the identical migration from
+        // scratch (a fresh run id/output directory, but the SAME already
+        // packed-and-fed local Gsharp.NET.Sdk nupkg and the SAME prebuilt
+        // sibling output on disk) and confirm the forgiveness and the compile
+        // success are fully deterministic, not an artifact of the first run's
+        // now-populated NuGet/MSBuild caches.
+        RunResult secondRun = await RunPipeline(outputRoot, sourceRoot, libProjectPath, libEnabledProjectPath, appProjectPath, compiler);
+        AppResult secondAppResult = secondRun.Apps.Single(a => a.AppId == "test/App");
+        Assert.True(
+            secondAppResult.Succeeded,
+            "Expected the second (repeated) --via-sdk run to succeed identically. Stages: " +
+                string.Join("; ", secondAppResult.Stages.Select(s => s.Stage + "=" + s.Status)));
+
+        string secondConsumerGs = ReadEmittedFile(outputRoot, secondRun.RunId, "test_App", "Consumer.gs");
+        Assert.Equal(Compact(firstConsumerGs), Compact(secondConsumerGs));
+        AssertExpectedForgiveness(secondConsumerGs);
+    }
+
+    private static async Task<RunResult> RunPipeline(
+        string outputRoot,
+        string sourceRoot,
+        string libProjectPath,
+        string libEnabledProjectPath,
+        string appProjectPath,
+        string compiler)
+    {
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+
+            // Left at its true default (issue #2261): this is exactly the
+            // path issue #2412's reopening reported as still broken.
+        };
+        var pipeline = new MigrationPipeline(options, new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+
+        // All three projects are migrated together as their own corpus apps —
+        // the exact real-world shape of the reported command
+        // (`cs2gs migrate --corpus <Oahu>/src --app Foundation --app Decrypt
+        // --app Data --app Core`): every project in the dependency chain is
+        // itself a selected app, and Lib is ADDITIONALLY prebuilt on disk
+        // before this call (mirroring an already-built solution).
+        var libApp = new CorpusApp("test/Lib", libProjectPath, TargetKind.Library);
+        var libEnabledApp = new CorpusApp("test/LibEnabled", libEnabledProjectPath, TargetKind.Library);
+        var appApp = new CorpusApp("test/App", appProjectPath, TargetKind.Library);
+
+        return await pipeline.RunAsync(new[] { libApp, libEnabledApp, appApp });
+    }
+
+    private static void AssertExpectedForgiveness(string consumerGs)
+    {
+        string compact = Compact(consumerGs);
+
+        // Property control (interface-edge taint — the exact real Oahu
+        // AaxExporter.Asin/IBookMeta shape: the tainting `?.` evidence and the
+        // interface-implementation edge both live in the sibling, Impl.Name
+        // implements IFoo.Name).
+        Assert.Contains("Target{Name: foo.Name!!}", compact);
+
+        // Method control (direct return-position taint from the sibling's own
+        // `?.`-seeded expression body).
+        Assert.Contains("Target{Label: widget.GetLabel()!!}", compact);
+
+        // Field control (direct `= null` seed on the sibling's own field).
+        Assert.Contains("Target{Tag: widget.Tag!!}", compact);
+
+        // Generic control: the cross-project-tainted interface member read
+        // THROUGH a generic wrapper type instantiated with it (Box<IFoo>) —
+        // proves the fix is not defeated by an intervening generic
+        // substitution between the sibling declaration and the consumption
+        // site. `Wrapped` itself also gets `!!`: it is a receiver-position
+        // read of an oblivious sibling member, and the pre-existing (#2113/
+        // #2202) blanket "unknowably-nullable oblivious external member"
+        // receiver rule intentionally still applies to it — this is a
+        // harmless, compiling extra forgiveness, not a defect. (An earlier
+        // version of this fix tried to discriminate sibling-project members
+        // out of that receiver rule so only `Value.Name` — not `Wrapped`
+        // itself — got forgiven; that was empirically PROVEN, against the
+        // real Oahu.Core corpus, to regress 47 -> 90 compile errors and to
+        // newly break the previously-clean Oahu.Data app. This fix
+        // deliberately leaves that receiver rule untouched and relies solely
+        // on restoring `TranslateStage`'s sibling-compilation loading, which
+        // resolves the reopened issue with zero new errors.)
+        Assert.Contains("Target{First: widget.Wrapped!!.Value.Name!!}", compact);
+
+        // Negative control: a sibling member with NO taint evidence anywhere
+        // must stay a bare, non-forgiven read — the fix must not over-promote
+        // every cross-project symbol wholesale.
+        Assert.Contains("Target{Untainted: widget.FixedLabel}", compact);
+        Assert.DoesNotContain("widget.FixedLabel!!", compact);
+
+        // Genuinely-nullable negative: a DIFFERENT sibling project that is
+        // nullable-ENABLED (a real `string?` annotation, not oblivious taint)
+        // must be completely unaffected by this fix — same forgiveness an
+        // intra-project nullable-enabled reference already gets, driven
+        // entirely by its own declared annotation.
+        Assert.Contains("Target{A: e.NonNull, B: e.Nullable!!}", compact);
+    }
+
+    private static (string LibProjectPath, string LibEnabledProjectPath, string AppProjectPath) WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+
+        string libDir = Path.Combine(sourceRoot, "Lib");
+        Directory.CreateDirectory(libDir);
+        string libProjectPath = Path.Combine(libDir, "Lib.csproj");
+        File.WriteAllText(libProjectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(libDir, "Types.cs"), """
+            namespace Lib
+            {
+                public interface IFoo
+                {
+                    string Name { get; }
+                }
+
+                public class Impl : IFoo
+                {
+                    public Impl Other { get; set; }
+
+                    public string Name => Other?.Name;
+                }
+
+                public class Box<T>
+                {
+                    public T Value { get; set; }
+                }
+
+                public class Widget
+                {
+                    public Widget Other { get; set; }
+
+                    public string GetLabel() => Other?.GetLabel();
+
+                    public string Tag = null;
+
+                    public Box<IFoo> Wrapped { get; set; }
+
+                    public string FixedLabel => "fixed";
+                }
+            }
+            """);
+
+        string libEnabledDir = Path.Combine(sourceRoot, "LibEnabled");
+        Directory.CreateDirectory(libEnabledDir);
+        string libEnabledProjectPath = Path.Combine(libEnabledDir, "LibEnabled.csproj");
+        File.WriteAllText(libEnabledProjectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(libEnabledDir, "Enabled.cs"), """
+            namespace LibEnabled
+            {
+                public class Enabled
+                {
+                    public string NonNull => "x";
+
+                    public string? Nullable => null;
+                }
+            }
+            """);
+
+        string appDir = Path.Combine(sourceRoot, "App");
+        Directory.CreateDirectory(appDir);
+        string appProjectPath = Path.Combine(appDir, "App.csproj");
+        File.WriteAllText(appProjectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <OutputType>Library</OutputType>
+              </PropertyGroup>
+              <ItemGroup>
+                <ProjectReference Include="../Lib/Lib.csproj" />
+                <ProjectReference Include="../LibEnabled/LibEnabled.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(appDir, "Consumer.cs"), """
+            using Lib;
+            using LibEnabled;
+
+            namespace App
+            {
+                public class Target
+                {
+                    public string Name { get; set; }
+
+                    public string Label { get; set; }
+
+                    public string Tag { get; set; }
+
+                    public string First { get; set; }
+
+                    public string Untainted { get; set; }
+
+                    public string A { get; set; }
+
+                    public string B { get; set; }
+                }
+
+                public class Consumer
+                {
+                    public Target FromInterfaceProperty(IFoo foo) => new Target { Name = foo.Name };
+
+                    public Target FromMethod(Widget widget) => new Target { Label = widget.GetLabel() };
+
+                    public Target FromField(Widget widget) => new Target { Tag = widget.Tag };
+
+                    public Target FromGenericWrapper(Widget widget) => new Target { First = widget.Wrapped.Value.Name };
+
+                    public Target FromUntainted(Widget widget) => new Target { Untainted = widget.FixedLabel };
+
+                    public Target FromNullableEnabledSibling(Enabled e) => new Target { A = e.NonNull, B = e.Nullable! };
+                }
+            }
+            """);
+
+        return (libProjectPath, libEnabledProjectPath, appProjectPath);
+    }
+
+    private static string ReadEmittedFile(string outputRoot, string runId, string sanitizedAppId, string fileName)
+    {
+        string appRunDir = Path.Combine(outputRoot, runId, sanitizedAppId);
+        string[] matches = Directory.GetFiles(appRunDir, fileName, SearchOption.AllDirectories);
+        Assert.True(matches.Length == 1, $"Expected exactly one '{fileName}' under '{appRunDir}', found {matches.Length}.");
+        return File.ReadAllText(matches[0]);
+    }
+
+    // Collapses incidental whitespace/newlines around composite-literal braces
+    // so an assertion on `Target{Name: foo.Name!!}` is not sensitive to the
+    // printer's exact line-wrapping.
+    private static string Compact(string printed) =>
+        string.Join(" ", printed.Split(
+            new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries));
+
+    private static void RunDotnetBuild(string projectPath)
+    {
+        var startInfo = new System.Diagnostics.ProcessStartInfo("dotnet", $"build \"{projectPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using System.Diagnostics.Process process = System.Diagnostics.Process.Start(startInfo);
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(
+            process.ExitCode == 0,
+            $"Prerequisite `dotnet build` failed (exit {process.ExitCode}); cannot exercise the prebuilt-sibling path.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    private static string NewOutputRoot(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "pipeline-tests", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string NewScratchDir(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "scratch-projects", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, projectDirName, dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/TranslationContext.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/TranslationContext.cs
@@ -52,7 +52,12 @@ public sealed class TranslationContext
     /// <param name="siblingCompilations">
     /// Issue #2412: every project's own <see cref="CSharpCompilation"/> loaded
     /// alongside <paramref name="compilation"/> in the same migration run (the
-    /// app plus its transitively-referenced sibling projects). A whole-program
+    /// app plus its transitively-referenced sibling projects — under the
+    /// default SDK-backed (<c>CompileViaSdk</c>) path, loaded independently
+    /// purely for this taint lookup by <c>TranslateStage</c>, since
+    /// <paramref name="compilation"/> itself resolves siblings as
+    /// <see cref="PortableExecutableReference"/> metadata there instead of
+    /// same-workspace source compilations). A whole-program
     /// fact computed only from one compilation's own syntax trees (e.g.
     /// <see cref="Translator.ObliviousNullabilityAnalyzer"/>'s taint fixpoint)
     /// can be TRUE in a sibling project's own result for a symbol this
@@ -61,8 +66,8 @@ public sealed class TranslationContext
     /// interface-implementation edges (issue #2285) can record taint for a
     /// symbol declared in a THIRD project (an interface member implemented by
     /// one of the sibling's own types). Pass <see langword="null"/> (default)
-    /// for a single-compilation translation (in-memory tests, <c>CompileViaSdk</c>,
-    /// a project with no references) — only <paramref name="compilation"/> is
+    /// for a single-compilation translation (in-memory tests, a standalone
+    /// project with no references) — only <paramref name="compilation"/> is
     /// then ever consulted, the exact prior behavior.
     /// </param>
     public TranslationContext(


### PR DESCRIPTION
## Summary

PR #2413 fixed cross-project oblivious-nullability taint (issue #2412) only for `TranslateStage`'s **NO**-`--via-sdk` path. The real, **default** `cs2gs migrate` path (`PipelineOptions.CompileViaSdk` true — the path every actual Oahu invocation uses) still emitted the un-forgiven read, because the project-loading call `TranslateStage` used to populate `TranslationContext.SiblingCompilations` was itself gated on `CompileViaSdk`. On the default path, that meant `SiblingCompilations` was always a single-element list (just the app itself), so #2413's cross-compilation `ObliviousNullabilityAnalyzer.IsTainted` overload had nothing to redirect to.

This closes the gap: `TranslateStage.cs` now loads sibling compilations **independently** of the existing, unchanged `CompileViaSdk`-gated loader call that PE-reference capture / the generated `.gsproj`'s `<Reference>` set depend on.

- The original loader choice for `projects`/`project` is left exactly as it was — still whichever loader `CompileViaSdk` selects — so the generated `.gsproj`'s references and the SDK-backed compile stage are unaffected.
- A second, independent `LoadProjectWithReferencesAsync` call populates `siblingCompilations` purely for taint analysis when `CompileViaSdk` is true, since that loader (unlike `LoadProjectAsync`) resolves sibling `ProjectReference`s as same-workspace source `Project`s instead of `PortableExecutableReference` metadata.
- `TranslationContext.cs`'s doc comment is corrected (it previously, incorrectly, said `CompileViaSdk` implied a null/absent `SiblingCompilations`).
- The no-`--via-sdk` path (#2413's original fix) is completely untouched.

## Real Oahu validation

Verified against the real Oahu corpus (fresh SDK pack + cleared NuGet caches): `cs2gs migrate --corpus <Oahu>/src --app Foundation --app Decrypt --app Data --app Core`

| | Oahu.Core errors | Oahu.Data errors |
|---|---|---|
| Before (this fix) | 47 (incl. reported `AaxExporter.gs:44` `GS0156` for `book.Asin`) | 0 |
| After (this fix) | 45 | 0 |

Fingerprint diff: **2 resolved, 0 new, 45 common**. `book.Asin!!` is now correctly emitted. Re-running the identical migration from scratch (fresh output dir, same prebuilt siblings, same packed SDK) reproduced **byte-identical** error fingerprints both times — no dependence on stale caches.

**No changes were made to the Oahu repository** (read-only validation only).

### Isolated next blocker (not fixed, out of scope for #2412)

The remaining 45 Oahu.Core errors are unrelated, pre-existing gaps, e.g.:
- `GS0159` "Cannot find function `Run`/`Add`" — BCL `Task.Run`, `ICollection<T>.Add` aren't resolved by the translator/stdlib mapping.
- `GS0155` nullable-vs-non-nullable interface-member mismatches (e.g. `bool?` vs `bool` through an intermediate interface property) — a gap in the existing single-project nullable-promotion machinery (#1354/#2167), not cross-project taint.

These are reported here for visibility but intentionally left unfixed as separate, unrelated work.

### A design path NOT taken

An earlier iteration of this fix additionally tried to narrow the pre-existing (#2113/#2202) blanket "unknowably-nullable oblivious external member" receiver rule so it would not apply to sibling-project members, deferring to the more precise, already-existing taint-based check instead. That was empirically proven — against the real Oahu corpus — to regress Oahu.Core from 47 to 90 errors and to newly break the previously-clean Oahu.Data app, because it exposed cases the existing single-project promotion machinery doesn't yet handle for newly-exposed cross-project taint. That change is **not** part of this PR; the harmless, compiling extra `!!` the blanket rule still places on cross-project oblivious receivers is intentional and is exactly what the new regression test's generic-wrapper control asserts.

## Test coverage

Adds `Issue2412SdkBackedCrossProjectObliviousNullabilityTests`: an exact on-disk, multi-project `cs2gs migrate` regression using the real default SDK-backed path (`CompileViaSdk` at its true default) with a prebuilt sibling project (Oahu.Core's real precondition), asserting:
- property/method/field/generic-wrapper cross-project taint controls all get `!!` forgiveness,
- a negative control (no taint evidence) stays un-forgiven,
- a genuinely-nullable-enabled (real `string?`) sibling negative control is unaffected,
- the real SDK build actually compiles successfully,
- a second from-scratch run produces byte-identical output (no stale-cache dependence).

- Targeted filter (`Issue2412`/`2215`/`2317`/`2319`/`2113`/`2202`/`2285`/`2167`, `CSharpProjectLoaderDiagnosticsTests`): **60/60 passed**.
- Full serialized `Cs2Gs.Tests` suite (`MSBUILDDISABLENODEREUSE=1`, `RunConfiguration.DisableParallelization=true`): **1435/1435 passed**.

Fixes #2412
