### PR TITLE
cs2gs: translate C# async void event handlers to fire-and-forget wrappers (#2438)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2438AsyncVoidEventHandlerTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2438AsyncVoidEventHandlerTranslationTests.cs
@@ -1,0 +1,889 @@
+// <copyright file="Issue2438AsyncVoidEventHandlerTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #2438 (Oahu <c>AudibleClient.SettingsChangedSettings</c>
+/// / <c>AudibleApi.AaxFileConversionProgressUpdate</c>): a genuine C# <c>async
+/// void</c> handler (instance/static method, local function, or lambda)
+/// subscribed via method group to <c>EventHandler</c>/<c>EventHandler&lt;T&gt;</c>/a
+/// custom void delegate.
+/// <para>
+/// G# has no distinct "async void" shape (ADR-0023): every G# <c>async func</c>
+/// is Task-observable at its call site, so translating an <c>async void</c>
+/// handler as an ordinary async G# function/lambda leaves its method-group/lambda
+/// value typed <c>(args) -&gt; Task</c>, which cannot convert to the
+/// <c>(args) -&gt; void</c> event-delegate shape it originally subscribed with
+/// (GS0155). cs2gs now detects the EXACT Roslyn shape <c>IsAsync &amp;&amp;
+/// ReturnsVoid</c> (true ONLY for a genuine <c>async void</c> — an ordinary
+/// <c>async Task</c> method/lambda has <c>ReturnsVoid == false</c>) and rewrites
+/// it into a non-async, void-returning wrapper with the SAME name/identity (so
+/// <c>+=</c>/<c>-=</c> keep resolving to the same symbol/value) that fires the
+/// untouched original async body immediately and surfaces any unobserved fault
+/// via <c>SynchronizationContext.Current</c> (or a direct rethrow with no
+/// context) instead of silently discarding it.
+/// </para>
+/// <para>
+/// This is a translator-ONLY fix (no gsc/Core change): an ordinary
+/// <c>async Task</c> method group, a <c>Func&lt;Task&gt;</c>-targeted lambda, and a
+/// direct Task-returning method-group VALUE remain untouched and must still
+/// correctly fail GS0155 when assigned to a void delegate — the negative
+/// controls below confirm cs2gs never globally loosens that gsc rule.
+/// </para>
+/// </summary>
+public class Issue2438AsyncVoidEventHandlerTranslationTests
+{
+    // ---------------------------------------------------------------
+    // Structural translation tests
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// The exact Oahu <c>AudibleClient.SettingsChangedSettings</c> shape: a
+    /// private, expression-bodied <c>async void</c> INSTANCE method subscribed
+    /// to a plain <c>EventHandler</c> via method group in the constructor.
+    /// </summary>
+    [Fact]
+    public void InstanceMethod_AudibleClientShape_TranslatesToNonAsyncVoidWrapper()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public sealed class Authorize
+    {
+        public event EventHandler SettingsChanged;
+
+        public Task WriteConfigurationAsync() => Task.CompletedTask;
+
+        public void Raise() => SettingsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public sealed class AudibleClient
+    {
+        private readonly Authorize Authorize = new Authorize();
+
+        public AudibleClient()
+        {
+            Authorize.SettingsChanged += SettingsChangedSettings;
+        }
+
+        private async void SettingsChangedSettings(object sender, EventArgs e) => await Authorize.WriteConfigurationAsync();
+    }
+}");
+
+        Assert.Contains("ContinueWith", printed, StringComparison.Ordinal);
+        Assert.Contains("OnlyOnFaulted", printed, StringComparison.Ordinal);
+        Assert.Contains("ExecuteSynchronously", printed, StringComparison.Ordinal);
+        Assert.Contains("SynchronizationContext", printed, StringComparison.Ordinal);
+
+        // The wrapper method itself is no longer declared `async` (it must be
+        // void-shaped, non-Task-observable, to convert to the EventHandler
+        // subscription it appears in unchanged, right above).
+        Assert.DoesNotContain("async func SettingsChangedSettings", printed, StringComparison.Ordinal);
+        Assert.Contains("func SettingsChangedSettings", printed, StringComparison.Ordinal);
+
+        // `+=` still subscribes by the SAME method name — identity preserved.
+        Assert.Contains("SettingsChanged += SettingsChangedSettings", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The exact Oahu <c>AudibleApi.AaxFileConversionProgressUpdate</c> shape: a
+    /// block-bodied <c>async void</c> LOCAL FUNCTION subscribed to a generic
+    /// <c>EventHandler&lt;T&gt;</c> via method group.
+    /// </summary>
+    [Fact]
+    public void LocalFunction_AaxFileConversionProgressUpdateShape_TranslatesToNonAsyncVoidWrapper()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public sealed class ConversionProgressEventArgs : EventArgs
+    {
+        public int Percent { get; set; }
+    }
+
+    public sealed class Converter
+    {
+        public event EventHandler<ConversionProgressEventArgs> Progress;
+
+        public Task ReportAsync(int percent) => Task.CompletedTask;
+
+        public void Raise(int percent) => Progress?.Invoke(this, new ConversionProgressEventArgs { Percent = percent });
+    }
+
+    public sealed class AudibleApi
+    {
+        public void ConvertFile(Converter converter)
+        {
+            async void AaxFileConversionProgressUpdate(object sender, ConversionProgressEventArgs e)
+            {
+                await converter.ReportAsync(e.Percent);
+            }
+
+            converter.Progress += AaxFileConversionProgressUpdate;
+            converter.Progress -= AaxFileConversionProgressUpdate;
+        }
+    }
+}");
+
+        Assert.Contains("ContinueWith", printed, StringComparison.Ordinal);
+        Assert.Contains("let AaxFileConversionProgressUpdate = func", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("let AaxFileConversionProgressUpdate = async func", printed, StringComparison.Ordinal);
+
+        // Both `+=` and `-=` reference the exact same identifier — the SAME
+        // `let`-bound wrapper value, so unsubscription is delegate-equal to
+        // the earlier subscription.
+        Assert.Contains("Progress += AaxFileConversionProgressUpdate", printed, StringComparison.Ordinal);
+        Assert.Contains("Progress -= AaxFileConversionProgressUpdate", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An async lambda assigned DIRECTLY to a plain <c>EventHandler</c>-typed
+    /// field/variable is Roslyn's async-void shape for a LAMBDA (its inferred
+    /// <c>IMethodSymbol.ReturnsVoid</c> comes from the converted <c>EventHandler
+    /// .Invoke</c> target, not from a <c>Task</c> of its own) and needs the same
+    /// rewrite.
+    /// </summary>
+    [Fact]
+    public void Lambda_AsyncVoidTargetingEventHandler_TranslatesToNonAsyncVoidWrapper()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public EventHandler Handler = async (sender, e) => await Task.Delay(1);
+    }
+}");
+
+        Assert.Contains("ContinueWith", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("async (sender", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An async lambda targeting a CUSTOM void delegate type (not one of the
+    /// BCL <c>EventHandler</c> family) must be rewritten identically — the
+    /// predicate is purely <c>IsAsync &amp;&amp; ReturnsVoid</c>, independent of the
+    /// specific delegate type.
+    /// </summary>
+    [Fact]
+    public void Lambda_AsyncVoidTargetingCustomVoidDelegate_TranslatesToNonAsyncVoidWrapper()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public delegate void Notify(int code);
+
+    public sealed class C
+    {
+        public Notify OnNotify = async code =>
+        {
+            await Task.Delay(1);
+        };
+    }
+}");
+
+        Assert.Contains("ContinueWith", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A STATIC <c>async void</c> method subscribed via method group must be
+    /// rewritten identically to an instance method.
+    /// </summary>
+    [Fact]
+    public void StaticMethod_AsyncVoid_TranslatesToNonAsyncVoidWrapper()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public event EventHandler Changed;
+
+        public void Subscribe() => Changed += OnChanged;
+
+        private static async void OnChanged(object sender, EventArgs e)
+        {
+            await Task.Delay(1);
+        }
+    }
+}");
+
+        Assert.Contains("ContinueWith", printed, StringComparison.Ordinal);
+        Assert.Contains("let __gsAsyncVoidBody", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("async func OnChanged", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A LAMBDA capturing an outer local (issue's "captures" scenario) must
+    /// still forward its captured state correctly into the nested async
+    /// literal — the wrapper is a plain nested closure, so capture semantics
+    /// are unaffected by construction, but this locks in that the capture
+    /// reference survives the rewrite unchanged.
+    /// </summary>
+    [Fact]
+    public void Lambda_CapturingOuterLocal_PreservesCapture()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public void Wire(int seed)
+        {
+            EventHandler h = async (sender, e) =>
+            {
+                await Task.Delay(1);
+                Console.WriteLine(seed);
+            };
+        }
+    }
+}");
+
+        Assert.Contains("Console.WriteLine(seed)", printed, StringComparison.Ordinal);
+        Assert.Contains("ContinueWith", printed, StringComparison.Ordinal);
+    }
+
+    // ---------------------------------------------------------------
+    // Negative controls: cs2gs must NOT globally loosen Task -> void
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// An ordinary <c>async Task</c> instance method (NOT <c>async void</c>) is
+    /// untouched: it keeps its <c>async func</c> shape and gets no wrapper.
+    /// </summary>
+    [Fact]
+    public void NegativeControl_AsyncTaskMethod_TranslationUnaffected()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public async Task Handle(object sender, EventArgs e)
+        {
+            await Task.Delay(1);
+        }
+    }
+}");
+
+        Assert.Contains("async func Handle", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("ContinueWith", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__gsAsyncVoidBody", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An async lambda targeting <c>Func&lt;Task&gt;</c> (an ordinary awaited
+    /// async value, not a void delegate) is untouched.
+    /// </summary>
+    [Fact]
+    public void NegativeControl_AsyncLambdaTargetingFuncOfTask_TranslationUnaffected()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public Func<Task> Work = async () => await Task.Delay(1);
+    }
+}");
+
+        Assert.DoesNotContain("ContinueWith", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__gsAsyncVoidBody", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A direct Task-returning method-group VALUE (assigned to a
+    /// <c>Func&lt;object, EventArgs, Task&gt;</c>-shaped variable, never a void
+    /// delegate) must remain an ordinary async method-group reference —
+    /// confirms the rewrite is keyed on the DECLARATION's own
+    /// <c>IsAsync &amp;&amp; ReturnsVoid</c>, not on how a caller happens to use it.
+    /// </summary>
+    [Fact]
+    public void NegativeControl_AsyncTaskMethodGroupValue_TranslationUnaffected()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public async Task Handle(object sender, EventArgs e)
+        {
+            await Task.Delay(1);
+        }
+
+        public Func<object, EventArgs, Task> Capture() => Handle;
+    }
+}");
+
+        Assert.Contains("async func Handle", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("ContinueWith", printed, StringComparison.Ordinal);
+        Assert.Contains("-> Handle", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The critical negative control the issue calls out explicitly: an
+    /// ordinary async G# method with no explicit return type (gsc's
+    /// <c>async func Handle(...) { ... }</c> — the SAME textual shape cs2gs
+    /// emits for a genuine C# <c>async Task Handle(...)</c>, since G# has no
+    /// distinct spelling for "async void" vs "async, no awaited result") is
+    /// STILL Task-observable at its call site (per gsc's
+    /// <c>MethodGroupObservableReturnType</c>, entirely UNTOUCHED by this
+    /// fix) and so must still fail to COMPILE when subscribed to a plain
+    /// VOID event delegate. This is deliberately raw G# (bypassing cs2gs
+    /// entirely, since real C# has no valid source that would even reach
+    /// cs2gs with this shape: `EventHandler h = anAsyncTaskMethod;` is
+    /// already a C# CS0407 error before translation) — it locks in that gsc
+    /// itself never globally discards an arbitrary Task to make this
+    /// conversion succeed.
+    /// </summary>
+    [Fact]
+    public void NegativeControl_AsyncFuncMethodGroupToVoidDelegate_StillFailsGsc()
+    {
+        const string source = @"package Demo
+
+import System
+import System.Threading.Tasks
+
+class C {
+    event Changed (object?, EventArgs) -> void
+
+    func Subscribe() {
+        Changed += Handle
+    }
+
+    async func Handle(sender object, e EventArgs) {
+        await Task.Delay(1)
+    }
+}
+";
+
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-2438-negctrl", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(gsPath, source);
+
+        (int exit, string output) = RunDotnet($"\"{compiler}\" /target:library /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.NotEqual(0, exit);
+        Assert.Contains("GS0155", output, StringComparison.Ordinal);
+    }
+
+    // ---------------------------------------------------------------
+    // Full compile+run behavioral tests
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// The exact Oahu <c>AudibleClient</c> shape end-to-end: subscribes,
+    /// fires, and lets the non-faulting async body run to completion. Proves
+    /// (a) the wrapper compiles and (b) the immediate call returns
+    /// synchronously (proving fire-and-forget dispatch) while the awaited
+    /// continuation still completes normally (proving no swallowed/broken
+    /// await).
+    /// </summary>
+    [Fact]
+    public void E2e_AudibleClientShape_FiresAndCompletesWithoutError()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public sealed class Authorize
+    {
+        public event EventHandler SettingsChanged;
+
+        public async Task WriteConfigurationAsync()
+        {
+            await Task.Delay(1);
+            Console.WriteLine(""wrote-configuration"");
+        }
+
+        public void Raise() => SettingsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public sealed class AudibleClient
+    {
+        public readonly Authorize Authorize = new Authorize();
+
+        public AudibleClient()
+        {
+            Authorize.SettingsChanged += SettingsChangedSettings;
+        }
+
+        private async void SettingsChangedSettings(object sender, EventArgs e) => await Authorize.WriteConfigurationAsync();
+
+        public void Fire()
+        {
+            Authorize.Raise();
+            Console.WriteLine(""fire-returned"");
+            Thread.Sleep(300);
+        }
+    }
+}");
+
+        string stdout = CompileAndRun(printed, "AudibleClient().Fire()");
+        string[] lines = stdout.Trim().Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        // `Fire` returns (and prints "fire-returned") BEFORE the awaited
+        // continuation inside the handler completes (proves the handler call
+        // itself is synchronous/void, matching real async-void dispatch).
+        Assert.Equal("fire-returned", lines[0]);
+        Assert.Contains("wrote-configuration", lines);
+    }
+
+    /// <summary>
+    /// Attaches a recording <see cref="SynchronizationContext"/> before firing
+    /// a faulting async-void handler: the unhandled exception must be posted
+    /// through THAT context (and only observed once the posted callback is
+    /// actually pumped) rather than crashing the process or being silently
+    /// dropped.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The recording <see cref="SynchronizationContext"/> subclass is compiled
+    /// as a SEPARATE, ordinary C# helper assembly (<see cref="CompileSupportAssembly"/>)
+    /// and referenced by the translated snippet, rather than being defined
+    /// inline in the C# source under translation. G# has no support for
+    /// overriding a virtual method of an EXTERNAL (BCL/metadata) base class
+    /// (confirmed independently: <c>structSymbol.BaseClass</c> is only
+    /// populated for G#-authored base types, so overriding e.g.
+    /// <c>SynchronizationContext.Post</c> directly in G#/cs2gs-translated
+    /// source silently drops the <c>override</c> modifier and produces a
+    /// non-virtual SHADOWING method — calls through a base-typed reference then
+    /// dispatch to the BCL base implementation instead, which is an unrelated,
+    /// pre-existing gsc/Core limitation, not a defect in this issue's fix). Using
+    /// a pre-compiled reference assembly for the subclass sidesteps that gap
+    /// entirely (exactly how real Oahu code would consume a helper type from
+    /// another already-compiled assembly) while still exercising the actual
+    /// translated <c>OnTick</c> wrapper end-to-end against a REAL captured
+    /// <see cref="SynchronizationContext"/>.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void E2e_FaultingHandler_WithSynchronizationContext_PostsExceptionInsteadOfCrashing()
+    {
+        // NOTE: `Post` only RECORDS — it does not invoke the callback. A real
+        // ambient `SynchronizationContext` is normally serviced by a message
+        // pump (WinForms/WPF/ASP.NET classic) that keeps invoking posted work
+        // as it arrives; the .NET async/await machinery ITSELF posts through
+        // the very same context to resume any `await`ed continuation, so a
+        // naive "invoke each posted callback with a `null` state" pump breaks
+        // as soon as the framework (not just our own fault-continuation) also
+        // posts through this context. `PumpAndCaptureFirstException` below
+        // pairs each callback with its OWN captured state and drains the list
+        // (including entries added DURING pumping, e.g. the exception-post
+        // that only happens once the delay's resume-post above is pumped).
+        string supportDll = CompileSupportAssembly(
+            @"
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Issue2438Support
+{
+    public sealed class RecordingSyncContext : SynchronizationContext
+    {
+        private readonly List<(SendOrPostCallback Callback, object State)> posted =
+            new List<(SendOrPostCallback, object)>();
+
+        public int PostedCount => posted.Count;
+
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            posted.Add((d, state));
+        }
+
+        public string PumpAndCaptureFirstException()
+        {
+            string firstMessage = null;
+            for (int i = 0; i < posted.Count; i++)
+            {
+                (SendOrPostCallback callback, object state) = posted[i];
+                try
+                {
+                    callback(state);
+                }
+                catch (Exception ex)
+                {
+                    firstMessage ??= ex.Message;
+                }
+            }
+
+            return firstMessage;
+        }
+    }
+}",
+            "Issue2438Support");
+
+        string printed = TranslateAndValidate(
+            @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Issue2438Support;
+
+namespace Demo
+{
+    public sealed class Worker
+    {
+        public event EventHandler Done;
+
+        private async void OnTick(object sender, EventArgs e)
+        {
+            await Task.Delay(1);
+            throw new InvalidOperationException(""boom"");
+        }
+
+        public void Fire()
+        {
+            Done += OnTick;
+            Done(this, EventArgs.Empty);
+        }
+    }
+
+    public static class Driver
+    {
+        public static void Run()
+        {
+            var ctx = new RecordingSyncContext();
+            SynchronizationContext.SetSynchronizationContext(ctx);
+
+            new Worker().Fire();
+            Thread.Sleep(300);
+
+            Console.WriteLine(""posted:"" + ctx.PostedCount);
+            string caught = ctx.PumpAndCaptureFirstException();
+            if (caught != null)
+            {
+                Console.WriteLine(""caught:"" + caught);
+            }
+        }
+    }
+}",
+            new[] { MetadataReference.CreateFromFile(supportDll) });
+
+        string stdout = CompileAndRun(printed, "Driver.Run()", new[] { supportDll });
+        Assert.Contains("posted:1", stdout);
+        Assert.Contains("caught:boom", stdout);
+    }
+
+    /// <summary>
+    /// With NO ambient <see cref="SynchronizationContext"/> (the common
+    /// console-app default), the same faulting handler must still surface its
+    /// exception rather than swallow it — matching real C# async-void, which
+    /// crashes the process on an unhandled exception with no context to post
+    /// to.
+    /// </summary>
+    [Fact]
+    public void E2e_FaultingHandler_WithoutSynchronizationContext_CrashesInsteadOfSwallowing()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public sealed class Worker
+    {
+        public event EventHandler Done;
+
+        private async void OnTick(object sender, EventArgs e)
+        {
+            await Task.Delay(1);
+            throw new InvalidOperationException(""boom"");
+        }
+
+        public void Fire()
+        {
+            Done += OnTick;
+            Done(this, EventArgs.Empty);
+        }
+    }
+
+    public static class Driver
+    {
+        public static void Run()
+        {
+            new Worker().Fire();
+            Console.WriteLine(""fire-returned"");
+            Thread.Sleep(500);
+            Console.WriteLine(""should-not-reach-here"");
+        }
+    }
+}");
+
+        (string stdout, int exitCode) = CompileAndRunAllowFailure(printed, "Driver.Run()");
+        Assert.Contains("fire-returned", stdout);
+        Assert.NotEqual(0, exitCode);
+        Assert.DoesNotContain("should-not-reach-here", stdout);
+    }
+
+    /// <summary>
+    /// Two handlers subscribed to the same event, then ONE unsubscribed by
+    /// name via <c>-=</c>: only the still-subscribed handler must fire on the
+    /// second raise — proves the wrapper preserves delegate-equality identity
+    /// across <c>+=</c>/<c>-=</c> (the local-function/lambda `let` binding and
+    /// the method-group name both resolve to the identical wrapper value each
+    /// time they're referenced).
+    /// </summary>
+    [Fact]
+    public void E2e_MultipleSubscribeThenUnsubscribeByName_OnlyRemainingHandlerFires()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public sealed class Publisher
+    {
+        public event EventHandler Ping;
+
+        public void Raise() => Ping?.Invoke(this, EventArgs.Empty);
+    }
+
+    public static class Driver
+    {
+        private static async void First(object sender, EventArgs e)
+        {
+            await Task.Delay(1);
+            Console.WriteLine(""first"");
+        }
+
+        private static async void Second(object sender, EventArgs e)
+        {
+            await Task.Delay(1);
+            Console.WriteLine(""second"");
+        }
+
+        public static void Run()
+        {
+            var publisher = new Publisher();
+            publisher.Ping += First;
+            publisher.Ping += Second;
+
+            publisher.Raise();
+            Thread.Sleep(200);
+
+            publisher.Ping -= First;
+            publisher.Raise();
+            Thread.Sleep(200);
+        }
+    }
+}");
+
+        string stdout = CompileAndRun(printed, "Driver.Run()");
+        int firstCount = System.Text.RegularExpressions.Regex.Matches(stdout, "first").Count;
+        int secondCount = System.Text.RegularExpressions.Regex.Matches(stdout, "second").Count;
+
+        // `First` fired only on the FIRST raise (before it was unsubscribed);
+        // `Second` fired on both raises.
+        Assert.Equal(1, firstCount);
+        Assert.Equal(2, secondCount);
+    }
+
+    // ---------------------------------------------------------------
+    // Shared helpers (pattern established by Issue1732LoopLoweringTranslationTests
+    // / Issue2434DelegateNullableInterfaceWideningTranslationTests)
+    // ---------------------------------------------------------------
+
+    private static string TranslateAndValidate(string source, IReadOnlyList<MetadataReference> extraReferences = null)
+    {
+        IReadOnlyList<MetadataReference> references = extraReferences is null
+            ? null
+            : CSharpProjectLoader.RuntimeReferences().Concat(extraReferences).ToList();
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) }, references);
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="source"/> as an ordinary (non-translated) C#
+    /// class-library assembly using Roslyn directly, so its members retain
+    /// REAL CLR override/virtual-dispatch semantics. Used by tests that need a
+    /// helper type (e.g. a <see cref="SynchronizationContext"/> subclass) which
+    /// itself is NOT the thing under test — see the remarks on
+    /// <see cref="E2e_FaultingHandler_WithSynchronizationContext_PostsExceptionInsteadOfCrashing"/>
+    /// for why such helper types must be pre-compiled rather than routed
+    /// through cs2gs/gsc.
+    /// </summary>
+    private static string CompileSupportAssembly(string source, string assemblyName)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Support.cs", source) },
+            references: null,
+            assemblyName: assemblyName,
+            outputKind: OutputKind.DynamicallyLinkedLibrary);
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Support assembly should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-2438-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string dllPath = Path.Combine(workDir, assemblyName + ".dll");
+        using (FileStream stream = File.Create(dllPath))
+        {
+            Microsoft.CodeAnalysis.Emit.EmitResult emitResult = project.Compilation.Emit(stream);
+            Assert.True(
+                emitResult.Success,
+                "Support assembly must emit with zero errors: " +
+                    string.Join(Environment.NewLine, emitResult.Diagnostics));
+        }
+
+        return dllPath;
+    }
+
+    private static string CompileAndRun(string printed, string callExpression, IReadOnlyList<string> extraReferenceDlls = null)
+    {
+        (string stdout, int exitCode) = CompileAndRunAllowFailure(printed, callExpression, extraReferenceDlls);
+        Assert.True(exitCode == 0, "Translated snippet must run successfully. Output:\n" + stdout);
+        return stdout;
+    }
+
+    private static (string Stdout, int ExitCode) CompileAndRunAllowFailure(
+        string printed,
+        string callExpression,
+        IReadOnlyList<string> extraReferenceDlls = null)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-2438-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(gsPath, printed + Environment.NewLine + callExpression + Environment.NewLine);
+
+        var referenceArgs = new StringBuilder();
+        if (extraReferenceDlls is not null)
+        {
+            foreach (string referenceDll in extraReferenceDlls)
+            {
+                // The compiled snippet is later invoked as a standalone
+                // process (`dotnet Snippet.dll`); the CLR probes for
+                // references next to the entry assembly, so any referenced
+                // helper assembly must be copied alongside it.
+                string copiedPath = Path.Combine(workDir, Path.GetFileName(referenceDll));
+                File.Copy(referenceDll, copiedPath, overwrite: true);
+                referenceArgs.Append(" /r:\"").Append(referenceDll).Append('"');
+            }
+        }
+
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"{referenceArgs}");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated snippet with zero errors. Output:\n" + compileOut +
+                "\n\nTranslated G#:\n" + printed);
+
+        (int runExit, string stdout) = RunDotnet($"\"{dllPath}\"");
+        return (stdout, runExit);
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.AsyncVoidHandlers.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.AsyncVoidHandlers.cs
@@ -1,0 +1,231 @@
+// <copyright file="CSharpToGSharpTranslator.AsyncVoidHandlers.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Microsoft.CodeAnalysis;
+
+namespace Cs2Gs.Translator;
+
+public sealed partial class CSharpToGSharpTranslator
+{
+    private sealed partial class DeclarationVisitor
+    {
+        // Issue #2438: G# has no distinct "async void" callable shape — EVERY
+        // G# `async func` (method, local function, or lambda) is Task-observable
+        // at its call site (gsc's `MethodGroupObservableReturnType` / the
+        // matching lambda-natural-type rule), matching C# `async Task`. A
+        // genuine C# `async void` handler (the ONLY C# shape with no awaitable
+        // result at all — used for event handlers, since C# forbids awaiting an
+        // async-void method) has no such Task to observe, so translating it
+        // as an ordinary `async func` leaves its method-group/lambda value
+        // typed `(args) -> Task`, which cannot convert to the `(args) -> void`
+        // event-delegate shape the original C# subscribed with (GS0155).
+        //
+        // The fix is scoped EXACTLY to a Roslyn symbol whose `IsAsync &&
+        // ReturnsVoid` is true (see <see cref="IsCSharpAsyncVoidHandler"/>) —
+        // an ordinary `async Task`/`async Task&lt;T&gt;` method, local function, or
+        // lambda keeps its existing (correct) Task-observable translation
+        // unchanged, and a Task-returning method group still correctly FAILS
+        // to convert to a void delegate (the negative control the issue calls
+        // out: cs2gs must not globally discard arbitrary Tasks).
+        //
+        // For a genuine async-void handler, the translator emits a
+        // NON-async, void-returning wrapper with the ORIGINAL name/identity
+        // (so method-group `+=`/`-=` subscription and unsubscription keep
+        // referring to the SAME symbol/value) whose body:
+        //   1. binds the untouched original body to a nested `async func`
+        //      value (so its own awaits/exception flow are lowered exactly
+        //      like any other G# async function — no new async semantics are
+        //      invented),
+        //   2. invokes it immediately with the wrapper's own parameters
+        //      (kicks off synchronously up to the first incomplete `await`,
+        //      matching C#'s async-void semantics: the call returns void as
+        //      soon as the state machine yields or completes), and
+        //   3. attaches a fire-and-forget continuation that surfaces any
+        //      unobserved fault the same way the real
+        //      `AsyncVoidMethodBuilder` does: posted through the
+        //      `SynchronizationContext.Current` CAPTURED SYNCHRONOUSLY AT
+        //      THE HANDLER'S OWN ENTRY (before the nested async body is
+        //      even invoked — exactly when `AsyncVoidMethodBuilder.Create()`
+        //      captures it) when one was set (so a UI handler's exception
+        //      reaches the same context a real C# async-void handler would
+        //      notify), or queued onto a bare `ThreadPool` work item
+        //      otherwise (a genuinely unhandled exception on that worker
+        //      thread crashes the process — matching the no-context C#
+        //      async-void behavior, and NOT the same as an inline `throw`
+        //      inside the `ContinueWith` continuation itself, which would
+        //      merely fault the continuation's own unobserved Task and be
+        //      silently dropped) — so the fault is never silently swallowed.
+        //
+        // Remaining, unavoidable semantic difference vs. real C# `async
+        // void`: the real `AsyncVoidMethodBuilder` throws directly on the
+        // ORIGINAL calling thread's stack when there is no context AND that
+        // stack is still live (synchronous-completion fast path); this
+        // wrapper always defers even a same-thread synchronous fault to a
+        // continuation, so a caller can never catch it with a surrounding
+        // `try`/`catch` at the subscription/raise call site — matching real
+        // async void's documented advice that a caller must never rely on
+        // catching an async-void handler's exceptions locally at all.
+        private static bool IsCSharpAsyncVoidHandler(IMethodSymbol symbol)
+            => symbol is { IsAsync: true, ReturnsVoid: true };
+
+        /// <summary>
+        /// Builds the fire-and-forget wrapper body described above. The
+        /// returned block is meant to become the ENTIRE (non-async, void)
+        /// body of the translated handler — <paramref name="originalAsyncBody"/>
+        /// (the handler's own, otherwise-unmodified translated body) becomes
+        /// the block body of a nested <c>async func</c> literal that the
+        /// wrapper invokes and observes.
+        /// </summary>
+        /// <param name="parameters">The handler's own parameter list (reused verbatim for the nested async literal and the forwarding call).</param>
+        /// <param name="originalAsyncBody">The handler's untouched translated body.</param>
+        /// <param name="location">A source location used to resolve/import the well-known BCL types the wrapper references.</param>
+        private BlockStatement BuildAsyncVoidHandlerWrapperBody(
+            IReadOnlyList<Parameter> parameters,
+            BlockStatement originalAsyncBody,
+            Location location)
+        {
+            const string bodyLocalName = "__gsAsyncVoidBody";
+            const string taskParamName = "__gsAsyncVoidTask";
+            const string exceptionLocalName = "__gsAsyncVoidEx";
+            const string contextLocalName = "__gsAsyncVoidCtx";
+            const string postStateParamName = "__gsAsyncVoidState";
+
+            string taskTypeName = this.ResolveWellKnownTypeName("System.Threading.Tasks.Task", location, "Task");
+            string syncContextTypeName = this.ResolveWellKnownTypeName("System.Threading.SynchronizationContext", location, "SynchronizationContext");
+            string continuationOptionsTypeName = this.ResolveWellKnownTypeName("System.Threading.Tasks.TaskContinuationOptions", location, "TaskContinuationOptions");
+            string threadPoolTypeName = this.ResolveWellKnownTypeName("System.Threading.ThreadPool", location, "ThreadPool");
+
+            // let __gsAsyncVoidCtx = SynchronizationContext.Current
+            //
+            // Captured HERE, synchronously, BEFORE the nested async literal
+            // below is ever invoked — exactly mirroring the real
+            // `AsyncVoidMethodBuilder.Create()`, which captures the ambient
+            // context once at the handler's own entry, before its first
+            // `await`. Reading `SynchronizationContext.Current` later,
+            // inside the `ContinueWith` continuation below, would instead
+            // observe whatever thread happens to run the fault continuation
+            // (usually a bare thread-pool worker with no context at all),
+            // which is NOT what a real async-void handler captures.
+            var captureContextDeclaration = new LocalDeclarationStatement(
+                BindingKind.Let,
+                contextLocalName,
+                type: new NamedTypeReference(syncContextTypeName) { IsNullable = true },
+                initializer: new MemberAccessExpression(new IdentifierExpression(syncContextTypeName), "Current"));
+
+            // let __gsAsyncVoidBody = async (params) -> { <original body> }
+            var bodyDeclaration = new LocalDeclarationStatement(
+                BindingKind.Let,
+                bodyLocalName,
+                initializer: new LambdaExpression(
+                    parameters,
+                    blockBody: originalAsyncBody,
+                    isAsync: true,
+                    isFunctionLiteral: true));
+
+            List<GExpression> forwardedArguments = parameters
+                .Select(p => (GExpression)new IdentifierExpression(p.Name))
+                .ToList();
+
+            // __gsAsyncVoidEx = __gsAsyncVoidTask.Exception!!.InnerException!!
+            GExpression exceptionInitializer = new NonNullAssertionExpression(
+                new MemberAccessExpression(
+                    new NonNullAssertionExpression(
+                        new MemberAccessExpression(new IdentifierExpression(taskParamName), "Exception")),
+                    "InnerException"));
+
+            // (state object) -> { throw __gsAsyncVoidEx }
+            var rethrowCallback = new LambdaExpression(
+                new List<Parameter> { new Parameter(postStateParamName, new NamedTypeReference("object")) },
+                blockBody: new BlockStatement(new GStatement[]
+                {
+                    new ThrowStatement(new IdentifierExpression(exceptionLocalName)),
+                }));
+
+            // No ambient context (the common console-app/background-thread
+            // case): queue the rethrow on a bare thread-pool work item — NOT
+            // an inline `throw` right here, which would only fault the
+            // (unobserved, silently-dropped) Task that `ContinueWith` itself
+            // returns. A raw `ThreadPool.QueueUserWorkItem` callback that
+            // throws is a genuinely unhandled exception on that worker
+            // thread, matching real async-void's crash-the-process behavior
+            // when there is no context to post to (mirrors the real
+            // `AsyncVoidMethodBuilder`'s own `ThreadPool.QueueUserWorkItem`
+            // fallback in `AsyncMethodBuilderCore.ThrowAsync`).
+            var elseBranch = new BlockStatement(new GStatement[]
+            {
+                new ExpressionStatement(new InvocationExpression(
+                    new MemberAccessExpression(new IdentifierExpression(threadPoolTypeName), "QueueUserWorkItem"),
+                    new List<GExpression> { rethrowCallback })),
+            });
+
+            var ifContextPresent = new IfStatement(
+                new BinaryExpression(new IdentifierExpression(contextLocalName), "!=", LiteralExpression.Null()),
+                new BlockStatement(new GStatement[]
+                {
+                    new ExpressionStatement(new InvocationExpression(
+                        new MemberAccessExpression(
+                            new NonNullAssertionExpression(new IdentifierExpression(contextLocalName)),
+                            "Post"),
+                        new List<GExpression> { rethrowCallback, LiteralExpression.Null() })),
+                }),
+                elseBranch);
+
+            var faultedBranch = new BlockStatement(new GStatement[]
+            {
+                new LocalDeclarationStatement(BindingKind.Let, exceptionLocalName, initializer: exceptionInitializer),
+                ifContextPresent,
+            });
+
+            var continuationBody = new BlockStatement(new GStatement[]
+            {
+                new IfStatement(
+                    new MemberAccessExpression(new IdentifierExpression(taskParamName), "IsFaulted"),
+                    faultedBranch),
+            });
+
+            var continuationLambda = new LambdaExpression(
+                new List<Parameter> { new Parameter(taskParamName, new NamedTypeReference(taskTypeName)) },
+                blockBody: continuationBody);
+
+            GExpression continuationOptions = new BinaryExpression(
+                new MemberAccessExpression(new IdentifierExpression(continuationOptionsTypeName), "OnlyOnFaulted"),
+                "|",
+                new MemberAccessExpression(new IdentifierExpression(continuationOptionsTypeName), "ExecuteSynchronously"));
+
+            // __gsAsyncVoidBody(args).ContinueWith((t) -> { ... }, OnlyOnFaulted | ExecuteSynchronously)
+            var continueWithCall = new ExpressionStatement(new InvocationExpression(
+                new MemberAccessExpression(
+                    new InvocationExpression(new IdentifierExpression(bodyLocalName), forwardedArguments),
+                    "ContinueWith"),
+                new List<GExpression> { continuationLambda, continuationOptions }));
+
+            return new BlockStatement(new GStatement[] { captureContextDeclaration, bodyDeclaration, continueWithCall });
+        }
+
+        /// <summary>
+        /// Resolves <paramref name="metadataName"/> through the real type
+        /// mapper (so the reference is shortened AND its namespace is
+        /// registered for auto-import, ADR-0115 §B.7/issue #2211) when the
+        /// compilation can see the type; falls back to
+        /// <paramref name="fallbackName"/> (fully qualifying nothing) only if
+        /// the well-known BCL type is somehow unavailable, which should not
+        /// happen for any real corpus referencing events/async at all.
+        /// </summary>
+        private string ResolveWellKnownTypeName(string metadataName, Location location, string fallbackName)
+        {
+            INamedTypeSymbol symbol = this.context.Compilation.GetTypeByMetadataName(metadataName);
+            if (symbol is null)
+            {
+                return fallbackName;
+            }
+
+            return this.typeMapper.Map(symbol, this.context, location) is NamedTypeReference named
+                ? named.Name
+                : fallbackName;
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -1245,9 +1245,20 @@ public sealed partial class CSharpToGSharpTranslator
             // is inferred void and `return expr` is rejected), and the explicit type
             // also supports recursion. The declared symbol carries the real return
             // type / void-ness; the async unwrap mirrors method `func`s.
-            GTypeReference returnType = this.context.GetDeclaredSymbol(localFunction) is IMethodSymbol localSymbol
+            IMethodSymbol localSymbol = this.context.GetDeclaredSymbol(localFunction) as IMethodSymbol;
+            GTypeReference returnType = localSymbol != null
                 ? this.MapDelegateLikeReturnType(localSymbol, isAsync, localFunction.ReturnType.GetLocation())
                 : null;
+
+            // Issue #2438: an `async void` LOCAL function (Oahu's
+            // `AaxFileConversionProgressUpdate` shape) needs the exact same
+            // fire-and-forget rewrite as an `async void` METHOD — see
+            // BuildAsyncVoidHandlerWrapperBody. The local function still
+            // lowers to a single `let`-bound literal either way, so its
+            // name/identity for `+=`/`-=` subscription is unaffected: only
+            // the literal it is bound to changes shape (non-async wrapper
+            // instead of the raw async literal).
+            bool isAsyncVoidHandler = localSymbol != null && IsCSharpAsyncVoidHandler(localSymbol);
 
             // A local function's body is its own evaluation scope: a spill hoisted
             // while translating it (issue #1731) must never leak into the
@@ -1263,7 +1274,10 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 if (localFunction.Body != null)
                 {
-                    lambda = new LambdaExpression(parameters, blockBody: this.WithParameterShadows(localFunction, this.TranslateBlock(localFunction.Body)), isAsync: isAsync, returnType: returnType, isFunctionLiteral: true);
+                    BlockStatement innerBody = this.WithParameterShadows(localFunction, this.TranslateBlock(localFunction.Body));
+                    lambda = isAsyncVoidHandler
+                        ? new LambdaExpression(parameters, blockBody: this.BuildAsyncVoidHandlerWrapperBody(parameters, innerBody, localFunction.GetLocation()), isAsync: false, returnType: null, isFunctionLiteral: true)
+                        : new LambdaExpression(parameters, blockBody: innerBody, isAsync: isAsync, returnType: returnType, isFunctionLiteral: true);
                 }
                 else if (localFunction.ExpressionBody != null)
                 {
@@ -1273,13 +1287,11 @@ public sealed partial class CSharpToGSharpTranslator
                     // <see cref="WithSpillSeam"/> — evaluated per call, inside this
                     // very body, rather than being silently dropped by the
                     // enclosing null seam above.
-                    lambda = new LambdaExpression(
-                        parameters,
-                        blockBody: new BlockStatement(this.WithSpillSeam(
-                            () => this.TranslateExpressionStatements(localFunction.ExpressionBody.Expression).ToList()).ToList()),
-                        isAsync: isAsync,
-                        returnType: returnType,
-                        isFunctionLiteral: true);
+                    BlockStatement innerBody = new BlockStatement(this.WithSpillSeam(
+                        () => this.TranslateExpressionStatements(localFunction.ExpressionBody.Expression).ToList()).ToList());
+                    lambda = isAsyncVoidHandler
+                        ? new LambdaExpression(parameters, blockBody: this.BuildAsyncVoidHandlerWrapperBody(parameters, innerBody, localFunction.GetLocation()), isAsync: false, returnType: null, isFunctionLiteral: true)
+                        : new LambdaExpression(parameters, blockBody: innerBody, isAsync: isAsync, returnType: returnType, isFunctionLiteral: true);
                 }
                 else
                 {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -1009,6 +1009,25 @@ public sealed partial class CSharpToGSharpTranslator
                 });
             }
 
+            // Issue #2438: a genuine C# `async void` method (an event handler
+            // — the only C# shape with no awaitable result at all) has no G#
+            // "async void" counterpart: every G# `async func` is
+            // Task-observable at its call site, so translating it as an
+            // ordinary async G# method would leave its method-group value
+            // typed `(args) -> Task`, unable to convert to the `(args) ->
+            // void` event-delegate shape it originally subscribed with
+            // (GS0155). Rewrite it into a non-async, void-returning wrapper
+            // with the SAME name (so `+=`/`-=` subscription/unsubscription
+            // keep referring to the same symbol) that fires the untouched
+            // original body off as a nested async literal and surfaces any
+            // unobserved fault instead of silently discarding it — see
+            // BuildAsyncVoidHandlerWrapperBody for the exact shape/rationale.
+            bool isAsyncVoidHandler = body != null && IsCSharpAsyncVoidHandler(symbol);
+            if (isAsyncVoidHandler)
+            {
+                body = this.BuildAsyncVoidHandlerWrapperBody(parameters, body, node.GetLocation());
+            }
+
             bool isOverride = symbol != null && symbol.IsOverride && !OverridesExternalBaseMethod(symbol);
 
             // Interface members are implicitly abstract in C#; in canonical G# the
@@ -1035,7 +1054,11 @@ public sealed partial class CSharpToGSharpTranslator
             // Issue #1278 / ADR-0131: a C# expression-bodied method (`=> expr`)
             // renders as the idiomatic G# arrow form `func F(...) T -> expr`
             // when the translated body folds to a single inline statement.
-            GStatement arrowBody = node.ExpressionBody != null ? TryFoldArrowBody(body) : null;
+            // Issue #2438: an async-void handler's wrapper body is never a
+            // single foldable statement (it always needs the nested
+            // async-literal binding plus the `ContinueWith` call), so it
+            // never takes the arrow form.
+            GStatement arrowBody = !isAsyncVoidHandler && node.ExpressionBody != null ? TryFoldArrowBody(body) : null;
             if (arrowBody != null)
             {
                 body = null;
@@ -1071,7 +1094,7 @@ public sealed partial class CSharpToGSharpTranslator
                 visibility: explicitInterfaceVisibility,
                 isOpen: isOpen,
                 isOverride: isOverride,
-                isAsync: symbol != null && symbol.IsAsync,
+                isAsync: !isAsyncVoidHandler && symbol != null && symbol.IsAsync,
                 attributes: this.MapAttributes(node.AttributeLists),
                 expressionBody: arrowBody,
                 explicitInterfaceType: explicitInterfaceType,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -77,6 +77,20 @@ public sealed partial class CSharpToGSharpTranslator
 
             bool isAsync = lambda.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword);
 
+            // Issue #2438: an async lambda directly targeting a VOID delegate
+            // (`EventHandler h = async (s, e) => await Foo();`,
+            // `button.Click += async (s, e) => { ... };`) is Roslyn's async-void
+            // shape for a lambda — its inferred `IMethodSymbol.ReturnsVoid` is
+            // `true` because it takes its signature from the CONVERTED target
+            // delegate's `Invoke` method, not from a `Task` value of its own. It
+            // needs the exact same fire-and-forget rewrite as an `async void`
+            // method/local function — an ordinary `async` lambda targeting
+            // `Func<Task>`/`Func<T, Task>` etc. has `ReturnsVoid == false` and is
+            // untouched. See BuildAsyncVoidHandlerWrapperBody.
+            bool isAsyncVoidTarget = isAsync &&
+                this.context.GetSymbolInfo(lambda).Symbol is IMethodSymbol lambdaSymbol &&
+                IsCSharpAsyncVoidHandler(lambdaSymbol);
+
             // A block-bodied lambda's body is its own evaluation scope: a spill
             // hoisted while translating it (issue #1731) must never leak into the
             // ENCLOSING statement's prologue (that would evaluate the operand
@@ -111,6 +125,25 @@ public sealed partial class CSharpToGSharpTranslator
             this.state.CurrentBodyScope = lambda;
             try
             {
+                if (isAsyncVoidTarget)
+                {
+                    // Every C# lambda body shape reduces to a plain STATEMENT
+                    // sequence here — never a `return`-wrapped value, even for
+                    // the generic expression-bodied shape below, since a
+                    // void-delegate target has no result to return (and the
+                    // expression itself, e.g. a bare `await voidTask`, has no
+                    // value to produce anyway).
+                    BlockStatement innerBody = lambda.Body is BlockSyntax asyncVoidBlock
+                        ? this.TranslateBlock(asyncVoidBlock)
+                        : new BlockStatement(this.WithSpillSeam(
+                            () => this.TranslateExpressionStatements((ExpressionSyntax)lambda.Body).ToList()).ToList());
+
+                    return new LambdaExpression(
+                        parameters,
+                        blockBody: this.BuildAsyncVoidHandlerWrapperBody(parameters, innerBody, lambda.GetLocation()),
+                        isAsync: false);
+                }
+
                 if (lambda.Body is BlockSyntax block)
                 {
                     // ADR-0128 / issue #1172: a block-bodied C# lambda renders as the


### PR DESCRIPTION
Fixes #2438.

## Problem

G# has no distinct "async void" callable shape (ADR-0023): every G# `async func`
(method, local function, or lambda) is Task-observable at its call site — gsc's
`MethodGroupObservableReturnType` (and the matching lambda-natural-type rule)
correctly types the method-group/lambda value as `(args) -> Task`, matching C#
`async Task`.

A genuine C# `async void` handler is the *only* C# shape with no awaitable
result at all (used for event handlers, since C# forbids `await`ing an
`async void` method). Translating it as an ordinary async G# function/lambda
left its method-group/lambda value typed `(args) -> Task`, which cannot
convert to the `(args) -> void` event-delegate shape it originally subscribed
with — GS0155.

Confirmed against the exact Oahu shapes named in the issue:
- `AudibleClient.SettingsChangedSettings` — an instance `async void` method
  subscribed via method group to `Authorize.SettingsChanged` (`EventHandler`).
- `AudibleApi`'s local function `AaxFileConversionProgressUpdate` — an
  `async void` local function subscribed the same way.

## Fix (cs2gs-translator only — no gsc/Core changes)

Per the issue's ladder, this is the narrowest semantics-preserving option:
detect the *exact* Roslyn predicate `IsAsync && ReturnsVoid` (true only for a
genuine `async void` — an ordinary `async Task`/`async Task<T>` method, local
function, or lambda has `ReturnsVoid == false`), for:

- instance/static methods (`TranslateMethod`),
- local functions (`TranslateLocalFunction`, the exact Oahu
  `AaxFileConversionProgressUpdate` shape), and
- lambdas whose target delegate makes them async-void (`TranslateLambda`,
  Roslyn infers `ReturnsVoid` from the converted target's `Invoke` signature).

and rewrite the handler into a **non-async, void-returning wrapper** with the
same name/identity (so `+=`/`-=` subscription and unsubscription keep
resolving to the same symbol/value), whose body:

1. binds the untouched original body to a nested `async func` value (so its
   own awaits/exception flow lower exactly like any other G# async function —
   no new async semantics are invented),
2. invokes it immediately with the wrapper's own parameters (kicks off
   synchronously up to the first incomplete `await` — the call returns
   `void` as soon as the state machine yields or completes, matching C#
   async-void call-site semantics), and
3. attaches a fire-and-forget `ContinueWith(OnlyOnFaulted |
   ExecuteSynchronously)` continuation that surfaces any unobserved fault by
   posting it through `SynchronizationContext.Current` — **captured
   synchronously at the handler's own entry**, before the nested async body
   is even invoked, exactly mirroring real `AsyncVoidMethodBuilder.Create()`
   capture timing — when one is set, or queuing a raw
   `ThreadPool.QueueUserWorkItem` otherwise (a genuinely unhandled exception
   there crashes the process, matching real async-void's documented
   no-context behavior — this mirrors `AsyncMethodBuilderCore.ThrowAsync`'s
   own `ThreadPool` fallback). No unobserved Task is ever silently dropped.

This does **not** globally allow arbitrary Task-returning method groups to
convert to void delegates — only the exact `async void` shape is rewritten.
An ordinary `async Task` method/lambda, a `Func<Task>` lambda, and a direct
Task-returning method-group value are all completely untouched, and gsc's
existing `MethodGroupObservableReturnType` behavior (rejecting an unmodified
Task-returning method group against a void delegate) is exercised unchanged
by a negative-control test.

## Remaining semantic difference vs. real C# `async void`

The real `AsyncVoidMethodBuilder` throws directly on the *original calling
thread's stack* when there is no context and that stack is still live (the
synchronous-completion fast path). This wrapper always defers even a
same-thread synchronous fault to a continuation, so a caller can never catch
it with a surrounding `try`/`catch` at the subscription/raise call site —
which matches real async void's own documented guidance that callers must
never rely on catching an async-void handler's exceptions locally at all, so
no real program should observe a behavior difference here.

## Tests

`tools/cs2gs/Cs2Gs.Tests/Issue2438AsyncVoidEventHandlerTranslationTests.cs`
adds 14 tests:

- Structural translation: instance-method (exact `AudibleClient` shape),
  local-function (exact `AaxFileConversionProgressUpdate` shape),
  lambda-to-`EventHandler`, lambda-to-custom-void-delegate, static method,
  and captures.
- Negative controls: an ordinary `async Task` method, a `Func<Task>` lambda,
  a direct method-group value assigned to a compatible delegate, and (via
  raw, hand-written G# source, bypassing cs2gs entirely) gsc's own
  unmodified `MethodGroupObservableReturnType` rejection of a Task-returning
  method group against a void delegate.
- Full compile+run end-to-end: fire/complete ordering (`Fire()` returns
  before the awaited continuation completes — proving the call is
  synchronous/void), a faulting handler with an ambient
  `SynchronizationContext` (posts instead of crashing), a faulting handler
  with none (crashes instead of silently swallowing), and multiple
  subscribe/unsubscribe-by-name identity (proving `+=`/`-=` resolve to the
  same wrapper value).

The `SynchronizationContext`-based e2e test compiles its recording
`SynchronizationContext` subclass as an **ordinary, separately-compiled C#
helper assembly** (real CLR override semantics) rather than routing it
through cs2gs/gsc — see the next section for why.

Ran the full `Cs2Gs.Tests` suite serialized
(`MSBUILDDISABLENODEREUSE=1`, `RunConfiguration.DisableParallelization=true`):
**1543/1543 passed**, no regressions.

## Oahu.Core migration re-run (read-only; no Oahu edits/PR)

Re-ran `cs2gs migrate --app corpus/Oahu.Core` against the rebuilt compiler
from the exact `origin/main` base (`af51d241`) plus this fix. Compile-stage
errors dropped from the previously-reported baseline of **31 to 29** — a
reduction of exactly the two `GS0155` errors this issue targeted
(`AudibleClient.SettingsChangedSettings` / `AaxFileConversionProgressUpdate`);
neither the handler names nor `MethodGroupObservableReturnType` appear
anywhere in the new run's diagnostics. The 5 `GS0155` occurrences still
present in the new run are unrelated nullable/tuple/pointer conversion
mismatches (e.g. `Cannot convert type 'bool?' to 'bool'`,
`Cannot convert type '*uint32' to 'uint32'`) — `GS0155` is a general
"cannot convert type" diagnostic reused across many unrelated conversion
failures, not an async-void-specific code.

### Next independent blocker (reported, not fixed, per instructions)

The largest remaining cluster (11 of the 29 errors: 6× `GS0158` "cannot find
member", 6× `GS0159` "cannot find function"; plus a related `GS0131` "is not
a function") traces to **`gsc` not narrowing/permitting invocation of a
nullable function-type value after an explicit `!= nil` guard**. In
`Oahu.Core/DownloadDecryptJob.cs`, `convertAction` is declared with a
nullable delegate type (`((Book, T, (Conversion) -> void) -> void)?`), guarded
with `if (succ && convertAction != nil)`, and then invoked
(`convertAction(book, context, OnNewStateCallback)`) inside that guarded
block — gsc reports `GS0131 'convertAction' is not a function` at the call
site rather than narrowing the guarded value to callable. That single failed
call cascades into the surrounding `Task.Run(...)` lambda's inferred type
becoming an error type, which in turn cascades into `Cannot find function Run`
and `Cannot find function Add` (`runningTasks.Add(convertTask)`) a few lines
later — three of the eleven GS0158/GS0159/GS0131 errors in this one file are
a single root cause. This looks like a good candidate for the next
Oahu-migration issue but is out of scope here and has not been touched.

## Discovered, unrelated, pre-existing gsc limitation (also not fixed here)

While building the `SynchronizationContext`-based e2e test, I found that G#
cannot correctly `override` a virtual method of an **external (BCL/metadata)
base class**: `structSymbol.BaseClass` (`DeclarationBinder.Structs.cs`) is
only populated for G#-authored base types, so an `override` targeting e.g.
`SynchronizationContext.Post` either fails with `GS0183` (hand-written G#) or
— when reached via cs2gs translating a C# `override` on an external base —
silently drops the `override` modifier and emits a plain, non-virtual
*shadowing* method instead of reporting anything, so a call through a
base-typed reference (e.g. `SynchronizationContext.Current`) silently
dispatches to the *base* implementation instead of the derived override. I
verified this both via a raw hand-written G# repro and via cs2gs's own
translated output. This is unrelated to async-void handlers specifically (it
would affect *any* G# class overriding *any* external framework virtual
method) and is out of scope for this issue; the e2e test sidesteps it by
compiling the `SynchronizationContext` subclass as a separate, ordinary C#
assembly instead. Flagging this as a good candidate for its own issue, but
not filing/fixing it as part of this PR per the instructions to report next
blockers without fixing them.
