### PR TITLE
Fix Cs2Gs test host resource exhaustion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,10 @@ jobs:
         run: dotnet build GSharp.sln --configuration Release --no-restore -graph
 
       - name: Test
+        env:
+          # Cs2Gs.Tests launches many nested SDK builds; reusable MSBuild
+          # workers eventually exhaust the test host's resources (#2407).
+          MSBUILDDISABLENODEREUSE: 1
         run: dotnet test GSharp.sln --configuration Release --no-build --logger "trx" --results-directory TestResults
 
       - name: Upload test results

--- a/tools/cs2gs/Cs2Gs.Tests/TestHostProcessSetup.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TestHostProcessSetup.cs
@@ -1,0 +1,29 @@
+// <copyright file="TestHostProcessSetup.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+internal static class TestHostProcessSetup
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        // Nested SDK builds otherwise retain MSBuild workers until the test host
+        // exhausts its resources and crashes non-deterministically (#2407).
+        Environment.SetEnvironmentVariable("MSBUILDDISABLENODEREUSE", "1");
+    }
+}
+
+public class TestHostProcessSetupTests
+{
+    [Fact]
+    public void NestedBuildsDisableMsBuildNodeReuse()
+    {
+        Assert.Equal("1", Environment.GetEnvironmentVariable("MSBUILDDISABLENODEREUSE"));
+    }
+}


### PR DESCRIPTION
## Summary
- disable MSBuild node reuse before Cs2Gs tests launch nested SDK builds
- apply the same setting to CI's outer `dotnet test` process
- add a regression assertion for the test-host environment

Fixes #2407

## Validation
- targeted setup and Golden tests pass
- rebuilt 1,485-test suite completed without a test-host crash; unrelated Windows-only/environment failures remained