### PR TITLE
cs2gs: emit tmp!! for tainted argument forwarded to external delegate Invoke (#2434)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2434DelegateNullableInterfaceWideningTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2434DelegateNullableInterfaceWideningTranslationTests.cs
@@ -1,0 +1,640 @@
+// <copyright file="Issue2434DelegateNullableInterfaceWideningTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #2434: an UNCONDITIONAL (no guard
+/// dominating the use) forward of a same-project promoted-nullable
+/// field/property/local/parameter/method as the ENTIRE (possibly
+/// parenthesized) expression of a call-site ARGUMENT whose bound parameter is
+/// a genuine non-null reference type cs2gs will not also promote. This is the
+/// argument-position counterpart of #2432's return-preserving-body rule,
+/// reusing the same <c>IsNullablePromotedValue</c>/guard-detection machinery
+/// (<see cref="Issue2432UnguardedForwardForgivenessTranslationTests"/>). The
+/// canonical shape is the real <c>Oahu.Core</c> <c>BookLibrary.gs:490</c>
+/// case: a same-project concrete <c>Conversion</c> local promoted to
+/// <c>Conversion?</c> by unrelated constructor-parameter taint, forwarded as
+/// the sole argument of a CONDITIONAL delegate invocation
+/// (<c>callback?(tmp)</c>) whose delegate parameter type is the concrete
+/// class's own interface <c>IConversion</c> — a fixed, external
+/// (<c>System.Action&lt;T&gt;</c>-shaped) function-type parameter that can
+/// NEVER itself be promoted to nullable the way an ordinary same-project
+/// method parameter can. gsc's own <c>Conversion.Classify</c> already
+/// composes an explicit nullable-unwrap (<c>!!</c>) with the implicit
+/// reference/interface widening correctly (issue #1627's deliberate
+/// <c>S? -&gt; S</c>/<c>S? -&gt; I</c> rejection without an explicit unwrap is
+/// BY DESIGN and unrelated to this bug) — the gap is entirely on the cs2gs
+/// side: it must actually EMIT the <c>!!</c> at this argument position.
+/// </summary>
+public class Issue2434DelegateNullableInterfaceWideningTranslationTests
+{
+    /// <summary>
+    /// The exact real-world <c>BookLibrary.gs:490</c> shape: a nullable
+    /// concrete class local forwarded, unguarded, as the sole argument of a
+    /// CONDITIONAL delegate invocation whose parameter type is the concrete
+    /// class's own interface. Must assert <c>!!</c> so gsc accepts the
+    /// <c>Conversion? -&gt; IConversion</c> widening.
+    /// </summary>
+    [Fact]
+    public void ConditionalDelegateInvoke_NullableConcreteToInterfaceArg_AssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+
+namespace Demo
+{
+    public interface IConversion { string Name { get; } }
+
+    public class Conversion : IConversion
+    {
+        public string Name { get; set; }
+
+        public static Conversion Find(int flag)
+        {
+            if (flag == 0) { return null; }
+            return new Conversion { Name = ""x"" };
+        }
+    }
+
+    public class BookLibrary
+    {
+        public Action<IConversion> callback;
+
+        public void Process(int flag)
+        {
+            Conversion tmp = Conversion.Find(flag);
+            callback?.Invoke(tmp);
+        }
+    }
+}");
+
+        Assert.Contains("callback?(tmp!!)", printed);
+    }
+
+    /// <summary>
+    /// Same tainted-forward shape, but a DIRECT (non-conditional) delegate
+    /// invocation (<c>callback.Invoke(tmp)</c> / G#'s <c>callback(tmp)</c>
+    /// spelling). The delegate's <c>Invoke</c> parameter is exactly as fixed
+    /// and external as the conditional form, so the same bridge applies.
+    /// </summary>
+    [Fact]
+    public void DirectDelegateInvoke_NullableConcreteToInterfaceArg_AssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+
+namespace Demo
+{
+    public interface IConversion { string Name { get; } }
+
+    public class Conversion : IConversion
+    {
+        public string Name { get; set; }
+
+        public static Conversion Find(int flag)
+        {
+            if (flag == 0) { return null; }
+            return new Conversion { Name = ""x"" };
+        }
+    }
+
+    public class BookLibrary
+    {
+        public Action<IConversion> callback = c => { };
+
+        public void Process(int flag)
+        {
+            Conversion tmp = Conversion.Find(flag);
+            callback.Invoke(tmp);
+        }
+    }
+}");
+
+        Assert.Contains("callback(tmp!!)", printed);
+    }
+
+    /// <summary>
+    /// The same forward through a LOCAL lambda-typed variable rather than a
+    /// field: local delegate-typed variables bind against the same fixed,
+    /// external <c>Invoke</c> parameter, so this must assert too — the rule
+    /// is scoped to the argument shape, not to fields specifically.
+    /// </summary>
+    [Fact]
+    public void LambdaTypedLocal_NullableConcreteToInterfaceArg_AssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+
+namespace Demo
+{
+    public interface IConversion { string Name { get; } }
+
+    public class Conversion : IConversion
+    {
+        public string Name { get; set; }
+
+        public static Conversion Find(int flag)
+        {
+            if (flag == 0) { return null; }
+            return new Conversion { Name = ""x"" };
+        }
+    }
+
+    public class BookLibrary
+    {
+        public void Process(int flag)
+        {
+            Action<IConversion> local = c => { };
+            Conversion tmp = Conversion.Find(flag);
+            local(tmp);
+        }
+    }
+}");
+
+        Assert.Contains("local(tmp!!)", printed);
+    }
+
+    /// <summary>
+    /// A GENERIC delegate (<c>Func&lt;IConversion, string&gt;</c>) invoked
+    /// conditionally — confirms the fix is not limited to <c>Action</c>-typed
+    /// delegates or a fixed non-generic BCL shape.
+    /// </summary>
+    [Fact]
+    public void GenericDelegate_NullableConcreteToInterfaceArg_AssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+
+namespace Demo
+{
+    public interface IConversion { string Name { get; } }
+
+    public class Conversion : IConversion
+    {
+        public string Name { get; set; }
+
+        public static Conversion Find(int flag)
+        {
+            if (flag == 0) { return null; }
+            return new Conversion { Name = ""x"" };
+        }
+    }
+
+    public class BookLibrary
+    {
+        public Func<IConversion, string> callback;
+
+        public string Process(int flag)
+        {
+            Conversion tmp = Conversion.Find(flag);
+            return callback?.Invoke(tmp);
+        }
+    }
+}");
+
+        Assert.Contains("callback?(tmp!!)", printed);
+    }
+
+    /// <summary>
+    /// The forward target is <c>object</c> rather than a source-declared
+    /// interface — confirms the rule covers the general <c>C? -&gt; object</c>
+    /// widening, not only <c>C? -&gt; I</c> for a source/imported interface.
+    /// </summary>
+    [Fact]
+    public void ObjectTarget_NullableConcreteToObjectArg_AssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+
+namespace Demo
+{
+    public class Conversion
+    {
+        public string Name { get; set; }
+
+        public static Conversion Find(int flag)
+        {
+            if (flag == 0) { return null; }
+            return new Conversion { Name = ""x"" };
+        }
+    }
+
+    public class BookLibrary
+    {
+        public Action<object> callback;
+
+        public void Process(int flag)
+        {
+            Conversion tmp = Conversion.Find(flag);
+            callback?.Invoke(tmp);
+        }
+    }
+}");
+
+        Assert.Contains("callback?(tmp!!)", printed);
+    }
+
+    /// <summary>
+    /// Contrast case: an ORDINARY same-project static method call
+    /// (<c>Run(IConversion c)</c>). The whole-program oblivious taint
+    /// fixpoint promotes <c>Run</c>'s OWN parameter to <c>IConversion?</c> in
+    /// lockstep with the tainted argument (unlike a delegate's fixed external
+    /// <c>Invoke</c> signature, an ordinary same-project parameter CAN be
+    /// promoted), so the call already widens <c>T? -&gt; T?</c> — asserting
+    /// <c>!!</c> here would be superfluous. Confirms the new rule's
+    /// "parameter declared in this compilation and itself promotable" carve-
+    /// out correctly stays silent for the case the fixpoint already handles.
+    /// </summary>
+    [Fact]
+    public void NormalMethodCall_CalleeParameterAlsoPromoted_DoesNotAssertNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+
+namespace Demo
+{
+    public interface IConversion { string Name { get; } }
+
+    public class Conversion : IConversion
+    {
+        public string Name { get; set; }
+
+        public static Conversion Find(int flag)
+        {
+            if (flag == 0) { return null; }
+            return new Conversion { Name = ""x"" };
+        }
+    }
+
+    public class BookLibrary
+    {
+        public static void Run(IConversion c) { }
+
+        public void Process(int flag)
+        {
+            Conversion tmp = Conversion.Find(flag);
+            Run(tmp);
+        }
+    }
+}");
+
+        Assert.Contains("func Run(c IConversion?)", printed);
+        Assert.DoesNotContain("tmp!!", printed);
+    }
+
+    /// <summary>
+    /// A local narrowed by a dominating textual null-check guard
+    /// (<c>if (tmp != null) { callback?.Invoke(tmp); }</c>) needs no help at
+    /// all from this rule: gsc's own Kotlin-style smart-cast already narrows
+    /// a syntactically-guarded LOCAL read, so forcing <c>!!</c> here would be
+    /// a redundant (if harmless) assertion — the rule must stay silent so the
+    /// forgiveness is reserved for the genuinely unconditional forward.
+    /// </summary>
+    [Fact]
+    public void GuardedLocal_ConditionalDelegateInvoke_DoesNotAssertNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+
+namespace Demo
+{
+    public interface IConversion { string Name { get; } }
+
+    public class Conversion : IConversion
+    {
+        public string Name { get; set; }
+
+        public static Conversion Find(int flag)
+        {
+            if (flag == 0) { return null; }
+            return new Conversion { Name = ""x"" };
+        }
+    }
+
+    public class BookLibrary
+    {
+        public Action<IConversion> callback;
+
+        public void Process(int flag)
+        {
+            Conversion tmp = Conversion.Find(flag);
+            if (tmp != null)
+            {
+                callback?.Invoke(tmp);
+            }
+        }
+    }
+}");
+
+        Assert.DoesNotContain("tmp!!", printed);
+        Assert.Contains("callback?(tmp)", printed);
+    }
+
+    /// <summary>
+    /// Negative control: the forwarded value is never null-tainted at all (no
+    /// flow of <c>null</c> anywhere in the compilation), so
+    /// <c>IsNullablePromotedValue</c> rejects it outright — no spurious
+    /// <c>!!</c> on an already-non-nullable forward.
+    /// </summary>
+    [Fact]
+    public void UnTaintedForward_DoesNotAssertNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+
+namespace Demo
+{
+    public interface IConversion { string Name { get; } }
+
+    public class Conversion : IConversion
+    {
+        public string Name { get; set; }
+    }
+
+    public class BookLibrary
+    {
+        public Action<IConversion> callback;
+
+        public void Process()
+        {
+            Conversion tmp = new Conversion { Name = ""x"" };
+            callback?.Invoke(tmp);
+        }
+    }
+}");
+
+        Assert.DoesNotContain("tmp!!", printed);
+    }
+
+    /// <summary>
+    /// Negative control: an UNRELATED, genuinely invalid conversion (a
+    /// concrete class with no relationship to the delegate parameter's type)
+    /// never reaches cs2gs at all — Roslyn itself rejects it as a C# compile
+    /// error before <see cref="Cs2Gs.ProjectLoading.LoadedCSharpProject.BoundWithoutErrors"/>
+    /// would pass, so <see cref="TranslateOblivious"/>'s own bind-assertion
+    /// is the control here: this snippet must simply fail to bind, proving
+    /// no cs2gs-side guard is needed for that case.
+    /// </summary>
+    [Fact]
+    public void UnrelatedInvalidConversion_FailsToBind()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("Snippet.cs", @"
+using System;
+
+namespace Demo
+{
+    public interface IConversion { string Name { get; } }
+
+    public interface IUnrelated { string Other { get; } }
+
+    public class Conversion : IConversion
+    {
+        public string Name { get; set; }
+    }
+
+    public class BookLibrary
+    {
+        public Action<IUnrelated> callback;
+
+        public void Process()
+        {
+            Conversion tmp = new Conversion { Name = ""x"" };
+            callback?.Invoke(tmp);
+        }
+    }
+}"),
+        });
+
+        Assert.False(project.BoundWithoutErrors, "An unrelated/invalid conversion must fail to bind in C# itself.");
+    }
+
+    /// <summary>
+    /// Negative control: a GENUINELY nullable-enabled compilation
+    /// (<c>NullableContextOptions.Enable</c>, project-wide).
+    /// <see cref="CSharpToGSharpTranslator.IsObliviousCompilation"/> gates
+    /// this entire rule to oblivious compilations, so a nullable-enabled
+    /// project's identical forwarding shape must stay byte-identical to
+    /// pre-#2434 behavior (the real compiler's own nullable analysis already
+    /// enforces the contract there; a genuine violation would be a C# error).
+    /// </summary>
+    [Fact]
+    public void NullableEnabledCompilation_Forward_DoesNotAssertNonNull()
+    {
+        string source = @"
+#nullable enable
+namespace Demo
+{
+    public interface IConversion { string Name { get; } }
+
+    public class Conversion : IConversion
+    {
+        public string Name { get; set; } = """";
+    }
+
+    public class BookLibrary
+    {
+        public System.Action<IConversion>? callback;
+
+        public void Process(Conversion tmp)
+        {
+            callback?.Invoke(tmp);
+        }
+    }
+}";
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue2434.EnabledInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        string printed = PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.DoesNotContain("tmp!!", printed);
+    }
+
+    /// <summary>
+    /// Full compile/run proof: the exact <c>Oahu.Core</c>
+    /// <c>BookLibrary.gs:490</c> shape, once translated, must actually
+    /// compile with the real <c>gsc</c> (zero errors — the concrete assertion
+    /// that GS0155 no longer reproduces) and RUN correctly, preserving the
+    /// original C#'s runtime null behavior: a non-null converted value
+    /// reaches the callback through the widened interface reference
+    /// (verified by invoking a real interface member on it inside the
+    /// callback), and a <see langword="null"/> callback field still safely
+    /// no-ops the whole conditional invocation (never touching the `!!`
+    /// asserted argument at all). Gated on the compiler artifact being
+    /// present (built via <c>GSharp.sln</c>); the translation-level
+    /// assertions in the other tests in this file still validate the fix
+    /// when only the cs2gs test project itself is built.
+    /// </summary>
+    [Fact]
+    public void ConditionalDelegateInvoke_BookLibraryShape_CompilesAndRunsWithGsc()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        string printed = TranslateOblivious(@"
+using System;
+
+namespace Demo
+{
+    public interface IConversion { string Name { get; } }
+
+    public class Conversion : IConversion
+    {
+        public string Name { get; set; }
+
+        public static Conversion Find(int flag)
+        {
+            if (flag == 0) { return null; }
+            return new Conversion { Name = ""x"" };
+        }
+    }
+
+    public class BookLibrary
+    {
+        public Action<IConversion> callback;
+
+        public void Process(int flag)
+        {
+            Conversion tmp = Conversion.Find(flag);
+            callback?.Invoke(tmp);
+        }
+
+        public static void Main()
+        {
+            var lib = new BookLibrary();
+            string invokedWithName = null;
+
+            // Happy path: the widened interface reference reaches the
+            // callback intact (a real interface member call proves it is not
+            // corrupted/boxed by the bridging conversion), preserving the
+            // original C#'s runtime behavior exactly.
+            lib.callback = c => { invokedWithName = c.Name; };
+            lib.Process(1);
+            string happyResult = invokedWithName == ""x"" ? ""invoked-ok"" : ""invoked-wrong"";
+            Console.WriteLine(happyResult);
+
+            // Null-callback path: the conditional invocation itself must
+            // still short-circuit safely and never touch the `!!`-asserted
+            // argument, even when it, too, is genuinely null.
+            lib.callback = null;
+            lib.Process(0);
+            Console.WriteLine(""no-crash"");
+        }
+    }
+}");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-2434-e2e");
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "BookLibrary.gs");
+        string dllPath = Path.Combine(workDir, "BookLibrary.dll");
+        File.WriteAllText(gsPath, printed);
+
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated BookLibrary shape with zero errors. Output:\n" + compileOut +
+                "\n\nTranslated G#:\n" + printed);
+
+        (int runExit, string stdout) = RunDotnet($"\"{dllPath}\"");
+        Assert.True(runExit == 0, "Translated BookLibrary must run successfully. Output:\n" + stdout);
+        Assert.Contains("invoked-ok", stdout);
+        Assert.Contains("no-crash", stdout);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, stdout + stderr);
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -845,6 +845,20 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
+            // Issue #2434: the ARGUMENT-position counterpart of the rule just
+            // above — an UNCONDITIONAL (no guard dominating this exact use)
+            // forward of a same-project promoted-nullable value as a call-site
+            // argument whose bound parameter is a genuine non-null reference
+            // type cs2gs will not also promote. Covers ordinary calls, direct
+            // delegate invocations, and conditional delegate invocations alike
+            // (the exact Oahu.Core BookLibrary.gs:490 shape:
+            // `callback?(tmp)` where `tmp` is `Conversion?` and the delegate
+            // parameter is `IConversion`).
+            if (this.IsUnguardedForwardOfTaintedValueAsArgument(recv))
+            {
+                return true;
+            }
+
             // Issue #2202: a call (or property/field read) whose result comes from
             // an EXTERNAL (metadata) member compiled without a nullable context is
             // oblivious — Roslyn reports its reference-type return/type as
@@ -1128,6 +1142,25 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
+            return this.IsDominatedByNullCheckGuard(use, symbol);
+        }
+
+        // Issue #2202 / #2434: true when a null-check guard for <paramref
+        // name="symbol"/> dominates <paramref name="use"/> — walking outward
+        // from the use to find an enclosing `if (F == null) {…} else { …F… }` /
+        // `if (F != null) { …F… }` statement, or `F == null ? … : …F…` /
+        // `F != null ? …F… : …` conditional expression, whose condition
+        // directly null-checks that same symbol. Originally scoped to the
+        // field/property caller (<see cref="IsNullGuardNarrowedFieldUse"/>),
+        // this walk is symbol-kind-agnostic and is reused as-is by the
+        // argument-forwarding rule (#2434,
+        // <see cref="IsUnguardedForwardOfTaintedValueAsArgument"/>), which
+        // needs the identical textual-guard detection for a LOCAL/PARAMETER —
+        // a guarded local is narrowed by gsc's own Kotlin-style smart-cast
+        // exactly as a guarded field is narrowed here, syntactically, so a
+        // single shared walk serves both callers.
+        private bool IsDominatedByNullCheckGuard(ExpressionSyntax use, ISymbol symbol)
+        {
             for (SyntaxNode node = use; node != null; node = node.Parent)
             {
                 switch (node.Parent)
@@ -1291,6 +1324,131 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return this.IsBodyOfReturnPreservingMember(use);
+        }
+
+        // Issue #2434: true when <paramref name="use"/> is a same-project
+        // field/property/local/parameter/method read that is ALREADY emitted
+        // `T?` (declared nullable, or promoted by the whole-program oblivious
+        // taint fixpoint — the same <see cref="IsNullablePromotedValue"/> test
+        // as the #2432 return-forwarding rule) AND is passed, UNGUARDED (no
+        // dominating null-check guard for the same symbol —
+        // <see cref="IsDominatedByNullCheckGuard"/>), as the (possibly
+        // parenthesized) ENTIRE expression of a call-site argument whose bound
+        // parameter is a genuine non-null reference type that cs2gs itself will
+        // NOT also promote to nullable (<see cref="ShouldPromoteToNullableReference"/>).
+        //
+        // The canonical shape is the Oahu.Core BookLibrary case: a same-project
+        // concrete `Conversion` local promoted to `Conversion?` by unrelated
+        // constructor-parameter taint, forwarded as the sole argument of a
+        // CONDITIONAL delegate invocation (`callback?(tmp)`) whose delegate
+        // parameter type is the concrete class's own interface `IConversion` —
+        // a fixed, external (`System.Action<T>`-shaped) function-type
+        // parameter that can NEVER itself be promoted to nullable the way an
+        // ordinary same-project method parameter can (contrast a plain
+        // `Run(IConversion c)` call, whose OWN parameter the taint fixpoint
+        // promotes to `IConversion?` in lockstep with the argument,
+        // sidestepping the gap entirely). The same gap reaches a DIRECT
+        // (non-conditional) delegate invocation, a lambda-typed local, and any
+        // ordinary same-project call whose parameter the fixpoint happens not
+        // to promote — this rule is scoped to the ARGUMENT SHAPE, not to
+        // delegates specifically, so a single rule (reusing gsc's existing
+        // explicit-nullable-unwrap-then-implicit-reference-widen composition
+        // in `Conversion.Classify`, which already accepts `tmp!!` here) covers
+        // every call form uniformly, matching #2432's "search existing
+        // conversion helpers, don't special-case" guidance. Unlike
+        // <see cref="IsUnguardedForwardOfTaintedValueInReturnPreservingBody"/>,
+        // a GUARDED local at this same call site needs no help at all: gsc's
+        // own Kotlin-style smart-cast already narrows a syntactically-guarded
+        // local read, so <see cref="IsDominatedByNullCheckGuard"/> must find NO
+        // guard for this rule to apply, keeping the forgiveness reserved for
+        // the truly unconditional forward the original (oblivious) C# accepted
+        // implicitly.
+        private bool IsUnguardedForwardOfTaintedValueAsArgument(ExpressionSyntax use)
+        {
+            if (!this.IsObliviousCompilation())
+            {
+                return false;
+            }
+
+            ISymbol symbol = this.context.GetSymbolInfo(use).Symbol;
+            if (symbol is not (IFieldSymbol or IPropertySymbol or ILocalSymbol or IParameterSymbol or IMethodSymbol))
+            {
+                return false;
+            }
+
+            if (!this.IsNullablePromotedValue(use))
+            {
+                return false;
+            }
+
+            // Walk up through parentheses to the immediate syntactic parent:
+            // this rule covers only a DIRECT (unwrapped) forward — a
+            // ternary/switch arm or any other composed expression never
+            // resolves to an ArgumentSyntax parent here and is intentionally
+            // left to the return-preserving-body rule (or unhandled) instead.
+            SyntaxNode node = use;
+            while (node.Parent is ParenthesizedExpressionSyntax)
+            {
+                node = node.Parent;
+            }
+
+            if (node.Parent is not ArgumentSyntax argumentSyntax)
+            {
+                return false;
+            }
+
+            // A dominating guard means gsc's own smart-cast (locals) or the
+            // sibling field/property rule (already checked earlier in
+            // ReceiverNeedsNullForgiveness) already makes this use safe
+            // without any help from this rule.
+            if (this.IsDominatedByNullCheckGuard(use, symbol))
+            {
+                return false;
+            }
+
+            if (this.context.SemanticModel.GetOperation(argumentSyntax) is not IArgumentOperation argumentOperation
+                || argumentOperation.Parameter is not { } parameter)
+            {
+                return false;
+            }
+
+            ITypeSymbol parameterType = parameter.Type;
+            if (parameterType is not { IsReferenceType: true }
+                || parameterType.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                return false;
+            }
+
+            // If cs2gs will ALSO promote the bound parameter to nullable (the
+            // ordinary same-project method case above), the argument already
+            // widens `T? -> T?` with no `!!` required — forcing one here would
+            // be superfluous, not incorrect. This ONLY applies when the
+            // parameter is itself declared by SOURCE inside THIS compilation:
+            // cs2gs can only ever change the rendered signature of a symbol it
+            // is translating from source — an EXTERNAL/BCL parameter (e.g. the
+            // synthesized `Invoke` of `System.Action<T>`/`System.Func<T,...>`)
+            // is never re-emitted, so its declared type can never actually be
+            // promoted, no matter what `ShouldPromoteToNullableReference`
+            // reports for it. That check alone is NOT a reliable signal here:
+            // `Canonical()` maps a CONSTRUCTED generic Invoke parameter (e.g.
+            // `Action<IConversion>.Invoke(IConversion)`) back to the single
+            // SHARED unbound-generic definition `Action<T>.Invoke(T)` — the
+            // very same canonical key the whole-program fixpoint uses to
+            // record evidence for the delegate-parameter-promotion feature
+            // (`PromoteDelegateParameterInvokedWithNull`) — so the CURRENT
+            // invocation being translated (a tainted argument passed to THIS
+            // delegate call) is itself sufficient evidence to mark that
+            // canonical key tainted, self-referentially, for EVERY `Action<T>`/
+            // `Func<T,...>` call site in the whole compilation. Requiring
+            // source-declared-in-this-compilation excludes that external
+            // symbol category entirely and leaves the same-project method
+            // case (whose parameter genuinely has a declaring syntax node
+            // here) unaffected.
+            bool parameterDeclaredInThisCompilation = parameter.DeclaringSyntaxReferences
+                .Any(reference => this.context.Compilation.ContainsSyntaxTree(reference.SyntaxTree));
+
+            return !(parameterDeclaredInThisCompilation
+                && this.ShouldPromoteToNullableReference(parameter));
         }
 
         // Walks outward from <paramref name="use"/> through parentheses to find


### PR DESCRIPTION
## Root cause

`BookLibrary.gs:490` (`callback?(tmp)`) failed `GS0155` because `tmp` is `Oahu.BooksDatabase.Conversion?` and the delegate parameter is `IConversion`. `Conversion` implements `IConversion`.

I confirmed via direct `gsc` compilation that gsc's own `Conversion.Classify` **already correctly composes** explicit nullable-unwrap (`!!`) with implicit interface widening (issue #1627's design is correct and is untouched by this PR). The bug is **entirely in cs2gs**: it failed to emit the `tmp!!` bridge when forwarding a same-project promoted-nullable value as an unguarded argument to a delegate/lambda `Invoke` call.

### Why cs2gs missed it

`ReceiverNeedsNullForgiveness` only skips the `!!` bridge when the callee's own parameter would itself be co-promoted to nullable by cs2gs' whole-program taint fixpoint (`ObliviousNullabilityAnalyzer`). For a constructed generic delegate's `Invoke` parameter (e.g. `Action<IConversion>.Invoke(IConversion)`), `Canonical(symbol)` collapses to the single shared `Action<T>.Invoke(T)` parameter from corlib — a key shared by **every** `Action<T>` instantiation in the whole compilation, self-referentially tainted by the very invocation being translated. This made `ShouldPromoteToNullableReference(parameter)` an unreliable signal for external/BCL parameters, which can never actually be re-promoted by cs2gs (there's no source for it to re-emit).

### Fix

Added `IsUnguardedForwardOfTaintedValueAsArgument`, wired into the existing `ReceiverNeedsNullForgiveness` decision ladder (same place as the #2432 return-forwarding rule). It now requires the callee parameter be **declared by source syntax inside this compilation** before trusting the taint-based co-promotion signal — external/BCL parameters (delegate `Invoke`, etc.) always get the `tmp!!` bridge; same-project method parameters that are genuinely co-promoted in lockstep still correctly skip the redundant assertion.

Reused the existing `IsDominatedByNullCheckGuard` / `IsNullablePromotedValue` / `ShouldPromoteToNullableReference` helpers — no delegate-only special case, and no `gsc`/`Conversion.Classify` changes were needed.

## Coverage

New test file `Issue2434DelegateNullableInterfaceWideningTranslationTests.cs` (11 tests) covers:
- Conditional delegate invoke (`callback?(tmp)`) and direct delegate invoke (`callback.Invoke(tmp)`)
- Lambda-typed local, generic delegate, `object`-typed target
- Normal method call negative control (callee's own parameter is co-promoted — no double forgiveness)
- Guarded-local negative control (already safe via gsc's smart-cast — no redundant assertion)
- Untainted-forward negative control
- Unrelated invalid conversion negative control (fails to bind in C#)
- Nullable-enabled-compilation negative control
- Full e2e compile + run proof mirroring the exact `BookLibrary.gs:490` shape, including verifying the nil-callback short-circuit (`callback?(...)` with a nil delegate never evaluates the argument, so a genuinely-nil `tmp` alongside a nil `callback` does not crash)

## Test results

- New test file: 11/11 passed.
- Full `Cs2Gs.Tests` suite (serialized, `MSBUILDDISABLENODEREUSE=1`, `RunConfiguration.DisableParallelization=true`): **1529/1529 passed**, 0 failed.
- Re-ran the default read-only `cs2gs migrate` against `Oahu.Core` (local sibling checkout, read-only, no Oahu edits/PR): compile-stage blockers went from the known baseline of **32 → 31** (confirmed `GS0155` at `BookLibrary.gs:490` is gone; the 7 other `GS0155` occurrences remaining are unrelated conversions — event-handler delegate signature mismatches, `bool?`/`HttpClientEx?` unwraps in non-argument positions, tuple mismatches, and a pointer/uint32 mismatch — none involve class→interface widening).

## Runtime-safety note (pre-existing trade-off, not a new regression)

`!!` is a real Kotlin-style runtime assertion in `gsc`: if the underlying value is genuinely nil, it throws `NullReferenceException`. I verified this same risk already exists in the shipped #2432 fix (manually reproducing its exact static-only shape with a genuinely-nil value also crashes identically) — this PR does not introduce a new crash-on-nil risk, it only extends an already-accepted trade-off to the delegate-argument-forwarding case. For the real-world `BookLibrary` pattern (`callback?(tmp!!)`), the conditional invoke's short-circuit on a nil `callback` means the `!!`-asserted argument is never evaluated when the delegate itself is absent, which is the common case this bug was blocking.

## Next independent blocker (reported, not fixed)

Continuing the `Oahu.Core` migration pass, the next distinct blocker is `AudibleClient.gs:23`: `this.ConfigSettings!!.ChangedSettings += SettingsChangedSettings` fails with `Cannot convert type '(object, System.EventArgs) -> System.Threading.Tasks.Task' to '(object?, System.EventArgs) -> void'` — an event-handler method-group conversion where the C# handler returns `Task` but the G# delegate target expects `void`, plus a parameter-nullability mismatch (`object` vs `object?`). This is unrelated to nullable/interface-widening entirely (different construct kind: event `+=` subscription, not argument-forwarding) and is left for a separate issue.

Closes #2434
