### PR TITLE
Fix generic operator declaration binding

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -32,14 +32,14 @@ internal sealed partial class DeclarationBinder
 
         var seenParameterNames = new HashSet<string>();
 
-        // Phase 4.1 / ADR-0020: bind generic type parameters first so that
-        // BindTypeClause can find them when binding parameter / return types.
-        var typeParameters = BindTypeParameterList(syntax.TypeParameterList);
         var previousTypeParameters = binderCtx.CurrentTypeParameters;
-        if (!typeParameters.IsDefaultOrEmpty)
+        var ownerTypeParameters = GetGenericOperatorOwnerTypeParameters(syntax, package);
+        if (!ownerTypeParameters.IsDefaultOrEmpty)
         {
-            binderCtx.CurrentTypeParameters = new Dictionary<string, TypeParameterSymbol>();
-            foreach (var tp in typeParameters)
+            binderCtx.CurrentTypeParameters = previousTypeParameters == null
+                ? new Dictionary<string, TypeParameterSymbol>()
+                : new Dictionary<string, TypeParameterSymbol>(previousTypeParameters);
+            foreach (var tp in ownerTypeParameters)
             {
                 binderCtx.CurrentTypeParameters[tp.Name] = tp;
             }
@@ -47,12 +47,104 @@ internal sealed partial class DeclarationBinder
 
         try
         {
+            // Phase 4.1 / ADR-0020: bind generic type parameters first so that
+            // BindTypeClause can find them when binding parameter / return types.
+            // Issue #2402: an open-self operator declaration (`Box[T]`) uses the
+            // owner's type parameters, published above, rather than declaring a
+            // generic operator method.
+            var typeParameters = BindTypeParameterList(syntax.TypeParameterList);
+            if (!typeParameters.IsDefaultOrEmpty)
+            {
+                var functionTypeParameterScope = binderCtx.CurrentTypeParameters == null
+                    ? new Dictionary<string, TypeParameterSymbol>()
+                    : new Dictionary<string, TypeParameterSymbol>(binderCtx.CurrentTypeParameters);
+                foreach (var tp in typeParameters)
+                {
+                    functionTypeParameterScope[tp.Name] = tp;
+                }
+
+                binderCtx.CurrentTypeParameters = functionTypeParameterScope;
+            }
+
             BindFunctionDeclarationCore(syntax, package, typeParameters, parameters, seenParameterNames);
         }
         finally
         {
             binderCtx.CurrentTypeParameters = previousTypeParameters;
         }
+    }
+
+    private ImmutableArray<TypeParameterSymbol> GetGenericOperatorOwnerTypeParameters(
+        FunctionDeclarationSyntax syntax,
+        PackageSymbol package)
+    {
+        if (syntax.IsExtension && syntax.Identifier.Text.StartsWith("op_", StringComparison.Ordinal))
+        {
+            return TryGetOpenSelfTypeParameters(syntax.Receiver.Type, package);
+        }
+
+        if (syntax.IsConversionOperator)
+        {
+            if (syntax.Parameters.Count > 0)
+            {
+                var sourceOwner = TryGetOpenSelfTypeParameters(syntax.Parameters[0].Type, package);
+                if (!sourceOwner.IsDefaultOrEmpty)
+                {
+                    return sourceOwner;
+                }
+            }
+
+            return TryGetOpenSelfTypeParameters(syntax.Type, package);
+        }
+
+        return ImmutableArray<TypeParameterSymbol>.Empty;
+    }
+
+    private ImmutableArray<TypeParameterSymbol> TryGetOpenSelfTypeParameters(
+        TypeClauseSyntax syntax,
+        PackageSymbol package)
+    {
+        if (syntax == null
+            || syntax.HasQualifier
+            || !syntax.HasTypeArguments
+            || syntax.IsArray
+            || syntax.IsNullable
+            || !scope.TryLookupTypeAlias(syntax.Identifier.Text, syntax.TypeArguments.Count, out var candidate)
+            || candidate is not StructSymbol candidateStruct)
+        {
+            return ImmutableArray<TypeParameterSymbol>.Empty;
+        }
+
+        var owner = candidateStruct.Definition ?? candidateStruct;
+        if (package == null
+            || !owner.IsGenericDefinition
+            || owner.TypeParameters.Length != syntax.TypeArguments.Count
+            || !string.Equals(owner.PackageName, package.Name, StringComparison.Ordinal))
+        {
+            return ImmutableArray<TypeParameterSymbol>.Empty;
+        }
+
+        for (var i = 0; i < owner.TypeParameters.Length; i++)
+        {
+            var argument = syntax.TypeArguments[i];
+            if (argument.Identifier == null
+                || argument.HasQualifier
+                || argument.HasTypeArguments
+                || argument.IsArray
+                || argument.IsNullable
+                || argument.IsTuple
+                || argument.IsFunction
+                || argument.IsMap
+                || argument.IsChannel
+                || argument.IsPointer
+                || argument.IsSequence
+                || argument.Identifier.Text != owner.TypeParameters[i].Name)
+            {
+                return ImmutableArray<TypeParameterSymbol>.Empty;
+            }
+        }
+
+        return owner.TypeParameters;
     }
 
     private void BindFunctionDeclarationCore(

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2402GenericOperatorDeclarationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2402GenericOperatorDeclarationTests.cs
@@ -1,0 +1,173 @@
+// <copyright file="Issue2402GenericOperatorDeclarationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public class Issue2402GenericOperatorDeclarationTests
+{
+    [Fact]
+    public void GenericStructReceiverStyleArithmeticOperator_BindsOpenOwnerShape()
+    {
+        var source =
+            """
+            struct Box[T] {
+                var Value T
+                var Rank int32
+            }
+
+            func (left Box[T]) operator +(right Box[T]) Box[T] {
+                return Box[T]{Value: left.Value, Rank: left.Rank + right.Rank}
+            }
+
+            42
+            """;
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+
+        var box = (StructSymbol)compilation.GlobalScope.Structs.Single(t => t.Name == "Box");
+        var add = box.StaticMethods.Single(m => m.Name == "op_Addition");
+        Assert.Same(box, add.StaticOwnerType);
+        Assert.Empty(add.TypeParameters);
+        AssertOpenSelfType(add.Parameters[0].Type, box);
+        AssertOpenSelfType(add.Parameters[1].Type, box);
+        AssertOpenSelfType(add.Type, box);
+    }
+
+    [Fact]
+    public void GenericStructReceiverStyleComparisonOperator_BindsWithoutDiagnostics()
+    {
+        var result = Evaluate(
+            """
+            struct Box[T] {
+                var Value T
+                var Rank int32
+            }
+
+            func (left Box[T]) operator <(right Box[T]) bool {
+                return left.Rank < right.Rank
+            }
+
+            true
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.True((bool)result.Value);
+    }
+
+    [Fact]
+    public void GenericStructConversionOperators_BindOpenOwnerShapes()
+    {
+        var source =
+            """
+            struct Box[T] {
+                var Value T
+                var Rank int32
+            }
+
+            func operator implicit (value Box[T]) int32 {
+                return value.Rank
+            }
+
+            func operator explicit (rank int32) Box[T] {
+                return Box[T]{Rank: rank}
+            }
+
+            42
+            """;
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+
+        var box = (StructSymbol)compilation.GlobalScope.Structs.Single(t => t.Name == "Box");
+        var conversion = box.StaticMethods.Single(m => m.Name == "op_Implicit");
+        Assert.Same(box, conversion.StaticOwnerType);
+        Assert.Empty(conversion.TypeParameters);
+        AssertOpenSelfType(conversion.Parameters[0].Type, box);
+
+        var reverseConversion = box.StaticMethods.Single(m => m.Name == "op_Explicit");
+        Assert.Same(box, reverseConversion.StaticOwnerType);
+        Assert.Empty(reverseConversion.TypeParameters);
+        AssertOpenSelfType(reverseConversion.Type, box);
+    }
+
+    [Fact]
+    public void GenericOperator_WithUndeclaredReceiverTypeArgument_ReportsUndefinedType()
+    {
+        var result = Evaluate(
+            """
+            struct Box[T] {
+                var Value T
+            }
+
+            func (left Box[Missing]) operator +(right Box[Missing]) Box[Missing] {
+                return left
+            }
+            """);
+
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0113");
+    }
+
+    [Fact]
+    public void GenericConversionOperator_WithMultipleParameters_StillReportsGS0393()
+    {
+        var result = Evaluate(
+            """
+            struct Box[T] {
+                var Value T
+            }
+
+            func operator implicit (value Box[T], extra int32) int32 {
+                return extra
+            }
+            """);
+
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0393");
+    }
+
+    [Fact]
+    public void ConversionOperator_WithoutSameCompilationOwner_StillReportsGS0394()
+    {
+        var result = Evaluate(
+            """
+            func operator implicit (value int32) string {
+                return "invalid"
+            }
+            """);
+
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0394");
+    }
+
+    private static void AssertOpenSelfType(TypeSymbol type, StructSymbol owner)
+    {
+        var constructed = Assert.IsType<StructSymbol>(type);
+        Assert.Same(owner, constructed.Definition);
+        Assert.Single(constructed.TypeArguments);
+        Assert.Same(owner.TypeParameters[0], constructed.TypeArguments[0]);
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        return Compile(source).Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #2402

## Summary
- publish a generic same-compilation operator owner's open-self type parameters while binding receiver, parameter, and return clauses
- attach receiver-style arithmetic/comparison and source/target conversion operators to the generic type definition with constructed `Owner[T]` operand shapes
- keep undeclared type arguments and invalid conversion declarations on their existing diagnostic paths

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --filter "FullyQualifiedName~Issue2402GenericOperatorDeclarationTests|FullyQualifiedName~Issue2377OperatorMetadataShapeTests|FullyQualifiedName~ConversionOperatorTests"` (34 passed)
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore` (6,476 passed, 1 skipped)
- final focused run: `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --filter FullyQualifiedName~Issue2402GenericOperatorDeclarationTests` (6 passed)
