### PR TITLE
Fix tuple element oblivious nullability propagation

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2423InterfaceMethodContractTaintTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2423InterfaceMethodContractTaintTests.cs
@@ -68,14 +68,9 @@ namespace Cs2Gs.Tests;
 /// awaited results (mirroring the #2421 async fix), so a value-typed
 /// `Task&lt;int&gt;` is never promoted. Base/override contracts are
 /// deliberately NOT synced (consistent with the pre-existing property
-/// behavior, which only handles interfaces). Tuple-returning interface
-/// methods are also NOT synced by this fix: tuple-return promotion
-/// (`PromoteTupleReturnIfTainted`) is an entirely separate, per-declaration
-/// SYNTACTIC mechanism that inspects a method's OWN `return` expressions — an
-/// interface method has no body/no `return` expressions to inspect, so it can
-/// never itself be promoted regardless of what an implementation's body
-/// contains; bridging that is a materially different mechanism and out of
-/// scope for this precise, symbol-taint-only fix.
+/// behavior, which only handles interfaces). Issue #2469 subsequently added
+/// an independent element-path graph for tuple returns; its contract handling
+/// is covered by the tuple-specific test below.
 /// </para>
 /// </summary>
 public class Issue2423InterfaceMethodContractTaintTests
@@ -228,15 +223,8 @@ namespace Demo
     }
 
     [Fact]
-    public void TupleReturningInterfaceMethod_IsNotSyncedByThisFix()
+    public void TupleReturningInterfaceMethod_IsSyncedByTupleElementAnalysis()
     {
-        // Negative/documentation control: tuple-return promotion is a
-        // separate, per-declaration SYNTACTIC mechanism
-        // (PromoteTupleReturnIfTainted) keyed off a method's OWN `return`
-        // expressions; an interface method has no body to inspect, so its
-        // tuple return can never be promoted by that mechanism regardless of
-        // what an implementation's body does. This fix's taint-graph sync
-        // does not bridge that gap (out of scope - see class remarks).
         string printed = TranslateOblivious(@"
 namespace Demo
 {
@@ -255,7 +243,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("func Get() (string, string);", printed);
+        Assert.Contains("func Get() (string?, string);", printed);
         Assert.Contains("func Get() (string?, string)", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2469TupleElementNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2469TupleElementNullabilityTranslationTests.cs
@@ -1,0 +1,268 @@
+// <copyright file="Issue2469TupleElementNullabilityTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public class Issue2469TupleElementNullabilityTranslationTests
+{
+    [Fact]
+    public void Oblivious_NamedTupleLiteral_PromotesEachNullElement()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+public static class Parser
+{
+    public static (string Action, string Method, Dictionary<string, string> Inputs) Parse(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return (null, null, null);
+
+        return (""/login"", ""POST"", new Dictionary<string, string>());
+    }
+
+    public static void Inspect(string text)
+    {
+        var parsed = Parse(text);
+        var method = parsed.Method;
+    }
+}");
+
+        Assert.Contains(
+            "func Parse(text string) (string?, string?, Dictionary[string, string]?)",
+            printed);
+        Assert.Contains("let method = parsed.Item2", printed);
+        Assert.DoesNotContain("nil!!", printed);
+    }
+
+    [Fact]
+    public void Oblivious_NestedConditionalSwitchAndForwardedTuple_PromoteOnlyAffectedLeaves()
+    {
+        string printed = TranslateOblivious(@"
+public static class Parser
+{
+    public static ((string Left, string Right) Names, int Count, string Keep, int? Maybe) Pick(bool flag, int value)
+    {
+        (string Left, string Right) names =
+            flag ? (null, ""right"") : value switch
+            {
+                0 => (""left"", null),
+                _ => (""left"", ""right"")
+            };
+
+        var result = (Names: names, Count: 1, Keep: ""fixed"", Maybe: (int?)null);
+        return result;
+    }
+}");
+
+        Assert.Contains(
+            "func Pick(flag bool, value int32) ((string?, string?), int32, string, int32?)",
+            printed);
+    }
+
+    [Fact]
+    public void Oblivious_AsyncInterfaceAndOverrideContracts_StayInLockstep()
+    {
+        string printed = TranslateOblivious(@"
+using System.Threading.Tasks;
+
+public interface IParser
+{
+    Task<(string Action, string Method)> ParseAsync();
+}
+
+public abstract class ParserBase
+{
+    public abstract (string Action, string Method) Parse();
+}
+
+public sealed class Parser : ParserBase, IParser
+{
+    public override (string Action, string Method) Parse()
+    {
+        return (null, ""GET"");
+    }
+
+    public async Task<(string Action, string Method)> ParseAsync()
+    {
+        return (null, ""POST"");
+    }
+}");
+
+        Assert.Contains("func ParseAsync() Task[(string?, string)];", printed);
+        Assert.Contains("async func ParseAsync() (string?, string)", printed);
+        Assert.Contains("open func Parse() (string?, string);", printed);
+        Assert.Contains("override func Parse() (string?, string)", printed);
+    }
+
+    [Fact]
+    public void Oblivious_GenericAndDeconstructionFlow_PreserveValueElements()
+    {
+        string printed = TranslateOblivious(@"
+public static class Parser
+{
+    public static (T Value, int Count, int? Maybe) Generic<T>() where T : class
+    {
+        return (null, 0, null);
+    }
+
+    public static (string First, string Second) Get()
+    {
+        return (null, ""second"");
+    }
+
+    public static string Forward()
+    {
+        var (first, second) = Get();
+        return first;
+    }
+}");
+
+        Assert.Contains("func Generic[T class]() (T?, int32, int32?)", printed);
+        Assert.Contains("func Get() (string?, string)", printed);
+        Assert.Contains("func Forward() string?", printed);
+    }
+
+    [Fact]
+    public void EnabledCompilation_PreservesDeclaredTupleAnnotations()
+    {
+        string printed = TranslateEnabled(@"
+#nullable enable
+
+public static class Parser
+{
+    public static (string Required, string? Optional, int Count, int? Maybe) Parse()
+    {
+        return (""required"", null, 0, null);
+    }
+}");
+
+        Assert.Contains("func Parse() (string, string?, int32, int32?)", printed);
+        Assert.DoesNotContain("(string?, string?, int32, int32?)", printed);
+    }
+
+    [Fact]
+    public void CrossProject_ForwardedTuple_UsesSiblingElementEvidence()
+    {
+        const string sourceB = @"
+namespace LibB
+{
+    public static class Parser
+    {
+        public static (string Action, string Method) Parse()
+        {
+            return (null, ""POST"");
+        }
+    }
+}";
+        const string sourceA = @"
+using LibB;
+
+namespace LibA
+{
+    public static class Forwarder
+    {
+        public static (string Action, string Method) Parse()
+        {
+            return Parser.Parse();
+        }
+    }
+}";
+
+        LoadedCSharpProject projectB = LoadOblivious(sourceB, "LibB");
+        LoadedCSharpProject projectA = LoadOblivious(
+            sourceA,
+            "LibA",
+            new MetadataReference[] { projectB.Compilation.ToMetadataReference() });
+        var siblings = new[] { projectA.Compilation, projectB.Compilation };
+
+        string printedB = TranslateProject(projectB, siblings);
+        string printedA = TranslateProject(projectA, siblings);
+
+        Assert.Contains("func Parse() (string?, string)", printedB);
+        Assert.Contains("func Parse() (string?, string)", printedA);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = LoadOblivious(source, "Snippet");
+        return TranslateProject(project, new[] { project.Compilation });
+    }
+
+    private static string TranslateEnabled(string source)
+    {
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest),
+            path: "Snippet.cs");
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "Snippet",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+
+        var document = new LoadedDocument("Snippet.cs", tree, compilation.GetSemanticModel(tree));
+        var project = new LoadedCSharpProject(compilation, new[] { document }, Array.Empty<Diagnostic>());
+        return TranslateProject(project, new[] { compilation });
+    }
+
+    private static LoadedCSharpProject LoadOblivious(
+        string source,
+        string assemblyName,
+        IReadOnlyList<MetadataReference> extraReferences = null)
+    {
+        IReadOnlyList<MetadataReference> references = extraReferences is null
+            ? CSharpProjectLoader.RuntimeReferences()
+            : CSharpProjectLoader.RuntimeReferences().Concat(extraReferences).ToList();
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { (assemblyName + ".cs", source) },
+            references,
+            assemblyName);
+        Assert.True(
+            project.BoundWithoutErrors,
+            $"{assemblyName} should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+        return project;
+    }
+
+    private static string TranslateProject(
+        LoadedCSharpProject project,
+        IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath,
+            siblingCompilations);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/ObliviousPromotionSinkCompilationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ObliviousPromotionSinkCompilationTests.cs
@@ -99,6 +99,16 @@ namespace Demo
                 _ => null,
             };
         }
+
+        public (string Action, string Method, Dictionary<string, string> Inputs) Parse(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return (null, null, null);
+            }
+
+            return (""/login"", ""POST"", new Dictionary<string, string>());
+        }
     }
 }");
 
@@ -110,6 +120,9 @@ namespace Demo
         Assert.Contains("dict[\"k\"] = box?.Text!!", printed);
         Assert.Contains("Field:", printed);
         Assert.Contains("default(string?)", printed);
+        Assert.Contains(
+            "Parse(text string) (string?, string?, Dictionary[string, string]?)",
+            printed);
         CompileWithGsc(printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -900,7 +900,7 @@ public sealed partial class CSharpToGSharpTranslator
                     ITypeSymbol awaitedType = task.TypeArguments[0];
                     GTypeReference awaitedMapped = this.typeMapper.Map(
                         awaitedType, this.context, node.ReturnType.GetLocation());
-                    awaitedMapped = this.PromoteTupleReturnIfTainted(awaitedMapped, awaitedType, node);
+                    awaitedMapped = this.PromoteTupleReturnIfTainted(awaitedMapped, awaitedType, symbol);
                     return this.PromoteAwaitedReturnIfTainted(awaitedMapped, awaitedType, symbol);
                 }
 
@@ -911,14 +911,10 @@ public sealed partial class CSharpToGSharpTranslator
                 // ref-return (`func F(...) ref T`, issue #490/ADR-0060).
                 GTypeReference mapped = this.typeMapper.Map(returnType, this.context, node.ReturnType.GetLocation());
 
-                // Issue #914 (oblivious sink): a TUPLE return whose returned tuple
-                // expression carries a promoted-nullable element (e.g. `return
-                // (dir, file)` where `dir`/`file` are promoted `string?` locals)
-                // is promoted per-element to `(string?, string?)`, otherwise the
-                // `(string?, string?) -> (string, string)` return is rejected
-                // (GS0155). Applied before the scalar promotion below (which is a
-                // no-op for a tuple value type).
-                mapped = this.PromoteTupleReturnIfTainted(mapped, returnType, node);
+                // Issue #2469: promote tuple return leaves independently from
+                // the analyzer's element-path evidence graph. Applied before
+                // scalar promotion, which is a no-op for tuple value types.
+                mapped = this.PromoteTupleReturnIfTainted(mapped, returnType, symbol);
 
                 // Issue #2423: a NON-async declaration (a C# interface member —
                 // interfaces cannot declare `async` members — or a synchronous

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -204,28 +204,25 @@ public sealed partial class CSharpToGSharpTranslator
                 return envelope;
             }
 
-            GTypeReference promotedInner = this.PromoteAwaitedReturnIfTainted(
+            GTypeReference promotedInner = this.PromoteTupleReturnIfTainted(
                 named.TypeArguments[0], awaitedType, symbol);
+            promotedInner = this.PromoteAwaitedReturnIfTainted(
+                promotedInner, awaitedType, symbol);
 
             return ReferenceEquals(promotedInner, named.TypeArguments[0])
                 ? envelope
                 : new NamedTypeReference(named.Name, new[] { promotedInner });
         }
 
-        // Issue #914 (oblivious sink): promote the ELEMENT types of a tuple return
-        // to `T?` for every position whose returned tuple-expression element is a
-        // promoted-nullable value. A method returning `(string Dir, string Path)`
-        // whose body does `return (dir, file)` — where `dir`/`file` are promoted
-        // `string?` locals — must render `(string?, string?)`, otherwise the
-        // `(string?, string?) -> (string, string)` return is rejected (GS0155).
-        // This stays separate because it answers a different question: tuple
-        // ELEMENT positions have no symbol of their own, so each returned value
-        // is inspected and any symbol value still routes through
-        // ShouldPromoteToNullableReference via IsNullablePromotedValue.
+        // Issue #2469: tuple return leaves are independent declaration sinks.
+        // Their evidence lives in ObliviousNullabilityAnalyzer's element-path
+        // graph so tuple literals, forwarded tuple values, nested tuples,
+        // conditionals/switches, async envelopes, and contracts all converge on
+        // the same per-position answer.
         private GTypeReference PromoteTupleReturnIfTainted(
             GTypeReference mapped,
             ITypeSymbol returnType,
-            SyntaxNode node)
+            IMethodSymbol symbol)
         {
             if (!this.IsObliviousCompilation()
                 || mapped is not TupleTypeReference tuple
@@ -235,87 +232,53 @@ public sealed partial class CSharpToGSharpTranslator
                 return mapped;
             }
 
-            List<TupleExpressionSyntax> returnedTuples = this.EnumerateMemberReturnExpressions(node)
-                .Select(UnwrapParenthesized)
-                .OfType<TupleExpressionSyntax>()
-                .Where(t => t.Arguments.Count == tuple.ElementTypes.Count)
-                .ToList();
+            return this.PromoteTupleElements(tuple, tupleType, symbol, new List<int>());
+        }
 
-            if (returnedTuples.Count == 0)
-            {
-                return mapped;
-            }
-
+        private GTypeReference PromoteTupleElements(
+            TupleTypeReference tuple,
+            INamedTypeSymbol tupleType,
+            IMethodSymbol symbol,
+            List<int> path)
+        {
             var elements = new List<GTypeReference>(tuple.ElementTypes.Count);
             bool changed = false;
             for (int i = 0; i < tuple.ElementTypes.Count; i++)
             {
                 GTypeReference element = tuple.ElementTypes[i];
                 IFieldSymbol elementField = tupleType.TupleElements[i];
-                if (!element.IsNullable
+                path.Add(i);
+                if (element is TupleTypeReference nestedMapped
+                    && elementField.Type is INamedTypeSymbol { IsTupleType: true } nestedType)
+                {
+                    GTypeReference promotedNested = this.PromoteTupleElements(
+                        nestedMapped,
+                        nestedType,
+                        symbol,
+                        path);
+                    changed |= !ReferenceEquals(promotedNested, element);
+                    element = promotedNested;
+                }
+                else if (!element.IsNullable
                     && elementField.Type is { IsReferenceType: true }
                     && elementField.Type.NullableAnnotation != NullableAnnotation.Annotated
-                    && returnedTuples.Any(t => this.IsNullablePromotedValue(t.Arguments[i].Expression)))
+                    && ObliviousNullabilityAnalyzer.IsTupleElementTainted(
+                        this.context.Compilation,
+                        symbol,
+                        path,
+                        this.context.SiblingCompilations))
                 {
                     element = MakeNullable(element);
                     changed = true;
                 }
 
+                path.RemoveAt(path.Count - 1);
                 elements.Add(element);
             }
 
             return changed
                 ? new TupleTypeReference(elements) { IsNullable = tuple.IsNullable }
-                : mapped;
-        }
-
-        // Issue #914: the `return`-position value expressions that belong to a
-        // method/accessor <paramref name="node"/> itself — its arrow expression
-        // body and every `return` statement not nested inside a lambda / local
-        // function (whose returns have their own contract). Used to inspect the
-        // returned tuple shapes for per-element nullable promotion.
-        private IEnumerable<ExpressionSyntax> EnumerateMemberReturnExpressions(SyntaxNode node)
-        {
-            ExpressionSyntax arrowBody = node switch
-            {
-                MethodDeclarationSyntax method => method.ExpressionBody?.Expression,
-                AccessorDeclarationSyntax accessor => accessor.ExpressionBody?.Expression,
-                _ => null,
-            };
-            if (arrowBody != null)
-            {
-                yield return arrowBody;
-            }
-
-            SyntaxNode body = node switch
-            {
-                MethodDeclarationSyntax method => method.Body,
-                AccessorDeclarationSyntax accessor => accessor.Body,
-                _ => null,
-            };
-            if (body == null)
-            {
-                yield break;
-            }
-
-            foreach (SyntaxNode descendant in body.DescendantNodes(
-                n => n is not (AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax)))
-            {
-                if (descendant is ReturnStatementSyntax { Expression: { } returned })
-                {
-                    yield return returned;
-                }
-            }
-        }
-
-        private static ExpressionSyntax UnwrapParenthesized(ExpressionSyntax expression)
-        {
-            while (expression is ParenthesizedExpressionSyntax paren)
-            {
-                expression = paren.Expression;
-            }
-
-            return expression;
+                : tuple;
         }
 
         // Issue #914: whether <paramref name="expression"/> yields a
@@ -324,8 +287,7 @@ public sealed partial class CSharpToGSharpTranslator
         // <see cref="IsNullableInitializer"/>, which also consults declared BCL
         // annotations) OR a field / property / local / parameter the whole-program
         // taint analysis promoted to `T?`, OR a method / local function whose
-        // return the analysis proved null-tainted. Shared by the tuple-return
-        // element promotion.
+        // return the analysis proved null-tainted.
         private bool IsNullablePromotedValue(ExpressionSyntax expression)
         {
             if (expression == null)

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -205,6 +205,109 @@ internal static class ObliviousNullabilityAnalyzer
     }
 
     /// <summary>
+    /// Whether one reference-typed leaf inside a tuple-valued declaration is
+    /// null-tainted. Tuple leaves are tracked independently so evidence for
+    /// one element never widens its siblings.
+    /// </summary>
+    /// <param name="compilation">The compilation containing the query.</param>
+    /// <param name="symbol">The tuple-valued declaration symbol.</param>
+    /// <param name="elementPath">Zero-based indexes from the outer tuple to the leaf.</param>
+    /// <param name="siblingCompilations">Other compilations loaded in the same translation run.</param>
+    /// <returns><see langword="true"/> when the selected tuple leaf is null-tainted.</returns>
+    public static bool IsTupleElementTainted(
+        CSharpCompilation compilation,
+        ISymbol symbol,
+        IReadOnlyList<int> elementPath,
+        IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        if (symbol == null
+            || elementPath == null
+            || elementPath.Count == 0
+            || compilation == null
+            || compilation.Options.NullableContextOptions != NullableContextOptions.Disable)
+        {
+            return false;
+        }
+
+        return IsTupleElementTaintedCore(
+            compilation,
+            Canonical(symbol),
+            EncodeTuplePath(elementPath),
+            siblingCompilations,
+            new HashSet<TupleElementQuery>(TupleElementQueryComparer.Instance));
+    }
+
+    private static bool IsTupleElementTaintedCore(
+        CSharpCompilation compilation,
+        ISymbol symbol,
+        string path,
+        IReadOnlyList<CSharpCompilation> siblingCompilations,
+        HashSet<TupleElementQuery> visited)
+    {
+        var key = new TupleElementKey(symbol, path);
+        if (!visited.Add(new TupleElementQuery(compilation, key)))
+        {
+            return false;
+        }
+
+        TaintResult result = Cache.GetValue(compilation, Compute);
+        if (result.TupleTainted.Contains(key))
+        {
+            return true;
+        }
+
+        foreach ((TupleElementKey target, ISymbol source) in result.TupleScalarEdges)
+        {
+            if (TupleElementKeyComparer.Instance.Equals(target, key)
+                && IsTainted(compilation, source, siblingCompilations))
+            {
+                return true;
+            }
+        }
+
+        foreach ((TupleElementKey target, TupleElementKey source) in result.TupleEdges)
+        {
+            if (TupleElementKeyComparer.Instance.Equals(target, key)
+                && IsTupleElementTaintedCore(
+                    compilation,
+                    source.Symbol,
+                    source.Path,
+                    siblingCompilations,
+                    visited))
+            {
+                return true;
+            }
+        }
+
+        if (siblingCompilations != null)
+        {
+            foreach (CSharpCompilation sibling in siblingCompilations)
+            {
+                if (sibling == null
+                    || ReferenceEquals(sibling, compilation)
+                    || sibling.Options.NullableContextOptions != NullableContextOptions.Disable)
+                {
+                    continue;
+                }
+
+                ISymbol remapped = RemapToCompilation(sibling, symbol);
+                if (remapped != null
+                    && IsTupleElementTaintedCore(
+                        sibling,
+                        Canonical(remapped),
+                        path,
+                        siblingCompilations,
+                        visited))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Finds the symbol in <paramref name="targetCompilation"/>'s own symbol
     /// table that is the "same" declaration as <paramref name="symbol"/>,
     /// which may have been resolved through an entirely different
@@ -298,12 +401,16 @@ internal static class ObliviousNullabilityAnalyzer
     private static TaintResult Compute(Compilation compilation)
     {
         var tainted = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        var tupleTainted = new HashSet<TupleElementKey>(TupleElementKeyComparer.Instance);
 
         // Transitive edges: (target <- source). If `source` is tainted then
         // `target` becomes tainted. Both are canonicalized declaration symbols
         // (field/property/parameter/local for a value target; method for a
         // return target; field/property/parameter/local/method for a source).
         var edges = new List<(ISymbol Target, ISymbol Source)>();
+        var tupleEdges = new List<(TupleElementKey Target, TupleElementKey Source)>();
+        var tupleScalarEdges = new List<(TupleElementKey Target, ISymbol Source)>();
+        var scalarTupleEdges = new List<(ISymbol Target, TupleElementKey Source)>();
 
         foreach (SyntaxTree tree in compilation.SyntaxTrees)
         {
@@ -322,6 +429,15 @@ internal static class ObliviousNullabilityAnalyzer
             // records a transitive edge from the return symbol to the returned
             // value's source.
             SeedReturnTaint(root, model, tainted, edges);
+            CollectTupleFlows(
+                root,
+                model,
+                tainted,
+                edges,
+                tupleTainted,
+                tupleEdges,
+                tupleScalarEdges,
+                scalarTupleEdges);
         }
 
         // Issue #2285: an interface member and every member that implements it
@@ -330,6 +446,7 @@ internal static class ObliviousNullabilityAnalyzer
         // parameter) to `T?` while leaving the other (the interface property it
         // satisfies) non-null `T` — see <see cref="CollectInterfaceImplementationEdges"/>.
         CollectInterfaceImplementationEdges(compilation, edges);
+        CollectTupleContractEdges(compilation, tupleTainted, tupleEdges);
 
         // Fixpoint: propagate taint along the edge set until it stabilizes.
         bool changed = true;
@@ -344,9 +461,40 @@ internal static class ObliviousNullabilityAnalyzer
                     changed = true;
                 }
             }
+
+            foreach ((TupleElementKey target, ISymbol source) in tupleScalarEdges)
+            {
+                if (!tupleTainted.Contains(target) && tainted.Contains(source))
+                {
+                    tupleTainted.Add(target);
+                    changed = true;
+                }
+            }
+
+            foreach ((ISymbol target, TupleElementKey source) in scalarTupleEdges)
+            {
+                if (!tainted.Contains(target) && tupleTainted.Contains(source))
+                {
+                    tainted.Add(target);
+                    changed = true;
+                }
+            }
+
+            foreach ((TupleElementKey target, TupleElementKey source) in tupleEdges)
+            {
+                if (!tupleTainted.Contains(target) && tupleTainted.Contains(source))
+                {
+                    tupleTainted.Add(target);
+                    changed = true;
+                }
+            }
         }
 
-        return new TaintResult(tainted);
+        return new TaintResult(
+            tainted,
+            tupleTainted,
+            tupleEdges,
+            tupleScalarEdges);
     }
 
     // Seeds direct null evidence for a value declaration symbol (field /
@@ -554,6 +702,833 @@ internal static class ObliviousNullabilityAnalyzer
             }
         }
     }
+
+    // Issue #2469: tuple-valued declarations need the same direct/transitive
+    // evidence graph as scalar declarations, but keyed by an element path.
+    // This pass covers tuple literals, nested tuples, conditionals/switches,
+    // tuple locals/parameters/properties, calls, and deconstruction.
+    private static void CollectTupleFlows(
+        SyntaxNode root,
+        SemanticModel model,
+        HashSet<ISymbol> tainted,
+        List<(ISymbol Target, ISymbol Source)> edges,
+        HashSet<TupleElementKey> tupleTainted,
+        List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges,
+        List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges,
+        List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges)
+    {
+        foreach (SyntaxNode node in root.DescendantNodes())
+        {
+            switch (node)
+            {
+                case MethodDeclarationSyntax method:
+                    CollectTupleReturnFlows(
+                        model.GetDeclaredSymbol(method),
+                        method.ExpressionBody?.Expression,
+                        method.Body,
+                        model,
+                        tupleTainted,
+                        tupleEdges,
+                        tupleScalarEdges);
+                    break;
+
+                case LocalFunctionStatementSyntax localFunction:
+                    CollectTupleReturnFlows(
+                        model.GetDeclaredSymbol(localFunction),
+                        localFunction.ExpressionBody?.Expression,
+                        localFunction.Body,
+                        model,
+                        tupleTainted,
+                        tupleEdges,
+                        tupleScalarEdges);
+                    break;
+
+                case PropertyDeclarationSyntax property:
+                    IPropertySymbol propertySymbol = model.GetDeclaredSymbol(property);
+                    if (TryGetTupleType(propertySymbol, out INamedTypeSymbol propertyTuple))
+                    {
+                        if (property.Initializer?.Value is ExpressionSyntax initializer)
+                        {
+                            CollectTupleValueFlow(
+                                Canonical(propertySymbol),
+                                propertyTuple,
+                                initializer,
+                                model,
+                                string.Empty,
+                                tupleTainted,
+                                tupleEdges,
+                                tupleScalarEdges);
+                        }
+
+                        CollectTupleGetterFlows(
+                            propertySymbol,
+                            propertyTuple,
+                            property.ExpressionBody?.Expression,
+                            property.AccessorList,
+                            model,
+                            tupleTainted,
+                            tupleEdges,
+                            tupleScalarEdges);
+                    }
+
+                    break;
+
+                case IndexerDeclarationSyntax indexer:
+                    IPropertySymbol indexerSymbol = model.GetDeclaredSymbol(indexer);
+                    if (TryGetTupleType(indexerSymbol, out INamedTypeSymbol indexerTuple))
+                    {
+                        CollectTupleGetterFlows(
+                            indexerSymbol,
+                            indexerTuple,
+                            indexer.ExpressionBody?.Expression,
+                            indexer.AccessorList,
+                            model,
+                            tupleTainted,
+                            tupleEdges,
+                            tupleScalarEdges);
+                    }
+
+                    break;
+
+                case VariableDeclaratorSyntax declarator
+                    when declarator.Initializer?.Value is ExpressionSyntax initializer:
+                    ISymbol declared = model.GetDeclaredSymbol(declarator);
+                    if (TryGetTupleType(declared, out INamedTypeSymbol declaredTuple))
+                    {
+                        CollectTupleValueFlow(
+                            Canonical(declared),
+                            declaredTuple,
+                            initializer,
+                            model,
+                            string.Empty,
+                            tupleTainted,
+                            tupleEdges,
+                            tupleScalarEdges);
+                    }
+
+                    break;
+
+                case AssignmentExpressionSyntax assignment
+                    when assignment.IsKind(SyntaxKind.SimpleAssignmentExpression):
+                    ISymbol target = ResolveAssignable(assignment.Left, model);
+                    if (TryGetTupleType(target, out INamedTypeSymbol targetTuple))
+                    {
+                        CollectTupleValueFlow(
+                            target,
+                            targetTuple,
+                            assignment.Right,
+                            model,
+                            string.Empty,
+                            tupleTainted,
+                            tupleEdges,
+                            tupleScalarEdges);
+                    }
+                    else if (assignment.Left is TupleExpressionSyntax or DeclarationExpressionSyntax)
+                    {
+                        CollectDeconstructionFlow(
+                            assignment.Left,
+                            assignment.Right,
+                            model,
+                            tainted,
+                            edges,
+                            scalarTupleEdges);
+                    }
+
+                    break;
+
+                case InvocationExpressionSyntax
+                    or ObjectCreationExpressionSyntax
+                    or ConstructorInitializerSyntax:
+                    CollectTupleArgumentFlows(
+                        node,
+                        model,
+                        tupleTainted,
+                        tupleEdges,
+                        tupleScalarEdges);
+                    break;
+            }
+        }
+    }
+
+    private static void CollectTupleReturnFlows(
+        IMethodSymbol method,
+        ExpressionSyntax arrowBody,
+        BlockSyntax body,
+        SemanticModel model,
+        HashSet<TupleElementKey> tupleTainted,
+        List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges,
+        List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges)
+    {
+        if (!TryGetTupleType(method, out INamedTypeSymbol tupleType))
+        {
+            return;
+        }
+
+        ISymbol target = Canonical(method);
+        if (arrowBody != null)
+        {
+            CollectTupleValueFlow(
+                target,
+                tupleType,
+                arrowBody,
+                model,
+                string.Empty,
+                tupleTainted,
+                tupleEdges,
+                tupleScalarEdges);
+        }
+
+        foreach (ReturnStatementSyntax statement in EnumerateOwnReturns(body))
+        {
+            if (statement.Expression != null)
+            {
+                CollectTupleValueFlow(
+                    target,
+                    tupleType,
+                    statement.Expression,
+                    model,
+                    string.Empty,
+                    tupleTainted,
+                    tupleEdges,
+                    tupleScalarEdges);
+            }
+        }
+    }
+
+    private static void CollectTupleGetterFlows(
+        IPropertySymbol property,
+        INamedTypeSymbol tupleType,
+        ExpressionSyntax arrowBody,
+        AccessorListSyntax accessorList,
+        SemanticModel model,
+        HashSet<TupleElementKey> tupleTainted,
+        List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges,
+        List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges)
+    {
+        ISymbol target = Canonical(property);
+        if (arrowBody != null)
+        {
+            CollectTupleValueFlow(
+                target,
+                tupleType,
+                arrowBody,
+                model,
+                string.Empty,
+                tupleTainted,
+                tupleEdges,
+                tupleScalarEdges);
+        }
+
+        AccessorDeclarationSyntax getter = accessorList?.Accessors
+            .FirstOrDefault(a => a.IsKind(SyntaxKind.GetAccessorDeclaration));
+        if (getter?.ExpressionBody?.Expression is ExpressionSyntax getterArrow)
+        {
+            CollectTupleValueFlow(
+                target,
+                tupleType,
+                getterArrow,
+                model,
+                string.Empty,
+                tupleTainted,
+                tupleEdges,
+                tupleScalarEdges);
+        }
+
+        foreach (ReturnStatementSyntax statement in EnumerateOwnReturns(getter?.Body))
+        {
+            if (statement.Expression != null)
+            {
+                CollectTupleValueFlow(
+                    target,
+                    tupleType,
+                    statement.Expression,
+                    model,
+                    string.Empty,
+                    tupleTainted,
+                    tupleEdges,
+                    tupleScalarEdges);
+            }
+        }
+    }
+
+    private static void CollectTupleArgumentFlows(
+        SyntaxNode call,
+        SemanticModel model,
+        HashSet<TupleElementKey> tupleTainted,
+        List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges,
+        List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges)
+    {
+        ImmutableArray<IArgumentOperation> arguments = model.GetOperation(call) switch
+        {
+            IInvocationOperation invocation => invocation.Arguments,
+            IObjectCreationOperation creation => creation.Arguments,
+            _ => default,
+        };
+
+        if (arguments.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        foreach (IArgumentOperation argument in arguments)
+        {
+            if (argument.Parameter is IParameterSymbol parameter
+                && argument.Value?.Syntax is ExpressionSyntax value
+                && TryGetTupleType(parameter, out INamedTypeSymbol tupleType))
+            {
+                CollectTupleValueFlow(
+                    Canonical(parameter),
+                    tupleType,
+                    value,
+                    model,
+                    string.Empty,
+                    tupleTainted,
+                    tupleEdges,
+                    tupleScalarEdges);
+            }
+        }
+    }
+
+    private static void CollectTupleValueFlow(
+        ISymbol target,
+        INamedTypeSymbol targetTuple,
+        ExpressionSyntax value,
+        SemanticModel model,
+        string prefix,
+        HashSet<TupleElementKey> tupleTainted,
+        List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges,
+        List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges)
+    {
+        value = UnwrapTupleValue(value);
+        switch (value)
+        {
+            case null:
+                return;
+
+            case ConditionalExpressionSyntax conditional:
+                CollectTupleValueFlow(target, targetTuple, conditional.WhenTrue, model, prefix, tupleTainted, tupleEdges, tupleScalarEdges);
+                CollectTupleValueFlow(target, targetTuple, conditional.WhenFalse, model, prefix, tupleTainted, tupleEdges, tupleScalarEdges);
+                return;
+
+            case SwitchExpressionSyntax switchExpression:
+                foreach (SwitchExpressionArmSyntax arm in switchExpression.Arms)
+                {
+                    CollectTupleValueFlow(target, targetTuple, arm.Expression, model, prefix, tupleTainted, tupleEdges, tupleScalarEdges);
+                }
+
+                return;
+
+            case TupleExpressionSyntax tuple
+                when tuple.Arguments.Count == targetTuple.TupleElements.Length:
+                for (int i = 0; i < targetTuple.TupleElements.Length; i++)
+                {
+                    ITypeSymbol targetType = targetTuple.TupleElements[i].Type;
+                    ExpressionSyntax elementValue = tuple.Arguments[i].Expression;
+                    string path = AppendTuplePath(prefix, i);
+                    if (targetType is INamedTypeSymbol { IsTupleType: true } nestedTarget)
+                    {
+                        CollectTupleValueFlow(
+                            target,
+                            nestedTarget,
+                            elementValue,
+                            model,
+                            path,
+                            tupleTainted,
+                            tupleEdges,
+                            tupleScalarEdges);
+                    }
+                    else if (IsEligibleTupleLeaf(targetType))
+                    {
+                        var targetKey = new TupleElementKey(target, path);
+                        if (IsDirectlyNullable(elementValue, model))
+                        {
+                            tupleTainted.Add(targetKey);
+                        }
+                        else if (TryResolveTupleElementSource(elementValue, model, out TupleElementKey tupleSource))
+                        {
+                            tupleEdges.Add((targetKey, tupleSource));
+                        }
+                        else
+                        {
+                            foreach (ISymbol scalarSource in ResolveSources(elementValue, model))
+                            {
+                                tupleScalarEdges.Add((targetKey, scalarSource));
+                            }
+                        }
+                    }
+                }
+
+                return;
+        }
+
+        if (IsDefaultTupleValue(value, model))
+        {
+            TaintAllTupleLeaves(target, targetTuple, prefix, tupleTainted);
+            return;
+        }
+
+        if (TryResolveTupleSource(value, model, out ISymbol source, out INamedTypeSymbol sourceTuple))
+        {
+            AddTupleShapeEdges(
+                target,
+                targetTuple,
+                prefix,
+                source,
+                sourceTuple,
+                string.Empty,
+                tupleTainted,
+                tupleEdges);
+        }
+    }
+
+    private static void AddTupleShapeEdges(
+        ISymbol target,
+        INamedTypeSymbol targetTuple,
+        string targetPrefix,
+        ISymbol source,
+        INamedTypeSymbol sourceTuple,
+        string sourcePrefix,
+        HashSet<TupleElementKey> tupleTainted,
+        List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges)
+    {
+        int count = System.Math.Min(targetTuple.TupleElements.Length, sourceTuple.TupleElements.Length);
+        for (int i = 0; i < count; i++)
+        {
+            ITypeSymbol targetType = targetTuple.TupleElements[i].Type;
+            ITypeSymbol sourceType = sourceTuple.TupleElements[i].Type;
+            string targetPath = AppendTuplePath(targetPrefix, i);
+            string sourcePath = AppendTuplePath(sourcePrefix, i);
+
+            if (targetType is INamedTypeSymbol { IsTupleType: true } nestedTarget
+                && sourceType is INamedTypeSymbol { IsTupleType: true } nestedSource)
+            {
+                AddTupleShapeEdges(
+                    target,
+                    nestedTarget,
+                    targetPath,
+                    source,
+                    nestedSource,
+                    sourcePath,
+                    tupleTainted,
+                    tupleEdges);
+            }
+            else if (IsEligibleTupleLeaf(targetType))
+            {
+                var targetKey = new TupleElementKey(target, targetPath);
+                if (sourceType is { IsReferenceType: true, NullableAnnotation: NullableAnnotation.Annotated })
+                {
+                    tupleTainted.Add(targetKey);
+                }
+                else
+                {
+                    tupleEdges.Add((targetKey, new TupleElementKey(source, sourcePath)));
+                }
+            }
+        }
+    }
+
+    private static void TaintAllTupleLeaves(
+        ISymbol target,
+        INamedTypeSymbol tupleType,
+        string prefix,
+        HashSet<TupleElementKey> tupleTainted)
+    {
+        for (int i = 0; i < tupleType.TupleElements.Length; i++)
+        {
+            ITypeSymbol elementType = tupleType.TupleElements[i].Type;
+            string path = AppendTuplePath(prefix, i);
+            if (elementType is INamedTypeSymbol { IsTupleType: true } nested)
+            {
+                TaintAllTupleLeaves(target, nested, path, tupleTainted);
+            }
+            else if (IsEligibleTupleLeaf(elementType))
+            {
+                tupleTainted.Add(new TupleElementKey(target, path));
+            }
+        }
+    }
+
+    private static void CollectDeconstructionFlow(
+        ExpressionSyntax targetPattern,
+        ExpressionSyntax value,
+        SemanticModel model,
+        HashSet<ISymbol> tainted,
+        List<(ISymbol Target, ISymbol Source)> edges,
+        List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges)
+    {
+        value = UnwrapTupleValue(value);
+        if (value is ConditionalExpressionSyntax conditional)
+        {
+            CollectDeconstructionFlow(targetPattern, conditional.WhenTrue, model, tainted, edges, scalarTupleEdges);
+            CollectDeconstructionFlow(targetPattern, conditional.WhenFalse, model, tainted, edges, scalarTupleEdges);
+            return;
+        }
+
+        if (value is SwitchExpressionSyntax switchExpression)
+        {
+            foreach (SwitchExpressionArmSyntax arm in switchExpression.Arms)
+            {
+                CollectDeconstructionFlow(targetPattern, arm.Expression, model, tainted, edges, scalarTupleEdges);
+            }
+
+            return;
+        }
+
+        if (value is TupleExpressionSyntax tupleValue
+            && TryGetDeconstructionElements(targetPattern, out IReadOnlyList<ExpressionSyntax> targets)
+            && targets.Count == tupleValue.Arguments.Count)
+        {
+            for (int i = 0; i < targets.Count; i++)
+            {
+                CollectDeconstructionFlow(
+                    targets[i],
+                    tupleValue.Arguments[i].Expression,
+                    model,
+                    tainted,
+                    edges,
+                    scalarTupleEdges);
+            }
+
+            return;
+        }
+
+        if (value is TupleExpressionSyntax declarationTupleValue
+            && targetPattern is DeclarationExpressionSyntax
+                { Designation: ParenthesizedVariableDesignationSyntax declarationPattern }
+            && declarationPattern.Variables.Count == declarationTupleValue.Arguments.Count)
+        {
+            for (int i = 0; i < declarationPattern.Variables.Count; i++)
+            {
+                CollectDesignationFlow(
+                    declarationPattern.Variables[i],
+                    declarationTupleValue.Arguments[i].Expression,
+                    model,
+                    tainted,
+                    edges,
+                    scalarTupleEdges);
+            }
+
+            return;
+        }
+
+        if (TryResolveDeconstructionTarget(targetPattern, model, out ISymbol scalarTarget))
+        {
+            if (IsDirectlyNullable(value, model))
+            {
+                tainted.Add(scalarTarget);
+            }
+            else if (TryResolveTupleElementSource(value, model, out TupleElementKey elementSource))
+            {
+                scalarTupleEdges.Add((scalarTarget, elementSource));
+            }
+            else
+            {
+                AddEdges(scalarTarget, value, model, edges);
+            }
+
+            return;
+        }
+
+        if (TryResolveTupleSource(value, model, out ISymbol tupleSource, out INamedTypeSymbol sourceTuple))
+        {
+            if (targetPattern is DeclarationExpressionSyntax
+                { Designation: ParenthesizedVariableDesignationSyntax forwardedPattern })
+            {
+                CollectDesignationPatternFromTupleSource(
+                    forwardedPattern,
+                    tupleSource,
+                    sourceTuple,
+                    string.Empty,
+                    model,
+                    scalarTupleEdges);
+                return;
+            }
+
+            CollectPatternFromTupleSource(
+                targetPattern,
+                tupleSource,
+                sourceTuple,
+                string.Empty,
+                model,
+                scalarTupleEdges);
+        }
+    }
+
+    private static void CollectDesignationFlow(
+        VariableDesignationSyntax target,
+        ExpressionSyntax value,
+        SemanticModel model,
+        HashSet<ISymbol> tainted,
+        List<(ISymbol Target, ISymbol Source)> edges,
+        List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges)
+    {
+        if (target is ParenthesizedVariableDesignationSyntax parenthesized
+            && value is TupleExpressionSyntax tuple
+            && parenthesized.Variables.Count == tuple.Arguments.Count)
+        {
+            for (int i = 0; i < parenthesized.Variables.Count; i++)
+            {
+                CollectDesignationFlow(
+                    parenthesized.Variables[i],
+                    tuple.Arguments[i].Expression,
+                    model,
+                    tainted,
+                    edges,
+                    scalarTupleEdges);
+            }
+
+            return;
+        }
+
+        if (target is not SingleVariableDesignationSyntax single
+            || model.GetDeclaredSymbol(single) is not ISymbol declared
+            || !IsValueDeclarationSymbol(declared))
+        {
+            return;
+        }
+
+        ISymbol scalarTarget = Canonical(declared);
+        if (IsDirectlyNullable(value, model))
+        {
+            tainted.Add(scalarTarget);
+        }
+        else if (TryResolveTupleElementSource(value, model, out TupleElementKey elementSource))
+        {
+            scalarTupleEdges.Add((scalarTarget, elementSource));
+        }
+        else
+        {
+            AddEdges(scalarTarget, value, model, edges);
+        }
+    }
+
+    private static void CollectPatternFromTupleSource(
+        ExpressionSyntax pattern,
+        ISymbol source,
+        INamedTypeSymbol sourceTuple,
+        string prefix,
+        SemanticModel model,
+        List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges)
+    {
+        if (!TryGetDeconstructionElements(pattern, out IReadOnlyList<ExpressionSyntax> targets))
+        {
+            return;
+        }
+
+        int count = System.Math.Min(targets.Count, sourceTuple.TupleElements.Length);
+        for (int i = 0; i < count; i++)
+        {
+            ITypeSymbol sourceType = sourceTuple.TupleElements[i].Type;
+            string path = AppendTuplePath(prefix, i);
+            if (sourceType is INamedTypeSymbol { IsTupleType: true } nested)
+            {
+                CollectPatternFromTupleSource(targets[i], source, nested, path, model, scalarTupleEdges);
+            }
+            else if (TryResolveDeconstructionTarget(targets[i], model, out ISymbol scalarTarget))
+            {
+                scalarTupleEdges.Add((scalarTarget, new TupleElementKey(source, path)));
+            }
+        }
+    }
+
+    private static void CollectDesignationPatternFromTupleSource(
+        ParenthesizedVariableDesignationSyntax pattern,
+        ISymbol source,
+        INamedTypeSymbol sourceTuple,
+        string prefix,
+        SemanticModel model,
+        List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges)
+    {
+        int count = System.Math.Min(pattern.Variables.Count, sourceTuple.TupleElements.Length);
+        for (int i = 0; i < count; i++)
+        {
+            VariableDesignationSyntax target = pattern.Variables[i];
+            ITypeSymbol sourceType = sourceTuple.TupleElements[i].Type;
+            string path = AppendTuplePath(prefix, i);
+            if (target is ParenthesizedVariableDesignationSyntax nestedPattern
+                && sourceType is INamedTypeSymbol { IsTupleType: true } nestedTuple)
+            {
+                CollectDesignationPatternFromTupleSource(
+                    nestedPattern,
+                    source,
+                    nestedTuple,
+                    path,
+                    model,
+                    scalarTupleEdges);
+            }
+            else if (target is SingleVariableDesignationSyntax single
+                && model.GetDeclaredSymbol(single) is ISymbol declared
+                && IsValueDeclarationSymbol(declared))
+            {
+                scalarTupleEdges.Add((Canonical(declared), new TupleElementKey(source, path)));
+            }
+        }
+    }
+
+    private static bool TryGetDeconstructionElements(
+        ExpressionSyntax pattern,
+        out IReadOnlyList<ExpressionSyntax> elements)
+    {
+        if (pattern is TupleExpressionSyntax tuple)
+        {
+            elements = tuple.Arguments.Select(a => a.Expression).ToList();
+            return true;
+        }
+
+        elements = null;
+        return false;
+    }
+
+    private static bool TryResolveDeconstructionTarget(
+        ExpressionSyntax target,
+        SemanticModel model,
+        out ISymbol symbol)
+    {
+        symbol = target switch
+        {
+            IdentifierNameSyntax identifier => model.GetSymbolInfo(identifier).Symbol,
+            DeclarationExpressionSyntax { Designation: SingleVariableDesignationSyntax single } =>
+                model.GetDeclaredSymbol(single),
+            _ => null,
+        };
+
+        if (symbol != null && IsValueDeclarationSymbol(symbol))
+        {
+            symbol = Canonical(symbol);
+            return true;
+        }
+
+        symbol = null;
+        return false;
+    }
+
+    private static bool TryResolveTupleSource(
+        ExpressionSyntax expression,
+        SemanticModel model,
+        out ISymbol symbol,
+        out INamedTypeSymbol tupleType)
+    {
+        expression = UnwrapTupleValue(expression);
+        symbol = expression switch
+        {
+            InvocationExpressionSyntax invocation => model.GetSymbolInfo(invocation).Symbol,
+            IdentifierNameSyntax or MemberAccessExpressionSyntax => model.GetSymbolInfo(expression).Symbol,
+            _ => null,
+        };
+
+        if (TryGetTupleType(symbol, out tupleType))
+        {
+            symbol = Canonical(symbol);
+            return true;
+        }
+
+        symbol = null;
+        tupleType = null;
+        return false;
+    }
+
+    private static bool TryResolveTupleElementSource(
+        ExpressionSyntax expression,
+        SemanticModel model,
+        out TupleElementKey source)
+    {
+        expression = UnwrapTupleValue(expression);
+        if (expression is MemberAccessExpressionSyntax member
+            && model.GetSymbolInfo(member).Symbol is IFieldSymbol field
+            && model.GetTypeInfo(member.Expression).Type is INamedTypeSymbol { IsTupleType: true } receiverTuple)
+        {
+            int index = TupleElementIndex(receiverTuple, field);
+            if (index >= 0)
+            {
+                if (TryResolveTupleSource(member.Expression, model, out ISymbol symbol, out _))
+                {
+                    source = new TupleElementKey(symbol, index.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                    return true;
+                }
+
+                if (TryResolveTupleElementSource(member.Expression, model, out TupleElementKey parent))
+                {
+                    source = new TupleElementKey(parent.Symbol, AppendTuplePath(parent.Path, index));
+                    return true;
+                }
+            }
+        }
+
+        source = default;
+        return false;
+    }
+
+    private static int TupleElementIndex(INamedTypeSymbol tupleType, IFieldSymbol field)
+    {
+        IFieldSymbol canonicalField = field.CorrespondingTupleField ?? field;
+        for (int i = 0; i < tupleType.TupleElements.Length; i++)
+        {
+            IFieldSymbol candidate = tupleType.TupleElements[i].CorrespondingTupleField
+                ?? tupleType.TupleElements[i];
+            if (SymbolEqualityComparer.Default.Equals(candidate, canonicalField)
+                || tupleType.TupleElements[i].Name == field.Name)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool TryGetTupleType(ISymbol symbol, out INamedTypeSymbol tupleType)
+    {
+        ITypeSymbol type = symbol switch
+        {
+            IMethodSymbol method => UnwrapAwaitedType(method.ReturnType),
+            IPropertySymbol property => property.Type,
+            IFieldSymbol field => field.Type,
+            ILocalSymbol local => local.Type,
+            IParameterSymbol parameter => parameter.Type,
+            _ => null,
+        };
+
+        tupleType = type as INamedTypeSymbol;
+        return tupleType is { IsTupleType: true };
+    }
+
+    private static bool IsEligibleTupleLeaf(ITypeSymbol type) =>
+        type is { IsReferenceType: true }
+            && type.NullableAnnotation != NullableAnnotation.Annotated;
+
+    private static bool IsDefaultTupleValue(ExpressionSyntax expression, SemanticModel model) =>
+        expression is DefaultExpressionSyntax
+            || (expression is LiteralExpressionSyntax literal
+                && literal.IsKind(SyntaxKind.DefaultLiteralExpression)
+                && model.GetTypeInfo(literal).ConvertedType is INamedTypeSymbol { IsTupleType: true });
+
+    private static ExpressionSyntax UnwrapTupleValue(ExpressionSyntax expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case ParenthesizedExpressionSyntax parenthesized:
+                    expression = parenthesized.Expression;
+                    continue;
+                case CastExpressionSyntax cast:
+                    expression = cast.Expression;
+                    continue;
+                case AwaitExpressionSyntax awaitExpression:
+                    expression = awaitExpression.Expression;
+                    continue;
+                default:
+                    return expression;
+            }
+        }
+    }
+
+    private static string AppendTuplePath(string prefix, int index) =>
+        string.IsNullOrEmpty(prefix)
+            ? index.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : prefix + "." + index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    private static string EncodeTuplePath(IReadOnlyList<int> path) =>
+        string.Join(".", path.Select(i => i.ToString(System.Globalization.CultureInfo.InvariantCulture)));
 
     // Return taint: for each method / accessor / local function, examine every
     // `return` (or arrow expression body) that belongs to it (not to a nested
@@ -905,6 +1880,88 @@ internal static class ObliviousNullabilityAnalyzer
         ISymbol implCanonical = Canonical(implementingMethod);
         edges.Add((interfaceCanonical, implCanonical));
         edges.Add((implCanonical, interfaceCanonical));
+    }
+
+    private static void CollectTupleContractEdges(
+        Compilation compilation,
+        HashSet<TupleElementKey> tupleTainted,
+        List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges)
+    {
+        foreach (INamedTypeSymbol type in EnumerateSourceNamedTypes(compilation))
+        {
+            foreach (IMethodSymbol method in type.GetMembers().OfType<IMethodSymbol>())
+            {
+                if (method.MethodKind != MethodKind.Ordinary
+                    || !TryGetTupleType(method, out INamedTypeSymbol methodTuple))
+                {
+                    continue;
+                }
+
+                if (method.OverriddenMethod is IMethodSymbol overridden
+                    && TryGetTupleType(overridden, out INamedTypeSymbol overriddenTuple))
+                {
+                    AddTupleContractPair(
+                        method,
+                        methodTuple,
+                        overridden,
+                        overriddenTuple,
+                        tupleTainted,
+                        tupleEdges);
+                }
+            }
+
+            foreach (INamedTypeSymbol iface in type.AllInterfaces)
+            {
+                foreach (IMethodSymbol interfaceMethod in iface.GetMembers().OfType<IMethodSymbol>())
+                {
+                    if (interfaceMethod.MethodKind != MethodKind.Ordinary
+                        || !TryGetTupleType(interfaceMethod, out INamedTypeSymbol interfaceTuple)
+                        || type.FindImplementationForInterfaceMember(interfaceMethod) is not IMethodSymbol implementation
+                        || !TryGetTupleType(implementation, out INamedTypeSymbol implementationTuple))
+                    {
+                        continue;
+                    }
+
+                    AddTupleContractPair(
+                        interfaceMethod,
+                        interfaceTuple,
+                        implementation,
+                        implementationTuple,
+                        tupleTainted,
+                        tupleEdges);
+                }
+            }
+        }
+    }
+
+    private static void AddTupleContractPair(
+        IMethodSymbol first,
+        INamedTypeSymbol firstTuple,
+        IMethodSymbol second,
+        INamedTypeSymbol secondTuple,
+        HashSet<TupleElementKey> tupleTainted,
+        List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges)
+    {
+        ISymbol firstCanonical = Canonical(first);
+        ISymbol secondCanonical = Canonical(second);
+        AddTupleShapeEdges(
+            firstCanonical,
+            firstTuple,
+            string.Empty,
+            secondCanonical,
+            secondTuple,
+            string.Empty,
+            tupleTainted,
+            tupleEdges);
+        AddTupleShapeEdges(
+            secondCanonical,
+            secondTuple,
+            string.Empty,
+            firstCanonical,
+            firstTuple,
+            string.Empty,
+            tupleTainted,
+            tupleEdges);
     }
 
     // Unwraps a (non-generic-parameter) `System.Threading.Tasks.Task<T>` or
@@ -1347,10 +2404,83 @@ internal static class ObliviousNullabilityAnalyzer
         return IsNullLiteral(expression);
     }
 
+    private readonly struct TupleElementKey
+    {
+        public TupleElementKey(ISymbol symbol, string path)
+        {
+            this.Symbol = Canonical(symbol);
+            this.Path = path;
+        }
+
+        public ISymbol Symbol { get; }
+
+        public string Path { get; }
+    }
+
+    private readonly struct TupleElementQuery
+    {
+        public TupleElementQuery(CSharpCompilation compilation, TupleElementKey key)
+        {
+            this.Compilation = compilation;
+            this.Key = key;
+        }
+
+        public CSharpCompilation Compilation { get; }
+
+        public TupleElementKey Key { get; }
+    }
+
+    private sealed class TupleElementKeyComparer : IEqualityComparer<TupleElementKey>
+    {
+        public static TupleElementKeyComparer Instance { get; } = new();
+
+        public bool Equals(TupleElementKey x, TupleElementKey y) =>
+            SymbolEqualityComparer.Default.Equals(x.Symbol, y.Symbol)
+                && string.Equals(x.Path, y.Path, System.StringComparison.Ordinal);
+
+        public int GetHashCode(TupleElementKey obj)
+        {
+            int symbolHash = obj.Symbol == null
+                ? 0
+                : SymbolEqualityComparer.Default.GetHashCode(obj.Symbol);
+            return System.HashCode.Combine(symbolHash, obj.Path);
+        }
+    }
+
+    private sealed class TupleElementQueryComparer : IEqualityComparer<TupleElementQuery>
+    {
+        public static TupleElementQueryComparer Instance { get; } = new();
+
+        public bool Equals(TupleElementQuery x, TupleElementQuery y) =>
+            ReferenceEquals(x.Compilation, y.Compilation)
+                && TupleElementKeyComparer.Instance.Equals(x.Key, y.Key);
+
+        public int GetHashCode(TupleElementQuery obj) =>
+            System.HashCode.Combine(
+                System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj.Compilation),
+                TupleElementKeyComparer.Instance.GetHashCode(obj.Key));
+    }
+
     private sealed class TaintResult
     {
-        public TaintResult(HashSet<ISymbol> tainted) => this.Tainted = tainted;
+        public TaintResult(
+            HashSet<ISymbol> tainted,
+            HashSet<TupleElementKey> tupleTainted,
+            List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges,
+            List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges)
+        {
+            this.Tainted = tainted;
+            this.TupleTainted = tupleTainted;
+            this.TupleEdges = tupleEdges;
+            this.TupleScalarEdges = tupleScalarEdges;
+        }
 
         public HashSet<ISymbol> Tainted { get; }
+
+        public HashSet<TupleElementKey> TupleTainted { get; }
+
+        public List<(TupleElementKey Target, TupleElementKey Source)> TupleEdges { get; }
+
+        public List<(TupleElementKey Target, ISymbol Source)> TupleScalarEdges { get; }
     }
 }


### PR DESCRIPTION
Fixes #2469

## Summary
- track oblivious-nullability evidence independently by tuple element path
- propagate through nested literals, conditionals/switches, tuple locals, calls, async/task returns, deconstruction, interface/override contracts, and sibling compilations
- preserve nullable-enabled controls, value elements, generic constraints, and positional named-tuple lowering without blanket `!!` insertion

## Tests
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-restore --nologo --verbosity quiet --filter ...` (39 focused/related tests passed)
- focused sink test compiles the canonical translated tuple with `gsc`

## Validation note
- the broader suite reached 443 passing tests with no assertion failures before the test host aborted; SDK pipeline tests are locally blocked by the missing built `Gsharp.NET.Sdk` nupkg (GS9999).

## Risk
- the main risk is added analyzer cost from the tuple element graph; it is cached per compilation and gated to nullable-oblivious compilations.