### PR TITLE
Fix from-end Span index ref semantics

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -798,7 +798,11 @@ internal sealed partial class ExpressionBinder
         return new BoundNullConditionalAccessExpression(null, receiver, capture, whenNotNull, resultType, resultSlot);
     }
 
-    private BoundExpression BindIndexAgainstTarget(BoundExpression target, ExpressionSyntax indexSyntax, TextLocation targetLocation)
+    private BoundExpression BindIndexAgainstTarget(
+        BoundExpression target,
+        ExpressionSyntax indexSyntax,
+        TextLocation targetLocation,
+        BoundExpression systemIndexOverride = null)
     {
         // ADR-0122 / issue #1014: pointer indexing `p[i]` == `*(p + i)`.
         if (target.Type is PointerTypeSymbol pointerTarget)
@@ -836,6 +840,11 @@ internal sealed partial class ExpressionBinder
 
         // Issue #1022: a from-end index (`a[^n]`) reads the single element
         // `length - n`.
+        if (systemIndexOverride != null)
+        {
+            return BindSystemIndexAccess(target, systemIndexOverride, targetLocation);
+        }
+
         if (indexSyntax is FromEndIndexExpressionSyntax fromEndSyntax)
         {
             return BindFromEndIndex(target, fromEndSyntax, targetLocation);
@@ -860,6 +869,11 @@ internal sealed partial class ExpressionBinder
             if (IsSystemRangeType(boundIndex.Type))
             {
                 return BindRangeValueSlice(target, boundIndex, targetLocation);
+            }
+
+            if (ClrTypeUtilities.AreSame(boundIndex.Type.ClrType, typeof(System.Index)))
+            {
+                return BindSystemIndexAccess(target, boundIndex, targetLocation);
             }
         }
 
@@ -1170,7 +1184,8 @@ internal sealed partial class ExpressionBinder
                 $"Failed to declare synthesized index-assignment target local '{tempName}'.");
         }
 
-        var declaration = new BoundVariableDeclaration(outerSyntax, tempVar, boundReceiver);
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        statements.Add(new BoundVariableDeclaration(outerSyntax, tempVar, boundReceiver));
 
         BoundExpression assignment;
         if (compoundOperatorToken != null)
@@ -1182,8 +1197,15 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
+            BoundExpression sharedSystemIndex = null;
+            if (TryBindSystemIndexValue(indexSyntax, out var boundSystemIndex))
+            {
+                var indexLocal = DeclareRangeTemp("index", boundSystemIndex.Type, boundSystemIndex, statements);
+                sharedSystemIndex = new BoundVariableExpression(null, indexLocal);
+            }
+
             var tempRef = new BoundVariableExpression(null, tempVar);
-            var indexRead = BindIndexAgainstTarget(tempRef, indexSyntax, diagnosticLocation);
+            var indexRead = BindIndexAgainstTarget(tempRef, indexSyntax, diagnosticLocation, sharedSystemIndex);
             if (indexRead is BoundErrorExpression)
             {
                 return indexRead;
@@ -1211,7 +1233,12 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
-            assignment = BindIndexedAssignmentToVariableWithBoundValue(tempVar, indexSyntax, combined, diagnosticLocation);
+            assignment = BindIndexedAssignmentToVariableWithBoundValue(
+                tempVar,
+                indexSyntax,
+                combined,
+                diagnosticLocation,
+                sharedSystemIndex);
         }
         else if (boundValueOverride != null)
         {
@@ -1227,7 +1254,7 @@ internal sealed partial class ExpressionBinder
             return assignment;
         }
 
-        return new BoundBlockExpression(outerSyntax, ImmutableArray.Create<BoundStatement>(declaration), assignment);
+        return new BoundBlockExpression(outerSyntax, statements.ToImmutable(), assignment);
     }
 
     private bool TrySplitAtLeftmostNullConditional(
@@ -1278,10 +1305,11 @@ internal sealed partial class ExpressionBinder
         VariableSymbol variable,
         ExpressionSyntax indexSyntax,
         BoundExpression boundValue,
-        TextLocation diagnosticLocation)
+        TextLocation diagnosticLocation,
+        BoundExpression systemIndexOverride = null)
     {
         return BindIndexedAssignmentToVariableCore(
-            variable, indexSyntax, valueSyntax: null, boundValueOverride: boundValue, diagnosticLocation);
+            variable, indexSyntax, valueSyntax: null, boundValueOverride: boundValue, diagnosticLocation, systemIndexOverride);
     }
 
     private BoundExpression BindIndexedAssignmentToVariableCore(
@@ -1289,7 +1317,8 @@ internal sealed partial class ExpressionBinder
         ExpressionSyntax indexSyntax,
         ExpressionSyntax valueSyntax,
         BoundExpression boundValueOverride,
-        TextLocation diagnosticLocation)
+        TextLocation diagnosticLocation,
+        BoundExpression systemIndexOverride = null)
     {
         BoundExpression BindValue(TypeSymbol elementType)
         {
@@ -1299,6 +1328,11 @@ internal sealed partial class ExpressionBinder
             }
 
             return conversions.BindConversion(valueSyntax, elementType);
+        }
+
+        if (systemIndexOverride != null || TryBindSystemIndexValue(indexSyntax, out systemIndexOverride))
+        {
+            return BindSystemIndexAssignment(variable, systemIndexOverride, BindValue, diagnosticLocation);
         }
 
         var element = GetIndexElementType(variable.Type);
@@ -1881,14 +1915,50 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
+        _ = TryBindSystemIndexValue(fromEnd, out var indexValue);
+        return BindSystemIndexAccess(target, indexValue, targetLocation);
+    }
+
+    private bool TryBindSystemIndexValue(ExpressionSyntax syntax, out BoundExpression indexValue)
+    {
+        if (syntax is FromEndIndexExpressionSyntax fromEnd)
+        {
+            var indexCtor = typeof(System.Index).GetConstructor(new[] { typeof(int), typeof(bool) });
+            var indexSym = TypeSymbol.FromClrType(typeof(System.Index));
+            var offset = conversions.BindConversion(fromEnd.Operand, TypeSymbol.Int32);
+            indexValue = new BoundClrConstructorCallExpression(
+                null,
+                typeof(System.Index),
+                indexCtor,
+                ImmutableArray.Create<BoundExpression>(offset, new BoundLiteralExpression(null, true)),
+                indexSym);
+            return true;
+        }
+
+        var bound = BindExpression(syntax);
+        if (bound is not BoundErrorExpression && ClrTypeUtilities.AreSame(bound.Type.ClrType, typeof(System.Index)))
+        {
+            indexValue = bound;
+            return true;
+        }
+
+        indexValue = null;
+        return false;
+    }
+
+    private BoundExpression BindSystemIndexAccess(BoundExpression target, BoundExpression indexValue, TextLocation targetLocation)
+    {
         var element = GetIndexElementType(target.Type);
         if (element != null)
         {
             var statements = ImmutableArray.CreateBuilder<BoundStatement>();
             var srcLocal = DeclareRangeTemp("src", target.Type, target, statements);
-            var idx = MakeFromEndOffset(fromEnd, new BoundLenExpression(null, new BoundVariableExpression(null, srcLocal)));
+            var idx = BuildSystemIndexOffset(
+                indexValue,
+                new BoundLenExpression(null, new BoundVariableExpression(null, srcLocal)),
+                statements);
             var read = new BoundIndexExpression(null, new BoundVariableExpression(null, srcLocal), idx, element);
-            return new BoundBlockExpression(fromEnd, statements.ToImmutable(), read);
+            return new BoundBlockExpression(null, statements.ToImmutable(), read);
         }
 
         var clrType = target.Type.ClrType;
@@ -1896,38 +1966,170 @@ internal sealed partial class ExpressionBinder
         {
             if (TryFindIndexIndexer(clrType, out var indexIndexer))
             {
-                var indexCtor = typeof(System.Index).GetConstructor(new[] { typeof(int), typeof(bool) });
-                var indexSym = TypeSymbol.FromClrType(typeof(System.Index));
-                var offset = conversions.BindConversion(fromEnd.Operand, TypeSymbol.Int32);
-                var indexValue = new BoundClrConstructorCallExpression(
-                    null,
-                    typeof(System.Index),
-                    indexCtor,
-                    ImmutableArray.Create<BoundExpression>(offset, new BoundLiteralExpression(null, true)),
-                    indexSym);
                 var resultType = ResolveIndexerElementType(target.Type, indexIndexer);
-                return new BoundClrIndexExpression(fromEnd, target, indexIndexer, ImmutableArray.Create<BoundExpression>(indexValue), resultType);
+                return ConversionClassifier.AutoDereferenceRefReturn(
+                    new BoundClrIndexExpression(null, target, indexIndexer, ImmutableArray.Create(indexValue), resultType));
             }
 
             if (TryFindCountedIntIndexer(clrType, out var lengthMember, out var intIndexer))
             {
                 var statements = ImmutableArray.CreateBuilder<BoundStatement>();
                 var srcLocal = DeclareRangeTemp("src", target.Type, target, statements);
-                var lengthExpr = new BoundClrPropertyAccessExpression(null, new BoundVariableExpression(null, srcLocal), lengthMember, TypeSymbol.Int32);
-                var idx = MakeFromEndOffset(fromEnd, lengthExpr);
+                var srcRef = new BoundVariableExpression(null, srcLocal);
+                var lengthExpr = new BoundClrPropertyAccessExpression(null, srcRef, lengthMember, TypeSymbol.Int32);
+                var idx = BuildSystemIndexOffset(indexValue, lengthExpr, statements);
                 var resultType = ResolveIndexerElementType(target.Type, intIndexer);
-                var read = new BoundClrIndexExpression(
+                var read = ConversionClassifier.AutoDereferenceRefReturn(
+                    new BoundClrIndexExpression(
+                        null,
+                        new BoundVariableExpression(null, srcLocal),
+                        intIndexer,
+                        ImmutableArray.Create<BoundExpression>(idx),
+                        resultType));
+                return new BoundBlockExpression(null, statements.ToImmutable(), read);
+            }
+        }
+
+        if (target.Type is StructSymbol userTarget
+            && TryGetUserIndexer(userTarget, out var userIndexer, out var substitution)
+            && userIndexer.Parameters.Length == 1
+            && userIndexer.GetterSymbol != null)
+        {
+            var parameterType = substitution != null
+                ? Binder.SubstituteType(userIndexer.Parameters[0].Type, substitution, scope.References.MapClrTypeToReferences)
+                : userIndexer.Parameters[0].Type;
+            if (ClrTypeUtilities.AreSame(parameterType.ClrType, typeof(System.Index)))
+            {
+                var resultType = substitution != null
+                    ? Binder.SubstituteType(userIndexer.Type, substitution, scope.References.MapClrTypeToReferences)
+                    : userIndexer.Type;
+                return new BoundUserInstanceCallExpression(
                     null,
-                    new BoundVariableExpression(null, srcLocal),
-                    intIndexer,
-                    ImmutableArray.Create<BoundExpression>(idx),
+                    target,
+                    userIndexer.GetterSymbol,
+                    ImmutableArray.Create(conversions.BindConversion(targetLocation, indexValue, parameterType)),
                     resultType);
-                return new BoundBlockExpression(fromEnd, statements.ToImmutable(), read);
             }
         }
 
         Diagnostics.ReportTypeNotIndexable(targetLocation, target.Type);
         return new BoundErrorExpression(null);
+    }
+
+    private BoundExpression BindSystemIndexAssignment(
+        VariableSymbol variable,
+        BoundExpression indexValue,
+        Func<TypeSymbol, BoundExpression> bindValue,
+        TextLocation diagnosticLocation)
+    {
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+
+        var element = GetIndexElementType(variable.Type);
+        if (element != null)
+        {
+            var idx = BuildSystemIndexOffset(
+                indexValue,
+                new BoundLenExpression(null, new BoundVariableExpression(null, variable)),
+                statements);
+            var assignment = new BoundIndexAssignmentExpression(null, variable, idx, bindValue(element), element);
+            return new BoundBlockExpression(null, statements.ToImmutable(), assignment);
+        }
+
+        var clrType = variable.Type.ClrType;
+        if (clrType != null)
+        {
+            PropertyInfo indexer;
+            ImmutableArray<BoundExpression> arguments;
+            if (TryFindIndexIndexer(clrType, out indexer))
+            {
+                arguments = ImmutableArray.Create(indexValue);
+            }
+            else if (TryFindCountedIntIndexer(clrType, out var lengthMember, out indexer))
+            {
+                var lengthExpr = new BoundClrPropertyAccessExpression(
+                    null,
+                    new BoundVariableExpression(null, variable),
+                    lengthMember,
+                    TypeSymbol.Int32);
+                arguments = ImmutableArray.Create(BuildSystemIndexOffset(indexValue, lengthExpr, statements));
+            }
+            else
+            {
+                Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
+                return new BoundErrorExpression(null);
+            }
+
+            var getter = indexer.GetGetMethod(nonPublic: false);
+            var valueType = ResolveIndexerElementType(variable.Type, indexer);
+            if (!indexer.CanWrite)
+            {
+                if (getter == null || !getter.ReturnType.IsByRef)
+                {
+                    Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
+                    return new BoundErrorExpression(null);
+                }
+
+                if (IsReadOnlyRefReturn(indexer, getter))
+                {
+                    Diagnostics.ReportCannotAssignReadOnlySpanElement(diagnosticLocation, variable.Type);
+                    return new BoundErrorExpression(null);
+                }
+
+                valueType = valueType is ByRefTypeSymbol byRef ? byRef.PointeeType : valueType;
+            }
+
+            return new BoundBlockExpression(
+                null,
+                statements.ToImmutable(),
+                new BoundClrIndexAssignmentExpression(
+                    null,
+                    variable,
+                    indexer,
+                    arguments,
+                    bindValue(valueType),
+                    valueType));
+        }
+
+        if (variable.Type is StructSymbol userTarget
+            && TryGetUserIndexer(userTarget, out var userIndexer, out var substitution)
+            && userIndexer.Parameters.Length == 1
+            && userIndexer.SetterSymbol != null)
+        {
+            var parameterType = substitution != null
+                ? Binder.SubstituteType(userIndexer.Parameters[0].Type, substitution, scope.References.MapClrTypeToReferences)
+                : userIndexer.Parameters[0].Type;
+            if (ClrTypeUtilities.AreSame(parameterType.ClrType, typeof(System.Index)))
+            {
+                var valueType = substitution != null
+                    ? Binder.SubstituteType(userIndexer.Type, substitution, scope.References.MapClrTypeToReferences)
+                    : userIndexer.Type;
+                return new BoundUserInstanceCallExpression(
+                    null,
+                    new BoundVariableExpression(null, variable),
+                    userIndexer.SetterSymbol,
+                    ImmutableArray.Create(
+                        conversions.BindConversion(diagnosticLocation, indexValue, parameterType),
+                        bindValue(valueType)));
+            }
+        }
+
+        Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
+        return new BoundErrorExpression(null);
+    }
+
+    private BoundExpression BuildSystemIndexOffset(
+        BoundExpression indexValue,
+        BoundExpression length,
+        ImmutableArray<BoundStatement>.Builder statements)
+    {
+        var indexLocal = DeclareRangeTemp("index", indexValue.Type, indexValue, statements);
+        var getOffset = typeof(System.Index).GetMethod("GetOffset", new[] { typeof(int) });
+        return new BoundImportedInstanceCallExpression(
+            null,
+            new BoundVariableExpression(null, indexLocal),
+            getOffset,
+            TypeSymbol.Int32,
+            ImmutableArray.Create(length));
     }
 
     // `length - n` for a from-end index `^n`.

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -236,6 +236,14 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
+        if (operand is BoundBlockExpression block)
+        {
+            return new BoundBlockExpression(
+                null,
+                block.Statements,
+                new BoundAddressOfExpression(null, block.Expression, unmanaged: binderCtx.InUnsafeContext));
+        }
+
         return new BoundAddressOfExpression(null, operand, unmanaged: binderCtx.InUnsafeContext);
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -995,6 +995,11 @@ internal sealed partial class ExpressionBinder
     /// <summary>ADR-0039: Determines whether an expression is an lvalue (can have its address taken).</summary>
     internal static bool IsLvalue(BoundExpression expression)
     {
+        if (expression is BoundBlockExpression block)
+        {
+            return IsLvalue(block.Expression);
+        }
+
         return expression is BoundVariableExpression
             or BoundFieldAccessExpression
             or BoundIndexExpression

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
@@ -329,7 +329,12 @@ internal sealed partial class StatementBinder
                 Diagnostics.ReportRefReturnEscapesLocalScope(syntax.Expression.Location);
             }
 
-            expression = new BoundAddressOfExpression(syntax.Expression, expression);
+            expression = expression is BoundBlockExpression block
+                ? new BoundBlockExpression(
+                    syntax.Expression,
+                    block.Statements,
+                    new BoundAddressOfExpression(syntax.Expression, block.Expression))
+                : new BoundAddressOfExpression(syntax.Expression, expression);
         }
 
         return new BoundReturnStatement(syntax, expression, isRefReturn);
@@ -351,6 +356,8 @@ internal sealed partial class StatementBinder
                 return true;
             case BoundDereferenceExpression:
                 return true;
+            case BoundBlockExpression block:
+                return IsLvalueForRefReturn(block.Expression);
             default:
                 return false;
         }
@@ -406,6 +413,8 @@ internal sealed partial class StatementBinder
                 // *p has whatever scope `p` itself yields; conservative — if p is a local
                 // variable of *T, its current value points into the local frame.
                 return HasFunctionLocalRefScope(deref.Operand);
+            case BoundBlockExpression block:
+                return HasFunctionLocalRefScope(block.Expression);
             default:
                 return true;
         }

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.cs
@@ -46,7 +46,11 @@ public partial class Parser
         {
             var identifierToken = NextToken();
             var openBracket = MatchToken(SyntaxKind.OpenSquareBracketToken);
-            var index = ParseExpression();
+
+            // Issue #2465: use the same index-context parser as ordinary and
+            // compound element access so a leading `^` is a from-end marker,
+            // not the one's-complement unary operator.
+            var index = ParseIndexArgument();
             var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
             var equalsToken = MatchToken(SyntaxKind.EqualsToken);
             var value = ParseAssignmentExpression();

--- a/test/Compiler.Tests/Emit/Issue2465SpanFromEndIndexEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2465SpanFromEndIndexEmitTests.cs
@@ -1,0 +1,108 @@
+// <copyright file="Issue2465SpanFromEndIndexEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>End-to-end compile, ILVerify, and runtime coverage for issue #2465.</summary>
+public class Issue2465SpanFromEndIndexEmitTests
+{
+    [Fact]
+    public void SpanFromEnd_ReadWriteCompoundAndSystemIndex_IlVerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2465Compiler
+            import System
+
+            func Run(values []int32) int32 {
+                var span Span[int32] = values
+                let last = Index(1, true)
+                span[^1] = span[last] + 7
+                span[^2] += 10
+                span[^3]++
+                return span[0] * 1000 + span[1] * 100 + span[2] * 10 + span[3]
+            }
+
+            Console.WriteLine(Run([]int32{ 1, 2, 3, 4 }))
+            """;
+
+        var workDir = Path.Combine(
+            Environment.CurrentDirectory,
+            "out",
+            "test-artifacts",
+            "issue2465-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var sourcePath = Path.Combine(workDir, "test.gs");
+            var assemblyPath = Path.Combine(workDir, "test.dll");
+            File.WriteAllText(sourcePath, Source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var originalOut = Console.Out;
+            var originalErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + assemblyPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalErr);
+            }
+
+            Assert.True(
+                exitCode == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(assemblyPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = workDir,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(assemblyPath);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            Assert.True(
+                process.ExitCode == 0,
+                $"dotnet exec failed ({process.ExitCode}):\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            Assert.Equal("1441\n", stdout.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(workDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2465SpanFromEndIndexEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2465SpanFromEndIndexEmitTests.cs
@@ -1,0 +1,270 @@
+// <copyright file="Issue2465SpanFromEndIndexEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #2465: System.Index-based access must preserve the ordinary
+/// ref-returning Span indexer's value and storage semantics.
+/// </summary>
+public class Issue2465SpanFromEndIndexEmitTests
+{
+    [Fact]
+    public void SpanAndReadOnlySpan_FromEndReads_AllElementKinds_Run()
+    {
+        const string Source = """
+            package Issue2465Reads
+            import System
+
+            data struct Pair { var Value int32 }
+            class Box { public var Value int32 = 0 }
+
+            func LastU(values Span[uint32]) uint32 -> values[^1]
+            func LastPair(values ReadOnlySpan[Pair]) Pair -> values[^1]
+            func LastBox(values Span[Box]) Box -> values[^1]
+            func ReadU(values []uint32) uint32 {
+                var span Span[uint32] = values
+                return LastU(span)
+            }
+            func ReadPair(values []Pair) Pair {
+                var span = ReadOnlySpan[Pair](values)
+                return LastPair(span)
+            }
+            func ReadBox(values []Box) Box {
+                var span = Span[Box](values)
+                return LastBox(span)
+            }
+
+            var us = []uint32{ 10, 20, 30 }
+            var ps = []Pair{ Pair{Value: 4}, Pair{Value: 9} }
+            var a = Box()
+            a.Value = 7
+            var b = Box()
+            b.Value = 13
+            var bs = []Box{ a, b }
+            Console.WriteLine(ReadU(us))
+            Console.WriteLine(ReadPair(ps).Value)
+            Console.WriteLine(ReadBox(bs).Value)
+            """;
+
+        Assert.Equal("30\n9\n13\n", CompileAndRun(Source));
+    }
+
+    [Fact]
+    public void Span_FromEndWritesCompoundAndIncrement_Run()
+    {
+        const string Source = """
+            package Issue2465Writes
+            import System
+
+            func Run(values []int32) int32 {
+                var span Span[int32] = values
+                span[^1] = 10
+                span[^2] += 20
+                span[^3]++
+                span[^4]--
+                return span[0] * 1000000 + span[1] * 10000 + span[2] * 100 + span[3]
+            }
+
+            Console.WriteLine(Run([]int32{ 1, 2, 3, 4 }))
+            """;
+
+        Assert.Equal("32310\n", CompileAndRun(Source));
+    }
+
+    [Fact]
+    public void Span_SystemIndexAndSideEffects_EvaluateOnce()
+    {
+        const string Source = """
+            package Issue2465Once
+            import System
+
+            func Pick(values Span[int32], calls []int32) Span[int32] {
+                calls[0]++
+                return values
+            }
+
+            func Next(calls []int32) int32 {
+                calls[1]++
+                return 1
+            }
+
+            func Run(values []int32, calls []int32) {
+                var span Span[int32] = values
+                Pick(span, calls)[^Next(calls)] += 4
+                let last = Index(1, true)
+                Console.WriteLine(span[last])
+                span[last]--
+                Console.WriteLine(span[^1])
+            }
+
+            var values = []int32{ 5, 6, 7 }
+            var calls = []int32{ 0, 0 }
+            Run(values, calls)
+            Console.WriteLine(calls[0])
+            Console.WriteLine(calls[1])
+            """;
+
+        Assert.Equal("11\n10\n1\n1\n", CompileAndRun(Source));
+    }
+
+    [Fact]
+    public void ArraysListsStringsAndCustomIndexers_RemainValueReturning()
+    {
+        const string Source = """
+            package Issue2465Controls
+            import System
+            import System.Collections.Generic
+
+            class IntIndex {
+                prop this[i int32] int32 -> i + 8
+            }
+
+            class EndIndex {
+                prop this[i Index] int32 { get { return 42 } }
+            }
+
+            var a = []int32{ 1, 2, 3 }
+            var l = List[int32]()
+            l.Add(4)
+            l.Add(5)
+            let s = "abc"
+            let ii = IntIndex()
+            let ei = EndIndex()
+            Console.WriteLine(a[^1])
+            Console.WriteLine(l[^1])
+            Console.WriteLine(s[^1])
+            Console.WriteLine(ii[1])
+            Console.WriteLine(ei[^1])
+            """;
+
+        Assert.Equal("3\n5\nc\n9\n42\n", CompileAndRun(Source));
+    }
+
+    [Fact]
+    public void SpanFromEndRead_ReflectionReturnTypesAreElements()
+    {
+        const string Source = """
+            package Issue2465Metadata
+            import System
+
+            data struct Pair { var Value int32 }
+
+            func LastU(values Span[uint32]) uint32 -> values[^1]
+            func LastPair(values ReadOnlySpan[Pair]) Pair -> values[^1]
+            """;
+
+        var assembly = Compile(Source, nameof(SpanFromEndRead_ReflectionReturnTypesAreElements));
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        Assert.Equal(typeof(uint), program.GetMethod("LastU")!.ReturnType);
+        Assert.Equal("Issue2465Metadata.Pair", program.GetMethod("LastPair")!.ReturnType.FullName);
+        Assert.False(program.GetMethod("LastU")!.ReturnType.IsByRef);
+        Assert.False(program.GetMethod("LastPair")!.ReturnType.IsByRef);
+    }
+
+    [Fact]
+    public void SpanFromEnd_AddressContextRetainsReference()
+    {
+        const string Source = """
+            package Issue2465Address
+            import System
+
+            unsafe func Update(values []int32) int32 {
+                var span Span[int32] = values
+                var pointer *int32 = &span[^1]
+                *pointer = 19
+                return span[^1]
+            }
+
+            Console.WriteLine(Update([]int32{ 1, 2, 3 }))
+            """;
+
+        Assert.Equal("19\n", CompileAndRun(Source));
+    }
+
+    [Fact]
+    public void ReadOnlySpan_FromEndWrite_RemainsRejected()
+    {
+        const string Source = """
+            package Issue2465ReadOnly
+            import System
+
+            func Update(values []int32) {
+                var span ReadOnlySpan[int32] = values
+                span[^1] = 9
+            }
+            """;
+
+        using var peStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(Source)));
+        var result = compilation.Emit(peStream);
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0226");
+    }
+
+    [Fact]
+    public void SpanFromEnd_ZeroPreservesBoundsException()
+    {
+        const string Source = """
+            package Issue2465Bounds
+            import System
+
+            func Read(values []int32) int32 {
+                var span Span[int32] = values
+                return span[^0]
+            }
+
+            Console.WriteLine(Read([]int32{ 1, 2, 3 }))
+            """;
+
+        var exception = Assert.Throws<TargetInvocationException>(() => CompileAndRun(Source));
+        Assert.IsType<IndexOutOfRangeException>(exception.InnerException);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var assembly = Compile(source, Guid.NewGuid().ToString("N"));
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(entry);
+
+        var originalOut = Console.Out;
+        using var captured = new StringWriter();
+        Console.SetOut(captured);
+        try
+        {
+            entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        return captured.ToString().Replace("\r\n", "\n");
+    }
+
+    private static Assembly Compile(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => $"{d.Id}: {d.Message}")));
+
+        peStream.Position = 0;
+        var context = new AssemblyLoadContext(contextName, isCollectible: true);
+        return context.LoadFromStream(peStream);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2438AsyncVoidEventHandlerTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2438AsyncVoidEventHandlerTranslationTests.cs
@@ -439,14 +439,16 @@ namespace Demo
     public sealed class Authorize
     {
         public event EventHandler SettingsChanged;
+        private readonly TaskCompletionSource<bool> completion = new TaskCompletionSource<bool>();
 
         public async Task WriteConfigurationAsync()
         {
-            await Task.Delay(1);
+            await completion.Task;
             Console.WriteLine(""wrote-configuration"");
         }
 
         public void Raise() => SettingsChanged?.Invoke(this, EventArgs.Empty);
+        public void Complete() => completion.SetResult(true);
     }
 
     public sealed class AudibleClient
@@ -464,6 +466,7 @@ namespace Demo
         {
             Authorize.Raise();
             Console.WriteLine(""fire-returned"");
+            Authorize.Complete();
             Thread.Sleep(300);
         }
     }


### PR DESCRIPTION
## Summary
- route syntactic from-end and runtime System.Index access through shared lowering
- auto-dereference ref-returning Span indexers in value contexts while preserving writes and address contexts
- parse bare indexed assignments with index-context rules and single-evaluate System.Index compound operands
- cover Span/ReadOnlySpan element kinds, writes, compound operations, increments, side effects, bounds, metadata, controls, runtime, and ILVerify

## Validation
- Core.Tests: 6,470 passed, 1 skipped
- Compiler.Tests: 3,165 passed
- Cs2Gs.Tests: 1,562 passed (parallelization disabled)
- Oahu.Core fresh read-only default --via-sdk migration using rebuilt SDK: 13 -> 12 fingerprints
  - removed: 37a85ff59ab7
  - added: none
  - no cascades

Closes #2465