### PR TITLE
Make named delegate binding syntax-tree order independent

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -768,16 +768,24 @@ public sealed class Binder
             RunWithPackage(owningPackage, typeAlias.SyntaxTree, () => binder.declarations.BindTypeAliasDeclaration(typeAlias, owningPackage));
         }
 
-        // ADR-0059 / issue #255: declare named delegate types BEFORE
-        // interfaces/structs/enums so that interface methods, struct fields,
-        // event handler types, etc. can reference a named delegate by name.
+        // Declare named delegate type-name shells before other type bodies so
+        // their members can reference delegates. Signatures are bound after all
+        // interface/enum/struct shells exist, making delegate constraints,
+        // parameters, and returns independent of syntax-tree order.
         var delegateDeclarations = syntaxTrees.SelectMany(st => st.Root.Members)
-                                              .OfType<DelegateDeclarationSyntax>();
+                                              .OfType<DelegateDeclarationSyntax>()
+                                              .ToList();
+        var declaredDelegates = new List<(DelegateDeclarationSyntax Syntax, DelegateTypeSymbol Symbol)>();
         foreach (var delegateSyntax in delegateDeclarations)
         {
             var owningPackage = packageByTree[delegateSyntax.SyntaxTree];
             binder.declarations.ValidateTopLevelProtected(delegateSyntax.AccessibilityModifier);
-            RunWithPackage(owningPackage, delegateSyntax.SyntaxTree, () => binder.declarations.BindDelegateDeclaration(delegateSyntax, owningPackage));
+            DelegateTypeSymbol sym = null;
+            RunWithPackage(owningPackage, delegateSyntax.SyntaxTree, () => sym = binder.declarations.DeclareDelegateSymbol(delegateSyntax, owningPackage));
+            if (sym != null)
+            {
+                declaredDelegates.Add((delegateSyntax, sym));
+            }
         }
 
         var interfaceDeclarations = PartialTypeMerger.MergeInterfaces(
@@ -864,6 +872,12 @@ public sealed class Binder
                 declaredStructs.Add((structSyntax, structSymbol));
                 syntheticDeclToSymbol[structSyntax] = structSymbol;
             }
+        }
+
+        foreach (var (delegateSyntax, delegateSymbol) in declaredDelegates)
+        {
+            var owningPackage = packageByTree[delegateSyntax.SyntaxTree];
+            RunWithPackage(owningPackage, delegateSyntax.SyntaxTree, () => binder.declarations.BindDelegateDeclarationBody(delegateSyntax, delegateSymbol));
         }
 
         // ADR-0146 / issue #2243: publish the rich anonymous-object literal →

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -806,8 +806,26 @@ internal sealed partial class DeclarationBinder
             return ImmutableArray<TypeParameterSymbol>.Empty;
         }
 
+        var symbols = CreateTypeParameterSymbols(syntax);
+
+        // Publish the bare symbols into the binder's type-parameter scope so the
+        // constraint type clauses bound in pass 2 can see them. Enclosing type
+        // parameters (e.g. for a generic method declared inside a generic type)
+        // remain visible because we copy the previous map.
+        onBareSymbolsPublished?.Invoke(symbols);
+        ResolveTypeParameterConstraints(syntax, symbols);
+        return symbols;
+    }
+
+    private ImmutableArray<TypeParameterSymbol> CreateTypeParameterSymbols(TypeParameterListSyntax syntax)
+    {
+        if (syntax == null)
+        {
+            return ImmutableArray<TypeParameterSymbol>.Empty;
+        }
+
         var count = syntax.Parameters.Count;
-        var symbols = new TypeParameterSymbol[count];
+        var symbols = ImmutableArray.CreateBuilder<TypeParameterSymbol>(count);
         var seen = new HashSet<string>();
 
         // Pass 1: create the bare type-parameter symbols (name, ordinal, variance)
@@ -830,8 +848,22 @@ internal sealed partial class DeclarationBinder
                 variance = p.VarianceModifier.Text == "in" ? TypeParameterVariance.In : TypeParameterVariance.Out;
             }
 
-            symbols[i] = new TypeParameterSymbol(name, i, TypeParameterConstraint.Any, variance);
+            symbols.Add(new TypeParameterSymbol(name, i, TypeParameterConstraint.Any, variance));
         }
+
+        return symbols.MoveToImmutable();
+    }
+
+    private void ResolveTypeParameterConstraints(
+        TypeParameterListSyntax syntax,
+        ImmutableArray<TypeParameterSymbol> symbols)
+    {
+        if (syntax == null)
+        {
+            return;
+        }
+
+        var count = syntax.Parameters.Count;
 
         // Publish the bare symbols into the binder's type-parameter scope so the
         // constraint type clauses bound in pass 2 can see them. Enclosing type
@@ -845,12 +877,6 @@ internal sealed partial class DeclarationBinder
         {
             constraintScope[s.Name] = s;
         }
-
-        // Issue #1056: let the caller register the declaring type's name shell
-        // (with these bare type parameters attached) before constraints resolve,
-        // so a self-referential base-class constraint resolves the type's own
-        // name and arity.
-        onBareSymbolsPublished?.Invoke(ImmutableArray.Create(symbols));
 
         binderCtx.CurrentTypeParameters = constraintScope;
         try
@@ -945,8 +971,6 @@ internal sealed partial class DeclarationBinder
         {
             binderCtx.CurrentTypeParameters = previousTypeParameters;
         }
-
-        return ImmutableArray.Create(symbols);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -233,7 +233,7 @@ internal sealed partial class DeclarationBinder
     /// current scope. Unlike a plain type alias, a named delegate produces a
     /// real CLR TypeDef at emit time.
     /// </summary>
-    internal void BindDelegateDeclaration(DelegateDeclarationSyntax syntax, PackageSymbol package)
+    internal DelegateTypeSymbol DeclareDelegateSymbol(DelegateDeclarationSyntax syntax, PackageSymbol package)
     {
         var name = syntax.Identifier.Text;
 
@@ -241,43 +241,53 @@ internal sealed partial class DeclarationBinder
         if (isPrimitiveTypeName(name))
         {
             Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
-            return;
+            return null;
         }
 
-        // Issue #1503 / ADR-0059 follow-up: a generic named delegate
-        // declaration (`type Predicate[T any] = delegate func(value T) bool`)
-        // binds its type-parameter list FIRST so the delegate's parameter and
-        // return type clauses can reference T, U, … — mirroring how generic
-        // struct/class/interface declarations bind their TypeParameterList. The
-        // emitter threads one GenericParam row per slot through the delegate
-        // TypeDef and references the type parameters (VAR(idx)) in the
-        // Invoke/ctor signatures.
+        var delegateSymbol = new DelegateTypeSymbol(
+            name,
+            package.Name,
+            resolveAccessibility(syntax.AccessibilityModifier),
+            ImmutableArray<ParameterSymbol>.Empty,
+            TypeSymbol.Void,
+            syntax);
+        var typeParameters = CreateTypeParameterSymbols(syntax.TypeParameterList);
+        if (!typeParameters.IsDefaultOrEmpty)
+        {
+            delegateSymbol.SetTypeParameters(typeParameters);
+        }
+
+        Binder.AttachDocumentation(delegateSymbol, syntax);
+        if (!scope.TryDeclareTypeAlias(name, delegateSymbol))
+        {
+            Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
+            return null;
+        }
+
+        return delegateSymbol;
+    }
+
+    internal void BindDelegateDeclarationBody(
+        DelegateDeclarationSyntax syntax,
+        DelegateTypeSymbol delegateSymbol)
+    {
         var previousTypeParameters = binderCtx.CurrentTypeParameters;
-        ImmutableArray<TypeParameterSymbol> typeParameters = ImmutableArray<TypeParameterSymbol>.Empty;
+        var typeParameters = delegateSymbol.TypeParameters;
+        if (!typeParameters.IsDefaultOrEmpty)
+        {
+            binderCtx.CurrentTypeParameters = previousTypeParameters == null
+                ? new Dictionary<string, TypeParameterSymbol>()
+                : new Dictionary<string, TypeParameterSymbol>(previousTypeParameters);
+            foreach (var tp in typeParameters)
+            {
+                binderCtx.CurrentTypeParameters[tp.Name] = tp;
+            }
+        }
+
         try
         {
-            if (syntax.TypeParameterList != null)
-            {
-                binderCtx.CurrentTypeParameters = new Dictionary<string, TypeParameterSymbol>();
-                typeParameters = BindTypeParameterList(syntax.TypeParameterList);
-            }
-
-            // Re-establish the type-parameter scope captured above so the
-            // delegate's parameter and return type clauses resolve T, U, ….
-            // (BindTypeParameterList restores CurrentTypeParameters to its prior
-            // value when it returns, so the scope must be rebuilt here.)
-            if (!typeParameters.IsDefaultOrEmpty)
-            {
-                binderCtx.CurrentTypeParameters = previousTypeParameters == null
-                    ? new Dictionary<string, TypeParameterSymbol>()
-                    : new Dictionary<string, TypeParameterSymbol>(previousTypeParameters);
-                foreach (var tp in typeParameters)
-                {
-                    binderCtx.CurrentTypeParameters[tp.Name] = tp;
-                }
-            }
-
-            BindDelegateDeclarationCore(syntax, package, typeParameters);
+            ResolveTypeParameterConstraints(syntax.TypeParameterList, typeParameters);
+            BindDelegateDeclarationBodyCore(syntax, delegateSymbol);
         }
         finally
         {
@@ -285,14 +295,10 @@ internal sealed partial class DeclarationBinder
         }
     }
 
-    private void BindDelegateDeclarationCore(
+    private void BindDelegateDeclarationBodyCore(
         DelegateDeclarationSyntax syntax,
-        PackageSymbol package,
-        ImmutableArray<TypeParameterSymbol> typeParameters)
+        DelegateTypeSymbol delegateSymbol)
     {
-        var name = syntax.Identifier.Text;
-        var accessibility = resolveAccessibility(syntax.AccessibilityModifier);
-
         var parameters = ImmutableArray.CreateBuilder<ParameterSymbol>();
         var seenParameterNames = new HashSet<string>();
         for (var pIndex = 0; pIndex < syntax.Parameters.Count; pIndex++)
@@ -357,25 +363,8 @@ internal sealed partial class DeclarationBinder
             "a delegate declaration",
             System.AttributeTargets.Delegate);
 
-        var delegateSymbol = new DelegateTypeSymbol(
-            name,
-            package.Name,
-            accessibility,
-            parameters.ToImmutable(),
-            returnType,
-            syntax);
-        if (!typeParameters.IsDefaultOrEmpty)
-        {
-            delegateSymbol.SetTypeParameters(typeParameters);
-        }
-
+        delegateSymbol.SetSignature(parameters.ToImmutable(), returnType);
         delegateSymbol.SetAttributes(delegateAttributes);
-        Binder.AttachDocumentation(delegateSymbol, syntax);
-
-        if (!scope.TryDeclareTypeAlias(name, delegateSymbol))
-        {
-            Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
-        }
     }
 
     internal EnumSymbol BindEnumDeclaration(EnumDeclarationSyntax syntax, PackageSymbol package, TypeSymbol containingType = null)

--- a/src/Core/CodeAnalysis/Symbols/DelegateTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/DelegateTypeSymbol.cs
@@ -66,10 +66,10 @@ public sealed class DelegateTypeSymbol : TypeSymbol
     public Accessibility Accessibility { get; }
 
     /// <summary>Gets the delegate's named parameters in declaration order.</summary>
-    public ImmutableArray<ParameterSymbol> Parameters { get; }
+    public ImmutableArray<ParameterSymbol> Parameters { get; private set; }
 
     /// <summary>Gets the delegate's return type (<see cref="TypeSymbol.Void"/> for a void delegate).</summary>
-    public TypeSymbol ReturnType { get; }
+    public TypeSymbol ReturnType { get; private set; }
 
     /// <summary>Gets the declaring syntax node.</summary>
     public DelegateDeclarationSyntax Declaration { get; }
@@ -143,13 +143,26 @@ public sealed class DelegateTypeSymbol : TypeSymbol
 
     /// <summary>
     /// Attaches the delegate's generic type parameters (issue #1503). Called
-    /// once by the binder during <see cref="Binding.DeclarationBinder.BindDelegateDeclaration"/>
+    /// once by the binder during delegate declaration binding
     /// before any constructed instance is materialized.
     /// </summary>
     /// <param name="typeParameters">The bound type parameters in declaration order.</param>
     public void SetTypeParameters(ImmutableArray<TypeParameterSymbol> typeParameters)
     {
         TypeParameters = typeParameters.IsDefault ? ImmutableArray<TypeParameterSymbol>.Empty : typeParameters;
+    }
+
+    /// <summary>
+    /// Installs the signature on a declaration shell after all compilation
+    /// type names have been registered.
+    /// </summary>
+    /// <param name="parameters">The delegate parameters.</param>
+    /// <param name="returnType">The delegate return type.</param>
+    public void SetSignature(ImmutableArray<ParameterSymbol> parameters, TypeSymbol returnType)
+    {
+        Parameters = parameters.IsDefault ? ImmutableArray<ParameterSymbol>.Empty : parameters;
+        ReturnType = returnType ?? Void;
+        equivalentFunctionType = null;
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2457CrossFileDelegateTypeBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2457CrossFileDelegateTypeBindingTests.cs
@@ -1,0 +1,165 @@
+// <copyright file="Issue2457CrossFileDelegateTypeBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2457: named delegate signatures bind against the complete declaration
+/// symbol table rather than the syntax-tree prefix processed so far.
+/// </summary>
+public class Issue2457CrossFileDelegateTypeBindingTests
+{
+    private const string Delegates = """
+        package Demo
+        import System.Collections.Generic
+
+        type Work[T ICancellation] = delegate func(
+            cancellation ICancellation,
+            values List[ConfigurationTokenResult]) Dictionary[string, ConfigurationTokenResult]
+        internal type GetResult = delegate func() ConfigurationTokenResult
+        """;
+
+    private const string Types = """
+        package Demo
+
+        interface ICancellation {}
+        internal data class ConfigurationTokenResult(Value string) {}
+        """;
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SamePackageTypes_ResolveInDelegateConstraintsParametersAndReturns_RegardlessOfFileOrder(bool delegateFirst)
+    {
+        var sources = delegateFirst ? new[] { Delegates, Types } : new[] { Types, Delegates };
+
+        AssertNoErrors(sources);
+    }
+
+    [Fact]
+    public void PublicImportedCrossPackageTypes_ResolveInDelegateSignature()
+    {
+        const string shared = """
+            package Shared
+
+            interface IConstraint {}
+            data class Result(Value string) {}
+            """;
+        const string consumer = """
+            package Consumer
+            import Shared
+            import System.Collections.Generic
+
+            type Convert[T IConstraint] = delegate func(value Result) List[Result]
+            """;
+
+        AssertNoErrors(new[] { consumer, shared });
+    }
+
+    [Fact]
+    public void SamePackageInternalType_IsVisibleToDelegateInAnotherFile()
+    {
+        const string consumer = """
+            package Demo
+
+            internal type Read = delegate func(value Hidden) Hidden
+            """;
+        const string hidden = """
+            package Demo
+
+            internal class Hidden {}
+            """;
+
+        AssertNoErrors(new[] { consumer, hidden });
+    }
+
+    [Fact]
+    public void UnrelatedFileImport_DoesNotMakeDelegateReferenceAmbiguous()
+    {
+        const string left = """
+            package Left
+
+            class Result {}
+            """;
+        const string right = """
+            package Right
+
+            class Result {}
+            """;
+        const string delegates = """
+            package Consumer
+            import Left
+
+            type Read = delegate func() Result
+            """;
+        const string unrelated = """
+            package Unrelated
+            import Right
+
+            class Marker {}
+            """;
+
+        AssertNoErrors(new[] { right, left, unrelated, delegates });
+    }
+
+    [Fact]
+    public void MissingDelegateSignatureType_StillReportsUndefinedType()
+    {
+        const string source = """
+            package Demo
+
+            type Read = delegate func(value Missing) Missing
+            """;
+
+        var errors = Errors(new[] { source }).ToArray();
+
+        Assert.Contains(errors, d => d.Id == "GS0113");
+    }
+
+    [Fact]
+    public void AmbiguousImportedDelegateSignatureType_StillReportsAmbiguity()
+    {
+        const string left = """
+            package Left
+
+            class Result {}
+            """;
+        const string right = """
+            package Right
+
+            class Result {}
+            """;
+        const string consumer = """
+            package Consumer
+            import Left
+            import Right
+
+            type Read = delegate func() Result
+            """;
+
+        var errors = Errors(new[] { left, right, consumer }).ToArray();
+
+        Assert.Contains(errors, d => d.Id == "GS0496");
+    }
+
+    private static void AssertNoErrors(string[] sources)
+        => Assert.DoesNotContain(Errors(sources), _ => true);
+
+    private static IEnumerable<Diagnostic> Errors(string[] sources)
+    {
+        var trees = sources.Select(source => SyntaxTree.Parse(SourceText.From(source))).ToArray();
+        var compilation = new Compilation(trees) { IsLibrary = true };
+        return compilation.GlobalScope.Diagnostics
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .Where(d => d.IsError);
+    }
+}


### PR DESCRIPTION
Closes #2457

## Summary
- predeclare named delegate shells before binding signatures
- bind delegate constraints, parameters, and returns after package-wide type shells exist
- preserve per-file import disambiguation and missing/ambiguous diagnostics
- add cross-file/order/import/negative regression coverage

## Validation
- Core.Tests: 6,447 passed, 1 skipped
- Compiler.Tests: 3,162 passed
- Cs2Gs.Tests: 1,556 passed (`RunConfiguration.DisableParallelization=true`)
- Oahu.Core SDK migration: 17 -> 15 fingerprints; removed only `7d53625d14a4`, `1474f39828a5`; no additions