### PR TITLE
Fix #2427: forgive oblivious-external nullable RHS on plain reassignment

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2427ObliviousExternalAssignmentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2427ObliviousExternalAssignmentForgivenessTranslationTests.cs
@@ -1,0 +1,698 @@
+// <copyright file="Issue2427ObliviousExternalAssignmentForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #2427: a plain REASSIGNMENT (`path =
+/// external.ObliviousReturn();`) to an already-declared non-null local/
+/// parameter/field/property/indexer drops null forgiveness for an oblivious
+/// EXTERNAL (metadata, no nullable context) member result. Issue #2202's
+/// value-read logic already asserts `!!` on a DIRECT return of such a member
+/// (`return external.ObliviousReturn();`), and issue #2425's fix asserts `!!`
+/// at an explicit-typed LOCAL DECLARATION's initializer (`T x =
+/// external.ObliviousReturn();`) — but neither reaches a subsequent bare
+/// assignment STATEMENT: `TranslateExpressionStatement`'s
+/// <c>AssignmentExpressionSyntax</c> case computes its RHS via
+/// <c>CoerceConstantToUnsigned</c> / <c>CoerceCompoundAssignmentRhs</c> /
+/// <c>CoercePointerConversion</c> / <c>ForgiveEventSubscriptionRhs</c> /
+/// <c>ForgiveElementAccessAssignmentRhs</c>, none of which apply
+/// <c>IsObliviousExternalNullableMember</c> forgiveness. This is exactly the
+/// real-world `Oahu.Core` `BookLibrary.gs:469` shape surfaced by #2426:
+/// `path = (pathStub + ext).AsUncIfLong();`, where <c>AsUncIfLong</c> is an
+/// oblivious external extension method and <c>path</c> is an already
+/// non-null-typed local.
+/// </summary>
+public class Issue2427ObliviousExternalAssignmentForgivenessTranslationTests
+{
+    /// <summary>
+    /// Positive test: the exact real-world <c>Oahu.Core</c>
+    /// <c>BookLibrary.gs:469</c> shape — a non-null local declared earlier in
+    /// the method, reassigned from a string-concatenation receiver's
+    /// oblivious external EXTENSION method call.
+    /// </summary>
+    [Fact]
+    public void BookLibraryShape_ExtensionMethodReassignment_ForgivenAtAssignment()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Resolve(string pathStub, string ext)
+        {
+            string path = ""seed"";
+            path = (pathStub + ext).AsUncIfLong();
+            return path;
+        }
+    }
+}");
+
+        Assert.Contains("path = (pathStub + ext)!!.AsUncIfLong()!!", printed);
+
+        // Parity: the assignment absorbs the SAME single forgiveness a
+        // direct return would need — the later `return path` must not need
+        // (or get) a second one.
+        Assert.DoesNotContain("return path!!", printed);
+    }
+
+    [Fact]
+    public void ParameterReassignment_ForgivenAtAssignment()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Format(ExtLib ext, string result)
+        {
+            result = ext.Combine(""hello"");
+            System.Console.WriteLine(result);
+        }
+    }
+}");
+
+        Assert.Contains("result = ext.Combine(\"hello\")!!", printed);
+    }
+
+    [Fact]
+    public void InstanceFieldReassignment_ForgivenAtAssignment()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Cached = ""seed"";
+
+        public void Format(ExtLib ext)
+        {
+            this.Cached = ext.Combine(""hello"");
+        }
+    }
+}");
+
+        Assert.Contains("this.Cached = ext.Combine(\"hello\")!!", printed);
+    }
+
+    [Fact]
+    public void InstancePropertyReassignment_ForgivenAtAssignment()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Cached { get; set; } = ""seed"";
+
+        public void Format(ExtLib ext)
+        {
+            this.Cached = ext.Combine(""hello"");
+        }
+    }
+}");
+
+        Assert.Contains("this.Cached = ext.Combine(\"hello\")!!", printed);
+    }
+
+    [Fact]
+    public void StaticFieldReassignment_ForgivenAtAssignment()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public static string Cached = ""seed"";
+
+        public static void Format(ExtLib ext)
+        {
+            C.Cached = ext.Combine(""hello"");
+        }
+    }
+}");
+
+        Assert.Contains("C.Cached = ext.Combine(\"hello\")!!", printed);
+    }
+
+    [Fact]
+    public void IndexerReassignment_ForgivenAtAssignment()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Format(ExtLib ext, string[] arr)
+        {
+            arr[0] = ext.Combine(""hello"");
+        }
+    }
+}");
+
+        Assert.Contains("arr[0] = ext.Combine(\"hello\")!!", printed);
+    }
+
+    [Fact]
+    public void StaticMethodResultReassignment_ForgivenAtAssignment()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Format()
+        {
+            string result = ""seed"";
+            result = ExtLib.StaticCombine(""hello"");
+            System.Console.WriteLine(result);
+        }
+    }
+}");
+
+        Assert.Contains("result = ExtLib.StaticCombine(\"hello\")!!", printed);
+    }
+
+    [Fact]
+    public void FieldReadReassignment_ForgivenAtAssignment()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Format(ExtLib ext)
+        {
+            string result = ""seed"";
+            result = ext.Field;
+            System.Console.WriteLine(result);
+        }
+    }
+}");
+
+        Assert.Contains("result = ext.Field!!", printed);
+    }
+
+    [Fact]
+    public void PropertyReadReassignment_ForgivenAtAssignment()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Format(ExtLib ext)
+        {
+            string result = ""seed"";
+            result = ext.Prop;
+            System.Console.WriteLine(result);
+        }
+    }
+}");
+
+        Assert.Contains("result = ext.Prop!!", printed);
+    }
+
+    /// <summary>
+    /// Positive test: a parenthesized RHS resolves the same underlying
+    /// symbol (Roslyn's <c>GetSymbolInfo</c> sees through parentheses), so the
+    /// forgiveness still applies.
+    /// </summary>
+    [Fact]
+    public void ParenthesizedRhs_ForgivenAtAssignment()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Format(ExtLib ext)
+        {
+            string result = ""seed"";
+            result = (ext.Combine(""hello""));
+            System.Console.WriteLine(result);
+        }
+    }
+}");
+
+        Assert.Contains("result = (ext.Combine(\"hello\"))!!", printed);
+    }
+
+    /// <summary>
+    /// Negative test: an external oblivious method whose declared return is an
+    /// UNSUBSTITUTED type parameter (<c>T Generic&lt;T&gt;(T seed)</c>) is
+    /// excluded by <c>IsObliviousExternalNullableMember</c> — the same filter
+    /// #2202/#2425 already rely on — so the assignment must not be forgiven.
+    /// </summary>
+    [Fact]
+    public void GenericMethod_UnsubstitutedTypeParameterReturn_IsNotForgiven()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Format(ExtLib ext)
+        {
+            string result = ""seed"";
+            result = ext.Generic(""seed"");
+            System.Console.WriteLine(result);
+        }
+    }
+}");
+
+        Assert.Contains("result = ext.Generic(\"seed\")", printed);
+        Assert.DoesNotContain("ext.Generic(\"seed\")!!", printed);
+    }
+
+    /// <summary>
+    /// Negative/scope control: the SAME oblivious external member assigned via
+    /// a COMPOUND assignment (<c>+=</c>). Scoped out deliberately — a compound
+    /// assignment's RHS is a distinct shape (also flows through
+    /// <c>CoerceCompoundAssignmentRhs</c>'s numeric-coercion logic) and is not
+    /// addressed by this fix.
+    /// </summary>
+    [Fact]
+    public void CompoundAssignment_IsNotForgiven_ScopeControl()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Format(ExtLib ext)
+        {
+            string result = ""seed"";
+            result += ext.Combine(""hello"");
+            System.Console.WriteLine(result);
+        }
+    }
+}");
+
+        Assert.Contains("result += ext.Combine(\"hello\")", printed);
+        Assert.DoesNotContain("ext.Combine(\"hello\")!!", printed);
+    }
+
+    /// <summary>
+    /// Negative/scope control: an already nullable-annotated target (`string?
+    /// result`) already accepts a `T?` RHS unchanged — nothing to forgive.
+    /// </summary>
+    [Fact]
+    public void NullableAnnotatedTarget_IsNotForgiven_ScopeControl()
+    {
+        string printed = TranslateObliviousWithAnnotatedTargetLibrary(@"
+namespace Demo
+{
+#nullable enable
+    public class C
+    {
+        public void Format(ExtLib ext, string? result)
+        {
+            result = ext.Combine(""hello"");
+            System.Console.WriteLine(result);
+        }
+    }
+#nullable disable
+}");
+
+        Assert.Contains("result = ext.Combine(\"hello\")", printed);
+        Assert.DoesNotContain("ext.Combine(\"hello\")!!", printed);
+    }
+
+    /// <summary>
+    /// Negative/scope control: a SAME-PROJECT (source) member RHS must not be
+    /// touched by this fix — only an EXTERNAL (metadata) oblivious member
+    /// qualifies.
+    /// </summary>
+    [Fact]
+    public void SameProjectSourceMember_IsNotForgiven()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class Helper
+    {
+        public string Get() { return ""a""; }
+    }
+
+    public class C
+    {
+        public void Format(Helper h)
+        {
+            string result = ""seed"";
+            result = h.Get();
+            System.Console.WriteLine(result);
+        }
+    }
+}");
+
+        Assert.Contains("result = h.Get()", printed);
+        Assert.DoesNotContain("h.Get()!!", printed);
+    }
+
+    /// <summary>
+    /// Negative test: the SAME external library but compiled WITH nullable
+    /// annotations enabled — a genuinely <c>string?</c>-returning method is a
+    /// real, deliberate nullability that must be preserved, not papered over
+    /// with a blind assignment `!!`.
+    /// </summary>
+    [Fact]
+    public void AnnotatedExternalNullableReturn_IsNotForgiven()
+    {
+        string printed = TranslateObliviousWithAnnotatedLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Format(AnnotatedLib lib)
+        {
+            string result = ""seed"";
+            result = lib.MaybeNull();
+            System.Console.WriteLine(result);
+        }
+    }
+}");
+
+        Assert.Contains("result = lib.MaybeNull()", printed);
+        Assert.DoesNotContain("lib.MaybeNull()!!", printed);
+    }
+
+    /// <summary>
+    /// Negative test: a nullable-ENABLED compilation calling the same oblivious
+    /// external method — the fix is gated to oblivious compilations only (its
+    /// own nullable flow analysis is authoritative), so no `!!` is inserted.
+    /// </summary>
+    [Fact]
+    public void NullableEnabledCompilation_IsNotForgiven()
+    {
+        string printed = TranslateEnabledWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Format(ExtLib ext)
+        {
+            string result = ""seed"";
+            result = ext.Combine(""hello"");
+            System.Console.WriteLine(result);
+        }
+    }
+}");
+
+        Assert.Contains("result = ext.Combine(\"hello\")", printed);
+        Assert.DoesNotContain("ext.Combine(\"hello\")!!", printed);
+    }
+
+    /// <summary>
+    /// Positive/scope control: the target local's `var` ORIGIN does not block
+    /// the assignment-side fix — unlike #2425 (scoped to explicit-typed
+    /// DECLARATIONS), this fix operates on an already-established local's
+    /// type (inferred or explicit), which is the same non-null `string`
+    /// either way by the time a later reassignment is translated.
+    /// </summary>
+    [Fact]
+    public void VarLocalOrigin_StillForgivenAtAssignment()
+    {
+        string printed = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext)
+        {
+            var result = ""seed"";
+            result = ext.Combine(""hello"");
+            return result;
+        }
+    }
+}");
+
+        Assert.Contains("result = ext.Combine(\"hello\")!!", printed);
+    }
+
+    /// <summary>
+    /// Direct-return/local-initializer parity: a reassignment-then-return and
+    /// a direct return of the identical call both end up with exactly one
+    /// <c>!!</c> bridging the same oblivious external member — the
+    /// assignment-side fix reproduces the #2202 direct-return outcome rather
+    /// than a different one (no double-forgiveness at the later return).
+    /// </summary>
+    [Fact]
+    public void ReassignmentThenReturn_MatchesDirectReturnForgivenessCount()
+    {
+        string viaReassignment = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext)
+        {
+            string result = ""seed"";
+            result = ext.Combine(""hello"");
+            return result;
+        }
+    }
+}");
+
+        string direct = TranslateObliviousWithObliviousLibrary(@"
+namespace Demo
+{
+    public class C
+    {
+        public string Format(ExtLib ext)
+        {
+            return ext.Combine(""hello"");
+        }
+    }
+}");
+
+        int CountForgiveness(string printed) => printed.Split("!!").Length - 1;
+
+        Assert.Equal(1, CountForgiveness(viaReassignment));
+        Assert.Equal(1, CountForgiveness(direct));
+    }
+
+    /// <summary>
+    /// Compiles a tiny "external" library WITHOUT a nullable context (oblivious),
+    /// then translates the <paramref name="source"/> snippet referencing it in an
+    /// oblivious compilation.
+    /// </summary>
+    private static string TranslateObliviousWithObliviousLibrary(string source)
+    {
+        const string LibSource = @"
+public class ExtLib
+{
+    public string Combine(string separator) { return separator; }
+
+    public string Field;
+
+    public string Prop { get; set; }
+
+    public static string StaticCombine(string separator) { return separator; }
+
+    public T Generic<T>(T seed) { return seed; }
+}
+
+public static class ExtLibExtensions
+{
+    public static string AsUncIfLong(this string path)
+    {
+        return path;
+    }
+
+    public static string ToUrlBase64String(this byte[] bytes)
+    {
+        return System.Convert.ToBase64String(bytes);
+    }
+}
+";
+        MetadataReference libRef = CompileObliviousLibrary(LibSource, "Issue2427ObliviousExtLib");
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue2427.ObliviousExternalAssignmentInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Append(libRef).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    /// <summary>
+    /// Same oblivious external library, but the CONSUMING snippet declares its
+    /// own reassignment target with an explicit nullable-annotated (`#nullable
+    /// enable`) parameter type — used for the already-nullable-target scope
+    /// control.
+    /// </summary>
+    private static string TranslateObliviousWithAnnotatedTargetLibrary(string source)
+    {
+        const string LibSource = @"
+public class ExtLib
+{
+    public string Combine(string separator) { return separator; }
+}
+";
+        MetadataReference libRef = CompileObliviousLibrary(LibSource, "Issue2427ObliviousExtLibForAnnotatedTarget");
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue2427.AnnotatedTargetInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Append(libRef).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    /// <summary>
+    /// Compiles a tiny "external" library WITH nullable annotations enabled (a
+    /// genuinely <c>string?</c>-returning method), then translates the
+    /// <paramref name="source"/> snippet referencing it in an oblivious
+    /// compilation.
+    /// </summary>
+    private static string TranslateObliviousWithAnnotatedLibrary(string source)
+    {
+        const string LibSource = @"
+#nullable enable
+public class AnnotatedLib
+{
+    public string? MaybeNull() { return null; }
+}
+";
+        MetadataReference libRef = CompileAnnotatedLibrary(LibSource, "Issue2427AnnotatedExtLib");
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue2427.AnnotatedExternalReturnInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Append(libRef).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    /// <summary>
+    /// Translates the <paramref name="source"/> in a nullable-ENABLED compilation
+    /// referencing the same oblivious external library — verifies the fix is gated.
+    /// </summary>
+    private static string TranslateEnabledWithObliviousLibrary(string source)
+    {
+        const string LibSource = @"
+public class ExtLib
+{
+    public string Combine(string separator) { return separator; }
+}
+";
+        MetadataReference libRef = CompileObliviousLibrary(LibSource, "Issue2427ObliviousExtLibForEnabled");
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue2427.EnabledCallingObliviousInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Append(libRef).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static MetadataReference CompileObliviousLibrary(string libSource, string assemblyName)
+    {
+        var libTree = CSharpSyntaxTree.ParseText(
+            libSource,
+            new CSharpParseOptions(LanguageVersion.Latest));
+        var libCompilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { libTree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable));
+        using var peStream = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult emit = libCompilation.Emit(peStream);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        peStream.Position = 0;
+        return MetadataReference.CreateFromStream(peStream);
+    }
+
+    private static MetadataReference CompileAnnotatedLibrary(string libSource, string assemblyName)
+    {
+        var libTree = CSharpSyntaxTree.ParseText(
+            libSource,
+            new CSharpParseOptions(LanguageVersion.Latest));
+        var libCompilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { libTree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+        using var peStream = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult emit = libCompilation.Emit(peStream);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        peStream.Position = 0;
+        return MetadataReference.CreateFromStream(peStream);
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -591,6 +591,56 @@ public sealed partial class CSharpToGSharpTranslator
             return new NonNullAssertionExpression(translatedRhs);
         }
 
+        // Issue #2427 (oblivious sink): a plain REASSIGNMENT (`path = (pathStub +
+        // ext).AsUncIfLong();`, the exact Oahu.Core BookLibrary.gs:469 shape) to an
+        // already-declared non-null local/parameter/field/property/indexer whose
+        // RHS reads an oblivious EXTERNAL (metadata, no nullable context) member
+        // trips the same `T? -> T` GS0156 that issue #2202's direct-return
+        // forgiveness (`ReceiverNeedsNullForgiveness`) and issue #2425's
+        // explicit-local-initializer forgiveness (`TranslateLocalDeclaration`)
+        // already apply for THEIR OWN value-read shapes (`return
+        // ext.Combine(...)`; `T x = ext.Combine(...);`) — gsc maps every such
+        // oblivious external reference read to `T?` regardless of where the value
+        // is consumed. Neither of those fixes reaches a subsequent bare assignment
+        // STATEMENT: `TranslateExpressionStatement`'s assignment case translates
+        // the RHS via plain `TranslateExpression` with no external-oblivious
+        // forgiveness of its own. This reuses the SAME `IsObliviousExternalNullableMember`
+        // detection those two fixes already use, applied at the assignment RHS use
+        // site instead. Gated to a target whose OWN type is a non-annotated,
+        // non-promoted reference type — i.e., one that genuinely expects
+        // non-null — so a target that is itself declared/promoted nullable (which
+        // already accepts a `T?` RHS unchanged) and a nullable-enabled compilation
+        // (whose external annotations are real) are both left byte-identical.
+        // Scoped to SIMPLE assignment: a compound assignment (`path +=
+        // ext.Combine(...)`) is a distinct shape (its RHS also flows through
+        // numeric-coercion logic) and is deliberately left untouched here.
+        private GExpression ForgiveObliviousExternalAssignmentRhs(
+            AssignmentExpressionSyntax assignment, GExpression translatedRhs)
+        {
+            if (!this.IsObliviousCompilation()
+                || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                || translatedRhs is NonNullAssertionExpression
+                || !IsObliviousExternalNullableMember(this.context.GetSymbolInfo(assignment.Right).Symbol))
+            {
+                return translatedRhs;
+            }
+
+            ITypeSymbol leftType = this.context.GetTypeInfo(assignment.Left).Type;
+            if (leftType is not { IsReferenceType: true }
+                || leftType.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                return translatedRhs;
+            }
+
+            if (this.context.GetSymbolInfo(assignment.Left).Symbol is { } leftSymbol
+                && this.ShouldPromoteToNullableReference(leftSymbol))
+            {
+                return translatedRhs;
+            }
+
+            return new NonNullAssertionExpression(translatedRhs);
+        }
+
         // For a compound numeric assignment `x OP= y` (`+= -= *= /= %= &= |= ^=`),
         // G# requires the RHS to share the LHS's numeric type; a mismatched RHS is
         // coerced to the LHS type via the conversion-call form (e.g. `x += int64(y)`).
@@ -1734,6 +1784,7 @@ public sealed partial class CSharpToGSharpTranslator
                     assignRhs = this.CoercePointerConversion(assignment.Right, assignRhs);
                     assignRhs = this.ForgiveEventSubscriptionRhs(assignment, assignRhs);
                     assignRhs = this.ForgiveElementAccessAssignmentRhs(assignment, assignRhs);
+                    assignRhs = this.ForgiveObliviousExternalAssignmentRhs(assignment, assignRhs);
                     return new AssignmentStatement(
                         this.TranslateAssignmentTarget(assignment.Left),
                         assignRhs,


### PR DESCRIPTION
## Root cause

Issue #2202 (direct returns) and issue #2425 (explicit-local initializers) already assert `!!` when a value read from an oblivious **external** (metadata, no nullable context) member flows into a position that requires non-null, because gsc maps every such oblivious external reference read to `T?` regardless of where the value is consumed.

Plain **reassignment** statements never got the same treatment. `TranslateExpressionStatement`'s `AssignmentExpressionSyntax` case built its RHS through `CoerceConstantToUnsigned` / `CoerceCompoundAssignmentRhs` / `CoercePointerConversion` / `ForgiveEventSubscriptionRhs` / `ForgiveElementAccessAssignmentRhs`, none of which apply `IsObliviousExternalNullableMember` forgiveness. This is exactly the real-world `Oahu.Core` shape newly surfaced by #2426 at `BookLibrary.gs:469`:

```
var path = (conv.DownloadFileName + ext)!!.AsUncIfLong()!!   // initial decl: correct, both !! present
...
path = (pathStub + ext)!!.AsUncIfLong()                      // reassignment: missing trailing !!
```

## Fix

Adds `ForgiveObliviousExternalAssignmentRhs`, reusing the **existing** `IsObliviousExternalNullableMember` detection/value-read helper (no new detection logic), and wires it into the assignment-statement RHS pipeline right before the assignment is built.

It only forgives a **simple** assignment (`SyntaxKind.SimpleAssignmentExpression`) whose LHS is itself a non-annotated, non-promoted reference type — i.e. one that genuinely expects non-null:
- A nullable-enabled compilation (real annotations) is untouched.
- A target that is itself nullable-annotated, or already promoted via the same/sibling-source taint fixpoint (`ShouldPromoteToNullableReference`, #2412), is untouched — it already accepts a `T?` RHS.
- Compound assignments (`+=` etc.) are a distinct shape (their RHS also flows through numeric-coercion logic) and are deliberately left untouched per the issue's scope.
- Tuple/deconstruction assignments don't route through this bridge at all (their RHS comes from tuple-element temporaries, not a direct symbol read), so they're unaffected — confirmed by inspection, not a regression.

## Tests

`Issue2427ObliviousExternalAssignmentForgivenessTranslationTests` (18 tests, all passing) covers:
- The exact `BookLibrary.gs:469` shape (parenthesized string-concat receiver + oblivious external extension-method call)
- Parameter / instance-field / instance-property / static-field / indexer reassignment
- Static-method / field / property RHS reads, parenthesized RHS
- Negative/scope-control cases: generic-unsubstituted type parameter, compound assignment, nullable-annotated target, same-project-source member, annotated-external-nullable return, nullable-enabled compilation
- `var`-origin positive control
- Direct-return vs. reassignment forgiveness-count parity

Full serialized suite: `MSBUILDDISABLENODEREUSE=1 dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release -- RunConfiguration.DisableParallelization=true`

```
Passed! - Failed: 0, Passed: 1484, Skipped: 0, Total: 1484
```//(1466 baseline + 18 new, 0 regressions)

## Real-world `Oahu.Core` migration validation (corpus untouched, read-only)

Built two isolated worktrees from the exact same `492b75a7` base (one unmodified baseline, one with only this fix), packed/refreshed `Gsharp.NET.Sdk` + cleared the matching NuGet cache for each, and ran:

```
cs2gs migrate --corpus <Oahu>/src --app Oahu.Core --config Release --gsc <gsc.dll>
```

| | compile-stage failures |
|---|---|
| Baseline (`492b75a7`, unmodified) | 40 |
| With this fix | **39** |

A full fingerprint diff between the two runs shows **exactly one** fingerprint removed (`BookLibrary.gs:469 GS0156`, the reassignment case this PR fixes) and **zero** new fingerprints introduced — a clean, isolated -1.

## Next independent blocker (isolated, not fixed here)

Object/collection-initializer member assignments (`Type{Member: expr}`) don't get the same RHS null-forgiveness bridge that plain assignment/local-decl/return now have. Three more `GS0156`s remain in `Oahu.Core` with this exact shape, e.g.:

```
corpus_Oahu.Core/AaxExporter.gs:194: let a = Oahu.Audible.Json.Author{Asin: author.Asin, Name: author.Name}
corpus_Oahu.Core/AaxExporter.gs:202: let s = Oahu.Audible.Json.Series{Asin: serbook.Series!!.Asin, Title: serbook.Series!!.Title, Sequence: serbook.SeqString}
corpus_Oahu.Core/BookLibrary.gs:124: return AccountAliasContext(account!!.Id, nil, nil){Alias = account!!.Alias}
```

This is structurally distinct from this PR's fix — object/collection-initializer member values are a different AST shape (`InitializerExpressionSyntax` member assignment, not `AssignmentExpressionSyntax`/`LocalDeclarationStatementSyntax`/`ReturnStatementSyntax`) — so it needs its own dedicated bridge and is left for a follow-up issue.

Closes #2427
