### PR TITLE
gsc: preserve symbolic interface call substitutions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2914,7 +2914,15 @@ public sealed class Binder
                 if (TypeSymbol.ContainsTypeParameter(ta) || TypeSymbol.ContainsSameCompilationUserType(ta))
                 {
                     hasTypeParameterArg = true;
-                    clrArgs[i] = scope.References.MapClrTypeToReferences(typeof(object));
+
+                    // Issue #2391: source enums use Int32 as their established
+                    // CLR ride-through. Preserve that surrogate when closing
+                    // an imported generic receiver as well; using object for a
+                    // struct-constrained interface leaves Nullable<T> member
+                    // signatures unconstructable and hides parameterized
+                    // methods from overload resolution.
+                    var erasedArgument = ta is EnumSymbol ? typeof(int) : typeof(object);
+                    clrArgs[i] = scope.References.MapClrTypeToReferences(erasedArgument);
                     continue;
                 }
 

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -977,6 +977,24 @@ internal sealed class ConversionClassifier
                         // produced unverifiable IL at imported call sites.
                         rebound = udcArg;
                     }
+                    else if (substituted != null
+                        && argument.Type != targetType
+                        && argument is not BoundFunctionLiteralExpression
+                        && !OverloadResolution.IsUnresolvedMethodGroupArgument(argument))
+                    {
+                        // Issue #2391: overload resolution necessarily sees the
+                        // receiver's erased CLR signature, but conversion must
+                        // still honor the symbolic closed parameter recovered
+                        // above. Do not silently pass an unrelated source type
+                        // merely because both types share the same erasure
+                        // (for example Other? and Color? both riding through
+                        // Nullable<Int32>).
+                        var sourceIndex = i - receiverArgCount;
+                        var location = call != null && sourceIndex >= 0 && sourceIndex < call.Arguments.Count
+                            ? call.Arguments[sourceIndex].Location
+                            : call?.Location ?? default;
+                        rebound = BindConversion(location, argument, targetType);
+                    }
                 }
             }
 

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -887,6 +887,32 @@ internal sealed class MemberLookup
             return TypeSymbol.FromClrType(openClr);
         }
 
+        // Issue #2391: keep substituted Nullable<T> positions in the
+        // canonical G# nullable shape. The generic reconstruction below is
+        // appropriate for ordinary imported generics, but using it for an
+        // interface member such as IRepo<T>.Echo(T?) previously produced an
+        // ImportedTypeSymbol for System.Nullable<Color>. The matching return
+        // position was then distinct from the source Color? symbol even
+        // though both came from the same receiver substitution.
+        if (NullableLifting.IsValueTypeNullableClr(openClr))
+        {
+            var openUnderlying = openClr.GetGenericArguments()[0];
+            var mappedUnderlying = MapOpenClrTypeToSymbolic(
+                openUnderlying,
+                openDefinition,
+                typeArguments,
+                openMethodDefinition,
+                methodTypeArguments);
+
+            if (TypeSymbol.ContainsTypeParameter(mappedUnderlying)
+                || TypeSymbol.ContainsSameCompilationUserType(mappedUnderlying))
+            {
+                return NullableTypeSymbol.Get(mappedUnderlying);
+            }
+
+            return TypeSymbol.FromClrType(openClr);
+        }
+
         if (openClr.IsGenericType && !openClr.IsGenericTypeDefinition)
         {
             var openArgs = openClr.GetGenericArguments();
@@ -2756,6 +2782,16 @@ internal sealed class MemberLookup
             case null:
             case TypeParameterSymbol:
                 return contextObject;
+            case EnumSymbol:
+                // Issue #2391: same-compilation enums already use Int32 as
+                // their overload-resolution ride-through. Use that same
+                // surrogate when closing an imported generic receiver so a
+                // struct-constrained interface such as IRepo<Color> can expose
+                // a closed Echo(Nullable<Int32>) candidate instead of falling
+                // back to the unusable open Echo(Nullable<T>) signature.
+                return contextObject.Assembly == typeof(object).Assembly
+                    ? typeof(int)
+                    : contextObject.Assembly.GetType(typeof(int).FullName, throwOnError: false);
             case ImportedTypeSymbol imp when imp.OpenDefinition != null && !imp.TypeArguments.IsDefaultOrEmpty:
                 return TryBuildErasedClosedGeneric(
                     imp.OpenDefinition,

--- a/test/Compiler.Tests/Emit/Issue2391SymbolicInterfaceCallSubstitutionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2391SymbolicInterfaceCallSubstitutionTests.cs
@@ -1,0 +1,291 @@
+// <copyright file="Issue2391SymbolicInterfaceCallSubstitutionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2391: calls through an imported generic interface closed over a
+/// same-compilation source type must substitute parameter and return positions
+/// from the same symbolic receiver mapping.
+/// </summary>
+public class Issue2391SymbolicInterfaceCallSubstitutionTests
+{
+    private const string CSharpContracts = """
+        namespace Issue2391.Contracts
+        {
+            public interface IRepo<T>
+                where T : struct
+            {
+                T? Find();
+
+                T? Echo(T? value);
+            }
+        }
+        """;
+
+    [Fact]
+    public void SourceEnum_NullableParameterAndReturnThroughInterface_CompilesRunsAndVerifies()
+    {
+        var source = """
+            package Issue2391Enum
+            import System
+            import Issue2391.Contracts
+
+            enum Color { Red, Green, Blue }
+
+            class ColorRepo : IRepo[Color] {
+                func Find() Color? { return Color.Green }
+                func Echo(value Color?) Color? { return value }
+            }
+
+            func Read(repo IRepo[Color]) Color? {
+                return repo.Find()
+            }
+
+            func Main() {
+                var repo IRepo[Color] = ColorRepo()
+                var found Color? = Read(repo)
+                var input Color? = Color.Blue
+                var echoed Color? = repo.Echo(input)
+                Console.WriteLine(found == Color.Green)
+                Console.WriteLine(echoed == Color.Blue)
+            }
+            """;
+
+        Assert.Equal("True\nTrue\n", CompileAndRunWithContracts(source));
+    }
+
+    [Fact]
+    public void SourceStruct_NullableParameterAndReturnThroughInterface_CompilesRunsAndVerifies()
+    {
+        var source = """
+            package Issue2391Struct
+            import System
+            import Issue2391.Contracts
+
+            struct Token {
+                var Value int32
+            }
+
+            class TokenRepo : IRepo[Token] {
+                func Find() Token? { return Token{ Value: 41 } }
+                func Echo(value Token?) Token? { return value }
+            }
+
+            func Main() {
+                var repo IRepo[Token] = TokenRepo()
+                var input Token? = Token{ Value: 42 }
+                var found Token? = repo.Find()
+                var echoed Token? = repo.Echo(input)
+                Console.WriteLine((found!!).Value)
+                Console.WriteLine((echoed!!).Value)
+            }
+            """;
+
+        Assert.Equal("41\n42\n", CompileAndRunWithContracts(source));
+    }
+
+    [Fact]
+    public void SymbolicInterfaceReturn_DoesNotConvertToUnrelatedSourceType()
+    {
+        var source = """
+            package Issue2391Negative
+            import Issue2391.Contracts
+
+            enum Color { Red, Green }
+            enum Other { A, B }
+
+            class ColorRepo : IRepo[Color] {
+                func Find() Color? { return Color.Green }
+                func Echo(value Color?) Color? { return value }
+            }
+
+            func Bad(repo IRepo[Color]) Other? {
+                return repo.Find()
+            }
+            """;
+
+        var (exitCode, stdout, stderr) = CompileWithContracts(source, run: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0155", stdout + stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SymbolicInterfaceParameter_DoesNotAcceptUnrelatedSourceType()
+    {
+        var source = """
+            package Issue2391ParameterNegative
+            import Issue2391.Contracts
+
+            enum Color { Red, Green }
+            enum Other { A, B }
+
+            class ColorRepo : IRepo[Color] {
+                func Find() Color? { return Color.Green }
+                func Echo(value Color?) Color? { return value }
+            }
+
+            func Bad(repo IRepo[Color], value Other?) Color? {
+                return repo.Echo(value)
+            }
+            """;
+
+        var (exitCode, stdout, stderr) = CompileWithContracts(source, run: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0155", stdout + stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ClosedBclTypeArgument_ControlStillRuns()
+    {
+        var source = """
+            package Issue2391Control
+            import System
+            import Issue2391.Contracts
+
+            class GuidRepo : IRepo[Guid] {
+                func Find() Guid? { return nil }
+                func Echo(value Guid?) Guid? { return value }
+            }
+
+            func Main() {
+                var value Guid = Guid.NewGuid()
+                var repo IRepo[Guid] = GuidRepo()
+                Console.WriteLine(repo.Echo(value) == value)
+            }
+            """;
+
+        Assert.Equal("True\n", CompileAndRunWithContracts(source));
+    }
+
+    private static string CompileAndRunWithContracts(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileWithContracts(source, run: true);
+        Assert.True(exitCode == 0, $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileWithContracts(string source, bool run)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2391_").FullName;
+        try
+        {
+            var contractPath = EmitCSharpContracts(tempDir);
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                run ? "/target:exe" : "/target:library",
+                "/targetframework:net10.0",
+                "/reference:" + contractPath,
+                "/nowarn:GS9100",
+            };
+            foreach (var reference in BclReferences.Value)
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousErr);
+            }
+
+            if (compileExit != 0 || !run)
+            {
+                return (compileExit, compileOut.ToString(), compileErr.ToString());
+            }
+
+            IlVerifier.Verify(outPath, additionalReferences: new[] { contractPath });
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outPath);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            return (process.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static string EmitCSharpContracts(string outputDirectory)
+    {
+        var outputPath = Path.Combine(outputDirectory, "Issue2391.Contracts.dll");
+        var syntaxTree = CSharpSyntaxTree.ParseText(CSharpContracts, new CSharpParseOptions(LanguageVersion.Latest));
+        var references = TrustedPlatformAssemblies()
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "Issue2391.Contracts",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return outputPath;
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var value = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        return string.IsNullOrEmpty(value)
+            ? Enumerable.Empty<string>()
+            : value.Split(Path.PathSeparator).Where(File.Exists);
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        return string.IsNullOrEmpty(runtimeDirectory) || !Directory.Exists(runtimeDirectory)
+            ? Array.Empty<string>()
+            : Directory.EnumerateFiles(runtimeDirectory, "*.dll", SearchOption.TopDirectoryOnly).ToList();
+    });
+}


### PR DESCRIPTION
## Summary
- close imported generic receivers over the established enum CLR surrogate so constrained interface methods remain callable
- canonicalize substituted `Nullable<T>` parameter/return shapes and enforce the recovered symbolic parameter type after erased overload resolution
- cover source enum/struct compile, runtime, type, IL verification, unrelated-type negatives, and a closed-BCL control

## Validation
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --no-restore --filter 'FullyQualifiedName~Issue794GenericInstanceCallReturnTypeEmitTests|FullyQualifiedName~Issue1100GenericMemberOnUserTypeArgEmitTests|FullyQualifiedName~Issue1107OutVarUserTypeErasureEmitTests|FullyQualifiedName~Issue2365ExpressionTreeGenericSubstitutionEmitTests|FullyQualifiedName~Issue2375ExpressionTreeMethodTypeArgumentEmitTests|FullyQualifiedName~Issue2380NullableInterfaceEmitTests|FullyQualifiedName~Issue2381AsyncGenericCollectionReturnEmitTests|FullyQualifiedName~Issue2385NullableSameCompilationStructGenericArgEmitTests|FullyQualifiedName~Issue2391SymbolicInterfaceCallSubstitutionTests' --verbosity minimal` (48 passed)

Fixes #2391