### PR TITLE
Fix #2425: forgive oblivious external nullable initializers on explicit-typed locals

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2425ExplicitLocalObliviousExternalForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2425ExplicitLocalObliviousExternalForgivenessTranslationTests.cs
@@ -1,0 +1,589 @@
+// <copyright file="Issue2425ExplicitLocalObliviousExternalForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #2425: an explicit-typed local declared
+/// `T x = external.ObliviousReturn();` — where the declared type equals the
+/// initializer's natural type (the common case that omits the type clause
+/// entirely, ADR-0115 §B.3) — drops null forgiveness for an oblivious EXTERNAL
+/// (metadata, no nullable context) member result. Issue #2202's value-read logic
+/// already asserts `!!` on a DIRECT return of such a member
+/// (`return external.ObliviousReturn();`), but issue #1737's explicit-local
+/// type-retention decision only consults the whole-program SAME/SIBLING-source
+/// taint fixpoint (issue #2412), which an EXTERNAL symbol can never seed an edge
+/// in. So the explicit type is dropped, gsc infers the local as `T?` (per its own
+/// unannotated-external-import rule, issue #1354), and a later `return
+/// codeVerifier;` has no external symbol left at the read site to trigger
+/// forgiveness (GS0156) — exactly the real-world `Oahu.Core`
+/// `Login.CreateCodeVerifier` shape (`string codeVerifier =
+/// tokenBytes.ToUrlBase64String(); return codeVerifier;`).
+///
+/// The fix asserts `!!` at the INITIALIZER (mirroring the direct-return fix)
+/// instead of retaining an explicit `T?` type, so the local infers the intended
+/// non-null type from the start and every later use (return/argument/
+/// assignment) needs no further special-casing.
+/// </summary>
+public class Issue2425ExplicitLocalObliviousExternalForgivenessTranslationTests
+{
+    /// <summary>
+    /// Positive test: the exact real-world <c>Oahu.Core</c>
+    /// <c>Login.CreateCodeVerifier</c> shape — an explicit-typed local
+    /// initialized from an oblivious external EXTENSION method, later returned.
+    /// </summary>
+    [Fact]
+    public void LoginCreateCodeVerifierShape_ExtensionMethodResult_ForgivenAtInitialization()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string CreateCodeVerifier(byte[] tokenBytes)
+        {
+            string codeVerifier = tokenBytes.ToUrlBase64String();
+            return codeVerifier;
+        }
+    }
+}");
+
+        Assert.Contains("let codeVerifier = tokenBytes.ToUrlBase64String()!!", printed);
+        Assert.Contains("return codeVerifier", printed);
+
+        // Parity: the local's declaration absorbs the SAME single forgiveness a
+        // direct return would need — the later `return codeVerifier` must not
+        // need (or get) a second one.
+        Assert.DoesNotContain("return codeVerifier!!", printed);
+    }
+
+    [Fact]
+    public void InstanceMethodResult_ForgivenAtInitialization()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext)
+        {
+            string result = ext.Combine(""hello"");
+            return result;
+        }
+    }
+}");
+
+        Assert.Contains("let result = ext.Combine(\"hello\")!!", printed);
+    }
+
+    [Fact]
+    public void StaticMethodResult_ForgivenAtInitialization()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format()
+        {
+            string result = ExtLib.StaticCombine(""hello"");
+            return result;
+        }
+    }
+}");
+
+        Assert.Contains("let result = ExtLib.StaticCombine(\"hello\")!!", printed);
+    }
+
+    [Fact]
+    public void FieldResult_ForgivenAtInitialization()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext)
+        {
+            string result = ext.Field;
+            return result;
+        }
+    }
+}");
+
+        Assert.Contains("let result = ext.Field!!", printed);
+    }
+
+    [Fact]
+    public void PropertyResult_ForgivenAtInitialization()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext)
+        {
+            string result = ext.Prop;
+            return result;
+        }
+    }
+}");
+
+        Assert.Contains("let result = ext.Prop!!", printed);
+    }
+
+    /// <summary>
+    /// Negative test: an external oblivious method whose declared return is an
+    /// UNSUBSTITUTED type parameter (<c>T Generic&lt;T&gt;(T seed)</c>) is
+    /// excluded by <c>IsObliviousExternalNullableMember</c> — a type parameter's
+    /// own nullability is decided by its substituted argument, not the
+    /// declaring assembly's nullable context — so the local must not be
+    /// forgiven.
+    /// </summary>
+    [Fact]
+    public void GenericMethod_UnsubstitutedTypeParameterReturn_IsNotForgiven()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext)
+        {
+            string result = ext.Generic(""seed"");
+            return result;
+        }
+    }
+}");
+
+        Assert.Contains("let result = ext.Generic(\"seed\")", printed);
+        Assert.DoesNotContain("ext.Generic(\"seed\")!!", printed);
+    }
+
+    /// <summary>
+    /// Positive test: a parenthesized initializer resolves the same underlying
+    /// symbol (Roslyn's <c>GetSymbolInfo</c> sees through parentheses), so the
+    /// forgiveness still applies — matching the direct-return path's behavior
+    /// for the identical shape.
+    /// </summary>
+    [Fact]
+    public void ParenthesizedInitializer_ForgivenAtInitialization()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext)
+        {
+            string result = (ext.Combine(""hello""));
+            return result;
+        }
+    }
+}");
+
+        Assert.Contains("let result = (ext.Combine(\"hello\"))!!", printed);
+    }
+
+    [Fact]
+    public void MultipleDeclarators_EachForgivenIndependently()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext)
+        {
+            string a = ext.Combine(""x""), b = ext.Combine(""y"");
+            return a + b;
+        }
+    }
+}");
+
+        Assert.Contains("let a = ext.Combine(\"x\")!!", printed);
+        Assert.Contains("let b = ext.Combine(\"y\")!!", printed);
+    }
+
+    [Fact]
+    public void LocalUsedAsArgument_ForgivenAtInitializationOnly()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Sink(string s) { }
+
+        public void Format(ExtLib ext)
+        {
+            string result = ext.Combine(""hello"");
+            this.Sink(result);
+        }
+    }
+}");
+
+        Assert.Contains("let result = ext.Combine(\"hello\")!!", printed);
+        Assert.Contains("this.Sink(result)", printed);
+        Assert.DoesNotContain("this.Sink(result!!)", printed);
+    }
+
+    [Fact]
+    public void LocalUsedInAssignment_ForgivenAtInitializationOnly()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Format(ExtLib ext)
+        {
+            string result = ext.Combine(""hello"");
+            string other;
+            other = result;
+            System.Console.WriteLine(other);
+        }
+    }
+}");
+
+        Assert.Contains("let result = ext.Combine(\"hello\")!!", printed);
+        Assert.Contains("other = result", printed);
+        Assert.DoesNotContain("other = result!!", printed);
+    }
+
+    /// <summary>
+    /// Negative/scope control: a `var` local reads the SAME oblivious external
+    /// member and is later returned, but the fix is intentionally scoped to
+    /// EXPLICIT-typed locals (issue #2425's title) — a `var` local never had an
+    /// explicit type to retain/drop in the first place, and gets no
+    /// initializer-forgiveness from this change. (Tracked as a related, but
+    /// distinct, gap — not fixed here.)
+    /// </summary>
+    [Fact]
+    public void VarLocal_IsNotForgiven_ScopeControl()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext)
+        {
+            var result = ext.Combine(""hello"");
+            return result;
+        }
+    }
+}");
+
+        Assert.Contains("let result = ext.Combine(\"hello\")", printed);
+        Assert.DoesNotContain("ext.Combine(\"hello\")!!", printed);
+    }
+
+    /// <summary>
+    /// Negative/scope control: an explicit-typed local initialized from a
+    /// SAME-PROJECT (source) member must not be touched by this fix — only an
+    /// EXTERNAL (metadata) oblivious member qualifies. A plain source method
+    /// returning a definitely-non-null literal is not itself tainted by the
+    /// whole-program fixpoint (issue #1737/#2412 territory), so the type
+    /// clause and initializer are both left exactly as before.
+    /// </summary>
+    [Fact]
+    public void SameProjectSourceMember_IsNotForgiven()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class Helper
+    {
+        public string Get() { return ""a""; }
+    }
+
+    public class C
+    {
+        public string Format(Helper h)
+        {
+            string result = h.Get();
+            return result;
+        }
+    }
+}");
+
+        Assert.Contains("let result = h.Get()", printed);
+        Assert.DoesNotContain("h.Get()!!", printed);
+    }
+
+    /// <summary>
+    /// Negative test: the SAME external library but compiled WITH nullable
+    /// annotations enabled — a genuinely <c>string?</c>-returning method is a
+    /// real, deliberate nullability that must be preserved (as `T?`), not
+    /// papered over with a blind initializer `!!`.
+    /// </summary>
+    [Fact]
+    public void AnnotatedExternalNullableReturn_IsNotForgiven()
+    {
+        string printed = TranslateObliviousWithAnnotatedLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(AnnotatedLib lib)
+        {
+            string result = lib.MaybeNull();
+            return result;
+        }
+    }
+}");
+
+        Assert.Contains("result string? = lib.MaybeNull()", printed);
+        Assert.DoesNotContain("lib.MaybeNull()!!", printed);
+    }
+
+    /// <summary>
+    /// Negative test: a nullable-ENABLED compilation calling the same oblivious
+    /// external method — the fix is gated to oblivious compilations only (its
+    /// own nullable flow analysis is authoritative), so no `!!` is inserted.
+    /// </summary>
+    [Fact]
+    public void NullableEnabledCompilation_IsNotForgiven()
+    {
+        string printed = TranslateEnabledWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext)
+        {
+            string result = ext.Combine(""hello"");
+            return result;
+        }
+    }
+}");
+
+        Assert.Contains("let result = ext.Combine(\"hello\")", printed);
+        Assert.DoesNotContain("ext.Combine(\"hello\")!!", printed);
+    }
+
+    /// <summary>
+    /// Direct-return parity: an explicit local later returned and a direct
+    /// return of the identical call both end up with exactly one <c>!!</c>
+    /// bridging the same oblivious external member — the local-declaration fix
+    /// reproduces the #2202 direct-return outcome rather than a different one.
+    /// </summary>
+    [Fact]
+    public void ExplicitLocalThenReturn_MatchesDirectReturnForgivenessCount()
+    {
+        string viaLocal = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext)
+        {
+            string result = ext.Combine(""hello"");
+            return result;
+        }
+    }
+}");
+
+        string direct = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext)
+        {
+            return ext.Combine(""hello"");
+        }
+    }
+}");
+
+        int CountForgiveness(string printed) => printed.Split("!!").Length - 1;
+
+        Assert.Equal(1, CountForgiveness(viaLocal));
+        Assert.Equal(1, CountForgiveness(direct));
+    }
+
+    /// <summary>
+    /// Compiles a tiny "external" library WITHOUT a nullable context (oblivious),
+    /// then translates the <paramref name="source"/> snippet referencing it in an
+    /// oblivious compilation.
+    /// </summary>
+    private static string TranslateObliviousWithObliviousLibrary(string source)
+    {
+        const string LibSource = @"
+public class ExtLib
+{
+    public string Combine(string separator) { return separator; }
+
+    public string Field;
+
+    public string Prop { get; set; }
+
+    public static string StaticCombine(string separator) { return separator; }
+
+    public T Generic<T>(T seed) { return seed; }
+}
+
+public static class ExtLibExtensions
+{
+    public static string ToUrlBase64String(this byte[] bytes)
+    {
+        return System.Convert.ToBase64String(bytes);
+    }
+}
+";
+        MetadataReference libRef = CompileObliviousLibrary(LibSource, "Issue2425ObliviousExtLib");
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue2425.ExplicitLocalObliviousExternalInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Append(libRef).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    /// <summary>
+    /// Compiles a tiny "external" library WITH nullable annotations enabled (a
+    /// genuinely <c>string?</c>-returning method), then translates the
+    /// <paramref name="source"/> snippet referencing it in an oblivious
+    /// compilation.
+    /// </summary>
+    private static string TranslateObliviousWithAnnotatedLibrary(string source)
+    {
+        const string LibSource = @"
+#nullable enable
+public class AnnotatedLib
+{
+    public string? MaybeNull() { return null; }
+}
+";
+        MetadataReference libRef = CompileAnnotatedLibrary(LibSource, "Issue2425AnnotatedExtLib");
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue2425.AnnotatedExternalReturnInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Append(libRef).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    /// <summary>
+    /// Translates the <paramref name="source"/> in a nullable-ENABLED compilation
+    /// referencing the same oblivious external library — verifies the fix is gated.
+    /// </summary>
+    private static string TranslateEnabledWithObliviousLibrary(string source)
+    {
+        const string LibSource = @"
+public class ExtLib
+{
+    public string Combine(string separator) { return separator; }
+}
+";
+        MetadataReference libRef = CompileObliviousLibrary(LibSource, "Issue2425ObliviousExtLibForEnabled");
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue2425.EnabledCallingObliviousInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Append(libRef).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static MetadataReference CompileObliviousLibrary(string libSource, string assemblyName)
+    {
+        var libTree = CSharpSyntaxTree.ParseText(
+            libSource,
+            new CSharpParseOptions(LanguageVersion.Latest));
+        var libCompilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { libTree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable));
+        using var peStream = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult emit = libCompilation.Emit(peStream);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        peStream.Position = 0;
+        return MetadataReference.CreateFromStream(peStream);
+    }
+
+    private static MetadataReference CompileAnnotatedLibrary(string libSource, string assemblyName)
+    {
+        var libTree = CSharpSyntaxTree.ParseText(
+            libSource,
+            new CSharpParseOptions(LanguageVersion.Latest));
+        var libCompilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { libTree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+        using var peStream = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult emit = libCompilation.Emit(peStream);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        peStream.Position = 0;
+        return MetadataReference.CreateFromStream(peStream);
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -212,6 +212,32 @@ public sealed partial class CSharpToGSharpTranslator
                             // natural type) promote identically.
                             emitType = true;
                         }
+                        else if (this.IsObliviousCompilation()
+                            && IsObliviousExternalNullableMember(
+                                this.context.GetSymbolInfo(declarator.Initializer.Value).Symbol))
+                        {
+                            // Issue #2425: the explicit-type-equals-initializer-type
+                            // shape above elides the type clause and relies on
+                            // inference (issue #1737 above doesn't fire — the
+                            // whole-program taint fixpoint only tracks
+                            // same/sibling-SOURCE symbols, and an EXTERNAL member
+                            // never seeds one of its edges). But the initializer
+                            // itself is a value-position read of an oblivious
+                            // (metadata, no nullable context) external member —
+                            // exactly the shape #2202's TranslateValueWithNullForgiveness
+                            // already forgives for a `return ext.Combine(...)` direct
+                            // return. gsc maps that read to `T?`, so with no type
+                            // clause emitted here gsc would infer the LOCAL itself as
+                            // `T?` (e.g. `let codeVerifier = tokenBytes.ToUrlBase64String()`
+                            // → `codeVerifier : string?`), and a later `return
+                            // codeVerifier;` has no external symbol left at the read
+                            // site to trigger forgiveness (GS0156). Assert `!!` at the
+                            // INITIALIZER instead — mirroring the direct-return fix —
+                            // so the local infers the declared non-null type from the
+                            // start and every later use (return/argument/assignment)
+                            // needs no further special-casing.
+                            initializer = new NonNullAssertionExpression(initializer);
+                        }
                     }
 
                     if (emitType)


### PR DESCRIPTION
Closes #2425.

## Root cause

`Login.CreateCodeVerifier` in Oahu.Core has:

```csharp
string codeVerifier = tokenBytes.ToUrlBase64String();
return codeVerifier;
```

`ToUrlBase64String` is an oblivious (no nullable annotations) extension
method from external metadata. gsc correctly imports its return as
`string?`.

`TranslateLocalDeclaration`'s #1737 shortcut — "declared type equals the
initializer's natural type, so elide the redundant type clause and rely on
gsc's inference" — only checked `ShouldPromoteToNullableReference`, the
same/sibling-**source** taint fixpoint. An oblivious **external** (metadata)
member read can never seed one of that fixpoint's edges (it only walks the
compilation's own/sibling syntax trees), so the check always returned
`false` for this shape. The type clause was dropped with no forgiveness,
`let codeVerifier = tokenBytes.ToUrlBase64String()`, gsc inferred
`codeVerifier : string?`, and the later `return codeVerifier;` had no
external symbol left at the read site to trigger #2202's direct-return
forgiveness — GS0156.

## Fix

`CSharpToGSharpTranslator.Statements.cs`, `TranslateLocalDeclaration`: added
a sibling `else if` branch, mutually exclusive with the #1737 check, that
reuses the existing `IsObliviousExternalNullableMember` helper (the same one
#2202 already uses for direct-return forgiveness) against the initializer's
resolved symbol:

```csharp
else if (this.IsObliviousCompilation()
    && IsObliviousExternalNullableMember(
        this.context.GetSymbolInfo(declarator.Initializer.Value).Symbol))
{
    initializer = new NonNullAssertionExpression(initializer);
}
```

Instead of retaining the declared type, this wraps the already-translated
initializer in `!!` at the point of initialization — mirroring the
direct-return fix — so the local infers a non-null type from the start and
every later use (return/argument/assignment) needs no further
special-casing. No external-nullability detection logic is duplicated.

Deliberately unaffected (verified empirically):
- `var` locals — out of scope per the issue title; a distinct, related gap.
- Generic methods returning an unsubstituted type parameter — excluded by
  `IsObliviousExternalNullableMember`'s existing filter.
- `await` expressions — `GetSymbolInfo` doesn't resolve through
  `AwaitExpressionSyntax`; this matches pre-existing direct-return parity,
  not a new gap.
- Nullable-enabled consumer compilations, genuinely annotated `string?`
  external returns, and same-project/source members — all excluded by the
  reused helper's existing conditions.

## Tests

Added `Issue2425ExplicitLocalObliviousExternalForgivenessTranslationTests.cs`
(15 tests, metadata-only oblivious library harness matching the exact Login
shape):
- Exact `Login.CreateCodeVerifier` reproduction (positive).
- External field / property / static method / instance method / extension
  method initializers (positive).
- Generic method with unsubstituted type-parameter return (negative).
- Parenthesized initializer (positive).
- Multiple declarators, each independently forgiven (positive).
- Local later used in `return`, as an argument, and in an assignment
  (positive, each site).
- `var` local control (negative — confirms fix is scoped to explicit types).
- Same-project/source member control (negative).
- Genuinely annotated external `string?` return (negative).
- Nullable-enabled consumer compilation (negative).
- Direct-return parity (asserts both the direct-return and explicit-local
  patterns produce exactly one `!!`).

Full suite: **1466/1466 passing**
(`MSBUILDDISABLENODEREUSE=1 dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release -- RunConfiguration.DisableParallelization=true`),
1451 baseline + 15 new.

## Oahu.Core real-world validation

Rebuilt/packed `Gsharp.NET.Sdk` locally, refreshed `.nugs/`, cleared the
matching version's NuGet cache, then ran
`cs2gs migrate --corpus <Oahu> --app Oahu.Core` against the real Oahu.Core
project (read-only; no edits or PR against that repo):

- **Before** (exact `b2cf5982`, unmodified translator): `FAIL(41)` — matches
  the baseline documented in #2424.
- **After** (with this fix): `FAIL(40)` — deterministic across repeated
  runs.

Fingerprint diff:
- **2 removed**: `Login.gs:83` (the reported issue) and an identical
  explicit-local shape at `AudibleApi.gs:248` — both
  `GS0156: Cannot convert type 'string?' to 'string'`.
- **1 added**: `BookLibrary.gs:469`, also `GS0156` — net **-1**.

## Next blocker (isolated, not fixed)

The newly-surfaced `BookLibrary.gs:469` diagnostic is not a regression from
this fix — it's a distinct, already-latent gap that this fix's Login/
AudibleApi corrections happened to make visible. It traces to:

```csharp
path = (pathStub + ext).AsUncIfLong();
```

a plain **reassignment** (not a declaration) of an already non-null-typed
local (`path`) from an oblivious external member read. Unlike declarations
(this fix) and direct returns (#2202),
`TranslateExpressionStatement`'s `AssignmentExpressionSyntax` case computes
`assignRhs` via `CoerceConstantToUnsigned` /
`CoerceCompoundAssignmentRhs` / `CoercePointerConversion` /
`ForgiveEventSubscriptionRhs` / `ForgiveElementAccessAssignmentRhs`, but
never applies `IsObliviousExternalNullableMember` forgiveness. This looks
like a small, symmetric follow-up fix in the same assignment-case switch,
intentionally left unaddressed here to keep this change minimal and
focused on #2425.
