### PR TITLE
Fix #2410: target-type lambdas assigned to imported delegates

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -188,21 +188,25 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
-    /// Issue #1316: binds the RHS of a simple assignment, threading the resolved
-    /// LHS <paramref name="targetType"/> into the binder for target-typed RHS
-    /// forms (if-/conditional-/switch-expression). This engages the same
-    /// branch-unification and nil-&gt;<c>T?</c> adaptation already used for a
-    /// <c>let x T? = ...</c> initializer (see StatementBinder), so a conditional
-    /// RHS with a <c>nil</c> arm unifies to the target instead of failing
-    /// GS0155. Other RHS forms keep their context-free binding; the per-form
-    /// conversion below still validates the result and reports genuine
-    /// mismatches.
+    /// Issue #1316 / #2410: binds the RHS of a simple assignment, threading
+    /// the resolved LHS <paramref name="targetType"/> into the binder for
+    /// target-typed RHS forms. Conditional forms engage the same branch-unification and
+    /// nil-&gt;<c>T?</c> adaptation already used for a <c>let x T? = ...</c>
+    /// initializer. Lambda forms reuse the event-subscription target-typing
+    /// path so imported delegate fields/properties can supply omitted
+    /// parameter types. Other RHS forms keep their context-free binding; the
+    /// per-form conversion below still validates genuine mismatches.
     /// </summary>
     /// <param name="syntax">The RHS expression syntax.</param>
     /// <param name="targetType">The resolved LHS declared type, or <see langword="null"/>.</param>
     /// <returns>The bound RHS expression.</returns>
     private BoundExpression BindAssignmentRhs(ExpressionSyntax syntax, TypeSymbol targetType)
     {
+        if (TryBindLambdaExpressionWithTargetType(syntax, targetType, out var targetTypedLambda))
+        {
+            return targetTypedLambda;
+        }
+
         if (targetType != null
             && (syntax is IfExpressionSyntax
                 || syntax is ConditionalExpressionSyntax
@@ -522,7 +526,6 @@ internal sealed partial class ExpressionBinder
         // ADR-0053: user-defined struct/class type → static field write.
         if (scope.TryLookupTypeAlias(receiverName, out var typeAlias) && typeAlias is StructSymbol userStruct)
         {
-            var staticValue = BindExpression(syntax.Value);
             var fieldName = syntax.FieldIdentifier.Text;
             if (TypeMemberModel.TryGetStaticField(userStruct, fieldName, out var staticField))
             {
@@ -531,6 +534,7 @@ internal sealed partial class ExpressionBinder
                     Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
                 }
 
+                var staticValue = BindAssignmentRhs(syntax.Value, staticField.Type);
                 var staticConverted = conversions.BindConversion(syntax.Value.Location, staticValue, staticField.Type);
                 return new BoundFieldAssignmentExpression(null, null, userStruct, staticField, staticConverted);
             }
@@ -544,6 +548,7 @@ internal sealed partial class ExpressionBinder
                     return new BoundErrorExpression(null);
                 }
 
+                var staticValue = BindAssignmentRhs(syntax.Value, prop.Type);
                 var propConverted = conversions.BindConversion(syntax.Value.Location, staticValue, prop.Type);
                 return new BoundPropertyAssignmentExpression(null, receiver: null, userStruct, prop, propConverted);
             }
@@ -558,7 +563,6 @@ internal sealed partial class ExpressionBinder
         // BoundFieldAssignmentExpression resolved by symbol identity.
         if (scope.TryLookupTypeAlias(receiverName, out var ifaceAlias) && ifaceAlias is InterfaceSymbol userInterface)
         {
-            var staticValue = BindExpression(syntax.Value);
             var fieldName = syntax.FieldIdentifier.Text;
             var staticField = userInterface.GetStaticField(fieldName);
             if (staticField != null)
@@ -568,6 +572,7 @@ internal sealed partial class ExpressionBinder
                     Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
                 }
 
+                var staticValue = BindAssignmentRhs(syntax.Value, staticField.Type);
                 var staticConverted = conversions.BindConversion(syntax.Value.Location, staticValue, staticField.Type);
                 return new BoundFieldAssignmentExpression(null, staticField, userInterface, staticConverted);
             }
@@ -582,7 +587,6 @@ internal sealed partial class ExpressionBinder
         // in-compilation source type win over a same-named imported CLR type.
         if (scope.TryLookupImportedClass(receiverName, declaration: null, out var importedClass))
         {
-            var staticValue = BindExpression(syntax.Value);
             if (!importedClass.TryLookupMember(syntax.FieldIdentifier.Text, ne: null, out var staticMember))
             {
                 Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
@@ -597,6 +601,7 @@ internal sealed partial class ExpressionBinder
 
             _ = staticWritable;
             _ = staticTargetType;
+            var staticValue = BindAssignmentRhs(syntax.Value, staticTargetSymbol);
             var staticConverted = conversions.BindConversion(syntax.Value.Location, staticValue, staticTargetSymbol);
             return new BoundClrPropertyAssignmentExpression(null, receiver: null, staticMember, staticConverted, staticTargetSymbol);
         }
@@ -1845,9 +1850,10 @@ internal sealed partial class ExpressionBinder
             return receiver;
         }
 
-        var value = BindExpression(syntax.Value);
         var fieldName = syntax.FieldIdentifier.Text;
         var receiverType = receiver.Type;
+        BoundExpression value = null;
+        BoundExpression BindValue(TypeSymbol targetType) => value ??= BindAssignmentRhs(syntax.Value, targetType);
 
         // User-defined struct/class receiver → field or property write.
         if (receiverType is StructSymbol structSym)
@@ -1876,7 +1882,7 @@ internal sealed partial class ExpressionBinder
                     field,
                     $"{declaringType.Name}.{field.Name}");
 
-                var converted = conversions.BindConversion(syntax.Value.Location, value, field.Type);
+                var converted = conversions.BindConversion(syntax.Value.Location, BindValue(field.Type), field.Type);
                 return BoundFieldAssignmentExpression.WithExpressionReceiver(null, receiver, declaringType, field, converted);
             }
 
@@ -1896,7 +1902,7 @@ internal sealed partial class ExpressionBinder
                     Diagnostics.ReportMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propDeclaringType.Name, prop.Accessibility);
                 }
 
-                var propConverted = conversions.BindConversion(syntax.Value.Location, value, prop.Type);
+                var propConverted = conversions.BindConversion(syntax.Value.Location, BindValue(prop.Type), prop.Type);
                 EnforceInitOnlyAssignment(prop, receiver, syntax.EqualsToken.Location);
                 return new BoundPropertyAssignmentExpression(null, receiver, structSym, prop, propConverted);
             }
@@ -1917,7 +1923,7 @@ internal sealed partial class ExpressionBinder
 
                     _ = inhWritable;
                     _ = inhTargetType;
-                    var inhConverted = conversions.BindConversion(syntax.Value.Location, value, inhTargetSymbol);
+                    var inhConverted = conversions.BindConversion(syntax.Value.Location, BindValue(inhTargetSymbol), inhTargetSymbol);
                     return new BoundClrPropertyAssignmentExpression(null, receiver, clrMember, inhConverted, inhTargetSymbol);
                 }
             }
@@ -1940,7 +1946,7 @@ internal sealed partial class ExpressionBinder
                     return new BoundErrorExpression(null);
                 }
 
-                var ifaceConverted = conversions.BindConversion(syntax.Value.Location, value, ifaceProp.Type);
+                var ifaceConverted = conversions.BindConversion(syntax.Value.Location, BindValue(ifaceProp.Type), ifaceProp.Type);
                 EnforceInitOnlyAssignment(ifaceProp, receiver, syntax.EqualsToken.Location);
                 return new BoundPropertyAssignmentExpression(null, receiver, null, ifaceProp, ifaceConverted);
             }
@@ -1974,7 +1980,7 @@ internal sealed partial class ExpressionBinder
 
             _ = instWritable;
             _ = instTargetType;
-            var instConverted = conversions.BindConversion(syntax.Value.Location, value, instTargetSymbol);
+            var instConverted = conversions.BindConversion(syntax.Value.Location, BindValue(instTargetSymbol), instTargetSymbol);
             return new BoundClrPropertyAssignmentExpression(null, receiver, instanceMember, instConverted, instTargetSymbol);
         }
 
@@ -2002,7 +2008,8 @@ internal sealed partial class ExpressionBinder
         ImportedClassSymbol constructedImported)
     {
         var fieldName = syntax.FieldIdentifier.Text;
-        var value = BindExpression(syntax.Value);
+        BoundExpression value = null;
+        BoundExpression BindValue(TypeSymbol targetType) => value ??= BindAssignmentRhs(syntax.Value, targetType);
 
         // User class/struct → static field or static property write.
         if (constructedStruct != null)
@@ -2014,7 +2021,7 @@ internal sealed partial class ExpressionBinder
                     Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
                 }
 
-                var staticConverted = conversions.BindConversion(syntax.Value.Location, value, staticField.Type);
+                var staticConverted = conversions.BindConversion(syntax.Value.Location, BindValue(staticField.Type), staticField.Type);
                 return new BoundFieldAssignmentExpression(null, null, constructedStruct, staticField, staticConverted);
             }
 
@@ -2026,7 +2033,7 @@ internal sealed partial class ExpressionBinder
                     return new BoundErrorExpression(null);
                 }
 
-                var propConverted = conversions.BindConversion(syntax.Value.Location, value, prop.Type);
+                var propConverted = conversions.BindConversion(syntax.Value.Location, BindValue(prop.Type), prop.Type);
                 return new BoundPropertyAssignmentExpression(null, receiver: null, constructedStruct, prop, propConverted);
             }
 
@@ -2046,7 +2053,7 @@ internal sealed partial class ExpressionBinder
                     Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
                 }
 
-                var ifaceConverted = conversions.BindConversion(syntax.Value.Location, value, ifaceStaticField.Type);
+                var ifaceConverted = conversions.BindConversion(syntax.Value.Location, BindValue(ifaceStaticField.Type), ifaceStaticField.Type);
                 return new BoundFieldAssignmentExpression(null, ifaceStaticField, constructedInterface, ifaceConverted);
             }
 
@@ -2060,7 +2067,7 @@ internal sealed partial class ExpressionBinder
         if (constructedImported.TryLookupMember(fieldName, ne: null, out var staticMember)
             && TryGetWritableClrMember(staticMember, out _, out var staticTargetSymbol, out _))
         {
-            var staticConverted = conversions.BindConversion(syntax.Value.Location, value, staticTargetSymbol);
+            var staticConverted = conversions.BindConversion(syntax.Value.Location, BindValue(staticTargetSymbol), staticTargetSymbol);
             return new BoundClrPropertyAssignmentExpression(null, receiver: null, staticMember, staticConverted, staticTargetSymbol);
         }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -362,13 +362,7 @@ internal sealed partial class ExpressionBinder
         // genuinely imported CLR delegate) fills in the omitted parameter
         // types before falling through to the same method-group / conversion
         // handling below that already covers typed lambdas.
-        BoundExpression bound;
-        if (handlerSyntax is LambdaExpressionSyntax lambdaHandler
-            && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(targetDelegateType, out var handlerTargetFnType))
-        {
-            bound = lambdas.BindLambdaExpression(lambdaHandler, handlerTargetFnType);
-        }
-        else
+        if (!TryBindLambdaExpressionWithTargetType(handlerSyntax, targetDelegateType, out var bound))
         {
             bound = BindExpression(handlerSyntax);
         }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -266,6 +266,24 @@ internal sealed partial class ExpressionBinder
         return conversions.BindConversion(syntax, targetType);
     }
 
+    private bool TryBindLambdaExpressionWithTargetType(
+        ExpressionSyntax syntax,
+        TypeSymbol targetType,
+        out BoundExpression bound)
+    {
+        // Keep event handlers and assignment RHS binding on one target-typing path.
+        bound = null;
+        if (syntax is not LambdaExpressionSyntax lambda
+            || targetType == null
+            || !MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(targetType, out var targetFunctionType))
+        {
+            return false;
+        }
+
+        bound = lambdas.BindLambdaExpression(lambda, targetFunctionType);
+        return true;
+    }
+
     internal BoundExpression BindExpression(ExpressionSyntax syntax, bool canBeVoid = false)
     {
         var result = BindExpressionpublic(syntax);

--- a/test/Compiler.Tests/Emit/Issue2410ImportedDelegateAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2410ImportedDelegateAssignmentEmitTests.cs
@@ -1,0 +1,162 @@
+// <copyright file="Issue2410ImportedDelegateAssignmentEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public class Issue2410ImportedDelegateAssignmentEmitTests
+{
+    [Fact]
+    public void ImportedStaticDelegateFieldAndProperty_UntypedLambdas_RunAndVerify()
+    {
+        var output = CompileAndRun(
+            """
+            package App
+            import System
+            import Lib2410Emit
+
+            func Main() {
+                Holder.StaticField = (x) -> x + 1
+                Holder.StaticProperty = (x) -> x + 2
+                Console.WriteLine(Holder.InvokeStaticField(10))
+                Console.WriteLine(Holder.InvokeStaticProperty(10))
+            }
+            """,
+            nameof(ImportedStaticDelegateFieldAndProperty_UntypedLambdas_RunAndVerify));
+
+        Assert.Equal("11\n12\n", output);
+    }
+
+    [Fact]
+    public void ImportedDelegateAssignment_SiblingMemberPaths_RunAndVerify()
+    {
+        var output = CompileAndRun(
+            """
+            package App
+            import System
+            import Lib2410Emit
+
+            func Same(h Holder) Holder -> h
+
+            func Main() {
+                let h = Holder()
+                h.InstanceField = (x) -> x + 3
+                Same(h).InstanceProperty = (x) -> x + 4
+                GenericHolder[int32].StaticField = (x) -> x + 5
+                GenericHolder[int32].StaticProperty = (x) -> x + 6
+                Console.WriteLine(h.InvokeInstanceField(10))
+                Console.WriteLine(h.InvokeInstanceProperty(10))
+                Console.WriteLine(GenericHolder[int32].InvokeStaticField(10))
+                Console.WriteLine(GenericHolder[int32].InvokeStaticProperty(10))
+            }
+            """,
+            nameof(ImportedDelegateAssignment_SiblingMemberPaths_RunAndVerify));
+
+        Assert.Equal("13\n14\n15\n16\n", output);
+    }
+
+    private static string CompileAndRun(string source, string caseName)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2410Emit", caseName);
+        Directory.CreateDirectory(directory);
+        var libraryPath = EmitCSharpLibrary(directory);
+        var consumerPath = Path.Combine(directory, "Consumer.dll");
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        var compilation = new GsCompilation(resolver, GsSyntaxTree.Parse(SourceText.From(source)));
+        using (var stream = File.Create(consumerPath))
+        {
+            var result = compilation.Emit(stream, pdbStream: null, refStream: null, assemblyName: "Issue2410." + caseName);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
+
+        var context = new AssemblyLoadContext("Issue2410." + caseName, isCollectible: true);
+        try
+        {
+            context.Resolving += (_, name) => name.Name == "Lib2410Emit"
+                ? context.LoadFromAssemblyPath(libraryPath)
+                : null;
+            var assembly = context.LoadFromAssemblyPath(consumerPath);
+            var output = Console.Out;
+            using var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                assembly.EntryPoint!.Invoke(null, null);
+            }
+            finally
+            {
+                Console.SetOut(output);
+            }
+
+            return captured.ToString().Replace("\r\n", "\n");
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    private static string EmitCSharpLibrary(string directory)
+    {
+        var libraryPath = Path.Combine(directory, "Lib2410Emit.dll");
+        const string source = """
+            namespace Lib2410Emit
+            {
+                public delegate int Mapper(int value);
+
+                public sealed class Holder
+                {
+                    public static Mapper StaticField;
+                    public static Mapper StaticProperty { get; set; }
+                    public Mapper InstanceField;
+                    public Mapper InstanceProperty { get; set; }
+
+                    public static int InvokeStaticField(int value) => StaticField(value);
+                    public static int InvokeStaticProperty(int value) => StaticProperty(value);
+                    public int InvokeInstanceField(int value) => InstanceField(value);
+                    public int InvokeInstanceProperty(int value) => InstanceProperty(value);
+                }
+
+                public sealed class GenericHolder<T>
+                {
+                    public static Mapper StaticField;
+                    public static Mapper StaticProperty { get; set; }
+                    public static int InvokeStaticField(int value) => StaticField(value);
+                    public static int InvokeStaticProperty(int value) => StaticProperty(value);
+                }
+            }
+            """;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "Lib2410Emit",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = File.Create(libraryPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return libraryPath;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2410ImportedDelegateAssignmentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2410ImportedDelegateAssignmentTests.cs
@@ -1,0 +1,175 @@
+// <copyright file="Issue2410ImportedDelegateAssignmentTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public class Issue2410ImportedDelegateAssignmentTests
+{
+    private static readonly string LibraryPath = EmitCSharpLibrary();
+
+    [Fact]
+    public void ImportedStaticDelegateFieldAndProperty_UntypedLambdas_Bind()
+    {
+        AssertNoErrors("""
+            package App
+            import Lib2410
+
+            func Main() {
+                Holder.StaticField = (x) -> x + 1
+                Holder.StaticProperty = (x) -> x + 2
+            }
+            """);
+    }
+
+    [Fact]
+    public void ImportedDelegateAssignment_SiblingMemberPaths_Bind()
+    {
+        AssertNoErrors("""
+            package App
+            import Lib2410
+
+            func Same(h Holder) Holder -> h
+
+            func Main() {
+                let h = Holder()
+                h.InstanceField = (x) -> x + 1
+                Same(h).InstanceProperty = (x) -> x + 2
+                GenericHolder[int32].StaticField = (x) -> x + 3
+                GenericHolder[int32].StaticProperty = (x) -> x + 4
+            }
+            """);
+    }
+
+    [Fact]
+    public void ImportedStaticDelegateField_TypedLambda_StillBinds()
+    {
+        AssertNoErrors("""
+            package App
+            import Lib2410
+
+            func Main() {
+                Holder.StaticField = (x int32) -> x + 1
+            }
+            """);
+    }
+
+    [Fact]
+    public void ImportedStaticDelegateField_ArityMismatch_RemainsRejected()
+    {
+        var diagnostics = Bind("""
+            package App
+            import Lib2410
+
+            func Main() {
+                Holder.StaticField = (x, y) -> x
+            }
+            """);
+
+        Assert.Contains(diagnostics, d => d.IsError);
+    }
+
+    [Fact]
+    public void ImportedStaticDelegateProperty_ReturnMismatch_RemainsRejected()
+    {
+        var diagnostics = Bind("""
+            package App
+            import Lib2410
+
+            func Main() {
+                Holder.StaticProperty = (x) -> "wrong"
+            }
+            """);
+
+        Assert.Contains(diagnostics, d => d.IsError);
+    }
+
+    [Fact]
+    public void ImportedStaticNonDelegateField_UntypedLambda_RemainsRejected()
+    {
+        var diagnostics = Bind("""
+            package App
+            import Lib2410
+
+            func Main() {
+                Holder.Number = (x) -> x
+            }
+            """);
+
+        Assert.Contains(diagnostics, d => d.IsError);
+    }
+
+    private static void AssertNoErrors(string source)
+    {
+        Assert.DoesNotContain(Bind(source), d => d.IsError);
+    }
+
+    private static IReadOnlyList<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
+    {
+        using var resolver = ReferenceResolver.WithReferences(new[] { LibraryPath });
+        var tree = GsSyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GsCompilation(resolver, tree);
+        return tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .ToList();
+    }
+
+    private static string EmitCSharpLibrary()
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "Issue2410Binding");
+        Directory.CreateDirectory(outputDir);
+        var libraryPath = Path.Combine(outputDir, "Lib2410.dll");
+
+        const string source = """
+            namespace Lib2410
+            {
+                public delegate int Mapper(int value);
+
+                public sealed class Holder
+                {
+                    public static Mapper StaticField;
+                    public static Mapper StaticProperty { get; set; }
+                    public static int Number;
+                    public Mapper InstanceField;
+                    public Mapper InstanceProperty { get; set; }
+                }
+
+                public sealed class GenericHolder<T>
+                {
+                    public static Mapper StaticField;
+                    public static Mapper StaticProperty { get; set; }
+                }
+            }
+            """;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "Lib2410",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = File.Create(libraryPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return libraryPath;
+    }
+}


### PR DESCRIPTION
## Summary
- share the event-subscription delegate target-typing path with assignment RHS binding
- target-type untyped lambdas for imported static delegate fields/properties
- cover simple instance, expression-receiver, and constructed-generic static member-write siblings through the same binder path
- preserve typed lambdas and reject arity, return-type, and non-delegate mismatches

## Tests
- Core.Tests targeted binder regressions: 25 passed
- Compiler.Tests targeted emit/ILVerify/runtime regressions: 21 passed

Fixes #2410.