### PR TITLE
cs2gs: preserve explicit-interface properties during constructor lift

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2436ExplicitInterfacePrimaryConstructorLiftTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2436ExplicitInterfacePrimaryConstructorLiftTests.cs
@@ -1,0 +1,154 @@
+// <copyright file="Issue2436ExplicitInterfacePrimaryConstructorLiftTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2436: constructor lifting tracked lifted properties by simple name,
+/// so a same-named explicit-interface forwarder was mistaken for the property
+/// consumed by the lift and silently omitted.
+/// </summary>
+public class Issue2436ExplicitInterfacePrimaryConstructorLiftTests
+{
+    [Fact]
+    public void ConstructorLift_SameNamedExplicitInterfaceForwarderSurvives()
+    {
+        (CompilationUnit unit, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public interface IValue
+    {
+        string Value { get; }
+    }
+
+    public class Holder : IValue
+    {
+        public Holder(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; }
+
+        string IValue.Value => Value;
+    }
+}");
+
+        TypeDeclaration holder = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "Holder");
+        Parameter parameter = Assert.Single(holder.PrimaryConstructorParameters);
+        Assert.Equal("Value", parameter.Name);
+
+        PropertyDeclaration forwarder = Assert.Single(
+            holder.Members.OfType<PropertyDeclaration>(),
+            p => p.Name == "Value");
+        Assert.True(forwarder.ExplicitInterfaceType is NamedTypeReference { Name: "IValue" });
+        Assert.DoesNotContain(holder.Members, m => m is ConstructorDeclaration);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        AssertRoundTripParses(GSharpPrinter.Print(unit));
+    }
+
+    [Fact]
+    public void ConstructorLift_SameNamedExplicitGetSetPropertyPreservesAccessorShape()
+    {
+        (CompilationUnit unit, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public interface IMutableValue
+    {
+        string Value { get; set; }
+    }
+
+    public class MutableHolder : IMutableValue
+    {
+        public MutableHolder(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; private set; }
+
+        string IMutableValue.Value
+        {
+            get => Value;
+            set => Value = value;
+        }
+    }
+}");
+
+        TypeDeclaration holder = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "MutableHolder");
+        Assert.Equal("Value", Assert.Single(holder.PrimaryConstructorParameters).Name);
+
+        PropertyDeclaration forwarder = Assert.Single(
+            holder.Members.OfType<PropertyDeclaration>(),
+            p => p.Name == "Value");
+        Assert.True(forwarder.ExplicitInterfaceType is NamedTypeReference { Name: "IMutableValue" });
+        Assert.Contains(forwarder.Accessors, a => a.Kind == AccessorKind.Get);
+        Assert.Contains(forwarder.Accessors, a => a.Kind == AccessorKind.Set);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        AssertRoundTripParses(GSharpPrinter.Print(unit));
+    }
+
+    [Fact]
+    public void RecordAutoPropertyLift_SameNamedExplicitInterfaceForwarderSurvives()
+    {
+        (CompilationUnit unit, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public interface IValue
+    {
+        string Value { get; }
+    }
+
+    public record Holder : IValue
+    {
+        public string Value { get; init; } = ""default"";
+
+        string IValue.Value => Value;
+    }
+}");
+
+        TypeDeclaration holder = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "Holder");
+        Parameter parameter = Assert.Single(holder.PrimaryConstructorParameters);
+        Assert.Equal("Value", parameter.Name);
+
+        PropertyDeclaration forwarder = Assert.Single(
+            holder.Members.OfType<PropertyDeclaration>(),
+            p => p.Name == "Value");
+        Assert.True(forwarder.ExplicitInterfaceType is NamedTypeReference { Name: "IValue" });
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        AssertRoundTripParses(GSharpPrinter.Print(unit));
+    }
+
+    private static (CompilationUnit Unit, TranslationContext Context) Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Source.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return (unit, context);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -1426,9 +1426,10 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             var primaryParameters = new List<Parameter>();
-            var propertiesAsParams = new HashSet<string>();
-            var propertiesAsBodyFields = new HashSet<string>();
-            var bodyFieldInitializers = new Dictionary<string, GExpression>();
+            var propertiesAsParams = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+            var propertiesAsBodyFields = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+            var bodyFieldInitializers =
+                new Dictionary<IPropertySymbol, GExpression>(SymbolEqualityComparer.Default);
             foreach (PropertyDeclarationSyntax prop in eligible)
             {
                 if (this.context.GetDeclaredSymbol(prop) is not IPropertySymbol propSymbol ||
@@ -1472,8 +1473,8 @@ public sealed partial class CSharpToGSharpTranslator
                     // parameter) reuses that machinery — the required/optional
                     // machinery on the primary constructor itself never needs
                     // to represent a non-constant value at all.
-                    propertiesAsBodyFields.Add(prop.Identifier.Text);
-                    bodyFieldInitializers[prop.Identifier.Text] = this.TranslateExpression(prop.Initializer.Value);
+                    propertiesAsBodyFields.Add(propSymbol);
+                    bodyFieldInitializers[propSymbol] = this.TranslateExpression(prop.Initializer.Value);
                     continue;
                 }
 
@@ -1482,7 +1483,7 @@ public sealed partial class CSharpToGSharpTranslator
                     : null;
 
                 primaryParameters.Add(new Parameter(SanitizeIdentifier(prop.Identifier.Text), type, defaultValue: defaultValue));
-                propertiesAsParams.Add(prop.Identifier.Text);
+                propertiesAsParams.Add(propSymbol);
             }
 
             if (primaryParameters.Count == 0 && propertiesAsBodyFields.Count == 0)
@@ -1490,7 +1491,10 @@ public sealed partial class CSharpToGSharpTranslator
                 return ConstructorLift.None;
             }
 
-            var reportedNames = propertiesAsParams.Concat(propertiesAsBodyFields).OrderBy(n => n, StringComparer.Ordinal);
+            var reportedNames = propertiesAsParams
+                .Concat(propertiesAsBodyFields)
+                .Select(p => p.Name)
+                .OrderBy(n => n, StringComparer.Ordinal);
             this.context.Report(new TranslationDiagnostic(
                 nameof(SyntaxKind.RecordDeclaration),
                 $"record '{record.Identifier.Text}' is canonicalized to a 'data class'/'data struct': body auto-property data member(s) {string.Join(", ", reportedNames)} become primary-constructor parameter fields (now public and mutable), or — for a non-constant initializer that cannot be a valid G# optional-parameter default — a plain body field carrying that initializer (ADR-0115 §B.3/§B.4, issue #2228, issue #2281).",
@@ -1564,7 +1568,9 @@ public sealed partial class CSharpToGSharpTranslator
                 return ConstructorLift.None;
             }
 
-            var paramToTarget = new Dictionary<IParameterSymbol, (string Name, ITypeSymbol Type, bool IsProperty)>(SymbolEqualityComparer.Default);
+            var paramToTarget =
+                new Dictionary<IParameterSymbol, (string Name, ITypeSymbol Type, IPropertySymbol Property)>(
+                    SymbolEqualityComparer.Default);
             var fieldInitializers = new Dictionary<string, GExpression>();
             var residualInitStatements = new List<GStatement>();
 
@@ -1586,7 +1592,7 @@ public sealed partial class CSharpToGSharpTranslator
                     // constructor parameter named after the member.
                     string targetName;
                     ITypeSymbol targetType;
-                    bool targetIsProperty;
+                    IPropertySymbol targetProperty;
                     ISymbol leftSymbol = this.context.GetSymbolInfo(assignment.Left).Symbol;
                     if (leftSymbol is IFieldSymbol fieldSymbol &&
                         !fieldSymbol.IsStatic &&
@@ -1594,7 +1600,7 @@ public sealed partial class CSharpToGSharpTranslator
                     {
                         targetName = fieldSymbol.Name;
                         targetType = fieldSymbol.Type;
-                        targetIsProperty = false;
+                        targetProperty = null;
                     }
                     else if (leftSymbol is IPropertySymbol propertySymbol &&
                         !propertySymbol.IsStatic &&
@@ -1602,7 +1608,7 @@ public sealed partial class CSharpToGSharpTranslator
                     {
                         targetName = propertySymbol.Name;
                         targetType = propertySymbol.Type;
-                        targetIsProperty = true;
+                        targetProperty = propertySymbol;
 
                         // OD-T1: G# primary-constructor parameters are NOT
                         // properties, so a *class* that copies a constructor
@@ -1637,7 +1643,7 @@ public sealed partial class CSharpToGSharpTranslator
                             return ConstructorLift.None;
                         }
 
-                        paramToTarget[paramSymbol] = (targetName, targetType, targetIsProperty);
+                        paramToTarget[paramSymbol] = (targetName, targetType, targetProperty);
                         continue;
                     }
 
@@ -1668,7 +1674,7 @@ public sealed partial class CSharpToGSharpTranslator
                     // is rejected). A constant assignment to a property therefore
                     // cannot be lifted to a member initializer; keep the explicit
                     // 'init' so its body faithfully assigns the property.
-                    if (targetIsProperty)
+                    if (targetProperty != null)
                     {
                         return ConstructorLift.None;
                     }
@@ -1718,10 +1724,10 @@ public sealed partial class CSharpToGSharpTranslator
 
             var primaryParameters = new List<Parameter>();
             var fieldsAsParams = new HashSet<string>();
-            var propertiesAsParams = new HashSet<string>();
+            var propertiesAsParams = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
             foreach (IParameterSymbol param in ctorSymbol.Parameters)
             {
-                (string Name, ITypeSymbol Type, bool IsProperty) target = paramToTarget[param];
+                (string Name, ITypeSymbol Type, IPropertySymbol Property) target = paramToTarget[param];
                 GTypeReference type = this.typeMapper.Map(target.Type, this.context, param.Locations.FirstOrDefault());
 
                 // Issue #914 (oblivious sink): a T2-lifted primary-constructor
@@ -1739,9 +1745,9 @@ public sealed partial class CSharpToGSharpTranslator
                 type = this.PromoteDelegateParameterInvokedWithNull(type, param);
                 GExpression liftedDefault = this.BuildOptionalParameterDefault(param, type, node);
                 primaryParameters.Add(new Parameter(SanitizeIdentifier(target.Name), type, defaultValue: liftedDefault));
-                if (target.IsProperty)
+                if (target.Property != null)
                 {
-                    propertiesAsParams.Add(target.Name);
+                    propertiesAsParams.Add(target.Property);
                 }
                 else
                 {
@@ -1749,7 +1755,10 @@ public sealed partial class CSharpToGSharpTranslator
                 }
             }
 
-            var allParamNames = fieldsAsParams.Concat(propertiesAsParams).OrderBy(n => n).ToList();
+            var allParamNames = fieldsAsParams
+                .Concat(propertiesAsParams.Select(p => p.Name))
+                .OrderBy(n => n)
+                .ToList();
             if (allParamNames.Count > 0)
             {
                 this.context.Report(new TranslationDiagnostic(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -87,7 +87,9 @@ public sealed partial class CSharpToGSharpTranslator
                     break;
 
                 case PropertyDeclarationSyntax property:
-                    if (lift.PropertiesAsPrimaryParameters.Contains(property.Identifier.Text))
+                    var propertySymbol = this.context.GetDeclaredSymbol(property) as IPropertySymbol;
+                    if (propertySymbol != null &&
+                        lift.PropertiesAsPrimaryParameters.Contains(propertySymbol))
                     {
                         break;
                     }
@@ -96,12 +98,12 @@ public sealed partial class CSharpToGSharpTranslator
                     // to a body field (see PropertiesAsBodyFields) emits as a plain
                     // `let Name Type = initializer` field rather than a primary-
                     // constructor parameter or a G# `prop`.
-                    if (lift.PropertiesAsBodyFields.Contains(property.Identifier.Text))
+                    if (propertySymbol != null &&
+                        lift.PropertiesAsBodyFields.Contains(propertySymbol))
                     {
-                        GExpression bodyFieldInit = lift.BodyFieldInitializers[property.Identifier.Text];
-                        GTypeReference bodyFieldType = this.context.GetDeclaredSymbol(property) is IPropertySymbol bodyFieldPropSymbol
-                            ? this.typeMapper.Map(bodyFieldPropSymbol.Type, this.context, property.Identifier.GetLocation())
-                            : null;
+                        GExpression bodyFieldInit = lift.BodyFieldInitializers[propertySymbol];
+                        GTypeReference bodyFieldType =
+                            this.typeMapper.Map(propertySymbol.Type, this.context, property.Identifier.GetLocation());
                         yield return (
                             new FieldDeclaration(
                                 BindingKind.Let,
@@ -119,7 +121,7 @@ public sealed partial class CSharpToGSharpTranslator
                     // defining part is dropped in favor of its implementation
                     // part (which translates normally), and an unimplemented
                     // partial-property definition is elided outright.
-                    if (this.context.GetDeclaredSymbol(property) is IPropertySymbol { IsPartialDefinition: true })
+                    if (propertySymbol is { IsPartialDefinition: true })
                     {
                         break;
                     }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Support.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Support.cs
@@ -40,7 +40,13 @@ public sealed partial class CSharpToGSharpTranslator
 
             public HashSet<string> FieldsAsPrimaryParameters { get; init; } = new HashSet<string>();
 
-            public HashSet<string> PropertiesAsPrimaryParameters { get; init; } = new HashSet<string>();
+            /// <summary>
+            /// Gets the exact property symbols consumed by primary-constructor
+            /// lifting. Symbol identity is required because ordinary and explicit-
+            /// interface properties may legally share a simple name.
+            /// </summary>
+            public HashSet<IPropertySymbol> PropertiesAsPrimaryParameters { get; init; } =
+                new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
 
             /// <summary>
             /// Gets the auto-properties whose inline initializer is NOT a
@@ -54,17 +60,18 @@ public sealed partial class CSharpToGSharpTranslator
             /// semantics), while the primary constructor's parameter list
             /// stays limited to constant-default/required members.
             /// </summary>
-            public HashSet<string> PropertiesAsBodyFields { get; init; } = new HashSet<string>();
+            public HashSet<IPropertySymbol> PropertiesAsBodyFields { get; init; } =
+                new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
 
             public Dictionary<string, GExpression> FieldInitializers { get; init; } =
                 new Dictionary<string, GExpression>();
 
             /// <summary>
             /// Gets the initializer expressions for <see cref="PropertiesAsBodyFields"/>
-            /// (issue #2281), keyed by property name.
+            /// (issue #2281), keyed by exact property symbol.
             /// </summary>
-            public Dictionary<string, GExpression> BodyFieldInitializers { get; init; } =
-                new Dictionary<string, GExpression>();
+            public Dictionary<IPropertySymbol, GExpression> BodyFieldInitializers { get; init; } =
+                new Dictionary<IPropertySymbol, GExpression>(SymbolEqualityComparer.Default);
 
             /// <summary>
             /// Gets the constructor-body assignments that could not be hoisted to a


### PR DESCRIPTION
## Summary
- track lifted properties by exact Roslyn property symbol rather than simple name
- skip only the property declaration actually consumed by constructor or record auto-property lifting
- preserve same-named explicit-interface qualifiers and get/set accessor shape while retaining genuine lift de-duplication

## Tests
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --filter "FullyQualifiedName~Issue2436ExplicitInterfacePrimaryConstructorLiftTests|FullyQualifiedName~Issue2362ExplicitInterfacePropertyTests|FullyQualifiedName~Issue2228AutoPropertyRecordDataClassTranslationTests|FullyQualifiedName~Issue1909PrimaryConstructorTranslationTests|FullyQualifiedName~L2TranslationTests" --no-restore --verbosity minimal` (35 passed)

Fixes #2436.