### PR TITLE
Fix extension method group binding

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Reflection;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
@@ -1347,16 +1348,31 @@ internal sealed class ConversionClassifier
         }
 
         var invokeParams = invoke.GetParameters();
-        var argTypes = new Type[invokeParams.Length];
+        var closesExtensionReceiver = group.Receiver != null
+            && group.Candidates.All(candidate => candidate.IsStatic);
+        var argTypes = new Type[invokeParams.Length + (closesExtensionReceiver ? 1 : 0)];
+        if (closesExtensionReceiver)
+        {
+            var receiverClr = group.Receiver.Type?.ClrType;
+            if (receiverClr == null
+                && !MemberLookup.TryProjectErasedClrType(group.Receiver.Type, out receiverClr))
+            {
+                Diagnostics.ReportCannotConvertMethodGroup(diagnosticLocation, group.MethodName, targetType);
+                return new BoundErrorExpression(null);
+            }
+
+            argTypes[0] = receiverClr;
+        }
+
         for (var i = 0; i < invokeParams.Length; i++)
         {
-            argTypes[i] = invokeParams[i].ParameterType;
+            argTypes[i + (closesExtensionReceiver ? 1 : 0)] = invokeParams[i].ParameterType;
         }
 
         var applicable = new List<MethodInfo>();
         foreach (var candidate in group.Candidates)
         {
-            if (candidate.GetParameters().Length != invokeParams.Length)
+            if (candidate.GetParameters().Length != argTypes.Length)
             {
                 continue;
             }
@@ -1438,15 +1454,16 @@ internal sealed class ConversionClassifier
         FunctionSymbol pick = null;
         foreach (var candidate in group.Candidates)
         {
-            if (candidate.Parameters.Length != targetParameterTypes.Length)
+            var parameterOffset = candidate.IsExtension && group.Receiver != null ? 1 : 0;
+            if (candidate.Parameters.Length - parameterOffset != targetParameterTypes.Length)
             {
                 continue;
             }
 
             var paramsMatch = true;
-            for (var i = 0; i < candidate.Parameters.Length; i++)
+            for (var i = 0; i < targetParameterTypes.Length; i++)
             {
-                if (!ReferenceEquals(candidate.Parameters[i].Type, targetParameterTypes[i]))
+                if (!ReferenceEquals(candidate.Parameters[i + parameterOffset].Type, targetParameterTypes[i]))
                 {
                     paramsMatch = false;
                     break;
@@ -1479,10 +1496,11 @@ internal sealed class ConversionClassifier
             return new BoundErrorExpression(null);
         }
 
-        var pickParams = ImmutableArray.CreateBuilder<TypeSymbol>(pick.Parameters.Length);
-        foreach (var p in pick.Parameters)
+        var pickParameterOffset = pick.IsExtension && group.Receiver != null ? 1 : 0;
+        var pickParams = ImmutableArray.CreateBuilder<TypeSymbol>(pick.Parameters.Length - pickParameterOffset);
+        for (var i = pickParameterOffset; i < pick.Parameters.Length; i++)
         {
-            pickParams.Add(p.Type);
+            pickParams.Add(pick.Parameters[i].Type);
         }
 
         var pickFnType = FunctionTypeSymbol.Get(pickParams.MoveToImmutable(), pick.Type ?? TypeSymbol.Void);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -141,8 +141,7 @@ internal sealed partial class ExpressionBinder
                             return staticGroup;
                         }
 
-                        Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
-                        return new BoundErrorExpression(null);
+                        return BindExtensionMethodGroupOrError(receiver, ne);
                     }
 
                     // Stream B: static field/property read on imported type.
@@ -307,7 +306,7 @@ internal sealed partial class ExpressionBinder
                         return inheritedClrGroup;
                     }
 
-                    Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
+                    return BindExtensionMethodGroupOrError(receiver, ne);
                 }
                 else if (receiver != null && receiver.Type is EnumSymbol)
                 {
@@ -322,7 +321,7 @@ internal sealed partial class ExpressionBinder
                         return enumClrGroup;
                     }
 
-                    Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
+                    return BindExtensionMethodGroupOrError(receiver, ne);
                 }
                 else if (receiver != null && receiver.Type is InterfaceSymbol ifaceSym)
                 {
@@ -396,7 +395,7 @@ internal sealed partial class ExpressionBinder
                         }
                     }
 
-                    Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
+                    return BindExtensionMethodGroupOrError(receiver, ne);
                 }
                 else if (receiver != null && receiver.Type is TupleTypeSymbol tupleSym)
                 {
@@ -409,8 +408,7 @@ internal sealed partial class ExpressionBinder
                         return new BoundTupleElementAccessExpression(null, receiver, tupleSym, oneBased - 1);
                     }
 
-                    Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
-                    return new BoundErrorExpression(null);
+                    return BindExtensionMethodGroupOrError(receiver, ne);
                 }
                 else if (receiver != null && receiver.Type is NullableTypeSymbol nullableSym
                     && nullableSym.UnderlyingType?.ClrType is { IsValueType: true } nullableInnerClr
@@ -436,8 +434,7 @@ internal sealed partial class ExpressionBinder
                         return nullableGroup;
                     }
 
-                    Diagnostics.ReportUnableToFindMember(ne.Location, nullableMemberName);
-                    return new BoundErrorExpression(null);
+                    return BindExtensionMethodGroupOrError(receiver, ne);
                 }
                 else if (receiver != null && receiver.Type is NullableTypeSymbol openNullableSym
                     && openNullableSym.UnderlyingType is TypeParameterSymbol openTp
@@ -479,8 +476,7 @@ internal sealed partial class ExpressionBinder
                         return openNullableGroup;
                     }
 
-                    Diagnostics.ReportUnableToFindMember(ne.Location, openNullableMemberName);
-                    return new BoundErrorExpression(null);
+                    return BindExtensionMethodGroupOrError(receiver, ne);
                 }
                 else if (receiver != null && receiver.Type != null && receiver.Type is not NullableTypeSymbol && receiver.Type.ClrType != null)
                 {
@@ -536,8 +532,7 @@ internal sealed partial class ExpressionBinder
                         return instanceGroup;
                     }
 
-                    Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
-                    return new BoundErrorExpression(null);
+                    return BindExtensionMethodGroupOrError(receiver, ne);
                 }
                 else if (receiver != null
                     && receiver.Type is SliceTypeSymbol or ArrayTypeSymbol
@@ -561,8 +556,7 @@ internal sealed partial class ExpressionBinder
                         return new BoundClrPropertyAccessExpression(null, receiver, arrayProp, ClrNullability.GetPropertyTypeSymbol(arrayProp));
                     }
 
-                    Diagnostics.ReportUnableToFindMember(ne.Location, arrayMemberName);
-                    return new BoundErrorExpression(null);
+                    return BindExtensionMethodGroupOrError(receiver, ne);
                 }
                 else if (receiver != null && receiver.Type is TypeParameterSymbol tpRecv)
                 {
@@ -580,18 +574,65 @@ internal sealed partial class ExpressionBinder
                         return tpMember;
                     }
 
-                    Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
+                    return BindExtensionMethodGroupOrError(receiver, ne);
                 }
                 else
                 {
-                    Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
+                    return BindExtensionMethodGroupOrError(receiver, ne);
                 }
-
-                return new BoundErrorExpression(null);
 
             default:
                 return new BoundErrorExpression(null);
         }
+    }
+
+    /// <summary>
+    /// Issue #2452: binds a receiver-style extension method reference used as a
+    /// value (<c>receiver.Extension</c>) after ordinary fields, properties, and
+    /// instance methods have all failed lookup. Calls already resolve extensions
+    /// through the overload resolver; method-group lookup must use the same
+    /// symbol tables instead of treating the name as a missing property.
+    /// </summary>
+    private BoundExpression BindExtensionMethodGroupOrError(BoundExpression receiver, NameExpressionSyntax name)
+    {
+        if (receiver != null)
+        {
+            var userCandidates = scope.TryLookupExtensionFunctions(receiver.Type, name.IdentifierToken.Text);
+            if (!userCandidates.IsDefaultOrEmpty)
+            {
+                if (userCandidates.Length == 1
+                    && userCandidates[0] is { IsExtension: true, TypeParameters.IsDefaultOrEmpty: true } single
+                    && single.Parameters.Length > 0)
+                {
+                    var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(single.Parameters.Length - 1);
+                    for (var i = 1; i < single.Parameters.Length; i++)
+                    {
+                        parameterTypes.Add(single.Parameters[i].Type);
+                    }
+
+                    var functionType = FunctionTypeSymbol.Get(
+                        parameterTypes.MoveToImmutable(),
+                        single.Type ?? TypeSymbol.Void);
+                    return new BoundMethodGroupExpression(name, receiver, single, functionType);
+                }
+
+                return new BoundMethodGroupExpression(name, receiver, userCandidates);
+            }
+
+            var importedCandidates = this.memberLookup.CollectImportedExtensionMethods(name.IdentifierToken.Text);
+            if (importedCandidates.Count > 0)
+            {
+                return new BoundClrMethodGroupExpression(
+                    name,
+                    receiver,
+                    declaringType: null,
+                    name.IdentifierToken.Text,
+                    importedCandidates.ToImmutableArray());
+            }
+        }
+
+        Diagnostics.ReportUnableToFindMember(name.Location, name.IdentifierToken.Text);
+        return new BoundErrorExpression(null);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -781,6 +781,22 @@ internal sealed partial class MethodBodyEmitter
             delegateType = overrideDelegateType ?? this.outer.signatures.ResolveDelegateClrType(methodGroup.FunctionType);
         }
 
+        if (methodGroup.Function.IsExtension && methodGroup.Receiver != null)
+        {
+            if (!this.outer.cache.FunctionHandles.TryGetValue(methodGroup.Function, out var methodHandle)
+                && !this.outer.cache.MethodHandles.TryGetValue(methodGroup.Function, out methodHandle))
+            {
+                throw new InvalidOperationException(
+                    $"Extension method group '{methodGroup.Function.Name}' has no emitted MethodDef.");
+            }
+
+            EntityHandle delegateTypeHandle = delegateType == null
+                ? this.outer.memberRefs.GetFunctionDelegateTypeSpec(methodGroup.FunctionType)
+                : this.outer.memberRefs.GetTypeHandleForMember(delegateType);
+            this.EmitClosedStaticMethodGroup(methodGroup.Receiver, methodHandle, delegateTypeHandle);
+            return;
+        }
+
         // Shared prologue: resolves the (interface/generic-aware) function
         // pointer token and leaves the delegate-ctor operands on the stack.
         this.EmitMethodGroupTarget(methodGroup);
@@ -818,6 +834,16 @@ internal sealed partial class MethodBodyEmitter
 
         var delegateType = this.outer.signatures.ResolveTargetDelegateClrType(hostDelegate);
         var methodRef = this.outer.memberRefs.GetMethodReference(method);
+
+        if (method.IsStatic && methodGroup.Receiver != null)
+        {
+            this.EmitClosedStaticMethodGroup(
+                methodGroup.Receiver,
+                methodRef,
+                this.outer.memberRefs.GetTypeHandleForMember(delegateType),
+                method);
+            return;
+        }
 
         if (method.IsStatic)
         {
@@ -859,6 +885,41 @@ internal sealed partial class MethodBodyEmitter
 
         this.il.OpCode(ILOpCode.Newobj);
         this.il.Token(this.outer.memberRefs.GetDelegateCtorReference(delegateType));
+    }
+
+    private void EmitClosedStaticMethodGroup(
+        BoundExpression receiver,
+        EntityHandle methodHandle,
+        EntityHandle delegateTypeHandle,
+        MethodInfo importedMethod = null)
+    {
+        this.il.OpCode(ILOpCode.Ldtoken);
+        this.il.Token(delegateTypeHandle);
+        this.il.Call(this.outer.wellKnown.GetTypeFromHandleReference());
+
+        this.EmitExpression(receiver);
+        if (ReflectionMetadataEmitter.IsValueTypeSymbol(receiver.Type))
+        {
+            this.il.OpCode(ILOpCode.Box);
+            this.il.Token(this.outer.memberRefs.GetElementTypeToken(receiver.Type));
+        }
+
+        if (importedMethod != null)
+        {
+            this.EmitMethodInfoLiteral(importedMethod);
+        }
+        else
+        {
+            this.il.OpCode(ILOpCode.Ldtoken);
+            this.il.Token(methodHandle);
+            this.il.Call(this.outer.wellKnown.GetMethodFromHandleReference());
+            this.il.OpCode(ILOpCode.Castclass);
+            this.il.Token(this.outer.memberRefs.GetTypeReference(typeof(MethodInfo)));
+        }
+
+        this.il.Call(this.outer.wellKnown.GetClosedStaticDelegateCreateReference());
+        this.il.OpCode(ILOpCode.Castclass);
+        this.il.Token(delegateTypeHandle);
     }
 
     // Phase 4 emit parity: load a captured variable. In a MoveNext body,

--- a/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
+++ b/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
@@ -877,6 +877,22 @@ internal sealed class WellKnownReferences
         return this.getMethodReference(method);
     }
 
+    public MemberReferenceHandle GetClosedStaticDelegateCreateReference()
+    {
+        // System.Delegate::CreateDelegate(Type, object, MethodInfo) creates a
+        // verifiable closed-static delegate whose target supplies the method's
+        // first parameter (issue #2452 extension method groups).
+        var delegateType = this.emitCtx.CoreObjectType.Assembly.GetType("System.Delegate")
+            ?? throw new InvalidOperationException("System.Delegate is not resolvable from the supplied references.");
+        var methodInfoType = this.emitCtx.CoreMethodBaseType.Assembly.GetType("System.Reflection.MethodInfo")
+            ?? throw new InvalidOperationException("System.Reflection.MethodInfo is not resolvable from the supplied references.");
+        var method = delegateType.GetMethod(
+            "CreateDelegate",
+            new[] { this.emitCtx.CoreSystemType, this.emitCtx.CoreObjectType, methodInfoType })
+            ?? throw new InvalidOperationException("Delegate.CreateDelegate(Type, object, MethodInfo) is not resolvable from the supplied references.");
+        return this.getMethodReference(method);
+    }
+
     public MemberReferenceHandle GetArrayCopyReference()
     {
         // System.Array::Copy(Array, Array, Int32) — used to implement append(slice, element).

--- a/test/Compiler.Tests/Emit/Adr0112UserMethodGroupEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Adr0112UserMethodGroupEmitTests.cs
@@ -192,6 +192,56 @@ public class Adr0112UserMethodGroupEmitTests
         Assert.Equal("17\n", CompileAndRun(source));
     }
 
+    [Fact]
+    public void ExtensionMethodGroup_ClosesStaticReceiverOnce_AndPreservesMethodIdentity()
+    {
+        var source = """
+            package P
+            import System
+
+            var receiverReads = 0
+
+            func NextText() string {
+                receiverReads++
+                return "abc"
+            }
+
+            func (text string) Checksum32() uint32 -> uint32(text.Length)
+
+            let checksum () -> uint32 = NextText().Checksum32
+            Console.WriteLine(receiverReads)
+            Console.WriteLine(checksum())
+            Console.WriteLine(checksum.Method.Name)
+            Console.WriteLine("group=${NextText().Checksum32}")
+            Console.WriteLine(receiverReads)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.StartsWith("1\n3\nChecksum32\ngroup=System.Func`1[System.UInt32]\n2\n", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ImportedExtensionMethodGroup_ClosesReceiver_AndRuns()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            let values = List[int32]()
+            values.Add(1)
+            values.Add(2)
+            let items IEnumerable[int32] = values
+            let count () -> int32 = items.Count
+
+            Console.WriteLine(count())
+            Console.WriteLine(count.Method.Name)
+            """;
+
+        Assert.Equal("2\nCount\n", CompileAndRun(source));
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_adr0112_emit_").FullName;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2452ExtensionMethodGroupTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2452ExtensionMethodGroupTests.cs
@@ -1,0 +1,154 @@
+// <copyright file="Issue2452ExtensionMethodGroupTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2452: receiver-style extension method references are method groups,
+/// not property reads. Ordinary members keep precedence, while source and
+/// imported extensions may be converted to delegates when no member exists.
+/// </summary>
+public class Issue2452ExtensionMethodGroupTests
+{
+    [Fact]
+    public void SourceExtensionMethodGroups_WorkAcrossRecordClassAndInterfaceReceivers()
+    {
+        var source = """
+            package Repro
+            import System
+
+            func (text string) Checksum32() uint32 -> uint32(text.Length)
+
+            interface IText { prop Text string { get; } }
+            interface IHasher { func Hash() uint32; }
+
+            data class Profile(AccountName string, DeviceName string)
+
+            class TextHolder : IText {
+                prop Text string -> "holder"
+            }
+
+            class Hasher : IHasher {
+                func (IHasher) Hash() uint32 -> 8u
+            }
+
+            func CaptureProfile(p Profile) uint32 {
+                let account () -> uint32 = p.AccountName.Checksum32
+                return account() + p.DeviceName.Checksum32()
+            }
+
+            func CaptureInterface(value IText) uint32 {
+                let checksum () -> uint32 = value.Text.Checksum32
+                return checksum()
+            }
+
+            let profile = Profile("abc", "de")
+            let holder IText = TextHolder()
+            let hasher IHasher = Hasher()
+            let explicitGroup () -> uint32 = hasher.Hash
+            Console.WriteLine(CaptureProfile(profile))
+            Console.WriteLine(CaptureInterface(holder))
+            Console.WriteLine(explicitGroup())
+            """;
+
+        AssertCompilesWithoutErrors(source);
+    }
+
+    [Fact]
+    public void RealPropertyAndParameterlessMethods_WinOverSameNameExtension()
+    {
+        var source = """
+            package Repro
+            import System
+
+            import System.Collections.Generic
+            import System.Linq
+
+            func (value string) Trim() string -> "extension"
+
+            open class Base {
+                func Shape() int32 -> 7
+            }
+
+            class Host : Base {}
+
+            class PropertyHost {
+                prop Shape int32 -> 11
+            }
+
+            let host = Host()
+            let inherited () -> int32 = host.Shape
+            let propertyHost = PropertyHost()
+            let textTrim () -> string = " padded ".Trim
+            let values = List[int32]()
+            values.Add(1)
+            Console.WriteLine(inherited())
+            Console.WriteLine(propertyHost.Shape)
+            Console.WriteLine(textTrim())
+            Console.WriteLine(values.Count)
+            """;
+
+        AssertCompilesWithoutErrors(source);
+    }
+
+    [Fact]
+    public void ImportedExtensionMethodGroup_ConvertsToDelegate()
+    {
+        var source = """
+            package Repro
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            let values = List[int32]()
+            values.Add(1)
+            values.Add(2)
+            let items IEnumerable[int32] = values
+            let count () -> int32 = items.Count
+            Console.WriteLine(count())
+            """;
+
+        AssertCompilesWithoutErrors(source);
+    }
+
+    [Fact]
+    public void NullForgivingAndNullConditionalExtensionReceivers_Compile()
+    {
+        var source = """
+            package Repro
+            import System
+
+            func (text string) Checksum32() uint32 -> uint32(text.Length)
+
+            let maybe string? = "abc"
+            let checksum () -> uint32 = maybe!!.Checksum32
+            let conditional = maybe?.Checksum32()
+            Console.WriteLine(checksum())
+            Console.WriteLine(conditional)
+            """;
+
+        AssertCompilesWithoutErrors(source);
+    }
+
+    private static void AssertCompilesWithoutErrors(string source)
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "Emit failed:\n" + string.Join("\n", result.Diagnostics.Select(d => d.ToString())));
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2452ExtensionMethodGroupTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2452ExtensionMethodGroupTranslationTests.cs
@@ -1,0 +1,131 @@
+// <copyright file="Issue2452ExtensionMethodGroupTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2452: Roslyn distinguishes a get-only record property, a reduced
+/// extension method group, and an invoked reduced extension method. cs2gs must
+/// preserve those symbol-directed shapes; gsc is responsible for binding the
+/// bare extension method group as a delegate value.
+/// </summary>
+public class Issue2452ExtensionMethodGroupTranslationTests
+{
+    [Fact]
+    public void RecordPropertyReceiver_ExtensionMethodGroupAndInvocation_KeepDistinctShapes()
+    {
+        const string source = """
+            using System;
+
+            namespace Repro
+            {
+                public static class Checksums
+                {
+                    public static uint Checksum32(this string text) => (uint)text.Length;
+                }
+
+                public record Profile(string AccountName, string DeviceName)
+                {
+                    public override string ToString() =>
+                        $"{nameof(AccountName)}=<{AccountName!.Checksum32}>, {nameof(DeviceName)}=<{DeviceName?.Checksum32()}>";
+                }
+            }
+            """;
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Records.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var root = document.GetRoot();
+        var accountAccess = root.DescendantNodes()
+            .OfType<InterpolationSyntax>()
+            .Select(h => h.Expression)
+            .OfType<MemberAccessExpressionSyntax>()
+            .Single(m => m.Name.Identifier.Text == "Checksum32");
+        var deviceInvocation = root.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Single(i => document.SemanticModel.GetSymbolInfo(i).Symbol is IMethodSymbol { Name: "Checksum32" });
+        var accountProperty = root.DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .First(i => i.Identifier.Text == "AccountName" && i.Parent is PostfixUnaryExpressionSyntax);
+
+        var accountMethod = Assert.IsAssignableFrom<IMethodSymbol>(
+            document.SemanticModel.GetSymbolInfo(accountAccess).Symbol);
+        var deviceMethod = Assert.IsAssignableFrom<IMethodSymbol>(
+            document.SemanticModel.GetSymbolInfo(deviceInvocation).Symbol);
+        Assert.Equal(MethodKind.ReducedExtension, accountMethod.MethodKind);
+        Assert.Equal(MethodKind.ReducedExtension, deviceMethod.MethodKind);
+        Assert.IsAssignableFrom<IPropertySymbol>(
+            document.SemanticModel.GetSymbolInfo(accountProperty).Symbol);
+
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        string printed = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+
+        Assert.Contains("AccountName!!.Checksum32}", printed, StringComparison.Ordinal);
+        Assert.Contains("DeviceName?.Checksum32()}", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("AccountName!!.Checksum32()}", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PropertyAndMethodCallSites_AreNotRewrittenByName()
+    {
+        const string source = """
+            namespace Repro
+            {
+                public interface IShape
+                {
+                    int Shape { get; }
+                }
+
+                public sealed class Host : IShape
+                {
+                    public int Shape => 7;
+                    public int Measure() => 9;
+                }
+
+                public static class Extensions
+                {
+                    public static int Shape(this Host host) => 99;
+                    public static int Measure(this Host host, int unused = 0) => 99;
+                }
+
+                public sealed class Consumer
+                {
+                    public int Read(Host host, IShape shape) =>
+                        host.Shape + shape.Shape + host.Measure();
+                }
+            }
+            """;
+
+        string printed = Translate(source);
+        Assert.Contains("host.Shape + shape.Shape + host.Measure()", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("host.Shape()", printed, StringComparison.Ordinal);
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return GSharpPrinter.Print(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+}


### PR DESCRIPTION
Closes #2452

## Summary
- bind source and imported extension methods in method-group/value position after ordinary member lookup
- close extension receivers during delegate conversion and emit verifiable closed-static delegates
- preserve cs2gs member-access versus invocation shapes and add regression coverage across records, interfaces, collisions, nullability, interpolation, and runtime reflection

## Validation
- Core.Tests: 6451 passed, 1 skipped
- Compiler.Tests: 3164 passed
- Cs2Gs.Tests: 1558 passed (parallelization disabled)
- targeted issue tests: Core 4, Compiler 2, Cs2Gs 2 passed
- fresh default `--via-sdk` Oahu.Core migration: baseline 15 fingerprints -> 14; removed only `9bc6e739a2dd`, no additions or cascades