### PR TITLE
Fix #2421: async Task<T> method/local-function returns skip return-promotion

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2421AsyncReturnTaintTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2421AsyncReturnTaintTranslationTests.cs
@@ -1,0 +1,291 @@
+// <copyright file="Issue2421AsyncReturnTaintTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #2421: an `async Task&lt;T&gt;` method,
+/// local function, or lambda whose body forwards an already-nullable value
+/// must be promoted to `T?` by the same whole-program oblivious-nullability
+/// taint analysis (<see cref="ObliviousNullabilityAnalyzer"/>) that the
+/// SYNCHRONOUS return path already applies (issues #2157/#2167). Prior to this
+/// fix, <c>CSharpToGSharpTranslator.MapReturnType</c> and
+/// <c>MapDelegateLikeReturnType</c> both unwrapped an `async Task&lt;T&gt;`
+/// return and returned the mapped `T` IMMEDIATELY, before ever reaching the
+/// tuple/scalar return-taint promotion the sync path applies unconditionally —
+/// so the literal async equivalent of an already-covered sync forwarding
+/// pattern silently skipped promotion and produced a `T? -&gt; T` mismatch at
+/// the call site (GS0155/GS0156). A companion gap in the same taint graph
+/// (<see cref="ObliviousNullabilityAnalyzer.IsDirectlyNullable"/> /
+/// <c>ResolveSources</c> ) had no case for `AwaitExpressionSyntax`, so
+/// `return await TaintedCall();` never created a transitive taint edge to the
+/// enclosing method at all; both gaps are covered here.
+/// </summary>
+public class Issue2421AsyncReturnTaintTranslationTests
+{
+    [Fact]
+    public void Oblivious_SyncMethodForwardingTaintedCall_IsPromotedToNullable()
+    {
+        // Negative control (issue #2167 behavior, unaffected by this fix):
+        // a synchronous method whose body forwards the result of a call whose
+        // OWN return is nullable must itself be promoted to `T?`.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Configuration
+    {
+        public string GetSorted() => null;
+    }
+
+    public class C
+    {
+        private readonly Configuration configuration = new Configuration();
+
+        public string GetSortedName()
+        {
+            return configuration.GetSorted();
+        }
+    }
+}");
+
+        Assert.Contains("func GetSortedName() string?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_AsyncMethodForwardingTaintedCall_IsPromotedToNullable()
+    {
+        // The literal async equivalent of the sync case above — the exact
+        // Oahu.Core `Authorize.GetRegisteredProfilesAsync` shape: an `async
+        // Task<T>` method forwarding a call whose own return is nullable.
+        // Before the fix, MapReturnType's async-unwrap branch returned before
+        // ever applying PromoteReturnIfTainted, so this stayed `string`
+        // (never promoted) and the caller-side `await` produced a `string? ->
+        // string` mismatch.
+        string printed = TranslateOblivious(@"
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public class Configuration
+    {
+        public string GetSorted() => null;
+    }
+
+    public class C
+    {
+        private readonly Configuration configuration = new Configuration();
+
+        public async Task<string> GetSortedNameAsync()
+        {
+            return configuration.GetSorted();
+        }
+    }
+}");
+
+        Assert.Contains("async func GetSortedNameAsync() string?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_AsyncMethodForwardingTaintedCall_ExpressionBodied_IsPromotedToNullable()
+    {
+        // Same shape, but as an arrow-bodied `async Task<T>` method (the exact
+        // AudibleClient.GetProfileAliasAsync / Authorize.GetRegisteredProfilesAsync
+        // rendering; MapReturnType handles both block- and expression-bodied
+        // async methods identically).
+        string printed = TranslateOblivious(@"
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public class Configuration
+    {
+        public string GetSorted() => null;
+    }
+
+    public class C
+    {
+        private readonly Configuration configuration = new Configuration();
+
+        public async Task<string> GetSortedNameAsync() => configuration.GetSorted();
+    }
+}");
+
+        Assert.Contains("async func GetSortedNameAsync() string?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_AsyncMethodReturningTaintedAwaitedCall_IsPromotedToNullable()
+    {
+        // Covers the companion AwaitExpressionSyntax gap: `return await
+        // OtherTaintedAsyncCall();` must create a transitive taint edge to the
+        // enclosing method (ResolveSources), and the awaited call's own
+        // nullability must be visible to IsDirectlyNullable/taint seeding.
+        string printed = TranslateOblivious(@"
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public class Configuration
+    {
+        public async Task<string> GetSortedAsync() => null;
+    }
+
+    public class C
+    {
+        private readonly Configuration configuration = new Configuration();
+
+        public async Task<string> ForwardAsync()
+        {
+            return await configuration.GetSortedAsync();
+        }
+    }
+}");
+
+        Assert.Contains("async func GetSortedAsync() string?", printed);
+        Assert.Contains("async func ForwardAsync() string?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_AsyncMethodReturningTaintedElementTuple_OnlyThatElementIsPromoted()
+    {
+        // Async tuple return (Task<(bool, IProfile)>-shaped): only the element
+        // whose own returned expression is tainted is promoted, mirroring the
+        // existing sync tuple-promotion precision guard (issue #914).
+        string printed = TranslateOblivious(@"
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public interface IProfile
+    {
+    }
+
+    public class Profile : IProfile
+    {
+    }
+
+    public class Configuration
+    {
+        public Profile Find() => null;
+    }
+
+    public class C
+    {
+        private readonly Configuration configuration = new Configuration();
+
+        public async Task<(bool Ok, IProfile Found)> TryFindAsync()
+        {
+            return (true, configuration.Find());
+        }
+    }
+}");
+
+        Assert.Contains("async func TryFindAsync() (bool, IProfile?)", printed);
+    }
+
+    [Fact]
+    public void Oblivious_AsyncValueTypedTaskReturn_IsNeverPromoted()
+    {
+        // Precision guard: an `async Task<int>` (value-typed T) must never be
+        // promoted through this path — PromoteAwaitedReturnIfTainted keys its
+        // reference-type guard off the UNWRAPPED awaited type, not the
+        // `Task<T>` envelope (which is always a reference type).
+        string printed = TranslateOblivious(@"
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public class Configuration
+    {
+        public string GetSorted() => null;
+    }
+
+    public class C
+    {
+        private readonly Configuration configuration = new Configuration();
+
+        public async Task<int> CountAsync()
+        {
+            var ignored = configuration.GetSorted();
+            return 0;
+        }
+    }
+}");
+
+        Assert.Contains("async func CountAsync() int32", printed);
+        Assert.DoesNotContain("int32?", printed);
+    }
+
+    [Fact]
+    public void Oblivious_AsyncLocalFunctionForwardingTaintedCall_IsPromotedToNullable()
+    {
+        // A capturing local function renders via a different emission path
+        // (`let Name = async func (...) ... { ... }`, TranslateLocalFunction)
+        // than a capture-free top-level local function
+        // (TranslateTopLevelLocalFunctionAsFunc); both reach
+        // MapDelegateLikeReturnType, and this exercises the capturing path.
+        string printed = TranslateOblivious(@"
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public class Configuration
+    {
+        public string GetSorted() => null;
+    }
+
+    public class C
+    {
+        public void Run(Configuration configuration)
+        {
+            async Task<string> GetSortedNameAsync()
+            {
+                return configuration.GetSorted();
+            }
+
+            GetSortedNameAsync();
+        }
+    }
+}");
+
+        Assert.Contains("let GetSortedNameAsync = async func () string?", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -887,9 +887,21 @@ public sealed partial class CSharpToGSharpTranslator
                     returnType is INamedTypeSymbol { Name: "Task" } task &&
                     task.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks")
                 {
-                    return task.IsGenericType
-                        ? this.typeMapper.Map(task.TypeArguments[0], this.context, node.ReturnType.GetLocation())
-                        : null;
+                    if (!task.IsGenericType)
+                    {
+                        return null;
+                    }
+
+                    // Issue #2421: an `async Task<T>` return is still a
+                    // declaration sink for T like any other method return —
+                    // the unwrap above must not skip the SAME tuple/scalar
+                    // promotion the synchronous path below applies, keyed off
+                    // the AWAITED type T (see PromoteAwaitedReturnIfTainted).
+                    ITypeSymbol awaitedType = task.TypeArguments[0];
+                    GTypeReference awaitedMapped = this.typeMapper.Map(
+                        awaitedType, this.context, node.ReturnType.GetLocation());
+                    awaitedMapped = this.PromoteTupleReturnIfTainted(awaitedMapped, awaitedType, node);
+                    return this.PromoteAwaitedReturnIfTainted(awaitedMapped, awaitedType, symbol);
                 }
 
                 // Issue #1900: `symbol.ReturnType` is already the pointee type T

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -144,6 +144,45 @@ public sealed partial class CSharpToGSharpTranslator
                 : type;
         }
 
+        // Issue #2421: mirrors PromoteReturnIfTainted's decision for an `async
+        // Task<T>` method/lambda/local function, keyed off the UNWRAPPED
+        // awaited type T rather than `symbol.ReturnType` (which for such a
+        // member is the `Task<T>` ENVELOPE — always a reference type regardless
+        // of whether T is a value or reference type). Calling
+        // ShouldPromoteToNullableReference directly would use that envelope for
+        // its `declared.IsReferenceType` guard, incorrectly bypassing the
+        // guard's protection for a value-typed T (e.g. `Task<int>`, whose
+        // awaited result must never become `int?`/`Nullable<int>` through this
+        // reference-only promotion). The taint MEMBERSHIP check itself is
+        // unchanged: it is the same whole-program symbol-keyed decision
+        // (`ObliviousNullabilityAnalyzer.IsTainted`) the synchronous path
+        // reaches via ShouldPromoteToNullableReference, since
+        // SeedMethodLikeReturnTaint already seeds/propagates taint on the
+        // method symbol uniformly regardless of its `Task<T>` envelope — only
+        // the CONSUMPTION side (this declaration's own rendered return type)
+        // was previously never asked the question at all for an async member.
+        private GTypeReference PromoteAwaitedReturnIfTainted(
+            GTypeReference type,
+            ITypeSymbol awaitedType,
+            IMethodSymbol symbol)
+        {
+            if (type == null || type.IsNullable || symbol == null)
+            {
+                return type;
+            }
+
+            if (awaitedType is not { IsReferenceType: true }
+                || awaitedType.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                return type;
+            }
+
+            return ObliviousNullabilityAnalyzer.IsTainted(
+                this.context.Compilation, symbol, this.context.SiblingCompilations)
+                ? MakeNullable(type)
+                : type;
+        }
+
         // Issue #914 (oblivious sink): promote the ELEMENT types of a tuple return
         // to `T?` for every position whose returned tuple-expression element is a
         // promoted-nullable value. A method returning `(string Dir, string Path)`

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -186,9 +186,18 @@ public sealed partial class CSharpToGSharpTranslator
                 returnType is INamedTypeSymbol { Name: "Task" } task &&
                 task.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks")
             {
-                return task.IsGenericType
-                    ? this.typeMapper.Map(task.TypeArguments[0], this.context, location)
-                    : null;
+                if (!task.IsGenericType)
+                {
+                    return null;
+                }
+
+                // Issue #2421: same declaration-sink promotion the sync path
+                // below applies, keyed off the AWAITED type (see
+                // CSharpToGSharpTranslator.MapReturnType /
+                // PromoteAwaitedReturnIfTainted for the full rationale).
+                ITypeSymbol awaitedType = task.TypeArguments[0];
+                GTypeReference awaitedMapped = this.typeMapper.Map(awaitedType, this.context, location);
+                return this.PromoteAwaitedReturnIfTainted(awaitedMapped, awaitedType, symbol);
             }
 
             // Issue #914 (oblivious sink): local-function/lambda return

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -983,6 +983,20 @@ internal static class ObliviousNullabilityAnalyzer
 
                 break;
 
+            // `await expr`: issue #2421 — a `return await TaintedAsyncCall()`
+            // must forward the SAME transitive edge a synchronous `return
+            // TaintedCall()` already gets, or the enclosing async method never
+            // converges to tainted despite forwarding a provably-nullable
+            // awaited result (mirrors the identical unwrap in
+            // IsDirectlyNullable above).
+            case AwaitExpressionSyntax awaitExpression:
+                foreach (ISymbol source in ResolveSources(awaitExpression.Expression, model, scope))
+                {
+                    yield return source;
+                }
+
+                break;
+
             case PostfixUnaryExpressionSyntax suppress
                 when suppress.IsKind(SyntaxKind.SuppressNullableWarningExpression):
                 yield break;
@@ -1111,6 +1125,17 @@ internal static class ObliviousNullabilityAnalyzer
 
             case ParenthesizedExpressionSyntax paren:
                 return IsDirectlyNullable(paren.Expression, model);
+
+            // `await expr`: an awaited `Task<T>`'s own nullability is that of
+            // T, which is exactly what the UNWRAPPED awaited expression's own
+            // syntactic shape already answers here (mirrors ResolveSources'
+            // identical unwrap immediately below, and the translator's
+            // symmetric async-return unwrap in
+            // CSharpToGSharpTranslator.PromoteAwaitedReturnIfTainted, issue
+            // #2421). Without this, `return await x?.M();` inside an async
+            // method would be treated as NOT directly nullable at all.
+            case AwaitExpressionSyntax awaitExpression:
+                return IsDirectlyNullable(awaitExpression.Expression, model);
 
             case PostfixUnaryExpressionSyntax suppress
                 when suppress.IsKind(SyntaxKind.SuppressNullableWarningExpression):


### PR DESCRIPTION
## Fix #2421: async `Task<T>` method/local-function returns skip return-promotion

Fixes #2421.

### Root cause

`CSharpToGSharpTranslator.MapReturnType` (`CSharpToGSharpTranslator.Constructors.cs`) and `MapDelegateLikeReturnType` (`CSharpToGSharpTranslator.Types.cs`) both special-case an `async` method/lambda/local-function whose C# return type is `Task<T>`: they unwrap to `T`, map it, and returned **immediately** — before ever reaching the tuple/scalar return-taint promotion calls (`PromoteTupleReturnIfTainted` / `PromoteReturnIfTainted`) that the **synchronous** return path already applies unconditionally (issue #2167). The literal async equivalent of an already-covered sync forwarding pattern silently skipped promotion, producing a `T? -> T` mismatch at the call site (GS0155/GS0156).

A companion gap in the same taint graph: `ObliviousNullabilityAnalyzer.IsDirectlyNullable` / `ResolveSources` had no case for `AwaitExpressionSyntax`, so `return await TaintedCall();` never created a transitive taint edge to the enclosing method at all — blocking propagation through async call chains once the primary fix is applied.

### Investigation (why this, not the originally-suspected interface-contract-sync gap)

The initial hypothesis was that `ObliviousNullabilityAnalyzer`'s interface-contract taint synchronization (`CollectInterfaceImplementationEdges`, `ImplementsBaseOrInterfaceMember`) is property-only, and extending it to methods would resolve the cluster. That hypothesis was investigated in depth and **disproven** as the primary root cause: most affected diagnostics (`Authorize.GetRegisteredProfilesAsync`, `AudibleClient.GetProfileAliasAsync`) are **not** interface implementations — they are ordinary `async Task<T>`-returning methods forwarding an already-nullable value. A minimal in-memory repro (sync forwarding call promotes correctly; the literal async equivalent does not) confirmed the actual root cause above before any fix was written.

### Fix

- New `PromoteAwaitedReturnIfTainted` helper (`CSharpToGSharpTranslator.Nullability.cs`), keyed off the **unwrapped awaited type**'s own reference-ness/annotation — not the `Task<T>` envelope's, which is always a reference type regardless of whether `T` is a value type — so `Task<int>` is correctly left untouched.
- `MapReturnType` and `MapDelegateLikeReturnType` now apply tuple/scalar promotion to the unwrapped awaited type before returning, instead of returning early. Both async-return emission paths (ordinary/local methods, and lambdas/capturing local functions) are fixed identically.
- `AwaitExpressionSyntax` unwrap case added to `IsDirectlyNullable` and `ResolveSources`, mirroring the existing `ParenthesizedExpressionSyntax` case.

No blanket nullable promotion: the fix only activates the analysis's own existing, already-vetted tainted-ness computation (`ObliviousNullabilityAnalyzer.IsTainted`) on the unwrapped awaited type. Genuinely non-null async returns, and value-typed `Task<T>` returns, are left untouched.

### Real Oahu.Core validation (default SDK-backed `cs2gs migrate`, fresh rebuild/repack)

Before: 43 errors (post-#2420 baseline), 19 GS0155/GS0156.
After: **42 errors**. Fixed (3, all confirmed members of the target GS0155/GS0156 cluster):
- `AudibleApi.GetDownloadLicenseAsync` (`AudibleApi.gs:122`, GS0155)
- `AudibleClient.GetProfileAliasAsync` (`AudibleClient.gs:157`, GS0156)
- `Authorize.GetRegisteredProfilesAsync` (`Authorize.gs:92`, GS0155)

Verified deterministic: two consecutive migrate runs against the identical rebuilt/repacked SDK produced identical diagnostics.

### Next blocker (reported, not fixed — out of scope for this PR, tracked in #2421)

Fixing this exposed `AudibleApi.GetLibraryAsync(bool)` (an `IAudibleApi` interface method whose body is a bare forwarding call to a sibling tainted overload) newly promoted via the await-unwrap fix, while its interface declaration (`Task[LibraryResponse]`, never treated as "async-shaped" since C# disallows `async` on interface members) stays unpromoted — gsc's interface-conformance check then rejects the class (new GS0187, `AudibleApi.gs:22`). Also discovered, disjoint from this fix's call graph: a new, deterministic `Login.gs:83` GS0156 whose emitted G# text (for both the caller and the called extension method's declaring file) is byte-identical to baseline — pointing to a `gsc`-binder-side (not cs2gs-translator) sensitivity to unrelated nullable-annotation changes elsewhere in the same `.gsproj` compilation. Both are root-caused and written up in detail in #2421 as follow-up work; neither is fixed here to keep this change minimal and surgical.

### Tests

Added `Issue2421AsyncReturnTaintTranslationTests.cs` covering: sync forwarding negative control, async ordinary method, async expression-bodied method, async return of a tainted awaited call (the transitive-edge companion fix), async tuple return with a tainted element (precision guard), async value-typed `Task<int>` negative control, and an async capturing local function (a separate emission path from top-level local functions).

- Targeted filter (this + related prior nullability-taint issues: #2113, #2167, #2202, #2285, #2412, #1354, #914, #2157): **146 passed**.
- Full serialized `Cs2Gs.Tests` (`MSBUILDDISABLENODEREUSE=1`, `RunConfiguration.DisableParallelization=true`): **1442 passed**.
