### PR TITLE
Fix #2423: sync interface-method contract taint and Task<T> envelope shape

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2423InterfaceMethodContractTaintTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2423InterfaceMethodContractTaintTests.cs
@@ -1,0 +1,381 @@
+// <copyright file="Issue2423InterfaceMethodContractTaintTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #2423: <c>ObliviousNullabilityAnalyzer
+/// .CollectInterfaceImplementationEdges</c> (added for issue #2285) only
+/// synchronized taint between an interface PROPERTY and the property that
+/// implements it — it had no case at all for methods. <c>SeedMethodLikeReturnTaint</c>,
+/// unlike its property counterpart (which gates transitivity via
+/// <c>ImplementsBaseOrInterfaceMember</c>), applies unconditional transitive
+/// return-taint promotion to every method, so a concrete method that
+/// implements an interface member and forwards a tainted call (e.g. an
+/// `async Task&lt;T&gt;` method delegating to a sibling overload that can
+/// return null — the exact Oahu.Core <c>AudibleApi.GetLibraryAsync</c> shape)
+/// is correctly promoted to <c>T?</c>, but the interface declaration it
+/// implements — which has no body to seed taint from, and C# interfaces
+/// cannot declare `async` members — never is. This produced an internally
+/// inconsistent translation that gsc's Kotlin-style interface-conformance
+/// check rejects (GS0187: "does not implement interface method").
+/// <para>
+/// <b>Fix, part 1 (taint-graph sync)</b>: <c>CollectInterfaceImplementationEdges</c>
+/// is split into a per-member-kind dispatcher; the existing property handling
+/// is extracted unchanged into <c>CollectInterfacePropertyEdges</c>, and a new
+/// <c>CollectInterfaceMethodEdges</c> adds the same bidirectional taint edges
+/// between an ordinary, non-void interface method and
+/// <c>type.FindImplementationForInterfaceMember</c>'s result, keyed off the
+/// UNWRAPPED `async Task&lt;T&gt;`/`ValueTask&lt;T&gt;` result
+/// (<c>UnwrapAwaitedType</c>) so the interface method's `Task&lt;T&gt;`-typed
+/// `ReturnType` is judged on the same effective type as an async
+/// implementation's awaited result.
+/// </para>
+/// <para>
+/// <b>Fix, part 2 (return-shape parity)</b>: syncing the taint symbols alone
+/// was insufficient. <c>CSharpToGSharpTranslator.MapReturnType</c>'s
+/// synchronous path mapped a `Task&lt;T&gt;`-returning, NON-async declaration
+/// (every interface method — interfaces can't be `async` — and any plain
+/// synchronous method that happens to return a `Task&lt;T&gt;` literally) by
+/// promoting the WHOLE mapped `Task[T]` envelope to nullable when tainted
+/// (`Task[T]?`), whereas an `async` implementation's sugar instead nullifies
+/// only the AWAITED result (`Task[T?]`, via `PromoteAwaitedReturnIfTainted`).
+/// These are different G# types (G# has real, structural nullable types, not
+/// C#-style annotations) — a nullable Task REFERENCE vs. a Task of a nullable
+/// result — so even after both endpoints were correctly marked tainted, gsc
+/// still rejected the mismatched shapes with the SAME GS0187 diagnostic
+/// (confirmed against the real Oahu.Core corpus: the taint-only fix, part 1
+/// alone, left the identical GS0187 fingerprint; combined with part 2 the
+/// fingerprint disappears and the failure count drops 42 -&gt; 41 with zero
+/// new fingerprints). The new <c>PromoteTaskEnvelopeReturnIfTainted</c> helper
+/// closes this by promoting only the inner type ARGUMENT of the (preserved)
+/// `Task[T]`/`ValueTask[T]` envelope, reusing `PromoteAwaitedReturnIfTainted`'s
+/// exact eligibility/taint decision so both declaration styles converge on the
+/// identical shape.
+/// </para>
+/// <para>
+/// <b>Scope</b>: eligibility is guarded to reference-typed, non-annotated
+/// awaited results (mirroring the #2421 async fix), so a value-typed
+/// `Task&lt;int&gt;` is never promoted. Base/override contracts are
+/// deliberately NOT synced (consistent with the pre-existing property
+/// behavior, which only handles interfaces). Tuple-returning interface
+/// methods are also NOT synced by this fix: tuple-return promotion
+/// (`PromoteTupleReturnIfTainted`) is an entirely separate, per-declaration
+/// SYNTACTIC mechanism that inspects a method's OWN `return` expressions — an
+/// interface method has no body/no `return` expressions to inspect, so it can
+/// never itself be promoted regardless of what an implementation's body
+/// contains; bridging that is a materially different mechanism and out of
+/// scope for this precise, symbol-taint-only fix.
+/// </para>
+/// </summary>
+public class Issue2423InterfaceMethodContractTaintTests
+{
+    [Fact]
+    public void ImplicitImplementation_AsyncForwardingOverload_PromotesInterfaceAndImplementationInLockstep()
+    {
+        // The exact Oahu.Core AudibleApi.GetLibraryAsync shape: an implicit
+        // interface implementation forwards to a sibling overload whose body
+        // genuinely returns null.
+        string printed = TranslateOblivious(@"
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public class LibraryResponse
+    {
+    }
+
+    public interface IAudibleApi
+    {
+        Task<LibraryResponse> GetLibraryAsync(bool resync);
+    }
+
+    public class AudibleApi : IAudibleApi
+    {
+        public async Task<LibraryResponse> GetLibraryAsync(bool resync) => await GetLibraryAsync(null, resync);
+
+        internal async Task<LibraryResponse> GetLibraryAsync(string json, bool resync)
+        {
+            return null;
+        }
+    }
+}");
+
+        Assert.Contains("func GetLibraryAsync(resync bool) Task[LibraryResponse?];", printed);
+        Assert.Contains("async func GetLibraryAsync(resync bool) LibraryResponse?", printed);
+    }
+
+    [Fact]
+    public void ExplicitImplementation_TaintedBody_PromotesInterfaceAndExplicitMember()
+    {
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public interface IFoo
+    {
+        string Get();
+    }
+
+    public class C : IFoo
+    {
+        string IFoo.Get() => null;
+    }
+}");
+
+        Assert.Contains("func Get() string?;", printed);
+        Assert.Contains("Get() string? -> nil", printed);
+    }
+
+    [Fact]
+    public void MultipleImplementations_OneTainted_PromotesInterfaceAndAllImplementations()
+    {
+        // The shared interface symbol is a single taint node: once ANY
+        // implementer proves the contract can return null, a caller holding
+        // only the interface-typed reference must see that possibility
+        // regardless of which concrete implementation it actually got at
+        // runtime — so the fixpoint correctly promotes every implementation
+        // of the same interface method, not just the one whose own body is
+        // tainted. This mirrors the pre-existing property behavior
+        // (Issue2285's NullCheckThroughInterfaceTypedReference_* test) and is
+        // intentional, not an unbounded/blanket promotion: it is still scoped
+        // to the members that share this exact interface-method contract.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public interface IFoo
+    {
+        string Get();
+    }
+
+    public class Tainted : IFoo
+    {
+        public string Get() => null;
+    }
+
+    public class Clean : IFoo
+    {
+        public string Get() => ""x"";
+    }
+}");
+
+        Assert.Contains("func Get() string?;", printed);
+        Assert.Contains("class Tainted : IFoo {\n    func Get() string? -> nil\n}", printed);
+        Assert.Contains("class Clean : IFoo {\n    func Get() string? -> \"x\"\n}", printed);
+    }
+
+    [Fact]
+    public void GenericInterface_UnconstrainedTypeParameter_LeavesInterfaceDeclarationUnpromoted()
+    {
+        // Negative/documentation control: the interface's own declared return
+        // is the (unconstrained) type parameter T itself, which is not
+        // `IsReferenceType` (it could be substituted by a value type at any
+        // instantiation site), so the eligibility guard correctly declines to
+        // promote the GENERIC declaration. The concrete instantiation's own
+        // implementation is still promoted independently, from its own
+        // tainted body (unrelated to this fix - the pre-existing, unconditional
+        // method-return taint seeding).
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public interface IRepo<T>
+    {
+        T Get();
+    }
+
+    public class Repo : IRepo<string>
+    {
+        public string Get() => null;
+    }
+}");
+
+        Assert.Contains("func Get() T;", printed);
+        Assert.Contains("func Get() string? -> nil", printed);
+    }
+
+    [Fact]
+    public void OverrideOfAbstractBase_IsNotSyncedByThisFix()
+    {
+        // Negative/documentation control: base-class virtual/abstract
+        // contracts are NOT interfaces, so CollectInterfaceMethodEdges (like
+        // its pre-existing property counterpart) does not create any edge for
+        // them - only the override's own tainted body is promoted.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public abstract class Base
+    {
+        public abstract string Get();
+    }
+
+    public class Derived : Base
+    {
+        public override string Get() => null;
+    }
+}");
+
+        Assert.Contains("open func Get() string;", printed);
+        Assert.Contains("override func Get() string? -> nil", printed);
+    }
+
+    [Fact]
+    public void TupleReturningInterfaceMethod_IsNotSyncedByThisFix()
+    {
+        // Negative/documentation control: tuple-return promotion is a
+        // separate, per-declaration SYNTACTIC mechanism
+        // (PromoteTupleReturnIfTainted) keyed off a method's OWN `return`
+        // expressions; an interface method has no body to inspect, so its
+        // tuple return can never be promoted by that mechanism regardless of
+        // what an implementation's body does. This fix's taint-graph sync
+        // does not bridge that gap (out of scope - see class remarks).
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public interface IFoo
+    {
+        (string, string) Get();
+    }
+
+    public class C : IFoo
+    {
+        public (string, string) Get()
+        {
+            string a = null;
+            return (a, ""x"");
+        }
+    }
+}");
+
+        Assert.Contains("func Get() (string, string);", printed);
+        Assert.Contains("func Get() (string?, string)", printed);
+    }
+
+    [Fact]
+    public void GenuinelyNonNullImplementation_InterfaceAndImplementationStayNonNull()
+    {
+        // Control: with no taint source anywhere, neither endpoint is
+        // promoted - the fix must not spuriously widen untainted contracts.
+        string printed = TranslateOblivious(@"
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public interface IFoo
+    {
+        Task<string> Get();
+    }
+
+    public class C : IFoo
+    {
+        public async Task<string> Get() => ""x"";
+    }
+}");
+
+        Assert.Contains("func Get() Task[string];", printed);
+        Assert.Contains("async func Get() string ->", printed);
+        Assert.DoesNotContain("Task[string?]", printed);
+        Assert.DoesNotContain("Task[string]?", printed);
+    }
+
+    [Fact]
+    public void ValueTypedAsyncTaskReturn_IsNeverPromoted()
+    {
+        // Negative control: a value-typed awaited result (Task<int>) must
+        // never be promoted through this reference-only mechanism, on either
+        // the interface or the implementation side, matching the existing
+        // #2421 async guard.
+        string printed = TranslateOblivious(@"
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public interface IFoo
+    {
+        Task<int> Get();
+    }
+
+    public class C : IFoo
+    {
+        public async Task<int> Get() => 1;
+    }
+}");
+
+        Assert.Contains("func Get() Task[int32];", printed);
+        Assert.Contains("async func Get() int32 -> 1", printed);
+    }
+
+    [Fact]
+    public void NullableEnabledCompilation_IsUnaffected()
+    {
+        // The oblivious taint analysis is gated to nullable-DISABLED
+        // compilations (issue #2113); a nullable-enabled compilation must be
+        // byte-identical to its own (correct, compiler-checked) annotations,
+        // matching the precedent set by Issue2285's equivalent control.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("Snippet.cs", @"
+#nullable enable
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public interface IFoo
+    {
+        Task<string> Get();
+    }
+
+    public class C : IFoo
+    {
+        public async Task<string> Get() => null!;
+    }
+}"),
+        });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        string printed = PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains("func Get() Task[string];", printed);
+        Assert.Contains("async func Get() string ->", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -920,6 +920,27 @@ public sealed partial class CSharpToGSharpTranslator
                 // no-op for a tuple value type).
                 mapped = this.PromoteTupleReturnIfTainted(mapped, returnType, node);
 
+                // Issue #2423: a NON-async declaration (a C# interface member —
+                // interfaces cannot declare `async` members — or a synchronous
+                // method that literally returns a `Task<T>`/`ValueTask<T>`
+                // envelope) is still a taint-consumption sink for the AWAITED
+                // type T, not for the envelope itself: the Task instance is not
+                // a nullability-bearing artifact of the source, only the
+                // logical awaited result is. Whole-envelope promotion here
+                // (`Task[T]?`) would render a structurally different shape
+                // from an `async` implementation's sugar, which instead
+                // nullifies the awaited result (`Task[T?]`,
+                // PromoteAwaitedReturnIfTainted) — defeating interface/impl
+                // conformance once CollectInterfaceMethodEdges syncs both
+                // sides' taint (GS0187).
+                if (returnType is INamedTypeSymbol { IsGenericType: true } taskLikeSync &&
+                    taskLikeSync.TypeArguments.Length == 1 &&
+                    taskLikeSync.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks" &&
+                    taskLikeSync.Name is "Task" or "ValueTask")
+                {
+                    return this.PromoteTaskEnvelopeReturnIfTainted(mapped, taskLikeSync.TypeArguments[0], symbol);
+                }
+
                 // Issue #2113: promote the return type to `T?` through the same
                 // shared symbol-position decision used by every declaration sink.
                 return this.PromoteReturnIfTainted(mapped, symbol);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -183,6 +183,35 @@ public sealed partial class CSharpToGSharpTranslator
                 : type;
         }
 
+        // Issue #2423: mirrors PromoteAwaitedReturnIfTainted's decision for a
+        // NON-async `Task<T>`/`ValueTask<T>`-returning declaration (a C#
+        // interface member — interfaces cannot declare `async` members — or a
+        // synchronous method that literally returns the envelope). Unlike the
+        // async path, there is no `async` keyword here to imply the envelope,
+        // so the literal `Task[T]`/`ValueTask[T]` reference from `envelope`
+        // must be PRESERVED and only its type ARGUMENT promoted — otherwise an
+        // interface declaration and its `async` implementation, once synced by
+        // CollectInterfaceMethodEdges, would promote to two structurally
+        // different shapes (`Task[T]?` outer-nullable vs `Task[T?]`
+        // inner-nullable) that still fail interface-conformance (GS0187).
+        private GTypeReference PromoteTaskEnvelopeReturnIfTainted(
+            GTypeReference envelope,
+            ITypeSymbol awaitedType,
+            IMethodSymbol symbol)
+        {
+            if (envelope is not NamedTypeReference { TypeArguments.Count: 1 } named || named.IsNullable)
+            {
+                return envelope;
+            }
+
+            GTypeReference promotedInner = this.PromoteAwaitedReturnIfTainted(
+                named.TypeArguments[0], awaitedType, symbol);
+
+            return ReferenceEquals(promotedInner, named.TypeArguments[0])
+                ? envelope
+                : new NamedTypeReference(named.Name, new[] { promotedInner });
+        }
+
         // Issue #914 (oblivious sink): promote the ELEMENT types of a tuple return
         // to `T?` for every position whose returned tuple-expression element is a
         // promoted-nullable value. A method returning `(string Dir, string Path)`

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -807,33 +807,125 @@ internal static class ObliviousNullabilityAnalyzer
             {
                 foreach (ISymbol member in iface.GetMembers())
                 {
-                    if (member is not IPropertySymbol interfaceProperty
-                        || interfaceProperty.Type is not { IsReferenceType: true }
-                        || interfaceProperty.Type.NullableAnnotation == NullableAnnotation.Annotated)
+                    switch (member)
                     {
-                        continue;
-                    }
+                        case IPropertySymbol interfaceProperty:
+                            CollectInterfacePropertyEdges(compilation, type, interfaceProperty, edges);
+                            break;
 
-                    if (type.FindImplementationForInterfaceMember(interfaceProperty) is not IPropertySymbol implementingProperty)
-                    {
-                        continue;
-                    }
-
-                    ISymbol interfaceCanonical = Canonical(interfaceProperty);
-                    ISymbol implCanonical = Canonical(implementingProperty);
-                    edges.Add((interfaceCanonical, implCanonical));
-                    edges.Add((implCanonical, interfaceCanonical));
-
-                    IParameterSymbol positionalParameter = FindPositionalRecordParameter(compilation, implementingProperty);
-                    if (positionalParameter != null)
-                    {
-                        ISymbol paramCanonical = Canonical(positionalParameter);
-                        edges.Add((interfaceCanonical, paramCanonical));
-                        edges.Add((paramCanonical, interfaceCanonical));
+                        case IMethodSymbol interfaceMethod:
+                            CollectInterfaceMethodEdges(type, interfaceMethod, edges);
+                            break;
                     }
                 }
             }
         }
+    }
+
+    private static void CollectInterfacePropertyEdges(
+        Compilation compilation,
+        INamedTypeSymbol type,
+        IPropertySymbol interfaceProperty,
+        List<(ISymbol Target, ISymbol Source)> edges)
+    {
+        if (interfaceProperty.Type is not { IsReferenceType: true }
+            || interfaceProperty.Type.NullableAnnotation == NullableAnnotation.Annotated)
+        {
+            return;
+        }
+
+        if (type.FindImplementationForInterfaceMember(interfaceProperty) is not IPropertySymbol implementingProperty)
+        {
+            return;
+        }
+
+        ISymbol interfaceCanonical = Canonical(interfaceProperty);
+        ISymbol implCanonical = Canonical(implementingProperty);
+        edges.Add((interfaceCanonical, implCanonical));
+        edges.Add((implCanonical, interfaceCanonical));
+
+        IParameterSymbol positionalParameter = FindPositionalRecordParameter(compilation, implementingProperty);
+        if (positionalParameter != null)
+        {
+            ISymbol paramCanonical = Canonical(positionalParameter);
+            edges.Add((interfaceCanonical, paramCanonical));
+            edges.Add((paramCanonical, interfaceCanonical));
+        }
+    }
+
+    // Issue #2423: the method-return analog of
+    // <see cref="CollectInterfacePropertyEdges"/>. `CollectInterfaceImplementationEdges`
+    // previously handled ONLY properties, so a method that implements an
+    // interface member had no synchronization at all: `SeedMethodLikeReturnTaint`
+    // (unlike its property counterpart) applies UNCONDITIONAL transitive
+    // return-taint promotion to every method, including one that implements an
+    // interface — so an implementation whose body forwards a tainted call (e.g.
+    // an `async Task&lt;T&gt;` method delegating to a sibling overload that can
+    // return null) is correctly promoted to `T?`, but the interface declaration
+    // it implements — which has no body of its own to seed taint from — never
+    // is, producing an internally-inconsistent translation gsc's Kotlin-style
+    // interface-conformance check rejects (GS0187: "does not implement interface
+    // method"). Only an ORDINARY method member is considered (interface property
+    // accessors surface as <see cref="IMethodSymbol"/> too via
+    // <see cref="ITypeSymbol.GetMembers()"/> and are already handled by the
+    // property edge above). The eligibility check is keyed off the UNWRAPPED
+    // `async Task&lt;T&gt;`/`ValueTask&lt;T&gt;` result type (mirroring
+    // <c>CSharpToGSharpTranslator.PromoteAwaitedReturnIfTainted</c>'s own
+    // unwrap), since the interface method symbol's own <c>ReturnType</c> is the
+    // `Task&lt;T&gt;` envelope regardless of the implementing method's `async`
+    // modifier (a signature-level fact, not an implementation detail) — so a
+    // value-typed `Task&lt;int&gt;` is correctly left untouched, exactly like the
+    // synchronous case. Both directions are recorded (mirroring the property
+    // fix) so the two endpoints always converge to the same tainted-ness
+    // regardless of which side (interface or implementation) the taint was
+    // originally seeded on.
+    private static void CollectInterfaceMethodEdges(
+        INamedTypeSymbol type,
+        IMethodSymbol interfaceMethod,
+        List<(ISymbol Target, ISymbol Source)> edges)
+    {
+        if (interfaceMethod.MethodKind != MethodKind.Ordinary || interfaceMethod.ReturnsVoid)
+        {
+            return;
+        }
+
+        ITypeSymbol effectiveReturnType = UnwrapAwaitedType(interfaceMethod.ReturnType);
+        if (effectiveReturnType is not { IsReferenceType: true }
+            || effectiveReturnType.NullableAnnotation == NullableAnnotation.Annotated)
+        {
+            return;
+        }
+
+        if (type.FindImplementationForInterfaceMember(interfaceMethod) is not IMethodSymbol implementingMethod)
+        {
+            return;
+        }
+
+        ISymbol interfaceCanonical = Canonical(interfaceMethod);
+        ISymbol implCanonical = Canonical(implementingMethod);
+        edges.Add((interfaceCanonical, implCanonical));
+        edges.Add((implCanonical, interfaceCanonical));
+    }
+
+    // Unwraps a (non-generic-parameter) `System.Threading.Tasks.Task<T>` or
+    // `System.Threading.Tasks.ValueTask<T>` return type to its awaited result
+    // `T`, mirroring `CSharpToGSharpTranslator.PromoteAwaitedReturnIfTainted`'s
+    // own unwrap so an interface method's `Task<T>`-declared signature is judged
+    // on the SAME effective type an `async` implementation's return is. Any
+    // other type (including the non-generic `Task`/`ValueTask`, and a
+    // value-typed `Task<int>`, whose `T` is filtered out by the reference-type
+    // eligibility check at the call site) is returned unchanged.
+    private static ITypeSymbol UnwrapAwaitedType(ITypeSymbol returnType)
+    {
+        if (returnType is INamedTypeSymbol { IsGenericType: true, TypeArguments.Length: 1 } named
+            && named.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T
+            && (named.Name == "Task" || named.Name == "ValueTask")
+            && named.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks")
+        {
+            return named.TypeArguments[0];
+        }
+
+        return returnType;
     }
 
     // A record's positional-parameter property has a declaring syntax


### PR DESCRIPTION
Fixes #2423.

## Summary

Reproduced and compared the two candidate "next blockers" documented in #2421's closing PR (#2422), against a fresh, default SDK-backed `cs2gs migrate --corpus <Oahu src> --app Oahu.Core` run at `3ecc5c78` (post-#2422 baseline: **42** compile-stage failures for Oahu.Core).

- **Candidate 1 (this PR): GS0187 at `AudibleApi.gs:22`** — confirmed via minimal repro as an independently-fixable, higher-impact root: interface-method contract taint synchronization was property-only, and even once synced, the non-async interface declaration promoted the wrong side of the `Task<T>` envelope.
- **Candidate 2: deterministic `Login.gs:83` GS0156`** — investigated but root cause remains unconfirmed (points to a `gsc`-binder-side sensitivity, not a cs2gs translator gap); reported as the next blocker below, intentionally **not** fixed here.

## Root cause (two compounding gaps)

`AudibleApi.GetLibraryAsync(bool resync)` implements `IAudibleApi.GetLibraryAsync(bool)` and forwards to a sibling `internal async Task<LibraryResponse> GetLibraryAsync(string, bool)` overload that genuinely returns `null`. The implementation is correctly promoted to nullable by the existing (unconditional) method-return taint seeding.

1. `ObliviousNullabilityAnalyzer.CollectInterfaceImplementationEdges` (added for #2285) only synced interface **properties** with their implementations — there was no equivalent edge for methods, so the interface declaration (which has no body to seed taint from, and can never be `async` in C#) stayed unpromoted while its implementation was, and gsc's interface-conformance check rejected the class (GS0187).
2. Fixing #1 alone was insufficient: `MapReturnType`'s synchronous path (taken by every interface method) promoted a tainted `Task<T>` return by wrapping the **whole envelope** in nullable (`Task[T]?`), while an `async` implementation's sugar nullifies only the **awaited result** (`Task[T?]`). These are different G# types, so both sides being "tainted" still didn't structurally match, and gsc kept reporting the identical GS0187 fingerprint even after #1's fix.

## Fix

- `ObliviousNullabilityAnalyzer.cs`: split `CollectInterfaceImplementationEdges` into a per-member-kind dispatcher; extracted the existing property handling unchanged into `CollectInterfacePropertyEdges`; added `CollectInterfaceMethodEdges` + `UnwrapAwaitedType` to add the same bidirectional taint edges for ordinary, non-void interface methods, keyed off the unwrapped `Task<T>`/`ValueTask<T>` awaited type.
- `CSharpToGSharpTranslator.Nullability.cs`: added `PromoteTaskEnvelopeReturnIfTainted`, promoting only the inner type argument of a preserved `Task[T]`/`ValueTask[T]` envelope (delegating to the existing `PromoteAwaitedReturnIfTainted` for the eligibility/taint decision) instead of wrapping the whole envelope.
- `CSharpToGSharpTranslator.Constructors.cs`: `MapReturnType`'s synchronous path now routes a `Task<T>`/`ValueTask<T>`-typed return (regardless of `symbol.IsAsync`) through `PromoteTaskEnvelopeReturnIfTainted`; every other synchronous return type is unaffected.

No blanket contract promotion: value-typed `Task<int>` returns are never promoted; base/override contracts and tuple-returning interface methods are deliberately out of scope (documented, tested negatives — different mechanisms govern them); multiple implementations of the same interface-method contract intentionally converge in lock-step, matching the pre-existing #2285 property behavior.

## Tests

Added `Issue2423InterfaceMethodContractTaintTests.cs` (9 cases): implicit/explicit interface implementation with async-forwarding, multiple implementations, generic interface (negative), override of abstract base (negative), tuple-returning interface method (negative), genuinely non-null control, value-typed `Task<int>` control, and `#nullable enable` control.

Full serialized `Cs2Gs.Tests` suite (1451 tests) passes:
```
MSBUILDDISABLENODEREUSE=1 dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --settings serialized.runsettings
Passed!  - Failed: 0, Passed: 1451, Skipped: 0, Total: 1451
```

## Real Oahu.Core validation

Fresh SDK rebuild/repack + targeted NuGet cache clear before each run, default SDK-backed `cs2gs migrate`:

- Before: **FAIL(42)**, including `GS0187` at `AudibleApi.gs:22` (fingerprint `sha256:5ac0691e…`).
- After: **FAIL(41)**. Fingerprint diff: exactly 1 removed (the GS0187 above), 0 added — an isolated, single-issue reduction with no cascades or regressions.

## Next blocker (not fixed here)

`Login.CreateCodeVerifier` (`Login.gs:83`, GS0156) remains the next independent blocker — its emitted G# is unaffected by this fix and its root cause (a suspected `gsc`-binder-side sensitivity) needs further delta-debugging, reported in #2423 for follow-up.
