### PR TITLE
Preserve smart-cast narrowing across closure capture for read-only bindings (#2442)

### DIFF
--- a/docs/adr/0069-smart-cast-flow-narrowing.md
+++ b/docs/adr/0069-smart-cast-flow-narrowing.md
@@ -79,7 +79,7 @@ Implicit-field reads (`_name` resolving to `this._name`) are already separately 
 The narrowing is dropped under any of these conditions, all of which already had infrastructure in place for the nullable-narrowing case:
 
 - **Reassignment**: an assignment to the narrowed variable inside the narrowed region drops the narrowing for that variable from every active frame (`InvalidateNarrowingsForAssignedVariables`). The narrowing is *not* restored after the assignment — Kotlin's same rule.
-- **Closure capture**: when the narrowed region contains a lambda or local-function literal that captures the narrowed variable, the narrowing is dropped before binding the lambda body and is restored once binding leaves the lambda. The capturing closure binds the variable at its declared type, so the closure body sees the original type even if the surrounding scope was narrowed.
+- **Closure capture**: when the narrowed region contains a lambda or local-function literal that captures the narrowed variable, the narrowing is dropped before binding the lambda body **unless** the captured binding is a read-only, plain-variable root — see the issue #2442 addendum below, which supersedes the blanket "always dropped" rule stated in the original ADR text.
 - **`var` with a structural risk of mutation**: for an immutable binding (`let` local, primary-ctor parameter passed by value, etc.) the narrowing is unconditional. For a mutable binding (`var` local) the narrowing applies but is dropped the first time the binder sees an assignment to that variable inside the narrowed region. This is the same conservative rule that nullable narrowing already uses.
 
 ### Combination with the existing nullable-narrowing path
@@ -118,7 +118,7 @@ No new diagnostic is introduced. The previously-emitted `GS0159` (member-not-fou
 - **Binder — early-exit narrowing propagation**. `BindBlockStatements` already keeps a `memberNotNullFrame` that survives across the block's statements. After binding each top-level statement, if the statement is a `BoundIfStatement` whose then-branch unconditionally exits the enclosing block (return / throw / unconditional goto, including `break` / `continue` which lower to goto, or a block whose last statement does any of those), the else-frame from the if-condition's classifier is merged into the persistent frame so that subsequent reads in this block see the narrowing. The else-frame is computed once at if-binding time and stored on the resulting `BoundIfStatement` via a per-binder side-table keyed by node identity, so the block-walker does not need to re-classify the condition.
 - **Emit — narrowed variable read**. `MethodBodyEmitter.EmitExpression(BoundVariableExpression)` is extended: after `EmitLoadVariable(v.Variable)`, if `v.NarrowedType` is non-null and the narrowed CLR type differs from the variable's declared CLR type, the emitter inserts a single conversion opcode — `unbox.any T` when the narrowed type is a value type (the boxed reference must be unboxed back to its native value-type representation) and `castclass T` for any reference-type narrowing. The cast is guaranteed safe because the binder placed it inside a region where an `is` test already verified the runtime type. This is the same single instruction the C# compiler emits at the use site for `if (x is Y y) { … }`; the only difference is that G# does not introduce a new local for `y` — the cast happens inline on each read.
 - **Bound tree**. No new bound-node kind is introduced. The narrowing is recorded on the existing `BoundVariableExpression.NarrowedType` slot, which the rewriter (`RewriteVariableExpression`), walker (`VisitVariableExpression`), printer (`WriteVariableExpression`), and spiller (`SpillSequenceSpiller`) already handle. The four bound-node exhaustiveness allowlists therefore require no updates.
-- **Closures / lambdas**. The lambda binder pushes a *new* `NarrowedVariables` frame stack when entering a lambda body. The outer frames are saved and restored around the lambda binding so the lambda body binds the captured variable at its declared type. This matches Kotlin's behaviour: a smart cast does not survive into a closure that captures the narrowed variable.
+- **Closures / lambdas**. The lambda binder pushes a *new* `NarrowedVariables` frame stack when entering a lambda body. The outer frames are saved and, prior to issue #2442, unconditionally cleared for the lambda body and restored once binding leaves the lambda. **Issue #2442 amends this**: see the addendum below — a read-only, plain-variable narrowing frame now survives into the new frame stack instead of being cleared.
 
 ## Examples
 
@@ -357,6 +357,94 @@ func CallInvalidates(b Box) {
     if b.Pet is Dog {
         SomethingElse()
         b.Pet.Bark()        // rejected — call may have mutated reachable state
+    }
+}
+```
+
+## Addendum — issue #2442 (narrowing survives closure capture for read-only bindings)
+
+- **Status**: Accepted (addendum)
+- **Related**: parent issue [#706](https://github.com/DavidObando/gsharp/issues/706), this addendum's issue [#2442](https://github.com/DavidObando/gsharp/issues/2442), the #712 and #1180 addenda above.
+
+The original ADR text and both prior addenda state that closure capture unconditionally drops every narrowing: "the narrowing is dropped before binding the lambda body ... the capturing closure binds the variable at its declared type". This addendum supersedes that blanket rule for one specific, provably-sound case: a nil-guard or type-test narrowing on a **read-only, plain-variable root** (no member access) now survives into a captured lambda, local-function literal, or async lambda body.
+
+### Motivation
+
+`if convertAction != nil { Task.Run(() -> convertAction(data)) }`, where `convertAction` is a nil-guarded `let`/by-value parameter of a nullable delegate/function type, is an extremely common pattern (fire-and-forget work, deferred callbacks, `Task.Run`/`go` bodies). Because a `let` local or by-value parameter can never be reassigned once bound, the guard's non-nil proof is still valid for every read reachable from the closure — there is no execution path between the guard and the closure's eventual invocation (however delayed) on which the binding could change. Unconditionally dropping the narrowing here was unnecessarily conservative and produced a spurious `GS0131`/`GS0159` diagnostic cascade for code that is, in fact, sound. Chasing this down as an Oahu-specific special case was explicitly rejected in favor of a general, symbol-mutability-based rule.
+
+### Rule
+
+When entering a lambda / local-function / async-lambda body, each active narrowing frame entry `variable → narrowedType` is preserved into the new (otherwise-cleared) frame stack **if and only if**:
+
+- The narrowing key has **no member-access path** (`AccessPath.HasMembers == false` — see the #1180 addendum). Member-bearing paths (`b.Pet`, `o.Box.Pet`, `self.field`, etc.) are *never* preserved across closure capture, regardless of the root's mutability — a receiver captured by the closure could still be mutated through an alias, and re-validating a member chain across a capture boundary is out of scope for this addendum.
+- The root variable is `IsReadOnly` (a `let` local, or a by-value/`in` parameter — anything the binder already tracks as never assignable after initialization). `var` locals, `ref`/`out` parameters, and any other mutable root are excluded unconditionally.
+
+This is deliberately **not** keyed on symbol *kind* (e.g. "parameters always narrow") — a mutable `var` parameter alias, if the language ever added one, would still be excluded, because the test is `IsReadOnly`, not `is ParameterSymbol`. It is also deliberately conservative about *when* the check is performed: `IsReadOnly` reflects whether the binder can ever observe an assignment to that variable anywhere in the function, so a `let` local or by-value parameter that is written to nowhere in the enclosing function qualifies, while a `var` local reassigned on a completely different, non-overlapping path still does not, because the binder does not attempt path-sensitive "the write happens after every possible closure invocation" reasoning — it conservatively treats *any* write to the root anywhere as disqualifying.
+
+Concretely, this covers:
+
+- A bare nil-guarded `let`/by-value-parameter binding of any callable type — a native G# function type (`(...) -> T`), a same-compilation named delegate (`type F = delegate func(...) T`), a generic named delegate, or an imported CLR delegate (`Func<...>`/custom `delegate`) — invoked directly or indirectly inside a nested lambda, a local function, an async lambda, an escaping/returned closure, or multiple sibling closures capturing the same binding.
+- Conditional invocation and branch-only narrowing carried into the closure (the guard may be nested inside further `if`/branch structure before the closure is created, as long as no write to the root occurs on the path reaching the closure's declaration).
+
+It explicitly does **not** cover, and these continue to drop narrowing (or were never narrowed) exactly as before:
+
+- `var` locals reassigned before or after closure creation (including across a loop).
+- `ref`/`out` parameters.
+- Any member-access path (`self.field`, `b.Pet`, etc.), even when every link is itself individually stable per the #1180 addendum — the combination of member-path stability *and* closure capture is out of scope for this addendum.
+- Captured aliases introduced by boxing (see *Implementation* below) do not change this: boxing is a storage mechanism for write-visibility across sibling closures, not a relaxation of the mutability test that already ran at bind time.
+
+### Soundness argument
+
+A `let` local or by-value/`in` parameter is, by construction, assigned exactly once (at declaration/parameter-binding) and never reassigned for the remainder of its enclosing function — `VariableSymbol.IsReadOnly` is exactly this invariant, already relied upon elsewhere in the binder (e.g. definite-assignment and capture-boxing skip these variables for by-reference semantics). Because there is no program point between the nil-guard and any later read of the binding (including a read from inside a closure invoked synchronously, asynchronously, or after the declaring function has returned) at which the binding's value could change, the guard's non-nil (or type-test) proof remains valid for every such read. This holds regardless of *when* the closure is actually invoked — the value in the binding's storage cell is fixed for the binding's entire lifetime, so no amount of scheduling delay, thread hand-off, or async suspension can invalidate it. Member-access paths are excluded because the same argument does not hold for them: even a `let`-rooted, all-stable-links member path reads through a receiver the closure also captures, and nothing prevents another alias of that receiver — reachable from a different call site the binder cannot see — from mutating a `var` link further down the chain between the guard and the closure's eventual invocation.
+
+### Implementation
+
+- **Binder** (`LambdaBinder.FilterNarrowingsSurvivingClosureCapture`): both closure-entry sites (the block-bodied function-literal path and the arrow-lambda path) now filter the current `NarrowedVariables` frames through this predicate instead of unconditionally clearing them, and push the filtered result as the new frame for the lambda body (still restoring the outer, unfiltered frames on exit, as before).
+- **Emit — capture boxing** (`CaptureBoxingRewriter.RewriteVariableExpression`): issue #523's capture-boxing pass unconditionally hoists every captured local/parameter (mutable or not) into a shared heap cell so multiple closures observe each other's writes; this pass runs before closure synthesis and previously discarded a captured `BoundVariableExpression`'s `NarrowedType` when rewriting the read into a box-field access. It now forwards `NarrowedType` onto the rewritten `BoundFieldAccessExpression` (which already had a `NarrowedType` slot from issue #208's member-narrowing support), so a narrowing proven sound at bind time is not silently lost by this unrelated storage-mechanism rewrite.
+- **Emit — closure display class** (`ClosureEmitter.CaptureRewriter.RewriteVariableExpression`): the closure-synthesis capture rewrite (which runs after boxing and replaces a captured-variable read with a `this.<field>` access on the synthesized display class) likewise now forwards `NarrowedType`, for the same reason.
+- These two emit-side changes were both necessary and are tightly coupled to this fix: once the binder change makes a narrowed, same-compilation named-delegate call newly reachable from inside a closure body, `EmitIndirectCall`'s existing `call.Target.Type is DelegateTypeSymbol` dispatch (in place since ADR-0059 / issue #255, for the direct, non-closure case) depends on the rewritten capture expression still reporting the narrowed (non-nullable, named-delegate) type; without forwarding `NarrowedType` through both rewrites, the dispatch silently fell back to the type-erased `Func<...>`/`Action<...>` `Invoke` overload and produced IL that failed ILVerify (`StackUnexpected`, wrong `Invoke` signature) — a previously-unreachable code path this fix newly exercises, not a pre-existing unrelated defect.
+
+### Examples (addendum)
+
+```gs
+type ConvertFunc = delegate func(data []uint8) []uint8
+
+class DownloadDecryptJob {
+    var runningTasks List[Task] = List[Task]()
+
+    func Convert(data []uint8, convertAction ConvertFunc?) {
+        if convertAction != nil {
+            // `convertAction` is a by-value parameter (IsReadOnly) with no
+            // member path — the narrowing to `ConvertFunc` now survives into
+            // the closure, so this call binds without GS0131/GS0159.
+            runningTasks.Add(Task.Run(() -> {
+                let result = convertAction(data)
+                Console.WriteLine(result.Length)
+            }))
+        }
+    }
+}
+
+// NOT narrowed — `var` root reassigned in the enclosing function
+// (the write need not be reachable before the closure to disqualify it;
+// IsReadOnly reflects "never reassigned anywhere in this function").
+func Retry(convertAction ConvertFunc?) {
+    if convertAction != nil {
+        var handler = convertAction
+        let f = () -> { handler(nil) }   // rejected — `handler` is `var`.
+        handler = nil
+        f()
+    }
+}
+
+// NOT narrowed — member-access path, even though `self` is stable and the
+// field is read-only; member paths never survive closure capture.
+class Job {
+    let convertAction ConvertFunc?
+    func Run(data []uint8) {
+        if self.convertAction != nil {
+            let f = () -> { self.convertAction(data) }  // rejected — GS0131.
+        }
     }
 }
 ```

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -317,13 +317,20 @@ internal sealed class LambdaBinder
             Scope.TryDeclareVariable(ps);
         }
 
-        // ADR-0069 / issue #700: smart-cast narrowings do not survive into a
-        // closure body — the narrowed variable could be reassigned by the
-        // enclosing scope between when the closure is created and when it
-        // runs. Save and restore the outer narrowing-frame stack so the
-        // lambda body binds at the captured variables' declared types.
+        // ADR-0069 / issue #700, amended by issue #2442: a smart-cast
+        // narrowing on a MUTABLE binding does not survive into a closure
+        // body — the narrowed variable could be reassigned by the enclosing
+        // scope between when the closure is created and when it runs. A
+        // narrowing on a read-only plain-variable binding (`let`, or a
+        // by-value/`in` parameter) is different: it can never be reassigned
+        // anywhere, so it survives unconditionally — see
+        // FilterNarrowingsSurvivingClosureCapture. Save the full outer
+        // frame stack so it can be restored verbatim once binding leaves the
+        // closure; only the filtered copy is visible while the body binds.
         var savedNarrowed = binderCtx.NarrowedVariables.ToList();
+        var survivingNarrowed = FilterNarrowingsSurvivingClosureCapture(savedNarrowed);
         binderCtx.NarrowedVariables.Clear();
+        binderCtx.NarrowedVariables.AddRange(survivingNarrowed);
 
         // Issue #2027: a function literal (lambda OR local function — this
         // method binds both) is its own goto/label frame; isolate it from
@@ -686,8 +693,16 @@ internal sealed class LambdaBinder
             Scope.TryDeclareVariable(ps);
         }
 
+        // ADR-0069 / issue #700, amended by issue #2442: see the matching
+        // comment in BindFunctionLiteralExpression — a read-only
+        // plain-variable narrowing survives into the arrow-lambda body
+        // unconditionally; every other narrowing (mutable `var` locals,
+        // ref/out parameters, member-access paths) is dropped exactly as
+        // before.
         var savedNarrowed = binderCtx.NarrowedVariables.ToList();
+        var survivingNarrowed = FilterNarrowingsSurvivingClosureCapture(savedNarrowed);
         binderCtx.NarrowedVariables.Clear();
+        binderCtx.NarrowedVariables.AddRange(survivingNarrowed);
 
         // Issue #2027: an arrow lambda is its own goto/label frame — a
         // block-bodied arrow lambda (`x => { ...; goto foo; foo: ...; }`)
@@ -1027,6 +1042,80 @@ internal sealed class LambdaBinder
         }
 
         return element;
+    }
+
+    /// <summary>
+    /// ADR-0069 amendment / issue #2442: computes the subset of the enclosing
+    /// scope's active narrowing frames that may legally survive into a
+    /// captured closure body (a lambda or local function literal).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A narrowing entry keyed on <see cref="AccessPath"/> <c>p</c> survives
+    /// into the closure only when <c>p.Root.IsReadOnly</c> is
+    /// <see langword="true"/> AND <c>p</c> is a plain variable path
+    /// (<c>!p.HasMembers</c>). <see cref="VariableSymbol.IsReadOnly"/> is the
+    /// binder's own "can never be reassigned" fact — it is exactly the
+    /// signal <see cref="ExpressionBinder"/> already consults to reject
+    /// <em>any</em> assignment to the variable (a <c>let</c> local, or a
+    /// by-value / <c>in</c> function parameter), and it is deliberately
+    /// <see langword="false"/> for <c>var</c> locals, <c>ref</c>/<c>out</c>
+    /// parameters, and <c>let ref</c>/<c>var ref</c> aliasing locals (which
+    /// bind a managed pointer to possibly-external storage — see
+    /// <c>StatementBinder.Narrowing.cs</c>'s ref-local declaration path,
+    /// which passes <c>isReadOnly: false</c> unconditionally). Because a
+    /// read-only binding can never be written again anywhere in its scope,
+    /// the value a nil-guard or <c>is</c>-test proved at the guard site can
+    /// never change later — no matter when the closure that captured it
+    /// eventually runs: immediately and synchronously (<c>Task.Run(() =>
+    /// …)</c>), after the enclosing function returns (an escaping/stored
+    /// delegate), repeatedly (invoked from inside a loop), concurrently on
+    /// another thread, or after an <c>await</c> suspension point. This is a
+    /// strictly stronger guarantee than "not reassigned along this
+    /// particular flow path": it holds for every path, so no additional
+    /// temporal/flow proof is required.
+    /// </para>
+    /// <para>
+    /// Member-access paths (<c>x.member</c>) are always dropped even when
+    /// the root is read-only: the ADR-0069 addendum (issue #1180) already
+    /// treats member reads as fragile because another call or another
+    /// receiver's assignment could mutate the member through an alias the
+    /// closure's own narrowing analysis never observes — the same reasoning
+    /// <see cref="StatementBinder.InvalidateNarrowingsForAssignedVariables(SyntaxNode)"/>
+    /// applies at ordinary statement boundaries. Widening that guarantee to
+    /// "safe forever, even across a closure capture" would be unsound, so
+    /// this method conservatively keeps the pre-existing behaviour (drop) for
+    /// every member-bearing key.
+    /// </para>
+    /// </remarks>
+    /// <param name="outerFrames">
+    /// The enclosing scope's narrowing-frame stack at the point the closure
+    /// literal is entered (a snapshot copy — not mutated by this method).
+    /// </param>
+    /// <returns>
+    /// A new frame stack, parallel in shape to <paramref name="outerFrames"/>,
+    /// containing only the entries that are sound to keep visible while
+    /// binding the closure body.
+    /// </returns>
+    private static List<Dictionary<AccessPath, TypeSymbol>> FilterNarrowingsSurvivingClosureCapture(
+        List<Dictionary<AccessPath, TypeSymbol>> outerFrames)
+    {
+        var result = new List<Dictionary<AccessPath, TypeSymbol>>(outerFrames.Count);
+        foreach (var frame in outerFrames)
+        {
+            var survivors = new Dictionary<AccessPath, TypeSymbol>();
+            foreach (var entry in frame)
+            {
+                if (!entry.Key.HasMembers && entry.Key.Root.IsReadOnly)
+                {
+                    survivors[entry.Key] = entry.Value;
+                }
+            }
+
+            result.Add(survivors);
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
@@ -537,11 +537,29 @@ internal sealed class ClosureEmitter
         {
             if (this.captureFields.TryGetValue(node.Variable, out var field))
             {
+                // Issue #2442: a read-only narrowed binding (see LambdaBinder's
+                // FilterNarrowingsSurvivingClosureCapture) carries a non-null
+                // NarrowedType on the pre-rewrite BoundVariableExpression — e.g.
+                // a nil-guarded named-delegate parameter narrowed from `T?` to
+                // `T` before the closure captured it. The synthesized capture
+                // field is always declared with the ORIGINAL (possibly
+                // nullable) variable type, so without forwarding NarrowedType
+                // here the rewritten field access reverts to that nullable
+                // view. EmitIndirectCall keys its named-delegate-vs-type-erased
+                // Invoke dispatch on the bound target expression's Type, so
+                // losing the narrowing here — despite it having been proven
+                // sound at bind time — causes the wrong Invoke overload to be
+                // emitted and invalid IL (ILVerify StackUnexpected). Forwarding
+                // the narrowed type mirrors the existing narrowed-field-access
+                // mechanism (issue #208) and keeps the field handle itself
+                // unchanged, so this only affects the static type surfaced to
+                // later phases, not runtime storage.
                 return new BoundFieldAccessExpression(
                     null,
                     new BoundVariableExpression(null, this.thisParam),
                     this.closureClass,
-                    field);
+                    field,
+                    node.NarrowedType);
             }
 
             return node;

--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -566,11 +566,27 @@ internal static class CaptureBoxingRewriter
         {
             if (this.boxInfo.TryGetValue(node.Variable, out var bi))
             {
+                // Issue #2442: forward a bind-time narrowed type (see
+                // LambdaBinder's FilterNarrowingsSurvivingClosureCapture) onto
+                // the rewritten box-field access. Boxing runs before
+                // ClosureEmitter's own capture rewrite and unconditionally
+                // wraps every captured local/parameter — including read-only
+                // bindings the binder has already proven safe to narrow
+                // across closure capture — in a heap cell purely for
+                // write-visibility semantics (see class remarks above); it
+                // does not itself introduce any new mutation. Dropping
+                // NarrowedType here would make EmitIndirectCall's
+                // `call.Target.Type is DelegateTypeSymbol` dispatch see the
+                // box field's declared (possibly nullable) type instead,
+                // selecting the wrong Invoke overload and producing invalid
+                // IL (ILVerify StackUnexpected) for a narrowed named-delegate
+                // call inside a closure.
                 return new BoundFieldAccessExpression(
                     null,
                     new BoundVariableExpression(null, bi.BoxLocal),
                     bi.BoxClass,
-                    bi.BoxField);
+                    bi.BoxField,
+                    node.NarrowedType);
             }
 
             return node;

--- a/test/Compiler.Tests/Emit/Issue2442ClosureCallableNarrowingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2442ClosureCallableNarrowingEmitTests.cs
@@ -1,0 +1,235 @@
+// <copyright file="Issue2442ClosureCallableNarrowingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// ADR-0069 amendment / issue #2442 — end-to-end compile + IL-verify + run
+/// coverage for the closure-callable-narrowing fix: a nil-guard's smart-cast
+/// narrowing on a read-only, plain-variable binding (a <c>let</c> local or a
+/// by-value/<c>in</c> parameter) now survives into a captured lambda / local
+/// function / async lambda body, and the emitted IL both verifies and
+/// actually invokes the guarded delegate at runtime.
+/// </summary>
+public class Issue2442ClosureCallableNarrowingEmitTests
+{
+    [Fact]
+    public void DownloadDecryptJobShape_NamedDelegateField_InvokesInsideTaskRunClosure()
+    {
+        var source = """
+            package Issue2442Pkg
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            type ConvertFunc = delegate func(data []uint8) []uint8
+
+            class DownloadDecryptJob {
+                var runningTasks List[Task] = List[Task]()
+
+                func Convert(data []uint8, convertAction ConvertFunc?) {
+                    if convertAction != nil {
+                        runningTasks.Add(Task.Run(() -> {
+                            let result = convertAction(data)
+                            Console.WriteLine(result.Length)
+                        }))
+                    }
+                    for t in runningTasks {
+                        t.Wait()
+                    }
+                }
+            }
+
+            var conv ConvertFunc = (data []uint8) -> { return []uint8{data[0] * 2} }
+            let job = DownloadDecryptJob()
+            job.Convert([]uint8{21}, conv)
+            """;
+
+        Assert.Equal("1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LetParameter_NamedDelegate_InvokedInsideArrowLambda()
+    {
+        var source = """
+            package Issue2442Pkg
+            import System
+
+            type ConvertFunc = delegate func(data int32) int32
+
+            func Run(convertAction ConvertFunc?, data int32) {
+                if convertAction != nil {
+                    let f = () -> { Console.WriteLine(convertAction(data)) }
+                    f()
+                }
+            }
+
+            var conv ConvertFunc = (x int32) -> { return x * 3 }
+            Run(conv, 7)
+            """;
+
+        Assert.Equal("21\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EscapingClosure_ReturnedAndInvokedAfterDeclaringFunctionReturns()
+    {
+        var source = """
+            package Issue2442Pkg
+            import System
+
+            type ConvertFunc = delegate func(data int32) int32
+
+            func Make(convertAction ConvertFunc?, data int32) (() -> void)? {
+                if convertAction != nil {
+                    return () -> { Console.WriteLine(convertAction(data)) }
+                }
+                return nil
+            }
+
+            var conv ConvertFunc = (x int32) -> { return x + 1 }
+            let f = Make(conv, 41)
+            if f != nil {
+                f()
+            }
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void AsyncLambda_InvokesAfterAwaitSuspension()
+    {
+        var source = """
+            package Issue2442Pkg
+            import System
+            import System.Threading.Tasks
+
+            type ConvertFunc = delegate func(data int32) int32
+
+            func Run(convertAction ConvertFunc?, data int32) {
+                if convertAction != nil {
+                    let task = Task.Run(async () -> {
+                        await Task.Delay(1)
+                        Console.WriteLine(convertAction(data))
+                    })
+                    task.Wait()
+                }
+            }
+
+            var conv ConvertFunc = (x int32) -> { return x * x }
+            Run(conv, 6)
+            """;
+
+        Assert.Equal("36\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void MultipleClosures_CapturingSameReadOnlyBinding_BothInvokeCorrectly()
+    {
+        var source = """
+            package Issue2442Pkg
+            import System
+
+            type ConvertFunc = delegate func(data int32) int32
+
+            func Run(convertAction ConvertFunc?, data int32) {
+                if convertAction != nil {
+                    let f1 = () -> { Console.WriteLine(convertAction(data)) }
+                    let f2 = () -> { Console.WriteLine(convertAction(data + 1)) }
+                    f1()
+                    f2()
+                }
+            }
+
+            var conv ConvertFunc = (x int32) -> { return -x }
+            Run(conv, 5)
+            """;
+
+        Assert.Equal("-5\n-6\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Path.Combine(AppContext.BaseDirectory, "Issue2442_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2442ClosureCallableNarrowingBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2442ClosureCallableNarrowingBinderTests.cs
@@ -1,0 +1,423 @@
+// <copyright file="Issue2442ClosureCallableNarrowingBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0069 amendment / issue #2442 — a nil-guard's smart-cast narrowing on a
+/// <em>read-only, plain-variable</em> binding (a <c>let</c> local or a
+/// by-value/<c>in</c> function parameter) now survives into a captured
+/// lambda or local-function body, instead of being unconditionally cleared
+/// the way every other narrowing (mutable <c>var</c> locals, <c>ref</c>/
+/// <c>out</c> parameters, member-access paths) still is.
+/// </summary>
+/// <remarks>
+/// The bug's original fingerprint (Oahu's <c>DownloadDecryptJob</c>) is a
+/// nullable, <em>named</em> G# delegate type
+/// (<c>type X = delegate func(...) ...</c>) invoked via direct call syntax
+/// inside <c>Task.Run(() -&gt; ...)</c>. A bare native G# arrow function type
+/// (<c>(...) -&gt; ...)?</c>) or an imported CLR generic delegate
+/// (<c>System.Func&lt;...&gt;</c>/<c>Action&lt;...&gt;</c>) both erase to a
+/// real CLR delegate <see cref="System.Type"/> at the
+/// <c>NullableTypeSymbol</c>/<c>FunctionTypeSymbol</c> level, so
+/// <c>OverloadResolver.CallBinding</c>'s "ClrType is a delegate type"
+/// fallback binds the call successfully whether or not any narrowing is in
+/// scope — a separate, pre-existing quirk this issue does not change. Only a
+/// same-compilation <c>DelegateTypeSymbol</c> reaches the
+/// narrowing-dependent branch and therefore reproduces the reported GS0131.
+/// Both shapes are covered below: the named-delegate cases prove the fix,
+/// the bare-function-type/CLR-delegate cases are regression coverage.
+/// </remarks>
+public class Issue2442ClosureCallableNarrowingBinderTests
+{
+    private const string NamedDelegate = "type ConvertFunc = delegate func(data []uint8) []uint8\n";
+
+    // ---- Positive: the exact reported shape -------------------------------
+
+    [Fact]
+    public void DownloadDecryptJobShape_NamedDelegateField_NarrowsInsideTaskRunClosure()
+    {
+        var result = Evaluate(@"
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+" + NamedDelegate + @"
+class DownloadDecryptJob {
+    var runningTasks List[Task] = List[Task]()
+
+    func Convert(data []uint8, convertAction ConvertFunc?) {
+        if convertAction != nil {
+            runningTasks.Add(Task.Run(() -> {
+                let result = convertAction(data)
+            }))
+        }
+    }
+}
+");
+
+        AssertClean(result);
+    }
+
+    [Fact]
+    public void LetParameter_NamedDelegate_DirectInvokeInsideArrowLambda()
+    {
+        var result = Evaluate(NamedDelegate + @"
+func Run(convertAction ConvertFunc?, data []uint8) {
+    if convertAction != nil {
+        let f = () -> { convertAction(data) }
+        f()
+    }
+}
+Run(nil, []uint8{})
+");
+
+        AssertClean(result);
+    }
+
+    [Fact]
+    public void ByValueParameter_NarrowsInsideLocalFunction()
+    {
+        // A local function is a `let Name = func() { ... }` function-literal
+        // declaration — its captured-variable analysis goes through the same
+        // BindFunctionLiteralExpression entry point as an ordinary lambda.
+        var result = Evaluate(NamedDelegate + @"
+func Run(convertAction ConvertFunc?, data []uint8) {
+    if convertAction != nil {
+        let Inner = func() {
+            convertAction(data)
+        }
+        Inner()
+    }
+}
+Run(nil, []uint8{})
+");
+
+        AssertClean(result);
+    }
+
+    [Fact]
+    public void LetLocal_CopiedFromParameter_NarrowsInsideClosure()
+    {
+        var result = Evaluate(NamedDelegate + @"
+func Run(convertActionIn ConvertFunc?, data []uint8) {
+    let convertAction = convertActionIn
+    if convertAction != nil {
+        let f = () -> { convertAction(data) }
+        f()
+    }
+}
+Run(nil, []uint8{})
+");
+
+        AssertClean(result);
+    }
+
+    // ---- Positive: closure execution/lifetime shapes ----------------------
+
+    [Fact]
+    public void NestedLambdas_InnerClosureStillSeesNarrowing()
+    {
+        var result = Evaluate(NamedDelegate + @"
+func Run(convertAction ConvertFunc?, data []uint8) {
+    if convertAction != nil {
+        let outer = () -> {
+            let inner = () -> { convertAction(data) }
+            inner()
+        }
+        outer()
+    }
+}
+Run(nil, []uint8{})
+");
+
+        AssertClean(result);
+    }
+
+    [Fact]
+    public void MultipleClosures_CapturingSameReadOnlyBinding_BothNarrow()
+    {
+        var result = Evaluate(NamedDelegate + @"
+func Run(convertAction ConvertFunc?, data []uint8) {
+    if convertAction != nil {
+        let f1 = () -> { convertAction(data) }
+        let f2 = () -> { convertAction(data) }
+        f1()
+        f2()
+    }
+}
+Run(nil, []uint8{})
+");
+
+        AssertClean(result);
+    }
+
+    [Fact]
+    public void EscapingClosure_ReturnedFromDeclaringFunction_StillNarrows()
+    {
+        // The closure runs strictly after the declaring function has
+        // returned — the read-only rule must hold across that boundary too,
+        // since a `let`/by-value parameter cannot be reassigned regardless
+        // of when or how many times the escaping delegate is later invoked.
+        var result = Evaluate(NamedDelegate + @"
+func Make(convertAction ConvertFunc?, data []uint8) (() -> void)? {
+    if convertAction != nil {
+        return () -> { convertAction(data) }
+    }
+    return nil
+}
+let f = Make(nil, []uint8{})
+");
+
+        AssertClean(result);
+    }
+
+    [Fact]
+    public void AsyncLambda_NarrowsAcrossAwaitSuspension()
+    {
+        var result = Evaluate(@"
+import System.Threading.Tasks
+" + NamedDelegate + @"
+func Run(convertAction ConvertFunc?, data []uint8) {
+    if convertAction != nil {
+        let task = Task.Run(async () -> {
+            await Task.Delay(1)
+            convertAction(data)
+        })
+    }
+}
+Run(nil, []uint8{})
+");
+
+        AssertClean(result);
+    }
+
+    [Fact]
+    public void ConditionalInvocation_InsideClosureBody_StillNarrows()
+    {
+        var result = Evaluate(NamedDelegate + @"
+func Run(convertAction ConvertFunc?, data []uint8, flag bool) {
+    if convertAction != nil {
+        let f = () -> {
+            if flag {
+                convertAction(data)
+            }
+        }
+        f()
+    }
+}
+Run(nil, []uint8{}, true)
+");
+
+        AssertClean(result);
+    }
+
+    [Fact]
+    public void NestedBranch_NarrowingEstablishedInInnerIf_SurvivesClosure()
+    {
+        var result = Evaluate(NamedDelegate + @"
+func Run(convertAction ConvertFunc?, data []uint8, flag bool) {
+    if flag {
+        if convertAction != nil {
+            let f = () -> { convertAction(data) }
+            f()
+        }
+    }
+}
+Run(nil, []uint8{}, true)
+");
+
+        AssertClean(result);
+    }
+
+    [Fact]
+    public void GenericNamedDelegate_NarrowsInsideClosure()
+    {
+        var result = Evaluate(@"
+type Transform[T any] = delegate func(v T) T
+func Run[T](a Transform[T]?, v T) T {
+    if a != nil {
+        let f = () -> { return a(v) }
+        return f()
+    }
+    return v
+}
+Run[int32](nil, 1)
+");
+
+        AssertClean(result);
+    }
+
+    // ---- Positive: coverage for bare function types and CLR delegates -----
+    //
+    // These shapes never reproduced GS0131 (see the class remarks) because
+    // OverloadResolver.CallBinding's ClrType-delegate fallback already binds
+    // the call regardless of narrowing. They are kept as permanent
+    // regression coverage: the closure-narrowing rule must not regress
+    // these either, even though they were never the differentiating case.
+
+    [Fact]
+    public void BareNullableFunctionType_NarrowsInsideClosure()
+    {
+        var result = Evaluate(@"
+func Run(convertAction (([]uint8) -> []uint8)?, data []uint8) {
+    if convertAction != nil {
+        let f = () -> { convertAction(data) }
+        f()
+    }
+}
+Run(nil, []uint8{})
+");
+
+        AssertClean(result);
+    }
+
+    [Fact]
+    public void ClrGenericDelegate_NarrowsInsideClosure()
+    {
+        var result = Evaluate(@"
+import System
+func Run(convertAction Func[[]uint8, []uint8]?, data []uint8) {
+    if convertAction != nil {
+        let f = () -> { convertAction(data) }
+        f()
+    }
+}
+Run(nil, []uint8{})
+");
+
+        AssertClean(result);
+    }
+
+    // ---- Negative: mutation, aliasing, and member-path cases must still
+    //      drop the narrowing (unsound to preserve) --------------------------
+
+    [Fact]
+    public void MutableVarLocal_ReassignedBeforeClosureCreation_DoesNotNarrow()
+    {
+        var result = Evaluate(NamedDelegate + @"
+func Run(convertActionIn ConvertFunc?, data []uint8) {
+    var convertAction = convertActionIn
+    if convertAction != nil {
+        convertAction = nil
+        let f = () -> { convertAction(data) }
+        f()
+    }
+}
+Run(nil, []uint8{})
+");
+
+        AssertContainsError(result, "GS0131");
+    }
+
+    [Fact]
+    public void MutableVarLocal_ReassignedAfterClosureCreation_DoesNotNarrow()
+    {
+        // The closure is created while `convertAction` is still narrowed,
+        // but the enclosing scope reassigns it before the closure actually
+        // runs — exactly the hazard ADR-0069 exists to prevent for mutable
+        // bindings. `var` is not `IsReadOnly`, so the fix's filter still
+        // drops this narrowing, unchanged from pre-#2442 behavior.
+        var result = Evaluate(NamedDelegate + @"
+func Run(convertActionIn ConvertFunc?, data []uint8) {
+    var convertAction = convertActionIn
+    if convertAction != nil {
+        let f = () -> { convertAction(data) }
+        convertAction = nil
+        f()
+    }
+}
+Run(nil, []uint8{})
+");
+
+        AssertContainsError(result, "GS0131");
+    }
+
+    [Fact]
+    public void MutableVarLocal_ReassignedAcrossLoopIterations_DoesNotNarrow()
+    {
+        var result = Evaluate(NamedDelegate + @"
+func Run(convertActionIn ConvertFunc?, data []uint8) {
+    var convertAction = convertActionIn
+    for i in 0...3 {
+        if convertAction != nil {
+            let f = () -> { convertAction(data) }
+            f()
+        }
+        convertAction = nil
+    }
+}
+Run(nil, []uint8{})
+");
+
+        AssertContainsError(result, "GS0131");
+    }
+
+    [Fact]
+    public void RefParameter_DoesNotNarrow()
+    {
+        // A `ref` parameter aliases external, possibly-shared storage; it is
+        // not `IsReadOnly` (RefKind != None/In), so it is excluded by the
+        // same filter that already excludes `var` locals.
+        var result = Evaluate(NamedDelegate + @"
+func Run(ref convertAction ConvertFunc?, data []uint8) {
+    if convertAction != nil {
+        let f = () -> { convertAction(data) }
+        f()
+    }
+}
+");
+
+        Assert.Contains(result.Diagnostics, d => d.IsError);
+    }
+
+    [Fact]
+    public void MemberAccessPath_ClassFieldNarrowing_DoesNotSurviveClosure()
+    {
+        // Member paths are always dropped across a closure boundary, even
+        // when the receiver and field are both otherwise stable/read-only —
+        // this mirrors the ADR-1180 member-path addendum: a member read
+        // could be mutated through an alias the narrowing analysis never
+        // observes, so widening the "read-only survives" rule to member
+        // paths would be unsound.
+        var result = Evaluate(NamedDelegate + @"
+class Box {
+    let convertAction ConvertFunc?
+}
+func Run(box Box, data []uint8) {
+    if box.convertAction != nil {
+        let f = () -> { box.convertAction(data) }
+        f()
+    }
+}
+Run(Box{convertAction: nil}, []uint8{})
+");
+
+        Assert.Contains(result.Diagnostics, d => d.IsError);
+    }
+
+    private static void AssertClean(EvaluationResult result)
+    {
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static void AssertContainsError(EvaluationResult result, string diagnosticId)
+    {
+        Assert.Contains(result.Diagnostics, d => d.IsError && d.Id == diagnosticId);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2442.

`LambdaBinder` unconditionally cleared **all** ADR-0069 smart-cast narrowing frames whenever it bound a closure body (block-bodied function literal or arrow lambda). That is sound for mutable bindings (`var`, fields/properties, `ref`/`out` params, captured aliases) but unsoundly *conservative* for read-only, non-member bindings (by-value parameters and `let` locals) that provably cannot be reassigned on any path between the nil-guard and the closure's execution.

This is exactly the shape used by `DownloadDecryptJob.DecryptAsync` in Oahu.Core: guard `convertAction is not nil`, then invoke it inside `Task.Run(() => convertAction(...))`. gsc reverted `convertAction` to its nullable declared type inside the lambda and reported `GS0131` (call-binding failure) plus `GS0159` cascades on the surrounding `Task.Run`/collection-add calls.

## Fix

**`src/Core/CodeAnalysis/Binding/LambdaBinder.cs`** — added `FilterNarrowingsSurvivingClosureCapture`, applied at both closure-entry points (block-bodied function literal, arrow lambda). It keeps only narrowing entries whose access path has **no member accesses** and whose **root symbol `IsReadOnly`**. `var` locals, fields/properties, `ref`/`out` parameters, captured aliases, and any path involving member access are still conservatively cleared — this is a targeted soundness relaxation, not a blanket "parameter ⇒ narrow" rule.

Fixing the binder exposed two pre-existing, tightly-coupled invalid-IL bugs in the capture-lowering pipeline: both `CaptureBoxingRewriter` (issue #523's unconditional capture boxing, runs first) and `ClosureEmitter`'s `CaptureRewriter` (runs second, at closure-display-class synthesis) silently dropped `NarrowedType` when reconstructing a captured variable's field-access node. Losing it before `EmitIndirectCall`'s dispatch check caused the wrong (`Func<...>`-erased) `Invoke` signature to be selected instead of the named delegate's own, producing IL that ILVerify correctly rejects as `StackUnexpected`. Both rewriters now forward `node.NarrowedType`.

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue2442ClosureCallableNarrowingBinderTests.cs` (18 tests): narrowing survival/loss across lambdas, local functions, `let`/`var`/parameters, writes before/after capture, branches, loops, async lambdas, escaping closures, multiple closures, generic callables, bare nullable function types and named CLR delegates, member-access and mutation negative cases.
- `test/Compiler.Tests/Emit/Issue2442ClosureCallableNarrowingEmitTests.cs` (5 tests): end-to-end compile + ILVerify + runtime execution, including the exact `DownloadDecryptJob` shape, an async-lambda suspension case, an escaping-closure case, and multiple closures sharing one narrowed binding.

All 23 new tests pass.

## Docs

`docs/adr/0069-smart-cast-flow-narrowing.md`: amended the "closure capture" and "closures / lambdas" bullets to note the blanket rule is superseded for read-only, non-member bindings, and added an addendum documenting the rule, the soundness argument, and the implementation (including why the two emit-side fixes were in-scope).

## Full suite results

Run with `MSBUILDDISABLENODEREUSE=1` (and `RunConfiguration.DisableParallelization=true` for Cs2Gs.Tests):

| Suite | Result |
|---|---|
| Core.Tests | 6400 passed, 0 failed, 1 skipped |
| Compiler.Tests | 3151 passed, 0 failed |
| InternalAnalyzers.Tests | 7 passed, 0 failed |
| Cs2Gs.Tests (serialized) | 1543 passed, 0 failed |

SDK repacked (Release), `.nugs/` refreshed, matching NuGet cache cleared, `e2etests/sdk-e2e.sh` smoke test passes.

## Migration corpus report

I re-ran the read-only Oahu.Core migration corpus (`cs2gs migrate --app corpus/Oahu.Core`) against the real Oahu.Core source, comparing a build of `gsc` from the exact pre-fix base commit (`712cf3fa`) against this branch's `gsc`, with everything else (pipeline binary, corpus, restore state) held identical:

- **Full-project compile stage: 81 diagnostics before, 81 after (no change observed at this granularity).** The specific `GS0131`/`GS0159` closure-narrowing cascade this issue targets does not appear in either run's diagnostic list, because ~10 other pre-existing, unrelated diagnostics earlier in the same file/function (`Cannot find member` on data-model properties, `Book?`→`Book` mismatches from cross-project nullability gaps, `ProgressMessage` arg-count mismatches) are hit first and suppress/mask further analysis of that scope before the binder reaches the `convertAction` call site — i.e., the full corpus is currently blocked by several unrelated, pre-existing translation/binding gaps before this fix's effect can be observed there.
- I confirmed the exact reproducing pattern **is** present verbatim in the translated source (`DownloadDecryptJob.gs` lines 139–155: nil-guard, then `Task.Run(() -> convertAction(...))` on the narrowed parameter) — it's just not independently observable in the full-corpus run due to the masking above. The dedicated 18+5 test suite added in this PR isolates and directly proves the fix against this exact shape (before this fix: `GS0131` + `GS0159` cascades and/or `ILVerify StackUnexpected`; after: clean compile, verifiable IL, correct runtime output).
- I could not reproduce the task's assumed baseline of "29 total diagnostics, expect root+2 cascades" reduction. The most recent prior historical artifact available in this environment (`oahu-repro/post-fix-2432`, built from a different, stale worktree) showed **32** total diagnostics (1×`GS0131`, 6×`GS0159` among them), not 29. My own fresh, apples-to-apples rerun (identical corpus/pipeline, only the `gsc` build swapped between the exact pre-fix commit and this branch) shows **81** total diagnostics in both states — this discrepancy versus both "29" and "32" is most likely explained by the corpus/restore state or `gsc` version differing between historical runs; I'm reporting the honestly-measured numbers rather than forcing a match.
- **Next independent blocker (not fixed here):** `GS0158` ("Cannot find member ...") is the largest remaining category (31 occurrences, concentrated in `BookLibrary.gs` and `AaxExporter.gs`), for properties like `FileSizeBytes`, `RunTimeLengthSeconds`, `Series`, `Authors`, `Asin` — these look like members of entity/record types defined in a sibling project (`Oahu.Data`/`Oahu.BooksDatabase`) that aren't being resolved when referenced cross-project. `GS0159` ("Cannot find function ...", 20 occurrences) is largely missing LINQ extension-method resolution (`Select`, `Add`, `FirstOrDefault`, `Append`, `ThenInclude`) in the same cross-project context. Either would be a reasonable next migration blocker to investigate independently.

No changes were made to the private Oahu repository; the migration re-run was strictly read-only (verified `git status --short` clean in the Oahu checkout before and after).
