### PR TITLE
Honor optional parameters on imported CLR callables

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -180,9 +180,38 @@ internal sealed class ConversionClassifier
     {
         var typeSymbol = TypeSymbol.FromClrType(parameter.ParameterType);
 
+        if (TryGetDateTimeParameterDefault(parameter, out var dateTime))
+        {
+            var constructor = parameter.ParameterType.GetConstructors()
+                .FirstOrDefault(static candidate =>
+                    candidate.GetParameters() is [{ ParameterType.FullName: "System.Int64" }]);
+            if (constructor != null)
+            {
+                return new BoundClrConstructorCallExpression(
+                    null,
+                    parameter.ParameterType,
+                    constructor,
+                    ImmutableArray.Create<BoundExpression>(new BoundLiteralExpression(null, dateTime.Ticks)),
+                    typeSymbol);
+            }
+        }
+
+        if (IsMissingParameterDefault(parameter))
+        {
+            var missingType = parameter.ParameterType.Assembly.GetType("System.Reflection.Missing");
+            var valueField = missingType?.GetField("Value", BindingFlags.Public | BindingFlags.Static);
+            if (valueField != null)
+            {
+                return new BoundClrPropertyAccessExpression(null, null, valueField, typeSymbol);
+            }
+        }
+
         if (TryGetConstantParameterDefault(parameter, out var constant))
         {
-            return new BoundLiteralExpression(null, constant);
+            var literal = new BoundLiteralExpression(null, constant);
+            return parameter.ParameterType.IsEnum
+                ? new BoundConversionExpression(null, typeSymbol, literal)
+                : literal;
         }
 
         return new BoundDefaultExpression(null, typeSymbol);
@@ -2101,10 +2130,8 @@ internal sealed class ConversionClassifier
         return false;
     }
 
-    // Issue #327/#321: extracts the CLR `RawDefaultValue` for an optional
-    // parameter when it is one of the primitive/string constant kinds that
-    // BoundLiteralExpression carries directly; returns false for `[Optional]`
-    // without a constant and any non-primitive type.
+    // Issue #327/#321/#2451: extracts the CLR `RawDefaultValue` for an optional
+    // parameter when it is a literal kind that BoundLiteralExpression carries.
     private static bool TryGetConstantParameterDefault(ParameterInfo parameter, out object value)
     {
         value = null;
@@ -2139,12 +2166,63 @@ internal sealed class ConversionClassifier
             case ulong:
             case float:
             case double:
+            case decimal:
             case char:
             case string:
                 value = raw;
                 return true;
             default:
                 return false;
+        }
+    }
+
+    private static bool TryGetDateTimeParameterDefault(ParameterInfo parameter, out DateTime value)
+    {
+        try
+        {
+            if (parameter.ParameterType.FullName == "System.DateTime")
+            {
+                if (parameter.RawDefaultValue is long ticks)
+                {
+                    value = new DateTime(ticks);
+                    return true;
+                }
+            }
+
+            var attribute = parameter.GetCustomAttributesData().FirstOrDefault(static candidate =>
+                candidate.AttributeType.FullName == "System.Runtime.CompilerServices.DateTimeConstantAttribute");
+            if (attribute != null
+                && attribute.ConstructorArguments.Count == 1)
+            {
+                var attributeTicks = Convert.ToInt64(
+                    attribute.ConstructorArguments[0].Value,
+                    System.Globalization.CultureInfo.InvariantCulture);
+                value = new DateTime(attributeTicks);
+                return true;
+            }
+        }
+        catch
+        {
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static bool IsMissingParameterDefault(ParameterInfo parameter)
+    {
+        try
+        {
+            var raw = parameter.RawDefaultValue;
+            return raw is Missing
+                || raw?.GetType().FullName == "System.Reflection.Missing"
+                || (parameter.ParameterType.FullName == "System.Object"
+                    && parameter.IsOptional
+                    && (raw is DBNull || !parameter.HasDefaultValue));
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -872,19 +872,21 @@ internal sealed partial class ExpressionBinder
         if (target.Type is NullabilityAnnotatedTypeSymbol annotIdx && annotIdx.ClrType is System.Type clrAnnotIdx)
         {
             var idxArgsAnnot = ImmutableArray.Create(BoundIndexArg());
-            if (this.memberLookup.TryResolveClrIndexer(clrAnnotIdx, idxArgsAnnot, out var idxPropAnnot))
+            if (this.memberLookup.TryResolveClrIndexer(clrAnnotIdx, idxArgsAnnot, out var idxPropAnnot, out var resolvedIdxArgsAnnot))
             {
                 var elemTypeAnnot = annotIdx.GetTypeArgumentSymbolForClrType(idxPropAnnot.PropertyType);
-                return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxPropAnnot, idxArgsAnnot, elemTypeAnnot));
+                return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxPropAnnot, resolvedIdxArgsAnnot, elemTypeAnnot));
             }
         }
-        else if (target.Type is ImportedTypeSymbol && target.Type.ClrType is System.Type clrTarget)
+        else if ((target.Type is ImportedTypeSymbol || target.Type is StructSymbol) && target.Type.ClrType is System.Type clrTarget)
         {
             var idxArgs = ImmutableArray.Create(BoundIndexArg());
-            if (this.memberLookup.TryResolveClrIndexer(clrTarget, idxArgs, out var idxProp))
+            if (this.memberLookup.TryResolveClrIndexer(clrTarget, idxArgs, out var idxProp, out var resolvedIdxArgs))
             {
-                var elementType = MapErasedIndexerElementType((ImportedTypeSymbol)target.Type, idxProp);
-                return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxProp, idxArgs, elementType));
+                var elementType = target.Type is ImportedTypeSymbol imported
+                    ? MapErasedIndexerElementType(imported, idxProp)
+                    : ClrNullability.GetPropertyTypeSymbol(idxProp);
+                return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxProp, resolvedIdxArgs, elementType));
             }
         }
 
@@ -1304,7 +1306,7 @@ internal sealed partial class ExpressionBinder
         if (variable.Type is NullabilityAnnotatedTypeSymbol annotWr && variable.Type.ClrType is System.Type clrAnnotWr)
         {
             var idxArgsAnnotWr = ImmutableArray.Create(BindExpression(indexSyntax));
-            if (this.memberLookup.TryResolveClrIndexer(clrAnnotWr, idxArgsAnnotWr, out var idxPropAnnotWr))
+            if (this.memberLookup.TryResolveClrIndexer(clrAnnotWr, idxArgsAnnotWr, out var idxPropAnnotWr, out var resolvedIdxArgsAnnotWr))
             {
                 if (!idxPropAnnotWr.CanWrite)
                 {
@@ -1314,13 +1316,13 @@ internal sealed partial class ExpressionBinder
 
                 var valueTypeAnnotWr = annotWr.GetTypeArgumentSymbolForClrType(idxPropAnnotWr.PropertyType);
                 var boundValueAnnotWr = BindValue(valueTypeAnnotWr);
-                return new BoundClrIndexAssignmentExpression(null, variable, idxPropAnnotWr, idxArgsAnnotWr, boundValueAnnotWr, valueTypeAnnotWr);
+                return new BoundClrIndexAssignmentExpression(null, variable, idxPropAnnotWr, resolvedIdxArgsAnnotWr, boundValueAnnotWr, valueTypeAnnotWr);
             }
         }
-        else if (variable.Type is ImportedTypeSymbol && variable.Type.ClrType is System.Type clrTarget)
+        else if ((variable.Type is ImportedTypeSymbol || variable.Type is StructSymbol) && variable.Type.ClrType is System.Type clrTarget)
         {
             var idxArgs = ImmutableArray.Create(BindExpression(indexSyntax));
-            if (this.memberLookup.TryResolveClrIndexer(clrTarget, idxArgs, out var idxProp))
+            if (this.memberLookup.TryResolveClrIndexer(clrTarget, idxArgs, out var idxProp, out var resolvedIdxArgs))
             {
                 // ADR-0056 §2: span element write. `Span[T]` has no `set_Item`; its
                 // indexer is a `ref T`-returning getter and writes go through that
@@ -1340,7 +1342,7 @@ internal sealed partial class ExpressionBinder
 
                         var pointeeType = TypeSymbol.FromClrType(refGetter.ReturnType.GetElementType()!);
                         var refValue = BindValue(pointeeType);
-                        return new BoundClrIndexAssignmentExpression(null, variable, idxProp, idxArgs, refValue, pointeeType);
+                        return new BoundClrIndexAssignmentExpression(null, variable, idxProp, resolvedIdxArgs, refValue, pointeeType);
                     }
 
                     Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
@@ -1359,9 +1361,11 @@ internal sealed partial class ExpressionBinder
                 // real element type (`T`), so the `T` value binds without a
                 // spurious boxing conversion — the WRITE-path counterpart to the
                 // READ-path element-type recovery (issues #313 / #671 / #957).
-                var valueType = MapErasedIndexerElementType((ImportedTypeSymbol)variable.Type, idxProp);
+                var valueType = variable.Type is ImportedTypeSymbol imported
+                    ? MapErasedIndexerElementType(imported, idxProp)
+                    : ClrNullability.GetPropertyTypeSymbol(idxProp);
                 var boundValue = BindValue(valueType);
-                return new BoundClrIndexAssignmentExpression(null, variable, idxProp, idxArgs, boundValue, valueType);
+                return new BoundClrIndexAssignmentExpression(null, variable, idxProp, resolvedIdxArgs, boundValue, valueType);
             }
         }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -755,8 +755,11 @@ internal sealed partial class ExpressionBinder
             && dataClassAggregate.IsData
             && dataClassAggregate.HasPrimaryConstructor)
         {
-            result = overloads.BindConstructorCallExpression(syntax, dataClassAggregate);
-            return true;
+            return TryBindClrConstructorFromType(
+                clrType,
+                syntax,
+                out result,
+                resultTypeOverride: dataClassAggregate);
         }
 
         if (TryBindClrConstructorFromType(clrType, syntax, out result, openGenericDefinition, symbolicTypeArgs))
@@ -881,13 +884,20 @@ internal sealed partial class ExpressionBinder
     /// alongside <paramref name="openGenericDefinition"/>. Default when no
     /// symbolic substitution is in effect.
     /// </param>
+    /// <param name="resultTypeOverride">
+    /// Semantic result type to expose instead of a plain imported CLR type.
+    /// Used for imported data aggregates so constructor binding still flows
+    /// through shared CLR overload resolution without reintroducing dual type
+    /// identity.
+    /// </param>
     /// <returns>Whether a constructor was resolved and bound.</returns>
     private bool TryBindClrConstructorFromType(
         System.Type clrType,
         CallExpressionSyntax syntax,
         out BoundExpression result,
         System.Type openGenericDefinition = null,
-        ImmutableArray<TypeSymbol> symbolicTypeArgs = default)
+        ImmutableArray<TypeSymbol> symbolicTypeArgs = default,
+        TypeSymbol resultTypeOverride = null)
     {
         result = null;
 
@@ -1119,7 +1129,11 @@ internal sealed partial class ExpressionBinder
         // the user-defined TypeDef tokens (so the NEWOBJ targets, e.g.,
         // `List<MyGs>` rather than the erased `List<object>`).
         TypeSymbol resultType;
-        if (openGenericDefinition != null && !symbolicTypeArgs.IsDefaultOrEmpty)
+        if (resultTypeOverride != null)
+        {
+            resultType = resultTypeOverride;
+        }
+        else if (openGenericDefinition != null && !symbolicTypeArgs.IsDefaultOrEmpty)
         {
             resultType = ImportedTypeSymbol.GetConstructed(clrType, openGenericDefinition, symbolicTypeArgs);
         }

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2230,38 +2230,42 @@ internal sealed class MemberLookup
     /// <param name="clrTarget">The CLR receiver type whose indexers to probe.</param>
     /// <param name="boundArguments">The pre-bound index argument expressions.</param>
     /// <param name="indexer">The matching <see cref="PropertyInfo"/>, on success.</param>
+    /// <param name="resolvedArguments">The arguments in parameter order, including omitted optional defaults.</param>
     /// <returns><see langword="true"/> when a matching indexer is found.</returns>
-    public bool TryResolveClrIndexer(Type clrTarget, ImmutableArray<BoundExpression> boundArguments, out PropertyInfo indexer)
+    public bool TryResolveClrIndexer(
+        Type clrTarget,
+        ImmutableArray<BoundExpression> boundArguments,
+        out PropertyInfo indexer,
+        out ImmutableArray<BoundExpression> resolvedArguments)
     {
         indexer = null;
+        resolvedArguments = default;
 
-        foreach (var prop in ClrTypeUtilities.SafeGetProperties(clrTarget, BindingFlags.Public | BindingFlags.Instance))
+        var properties = ClrTypeUtilities.SafeGetProperties(clrTarget, BindingFlags.Public | BindingFlags.Instance)
+            .Where(static property => property.GetMethod != null && property.GetIndexParameters().Length > 0)
+            .ToArray();
+        var argTypes = new Type[boundArguments.Length];
+        for (var i = 0; i < boundArguments.Length; i++)
         {
-            var ps = prop.GetIndexParameters();
-            if (ps.Length != boundArguments.Length)
+            argTypes[i] = boundArguments[i].Type?.ClrType;
+            if (argTypes[i] == null)
             {
-                continue;
-            }
-
-            var ok = true;
-            for (var i = 0; i < ps.Length; i++)
-            {
-                var argClr = boundArguments[i].Type?.ClrType;
-                if (argClr == null || !ClrTypeUtilities.IsAssignableByName(ps[i].ParameterType, argClr))
-                {
-                    ok = false;
-                    break;
-                }
-            }
-
-            if (ok)
-            {
-                indexer = prop;
-                return true;
+                return false;
             }
         }
 
-        return false;
+        var resolution = OverloadResolution.Resolve(properties.Select(static property => property.GetMethod).ToArray(), argTypes);
+        if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
+        {
+            return false;
+        }
+
+        indexer = properties.First(property => ReferenceEquals(property.GetMethod, resolution.Best));
+        resolvedArguments = OverloadResolver.BuildOrderedCallArguments(
+            boundArguments,
+            resolution.ParameterMapping,
+            resolution.Best.GetParameters());
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -1089,7 +1089,7 @@ internal static class OverloadResolution
 
         for (var i = argTypes.Count; i < parameters.Length; i++)
         {
-            if (!parameters[i].IsOptional)
+            if (!IsOptionalParameter(parameters[i]))
             {
                 return false;
             }
@@ -2496,7 +2496,7 @@ internal static class OverloadResolution
         // allocates an empty array).
         for (var i = 0; i < paramsIndex; i++)
         {
-            if (!filled[i] && !parameters[i].IsOptional)
+            if (!filled[i] && !IsOptionalParameter(parameters[i]))
             {
                 return;
             }
@@ -2729,7 +2729,7 @@ internal static class OverloadResolution
         // Every unfilled parameter must be optional.
         for (var i = 0; i < parameters.Length; i++)
         {
-            if (!filled[i] && !parameters[i].IsOptional)
+            if (!filled[i] && !IsOptionalParameter(parameters[i]))
             {
                 return false;
             }
@@ -2847,13 +2847,27 @@ internal static class OverloadResolution
     {
         for (var i = suppliedCount; i < parameters.Length; i++)
         {
-            if (!parameters[i].IsOptional)
+            if (!IsOptionalParameter(parameters[i]))
             {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private static bool IsOptionalParameter(ParameterInfo parameter)
+    {
+        if (parameter.IsOptional || parameter.HasDefaultValue)
+        {
+            return true;
+        }
+
+        return parameter.GetCustomAttributesData().Any(static attribute =>
+            attribute.AttributeType.FullName is
+                "System.Runtime.CompilerServices.DecimalConstantAttribute" or
+                "System.Runtime.CompilerServices.DateTimeConstantAttribute" or
+                "System.Runtime.InteropServices.OptionalAttribute");
     }
 
     /// <summary>
@@ -2945,7 +2959,7 @@ internal static class OverloadResolution
         // Phase 2b — prefer the candidate whose parameter types are
         // "more specific" (parameter-by-parameter assignability — a less
         // derived type is implicitly assignable from a more derived one).
-        if (pool.Count > 1)
+        if (pool.Count > 1 && argTypes.Count > 0)
         {
             var mostSpecific = pool
                 .Where(w => pool.All(o => ReferenceEquals(w.Method, o.Method) || IsAtLeastAsSpecific(w.Method, o.Method)))
@@ -3132,14 +3146,16 @@ internal static class OverloadResolution
             return false;
         }
 
-        if (aParamTypes.Length != bParamTypes.Length)
+        var aParameters = a.GetParameters();
+        var bParameters = b.GetParameters();
+        if (aParameters.Length != bParameters.Length)
         {
             return false;
         }
 
-        for (var i = 0; i < aParamTypes.Length; i++)
+        for (var i = 0; i < aParameters.Length; i++)
         {
-            if (!ClrTypeUtilities.AreSame(aParamTypes[i], bParamTypes[i]))
+            if (!ClrTypeUtilities.AreSame(aParameters[i].ParameterType, bParameters[i].ParameterType))
             {
                 return false;
             }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Arguments.cs
@@ -91,14 +91,8 @@ internal sealed partial class OverloadResolver
         }
 
         var fixedCount = paramsIndex;
-        var tailCount = arguments.Length - fixedCount;
-        if (tailCount < 0)
-        {
-            // Shouldn't happen: overload resolution rejects expanded-form
-            // candidates whose fixed leading parameters are not all supplied.
-            // Defensive fallback: leave the arguments unchanged.
-            return arguments;
-        }
+        var suppliedFixedCount = Math.Min(arguments.Length, fixedCount);
+        var tailCount = Math.Max(0, arguments.Length - fixedCount);
 
         var packed = ImmutableArray.CreateBuilder<BoundExpression>(tailCount);
         for (var i = 0; i < tailCount; i++)
@@ -110,9 +104,14 @@ internal sealed partial class OverloadResolver
         var arrayExpr = new BoundArrayCreationExpression(callSyntax, sliceType, packed.MoveToImmutable());
 
         var result = ImmutableArray.CreateBuilder<BoundExpression>(parameters.Length);
-        for (var i = 0; i < fixedCount; i++)
+        for (var i = 0; i < suppliedFixedCount; i++)
         {
             result.Add(arguments[i]);
+        }
+
+        for (var i = suppliedFixedCount; i < fixedCount; i++)
+        {
+            result.Add(ConversionClassifier.CreateOptionalDefaultArgument(parameters[i]));
         }
 
         result.Add(arrayExpr);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
@@ -891,8 +891,17 @@ internal sealed partial class OverloadResolver
             }
             else if (syntax.Arguments.Count != namedDelegateSym.Parameters.Length)
             {
-                Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, namedDelegateVar.Name, namedDelegateSym.Parameters.Length, syntax.Arguments.Count);
-                return new BoundErrorExpression(null);
+                var requiredCount = namedDelegateSym.Parameters.Length;
+                while (requiredCount > 0 && namedDelegateSym.Parameters[requiredCount - 1].HasExplicitDefaultValue)
+                {
+                    requiredCount--;
+                }
+
+                if (syntax.Arguments.Count < requiredCount || syntax.Arguments.Count > namedDelegateSym.Parameters.Length)
+                {
+                    Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, namedDelegateVar.Name, namedDelegateSym.Parameters.Length, syntax.Arguments.Count);
+                    return new BoundErrorExpression(null);
+                }
             }
 
             ImmutableArray<BoundExpression> ndPermutedArgs = boundArguments.ToImmutable();
@@ -919,6 +928,17 @@ internal sealed partial class OverloadResolver
                 {
                     return new BoundErrorExpression(null);
                 }
+            }
+            else if (ndPermutedArgs.Length < namedDelegateSym.Parameters.Length)
+            {
+                var padded = ImmutableArray.CreateBuilder<BoundExpression>(namedDelegateSym.Parameters.Length);
+                padded.AddRange(ndPermutedArgs);
+                for (var i = ndPermutedArgs.Length; i < namedDelegateSym.Parameters.Length; i++)
+                {
+                    padded.Add(CreateOptionalUserDefaultArgument(namedDelegateSym.Parameters[i]));
+                }
+
+                ndPermutedArgs = padded.MoveToImmutable();
             }
 
             var convertedNamedArgs = ImmutableArray.CreateBuilder<BoundExpression>(ndPermutedArgs.Length);

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -617,6 +617,10 @@ public sealed partial class Evaluator
                 ? CheckedNumericConvert(value, node.Type.ClrType)
                 : UncheckedNumericConvert(value, node.Type.ClrType);
         }
+        else if (node.Type?.ClrType?.IsEnum == true)
+        {
+            return Enum.ToObject(node.Type.ClrType, value);
+        }
         else
         {
             throw new EvaluatorException($"Unexpected type {node.Type}", node);

--- a/test/Compiler.Tests/ImportedMemberMatrixTests.cs
+++ b/test/Compiler.Tests/ImportedMemberMatrixTests.cs
@@ -190,6 +190,146 @@ public class ImportedMemberMatrixTests
         Assert.Contains(diagnostics, d => d.Contains("data class or data struct", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void ImportedMemberMatrix_OptionalDefaults_AreResolvedAndEmittedAcrossCallableKinds()
+    {
+        const string csSource = """
+            using System;
+            using System.Reflection;
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Threading;
+
+            namespace ImportedOptional.CSharp
+            {
+                public enum Tone { First = 1, Second = 2 }
+
+                public record ProgressMessage(int Count, string Text = "ready");
+
+                public delegate string OptionalDelegate(bool enabled = true);
+
+                public sealed class OptionalApi
+                {
+                    private readonly int seed;
+                    private string? indexed;
+
+                    public OptionalApi(int seed, int add = 5) => this.seed = seed + add;
+
+                    public int Instance(int value = 7) => seed + value;
+
+                    public static string Constants(
+                        string text = "ok",
+                        Tone tone = Tone.Second,
+                        decimal amount = 12.5m,
+                        CancellationToken token = default) =>
+                        $"{text}:{(int)tone}:{amount}:{token.CanBeCanceled}";
+
+                    public static long Date([Optional, DateTimeConstant(123)] DateTime value) => value.Ticks;
+
+                    public static bool MissingValue([Optional] object value) =>
+                        ReferenceEquals(value, Missing.Value);
+
+                    public static int Params(int prefix = 2, params int[] values) =>
+                        prefix + values.Length;
+
+                    public string this[int x, int y = 4]
+                    {
+                        get => indexed ?? $"{x}:{y}";
+                        set => indexed = $"{x}:{y}:{value}";
+                    }
+                }
+            }
+            """;
+
+        const string gsSource = """
+            package ImportedOptional.Probe
+            import ImportedOptional.CSharp
+            import System
+
+            var message = ProgressMessage(3)
+            var api = OptionalApi(10)
+            var callback OptionalDelegate = func(enabled bool) string {
+                return enabled ? "yes" : "no"
+            }
+
+            Console.WriteLine(message.Text)
+            Console.WriteLine(api.Instance())
+            Console.WriteLine(OptionalApi.Constants())
+            Console.WriteLine(OptionalApi.Date())
+            Console.WriteLine(OptionalApi.MissingValue())
+            Console.WriteLine(OptionalApi.Params())
+            Console.WriteLine(callback())
+            Console.WriteLine(api[3])
+            api[3] = "set"
+            Console.WriteLine(api[3])
+            """;
+
+        Assert.Equal(
+            "ready\n22\nok:2:12.5:False\n123\nTrue\n2\nyes\n3:4\n3:4:set\n",
+            CompileAndRunWithSiblingCs(csSource, gsSource, "ImportedOptional.CSharp"));
+    }
+
+    [Fact]
+    public void ImportedMemberMatrix_OptionalOverloads_PreserveAmbiguityAndRequiredDiagnostics()
+    {
+        const string csSource = """
+            namespace ImportedOptionalDiagnostics.CSharp
+            {
+                public static class Calls
+                {
+                    public static int Ambiguous(string? value = null) => 1;
+                    public static long Ambiguous(System.Uri? value = null) => 2;
+                    public static int Required(int value, int extra = 2) => value + extra;
+                }
+            }
+            """;
+
+        const string ambiguousSource = """
+            package ImportedOptionalDiagnostics.Probe
+            import ImportedOptionalDiagnostics.CSharp
+
+            var a = Calls.Ambiguous()
+            """;
+
+        var ambiguityDiagnostics = CompileExpectingErrorsWithSiblingCs(
+            csSource,
+            ambiguousSource,
+            "ImportedOptionalDiagnostics.CSharp");
+        Assert.Contains(ambiguityDiagnostics, d => d.Contains("ambiguous", StringComparison.OrdinalIgnoreCase));
+
+        const string requiredSource = """
+            package ImportedOptionalDiagnostics.Probe
+            import ImportedOptionalDiagnostics.CSharp
+
+            var b = Calls.Required()
+            """;
+
+        var requiredDiagnostics = CompileExpectingErrorsWithSiblingCs(
+            csSource,
+            requiredSource,
+            "ImportedOptionalDiagnostics.CSharp");
+        Assert.Contains(requiredDiagnostics, d => d.Contains("Required", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void NamedDelegate_OmittedOptionalArgument_UsesDeclaredDefault()
+    {
+        const string source = """
+            package OptionalDelegate.Probe
+            import System
+
+            type Toggle = delegate func(enabled bool = true) string
+
+            var callback Toggle = func(enabled bool) string {
+                return enabled ? "yes" : "no"
+            }
+
+            Console.WriteLine(callback())
+            """;
+
+        Assert.Equal("yes\n", CompileAndRun(source));
+    }
+
     private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)
     {
         var workDir = CreateWorkDir("imported_member_matrix_");

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
@@ -97,6 +97,29 @@ namespace Corpus.Issue1901
     }
 
     [Fact]
+    public void NullableNamedDelegate_DefaultParameter_IsMaterializedAtConditionalCall()
+    {
+        string rendered = Render(@"
+#nullable enable
+namespace Corpus.Issue2451
+{
+    public delegate string TokenProvider(bool enforce = false);
+
+    public class Holder
+    {
+        public static string? Read(TokenProvider? provider)
+        {
+            return provider?.Invoke();
+        }
+    }
+}
+");
+
+        Assert.True(rendered.Contains("return provider?(false)", StringComparison.Ordinal), rendered);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
     public void LambdaDefaultParameter_EnumAndNullConstants_MaterializedAtOmittedCallSite()
     {
         string rendered = Render(@"

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -80,7 +80,7 @@ public sealed partial class CSharpToGSharpTranslator
                     { MethodKind: MethodKind.DelegateInvoke }
                 && TryGetDelegateInvokeReceiver(invocation.Expression, out GExpression invokeTarget))
             {
-                var invokeArguments = this.TranslateArguments(invocation.ArgumentList.Arguments);
+                var invokeArguments = this.TranslateCallArguments(invocation, invocation.ArgumentList.Arguments);
                 return new InvocationExpression(invokeTarget, invokeArguments, null);
             }
 
@@ -416,7 +416,7 @@ public sealed partial class CSharpToGSharpTranslator
 
             GExpression receiver = this.SpillOperand(
                 this.TranslateExpression(conditionalAccess.Expression));
-            var invokeArguments = this.TranslateArguments(invocation.ArgumentList.Arguments);
+            var invokeArguments = this.TranslateCallArguments(invocation, invocation.ArgumentList.Arguments);
             result = new ConditionalAccessExpression(
                 receiver,
                 new InvocationExpression(new ConditionalReceiverExpression(), invokeArguments, null));


### PR DESCRIPTION
## Summary
- route imported record constructors and CLR indexers through shared overload/default-argument resolution
- materialize CLR defaults for constants, null/default values, enums, decimal, DateTime, Missing, optional+params, and named delegates
- preserve required-argument and ambiguity diagnostics, including zero-argument overload sets
- make cs2gs reuse resolved delegate defaults for direct and null-conditional invocation

## Validation
- Core.Tests: 6440 passed, 1 skipped
- Compiler.Tests: 3162 passed
- Cs2Gs.Tests (parallelization disabled): 1556 passed
- ImportedMemberMatrixTests: 8 passed
- Issue1901LambdaDefaultsTranslationTests: 11 passed
- rebuilt `Gsharp.NET.Sdk` Release package, refreshed `.nugs`, cleared the exact package cache, and ran a fresh default `--via-sdk` Oahu.Core migration read-only
- Oahu fingerprints: 22 -> 17; removed `4eab36fd5969`, `8e46594388bd`, `9aa3f91d953c`, `9dd3129313c4`, `a8d4ee17a509`; no new fingerprints

Closes #2451
