### PR TITLE
Fix external CLR virtual overrides

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -1043,6 +1043,7 @@ internal sealed partial class DeclarationBinder
                     // base class chain per ADR-0017.
                     FunctionSymbol overriddenMethod = null;
                     MethodInfo externalOverriddenMethod = null;
+                    TypeSymbol externalOverrideContainingType = null;
                     bool reportedMissingOverride = false;
                     if (methodSyntax.IsOverride)
                     {
@@ -1078,6 +1079,7 @@ internal sealed partial class DeclarationBinder
                             if (externalMatch.Member != null)
                             {
                                 externalOverriddenMethod = externalMatch.Member;
+                                externalOverrideContainingType = externalMatch.ContainingType;
                             }
                             else if (externalMatch.IsSealed)
                             {
@@ -1196,6 +1198,7 @@ internal sealed partial class DeclarationBinder
                         isOverride: methodSyntax.IsOverride);
                     methodSymbol.OverriddenMethod = overriddenMethod;
                     methodSymbol.ExternalOverriddenMethod = externalOverriddenMethod;
+                    methodSymbol.ExternalOverrideContainingType = externalOverrideContainingType;
                     methodSymbol.TypeParameters = methodTypeParameters;
                     methodSymbol.ReturnRefKind = methodReturnRefKind;
                     methodSymbol.IsAsync = methodSyntax.IsAsync || isAsyncIteratorReturnType(returnType);
@@ -1476,6 +1479,7 @@ internal sealed partial class DeclarationBinder
 
                 // Validate: override needs base property
                 PropertyInfo externalOverriddenProperty = null;
+                TypeSymbol externalPropertyContainingType = null;
                 if (isOverride)
                 {
                     if (structSymbol.BaseClass != null && TypeMemberModel.TryGetProperty(structSymbol.BaseClass, propName, out var baseProp))
@@ -1498,6 +1502,7 @@ internal sealed partial class DeclarationBinder
                         if (externalMatch.Member != null)
                         {
                             externalOverriddenProperty = externalMatch.Member;
+                            externalPropertyContainingType = externalMatch.ContainingType;
                         }
                         else if (externalMatch.IsSealed)
                         {
@@ -1553,6 +1558,7 @@ internal sealed partial class DeclarationBinder
                 {
                     propertySymbol.ExternalOverriddenGetter = externalOverriddenProperty.GetGetMethod(nonPublic: true);
                     propertySymbol.ExternalOverriddenSetter = externalOverriddenProperty.GetSetMethod(nonPublic: true);
+                    propertySymbol.ExternalOverrideContainingType = externalPropertyContainingType;
                 }
 
                 // Create backing field for auto-properties
@@ -1697,6 +1703,7 @@ internal sealed partial class DeclarationBinder
                 }
 
                 EventInfo externalOverriddenEvent = null;
+                TypeSymbol externalEventContainingType = null;
                 if (isOverride)
                 {
                     if (structSymbol.BaseClass != null && TypeMemberModel.TryGetEvent(structSymbol.BaseClass, eventName, out var baseEvent))
@@ -1720,6 +1727,7 @@ internal sealed partial class DeclarationBinder
                         if (externalMatch.Member != null)
                         {
                             externalOverriddenEvent = externalMatch.Member;
+                            externalEventContainingType = externalMatch.ContainingType;
                         }
                         else if (externalMatch.IsSealed)
                         {
@@ -1765,6 +1773,7 @@ internal sealed partial class DeclarationBinder
                     eventSymbol.ExternalOverriddenAddMethod = externalOverriddenEvent.GetAddMethod(nonPublic: true);
                     eventSymbol.ExternalOverriddenRemoveMethod = externalOverriddenEvent.GetRemoveMethod(nonPublic: true);
                     eventSymbol.ExternalOverriddenRaiseMethod = externalOverriddenEvent.GetRaiseMethod(nonPublic: true);
+                    eventSymbol.ExternalOverrideContainingType = externalEventContainingType;
                 }
 
                 // Create backing field for field-like events

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -1044,7 +1044,6 @@ internal sealed partial class DeclarationBinder
                     FunctionSymbol overriddenMethod = null;
                     MethodInfo externalOverriddenMethod = null;
                     TypeSymbol externalOverrideContainingType = null;
-                    bool reportedMissingOverride = false;
                     if (methodSyntax.IsOverride)
                     {
                         // ADR-0063 §8: when the base exposes a name-overload set, the
@@ -1161,28 +1160,8 @@ internal sealed partial class DeclarationBinder
                             if (SignaturesMatch(shadowed, methodParameters, returnType, methodReturnRefKind, shadowedTypeArgSubst, methodIsAsync))
                             {
                                 Diagnostics.ReportMissingOverride(methodSyntax.Identifier.Location, shadowed.ReceiverType.Name, methodName);
-                                reportedMissingOverride = true;
                                 break;
                             }
-                        }
-                    }
-
-                    if (!methodSyntax.IsOverride && !reportedMissingOverride)
-                    {
-                        var externalMatch = ExternalClrOverrideResolver.FindMethod(
-                            structSymbol,
-                            methodName,
-                            methodParameters,
-                            returnType,
-                            methodReturnRefKind,
-                            methodTypeParameters,
-                            methodAccessibility);
-                        if (externalMatch.Member != null)
-                        {
-                            Diagnostics.ReportMissingOverride(
-                                methodSyntax.Identifier.Location,
-                                externalMatch.Member.DeclaringType?.Name ?? structSymbol.ImportedBaseType?.Name ?? "?",
-                                methodName);
                         }
                     }
 
@@ -1518,24 +1497,6 @@ internal sealed partial class DeclarationBinder
                         }
                     }
                 }
-                else
-                {
-                    var externalMatch = ExternalClrOverrideResolver.FindProperty(
-                        structSymbol,
-                        propName,
-                        indexerParameters,
-                        propType,
-                        hasGetter,
-                        hasSetter,
-                        propAccessibility);
-                    if (externalMatch.Member != null)
-                    {
-                        Diagnostics.ReportMissingOverride(
-                            propSyntax.Identifier.Location,
-                            externalMatch.Member.DeclaringType?.Name ?? structSymbol.ImportedBaseType?.Name ?? "?",
-                            propName);
-                    }
-                }
 
                 var propertySymbol = new PropertySymbol(
                     propName,
@@ -1741,21 +1702,6 @@ internal sealed partial class DeclarationBinder
                         {
                             Diagnostics.ReportNoBaseMethodToOverride(eventSyntax.Identifier.Location, eventName);
                         }
-                    }
-                }
-                else
-                {
-                    var externalMatch = ExternalClrOverrideResolver.FindEvent(
-                        structSymbol,
-                        eventName,
-                        handlerType,
-                        eventAccessibility);
-                    if (externalMatch.Member != null)
-                    {
-                        Diagnostics.ReportMissingOverride(
-                            eventSyntax.Identifier.Location,
-                            externalMatch.Member.DeclaringType?.Name ?? structSymbol.ImportedBaseType?.Name ?? "?",
-                            eventName);
                     }
                 }
 

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -1042,6 +1042,8 @@ internal sealed partial class DeclarationBinder
                     // Phase 3.B.3 sub-step 3: open/override validation against
                     // base class chain per ADR-0017.
                     FunctionSymbol overriddenMethod = null;
+                    MethodInfo externalOverriddenMethod = null;
+                    bool reportedMissingOverride = false;
                     if (methodSyntax.IsOverride)
                     {
                         // ADR-0063 §8: when the base exposes a name-overload set, the
@@ -1065,7 +1067,30 @@ internal sealed partial class DeclarationBinder
 
                         if (baseMethod == null)
                         {
-                            Diagnostics.ReportNoBaseMethodToOverride(methodSyntax.Identifier.Location, methodName);
+                            var externalMatch = ExternalClrOverrideResolver.FindMethod(
+                                structSymbol,
+                                methodName,
+                                methodParameters,
+                                returnType,
+                                methodReturnRefKind,
+                                methodTypeParameters,
+                                methodAccessibility);
+                            if (externalMatch.Member != null)
+                            {
+                                externalOverriddenMethod = externalMatch.Member;
+                            }
+                            else if (externalMatch.IsSealed)
+                            {
+                                Diagnostics.ReportOverrideOfSealedMethod(methodSyntax.Identifier.Location, methodName);
+                            }
+                            else if (externalMatch.SawName)
+                            {
+                                Diagnostics.ReportOverrideSignatureMismatch(methodSyntax.Identifier.Location, methodName);
+                            }
+                            else
+                            {
+                                Diagnostics.ReportNoBaseMethodToOverride(methodSyntax.Identifier.Location, methodName);
+                            }
                         }
                         else if (baseSignatureMatch != null)
                         {
@@ -1134,8 +1159,28 @@ internal sealed partial class DeclarationBinder
                             if (SignaturesMatch(shadowed, methodParameters, returnType, methodReturnRefKind, shadowedTypeArgSubst, methodIsAsync))
                             {
                                 Diagnostics.ReportMissingOverride(methodSyntax.Identifier.Location, shadowed.ReceiverType.Name, methodName);
+                                reportedMissingOverride = true;
                                 break;
                             }
+                        }
+                    }
+
+                    if (!methodSyntax.IsOverride && !reportedMissingOverride)
+                    {
+                        var externalMatch = ExternalClrOverrideResolver.FindMethod(
+                            structSymbol,
+                            methodName,
+                            methodParameters,
+                            returnType,
+                            methodReturnRefKind,
+                            methodTypeParameters,
+                            methodAccessibility);
+                        if (externalMatch.Member != null)
+                        {
+                            Diagnostics.ReportMissingOverride(
+                                methodSyntax.Identifier.Location,
+                                externalMatch.Member.DeclaringType?.Name ?? structSymbol.ImportedBaseType?.Name ?? "?",
+                                methodName);
                         }
                     }
 
@@ -1150,6 +1195,7 @@ internal sealed partial class DeclarationBinder
                         isOpen: methodSyntax.IsOpen,
                         isOverride: methodSyntax.IsOverride);
                     methodSymbol.OverriddenMethod = overriddenMethod;
+                    methodSymbol.ExternalOverriddenMethod = externalOverriddenMethod;
                     methodSymbol.TypeParameters = methodTypeParameters;
                     methodSymbol.ReturnRefKind = methodReturnRefKind;
                     methodSymbol.IsAsync = methodSyntax.IsAsync || isAsyncIteratorReturnType(returnType);
@@ -1429,20 +1475,60 @@ internal sealed partial class DeclarationBinder
                 }
 
                 // Validate: override needs base property
-                PropertySymbol overriddenProperty = null;
+                PropertyInfo externalOverriddenProperty = null;
                 if (isOverride)
                 {
-                    if (structSymbol.BaseClass == null || !TypeMemberModel.TryGetProperty(structSymbol.BaseClass, propName, out var baseProp))
+                    if (structSymbol.BaseClass != null && TypeMemberModel.TryGetProperty(structSymbol.BaseClass, propName, out var baseProp))
                     {
-                        Diagnostics.ReportNoBaseMethodToOverride(propSyntax.Identifier.Location, propName);
-                    }
-                    else if (!baseProp.IsVirtual && !baseProp.IsOverride)
-                    {
-                        Diagnostics.ReportOverrideOfSealedMethod(propSyntax.Identifier.Location, propName);
+                        if (!baseProp.IsVirtual && !baseProp.IsOverride)
+                        {
+                            Diagnostics.ReportOverrideOfSealedMethod(propSyntax.Identifier.Location, propName);
+                        }
                     }
                     else
                     {
-                        overriddenProperty = baseProp;
+                        var externalMatch = ExternalClrOverrideResolver.FindProperty(
+                            structSymbol,
+                            propName,
+                            indexerParameters,
+                            propType,
+                            hasGetter,
+                            hasSetter,
+                            propAccessibility);
+                        if (externalMatch.Member != null)
+                        {
+                            externalOverriddenProperty = externalMatch.Member;
+                        }
+                        else if (externalMatch.IsSealed)
+                        {
+                            Diagnostics.ReportOverrideOfSealedMethod(propSyntax.Identifier.Location, propName);
+                        }
+                        else if (externalMatch.SawName)
+                        {
+                            Diagnostics.ReportOverrideSignatureMismatch(propSyntax.Identifier.Location, propName);
+                        }
+                        else
+                        {
+                            Diagnostics.ReportNoBaseMethodToOverride(propSyntax.Identifier.Location, propName);
+                        }
+                    }
+                }
+                else
+                {
+                    var externalMatch = ExternalClrOverrideResolver.FindProperty(
+                        structSymbol,
+                        propName,
+                        indexerParameters,
+                        propType,
+                        hasGetter,
+                        hasSetter,
+                        propAccessibility);
+                    if (externalMatch.Member != null)
+                    {
+                        Diagnostics.ReportMissingOverride(
+                            propSyntax.Identifier.Location,
+                            externalMatch.Member.DeclaringType?.Name ?? structSymbol.ImportedBaseType?.Name ?? "?",
+                            propName);
                     }
                 }
 
@@ -1463,6 +1549,11 @@ internal sealed partial class DeclarationBinder
                     Parameters = indexerParameters,
                 };
                 Binder.AttachDocumentation(propertySymbol, propSyntax);
+                if (externalOverriddenProperty != null)
+                {
+                    propertySymbol.ExternalOverriddenGetter = externalOverriddenProperty.GetGetMethod(nonPublic: true);
+                    propertySymbol.ExternalOverriddenSetter = externalOverriddenProperty.GetSetMethod(nonPublic: true);
+                }
 
                 // Create backing field for auto-properties
                 if (isAutoProperty && !syntax.IsData)
@@ -1499,6 +1590,7 @@ internal sealed partial class DeclarationBinder
                         // ADR-0118: indexer accessors are emitted as SpecialName
                         // CLR default-member accessors (get_Item).
                         getterSymbol.IsSpecialName = isIndexer;
+                        getterSymbol.ExternalOverriddenMethod = propertySymbol.ExternalOverriddenGetter;
                         propertySymbol.GetterSymbol = getterSymbol;
                         propertySymbol.GetterBodySyntax = getAccessor.Body;
                     }
@@ -1521,6 +1613,7 @@ internal sealed partial class DeclarationBinder
                             isOverride: isOverride);
                         setterSymbol.IsSpecialName = isIndexer;
                         setterSymbol.IsInitOnlySetter = isInitOnly;
+                        setterSymbol.ExternalOverriddenMethod = propertySymbol.ExternalOverriddenSetter;
                         propertySymbol.SetterSymbol = setterSymbol;
                         propertySymbol.SetterBodySyntax = setAccessor.Body;
                     }
@@ -1603,6 +1696,61 @@ internal sealed partial class DeclarationBinder
                     Diagnostics.ReportOpenMemberInNonOpenClass(eventSyntax.OpenModifier.Location, eventName);
                 }
 
+                EventInfo externalOverriddenEvent = null;
+                if (isOverride)
+                {
+                    if (structSymbol.BaseClass != null && TypeMemberModel.TryGetEvent(structSymbol.BaseClass, eventName, out var baseEvent))
+                    {
+                        if (!baseEvent.IsVirtual && !baseEvent.IsOverride)
+                        {
+                            Diagnostics.ReportOverrideOfSealedMethod(eventSyntax.Identifier.Location, eventName);
+                        }
+                        else if (baseEvent.Type != handlerType)
+                        {
+                            Diagnostics.ReportOverrideSignatureMismatch(eventSyntax.Identifier.Location, eventName);
+                        }
+                    }
+                    else
+                    {
+                        var externalMatch = ExternalClrOverrideResolver.FindEvent(
+                            structSymbol,
+                            eventName,
+                            handlerType,
+                            eventAccessibility);
+                        if (externalMatch.Member != null)
+                        {
+                            externalOverriddenEvent = externalMatch.Member;
+                        }
+                        else if (externalMatch.IsSealed)
+                        {
+                            Diagnostics.ReportOverrideOfSealedMethod(eventSyntax.Identifier.Location, eventName);
+                        }
+                        else if (externalMatch.SawName)
+                        {
+                            Diagnostics.ReportOverrideSignatureMismatch(eventSyntax.Identifier.Location, eventName);
+                        }
+                        else
+                        {
+                            Diagnostics.ReportNoBaseMethodToOverride(eventSyntax.Identifier.Location, eventName);
+                        }
+                    }
+                }
+                else
+                {
+                    var externalMatch = ExternalClrOverrideResolver.FindEvent(
+                        structSymbol,
+                        eventName,
+                        handlerType,
+                        eventAccessibility);
+                    if (externalMatch.Member != null)
+                    {
+                        Diagnostics.ReportMissingOverride(
+                            eventSyntax.Identifier.Location,
+                            externalMatch.Member.DeclaringType?.Name ?? structSymbol.ImportedBaseType?.Name ?? "?",
+                            eventName);
+                    }
+                }
+
                 var eventSymbol = new EventSymbol(
                     eventName,
                     handlerType,
@@ -1612,6 +1760,12 @@ internal sealed partial class DeclarationBinder
                     isOverride,
                     declaration: eventSyntax);
                 Binder.AttachDocumentation(eventSymbol, eventSyntax);
+                if (externalOverriddenEvent != null)
+                {
+                    eventSymbol.ExternalOverriddenAddMethod = externalOverriddenEvent.GetAddMethod(nonPublic: true);
+                    eventSymbol.ExternalOverriddenRemoveMethod = externalOverriddenEvent.GetRemoveMethod(nonPublic: true);
+                    eventSymbol.ExternalOverriddenRaiseMethod = externalOverriddenEvent.GetRaiseMethod(nonPublic: true);
+                }
 
                 // Create backing field for field-like events
                 if (isFieldLike)
@@ -1658,7 +1812,11 @@ internal sealed partial class DeclarationBinder
                     eventAccessibility,
                     receiverType: structSymbol,
                     isOpen: isVirtual,
-                    isOverride: isOverride) { IsSpecialName = true };
+                    isOverride: isOverride)
+                {
+                    IsSpecialName = true,
+                    ExternalOverriddenMethod = eventSymbol.ExternalOverriddenAddMethod,
+                };
                 eventSymbol.RemoveMethodSymbol = new FunctionSymbol(
                     $"remove_{eventName}",
                     ImmutableArray.Create(handlerParam),
@@ -1668,7 +1826,11 @@ internal sealed partial class DeclarationBinder
                     eventAccessibility,
                     receiverType: structSymbol,
                     isOpen: isVirtual,
-                    isOverride: isOverride) { IsSpecialName = true };
+                    isOverride: isOverride)
+                {
+                    IsSpecialName = true,
+                    ExternalOverriddenMethod = eventSymbol.ExternalOverriddenRemoveMethod,
+                };
 
                 // Issue #257: create raise method symbol if raise accessor is present.
                 if (eventSyntax.Accessors.Any(a => a.IsRaise))
@@ -1694,7 +1856,11 @@ internal sealed partial class DeclarationBinder
                         eventAccessibility,
                         receiverType: structSymbol,
                         isOpen: isVirtual,
-                        isOverride: isOverride) { IsSpecialName = true };
+                        isOverride: isOverride)
+                    {
+                        IsSpecialName = true,
+                        ExternalOverriddenMethod = eventSymbol.ExternalOverriddenRaiseMethod,
+                    };
                 }
 
                 // Bind annotations

--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -26,7 +26,9 @@ internal static class ExternalClrOverrideResolver
         Accessibility accessibility)
     {
         bool sawName = false;
-        foreach (var method in EnumerateMethods(FindImportedBaseType(derivedType), name))
+        var importedBase = FindImportedBaseType(derivedType);
+        var typeArguments = GetSymbolicTypeArguments(importedBase);
+        foreach (var method in EnumerateMethods(GetReflectionBaseType(importedBase), name))
         {
             if (!IsAccessibleOverrideTarget(method, accessibility))
             {
@@ -35,21 +37,21 @@ internal static class ExternalClrOverrideResolver
 
             sawName = true;
             if (method.GetGenericArguments().Length != typeParameters.Length
-                || !ParametersMatch(method.GetParameters(), parameters, typeParameters)
-                || !ReturnMatches(method.ReturnType, returnType, returnRefKind, typeParameters))
+                || !ParametersMatch(method.GetParameters(), parameters, typeParameters, typeArguments)
+                || !ReturnMatches(method.ReturnType, returnType, returnRefKind, typeParameters, typeArguments))
             {
                 continue;
             }
 
             if (!method.IsVirtual || method.IsFinal)
             {
-                return new MatchResult<MethodInfo>(null, sawName, IsSealed: true);
+                return new MatchResult<MethodInfo>(null, importedBase, sawName, IsSealed: true);
             }
 
-            return new MatchResult<MethodInfo>(method, sawName, IsSealed: false);
+            return new MatchResult<MethodInfo>(method, importedBase, sawName, IsSealed: false);
         }
 
-        return new MatchResult<MethodInfo>(null, sawName, IsSealed: false);
+        return new MatchResult<MethodInfo>(null, importedBase, sawName, IsSealed: false);
     }
 
     internal static MatchResult<PropertyInfo> FindProperty(
@@ -62,7 +64,9 @@ internal static class ExternalClrOverrideResolver
         Accessibility accessibility)
     {
         bool sawName = false;
-        foreach (var property in EnumerateProperties(FindImportedBaseType(derivedType), name))
+        var importedBase = FindImportedBaseType(derivedType);
+        var typeArguments = GetSymbolicTypeArguments(importedBase);
+        foreach (var property in EnumerateProperties(GetReflectionBaseType(importedBase), name))
         {
             var getter = property.GetGetMethod(nonPublic: true);
             var setter = property.GetSetMethod(nonPublic: true);
@@ -77,8 +81,8 @@ internal static class ExternalClrOverrideResolver
                 || (hasSetter && setter == null)
                 || (!hasGetter && getter != null)
                 || (!hasSetter && setter != null)
-                || !ParametersMatch(property.GetIndexParameters(), indexParameters, ImmutableArray<TypeParameterSymbol>.Empty)
-                || !PropertyTypeMatches(property.PropertyType, propertyType, hasSetter))
+                || !ParametersMatch(property.GetIndexParameters(), indexParameters, ImmutableArray<TypeParameterSymbol>.Empty, typeArguments)
+                || !PropertyTypeMatches(property.PropertyType, propertyType, hasSetter, typeArguments))
             {
                 continue;
             }
@@ -86,13 +90,13 @@ internal static class ExternalClrOverrideResolver
             if ((getter != null && (!getter.IsVirtual || getter.IsFinal))
                 || (setter != null && (!setter.IsVirtual || setter.IsFinal)))
             {
-                return new MatchResult<PropertyInfo>(null, sawName, IsSealed: true);
+                return new MatchResult<PropertyInfo>(null, importedBase, sawName, IsSealed: true);
             }
 
-            return new MatchResult<PropertyInfo>(property, sawName, IsSealed: false);
+            return new MatchResult<PropertyInfo>(property, importedBase, sawName, IsSealed: false);
         }
 
-        return new MatchResult<PropertyInfo>(null, sawName, IsSealed: false);
+        return new MatchResult<PropertyInfo>(null, importedBase, sawName, IsSealed: false);
     }
 
     internal static MatchResult<EventInfo> FindEvent(
@@ -102,7 +106,9 @@ internal static class ExternalClrOverrideResolver
         Accessibility accessibility)
     {
         bool sawName = false;
-        foreach (var eventInfo in EnumerateEvents(FindImportedBaseType(derivedType), name))
+        var importedBase = FindImportedBaseType(derivedType);
+        var typeArguments = GetSymbolicTypeArguments(importedBase);
+        foreach (var eventInfo in EnumerateEvents(GetReflectionBaseType(importedBase), name))
         {
             var add = eventInfo.GetAddMethod(nonPublic: true);
             var remove = eventInfo.GetRemoveMethod(nonPublic: true);
@@ -113,7 +119,7 @@ internal static class ExternalClrOverrideResolver
             }
 
             sawName = true;
-            if (!TypeMatches(eventInfo.EventHandlerType, handlerType, ImmutableArray<TypeParameterSymbol>.Empty))
+            if (!TypeMatches(eventInfo.EventHandlerType, handlerType, ImmutableArray<TypeParameterSymbol>.Empty, typeArguments))
             {
                 continue;
             }
@@ -121,27 +127,38 @@ internal static class ExternalClrOverrideResolver
             if ((add != null && (!add.IsVirtual || add.IsFinal))
                 || (remove != null && (!remove.IsVirtual || remove.IsFinal)))
             {
-                return new MatchResult<EventInfo>(null, sawName, IsSealed: true);
+                return new MatchResult<EventInfo>(null, importedBase, sawName, IsSealed: true);
             }
 
-            return new MatchResult<EventInfo>(eventInfo, sawName, IsSealed: false);
+            return new MatchResult<EventInfo>(eventInfo, importedBase, sawName, IsSealed: false);
         }
 
-        return new MatchResult<EventInfo>(null, sawName, IsSealed: false);
+        return new MatchResult<EventInfo>(null, importedBase, sawName, IsSealed: false);
     }
 
-    private static Type FindImportedBaseType(StructSymbol type)
+    private static TypeSymbol FindImportedBaseType(StructSymbol type)
     {
         for (var current = type; current != null; current = current.BaseClass)
         {
-            if (current.ImportedBaseType?.ClrType != null)
+            if (current.ImportedBaseType != null)
             {
-                return current.ImportedBaseType.ClrType;
+                return current.ImportedBaseType;
             }
         }
 
         return null;
     }
+
+    private static Type GetReflectionBaseType(TypeSymbol importedBase)
+        => importedBase is ImportedTypeSymbol { OpenDefinition: not null } imported
+            && imported.HasSubstitutableTypeArgument
+                ? imported.OpenDefinition
+                : importedBase?.ClrType;
+
+    private static ImmutableArray<TypeSymbol> GetSymbolicTypeArguments(TypeSymbol importedBase)
+        => importedBase is ImportedTypeSymbol { OpenDefinition: not null, HasSubstitutableTypeArgument: true } imported
+            ? imported.TypeArguments
+            : ImmutableArray<TypeSymbol>.Empty;
 
     private static IEnumerable<MethodInfo> EnumerateMethods(Type baseType, string name)
     {
@@ -218,7 +235,8 @@ internal static class ExternalClrOverrideResolver
     private static bool ParametersMatch(
         ParameterInfo[] clrParameters,
         ImmutableArray<ParameterSymbol> parameters,
-        ImmutableArray<TypeParameterSymbol> typeParameters)
+        ImmutableArray<TypeParameterSymbol> typeParameters,
+        ImmutableArray<TypeSymbol> containingTypeArguments)
     {
         if (clrParameters.Length != parameters.Length)
         {
@@ -241,7 +259,7 @@ internal static class ExternalClrOverrideResolver
             }
 
             if (clrRefKind != parameters[i].RefKind
-                || !TypeMatches(clrType, parameters[i].Type, typeParameters))
+                || !TypeMatches(clrType, parameters[i].Type, typeParameters, containingTypeArguments))
             {
                 return false;
             }
@@ -254,7 +272,8 @@ internal static class ExternalClrOverrideResolver
         Type clrReturnType,
         TypeSymbol returnType,
         RefKind returnRefKind,
-        ImmutableArray<TypeParameterSymbol> typeParameters)
+        ImmutableArray<TypeParameterSymbol> typeParameters,
+        ImmutableArray<TypeSymbol> containingTypeArguments)
     {
         var clrReturnsByRef = clrReturnType.IsByRef;
         if ((returnRefKind == RefKind.Ref) != clrReturnsByRef)
@@ -267,7 +286,7 @@ internal static class ExternalClrOverrideResolver
             clrReturnType = clrReturnType.GetElementType();
         }
 
-        if (TypeMatches(clrReturnType, returnType, typeParameters))
+        if (TypeMatches(clrReturnType, returnType, typeParameters, containingTypeArguments))
         {
             return true;
         }
@@ -275,14 +294,23 @@ internal static class ExternalClrOverrideResolver
         return returnRefKind == RefKind.None && IsCovariantReturn(clrReturnType, returnType);
     }
 
-    private static bool PropertyTypeMatches(Type clrPropertyType, TypeSymbol propertyType, bool hasSetter)
-        => TypeMatches(clrPropertyType, propertyType, ImmutableArray<TypeParameterSymbol>.Empty)
+    private static bool PropertyTypeMatches(
+        Type clrPropertyType,
+        TypeSymbol propertyType,
+        bool hasSetter,
+        ImmutableArray<TypeSymbol> containingTypeArguments)
+        => TypeMatches(
+            clrPropertyType,
+            propertyType,
+            ImmutableArray<TypeParameterSymbol>.Empty,
+            containingTypeArguments)
             || (!hasSetter && IsCovariantReturn(clrPropertyType, propertyType));
 
     private static bool TypeMatches(
         Type clrType,
         TypeSymbol type,
-        ImmutableArray<TypeParameterSymbol> methodTypeParameters)
+        ImmutableArray<TypeParameterSymbol> methodTypeParameters,
+        ImmutableArray<TypeSymbol> containingTypeArguments)
     {
         type = type switch
         {
@@ -292,12 +320,20 @@ internal static class ExternalClrOverrideResolver
 
         if (type is TypeParameterSymbol typeParameter)
         {
-            return clrType != null
-                && clrType.IsGenericParameter
-                && clrType.DeclaringMethod != null
-                && typeParameter.Ordinal < methodTypeParameters.Length
-                && ReferenceEquals(typeParameter, methodTypeParameters[typeParameter.Ordinal])
-                && clrType.GenericParameterPosition == typeParameter.Ordinal;
+            if (clrType == null || !clrType.IsGenericParameter)
+            {
+                return false;
+            }
+
+            if (clrType.DeclaringMethod != null)
+            {
+                return typeParameter.Ordinal < methodTypeParameters.Length
+                    && ReferenceEquals(typeParameter, methodTypeParameters[typeParameter.Ordinal])
+                    && clrType.GenericParameterPosition == typeParameter.Ordinal;
+            }
+
+            return clrType.GenericParameterPosition < containingTypeArguments.Length
+                && TypeSymbolsMatch(containingTypeArguments[clrType.GenericParameterPosition], typeParameter);
         }
 
         var effectiveClrType = NullableLifting.GetEffectiveClrType(type);
@@ -307,6 +343,18 @@ internal static class ExternalClrOverrideResolver
         }
 
         return false;
+    }
+
+    private static bool TypeSymbolsMatch(TypeSymbol left, TypeSymbol right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        var leftClr = NullableLifting.GetEffectiveClrType(left);
+        var rightClr = NullableLifting.GetEffectiveClrType(right);
+        return leftClr != null && rightClr != null && ClrTypeUtilities.AreSame(leftClr, rightClr);
     }
 
     private static bool IsCovariantReturn(Type baseReturnType, TypeSymbol derivedReturnType)
@@ -351,6 +399,7 @@ internal static class ExternalClrOverrideResolver
 
     internal readonly record struct MatchResult<T>(
         T Member,
+        TypeSymbol ContainingType,
         bool SawName,
         bool IsSealed)
         where T : MemberInfo;

--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -1,0 +1,357 @@
+// <copyright file="ExternalClrOverrideResolver.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Resolves override declarations against virtual members inherited from an
+/// imported CLR base class.
+/// </summary>
+internal static class ExternalClrOverrideResolver
+{
+    internal static MatchResult<MethodInfo> FindMethod(
+        StructSymbol derivedType,
+        string name,
+        ImmutableArray<ParameterSymbol> parameters,
+        TypeSymbol returnType,
+        RefKind returnRefKind,
+        ImmutableArray<TypeParameterSymbol> typeParameters,
+        Accessibility accessibility)
+    {
+        bool sawName = false;
+        foreach (var method in EnumerateMethods(FindImportedBaseType(derivedType), name))
+        {
+            if (!IsAccessibleOverrideTarget(method, accessibility))
+            {
+                continue;
+            }
+
+            sawName = true;
+            if (method.GetGenericArguments().Length != typeParameters.Length
+                || !ParametersMatch(method.GetParameters(), parameters, typeParameters)
+                || !ReturnMatches(method.ReturnType, returnType, returnRefKind, typeParameters))
+            {
+                continue;
+            }
+
+            if (!method.IsVirtual || method.IsFinal)
+            {
+                return new MatchResult<MethodInfo>(null, sawName, IsSealed: true);
+            }
+
+            return new MatchResult<MethodInfo>(method, sawName, IsSealed: false);
+        }
+
+        return new MatchResult<MethodInfo>(null, sawName, IsSealed: false);
+    }
+
+    internal static MatchResult<PropertyInfo> FindProperty(
+        StructSymbol derivedType,
+        string name,
+        ImmutableArray<ParameterSymbol> indexParameters,
+        TypeSymbol propertyType,
+        bool hasGetter,
+        bool hasSetter,
+        Accessibility accessibility)
+    {
+        bool sawName = false;
+        foreach (var property in EnumerateProperties(FindImportedBaseType(derivedType), name))
+        {
+            var getter = property.GetGetMethod(nonPublic: true);
+            var setter = property.GetSetMethod(nonPublic: true);
+            var representative = getter ?? setter;
+            if (representative == null || !IsAccessibleOverrideTarget(representative, accessibility))
+            {
+                continue;
+            }
+
+            sawName = true;
+            if ((hasGetter && getter == null)
+                || (hasSetter && setter == null)
+                || (!hasGetter && getter != null)
+                || (!hasSetter && setter != null)
+                || !ParametersMatch(property.GetIndexParameters(), indexParameters, ImmutableArray<TypeParameterSymbol>.Empty)
+                || !PropertyTypeMatches(property.PropertyType, propertyType, hasSetter))
+            {
+                continue;
+            }
+
+            if ((getter != null && (!getter.IsVirtual || getter.IsFinal))
+                || (setter != null && (!setter.IsVirtual || setter.IsFinal)))
+            {
+                return new MatchResult<PropertyInfo>(null, sawName, IsSealed: true);
+            }
+
+            return new MatchResult<PropertyInfo>(property, sawName, IsSealed: false);
+        }
+
+        return new MatchResult<PropertyInfo>(null, sawName, IsSealed: false);
+    }
+
+    internal static MatchResult<EventInfo> FindEvent(
+        StructSymbol derivedType,
+        string name,
+        TypeSymbol handlerType,
+        Accessibility accessibility)
+    {
+        bool sawName = false;
+        foreach (var eventInfo in EnumerateEvents(FindImportedBaseType(derivedType), name))
+        {
+            var add = eventInfo.GetAddMethod(nonPublic: true);
+            var remove = eventInfo.GetRemoveMethod(nonPublic: true);
+            var representative = add ?? remove;
+            if (representative == null || !IsAccessibleOverrideTarget(representative, accessibility))
+            {
+                continue;
+            }
+
+            sawName = true;
+            if (!TypeMatches(eventInfo.EventHandlerType, handlerType, ImmutableArray<TypeParameterSymbol>.Empty))
+            {
+                continue;
+            }
+
+            if ((add != null && (!add.IsVirtual || add.IsFinal))
+                || (remove != null && (!remove.IsVirtual || remove.IsFinal)))
+            {
+                return new MatchResult<EventInfo>(null, sawName, IsSealed: true);
+            }
+
+            return new MatchResult<EventInfo>(eventInfo, sawName, IsSealed: false);
+        }
+
+        return new MatchResult<EventInfo>(null, sawName, IsSealed: false);
+    }
+
+    private static Type FindImportedBaseType(StructSymbol type)
+    {
+        for (var current = type; current != null; current = current.BaseClass)
+        {
+            if (current.ImportedBaseType?.ClrType != null)
+            {
+                return current.ImportedBaseType.ClrType;
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<MethodInfo> EnumerateMethods(Type baseType, string name)
+    {
+        for (var current = baseType; current != null; current = current.BaseType)
+        {
+            MethodInfo[] methods;
+            try
+            {
+                methods = current.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            }
+            catch (Exception ex) when (ex is NotSupportedException or InvalidOperationException)
+            {
+                continue;
+            }
+
+            foreach (var method in methods)
+            {
+                if (string.Equals(method.Name, name, StringComparison.Ordinal))
+                {
+                    yield return method;
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<PropertyInfo> EnumerateProperties(Type baseType, string name)
+    {
+        for (var current = baseType; current != null; current = current.BaseType)
+        {
+            PropertyInfo[] properties;
+            try
+            {
+                properties = current.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            }
+            catch (Exception ex) when (ex is NotSupportedException or InvalidOperationException)
+            {
+                continue;
+            }
+
+            foreach (var property in properties)
+            {
+                if (string.Equals(property.Name, name, StringComparison.Ordinal))
+                {
+                    yield return property;
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<EventInfo> EnumerateEvents(Type baseType, string name)
+    {
+        for (var current = baseType; current != null; current = current.BaseType)
+        {
+            EventInfo[] events;
+            try
+            {
+                events = current.GetEvents(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            }
+            catch (Exception ex) when (ex is NotSupportedException or InvalidOperationException)
+            {
+                continue;
+            }
+
+            foreach (var eventInfo in events)
+            {
+                if (string.Equals(eventInfo.Name, name, StringComparison.Ordinal))
+                {
+                    yield return eventInfo;
+                }
+            }
+        }
+    }
+
+    private static bool ParametersMatch(
+        ParameterInfo[] clrParameters,
+        ImmutableArray<ParameterSymbol> parameters,
+        ImmutableArray<TypeParameterSymbol> typeParameters)
+    {
+        if (clrParameters.Length != parameters.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < clrParameters.Length; i++)
+        {
+            var clrParameter = clrParameters[i];
+            var clrType = clrParameter.ParameterType;
+            var clrRefKind = RefKind.None;
+            if (clrType.IsByRef)
+            {
+                clrRefKind = clrParameter.IsOut
+                    ? RefKind.Out
+                    : clrParameter.IsIn
+                        ? RefKind.In
+                        : RefKind.Ref;
+                clrType = clrType.GetElementType();
+            }
+
+            if (clrRefKind != parameters[i].RefKind
+                || !TypeMatches(clrType, parameters[i].Type, typeParameters))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ReturnMatches(
+        Type clrReturnType,
+        TypeSymbol returnType,
+        RefKind returnRefKind,
+        ImmutableArray<TypeParameterSymbol> typeParameters)
+    {
+        var clrReturnsByRef = clrReturnType.IsByRef;
+        if ((returnRefKind == RefKind.Ref) != clrReturnsByRef)
+        {
+            return false;
+        }
+
+        if (clrReturnsByRef)
+        {
+            clrReturnType = clrReturnType.GetElementType();
+        }
+
+        if (TypeMatches(clrReturnType, returnType, typeParameters))
+        {
+            return true;
+        }
+
+        return returnRefKind == RefKind.None && IsCovariantReturn(clrReturnType, returnType);
+    }
+
+    private static bool PropertyTypeMatches(Type clrPropertyType, TypeSymbol propertyType, bool hasSetter)
+        => TypeMatches(clrPropertyType, propertyType, ImmutableArray<TypeParameterSymbol>.Empty)
+            || (!hasSetter && IsCovariantReturn(clrPropertyType, propertyType));
+
+    private static bool TypeMatches(
+        Type clrType,
+        TypeSymbol type,
+        ImmutableArray<TypeParameterSymbol> methodTypeParameters)
+    {
+        type = type switch
+        {
+            NullabilityAnnotatedTypeSymbol annotated => annotated.BaseType,
+            _ => type,
+        };
+
+        if (type is TypeParameterSymbol typeParameter)
+        {
+            return clrType != null
+                && clrType.IsGenericParameter
+                && clrType.DeclaringMethod != null
+                && typeParameter.Ordinal < methodTypeParameters.Length
+                && ReferenceEquals(typeParameter, methodTypeParameters[typeParameter.Ordinal])
+                && clrType.GenericParameterPosition == typeParameter.Ordinal;
+        }
+
+        var effectiveClrType = NullableLifting.GetEffectiveClrType(type);
+        if (effectiveClrType != null && clrType != null)
+        {
+            return ClrTypeUtilities.AreSame(clrType, effectiveClrType);
+        }
+
+        return false;
+    }
+
+    private static bool IsCovariantReturn(Type baseReturnType, TypeSymbol derivedReturnType)
+    {
+        var derivedClrType = NullableLifting.GetEffectiveClrType(derivedReturnType);
+        if (derivedClrType != null)
+        {
+            return !baseReturnType.IsValueType
+                && !derivedClrType.IsValueType
+                && ClrTypeUtilities.IsAssignableByName(baseReturnType, derivedClrType);
+        }
+
+        if (derivedReturnType is StructSymbol derivedStruct && derivedStruct.IsClass)
+        {
+            for (var current = derivedStruct; current != null; current = current.BaseClass)
+            {
+                if (current.ImportedBaseType?.ClrType is Type imported
+                    && ClrTypeUtilities.IsAssignableByName(baseReturnType, imported))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsAccessibleOverrideTarget(MethodInfo method, Accessibility accessibility)
+    {
+        if (method.IsPublic)
+        {
+            return accessibility == Accessibility.Public;
+        }
+
+        if (method.IsFamily || method.IsFamilyOrAssembly)
+        {
+            return accessibility == Accessibility.Protected;
+        }
+
+        return false;
+    }
+
+    internal readonly record struct MatchResult<T>(
+        T Member,
+        bool SawName,
+        bool IsSealed)
+        where T : MemberInfo;
+}

--- a/src/Core/CodeAnalysis/Emit/InterfaceImplEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/InterfaceImplEmitter.cs
@@ -49,6 +49,78 @@ internal sealed class InterfaceImplEmitter
     }
 
     /// <summary>
+    /// Issue #2443: binds G# methods and property/event accessors to virtual
+    /// slots inherited from imported CLR base classes. Exact-signature
+    /// overrides would usually reuse the slot from their Virtual/ReuseSlot
+    /// flags alone, but an explicit MethodImpl also supports covariant returns
+    /// and records the intended external declaration unambiguously.
+    /// </summary>
+    internal void EmitExternalBaseMethodImpls(StructSymbol structSymbol)
+    {
+        if (structSymbol == null
+            || !this.cache.StructTypeDefs.TryGetValue(structSymbol, out var implTypeDef))
+        {
+            return;
+        }
+
+        foreach (var method in structSymbol.Methods)
+        {
+            if (method.ExternalOverriddenMethod != null
+                && this.cache.MethodHandles.TryGetValue(method, out var implHandle))
+            {
+                var declaration = this.outer.memberRefs.GetMethodReference(method.ExternalOverriddenMethod);
+                this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implHandle, declaration);
+            }
+        }
+
+        foreach (var property in structSymbol.Properties)
+        {
+            if (!this.cache.PropertyAccessorHandles.TryGetValue(property, out var accessors))
+            {
+                continue;
+            }
+
+            if (property.ExternalOverriddenGetter != null && accessors.Getter.HasValue)
+            {
+                var declaration = this.outer.memberRefs.GetMethodReference(property.ExternalOverriddenGetter);
+                this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, accessors.Getter.Value, declaration);
+            }
+
+            if (property.ExternalOverriddenSetter != null && accessors.Setter.HasValue)
+            {
+                var declaration = this.outer.memberRefs.GetMethodReference(property.ExternalOverriddenSetter);
+                this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, accessors.Setter.Value, declaration);
+            }
+        }
+
+        foreach (var eventSymbol in structSymbol.Events)
+        {
+            if (!this.cache.EventAccessorHandles.TryGetValue(eventSymbol, out var accessors))
+            {
+                continue;
+            }
+
+            if (eventSymbol.ExternalOverriddenAddMethod != null)
+            {
+                var declaration = this.outer.memberRefs.GetMethodReference(eventSymbol.ExternalOverriddenAddMethod);
+                this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, accessors.Add, declaration);
+            }
+
+            if (eventSymbol.ExternalOverriddenRemoveMethod != null)
+            {
+                var declaration = this.outer.memberRefs.GetMethodReference(eventSymbol.ExternalOverriddenRemoveMethod);
+                this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, accessors.Remove, declaration);
+            }
+
+            if (eventSymbol.ExternalOverriddenRaiseMethod != null && accessors.Raise.HasValue)
+            {
+                var declaration = this.outer.memberRefs.GetMethodReference(eventSymbol.ExternalOverriddenRaiseMethod);
+                this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, accessors.Raise.Value, declaration);
+            }
+        }
+    }
+
+    /// <summary>
     /// Issue #985 / #2010: emit MethodImpl rows for covariant-return interface
     /// bridges AND for mangled-name explicit interface implementations. A
     /// method whose <see cref="FunctionSymbol.ExplicitInterfaceSlot"/> is set

--- a/src/Core/CodeAnalysis/Emit/InterfaceImplEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/InterfaceImplEmitter.cs
@@ -68,7 +68,9 @@ internal sealed class InterfaceImplEmitter
             if (method.ExternalOverriddenMethod != null
                 && this.cache.MethodHandles.TryGetValue(method, out var implHandle))
             {
-                var declaration = this.outer.memberRefs.GetMethodReference(method.ExternalOverriddenMethod);
+                var declaration = this.outer.memberRefs.GetMethodEntityHandle(
+                    method.ExternalOverriddenMethod,
+                    method.ExternalOverrideContainingType);
                 this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implHandle, declaration);
             }
         }
@@ -82,13 +84,17 @@ internal sealed class InterfaceImplEmitter
 
             if (property.ExternalOverriddenGetter != null && accessors.Getter.HasValue)
             {
-                var declaration = this.outer.memberRefs.GetMethodReference(property.ExternalOverriddenGetter);
+                var declaration = this.outer.memberRefs.GetMethodEntityHandle(
+                    property.ExternalOverriddenGetter,
+                    property.ExternalOverrideContainingType);
                 this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, accessors.Getter.Value, declaration);
             }
 
             if (property.ExternalOverriddenSetter != null && accessors.Setter.HasValue)
             {
-                var declaration = this.outer.memberRefs.GetMethodReference(property.ExternalOverriddenSetter);
+                var declaration = this.outer.memberRefs.GetMethodEntityHandle(
+                    property.ExternalOverriddenSetter,
+                    property.ExternalOverrideContainingType);
                 this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, accessors.Setter.Value, declaration);
             }
         }
@@ -102,19 +108,25 @@ internal sealed class InterfaceImplEmitter
 
             if (eventSymbol.ExternalOverriddenAddMethod != null)
             {
-                var declaration = this.outer.memberRefs.GetMethodReference(eventSymbol.ExternalOverriddenAddMethod);
+                var declaration = this.outer.memberRefs.GetMethodEntityHandle(
+                    eventSymbol.ExternalOverriddenAddMethod,
+                    eventSymbol.ExternalOverrideContainingType);
                 this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, accessors.Add, declaration);
             }
 
             if (eventSymbol.ExternalOverriddenRemoveMethod != null)
             {
-                var declaration = this.outer.memberRefs.GetMethodReference(eventSymbol.ExternalOverriddenRemoveMethod);
+                var declaration = this.outer.memberRefs.GetMethodEntityHandle(
+                    eventSymbol.ExternalOverriddenRemoveMethod,
+                    eventSymbol.ExternalOverrideContainingType);
                 this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, accessors.Remove, declaration);
             }
 
             if (eventSymbol.ExternalOverriddenRaiseMethod != null && accessors.Raise.HasValue)
             {
-                var declaration = this.outer.memberRefs.GetMethodReference(eventSymbol.ExternalOverriddenRaiseMethod);
+                var declaration = this.outer.memberRefs.GetMethodEntityHandle(
+                    eventSymbol.ExternalOverriddenRaiseMethod,
+                    eventSymbol.ExternalOverrideContainingType);
                 this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, accessors.Raise.Value, declaration);
             }
         }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1083,6 +1083,7 @@ internal sealed class ReflectionMetadataEmitter
             this.signatures.EncodeTypeSymbol,
             this.signatures.EncodeReturnSymbol,
             this.memberRefs.GetTypeReference,
+            this.memberRefs.GetTypeHandleForMember,
             this.userTokens.GetUserStructTypeSpec,
             this.userTokens.ResolveConstructedBaseParameterlessCtorToken,
             this.userTokens.ResolveConstructedBaseExplicitCtorToken,
@@ -3337,6 +3338,10 @@ internal sealed class ReflectionMetadataEmitter
             // bridges (e.g. the non-generic IEnumerable.GetEnumerator).
             this.interfaceImpls.EmitExplicitInterfaceMethodImpls(c);
 
+            // Issue #2443: bind overrides to virtual members inherited from an
+            // imported CLR base class (including covariant-return slots).
+            this.interfaceImpls.EmitExternalBaseMethodImpls(c);
+
             // Issue #2362: emit MethodImpl rows for mangled-name explicit
             // interface property implementations (accessor methods).
             this.interfaceImpls.EmitExplicitInterfacePropertyMethodImpls(c);
@@ -3438,6 +3443,8 @@ internal sealed class ReflectionMetadataEmitter
             // Issue #985: emit MethodImpl rows for covariant-return interface
             // bridges declared on a struct that implements `IEnumerable[T]` &c.
             this.interfaceImpls.EmitExplicitInterfaceMethodImpls(s);
+
+            this.interfaceImpls.EmitExternalBaseMethodImpls(s);
 
             // Issue #2362: emit MethodImpl rows for mangled-name explicit
             // interface property implementations (accessor methods).

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1094,6 +1094,7 @@ internal sealed class ReflectionMetadataEmitter
             this.customAttrEncoder.EmitIsReadOnlyAttributeOnParameter,
             this.customAttrEncoder.EmitParamArrayAttributeOnParameter,
             this.memberRefs.GetCtorReference,
+            (ctor, containingType) => this.memberRefs.GetCtorReference(ctor, containingType),
             this.ctorBodies.EmitStaticConstructorBodyBytes,
             this.ctorBodies.EmitClassDefaultConstructorBodyBytes,
             this.ctorBodies.EmitClassPrimaryConstructorBodyBytes,

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -91,6 +91,7 @@ internal sealed class TypeDefEmitter
     private readonly Action<SignatureTypeEncoder, TypeSymbol> encodeTypeSymbol;
     private readonly Action<ReturnTypeEncoder, TypeSymbol, RefKind> encodeReturnSymbol;
     private readonly Func<Type, TypeReferenceHandle> getTypeReference;
+    private readonly Func<Type, EntityHandle> getImportedTypeHandle;
     private readonly Func<StructSymbol, EntityHandle> getUserStructTypeSpec;
     private readonly Func<StructSymbol, EntityHandle> resolveConstructedBaseCtorToken;
     private readonly Func<StructSymbol, ConstructorSymbol, EntityHandle> resolveConstructedBaseExplicitCtorToken;
@@ -115,6 +116,7 @@ internal sealed class TypeDefEmitter
         Action<SignatureTypeEncoder, TypeSymbol> encodeTypeSymbol,
         Action<ReturnTypeEncoder, TypeSymbol, RefKind> encodeReturnSymbol,
         Func<Type, TypeReferenceHandle> getTypeReference,
+        Func<Type, EntityHandle> getImportedTypeHandle,
         Func<StructSymbol, EntityHandle> getUserStructTypeSpec,
         Func<StructSymbol, EntityHandle> resolveConstructedBaseCtorToken,
         Func<StructSymbol, ConstructorSymbol, EntityHandle> resolveConstructedBaseExplicitCtorToken,
@@ -138,6 +140,7 @@ internal sealed class TypeDefEmitter
         this.encodeTypeSymbol = encodeTypeSymbol ?? throw new ArgumentNullException(nameof(encodeTypeSymbol));
         this.encodeReturnSymbol = encodeReturnSymbol ?? throw new ArgumentNullException(nameof(encodeReturnSymbol));
         this.getTypeReference = getTypeReference ?? throw new ArgumentNullException(nameof(getTypeReference));
+        this.getImportedTypeHandle = getImportedTypeHandle ?? throw new ArgumentNullException(nameof(getImportedTypeHandle));
         this.getUserStructTypeSpec = getUserStructTypeSpec ?? throw new ArgumentNullException(nameof(getUserStructTypeSpec));
         this.resolveConstructedBaseCtorToken = resolveConstructedBaseCtorToken ?? throw new ArgumentNullException(nameof(resolveConstructedBaseCtorToken));
         this.resolveConstructedBaseExplicitCtorToken = resolveConstructedBaseExplicitCtorToken ?? throw new ArgumentNullException(nameof(resolveConstructedBaseExplicitCtorToken));
@@ -529,7 +532,7 @@ internal sealed class TypeDefEmitter
                 // Issue #296: the class inherits from an imported CLR base
                 // class; reference it as the TypeDef's base type so the emitted
                 // metadata extends the imported base.
-                baseType = this.getTypeReference(importedBaseClr);
+                baseType = this.getImportedTypeHandle(importedBaseClr);
             }
             else
             {
@@ -705,7 +708,7 @@ internal sealed class TypeDefEmitter
             else if (structSym.ImportedBaseType?.ClrType is Type importedBaseClr)
             {
                 // Issue #296: nested class inheriting an imported CLR base.
-                baseType = this.getTypeReference(importedBaseClr);
+                baseType = this.getImportedTypeHandle(importedBaseClr);
             }
             else
             {
@@ -1849,7 +1852,7 @@ internal sealed class TypeDefEmitter
         new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
             .Parameters(0, r => r.Void(), _ => { });
         return this.emitCtx.Metadata.AddMemberReference(
-            parent: this.getTypeReference(importedBaseClr),
+            parent: this.getImportedTypeHandle(importedBaseClr),
             name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
     }

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -102,6 +102,7 @@ internal sealed class TypeDefEmitter
     private readonly Action<ParameterHandle> emitIsReadOnlyAttributeOnParameter;
     private readonly Action<ParameterHandle> emitParamArrayAttributeOnParameter;
     private readonly Func<ConstructorInfo, MemberReferenceHandle> getCtorReference;
+    private readonly Func<ConstructorInfo, TypeSymbol, MemberReferenceHandle> getCtorReferenceForType;
     private readonly Func<StructSymbol, int> emitStaticConstructorBodyBytes;
     private readonly Func<StructSymbol, EntityHandle, int> emitClassDefaultConstructorBodyBytes;
     private readonly Func<StructSymbol, EntityHandle, int> emitClassPrimaryConstructorBodyBytes;
@@ -127,6 +128,7 @@ internal sealed class TypeDefEmitter
         Action<ParameterHandle> emitIsReadOnlyAttributeOnParameter,
         Action<ParameterHandle> emitParamArrayAttributeOnParameter,
         Func<ConstructorInfo, MemberReferenceHandle> getCtorReference,
+        Func<ConstructorInfo, TypeSymbol, MemberReferenceHandle> getCtorReferenceForType,
         Func<StructSymbol, int> emitStaticConstructorBodyBytes,
         Func<StructSymbol, EntityHandle, int> emitClassDefaultConstructorBodyBytes,
         Func<StructSymbol, EntityHandle, int> emitClassPrimaryConstructorBodyBytes,
@@ -151,6 +153,7 @@ internal sealed class TypeDefEmitter
         this.emitIsReadOnlyAttributeOnParameter = emitIsReadOnlyAttributeOnParameter ?? throw new ArgumentNullException(nameof(emitIsReadOnlyAttributeOnParameter));
         this.emitParamArrayAttributeOnParameter = emitParamArrayAttributeOnParameter ?? throw new ArgumentNullException(nameof(emitParamArrayAttributeOnParameter));
         this.getCtorReference = getCtorReference ?? throw new ArgumentNullException(nameof(getCtorReference));
+        this.getCtorReferenceForType = getCtorReferenceForType ?? throw new ArgumentNullException(nameof(getCtorReferenceForType));
         this.emitStaticConstructorBodyBytes = emitStaticConstructorBodyBytes ?? throw new ArgumentNullException(nameof(emitStaticConstructorBodyBytes));
         this.emitClassDefaultConstructorBodyBytes = emitClassDefaultConstructorBodyBytes ?? throw new ArgumentNullException(nameof(emitClassDefaultConstructorBodyBytes));
         this.emitClassPrimaryConstructorBodyBytes = emitClassPrimaryConstructorBodyBytes ?? throw new ArgumentNullException(nameof(emitClassPrimaryConstructorBodyBytes));
@@ -527,12 +530,12 @@ internal sealed class TypeDefEmitter
             {
                 baseType = baseHandle;
             }
-            else if (structSym.ImportedBaseType?.ClrType is Type importedBaseClr)
+            else if (structSym.ImportedBaseType?.ClrType != null)
             {
                 // Issue #296: the class inherits from an imported CLR base
                 // class; reference it as the TypeDef's base type so the emitted
                 // metadata extends the imported base.
-                baseType = this.getImportedTypeHandle(importedBaseClr);
+                baseType = this.GetImportedBaseTypeHandle(structSym.ImportedBaseType);
             }
             else
             {
@@ -705,10 +708,10 @@ internal sealed class TypeDefEmitter
             {
                 baseType = baseHandle;
             }
-            else if (structSym.ImportedBaseType?.ClrType is Type importedBaseClr)
+            else if (structSym.ImportedBaseType?.ClrType != null)
             {
                 // Issue #296: nested class inheriting an imported CLR base.
-                baseType = this.getImportedTypeHandle(importedBaseClr);
+                baseType = this.GetImportedBaseTypeHandle(structSym.ImportedBaseType);
             }
             else
             {
@@ -1809,10 +1812,32 @@ internal sealed class TypeDefEmitter
         {
             // Issue #296: chain the generated ctor to the imported CLR base's
             // accessible parameterless constructor.
-            return this.GetImportedBaseDefaultCtorReference(importedBaseClr);
+            return this.GetImportedBaseDefaultCtorReference(classSym.ImportedBaseType);
         }
 
         return this.wellKnown.ObjectCtorRef;
+    }
+
+    /// <summary>
+    /// Returns a TypeRef or symbolic TypeSpec for an imported base class.
+    /// </summary>
+    private EntityHandle GetImportedBaseTypeHandle(TypeSymbol importedBaseType)
+    {
+        if (importedBaseType is ImportedTypeSymbol
+            {
+                OpenDefinition: not null,
+                HasSubstitutableTypeArgument: true,
+            })
+        {
+            var signature = new BlobBuilder();
+            this.encodeTypeSymbol(
+                new BlobEncoder(signature).TypeSpecificationSignature(),
+                importedBaseType);
+            return this.emitCtx.Metadata.AddTypeSpecification(
+                this.emitCtx.Metadata.GetOrAddBlob(signature));
+        }
+
+        return this.getImportedTypeHandle(importedBaseType.ClrType);
     }
 
     /// <summary>
@@ -1822,8 +1847,9 @@ internal sealed class TypeDefEmitter
     /// MetadataLoadContext). Falls back to a synthesized parameterless ctor
     /// reference when no explicit parameterless ctor is discoverable.
     /// </summary>
-    private EntityHandle GetImportedBaseDefaultCtorReference(Type importedBaseClr)
+    private EntityHandle GetImportedBaseDefaultCtorReference(TypeSymbol importedBaseType)
     {
+        var importedBaseClr = importedBaseType.ClrType;
         ConstructorInfo parameterless = null;
         foreach (var ctor in importedBaseClr.GetConstructors(
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
@@ -1842,7 +1868,7 @@ internal sealed class TypeDefEmitter
 
         if (parameterless != null)
         {
-            return this.getCtorReference(parameterless);
+            return this.getCtorReferenceForType(parameterless, importedBaseType);
         }
 
         // No explicit accessible parameterless ctor was found; reference a
@@ -1852,7 +1878,7 @@ internal sealed class TypeDefEmitter
         new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
             .Parameters(0, r => r.Void(), _ => { });
         return this.emitCtx.Metadata.AddMemberReference(
-            parent: this.getImportedTypeHandle(importedBaseClr),
+            parent: this.GetImportedBaseTypeHandle(importedBaseType),
             name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
     }
@@ -1862,7 +1888,7 @@ internal sealed class TypeDefEmitter
     {
         if (init.IsClrBase)
         {
-            return this.getCtorReference(init.ClrConstructor);
+            return this.getCtorReferenceForType(init.ClrConstructor, classSym.ImportedBaseType);
         }
 
         var gsharpBase = init.GSharpBaseType;

--- a/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
@@ -88,6 +88,9 @@ public sealed class EventSymbol : Symbol
     /// <summary>Gets or sets the imported CLR raise slot overridden by this event.</summary>
     public MethodInfo ExternalOverriddenRaiseMethod { get; set; }
 
+    /// <summary>Gets or sets the imported constructed base type that owns the overridden event accessors.</summary>
+    public TypeSymbol ExternalOverrideContainingType { get; set; }
+
     /// <summary>Gets or sets the explicit add body syntax (null for field-like events).</summary>
     public Syntax.BlockStatementSyntax AddBodySyntax { get; set; }
 

--- a/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Reflection;
 using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
@@ -77,6 +78,15 @@ public sealed class EventSymbol : Symbol
 
     /// <summary>Gets or sets the synthesized raise method symbol (issue #257). Null when no <c>raise</c> accessor is declared.</summary>
     public FunctionSymbol RaiseMethodSymbol { get; set; }
+
+    /// <summary>Gets or sets the imported CLR add slot overridden by this event.</summary>
+    public MethodInfo ExternalOverriddenAddMethod { get; set; }
+
+    /// <summary>Gets or sets the imported CLR remove slot overridden by this event.</summary>
+    public MethodInfo ExternalOverriddenRemoveMethod { get; set; }
+
+    /// <summary>Gets or sets the imported CLR raise slot overridden by this event.</summary>
+    public MethodInfo ExternalOverriddenRaiseMethod { get; set; }
 
     /// <summary>Gets or sets the explicit add body syntax (null for field-like events).</summary>
     public Syntax.BlockStatementSyntax AddBodySyntax { get; set; }

--- a/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Collections.Immutable;
+using System.Reflection;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Syntax;
 
@@ -206,6 +207,14 @@ public sealed class FunctionSymbol : Symbol
 
     /// <summary>Gets or sets the base method this method overrides. Set by the binder when <see cref="IsOverride"/> is true and a matching open base method is found; <c>null</c> otherwise.</summary>
     public FunctionSymbol OverriddenMethod { get; set; }
+
+    /// <summary>
+    /// Gets or sets the imported CLR virtual method this method overrides.
+    /// The emitter uses this target to write an explicit MethodImpl row, which
+    /// is required for covariant-return overrides and keeps reflection/runtime
+    /// dispatch tied to the external base slot.
+    /// </summary>
+    public MethodInfo ExternalOverriddenMethod { get; set; }
 
     /// <summary>Gets or sets a value indicating whether this function is an extension function (Phase 3.B.6, ADR-0019). When true, the function's first parameter is the receiver and call sites <c>x.Foo(args)</c> bind to <c>Foo(x, args)</c>.</summary>
     public bool IsExtension { get; set; }

--- a/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -216,6 +216,13 @@ public sealed class FunctionSymbol : Symbol
     /// </summary>
     public MethodInfo ExternalOverriddenMethod { get; set; }
 
+    /// <summary>
+    /// Gets or sets the imported constructed base type that owns
+    /// <see cref="ExternalOverriddenMethod"/>. Preserves symbolic generic type
+    /// arguments when the base is inherited as <c>Base[T]</c>.
+    /// </summary>
+    public TypeSymbol ExternalOverrideContainingType { get; set; }
+
     /// <summary>Gets or sets a value indicating whether this function is an extension function (Phase 3.B.6, ADR-0019). When true, the function's first parameter is the receiver and call sites <c>x.Foo(args)</c> bind to <c>Foo(x, args)</c>.</summary>
     public bool IsExtension { get; set; }
 

--- a/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Reflection;
 using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
@@ -106,6 +107,12 @@ public sealed class PropertySymbol : Symbol
 
     /// <summary>Gets or sets the synthesized setter function symbol.</summary>
     public FunctionSymbol SetterSymbol { get; set; }
+
+    /// <summary>Gets or sets the imported CLR getter slot overridden by this property.</summary>
+    public MethodInfo ExternalOverriddenGetter { get; set; }
+
+    /// <summary>Gets or sets the imported CLR setter slot overridden by this property.</summary>
+    public MethodInfo ExternalOverriddenSetter { get; set; }
 
     /// <summary>
     /// Gets a value indicating whether this property is an indexer member

--- a/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
@@ -114,6 +114,9 @@ public sealed class PropertySymbol : Symbol
     /// <summary>Gets or sets the imported CLR setter slot overridden by this property.</summary>
     public MethodInfo ExternalOverriddenSetter { get; set; }
 
+    /// <summary>Gets or sets the imported constructed base type that owns the overridden accessors.</summary>
+    public TypeSymbol ExternalOverrideContainingType { get; set; }
+
     /// <summary>
     /// Gets a value indicating whether this property is an indexer member
     /// (ADR-0118 / issue #944). Indexers are emitted as the CLR default

--- a/test/Compiler.Tests/Emit/Issue2443ExternalClrOverrideEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2443ExternalClrOverrideEmitTests.cs
@@ -1,0 +1,442 @@
+// <copyright file="Issue2443ExternalClrOverrideEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2443: overrides can target virtual members inherited from imported
+/// CLR base classes instead of only members represented by a G# BaseClass.
+/// </summary>
+public sealed class Issue2443ExternalClrOverrideEmitTests
+{
+    private static readonly Lazy<string> ExternalBaseAssembly = new(EmitExternalBaseAssembly);
+
+    [Fact]
+    public void BclObjectOverride_DispatchesAndReflectsBaseSlot()
+    {
+        const string Source = """
+            package Issue2443
+            import System
+
+            class Derived : Object {
+                override func ToString() string -> "derived"
+            }
+
+            func Main() {
+                let value object = Derived()
+                Console.WriteLine(value.ToString())
+            }
+            """;
+
+        var result = Compile(Source, target: "exe");
+        try
+        {
+            Assert.Equal("derived\n", Run(result.OutputPath));
+            IlVerifier.Verify(result.OutputPath);
+
+            var assembly = Assembly.LoadFrom(result.OutputPath);
+            var method = assembly.GetType("Issue2443.Derived")!.GetMethod(
+                "ToString",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!;
+
+            Assert.True(method.IsVirtual);
+            Assert.True(method.IsFinal);
+            Assert.False((method.Attributes & MethodAttributes.NewSlot) != 0);
+            Assert.Equal(typeof(object).GetMethod("ToString"), method.GetBaseDefinition());
+        }
+        finally
+        {
+            result.Dispose();
+        }
+    }
+
+    [Fact]
+    public void SiblingAssemblyOverrides_MethodsPropertiesEventsGenericsAndCovariance_WorkForCSharpConsumer()
+    {
+        const string Source = """
+            package Issue2443
+            import System
+            import Issue2443Base
+
+            open class Derived : ExternalBase[int32] {
+                override func Echo(value int32) string -> "echo:" + value.ToString()
+                override func Identity[U](value U) U -> value
+                override func Covariant() Marker -> Marker()
+                override prop Value int32 { get { return 7 } }
+                override prop this[index int32] int32 { get { return index + 10 } }
+                override event Changed EventHandler {
+                    add { }
+                    remove { }
+                }
+                protected override func ProtectedCore(value int32) int32 -> value + 1
+                override func AbstractName() string -> "abstract"
+            }
+
+            open class AbstractDerived : ExternalBase[int32] {
+                open override func AbstractName() string;
+            }
+            """;
+
+        var result = Compile(Source, target: "library", ExternalBaseAssembly.Value);
+        try
+        {
+            IlVerifier.Verify(result.OutputPath, additionalReferences: new[] { ExternalBaseAssembly.Value });
+
+            var baseAssembly = Assembly.LoadFrom(ExternalBaseAssembly.Value);
+            var derivedAssembly = Assembly.LoadFrom(result.OutputPath);
+            var derived = derivedAssembly.GetType("Issue2443.Derived")!;
+            var closedBase = baseAssembly.GetType("Issue2443Base.ExternalBase`1")!.MakeGenericType(typeof(int));
+
+            AssertOverrideSlot(derived.GetMethod("Echo")!, closedBase.GetMethod("Echo")!);
+            AssertOverrideSlot(derived.GetMethod("Identity")!, closedBase.GetMethod("Identity")!);
+            AssertVirtualReuseSlot(derived.GetMethod("Covariant")!);
+            AssertOverrideSlot(derived.GetProperty("Value")!.GetMethod!, closedBase.GetProperty("Value")!.GetMethod!);
+            AssertOverrideSlot(
+                derived.GetProperty("Item")!.GetMethod!,
+                closedBase.GetProperty("Item")!.GetMethod!);
+            AssertOverrideSlot(
+                derived.GetEvent("Changed")!.AddMethod!,
+                closedBase.GetEvent("Changed")!.AddMethod!);
+
+            Assert.Equal(
+                baseAssembly.GetType("Issue2443Base.Marker"),
+                derived.GetMethod("Covariant")!.ReturnType);
+
+            var abstractDerived = derivedAssembly.GetType("Issue2443.AbstractDerived")!;
+            Assert.True(abstractDerived.IsAbstract);
+            Assert.True(abstractDerived.GetMethod("AbstractName")!.IsAbstract);
+            AssertOverrideSlot(
+                abstractDerived.GetMethod("AbstractName")!,
+                closedBase.GetMethod("AbstractName")!);
+
+            var consumerPath = EmitCSharpConsumer(result.DirectoryPath, result.OutputPath, ExternalBaseAssembly.Value);
+            Assert.Equal("echo:4\nid\nMarker\n7\n13\n5\nabstract\n", Run(consumerPath));
+        }
+        finally
+        {
+            result.Dispose();
+        }
+    }
+
+    [Theory]
+    [InlineData("""
+        package Issue2443
+        import Issue2443Base
+        class Bad : SealedBase {
+            override func ToString() string -> "bad"
+        }
+        """, "GS0184")]
+    [InlineData("""
+        package Issue2443
+        import Issue2443Base
+        class Bad : ExternalBase[int32] {
+            func Echo(value int32) string -> "bad"
+            override func AbstractName() string -> "abstract"
+        }
+        """, "GS0182")]
+    [InlineData("""
+        package Issue2443
+        import Issue2443Base
+        class Bad : ExternalBase[int32] {
+            override func Echo(value string) string -> value
+            override func AbstractName() string -> "abstract"
+        }
+        """, "GS0185")]
+    public void InvalidExternalOverrideShapes_ReportInsteadOfShadowing(string source, string diagnosticId)
+    {
+        var result = TryCompile(source, "library", ExternalBaseAssembly.Value);
+        try
+        {
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.Contains(diagnosticId, result.Stdout + result.Stderr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            result.Dispose();
+        }
+    }
+
+    private static void AssertOverrideSlot(MethodInfo implementation, MethodInfo declaration)
+    {
+        AssertVirtualReuseSlot(implementation);
+        Assert.Equal(declaration.GetBaseDefinition().MetadataToken, implementation.GetBaseDefinition().MetadataToken);
+        Assert.Equal(declaration.GetBaseDefinition().Module, implementation.GetBaseDefinition().Module);
+    }
+
+    private static void AssertVirtualReuseSlot(MethodInfo implementation)
+    {
+        Assert.True(implementation.IsVirtual);
+        Assert.False((implementation.Attributes & MethodAttributes.NewSlot) != 0);
+    }
+
+    private static CompilationResult Compile(string source, string target, params string[] references)
+    {
+        var result = TryCompile(source, target, references);
+        Assert.True(
+            result.ExitCode == 0,
+            $"gsc failed ({result.ExitCode}):\nstdout:\n{result.Stdout}\nstderr:\n{result.Stderr}");
+        return result;
+    }
+
+    private static CompilationResult TryCompile(string source, string target, params string[] references)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue2443_").FullName;
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var assemblyName = "Issue2443Derived_" + Guid.NewGuid().ToString("N");
+        var outputPath = Path.Combine(directory, assemblyName + ".dll");
+        File.WriteAllText(sourcePath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + outputPath,
+            "/assemblyname:" + assemblyName,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+        foreach (var reference in references)
+        {
+            args.Add("/r:" + reference);
+        }
+
+        foreach (var reference in BclReferences.Value)
+        {
+            args.Add("/r:" + reference);
+        }
+
+        args.Add(sourcePath);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        if (File.Exists(ExternalBaseAssembly.Value))
+        {
+            File.Copy(
+                ExternalBaseAssembly.Value,
+                Path.Combine(directory, Path.GetFileName(ExternalBaseAssembly.Value)),
+                overwrite: true);
+        }
+
+        return new CompilationResult(directory, outputPath, exitCode, stdout.ToString(), stderr.ToString());
+    }
+
+    private static string EmitExternalBaseAssembly()
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2443ExternalBase");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "Issue2443Base.dll");
+        const string Source = """
+            using System;
+
+            namespace Issue2443Base;
+
+            public sealed class Marker
+            {
+            }
+
+            public abstract class ExternalBase<T>
+            {
+                public virtual int Value => -1;
+
+                public virtual T this[int index] => default!;
+
+                public virtual event EventHandler Changed
+                {
+                    add { }
+                    remove { }
+                }
+
+                public virtual string Echo(T value) => "base";
+
+                public virtual U Identity<U>(U value) => value;
+
+                public virtual object Covariant() => new object();
+
+                public abstract string AbstractName();
+
+                public int CallProtected(int value) => ProtectedCore(value);
+
+                protected virtual int ProtectedCore(int value) => -1;
+            }
+
+            public class SealedBase
+            {
+                public sealed override string ToString() => "sealed";
+            }
+            """;
+
+        EmitCSharpAssembly(path, "Issue2443Base", Source, OutputKind.DynamicallyLinkedLibrary);
+        return path;
+    }
+
+    private static string EmitCSharpConsumer(string directory, string gsharpAssembly, string baseAssembly)
+    {
+        var outputPath = Path.Combine(directory, "Issue2443Consumer.dll");
+        const string Source = """
+            using System;
+            using Issue2443;
+            using Issue2443Base;
+
+            internal static class Program
+            {
+                private static void Main()
+                {
+                    ExternalBase<int> value = new Derived();
+                    value.Changed += (_, _) => { };
+                    Console.WriteLine(value.Echo(4));
+                    Console.WriteLine(value.Identity("id"));
+                    Console.WriteLine(value.Covariant().GetType().Name);
+                    Console.WriteLine(value.Value);
+                    Console.WriteLine(value[3]);
+                    Console.WriteLine(value.CallProtected(4));
+                    Console.WriteLine(value.AbstractName());
+                }
+            }
+            """;
+
+        EmitCSharpAssembly(
+            outputPath,
+            "Issue2443Consumer",
+            Source,
+            OutputKind.ConsoleApplication,
+            gsharpAssembly,
+            baseAssembly);
+        return outputPath;
+    }
+
+    private static void EmitCSharpAssembly(
+        string outputPath,
+        string assemblyName,
+        string source,
+        OutputKind outputKind,
+        params string[] additionalReferences)
+    {
+        var references = TrustedPlatformReferences()
+            .Concat(additionalReferences.Select(path => MetadataReference.CreateFromFile(path)))
+            .ToArray();
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(outputKind));
+
+        using var peStream = File.Create(outputPath);
+        var emitResult = compilation.Emit(peStream);
+        Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+    }
+
+    private static string Run(string assemblyPath)
+    {
+        var runtimeConfigPath = Path.ChangeExtension(assemblyPath, "runtimeconfig.json");
+        File.WriteAllText(runtimeConfigPath, """
+            {
+              "runtimeOptions": {
+                "tfm": "net10.0",
+                "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+              }
+            }
+            """);
+
+        var startInfo = new ProcessStartInfo("dotnet", "exec \"" + assemblyPath + "\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        using var process = Process.Start(startInfo)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, $"exit {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static IEnumerable<MetadataReference> TrustedPlatformReferences()
+        => ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+            ?.Split(Path.PathSeparator)
+            ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => MetadataReference.CreateFromFile(path));
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDirectory) || !Directory.Exists(runtimeDirectory))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDirectory, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(path =>
+            {
+                var name = Path.GetFileName(path);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToArray();
+    });
+
+    private sealed class CompilationResult : IDisposable
+    {
+        public CompilationResult(
+            string directoryPath,
+            string outputPath,
+            int exitCode,
+            string stdout,
+            string stderr)
+        {
+            DirectoryPath = directoryPath;
+            OutputPath = outputPath;
+            ExitCode = exitCode;
+            Stdout = stdout;
+            Stderr = stderr;
+        }
+
+        public string DirectoryPath { get; }
+
+        public string OutputPath { get; }
+
+        public int ExitCode { get; }
+
+        public string Stdout { get; }
+
+        public string Stderr { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(DirectoryPath, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2443ExternalClrOverrideEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2443ExternalClrOverrideEmitTests.cs
@@ -86,6 +86,11 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
             open class AbstractDerived : ExternalBase[int32] {
                 open override func AbstractName() string;
             }
+
+            open class GenericDerived[T] : ExternalBase[T] {
+                override func Echo(value T) string -> "generic"
+                override func AbstractName() string -> "generic-abstract"
+            }
             """;
 
         var result = Compile(Source, target: "library", ExternalBaseAssembly.Value);
@@ -120,8 +125,16 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
                 abstractDerived.GetMethod("AbstractName")!,
                 closedBase.GetMethod("AbstractName")!);
 
+            var genericDerived = derivedAssembly.GetType("Issue2443.GenericDerived`1")!;
+            Assert.True(genericDerived.BaseType!.IsGenericType);
+            Assert.Equal(
+                genericDerived.GetGenericArguments()[0],
+                genericDerived.BaseType.GetGenericArguments()[0]);
+
             var consumerPath = EmitCSharpConsumer(result.DirectoryPath, result.OutputPath, ExternalBaseAssembly.Value);
-            Assert.Equal("echo:4\nid\nMarker\n7\n13\n5\nabstract\n", Run(consumerPath));
+            Assert.Equal(
+                "echo:4\nid\nMarker\n7\n13\n5\nabstract\ngeneric\ngeneric-abstract\n",
+                Run(consumerPath));
         }
         finally
         {
@@ -315,6 +328,10 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
                     Console.WriteLine(value[3]);
                     Console.WriteLine(value.CallProtected(4));
                     Console.WriteLine(value.AbstractName());
+
+                    ExternalBase<int> generic = new GenericDerived<int>();
+                    Console.WriteLine(generic.Echo(4));
+                    Console.WriteLine(generic.AbstractName());
                 }
             }
             """;

--- a/test/Compiler.Tests/Emit/Issue2443ExternalClrOverrideEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2443ExternalClrOverrideEmitTests.cs
@@ -142,6 +142,39 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
         }
     }
 
+    [Fact]
+    public void MatchingExternalVirtualWithoutOverride_RemainsAnAcceptedShadow()
+    {
+        const string Source = """
+            package Issue2443
+            import Issue2443Base
+
+            class ShadowingDerived : ExternalBase[int32] {
+                func Echo(value int32) string -> "shadow"
+                override func AbstractName() string -> "abstract"
+            }
+            """;
+
+        var result = Compile(Source, target: "library", ExternalBaseAssembly.Value);
+        try
+        {
+            var baseAssembly = Assembly.LoadFrom(ExternalBaseAssembly.Value);
+            var derivedAssembly = Assembly.LoadFrom(result.OutputPath);
+            var derivedType = derivedAssembly.GetType("Issue2443.ShadowingDerived")!;
+            var instance = Activator.CreateInstance(derivedType);
+            var closedBase = baseAssembly.GetType("Issue2443Base.ExternalBase`1")!.MakeGenericType(typeof(int));
+            var shadow = derivedType.GetMethod("Echo", BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!;
+
+            Assert.True((shadow.Attributes & MethodAttributes.NewSlot) != 0);
+            Assert.Equal("shadow", shadow.Invoke(instance, new object[] { 1 }));
+            Assert.Equal("base", closedBase.GetMethod("Echo")!.Invoke(instance, new object[] { 1 }));
+        }
+        finally
+        {
+            result.Dispose();
+        }
+    }
+
     [Theory]
     [InlineData("""
         package Issue2443
@@ -154,19 +187,11 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
         package Issue2443
         import Issue2443Base
         class Bad : ExternalBase[int32] {
-            func Echo(value int32) string -> "bad"
-            override func AbstractName() string -> "abstract"
-        }
-        """, "GS0182")]
-    [InlineData("""
-        package Issue2443
-        import Issue2443Base
-        class Bad : ExternalBase[int32] {
             override func Echo(value string) string -> value
             override func AbstractName() string -> "abstract"
         }
         """, "GS0185")]
-    public void InvalidExternalOverrideShapes_ReportInsteadOfShadowing(string source, string diagnosticId)
+    public void InvalidExplicitExternalOverrideShapes_Report(string source, string diagnosticId)
     {
         var result = TryCompile(source, "library", ExternalBaseAssembly.Value);
         try

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
@@ -464,6 +464,8 @@ public sealed class EventDeclaration : GMember
     /// field-like), so this is only ever set alongside non-null
     /// <paramref name="addBody"/>/<paramref name="removeBody"/>.
     /// </param>
+    /// <param name="isOpen">Whether the event is <c>open</c> (virtual).</param>
+    /// <param name="isOverride">Whether the event is an <c>override</c>.</param>
     public EventDeclaration(
         string name,
         GTypeReference type,
@@ -471,7 +473,9 @@ public sealed class EventDeclaration : GMember
         IReadOnlyList<AttributeUse> attributes = null,
         BlockStatement addBody = null,
         BlockStatement removeBody = null,
-        GTypeReference explicitInterfaceType = null)
+        GTypeReference explicitInterfaceType = null,
+        bool isOpen = false,
+        bool isOverride = false)
     {
         Name = name;
         Type = type;
@@ -480,6 +484,8 @@ public sealed class EventDeclaration : GMember
         AddBody = addBody;
         RemoveBody = removeBody;
         ExplicitInterfaceType = explicitInterfaceType;
+        IsOpen = isOpen;
+        IsOverride = isOverride;
     }
 
     /// <summary>Gets the event name.</summary>
@@ -493,6 +499,12 @@ public sealed class EventDeclaration : GMember
 
     /// <summary>Gets the event attributes.</summary>
     public IReadOnlyList<AttributeUse> Attributes { get; }
+
+    /// <summary>Gets a value indicating whether the event is <c>open</c>.</summary>
+    public bool IsOpen { get; }
+
+    /// <summary>Gets a value indicating whether the event is an <c>override</c>.</summary>
+    public bool IsOverride { get; }
 
     /// <summary>
     /// Gets the explicit <c>add</c> accessor body, or <see langword="null"/> for a

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1410,7 +1410,10 @@ public static class GSharpPrinter
         var explicitClause = declaration.ExplicitInterfaceType != null
             ? $"({RenderType(declaration.ExplicitInterfaceType)}) "
             : string.Empty;
-        var header = $"{RenderAttributeBlock(declaration.Attributes, indent)}{pad}{RenderVisibility(declaration.Visibility)}event {explicitClause}{declaration.Name} {RenderType(declaration.Type)}";
+        var modifiers = declaration.IsOpen
+            ? declaration.IsOverride ? "open override " : "open "
+            : declaration.IsOverride ? "override " : string.Empty;
+        var header = $"{RenderAttributeBlock(declaration.Attributes, indent)}{pad}{RenderVisibility(declaration.Visibility)}{modifiers}event {explicitClause}{declaration.Name} {RenderType(declaration.Type)}";
         if (!declaration.HasExplicitAccessors)
         {
             return header;

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2443ExternalOverrideTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2443ExternalOverrideTranslationTests.cs
@@ -1,0 +1,140 @@
+// <copyright file="Issue2443ExternalOverrideTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2443: cs2gs must preserve overrides whose root declaration comes
+/// from metadata; dropping the modifier silently creates a shadowing member.
+/// </summary>
+public sealed class Issue2443ExternalOverrideTranslationTests
+{
+    [Fact]
+    public void MetadataBaseOverrides_ArePrintedForEverySupportedMemberKind()
+    {
+        const string Source = """
+            using System;
+            using External2443;
+
+            namespace Demo;
+
+            public class Derived : ExternalBase<int>
+            {
+                public override string Echo(int value) => value.ToString();
+
+                public sealed override object Identity(object value) => value;
+
+                public override int Value => 7;
+
+                public override int this[int index] => index;
+
+                public override event EventHandler Changed
+                {
+                    add { }
+                    remove { }
+                }
+            }
+            """;
+
+        string printed = Translate(Source);
+
+        Assert.Contains("override func Echo", printed, StringComparison.Ordinal);
+        Assert.Contains("override func Identity", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("open override func Identity", printed, StringComparison.Ordinal);
+        Assert.Contains("override prop Value", printed, StringComparison.Ordinal);
+        Assert.Contains("override prop this[", printed, StringComparison.Ordinal);
+        Assert.Contains("override event Changed", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BclOverride_IsNotSilentlyLoweredToPlainMethod()
+    {
+        const string Source = """
+            using System;
+            using System.Threading;
+
+            namespace Demo;
+
+            public sealed class Context : SynchronizationContext
+            {
+                public override void Post(SendOrPostCallback callback, object state)
+                {
+                }
+            }
+            """;
+
+        string printed = Translate(Source, includeExternalBase: false);
+        Assert.Contains("override func Post", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n    func Post", printed, StringComparison.Ordinal);
+    }
+
+    private static string Translate(string source, bool includeExternalBase = true)
+    {
+        var references = CSharpProjectLoader.RuntimeReferences().ToList();
+        if (includeExternalBase)
+        {
+            references.Add(BuildExternalBaseReference());
+        }
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Derived.cs", source) },
+            references);
+        Assert.True(
+            project.BoundWithoutErrors,
+            string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        var unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(context.Diagnostics, diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+        return GSharpPrinter.Print(unit);
+    }
+
+    private static MetadataReference BuildExternalBaseReference()
+    {
+        const string Source = """
+            using System;
+
+            namespace External2443;
+
+            public class ExternalBase<T>
+            {
+                public virtual T Value => default!;
+
+                public virtual T this[int index] => default!;
+
+                public virtual event EventHandler Changed
+                {
+                    add { }
+                    remove { }
+                }
+
+                public virtual string Echo(T value) => string.Empty;
+
+                public virtual object Identity(object value) => value;
+            }
+            """;
+
+        var compilation = CSharpCompilation.Create(
+            "External2443",
+            new[] { CSharpSyntaxTree.ParseText(Source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var stream = new MemoryStream();
+        var emitResult = compilation.Emit(stream);
+        Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+        return MetadataReference.CreateFromImage(stream.ToArray());
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -122,7 +122,7 @@ public sealed partial class CSharpToGSharpTranslator
                 accessors = new List<PropertyAccessor>();
             }
 
-            bool isOverride = symbol != null && symbol.IsOverride && !OverridesExternalBaseProperty(symbol);
+            bool isOverride = symbol != null && symbol.IsOverride;
             bool isOpen = this.IsMemberEmittedOpen(symbol, isOverride);
 
             // ADR-0149: see the matching visibility comment in

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -459,7 +459,9 @@ public sealed partial class CSharpToGSharpTranslator
                     SanitizeIdentifier(declarator.Identifier.Text),
                     type,
                     MapVisibility(symbol, this.context, node),
-                    this.MapAttributes(node.AttributeLists));
+                    this.MapAttributes(node.AttributeLists),
+                    isOpen: this.IsMemberEmittedOpen(symbol, symbol?.IsOverride == true),
+                    isOverride: symbol?.IsOverride == true);
 
                 yield return (declaration, symbol != null && symbol.IsStatic);
             }
@@ -577,7 +579,9 @@ public sealed partial class CSharpToGSharpTranslator
                 this.MapAttributes(node.AttributeLists),
                 addBody,
                 removeBody,
-                explicitInterfaceType: explicitInterfaceEventType);
+                explicitInterfaceType: explicitInterfaceEventType,
+                isOpen: this.IsMemberEmittedOpen(symbol, symbol?.IsOverride == true),
+                isOverride: symbol?.IsOverride == true);
 
             return (declaration, symbol != null && symbol.IsStatic);
         }
@@ -639,52 +643,6 @@ public sealed partial class CSharpToGSharpTranslator
         private static bool IsUnsignedIntegerSpecialType(SpecialType type) =>
             type is SpecialType.System_Byte or SpecialType.System_UInt16
                 or SpecialType.System_UInt32 or SpecialType.System_UInt64;
-
-        /// <summary>
-        /// Determines whether a C# method override ultimately overrides a base
-        /// method that is defined outside the translated source (e.g. an
-        /// <see cref="object"/> virtual such as <c>ToString</c>, or a framework
-        /// base like <c>System.IO.Stream.Read</c>). G# does not treat the virtual
-        /// members of metadata (non-source) types as <c>open</c>, so re-declaring
-        /// them must omit the <c>override</c> modifier (OD-T5; otherwise
-        /// GS0183/GS0184). The plain <c>func</c> form binds as the override.
-        /// </summary>
-        private static bool OverridesExternalBaseMethod(IMethodSymbol method)
-        {
-            IMethodSymbol baseMethod = method.OverriddenMethod;
-            if (baseMethod == null)
-            {
-                return false;
-            }
-
-            while (baseMethod.OverriddenMethod != null)
-            {
-                baseMethod = baseMethod.OverriddenMethod;
-            }
-
-            return baseMethod.DeclaringSyntaxReferences.IsEmpty;
-        }
-
-        /// <summary>
-        /// Property counterpart of <see cref="OverridesExternalBaseMethod"/>: a C#
-        /// property override (e.g. <c>Stream.CanRead</c>) whose root base property
-        /// is defined outside the translated source must drop <c>override</c>.
-        /// </summary>
-        private static bool OverridesExternalBaseProperty(IPropertySymbol property)
-        {
-            IPropertySymbol baseProperty = property.OverriddenProperty;
-            if (baseProperty == null)
-            {
-                return false;
-            }
-
-            while (baseProperty.OverriddenProperty != null)
-            {
-                baseProperty = baseProperty.OverriddenProperty;
-            }
-
-            return baseProperty.DeclaringSyntaxReferences.IsEmpty;
-        }
 
         private IEnumerable<(GMember Member, bool IsStatic)> TranslateField(
             FieldDeclarationSyntax field,
@@ -1036,7 +994,7 @@ public sealed partial class CSharpToGSharpTranslator
                 body = this.BuildAsyncVoidHandlerWrapperBody(parameters, body, node.GetLocation());
             }
 
-            bool isOverride = symbol != null && symbol.IsOverride && !OverridesExternalBaseMethod(symbol);
+            bool isOverride = symbol != null && symbol.IsOverride;
 
             // Interface members are implicitly abstract in C#; in canonical G# the
             // members of an `interface` carry no modifier (the `open` keyword is for
@@ -1809,7 +1767,7 @@ public sealed partial class CSharpToGSharpTranslator
                 accessors = new List<PropertyAccessor>();
             }
 
-            bool isOverride = symbol != null && symbol.IsOverride && !OverridesExternalBaseProperty(symbol);
+            bool isOverride = symbol != null && symbol.IsOverride;
 
             // Interface members are implicitly abstract; canonical G# interface
             // members carry no `open` modifier (ADR-0115 §B.6).


### PR DESCRIPTION
## Summary
- resolve explicit method, property/indexer, and event overrides against imported CLR base metadata, including generic methods/bases, protected slots, abstract overrides, and covariant returns
- emit explicit MethodImpl mappings and correct constructed-generic base TypeSpecs so runtime/reflection/C# consumer dispatch reaches G# overrides
- preserve external override modifiers in cs2gs, including events
- retain backward-compatible non-override shadowing for existing G# sources; only explicit override declarations opt into CLR slot binding

## Validation
- Issue1582MetadataBaseInheritedMemberTests: 12 passed
- Issue1584InheritedMemberBareWriteTests: 20 passed
- Issue2335StructConstrainedGenericPatternEmitTests: 9 passed
- Issue2443ExternalClrOverrideEmitTests: 5 passed (explicit dispatch plus accepted non-override shadowing, reflection, C# consumer, ILVerify, negatives)

All targeted runs used MSBUILDDISABLENODEREUSE=1 and ran sequentially.

Fixes #2443