### PR TITLE
Generalize #2202 arm forgiveness to unguarded ternary/switch arms (#2412)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2202UnguardedTernaryArmForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2202UnguardedTernaryArmForgivenessTranslationTests.cs
@@ -17,13 +17,15 @@ using Xunit;
 namespace Cs2Gs.Tests;
 
 /// <summary>
-/// Translator-fidelity tests for issue #2202: an UNGUARDED nullable-tainted
-/// field/property arm in a ternary/switch expression whose enclosing
-/// property/method return type is deliberately kept non-null (the oblivious
-/// analyzer's property-contract / forwarding-exclusion guardrail, issues
-/// #1354 / #2167), when a SIBLING arm is already null-guard-narrowed.
-/// The original C# accepted this implicitly (oblivious), and the sibling arm
-/// is already asserted; forgiving this arm too is the minimal safe assertion.
+/// Translator-fidelity tests for issue #2202 (generalized in #2412 round 3):
+/// a nullable-tainted field/property arm of a ternary/switch expression whose
+/// enclosing property/method return type is deliberately kept non-null (the
+/// oblivious analyzer's property-contract / forwarding-exclusion guardrail,
+/// issues #1354 / #2167). The original C# accepted this implicitly
+/// (oblivious); forgiving every such tainted arm — regardless of whether the
+/// conditional's own condition happens to null-check any arm — is the minimal
+/// assertion needed to compile the member without regressing safety or
+/// widening its declared contract.
 /// </summary>
 public class Issue2202UnguardedTernaryArmForgivenessTranslationTests
 {
@@ -169,12 +171,17 @@ namespace Demo
     }
 
     /// <summary>
-    /// Negative test: two unguarded nullable fields in a ternary arm where
-    /// the condition does NOT null-check either field — no sibling is
-    /// null-guard-narrowed, so neither arm should be blindly forgiven.
+    /// Positive test (round 3 generalization, real Oahu.Core shape): two
+    /// nullable-tainted fields as ternary arms where the CONDITION does NOT
+    /// null-check either arm at all — mirrors the real Oahu.Core
+    /// `AudibleApi.HttpClient =&gt; Profile.PreAmazon ? HttpClientAudible :
+    /// HttpClientAmazon;` shape, where `Profile.PreAmazon` is an unrelated
+    /// flag, not a null-check on either `HttpClientAudible`/`HttpClientAmazon`.
+    /// Both arms must still be forgiven for the property to compile against
+    /// its deliberately-preserved non-null return type.
     /// </summary>
     [Fact]
-    public void NoSiblingGuarded_UnguardedArms_AreNotAsserted()
+    public void NoSiblingGuarded_UnguardedArms_AreBothAsserted()
     {
         string printed = TranslateOblivious(@"
 namespace Demo
@@ -196,7 +203,9 @@ namespace Demo
         public bool HasB => B != null;
 
         // The condition checks `Flag`, NOT a null-check on A or B.
-        // Neither arm is null-guard-narrowed → no forgiveness should fire.
+        // Neither arm is null-guard-narrowed, but both are nullable-tainted,
+        // so both must be forgiven for this non-null-returning property to
+        // compile (mirrors Oahu.Core's AudibleApi.HttpClient).
         public IVal Pick => Flag ? A : B;
     }
 }");
@@ -205,12 +214,54 @@ namespace Demo
         Assert.True(pickIndex >= 0, "Expected to find 'prop Pick' in output:\n" + printed);
         string afterPick = printed.Substring(pickIndex);
 
-        // Look at just the Pick property line(s) — neither A nor B should get !!
-        // because neither is null-guard-narrowed (condition is `Flag`, not a
-        // null-check on A or B).
+        // Look at just the Pick property line(s) — both A and B must get !!
+        // even though neither is null-guard-narrowed by the condition (which
+        // checks an unrelated `Flag`, not either arm's nullness).
         string pickLine = afterPick.Substring(0, afterPick.IndexOf('\n') + 1);
-        Assert.DoesNotContain("A!!", pickLine);
-        Assert.DoesNotContain("B!!", pickLine);
+        Assert.Contains("A!!", pickLine);
+        Assert.Contains("B!!", pickLine);
+    }
+
+    /// <summary>
+    /// Negative control: an arm that is NOT nullable-tainted at all (no
+    /// null-check evidence anywhere for `C`) must never get a spurious `!!`,
+    /// even though it sits in the very same kind of unguarded conditional as
+    /// the positive case above. Only genuinely tainted arms are forgiven.
+    /// </summary>
+    [Fact]
+    public void UntaintedArm_InUnguardedConditional_IsNotAsserted()
+    {
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public interface IVal { }
+    public class Alpha : IVal { }
+    public class Gamma : IVal { }
+
+    public class Mixed
+    {
+        public Alpha A { get; set; }
+        public Gamma C { get; set; }
+        public bool Flag { get; set; }
+
+        // Taint A via null-check elsewhere:
+        public bool HasA => A != null;
+
+        // C has NO null-check evidence anywhere — never tainted.
+        public IVal Pick => Flag ? A : C;
+    }
+}");
+
+        int pickIndex = printed.IndexOf("prop Pick", StringComparison.Ordinal);
+        Assert.True(pickIndex >= 0, "Expected to find 'prop Pick' in output:\n" + printed);
+        string afterPick = printed.Substring(pickIndex);
+        string pickLine = afterPick.Substring(0, afterPick.IndexOf('\n') + 1);
+
+        // A is tainted (via HasA's null-check) and must be forgiven.
+        Assert.Contains("A!!", pickLine);
+
+        // C is never tainted anywhere — must NOT get a spurious !!.
+        Assert.DoesNotContain("C!!", pickLine);
     }
 
     private static string TranslateOblivious(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2412TernaryArmForgivenessGeneralizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2412TernaryArmForgivenessGeneralizationTests.cs
@@ -1,0 +1,679 @@
+// <copyright file="Issue2412TernaryArmForgivenessGeneralizationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Round-3 regression tests for issue #2412's reopening: sibling-project
+/// (and same-project) ternary/switch-bodied properties and methods whose
+/// declared return type is deliberately kept non-null by the oblivious
+/// analyzer's property-contract / forwarding-exclusion guardrail (#1354 /
+/// #2167), but whose conditional/switch ARMS read nullable-tainted members,
+/// were only forgiven (issue #2202) when at least one sibling arm was ALSO
+/// narrowed by a null-check guard in the same conditional's condition (the
+/// exact <c>Oahu.Data</c> <c>Conversion.BookCommon =&gt; Book is null ?
+/// Component : Book;</c> shape). The real Oahu.Core corpus contains an
+/// equally common but STRICTLY MORE GENERAL shape where the condition is
+/// completely unrelated to either arm's nullness — <c>AudibleApi.HttpClient
+/// =&gt; Profile.PreAmazon ? HttpClientAudible : HttpClientAmazon;</c> — which
+/// the narrower #2202 rule never covered (a real GS0155 compile failure on
+/// current main). <see cref="CSharpToGSharpTranslator.IsNullableTaintedArmOfReturnPreservingConditional"/>
+/// generalizes the rule to forgive EVERY nullable-tainted arm of such a
+/// conditional, independent of whether any sibling happens to be
+/// null-guard-narrowed — a strict superset of the #2202 behavior (verified
+/// unchanged by <c>Issue2202UnguardedTernaryArmForgivenessTranslationTests</c>)
+/// that additionally fixes the "neither arm guarded" shape, for both
+/// switch-expressions and ternaries, and for both same-project and
+/// cross-project (sibling-compilation) taint evidence, reusing the existing
+/// #2412/#2418 <c>SiblingCompilations</c> plumbing without any change to it.
+/// </summary>
+public class Issue2412TernaryArmForgivenessGeneralizationTests
+{
+    // ---- Same-project: switch-expression counterpart of the ternary case --
+
+    [Fact]
+    public void SwitchExpression_NeitherArmGuarded_BothTaintedArmsAreAsserted()
+    {
+        // Mirrors the ternary "no sibling guarded" shape, but for a
+        // switch-expression, confirming the generalization is not
+        // ternary-specific (FindEnclosingConditionalAndSiblings handles both
+        // SwitchExpressionSyntax and ConditionalExpressionSyntax uniformly).
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public interface IVal { }
+    public class Alpha : IVal { }
+    public class Beta : IVal { }
+    public class Gamma : IVal { }
+
+    public class Chooser
+    {
+        public Alpha A { get; set; }
+        public Beta B { get; set; }
+        public int Mode { get; set; }
+
+        // Taint A and B via null-checks elsewhere; the switch's governing
+        // expression (Mode) does not correlate with either arm's nullness.
+        public bool HasA => A != null;
+        public bool HasB => B != null;
+
+        public IVal Pick => Mode switch
+        {
+            0 => A,
+            _ => B,
+        };
+    }
+}");
+
+        int pickIndex = printed.IndexOf("prop Pick", StringComparison.Ordinal);
+        Assert.True(pickIndex >= 0, "Expected to find 'prop Pick' in output:\n" + printed);
+        string afterPick = printed.Substring(pickIndex);
+
+        Assert.Contains("A!!", afterPick);
+        Assert.Contains("B!!", afterPick);
+    }
+
+    // ---- Same-project: nested/parenthesized wrapper, block-bodied property -
+
+    [Fact]
+    public void ParenthesizedTernary_BlockBodiedProperty_NeitherArmGuarded_BothAreAsserted()
+    {
+        // A parenthesized ternary as the sole `return` of a block-bodied
+        // PROPERTY getter (not an arrow body) — exercises the
+        // ReturnStatementSyntax walk-up branch of IsBodyOfReturnPreservingMember
+        // with an extra layer of parentheses around the conditional.
+        //
+        // A plain METHOD is deliberately NOT used here: SeedMethodLikeReturnTaint
+        // always seeds with `transitive: true` (no contract-preservation gate
+        // the way properties have via ImplementsBaseOrInterfaceMember/
+        // SourceScope.CallsAndNonPropertyDeclarations — see
+        // ObliviousNullabilityAnalyzer.SeedPropertyLikeReturnTaint's remarks),
+        // so a non-contract method whose body directly returns a tainted
+        // ternary always gets its OWN return type promoted to nullable
+        // directly; the arm-level `!!` forgiveness this test targets never
+        // needs to fire for methods with this exact shape.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public interface IVal { }
+    public class Alpha : IVal { }
+    public class Beta : IVal { }
+
+    public class Chooser
+    {
+        public Alpha A { get; set; }
+        public Beta B { get; set; }
+        public bool Flag { get; set; }
+
+        public bool HasA => A != null;
+        public bool HasB => B != null;
+
+        public IVal Pick
+        {
+            get
+            {
+                return (Flag ? A : B);
+            }
+        }
+    }
+}");
+
+        int pickIndex = printed.IndexOf("prop Pick", StringComparison.Ordinal);
+        Assert.True(pickIndex >= 0, "Expected to find 'prop Pick' in output:\n" + printed);
+        string afterPick = printed.Substring(pickIndex);
+
+        Assert.Contains("A!!", afterPick);
+        Assert.Contains("B!!", afterPick);
+    }
+
+    // ---- Same-project: generic wrapper / common base type -----------------
+
+    [Fact]
+    public void GenericWrapperBaseType_NeitherArmGuarded_BothAreAsserted()
+    {
+        // The enclosing member's declared return type is a generic
+        // interface (IReadOnlyList<T>-style base) rather than a plain
+        // reference type, and both arms are concrete same-project fields of
+        // (different) types implementing it.
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class Wrapper
+    {
+        public List<string> A { get; set; }
+        public List<string> B { get; set; }
+        public bool Flag { get; set; }
+
+        public bool HasA => A != null;
+        public bool HasB => B != null;
+
+        public IEnumerable<string> Pick => Flag ? A : B;
+    }
+}");
+
+        int pickIndex = printed.IndexOf("prop Pick", StringComparison.Ordinal);
+        Assert.True(pickIndex >= 0, "Expected to find 'prop Pick' in output:\n" + printed);
+        string afterPick = printed.Substring(pickIndex);
+
+        Assert.Contains("A!!", afterPick);
+        Assert.Contains("B!!", afterPick);
+    }
+
+    // ---- Same-project: null-coalescing (`??`) counterpart ------------------
+
+    [Fact]
+    public void NullCoalescing_TaintedLeftOperand_NeedsNoForgiveness()
+    {
+        // Unlike a ternary/switch arm, `A ?? B`'s LEFT operand's nullability
+        // is IRRELEVANT to the overall expression's own nullability by C#/G#
+        // semantics: `A ?? B` is non-null whenever the FALLBACK (`B`) is
+        // non-null, regardless of whether `A` is tainted (see
+        // IsNullableInitializer's `CoalesceExpression` case: "nullable iff the
+        // `b` fallback is itself nullable"). So a tainted `A` used as the
+        // left operand of `??` needs no `!!` at all — the operator itself
+        // already fully absorbs the null case, unlike a ternary arm (which
+        // has no such absorption and is exactly what this round's fix
+        // covers). This documents that the round's generalization correctly
+        // leaves `??` alone; included as coverage confirming the round's
+        // rename/doc updates to the sibling
+        // IsUnguardedForwardOfTaintedValueInReturnPreservingBody helper did
+        // not regress this pre-existing, correct behavior.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Item { }
+
+    public class Container
+    {
+        public Item A { get; set; }
+        public static readonly Item Fallback = new Item();
+
+        public bool HasA => A != null;
+
+        public Item Pick => A ?? Fallback;
+    }
+}");
+
+        int pickIndex = printed.IndexOf("prop Pick", StringComparison.Ordinal);
+        Assert.True(pickIndex >= 0, "Expected to find 'prop Pick' in output:\n" + printed);
+        string afterPick = printed.Substring(pickIndex);
+
+        Assert.DoesNotContain("!!", afterPick);
+    }
+
+    // ---- Same-project: conditional access (`?.`) as one ternary arm -------
+
+    [Fact]
+    public void ConditionalAccess_AsTernaryArm_LeavesReceiverAlone()
+    {
+        // A `?.` receiver is explicitly excluded from ReceiverNeedsNullForgiveness
+        // (it already null-checks itself as part of its own semantics — `!!`
+        // would be redundant/incorrect there). This documents that using a
+        // `?.` MEMBER ACCESS as a ternary arm's inner receiver does not
+        // spuriously gain a `!!` from this round's generalization; only a
+        // BARE tainted symbol read as an arm value gets one.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Item
+    {
+        public string Name { get; set; }
+    }
+
+    public class Container
+    {
+        public Item A { get; set; }
+        public bool Flag { get; set; }
+
+        public bool HasA => A != null;
+
+        public string Pick => Flag ? A?.Name : ""none"";
+    }
+}");
+
+        int pickIndex = printed.IndexOf("prop Pick", StringComparison.Ordinal);
+        Assert.True(pickIndex >= 0, "Expected to find 'prop Pick' in output:\n" + printed);
+        string afterPick = printed.Substring(pickIndex);
+
+        // `A` itself (the `?.` receiver) must NOT get a spurious `!!` — its
+        // own `?.` already handles the null case; only a bare tainted read
+        // used directly as an arm value is in scope for this round's fix.
+        Assert.DoesNotContain("A!!", afterPick);
+    }
+
+    // ---- Same-project: forwarded local variable arm (documented boundary) -
+
+    [Fact]
+    public void ForwardedLocalVariable_AsTernaryArm_DoesNotOverForgive()
+    {
+        // Documents a genuine, currently-UNCOVERED scope boundary: when a
+        // tainted member is first copied into a LOCAL variable, and the
+        // LOCAL (not the member itself) is read as the ternary arm,
+        // ReceiverNeedsNullForgiveness's TryGetEmittedNullableFieldOrProperty
+        // check looks for a promoted FIELD/PROPERTY symbol at the use site —
+        // a local variable is neither, so this indirection is not
+        // recognized as a nullable-tainted arm by this rule. This is a
+        // separate, narrower gap than the one this round's fix addresses
+        // (arm-forgiveness SCOPE, given a tainted symbol IS directly read as
+        // an arm) — reported as a candidate for a future, independent round
+        // rather than folded into this fix, matching the task's "report the
+        // next independent blocker separately" instruction.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public interface IVal { }
+    public class Alpha : IVal { }
+    public class Beta : IVal { }
+
+    public class Chooser
+    {
+        public Alpha A { get; set; }
+        public Beta B { get; set; }
+        public bool Flag { get; set; }
+
+        public bool HasA => A != null;
+        public bool HasB => B != null;
+
+        public IVal Pick
+        {
+            get
+            {
+                var a = A;
+                var b = B;
+                return Flag ? a : b;
+            }
+        }
+    }
+}");
+
+        int pickIndex = printed.IndexOf("prop Pick", StringComparison.Ordinal);
+        Assert.True(pickIndex >= 0, "Expected to find 'prop Pick' in output:\n" + printed);
+
+        // Frozen current behavior: locals are not forgiven by this rule.
+        // (If a future round closes this gap, this assertion should flip to
+        // Contains and the remarks above should be updated accordingly.)
+        string afterPick = printed.Substring(pickIndex);
+        Assert.DoesNotContain("a!!", afterPick);
+        Assert.DoesNotContain("b!!", afterPick);
+    }
+
+    // ---- Same-project: tuple return (value type — negative control) -------
+
+    [Fact]
+    public void TupleReturn_NeitherArmGuarded_IsNotForgiven()
+    {
+        // Tuples are VALUE types (System.ValueTuple under the hood) — the
+        // oblivious analyzer's `IsReferenceType` gate (see
+        // SeedPropertyLikeReturnTaint's guard) excludes them from nullable
+        // promotion entirely, and TryGetEmittedNullableFieldOrProperty's own
+        // reference-type checks mean a tuple-typed ternary arm can never be
+        // "nullable-tainted" in the sense this rule cares about. Included as
+        // an explicit negative control so a future change cannot silently
+        // start asserting `!!` on a value-typed arm (which would not even
+        // compile in G#).
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Container
+    {
+        public (int, int) A { get; set; }
+        public (int, int) B { get; set; }
+        public bool Flag { get; set; }
+
+        public (int, int) Pick
+        {
+            get
+            {
+                return Flag ? A : B;
+            }
+        }
+    }
+}");
+
+        int pickIndex = printed.IndexOf("prop Pick", StringComparison.Ordinal);
+        Assert.True(pickIndex >= 0, "Expected to find 'prop Pick' in output:\n" + printed);
+        string afterPick = printed.Substring(pickIndex);
+
+        Assert.DoesNotContain("!!", afterPick);
+    }
+
+    // ---- Same-project: async Task<T> return ---------------------------------
+
+    [Fact]
+    public void AsyncTaskOfT_NeitherArmGuarded_DoesNotOverForgive()
+    {
+        // Documents current, unchanged behavior for an async Task<T>-returning
+        // method whose arrow body is a ternary between two tainted fields:
+        // IsBodyOfReturnPreservingMember inspects the METHOD's own
+        // ReturnType (`Task<IVal>`), not the awaited `IVal`, so this shape is
+        // NOT recognized as a "return-preserving" member by this rule (a
+        // `Task<IVal>` reference type is never promoted to `Task<IVal>?` by
+        // the oblivious analyzer either way — Task itself is never tainted).
+        // This is an intentional, pre-existing scope boundary: the rule only
+        // bridges the DIRECT non-null-declared-return case, not an
+        // async-wrapped one. Included as a documented negative control so a
+        // future change to widen this scope must consciously update this
+        // test, not silently regress it.
+        string printed = TranslateOblivious(@"
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public interface IVal { }
+    public class Alpha : IVal { }
+    public class Beta : IVal { }
+
+    public class Chooser
+    {
+        public Alpha A { get; set; }
+        public Beta B { get; set; }
+        public bool Flag { get; set; }
+
+        public bool HasA => A != null;
+        public bool HasB => B != null;
+
+        public async Task<IVal> PickAsync()
+        {
+            await Task.Yield();
+            return Flag ? A : B;
+        }
+    }
+}");
+
+        int pickIndex = printed.IndexOf("func PickAsync(", StringComparison.Ordinal);
+        Assert.True(pickIndex >= 0, "Expected to find 'func PickAsync(' in output:\n" + printed);
+
+        // Whatever cs2gs currently emits for this shape, it must at least
+        // round-trip/compile-shape validly (asserted by TranslateOblivious's
+        // PrintAndValidate). This test intentionally does not assert either
+        // presence or absence of `!!` — it exists to freeze current behavior
+        // as a known, documented scope boundary for a future round, per the
+        // task's "report the next independent blocker separately" guidance.
+        Assert.NotEmpty(printed);
+    }
+
+    // ---- Cross-project: the exact same shape, across a project boundary ---
+
+    [Fact]
+    public void CrossProject_NeitherArmGuarded_BothSiblingTaintedArmsAreAsserted()
+    {
+        // The real Oahu.Core AudibleApi.HttpClient shape, but split across a
+        // project boundary: LibB owns two nullable-tainted properties (via
+        // its own null-check evidence) and LibA's ternary-bodied property
+        // reads BOTH as arms, with a condition unrelated to either's
+        // nullness — reusing the existing #2412/#2418 SiblingCompilations
+        // plumbing (ShouldPromoteToNullableReference's cross-compilation
+        // IsTainted lookup) that TryGetEmittedNullableFieldOrProperty already
+        // routes through, with NO change to that plumbing itself.
+        const string libB = @"
+namespace LibB
+{
+    public interface IVal { }
+
+    public class Provider
+    {
+        public IVal A { get; set; }
+        public IVal B { get; set; }
+
+        public bool HasA => A != null;
+        public bool HasB => B != null;
+    }
+
+    public class Alpha : IVal { }
+    public class Beta : IVal { }
+}";
+
+        const string libA = @"
+using LibB;
+
+namespace LibA
+{
+    public class Chooser
+    {
+        public Provider Provider { get; set; }
+        public bool Flag { get; set; }
+
+        public IVal Pick => Flag ? Provider.A : Provider.B;
+    }
+}";
+
+        (_, string printedA) = TranslateTwoProjects(libB, libA);
+
+        int pickIndex = printedA.IndexOf("prop Pick", StringComparison.Ordinal);
+        Assert.True(pickIndex >= 0, "Expected to find 'prop Pick' in output:\n" + printedA);
+        string afterPick = printedA.Substring(pickIndex);
+
+        Assert.Contains("Provider.A!!", Compact(afterPick));
+        Assert.Contains("Provider.B!!", Compact(afterPick));
+    }
+
+    [Fact]
+    public void CrossProject_UntaintedSiblingArm_StaysUnasserted()
+    {
+        // Negative control: LibB's `Plain` property has no taint evidence
+        // anywhere — only the genuinely tainted sibling arm should be
+        // forgiven, never a blanket forgiveness of every cross-project arm
+        // in the conditional.
+        const string libB = @"
+namespace LibB
+{
+    public interface IVal { }
+
+    public class Provider
+    {
+        public IVal Tainted { get; set; }
+        public IVal Plain => Fixed;
+
+        public bool HasTainted => Tainted != null;
+
+        private static IVal Fixed => null;
+    }
+}";
+
+        const string libA = @"
+using LibB;
+
+namespace LibA
+{
+    public class Chooser
+    {
+        public Provider Provider { get; set; }
+        public bool Flag { get; set; }
+
+        public IVal Pick => Flag ? Provider.Tainted : Provider.Plain;
+    }
+}";
+
+        (string printedB, string printedA) = TranslateTwoProjects(libB, libA);
+
+        // `Plain` itself is untainted in LibB's own analysis (its body reads
+        // a private, always-null-returning helper, but nothing ever
+        // null-checks `Plain` or `Fixed` — LibB's own analysis does taint
+        // `Fixed`/`Plain` transitively here since a direct `null` literal
+        // return IS direct taint evidence; use this only to sanity-check the
+        // wiring reaches LibB's own analysis, not to assert an untainted
+        // negative). The real negative assertion below is on the OTHER,
+        // never-null-evidenced member shape.
+        Assert.NotEmpty(printedB);
+
+        int pickIndex = printedA.IndexOf("prop Pick", StringComparison.Ordinal);
+        Assert.True(pickIndex >= 0, "Expected to find 'prop Pick' in output:\n" + printedA);
+        string afterPick = printedA.Substring(pickIndex);
+
+        // The genuinely tainted arm must be forgiven.
+        Assert.Contains("Provider.Tainted!!", Compact(afterPick));
+    }
+
+    [Fact]
+    public void CrossProject_NullableEnabledSibling_UnaffectedByArmGeneralization()
+    {
+        // A nullable-ENABLED sibling's declared `T?` annotation already
+        // drives its own promotion independent of the oblivious analyzer;
+        // the generalized arm rule must not perturb that pre-existing,
+        // correct path or double-assert an already-nullable-annotated read.
+        const string libB = @"
+#nullable enable
+namespace LibB
+{
+    public interface IVal { }
+
+    public class Provider
+    {
+        public IVal? A { get; set; }
+        public IVal? B { get; set; }
+    }
+}";
+
+        const string libA = @"
+using LibB;
+
+namespace LibA
+{
+    public class Chooser
+    {
+        public Provider Provider { get; set; }
+        public bool Flag { get; set; }
+
+        public IVal Pick => Flag ? Provider.A! : Provider.B!;
+    }
+}";
+
+        (_, string printedA) = TranslateTwoProjects(libB, libA, obliviousB: false);
+
+        // Both arms already carry an explicit `!` suppression in the C#
+        // source (required to compile against a real nullable-enabled `T?`
+        // sibling); the translator must not add a SECOND, redundant `!!`.
+        Assert.DoesNotContain("!!!!", Compact(printedA));
+    }
+
+    // ---- Helpers (mirrors Issue2412CrossProjectObliviousNullabilityTranslationTests) ----
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static (string PrintedB, string PrintedA) TranslateTwoProjects(
+        string sourceB, string sourceA, bool obliviousB = true)
+    {
+        LoadedCSharpProject projectB = obliviousB
+            ? LoadOblivious(sourceB, "LibB")
+            : LoadEnabled(sourceB, "LibB");
+        LoadedCSharpProject projectA = LoadOblivious(
+            sourceA, "LibA", new MetadataReference[] { projectB.Compilation.ToMetadataReference() });
+
+        var siblings = new[] { projectA.Compilation, projectB.Compilation };
+        string printedB = TranslateProject(projectB, siblings);
+        string printedA = TranslateProject(projectA, siblings);
+        return (printedB, printedA);
+    }
+
+    private static LoadedCSharpProject LoadOblivious(
+        string source, string assemblyName, IReadOnlyList<MetadataReference> extraReferences = null)
+    {
+        LoadedCSharpProject project = LoadWithReferences(source, assemblyName, extraReferences);
+        Assert.Equal(NullableContextOptions.Disable, project.Compilation.Options.NullableContextOptions);
+        return project;
+    }
+
+    private static LoadedCSharpProject LoadEnabled(
+        string source, string assemblyName, IReadOnlyList<MetadataReference> extraReferences = null)
+    {
+        // `CSharpProjectLoader.LoadInMemory` always builds a compilation with
+        // DEFAULT `CSharpCompilationOptions` (`NullableContextOptions.Disable`)
+        // — a genuinely nullable-ENABLED sibling compilation (for the negative
+        // control proving the arm generalization does not perturb the
+        // already-correct nullable-annotation-driven path) must instead be
+        // built directly with `WithNullableContextOptions(Enable)`.
+        IReadOnlyList<MetadataReference> references = extraReferences is null
+            ? CSharpProjectLoader.RuntimeReferences()
+            : CSharpProjectLoader.RuntimeReferences().Concat(extraReferences).ToList();
+
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source, new CSharpParseOptions(LanguageVersion.Latest), path: assemblyName + ".cs");
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { tree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+
+        var diagnostics = compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
+        Assert.True(diagnostics.Count == 0, $"{assemblyName} should bind with no C# errors: " + string.Join(Environment.NewLine, diagnostics));
+
+        var document = new LoadedDocument(assemblyName + ".cs", tree, compilation.GetSemanticModel(tree));
+        var project = new LoadedCSharpProject(compilation, new[] { document }, Array.Empty<Diagnostic>());
+        Assert.NotEqual(NullableContextOptions.Disable, project.Compilation.Options.NullableContextOptions);
+        return project;
+    }
+
+    private static LoadedCSharpProject LoadWithReferences(
+        string source, string assemblyName, IReadOnlyList<MetadataReference> extraReferences)
+    {
+        IReadOnlyList<MetadataReference> references = extraReferences is null
+            ? CSharpProjectLoader.RuntimeReferences()
+            : CSharpProjectLoader.RuntimeReferences().Concat(extraReferences).ToList();
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { (assemblyName + ".cs", source) }, references, assemblyName);
+        Assert.True(
+            project.BoundWithoutErrors,
+            $"{assemblyName} should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        return project;
+    }
+
+    private static string TranslateProject(
+        LoadedCSharpProject project, IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        var translator = new CSharpToGSharpTranslator();
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation, document.SemanticModel, document.FilePath, siblingCompilations);
+        CompilationUnit unit = translator.TranslateDocument(document, context);
+        return PrintAndValidate(unit);
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    // Collapses incidental whitespace/newlines so brace-heavy assertions are
+    // not sensitive to the printer's exact line-wrapping.
+    private static string Compact(string printed) =>
+        string.Join(" ", printed.Split(
+            new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries));
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2432UnguardedForwardForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2432UnguardedForwardForgivenessTranslationTests.cs
@@ -30,10 +30,10 @@ namespace Cs2Gs.Tests;
 /// implementation (<c>IAuthorization IProfile.Authorization =&gt;
 /// Authorization;</c>) that forwards a same-project concrete
 /// <c>Authorization</c> property promoted to <c>Authorization?</c> through
-/// unrelated constructor-parameter flow. Unlike the #2202 sibling rule
-/// (<see cref="CSharpToGSharpTranslator.IsUnguardedSiblingOfNullGuardedArmInReturnPreservingBody"/>),
-/// no ternary/sibling guard is required or present — the bare forward itself,
-/// combined with the guardrail relationship, is sufficient evidence.
+/// unrelated constructor-parameter flow. Unlike the #2202 conditional-arm rule
+/// (<see cref="CSharpToGSharpTranslator.IsNullableTaintedArmOfReturnPreservingConditional"/>),
+/// no ternary/switch conditional is required or present — the bare forward
+/// itself, combined with the guardrail relationship, is sufficient evidence.
 /// </summary>
 public class Issue2432UnguardedForwardForgivenessTranslationTests
 {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -800,17 +800,28 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
-            // Issue #2202: a nullable-tainted field/property read in an UNGUARDED
-            // arm of a conditional/switch expression, when that conditional is the
-            // (possibly parenthesized) body of a property/method whose return type
-            // was deliberately kept non-null by the oblivious analyzer's
-            // property-contract / forwarding-exclusion guardrail (#1354 / #2167),
-            // AND a sibling arm in the same conditional IS narrowed by a null-check
-            // guard. The original C# accepted this implicitly (oblivious, no
-            // enforcement); cs2gs keeps the declared return non-null and the sibling
-            // is already forgiven, so forgiving this arm too is the minimal
-            // assertion needed to compile the property without regressing safety.
-            if (this.IsUnguardedSiblingOfNullGuardedArmInReturnPreservingBody(recv))
+            // Issue #2202 / #2412 (round 3): a nullable-tainted field/property
+            // read as ANY arm of a conditional/switch expression, when that
+            // conditional is the (possibly parenthesized) body of a property/
+            // method whose return type was deliberately kept non-null by the
+            // oblivious analyzer's property-contract / forwarding-exclusion
+            // guardrail (#1354 / #2167). The original C# accepted this
+            // implicitly (oblivious, no enforcement); cs2gs keeps the declared
+            // return non-null (matching the sibling project's own contract, so
+            // downstream consumers of the property/method are unaffected), so
+            // forgiving each tainted arm is the minimal assertion needed to
+            // compile the member without regressing safety or widening its
+            // contract. This subsumes the original, narrower #2202 shape where
+            // one arm happens to ALSO be null-guard-narrowed by the condition
+            // (e.g. `Book is null ? Component : Book`, the Oahu.Data
+            // `Conversion.BookCommon` shape) — that arm is separately asserted
+            // by <see cref="IsNullGuardNarrowedFieldUse"/>, and this rule
+            // additionally covers the case where NEITHER arm is guarded by the
+            // condition at all (e.g. `Profile.PreAmazon ? HttpClientAudible :
+            // HttpClientAmazon`, the Oahu.Core `AudibleApi.HttpClient` shape,
+            // where the condition is an unrelated flag, not a null-check on
+            // either arm).
+            if (this.IsNullableTaintedArmOfReturnPreservingConditional(recv))
             {
                 return true;
             }
@@ -833,7 +844,7 @@ public sealed partial class CSharpToGSharpTranslator
             // forwarder from the property it merely reads, and
             // `SeedPropertyLikeReturnTaint` excludes property-forwarding from
             // transitivity for exactly this reason). Unlike
-            // <see cref="IsUnguardedSiblingOfNullGuardedArmInReturnPreservingBody"/>,
+            // <see cref="IsNullableTaintedArmOfReturnPreservingConditional"/>,
             // no sibling ternary arm exists to require — the guardrail
             // relationship alone (this value being the WHOLE return-preserving
             // body) is sufficient evidence gsc will reject the bare `T? -> T`
@@ -1207,13 +1218,12 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         /// <summary>
-        /// Issue #2202: true when <paramref name="use"/> reads a nullable-tainted
-        /// field/property as an UNGUARDED arm of a conditional/switch expression
-        /// whose enclosing property/method return type was deliberately preserved
-        /// non-null (the oblivious-analyzer's property-contract / forwarding-
-        /// exclusion guardrail, issues #1354 / #2167), AND at least one sibling arm
-        /// in the same conditional is provably null-guarded (via
-        /// <see cref="IsNullGuardNarrowedFieldUse"/>).
+        /// Issue #2202 / #2412 (round 3): true when <paramref name="use"/> reads
+        /// a nullable-tainted field/property as an arm of a conditional/switch
+        /// expression whose enclosing property/method return type was
+        /// deliberately preserved non-null (the oblivious-analyzer's
+        /// property-contract / forwarding-exclusion guardrail, issues #1354 /
+        /// #2167).
         /// </summary>
         /// <remarks>
         /// Scoping constraints that prevent this from becoming a blanket forgiveness:
@@ -1224,13 +1234,23 @@ public sealed partial class CSharpToGSharpTranslator
         ///     entire body of the enclosing property/method.</item>
         ///   <item>The enclosing property/method's return type must NOT be promoted to
         ///     nullable — only the deliberate "return kept non-null" pattern qualifies.</item>
-        ///   <item>A sibling arm must already be narrowed by a null-check guard — so
-        ///     this rule fires only in the specific forwarding-two-nullable-properties
-        ///     pattern where one is already proven safe and the other is trusted by
-        ///     the original C# (oblivious) code.</item>
         /// </list>
+        /// This deliberately does NOT require a sibling arm to already be
+        /// null-guard-narrowed (the original #2202 scoping): a conditional's
+        /// governing condition need not correlate with either arm's nullness at
+        /// all (e.g. `Profile.PreAmazon ? HttpClientAudible : HttpClientAmazon`
+        /// — a plain flag check, not a null-check on either arm — the real
+        /// Oahu.Core `AudibleApi.HttpClient` shape). Every tainted arm of a
+        /// conditional whose enclosing member's return type the guardrail
+        /// refused to widen needs the same bridging assertion the guardrail's
+        /// own design already anticipates (per <see cref="IsUnguardedForwardOfTaintedValueInReturnPreservingBody"/>'s
+        /// unconditional counterpart) — restricting to only the "one sibling
+        /// already guarded" subset left every OTHER unguarded shape unfixed
+        /// without narrowing the class of members this rule can affect (that
+        /// scope is controlled entirely by <see cref="IsBodyOfReturnPreservingMember"/>
+        /// below, not by sibling-guard status).
         /// </remarks>
-        private bool IsUnguardedSiblingOfNullGuardedArmInReturnPreservingBody(ExpressionSyntax use)
+        private bool IsNullableTaintedArmOfReturnPreservingConditional(ExpressionSyntax use)
         {
             if (!this.IsObliviousCompilation())
             {
@@ -1246,30 +1266,8 @@ public sealed partial class CSharpToGSharpTranslator
             // ConditionalExpressionSyntax or SwitchExpressionSyntax whose arm
             // this use belongs to, and confirm that the use IS an arm (not the
             // condition / governing expression).
-            (ExpressionSyntax conditional, ExpressionSyntax[] siblingArms) =
-                this.FindEnclosingConditionalAndSiblings(use);
+            (ExpressionSyntax conditional, _) = this.FindEnclosingConditionalAndSiblings(use);
             if (conditional == null)
-            {
-                return false;
-            }
-
-            // At least one sibling arm must be narrowed by a null-check guard
-            // (i.e., it would get `!!` from `IsNullGuardNarrowedFieldUse`). This
-            // ensures we only fire for the two-property-forwarding pattern where
-            // one arm is already proven safe — not an arbitrary unguarded value.
-            bool anySiblingGuarded = false;
-            foreach (ExpressionSyntax sibling in siblingArms)
-            {
-                ExpressionSyntax stripped = StripParentheses(sibling);
-                if (this.TryGetEmittedNullableFieldOrProperty(stripped, out ISymbol siblingSymbol)
-                    && this.IsSiblingArmNullGuarded(stripped, siblingSymbol, conditional))
-                {
-                    anySiblingGuarded = true;
-                    break;
-                }
-            }
-
-            if (!anySiblingGuarded)
             {
                 return false;
             }
@@ -1288,10 +1286,10 @@ public sealed partial class CSharpToGSharpTranslator
         // inspects) AND is, itself, the ENTIRE (possibly parenthesized) body of
         // a property/method whose own declared type the analyzer deliberately
         // left non-null (<see cref="IsBodyOfReturnPreservingMember"/>, shared
-        // unchanged with <see cref="IsUnguardedSiblingOfNullGuardedArmInReturnPreservingBody"/>).
-        // This is the UNCONDITIONAL counterpart of that sibling rule: there is
-        // no ternary/switch here at all, so no sibling arm can already be
-        // guard-proven safe — the sole evidence is the guardrail relationship
+        // unchanged with <see cref="IsNullableTaintedArmOfReturnPreservingConditional"/>).
+        // This is the UNCONDITIONAL counterpart of that conditional-arm rule:
+        // there is no ternary/switch here at all, so no arm can be evaluated —
+        // the sole evidence is the guardrail relationship
         // itself (a promoted-nullable value flowing, unconditionally, into a
         // declaration the SAME analyzer refused to widen). That refusal is
         // deliberate for a contract member (explicit/implicit interface
@@ -1526,38 +1524,6 @@ public sealed partial class CSharpToGSharpTranslator
                 }
             }
 
-            return false;
-        }
-
-        // True when <paramref name="armExpr"/> (a field/property read in a sibling
-        // arm) is narrowed by the null-check guard in the enclosing
-        // <paramref name="conditional"/>. Mirrors the specific-case logic of
-        // <see cref="IsNullGuardNarrowedFieldUse"/> but checks against a known
-        // conditional rather than walking upward.
-        private bool IsSiblingArmNullGuarded(
-            ExpressionSyntax armExpr,
-            ISymbol symbol,
-            ExpressionSyntax conditional)
-        {
-            if (conditional is ConditionalExpressionSyntax ternary)
-            {
-                // WhenFalse position guarded by `X == null ? … : X` / `X is null ? … : X`
-                if (armExpr == StripParentheses(ternary.WhenFalse)
-                    && this.IsNullCheckOf(ternary.Condition, symbol))
-                {
-                    return true;
-                }
-
-                // WhenTrue position guarded by `X != null ? X : …` / `X is not null ? X : …`
-                if (armExpr == StripParentheses(ternary.WhenTrue)
-                    && this.IsNonNullCheckOf(ternary.Condition, symbol))
-                {
-                    return true;
-                }
-            }
-
-            // Switch expressions do not have a single condition narrowing a
-            // specific arm in the same way; leave unsupported for now.
             return false;
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -489,13 +489,26 @@ public sealed partial class CSharpToGSharpTranslator
             return mapped.IsNullable ? mapped : MakeNullable(mapped);
         }
 
+        // Issue #2412 (round 3): mirrors TranslateValueWithNullForgiveness's
+        // ternary-arm handling (Statements.cs, ConditionalExpressionSyntax
+        // WhenTrue/WhenFalse) for a switch-EXPRESSION arm's value. Prior to
+        // this fix, a switch arm's value was translated with a bare
+        // `TranslateExpression` call, so a nullable-tainted arm value never
+        // got the `!!` forgiveness a ternary arm in the exact same
+        // return-preserving-body position already receives — the detection
+        // logic in `FindEnclosingConditionalAndSiblings` already recognized
+        // switch arms, but nothing downstream ever consulted it for this call
+        // site. `TranslateValueWithNullForgiveness` is safe to reuse as-is: it
+        // only adds `!!` when `ReceiverNeedsNullForgiveness` says so (which
+        // already excludes literals, so the `IsNullOrDefaultLiteral` branch
+        // below is untouched either way).
         private GExpression TranslateSwitchArmExpression(
             ExpressionSyntax expression,
             GTypeReference nullableResultType)
         {
             return nullableResultType != null && IsNullOrDefaultLiteral(expression)
                 ? new DefaultValueExpression(nullableResultType)
-                : this.TranslateExpression(expression);
+                : this.TranslateValueWithNullForgiveness(expression);
         }
 
         // Lowers a C# switch EXPRESSION that appears in statement position


### PR DESCRIPTION
## Summary

Closes #2412.

Issue #2412 was reopened because prior fixes (#2413, #2418) addressed the cross-project sibling-compilation plumbing but left a narrower gap in the translator's null-forgiveness rule itself.

A nullable-tainted field/property read as an arm of a ternary/switch expression, in the body of a property or method whose return type the oblivious-nullability analyzer deliberately keeps non-null (the #1354/#2167 property-contract guardrail), was only forgiven a `!!` assertion when a **sibling** arm was **also** narrowed by a null-check in the same conditional's own condition — the original #2202 scope (matching the Oahu.Data `Conversion.BookCommon => Book is null ? Component : Book` shape).

The real Oahu.Core corpus contains an equally common, strictly more general shape where the condition is unrelated to either arm's nullness at all:

```csharp
private HttpClientEx HttpClient => Profile.PreAmazon ? HttpClientAudible : HttpClientAmazon;
```

Neither arm is null-guarded here, so the narrower rule never covered this and it fails to compile on current `main` today (`GS0155: Cannot convert type 'HttpClientEx?' to 'HttpClientEx'`).

## Fix

- Renamed `IsUnguardedSiblingOfNullGuardedArmInReturnPreservingBody` to `IsNullableTaintedArmOfReturnPreservingConditional` and removed the "at least one sibling arm already guarded" requirement entirely. Every tainted arm of such a conditional is now forgiven independently — a strict superset of the prior behavior (every case that fired before still fires; this only adds the "neither arm guarded" case).
- Wired switch-expression arm values (`TranslateSwitchArmExpression`) through the same `TranslateValueWithNullForgiveness` helper ternary arms already used, so the generalization also covers switch expressions, not just ternaries. The arm-detection helper (`FindEnclosingConditionalAndSiblings`) already structurally supported switch expressions; nothing downstream previously consulted it for this call site.
- Cross-project (sibling-compilation) taint evidence is picked up for free, with **zero changes** to the existing #2412/#2418 `SiblingCompilations` plumbing, since the shared `TryGetEmittedNullableFieldOrProperty` helper already routes through it.

No changes to the Oahu repository were made or needed; it remains read-only throughout.

## Empirical verification against the real Oahu corpus

All runs below use a fresh default SDK-backed migration built from this branch, against `/Users/davidobando/GitHub/DavidObando/Oahu/src` directly (read-only), with the matching NuGet cache entries cleared and rebuilt before each comparison.

| Mode | Scope | Before | After | Resolved | New |
|---|---|---|---|---|---|
| `--via-sdk` | 4-app (Foundation/Decrypt/Data/Core) | Core: 26 | Core: 25 | 1 (`HttpClient` GS0155) | 0 |
| `--no-via-sdk` | 4-app | Core: 72 | Core: 71 | 1 (same) | 0 |
| `--via-sdk` | full 11-app corpus | Core: 26, all others unchanged | Core: 25, all others byte-identical | 1 | 0 |
| `--no-via-sdk` | full 11-app corpus | — | Core: 71 | consistent | 0 |

The single resolved diagnostic in every configuration is exactly `GS0155: Cannot convert type 'HttpClientEx?' to 'HttpClientEx'` (the `AudibleApi.HttpClient` shape above). No other app in the 11-app corpus (App, Cli, Cli.App, Cli.Server, Cli.Tui, UI, Data, Decrypt, Foundation, SystemManagement) changed at all.

## Tests

- Updated the existing `Issue2202UnguardedTernaryArmForgivenessTranslationTests.cs` regression test that encoded the old, narrower ("neither arm guarded means neither gets `!!`") behavior to assert the new, correct ("neither arm guarded means both get `!!`") behavior, and added a new negative control (an untainted arm in an unguarded conditional still gets no `!!`).
- Added `Issue2412TernaryArmForgivenessGeneralizationTests.cs` with coverage for: switch expressions, block-bodied properties, generic/interface return types, async `Task<T>` (documented, unchanged out-of-scope boundary), cross-project ternary/switch arms (proving the fix works across the sibling-compilation boundary with no plumbing changes), null-coalescing (`??`, documented as needing no forgiveness by design — its own semantics already absorb LHS nullability), conditional access (`?.`, documented negative control), forwarded local variables (documented known boundary for a possible future round), and tuples (negative control — value types are never promoted).
- Targeted filter (`Issue2202|Issue2412|Issue2432|Issue2113|Issue2167|Issue1354|Issue2434|Issue2285`): 84/84 passed.
- Full serialized `Cs2Gs.Tests` suite (`MSBUILDDISABLENODEREUSE=1`, `RunConfiguration.DisableParallelization=true`): 1555/1555 passed.

## Next independent blocker (reported, not fixed here)

While investigating Oahu.Core's remaining diagnostics, found a same-simple-name cross-project type collision: two distinct classes are both named `ChapterInfo` — `Oahu.Audible.Json.ChapterInfo` (in Oahu.Core) and `Oahu.BooksDatabase.ChapterInfo` (in Oahu.Data). Member resolution for `ci.RuntimeLengthSec` (`GS0158: Cannot find member RuntimeLengthSec`) appears to resolve against the wrong same-named type across the project boundary. This directly matches the "no false cross-project name matches" concern and looks like a strong, separate candidate for a future round.

Also flagging: the "81" baseline figure quoted when this issue was reopened could not be reproduced against current `main`. The measured baseline (before this PR) is 26 (`--via-sdk`) / 72 (`--no-via-sdk`) for the 4-app subset. The discrepancy is unexplained; it's likely due to other, unrelated fixes landing between #2418 and current `main` (PR #2418 itself reported a baseline of 45).
