### PR TITLE
Fix #2395: scope imports to referencing syntax trees

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -686,7 +686,7 @@ public sealed class Binder
     /// <returns>The new chained bound global scope.</returns>
     public static BoundGlobalScope BindGlobalScope(BoundGlobalScope previous, ImmutableArray<SyntaxTree> syntaxTrees, ReferenceResolver references, bool implicitSystemImport, ImmutableHashSet<string> preprocessorSymbols, bool isLibrary)
     {
-        var parentScope = CreateParentScope(previous, references, preprocessorSymbols);
+        var parentScope = CreateParentScope(previous, references, preprocessorSymbols, preserveLatestImportSyntaxTrees: false);
         var binder = new Binder(parentScope, function: null);
 
         if (implicitSystemImport && previous == null)
@@ -1038,8 +1038,10 @@ public sealed class Binder
             var tlsBinder = new Binder(binder.scope, synthesizedEntryPoint);
             foreach (var globalStatement in globalStatements)
             {
-                var statement = tlsBinder.statements.BindStatement(globalStatement.Statement);
-                statements.Add(statement);
+                RunWithPackage(
+                    packageByTree[globalStatement.SyntaxTree],
+                    globalStatement.SyntaxTree,
+                    () => statements.Add(tlsBinder.statements.BindStatement(globalStatement.Statement)));
             }
 
             // Issue #1884: all TLS global statements share the synthesized
@@ -1228,7 +1230,7 @@ public sealed class Binder
     /// <returns>A bound program.</returns>
     public static BoundProgram BindProgram(BoundGlobalScope globalScope, ReferenceResolver references, BoundBodyCache cache, ImmutableHashSet<SyntaxTree> dirtyTrees)
     {
-        var parentScope = CreateParentScope(globalScope, references, preprocessorSymbols: globalScope?.PreprocessorSymbols);
+        var parentScope = CreateParentScope(globalScope, references, preprocessorSymbols: globalScope?.PreprocessorSymbols, preserveLatestImportSyntaxTrees: true);
 
         // ADR-0146 / issue #2243: rehydrate the rich anonymous-object literal →
         // synthesized-class map onto this pass's scope chain so a literal
@@ -2015,6 +2017,7 @@ public sealed class Binder
         };
 
         var previousPackage = parentScope.SetCurrentDeclaringPackage(structSym.PackageName);
+        var previousTree = parentScope.SetCurrentReferencingSyntaxTree(structSym.Declaration.SyntaxTree);
         try
         {
             var binder = new Binder(parentScope, context);
@@ -2033,6 +2036,7 @@ public sealed class Binder
         finally
         {
             parentScope.SetCurrentDeclaringPackage(previousPackage);
+            parentScope.SetCurrentReferencingSyntaxTree(previousTree);
         }
     }
 
@@ -2065,30 +2069,35 @@ public sealed class Binder
 
         try
         {
-            var parentScope = CreateParentScope(globalScope, references, globalScope.PreprocessorSymbols);
+            var parentScope = CreateParentScope(globalScope, references, globalScope.PreprocessorSymbols, preserveLatestImportSyntaxTrees: true);
             var binder = new Binder(parentScope, containingFunction);
+            var previousPackage = parentScope.SetCurrentDeclaringPackage(containingFunction?.Package?.Name);
+            var previousTree = parentScope.SetCurrentReferencingSyntaxTree(expression.SyntaxTree);
 
-            if (additionalLocals != null)
+            try
             {
-                foreach (var local in additionalLocals)
+                if (additionalLocals != null)
                 {
-                    if (local != null)
+                    foreach (var local in additionalLocals)
                     {
-                        // Speculative binding: collisions with already-declared
-                        // parameters are expected and harmless (TryDeclareVariable
-                        // simply reports false).
-                        binder.scope.TryDeclareVariable(local);
+                        if (local != null)
+                        {
+                            binder.scope.TryDeclareVariable(local);
+                        }
                     }
                 }
-            }
 
-            // The binder writes any diagnostics into its own throwaway bag, so
-            // speculative binding never leaks errors into the open document.
-            var bound = binder.expressions.BindExpression(expression);
-            var type = bound?.Type;
-            return type == null || ReferenceEquals(type, TypeSymbol.Error) || ReferenceEquals(type, TypeSymbol.Void)
-                ? null
-                : type;
+                var bound = binder.expressions.BindExpression(expression);
+                var type = bound?.Type;
+                return type == null || ReferenceEquals(type, TypeSymbol.Error) || ReferenceEquals(type, TypeSymbol.Void)
+                    ? null
+                    : type;
+            }
+            finally
+            {
+                parentScope.SetCurrentDeclaringPackage(previousPackage);
+                parentScope.SetCurrentReferencingSyntaxTree(previousTree);
+            }
         }
         catch (Exception)
         {
@@ -2393,7 +2402,11 @@ public sealed class Binder
         }
     }
 
-    private static BoundScope CreateParentScope(BoundGlobalScope previous, ReferenceResolver references, ImmutableHashSet<string> preprocessorSymbols)
+    private static BoundScope CreateParentScope(
+        BoundGlobalScope previous,
+        ReferenceResolver references,
+        ImmutableHashSet<string> preprocessorSymbols,
+        bool preserveLatestImportSyntaxTrees)
     {
         var stack = new Stack<BoundGlobalScope>();
         while (previous != null)
@@ -2408,10 +2421,13 @@ public sealed class Binder
         {
             previous = stack.Pop();
             var scope = new BoundScope(parent);
+            var preserveImportSyntaxTrees = preserveLatestImportSyntaxTrees && stack.Count == 0;
 
             foreach (var i in previous.Imports)
             {
-                scope.TryImport(i);
+                scope.TryImport(preserveImportSyntaxTrees
+                    ? i
+                    : new ImportSymbol(i.Name, i.Target, declaration: null));
             }
 
             foreach (var alias in previous.TypeAliases)

--- a/src/Core/CodeAnalysis/Binding/BinderContext.cs
+++ b/src/Core/CodeAnalysis/Binding/BinderContext.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
@@ -117,6 +118,7 @@ internal sealed class BinderContext
     private int cachedStaticImportImportCount = -1;
 
     private int cachedStaticImportStructCount = -1;
+    private SyntaxTree cachedStaticImportSyntaxTree;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BinderContext"/> class.
@@ -264,6 +266,8 @@ internal sealed class BinderContext
     /// </summary>
     public int CachedImportedExtensionImportCount { get; set; } = -1;
 
+    public SyntaxTree CachedImportedExtensionSyntaxTree { get; set; }
+
     /// <summary>
     /// Issue #1201: resolves the compilation's non-alias type imports
     /// (<c>import Ns.Type</c>) to the user-defined <see cref="StructSymbol"/>s
@@ -282,7 +286,8 @@ internal sealed class BinderContext
         var structs = RootScope.GetDeclaredStructs();
         if (cachedStaticImportTypes is { } cached
             && cachedStaticImportImportCount == imports.Length
-            && cachedStaticImportStructCount == structs.Length)
+            && cachedStaticImportStructCount == structs.Length
+            && ReferenceEquals(cachedStaticImportSyntaxTree, RootScope.GetCurrentReferencingSyntaxTreeForCache()))
         {
             return cached;
         }
@@ -320,6 +325,7 @@ internal sealed class BinderContext
         cachedStaticImportTypes = result;
         cachedStaticImportImportCount = imports.Length;
         cachedStaticImportStructCount = structs.Length;
+        cachedStaticImportSyntaxTree = RootScope.GetCurrentReferencingSyntaxTreeForCache();
         return result;
 
         // Issue #1201: whether the fully-qualified import `target` names the user

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 
@@ -48,18 +49,16 @@ public sealed class BoundScope
     // Issue #2342: the ambient "current declaring package" (see
     // SetCurrentDeclaringPackage), lazily set/cleared only on the root scope
     // of the chain, exactly like anonymousTypeCache above.
-    private string currentDeclaringPackageName;
+    private AsyncLocal<string> currentDeclaringPackageName = new AsyncLocal<string>();
 
     // Issue #2456 (per-file import scoping / #2395 follow-up): the ambient
     // "current referencing syntax tree" (see SetCurrentReferencingSyntaxTree),
     // set for the duration of binding a single declaration's type clauses or a
     // single member body, mirroring currentDeclaringPackageName exactly.
-    // TryResolveCollidingTypeAliasByImport consults this to restrict its
-    // import-based disambiguation to imports declared in the SAME file as the
-    // reference being resolved — never an unrelated file's import — so this
-    // fix does not entrench issue #2395's compilation-wide import leakage
-    // into type-identity resolution.
-    private GSharp.Core.CodeAnalysis.Syntax.SyntaxTree currentReferencingSyntaxTree;
+    // Import enumeration consults this to expose only imports declared in the
+    // same file as the reference being resolved, plus implicit imports.
+    private AsyncLocal<GSharp.Core.CodeAnalysis.Syntax.SyntaxTree> currentReferencingSyntaxTree =
+        new AsyncLocal<GSharp.Core.CodeAnalysis.Syntax.SyntaxTree>();
 
     // Issue #2455: the ambient "qualified construction package hint" (see
     // SetQualifiedConstructionPackageHint), set only while re-binding the
@@ -72,7 +71,7 @@ public sealed class BoundScope
     // even though the qualification already disambiguates it. Lazily set/
     // cleared only on the root scope of the chain, exactly like
     // currentDeclaringPackageName above.
-    private string qualifiedConstructionPackageHint;
+    private AsyncLocal<string> qualifiedConstructionPackageHint = new AsyncLocal<string>();
 
     private Dictionary<GSharp.Core.CodeAnalysis.Syntax.AnonymousClassExpressionSyntax, StructSymbol> richAnonymousClassMap;
 
@@ -970,9 +969,8 @@ public sealed class BoundScope
     /// but also reports (via <paramref name="ambiguousAcrossImportedPackages"/>)
     /// when the simple name genuinely cannot be determined because two or more
     /// DIFFERENT packages that both declare a same-named top-level type are
-    /// EACH visible via an explicit <c>import</c> somewhere in the compilation
-    /// (imports are bound compilation-wide — see the Issue #2394 binder
-    /// remarks). Callers that can surface a location-bearing diagnostic (e.g.
+    /// EACH visible via an explicit <c>import</c> in the referencing syntax
+    /// tree. Callers that can surface a location-bearing diagnostic (e.g.
     /// <see cref="Binder.BindNonNullableTypeClause"/>'s bare-name branch) should
     /// use this overload and report a dedicated ambiguity diagnostic instead of
     /// the generic "cannot find type"; every other caller keeps using the
@@ -984,7 +982,8 @@ public sealed class BoundScope
     /// <param name="type">The aliased type, when found.</param>
     /// <param name="ambiguousAcrossImportedPackages">
     /// Whether resolution failed specifically because two or more colliding
-    /// packages are both imported (as opposed to no match at all).
+    /// packages are both imported by the referencing file (as opposed to no
+    /// match at all).
     /// </param>
     /// <returns>Whether an alias exists.</returns>
     public bool TryLookupTypeAlias(string name, int preferredArity, out TypeSymbol type, out bool ambiguousAcrossImportedPackages)
@@ -1054,8 +1053,8 @@ public sealed class BoundScope
         // ordering/tree-order-dependent choice that does not reflect what the
         // referencing code actually means. When the referencing scope isn't
         // either colliding package itself (the check above), consult the
-        // compilation-wide `import` set: if EXACTLY ONE colliding package is
-        // imported anywhere in the compilation, its type is the only one the
+        // referencing file's `import` set: if EXACTLY ONE colliding package is
+        // imported by that file, its type is the only one the
         // reference could plausibly mean, so prefer it deterministically over
         // the order-dependent plain-key winner. If two or more colliding
         // packages are each imported, the reference is genuinely ambiguous.
@@ -1301,8 +1300,8 @@ public sealed class BoundScope
             return Parent.SetCurrentDeclaringPackage(packageName);
         }
 
-        var previous = currentDeclaringPackageName;
-        currentDeclaringPackageName = packageName;
+        var previous = currentDeclaringPackageName.Value;
+        currentDeclaringPackageName.Value = packageName;
         return previous;
     }
 
@@ -1311,21 +1310,14 @@ public sealed class BoundScope
     /// syntax tree (file) of the declaration whose type clauses, or member
     /// whose body, is CURRENTLY being bound, so
     /// <see cref="TryResolveCollidingTypeAliasByImport(string, int, out TypeSymbol, out bool)"/>
-    /// can restrict its import-based disambiguation to imports declared in
-    /// THIS file only — never a sibling file's import, which issue #2395
-    /// documents as leaking compilation-wide through <see cref="EnumerateImports"/>
-    /// for OTHER purposes (CLR-imported-class/static-member lookup). Without
-    /// this restriction, a same-simple-name collision fix built directly on
-    /// top of that same leaky, compilation-wide import enumeration would
-    /// silently let an import in one file disambiguate — correctly or
-    /// incorrectly — a reference in a completely unrelated file, entrenching
-    /// #2395's cross-file order-dependence into type identity resolution
-    /// rather than fixing it. Stored at the root of this scope's chain,
-    /// exactly like <see cref="currentDeclaringPackageName"/>. Pass
+    /// and all other import-dependent lookup to imports declared in THIS file
+    /// only — never a sibling file's import. Stored at the root of this
+    /// scope's chain, exactly like <see cref="currentDeclaringPackageName"/>.
+    /// The value is execution-context-local so concurrent binder operations
+    /// sharing the same reconstructed scope cannot overwrite one another. Pass
     /// <see langword="null"/> to clear (falls back to the legacy
     /// order-dependent "first declared wins" behavior for that lookup,
-    /// exactly as if this fix did not exist — never to the leaky
-    /// compilation-wide set). Returns the PREVIOUS value so the caller can
+    /// exactly as if this fix did not exist). Returns the PREVIOUS value so the caller can
     /// restore it once binding finishes.
     /// </summary>
     /// <param name="tree">The syntax tree to make ambient for lookup, or <see langword="null"/> to clear it.</param>
@@ -1337,10 +1329,13 @@ public sealed class BoundScope
             return Parent.SetCurrentReferencingSyntaxTree(tree);
         }
 
-        var previous = currentReferencingSyntaxTree;
-        currentReferencingSyntaxTree = tree;
+        var previous = currentReferencingSyntaxTree.Value;
+        currentReferencingSyntaxTree.Value = tree;
         return previous;
     }
+
+    internal GSharp.Core.CodeAnalysis.Syntax.SyntaxTree GetCurrentReferencingSyntaxTreeForCache()
+        => GetCurrentReferencingSyntaxTree();
 
     /// <summary>
     /// Gets the per-compile-pass map from a "rich" anonymous-object literal
@@ -1382,8 +1377,8 @@ public sealed class BoundScope
             return Parent.SetQualifiedConstructionPackageHint(packageName);
         }
 
-        var previous = qualifiedConstructionPackageHint;
-        qualifiedConstructionPackageHint = packageName;
+        var previous = qualifiedConstructionPackageHint.Value;
+        qualifiedConstructionPackageHint.Value = packageName;
         return previous;
     }
 
@@ -1393,17 +1388,16 @@ public sealed class BoundScope
     /// none is set.
     /// </summary>
     private string GetCurrentDeclaringPackage()
-        => Parent != null ? Parent.GetCurrentDeclaringPackage() : currentDeclaringPackageName;
+        => Parent != null ? Parent.GetCurrentDeclaringPackage() : currentDeclaringPackageName.Value;
 
     /// <summary>
     /// Issue #2456: gets the ambient "current referencing syntax tree" set by
     /// <see cref="SetCurrentReferencingSyntaxTree"/>, or <see langword="null"/>
     /// when none is set (no per-file import restriction available; the
-    /// import-based disambiguation this fix adds simply does not fire, rather
-    /// than falling back to the leaky compilation-wide import set).
+    /// import-based disambiguation this fix adds simply does not fire).
     /// </summary>
     private GSharp.Core.CodeAnalysis.Syntax.SyntaxTree GetCurrentReferencingSyntaxTree()
-        => Parent != null ? Parent.GetCurrentReferencingSyntaxTree() : currentReferencingSyntaxTree;
+        => Parent != null ? Parent.GetCurrentReferencingSyntaxTree() : currentReferencingSyntaxTree.Value;
 
     /// <summary>
     /// Issue #2455: gets the ambient qualified-construction package hint set
@@ -1411,7 +1405,7 @@ public sealed class BoundScope
     /// <see langword="null"/> when none is set.
     /// </summary>
     private string GetQualifiedConstructionPackageHint()
-        => Parent != null ? Parent.GetQualifiedConstructionPackageHint() : qualifiedConstructionPackageHint;
+        => Parent != null ? Parent.GetQualifiedConstructionPackageHint() : qualifiedConstructionPackageHint.Value;
 
     /// <summary>
     /// Issue #2455: tries to resolve (<paramref name="name"/>, <paramref name="arity"/>)
@@ -1595,10 +1589,7 @@ public sealed class BoundScope
     /// compiler-synthesized (implicit — visible everywhere) or declared in
     /// the SAME file as the reference currently being resolved (see
     /// <see cref="GetCurrentReferencingSyntaxTree"/>). An import declared in
-    /// any OTHER file is never consulted, even though it is technically
-    /// reachable through <see cref="GetDeclaredImports"/>'s compilation-wide
-    /// enumeration (issue #2395) — this method deliberately does not use that
-    /// leaked visibility as a type-identity authority. Returns
+    /// any OTHER file is never consulted. Returns
     /// <see langword="false"/> with <paramref name="type"/> null and
     /// <paramref name="ambiguous"/> false when this name has no genuine
     /// cross-package collision at all (the ordinary plain-key fallback should
@@ -1660,18 +1651,11 @@ public sealed class BoundScope
         // Issue #2456 (per-file import scoping / #2395 follow-up): only
         // imports declared in the SAME file as the reference being resolved
         // (plus compiler-synthesized implicit imports, which apply
-        // everywhere) may disambiguate it. GetDeclaredImports() itself walks
-        // the whole compilation's flattened import list (issue #2395 — every
-        // file's imports are bound onto one shared scope with no per-file
-        // boundary), so without this filter a completely unrelated file's
-        // import could silently decide this reference's type identity,
-        // entrenching #2395's cross-file leakage into type-identity
-        // resolution instead of fixing the collision deterministically. When
+        // everywhere) may disambiguate it. EnumerateImports already enforces
+        // this boundary; the explicit declaration check remains defensive
+        // for imports rehydrated from incremental scopes. When
         // the ambient referencing tree is unset (null — no per-file context
-        // available at this call site), no import can disambiguate here: the
-        // legacy order-dependent plain-key fallback runs unmodified, exactly
-        // as if this fix did not exist, rather than silently falling back to
-        // the leaky compilation-wide set.
+        // available at this call site), no import can disambiguate here.
         var referencingTree = GetCurrentReferencingSyntaxTree();
         if (referencingTree == null)
         {
@@ -1688,8 +1672,7 @@ public sealed class BoundScope
 
             if (import.Declaration != null && import.Declaration.SyntaxTree != referencingTree)
             {
-                // Declared in a different file than the reference — issue
-                // #2395's leakage must not decide this reference's identity.
+                // Declared in a different file than the reference.
                 continue;
             }
 
@@ -2439,9 +2422,9 @@ public sealed class BoundScope
     }
 
     /// <summary>
-    /// Enumerates every import visible from this scope: ancestor scopes'
-    /// imports first (outermost first), then this scope's own — matching the
-    /// order the old eager parent-to-child copy produced.
+    /// Enumerates every import visible from the currently referencing syntax
+    /// tree: ancestor scopes' imports first (outermost first), then this
+    /// scope's own. Compiler-synthesized imports are visible everywhere.
     /// </summary>
     private IEnumerable<ImportSymbol> EnumerateImports()
     {
@@ -2455,9 +2438,14 @@ public sealed class BoundScope
 
         if (imports != null)
         {
+            var referencingTree = GetCurrentReferencingSyntaxTree();
             foreach (var import in imports)
             {
-                yield return import;
+                if (import.Declaration == null
+                    || (referencingTree != null && import.Declaration.SyntaxTree == referencingTree))
+                {
+                    yield return import;
+                }
             }
         }
     }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
@@ -54,6 +54,7 @@ internal sealed partial class DeclarationBinder
             // ambient lookup preference (see field-initializer closure above
             // for the full rationale) for the duration of this deferred bind.
             var savedPackage = scope.SetCurrentDeclaringPackage(structSymbol.PackageName);
+            var savedTree = scope.SetCurrentReferencingSyntaxTree(syntax.SyntaxTree);
             try
             {
                 BindBaseConstructorInitializerCore(syntax, structSymbol, baseClassSymbol, importedBaseType, primaryCtorParameters);
@@ -61,6 +62,7 @@ internal sealed partial class DeclarationBinder
             finally
             {
                 scope.SetCurrentDeclaringPackage(savedPackage);
+                scope.SetCurrentReferencingSyntaxTree(savedTree);
                 scope = outerScope;
             }
         });
@@ -830,6 +832,7 @@ internal sealed partial class DeclarationBinder
                 // above for the full rationale) for the duration of this
                 // deferred bind.
                 var savedPackage = scope.SetCurrentDeclaringPackage(structSymbol.PackageName);
+                var savedTree = scope.SetCurrentReferencingSyntaxTree(ctorSyntax.SyntaxTree);
                 try
                 {
                     BindConstructorBaseInitializerCore(ctorSyntax, constructorSymbol, ctorFunction, structSymbol, baseClassSymbol, importedBaseType);
@@ -837,6 +840,7 @@ internal sealed partial class DeclarationBinder
                 finally
                 {
                     scope.SetCurrentDeclaringPackage(savedPackage);
+                    scope.SetCurrentReferencingSyntaxTree(savedTree);
                     scope = outerScope;
                 }
             });

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -1827,6 +1827,8 @@ internal sealed partial class DeclarationBinder
             }
 
             var savedTypeParameters = binderCtx.CurrentTypeParameters;
+            var savedPackage = scope.SetCurrentDeclaringPackage(structSymbol.PackageName);
+            var savedTree = scope.SetCurrentReferencingSyntaxTree(syntax.SyntaxTree);
             if (!structSymbol.TypeParameters.IsDefaultOrEmpty)
             {
                 binderCtx.CurrentTypeParameters = new Dictionary<string, TypeParameterSymbol>();
@@ -1995,6 +1997,8 @@ internal sealed partial class DeclarationBinder
             finally
             {
                 binderCtx.CurrentTypeParameters = savedTypeParameters;
+                scope.SetCurrentDeclaringPackage(savedPackage);
+                scope.SetCurrentReferencingSyntaxTree(savedTree);
             }
         }
     }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -2462,6 +2462,7 @@ internal sealed partial class DeclarationBinder
             // reference in the initializer could resolve against an unrelated
             // package's same-simple-name homonym.
             var savedFieldInitPackage = scope.SetCurrentDeclaringPackage(fieldInitPackageName);
+            var savedFieldInitTree = scope.SetCurrentReferencingSyntaxTree(structSymbol.Declaration.SyntaxTree);
 
             // Issue #2111: a static field/property initializer is bound outside
             // any function body, so no "current function" is established. The
@@ -2502,6 +2503,7 @@ internal sealed partial class DeclarationBinder
             finally
             {
                 scope.SetCurrentDeclaringPackage(savedFieldInitPackage);
+                scope.SetCurrentReferencingSyntaxTree(savedFieldInitTree);
                 scope = savedFieldInitScope;
                 binderCtx.CurrentTypeParameters = savedFieldInitTypeParameters;
                 setCurrentFunction(savedFieldInitFunction);

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2392,7 +2392,11 @@ internal sealed class MemberLookup
     {
         var imports = this.binderCtx.RootScope.GetDeclaredImports();
         var importCount = imports.IsDefault ? 0 : imports.Length;
-        if (this.binderCtx.CachedImportedExtensionClasses != null && this.binderCtx.CachedImportedExtensionImportCount == importCount)
+        if (this.binderCtx.CachedImportedExtensionClasses != null
+            && this.binderCtx.CachedImportedExtensionImportCount == importCount
+            && ReferenceEquals(
+                this.binderCtx.CachedImportedExtensionSyntaxTree,
+                this.binderCtx.RootScope.GetCurrentReferencingSyntaxTreeForCache()))
         {
             return this.binderCtx.CachedImportedExtensionClasses;
         }
@@ -2447,6 +2451,7 @@ internal sealed class MemberLookup
 
         this.binderCtx.CachedImportedExtensionClasses = classes;
         this.binderCtx.CachedImportedExtensionImportCount = importCount;
+        this.binderCtx.CachedImportedExtensionSyntaxTree = this.binderCtx.RootScope.GetCurrentReferencingSyntaxTreeForCache();
         return classes;
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2395FileScopedImportTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2395FileScopedImportTests.cs
@@ -1,0 +1,261 @@
+// <copyright file="Issue2395FileScopedImportTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2395: imports belong to the syntax tree that declares them.
+/// </summary>
+public class Issue2395FileScopedImportTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ClrNamespaceImport_IsVisibleOnlyInDeclaringFile_ForSignaturesAndBodies(bool importingFileFirst)
+    {
+        const string importing = """
+            package Demo
+            import System.Text
+
+            class ImportedUser {
+                func Make(value StringBuilder) StringBuilder {
+                    return StringBuilder(value.ToString())
+                }
+            }
+            """;
+        const string unrelated = """
+            package Demo
+
+            class UnrelatedUser {
+                func Make(value StringBuilder) StringBuilder {
+                    return StringBuilder(value.ToString())
+                }
+            }
+            """;
+
+        var errors = Errors(Order(importingFileFirst, importing, unrelated)).ToArray();
+
+        Assert.DoesNotContain(errors, d => d.Location.FileName == "importing.gs");
+        Assert.Contains(errors, d => d.Location.FileName == "unrelated.gs");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void StaticTypeImport_AndClrAlias_DoNotLeakToSiblingFile(bool importingFileFirst)
+    {
+        const string library = """
+            package Library
+
+            class MathUtil {
+                shared {
+                    func Twice(value int32) int32 { return value * 2 }
+                }
+            }
+            """;
+        const string importing = """
+            package Demo
+            import Library.MathUtil
+            import io = System.IO
+
+            class ImportedUser {
+                func Calculate() int32 { return Twice(16) }
+                func Current() string { return io.Directory.GetCurrentDirectory() }
+            }
+            """;
+        const string unrelated = """
+            package Demo
+
+            class UnrelatedUser {
+                func Calculate() int32 { return Twice(16) }
+                func Current() string { return io.Directory.GetCurrentDirectory() }
+            }
+            """;
+
+        var ordered = importingFileFirst
+            ? new[] { ("library.gs", library), ("importing.gs", importing), ("unrelated.gs", unrelated) }
+            : new[] { ("unrelated.gs", unrelated), ("importing.gs", importing), ("library.gs", library) };
+        var errors = Errors(ordered).ToArray();
+
+        Assert.DoesNotContain(errors, d => d.Location.FileName == "importing.gs");
+        Assert.Contains(errors, d => d.Location.FileName == "unrelated.gs");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ClrExtensionNamespaceImport_DoesNotLeakToSiblingFile(bool importingFileFirst)
+    {
+        const string importing = """
+            package Demo
+            import System.Linq
+
+            class ImportedUser {
+                func Convert(values []int32) object { return values.ToHashSet() }
+            }
+            """;
+        const string unrelated = """
+            package Demo
+
+            class UnrelatedUser {
+                func Convert(values []int32) object { return values.ToHashSet() }
+            }
+            """;
+
+        var errors = Errors(Order(importingFileFirst, importing, unrelated)).ToArray();
+
+        Assert.DoesNotContain(errors, d => d.Location.FileName == "importing.gs");
+        Assert.Contains(errors, d => d.Location.FileName == "unrelated.gs");
+    }
+
+    [Fact]
+    public void SamePackageDeclarationsRemainVisibleAcrossFiles_AndForeignTypeCanBeQualified()
+    {
+        const string declarations = """
+            package Demo
+
+            class Shared {}
+            func MakeShared() Shared { return Shared{} }
+            """;
+        const string consumer = """
+            package Demo
+
+            class Consumer {
+                func Use(value Shared) Shared { return MakeShared() }
+            }
+            """;
+        const string foreign = """
+            package Foreign
+
+            class External {}
+            """;
+        const string qualified = """
+            package Demo
+
+            class Qualified {
+                func Make() object { return Foreign.External{} }
+            }
+            """;
+
+        Assert.Empty(Errors(new[]
+        {
+            ("declarations.gs", declarations),
+            ("consumer.gs", consumer),
+            ("foreign.gs", foreign),
+            ("qualified.gs", qualified),
+        }));
+    }
+
+    [Fact]
+    public void UnrelatedFileImport_CannotDisambiguateCollidingSimpleName()
+    {
+        const string left = "package Left\nclass Result {}\n";
+        const string right = "package Right\nclass Result {}\n";
+        const string unrelated = "package Other\nimport Left\nclass Marker {}\n";
+        const string consumer = """
+            package Consumer
+
+            class UsesResult {
+                prop Value Result
+            }
+            """;
+
+        var errors = Errors(new[]
+        {
+            ("left.gs", left),
+            ("right.gs", right),
+            ("unrelated.gs", unrelated),
+            ("consumer.gs", consumer),
+        }).ToArray();
+
+        Assert.DoesNotContain(errors, d => d.Id == "GS0496");
+    }
+
+    [Fact]
+    public void SameFileCollidingImports_ReportAmbiguityAtReferencingFile()
+    {
+        const string left = "package Left\nclass Result {}\n";
+        const string right = "package Right\nclass Result {}\n";
+        const string consumer = """
+            package Consumer
+            import Left
+            import Right
+
+            class UsesResult {
+                prop Value Result
+            }
+            """;
+
+        var errors = Errors(new[]
+        {
+            ("right.gs", right),
+            ("consumer.gs", consumer),
+            ("left.gs", left),
+        }).ToArray();
+
+        Assert.Contains(errors, d => d.Id == "GS0496" && d.Location.FileName == "consumer.gs");
+    }
+
+    [Fact]
+    public async Task ConcurrentReferencingTrees_DoNotShareAmbientImportContext()
+    {
+        var leftTree = SyntaxTree.Parse(SourceText.From("import System.Text\n", "left.gs"));
+        var rightTree = SyntaxTree.Parse(SourceText.From("import System.IO\n", "right.gs"));
+        var leftImport = leftTree.Root.Members.OfType<ImportSyntax>().Single();
+        var rightImport = rightTree.Root.Members.OfType<ImportSyntax>().Single();
+        var scope = new BoundScope(parent: null);
+        scope.TryImport(new ImportSymbol("System.Text", "System.Text", leftImport));
+        scope.TryImport(new ImportSymbol("System.IO", "System.IO", rightImport));
+        using var ready = new CountdownEvent(2);
+
+        async Task<ImmutableArray<string>> VisibleImports(SyntaxTree tree)
+        {
+            var previous = scope.SetCurrentReferencingSyntaxTree(tree);
+            try
+            {
+                ready.Signal();
+                await Task.Run(() => ready.Wait());
+                return scope.GetDeclaredImports().Select(i => i.Target).ToImmutableArray();
+            }
+            finally
+            {
+                scope.SetCurrentReferencingSyntaxTree(previous);
+            }
+        }
+
+        var results = await Task.WhenAll(VisibleImports(leftTree), VisibleImports(rightTree));
+
+        Assert.Equal(new[] { "System.Text" }, results[0]);
+        Assert.Equal(new[] { "System.IO" }, results[1]);
+    }
+
+    private static (string FileName, string Source)[] Order(bool first, string importing, string unrelated)
+        => first
+            ? new[] { ("importing.gs", importing), ("unrelated.gs", unrelated) }
+            : new[] { ("unrelated.gs", unrelated), ("importing.gs", importing) };
+
+    private static IEnumerable<Diagnostic> Errors(IEnumerable<(string FileName, string Source)> sources)
+    {
+        var trees = sources
+            .Select(source => SyntaxTree.Parse(SourceText.From(source.Source, source.FileName)))
+            .ToArray();
+        var compilation = new Compilation(trees) { IsLibrary = true };
+        return compilation.GlobalScope.Diagnostics
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .Where(d => d.IsError);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2416NullAssertedMemberExtensionInferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2416NullAssertedMemberExtensionInferenceTests.cs
@@ -65,6 +65,8 @@ public class Issue2416NullAssertedMemberExtensionInferenceTests
 
     private const string ChapterModelSource = """
         package Core
+        import System.Collections.Generic
+
         class Chapter {
             prop Title string
             prop Chapters []Chapter

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2455CompositeTypeCollisionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2455CompositeTypeCollisionTests.cs
@@ -523,6 +523,7 @@ public class Issue2455CompositeTypeCollisionTests
         // the projection is checked against.
         const string sourceShape = """
             package Oahu.Audible.Alt
+            import Oahu.Audible.Json
 
             class ChapterInfoLike {
                 prop Chapters []Chapter


### PR DESCRIPTION
## Summary

- filter every import-dependent binder lookup to the current referencing syntax tree, while keeping implicit imports globally visible
- carry the existing syntax-tree/package context through declaration shells, deferred initializers, explicit-interface clauses, static initializers, top-level statements, bodies, and speculative binding
- make ambient package/tree/qualified-construction state execution-context-local and key import-derived caches by syntax tree
- preserve incremental/REPL import persistence and package-wide declaration visibility
- add multi-file regressions for CLR types/members, static imports, aliases, extension methods, declaration signatures/bodies, file-order reversal, collisions, qualified access, diagnostic locations, and concurrent binding

## Validation

- Core.Tests targeted (#2395/#2455/#2457): 57 passed
- Core.Tests full, serialized: 6460 passed, 1 skipped
- Cs2Gs.Tests full, serialized with `RunConfiguration.DisableParallelization=true`: 1558 passed
- committed `Gsharp.NET.Sdk` Release pack: `0.3.131-g86a4ff6d7e`; `.nugs` refreshed and exact NuGet cache cleared
- fresh read-only default `--via-sdk` Oahu.Core migration: unchanged exact 14-fingerprint baseline
  - removals: none
  - additions: none
  - retained: `230052846aec`, `37a85ff59ab7`, `4ecbc49f9a4b`, `736897bac0c6`, `78a893989661`, `7957ed4d7be6`, `7a093a75108b`, `7a471f332fd9`, `7cd285723a5c`, `9acf37f1634a`, `9cc3e6196479`, `bb13273b0730`, `c7ef9251a44f`, `e67cbcf7a848`
- Oahu remained read-only

The existing `IPerson` constraint (`4ecbc49f9a4b`), `Domain` (`7957ed4d7be6`), `Deserialize` (`7a471f332fd9`), and `ChapterInfo` (`9acf37f1634a`) diagnostics are unchanged; no unrelated fixes were added.

Closes #2395