### PR TITLE
Fix #2419: don't let a value-symbol shadow of a middle namespace segment defeat qualified source-type peeling

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -2253,15 +2253,34 @@ internal sealed partial class ExpressionBinder
 
     /// <summary>
     /// Whether <paramref name="segment"/> is a pure namespace/package prefix
-    /// component — it does not name an in-scope value, a known type/alias, an
-    /// import alias, or an imported class. cs2gs fully-qualifies type references,
-    /// so a leading run of such segments in front of a same-compilation source
-    /// type is redundant and must be peeled before binding by simple name.
+    /// component — it does not name a known type/alias, an import alias, or an
+    /// imported class, and (only for the leading segment of a chain, per
+    /// <paramref name="isLeadingSegment"/>) does not name an in-scope value.
+    /// cs2gs fully-qualifies type references, so a leading run of such segments
+    /// in front of a same-compilation source type is redundant and must be
+    /// peeled before binding by simple name.
+    /// <para>
+    /// The in-scope-value check is restricted to the leading segment because it
+    /// is what distinguishes a genuine value-access chain (e.g.
+    /// <c>myOahu.Foo.Ctor()</c>, where <c>myOahu</c> really is a value) from a
+    /// namespace-qualified construction. Once a segment has already been
+    /// accepted as a namespace-prefix component (i.e. peeling is past the first
+    /// segment), the chain can no longer be reinterpreted as a value-access
+    /// chain — there is no value at its head to access <c>.member</c> on — so a
+    /// later segment coincidentally sharing a name with an unrelated in-scope
+    /// value (e.g. a field or const declared on the enclosing type, see issue
+    /// #2419) is not a genuine alternate interpretation and must not stop
+    /// peeling.
+    /// </para>
     /// </summary>
     /// <param name="segment">The dotted-name segment to classify.</param>
+    /// <param name="isLeadingSegment">
+    /// Whether <paramref name="segment"/> is the first segment being peeled from
+    /// the chain (as opposed to a later, already-committed continuation).
+    /// </param>
     /// <returns>Whether the segment is a pure namespace/package prefix.</returns>
-    private bool IsNamespacePrefixSegment(string segment) =>
-        scope.TryLookupSymbol(segment) is not VariableSymbol
+    private bool IsNamespacePrefixSegment(string segment, bool isLeadingSegment = true) =>
+        (!isLeadingSegment || scope.TryLookupSymbol(segment) is not VariableSymbol)
         && !scope.TryLookupTypeAlias(segment, out _)
         && !scope.TryLookupImport(segment, out _)
         && !scope.TryLookupImportedClass(segment, declaration: null, out _);
@@ -2277,12 +2296,14 @@ internal sealed partial class ExpressionBinder
     private ExpressionSyntax PeelNamespacePrefix(ExpressionSyntax expr)
     {
         var current = expr;
+        var peeledAny = false;
         while (current is AccessorExpressionSyntax accessor
                && !accessor.IsNullConditional
                && accessor.LeftPart is NameExpressionSyntax leftName
-               && IsNamespacePrefixSegment(leftName.IdentifierToken.Text))
+               && IsNamespacePrefixSegment(leftName.IdentifierToken.Text, isLeadingSegment: !peeledAny))
         {
             current = accessor.RightPart;
+            peeledAny = true;
         }
 
         return current;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -315,13 +315,19 @@ internal sealed partial class ExpressionBinder
         // that does NOT resolve to a value, a type, an import alias, or an
         // imported class — i.e. a pure namespace/package component. Stop at the
         // first segment that is anything else (a generic-name type reference, a
-        // type name, or the terminal construction).
+        // type name, or the terminal construction). Only the FIRST segment is
+        // required to fail the in-scope-value check: once a segment has been
+        // accepted as a namespace-prefix component, the chain can no longer be a
+        // value-access chain (there is no value at its head to access `.member`
+        // on), so a later segment coincidentally sharing a name with an unrelated
+        // in-scope value (e.g. a field on the enclosing type) is not a genuine
+        // alternate interpretation and must not stop peeling (issue #2419).
         ExpressionSyntax current = syntax;
         var peeledAny = false;
         while (current is AccessorExpressionSyntax accessor
                && !accessor.IsNullConditional
                && accessor.LeftPart is NameExpressionSyntax leftName
-               && IsNamespacePrefixSegment(leftName.IdentifierToken.Text))
+               && IsNamespacePrefixSegment(leftName.IdentifierToken.Text, isLeadingSegment: !peeledAny))
         {
             current = accessor.RightPart;
             peeledAny = true;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2419QualifiedSourceTypeNamespaceShadowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2419QualifiedSourceTypeNamespaceShadowTests.cs
@@ -1,0 +1,332 @@
+// <copyright file="Issue2419QualifiedSourceTypeNamespaceShadowTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2419: <c>TryBindQualifiedSourceTypeConstruction</c> (and the
+/// sibling <c>PeelNamespacePrefix</c> used for constructed-generic-type
+/// assignment targets) peel a redundant package prefix off a fully-qualified,
+/// same-compilation source-type construction one dotted segment at a time via
+/// <c>IsNamespacePrefixSegment</c>. That helper required EVERY peeled segment
+/// — not just the first — to fail lookup as an in-scope value/type/import.
+/// When an unrelated in-scope value (e.g. a <c>const</c> field on the
+/// enclosing type) happened to share its simple name with a middle or trailing
+/// segment of the qualified package path (e.g. <c>Oahu.Audible.Json.Author</c>
+/// where the enclosing <c>AaxExporter</c> class also declares
+/// <c>private const Json string = ".json"</c>), peeling stopped one segment
+/// short of the construction terminal, and the whole qualified name failed to
+/// bind — reported as GS0157 "Cannot find type" against the leftmost segment.
+/// <para>
+/// The fix restricts the in-scope-value shadow check to the FIRST peeled
+/// segment (which is what correctly protects a genuine value-access chain,
+/// e.g. <c>myValue.Foo.Ctor()</c>, from being misinterpreted as a namespace
+/// prefix) and ignores value shadowing for later segments, since once the
+/// first segment has been accepted as a namespace component the chain can no
+/// longer be a value-access chain at all. The type-alias/import/imported-class
+/// checks are unchanged and still gate every segment, so this does not affect
+/// disambiguation between same-simple-name types declared in different
+/// packages — the terminal type is still resolved exactly as it was for the
+/// already-supported unshadowed case.
+/// </para>
+/// </summary>
+public class Issue2419QualifiedSourceTypeNamespaceShadowTests
+{
+    [Fact]
+    public void QualifiedStructLiteral_ShadowedByConstFieldOnEnclosingType_Binds()
+    {
+        // Mirrors the exact real-world shape: AaxExporter declares
+        // `private const Json string = ".json"`, and separately constructs
+        // `Oahu.Audible.Json.Author{...}` — the const's simple name ("Json")
+        // collides with the namespace's terminal package segment.
+        const string source = """
+            package Oahu.Core
+            import Oahu.Audible.Json
+
+            class Author {
+                prop Asin string
+                prop Name string
+            }
+            """;
+
+        const string consumer = """
+            package Oahu.Core
+            import Oahu.Audible.Json
+
+            class AaxExporter {
+                func Make() Oahu.Audible.Json.Author {
+                    return Oahu.Audible.Json.Author{Asin: "x", Name: "y"}
+                }
+
+                private const Json string = ".json"
+            }
+            """;
+
+        var compilation = Compile(source, consumer);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void QualifiedConstructorCall_ShadowedByConstFieldOnEnclosingType_Binds()
+    {
+        const string source = """
+            package Oahu.Audible.Json
+
+            class ChapterInfo {
+                func Hello() int32 -> 42
+            }
+            """;
+
+        const string consumer = """
+            package Oahu.Core
+            import Oahu.Audible.Json
+
+            class AaxExporter {
+                func Make() int32 {
+                    let ci = Oahu.Audible.Json.ChapterInfo()
+                    return ci.Hello()
+                }
+
+                private const Json string = ".json"
+            }
+            """;
+
+        var compilation = Compile(source, consumer);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void QualifiedStructLiteral_ShadowedByLocalVariableInSameMethod_Binds()
+    {
+        // The shadow does not have to be a class-level field — an ordinary
+        // local variable earlier in the same method whose name matches a
+        // middle namespace segment must not stop peeling either.
+        const string source = """
+            package App.Models
+
+            class Foo {
+                prop X int32
+            }
+            """;
+
+        const string consumer = """
+            package App
+            import App.Models
+
+            func Make() int32 {
+                let Models = 7
+                let f = App.Models.Foo{X: Models}
+                return f.X
+            }
+            """;
+
+        var compilation = Compile(source, consumer);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void QualifiedGenericTypeArgument_ShadowedByConstFieldOnEnclosingType_Binds()
+    {
+        // Type clauses and generic type arguments already went through a
+        // separate, unaffected binding path — this pins that they remain
+        // unaffected by the fix (and were never broken by the shadow).
+        const string source = """
+            package App.Models
+
+            class Foo {
+                prop X int32
+            }
+            """;
+
+        const string consumer = """
+            package App
+            import App.Models
+            import System.Collections.Generic
+
+            class Widget {
+                func Make() int32 {
+                    let list = List[App.Models.Foo]()
+                    list.Add(App.Models.Foo{X: 9})
+                    return list[0].X
+                }
+
+                private const Models string = ".models"
+            }
+            """;
+
+        var compilation = Compile(source, consumer);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void QualifiedTypeClauseAnnotation_ShadowedByConstFieldOnEnclosingType_Binds()
+    {
+        const string source = """
+            package App.Models
+
+            class Foo {
+                prop X int32
+            }
+            """;
+
+        const string consumer = """
+            package App
+            import App.Models
+
+            class Widget {
+                func Make() int32 {
+                    let f App.Models.Foo = App.Models.Foo{X: 5}
+                    return f.X
+                }
+
+                private const Models string = ".models"
+            }
+            """;
+
+        var compilation = Compile(source, consumer);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void QualifiedStructLiteral_AsParameterAndReturn_ShadowedByConstField_Binds()
+    {
+        const string source = """
+            package App.Models
+
+            class Foo {
+                prop X int32
+            }
+            """;
+
+        const string consumer = """
+            package App
+            import App.Models
+
+            class Widget {
+                func Echo(f App.Models.Foo) App.Models.Foo {
+                    return f
+                }
+
+                func Make() int32 {
+                    return this.Echo(App.Models.Foo{X: 11}).X
+                }
+
+                private const Models string = ".models"
+            }
+            """;
+
+        var compilation = Compile(source, consumer);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void QualifiedStructLiteral_InArrayInitializer_ShadowedByConstField_Binds()
+    {
+        const string source = """
+            package App.Models
+
+            class Foo {
+                prop X int32
+            }
+            """;
+
+        const string consumer = """
+            package App
+            import App.Models
+
+            class Widget {
+                func Make() int32 {
+                    let items = []App.Models.Foo{App.Models.Foo{X: 1}, App.Models.Foo{X: 2}}
+                    return items[0].X + items[1].X
+                }
+
+                private const Models string = ".models"
+            }
+            """;
+
+        var compilation = Compile(source, consumer);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void QualifiedStructLiteral_ShadowedByConstField_DisambiguatesFromSameSimpleNameInSiblingPackage()
+    {
+        // Combines the shadow with a genuine same-simple-name collision across
+        // sibling packages (the real Oahu.Audible.Json.Author vs.
+        // Oahu.BooksDatabase.Author shape) to prove the fix does not fall back
+        // to a flat/ambiguous simple-name resolution: the qualified
+        // construction must still bind to the SPECIFIC package's type, not
+        // whichever same-named type happens to resolve first.
+        const string source = """
+            package Oahu.Audible.Json
+
+            class Author {
+                prop Asin string
+                prop Name string
+            }
+            """;
+
+        const string other = """
+            package Oahu.BooksDatabase
+
+            class Author {
+                prop Id int32
+            }
+            """;
+
+        const string consumer = """
+            package Oahu.Core
+            import Oahu.Audible.Json
+            import Oahu.BooksDatabase
+
+            class AaxExporter {
+                func Make() string {
+                    let a = Oahu.Audible.Json.Author{Asin: "x", Name: "y"}
+                    return a.Name
+                }
+
+                private const Json string = ".json"
+            }
+            """;
+
+        var compilation = Compile(source, other, consumer);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void UnqualifiedValueAccessChain_WithGenuineFirstSegmentValue_IsNotMisboundAsNamespace()
+    {
+        // Negative/ambiguity control: when the FIRST segment of a dotted chain
+        // genuinely is an in-scope value, the chain must still be bound as an
+        // ordinary member-access/call on that value — never reinterpreted as a
+        // namespace-prefixed type construction. This protects the existing,
+        // unchanged first-segment shadow check.
+        const string source = """
+            package App
+
+            class Holder {
+                prop Value int32
+            }
+
+            func Make() int32 {
+                let Holder = App.Holder{Value: 3}
+                return Holder.Value
+            }
+            """;
+
+        var compilation = Compile(source);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+    }
+
+    private static Compilation Compile(params string[] sources)
+    {
+        var trees = sources.Select(s => GSharp.Core.CodeAnalysis.Syntax.SyntaxTree.Parse(SourceText.From(s))).ToArray();
+        return new Compilation(trees) { IsLibrary = true };
+    }
+}


### PR DESCRIPTION
## Fix #2419: value-symbol shadow of a middle namespace segment defeats qualified source-type peeling

Fixes #2419.

### Root cause

`TryBindQualifiedSourceTypeConstruction` (added for #2256) and `PeelNamespacePrefix` peel a redundant package prefix off a fully-qualified, same-compilation source-type construction (e.g. `Oahu.Audible.Json.Author{...}`) one dotted segment at a time via `IsNamespacePrefixSegment`, which required **every** peeled segment — not just the first — to fail lookup as an in-scope value/type-alias/import/imported-class.

`AaxExporter` (Oahu.Core) declares `private const Json string = ".json"`. That const's `VariableSymbol` is in scope throughout the whole class, so when peeling reaches the `Json` segment of `Oahu.Audible.Json.Author`, the segment fails the check even though it's unrelated to the const. Peeling stops one segment short of the construction terminal, the remainder no longer satisfies `RemainderHeadIsSourceType`, and the whole qualified name falls through to the generic accessor binder, which reports `GS0157: Cannot find type Oahu` against the leftmost segment.

Reproduced from scratch with the default SDK-backed `cs2gs migrate` against Oahu.Core (45-error baseline; 4 identical GS0157s at `AaxExporter.gs:45,61,194,202`), and confirmed with a minimal, dependency-free 2-file G# repro completely independent of Oahu/cs2gs.

### Fix

Only the **first** peeled segment is required to fail the in-scope-value check. Once a segment has already been accepted as a namespace-prefix component, the chain can no longer be reinterpreted as a value-access chain (there is no value at its head to access `.member` on), so a later segment's incidental name collision with an unrelated in-scope value must not stop peeling. The type-alias/import/imported-class checks are unchanged and still gate every segment, so disambiguation between same-simple-name source types declared in different packages is preserved — pinned by a test combining the shadow with a genuine cross-package `Author`/`Author` collision.

Applied identically to `PeelNamespacePrefix` (constructed-generic-type assignment targets), which had the same latent defect.

### Tests

`Issue2419QualifiedSourceTypeNamespaceShadowTests.cs` covers: struct-literal and constructor-call construction shadowed by a class-level const, a local-variable shadow, generic type arguments and type-clause annotations under the identical shadow (regression lock-in — these already worked and still do), parameter/return positions, array-literal elements, a same-simple-name cross-package disambiguation combined with the shadow, and a negative control confirming a genuine first-segment value receiver is never reinterpreted as a namespace prefix.

Full suites, all green:
- Core.Tests: 6378 passed, 0 failed
- Compiler.Tests: 3146 passed, 0 failed
- Cs2Gs.Tests: 1435 passed, 0 failed (serialized: `MSBUILDDISABLENODEREUSE=1`, `RunConfiguration.DisableParallelization=true`)

### Oahu.Core migration impact

Rebuilt/repacked the SDK, refreshed `.nugs` and cleared the matching versioned NuGet cache folder, then re-ran the from-scratch `cs2gs migrate` against Oahu.Core:

- **45 → 43 compile errors.** All 4 GS0157s are eliminated.
- The 2 fewer errors (rather than 4) reflect that the previously-unbound constructions now genuinely type-check, surfacing distinct pre-existing downstream issues on the same lines (`GS0490` "Cannot project `Oahu.BooksDatabase.ChapterInfo.Chapters`", `GS0127` read-only `Chapters` assignment, plus a couple of additional `GS0156` nullable-string mismatches) — these are separate, unrelated bugs, not part of this fix.

### Next blocker (reported only, not fixed)

The largest remaining cluster in the current 43-error baseline is a nullable/oblivious type mismatch: `GS0155` ("Cannot convert type `X?` to `X`") + `GS0156` ("`string?` to `string`") together account for **19 of the 43** remaining errors, spanning 8 files (`BookLibrary.gs`, `DownloadDecryptJob.gs`, `AudibleApi.gs`, `Authorize.gs`, `AudibleClient.gs`, `Profile.gs`, `ProgrammaticLogin.gs`, `Cryptography/XXTEA.gs`). Not investigated or fixed as part of this PR, per scope.
