### PR TITLE
Fix dictionary index assignment for source generic arguments

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -802,7 +802,7 @@ internal sealed partial class ExpressionBinder
         BoundExpression target,
         ExpressionSyntax indexSyntax,
         TextLocation targetLocation,
-        BoundExpression systemIndexOverride = null)
+        BoundExpression boundIndexOverride = null)
     {
         // ADR-0122 / issue #1014: pointer indexing `p[i]` == `*(p + i)`.
         if (target.Type is PointerTypeSymbol pointerTarget)
@@ -816,7 +816,7 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
-            var pointerIndex = BindExpression(indexSyntax);
+            var pointerIndex = boundIndexOverride ?? BindExpression(indexSyntax);
             if (pointerIndex is BoundErrorExpression)
             {
                 return pointerIndex;
@@ -824,7 +824,9 @@ internal sealed partial class ExpressionBinder
 
             if (!IsPointerOffsetType(pointerIndex.Type))
             {
-                pointerIndex = conversions.BindConversion(indexSyntax, TypeSymbol.NInt);
+                pointerIndex = boundIndexOverride != null
+                    ? conversions.BindConversion(indexSyntax.Location, pointerIndex, TypeSymbol.NInt)
+                    : conversions.BindConversion(indexSyntax, TypeSymbol.NInt);
             }
 
             var elementPointer = LowerPointerOffset(target, pointerTarget, pointerIndex, subtract: false);
@@ -840,12 +842,13 @@ internal sealed partial class ExpressionBinder
 
         // Issue #1022: a from-end index (`a[^n]`) reads the single element
         // `length - n`.
-        if (systemIndexOverride != null)
+        if (boundIndexOverride != null
+            && ClrTypeUtilities.AreSame(boundIndexOverride.Type?.ClrType, typeof(System.Index)))
         {
-            return BindSystemIndexAccess(target, systemIndexOverride, targetLocation);
+            return BindSystemIndexAccess(target, boundIndexOverride, targetLocation);
         }
 
-        if (indexSyntax is FromEndIndexExpressionSyntax fromEndSyntax)
+        if (boundIndexOverride == null && indexSyntax is FromEndIndexExpressionSyntax fromEndSyntax)
         {
             return BindFromEndIndex(target, fromEndSyntax, targetLocation);
         }
@@ -857,8 +860,10 @@ internal sealed partial class ExpressionBinder
         // expression in the ordinary index paths below to avoid re-binding.
         // `default`/interpolated index syntaxes can never be a range value and
         // keep their dedicated conversion handling, so they are not pre-bound.
-        BoundExpression boundIndex = null;
-        if (indexSyntax is not DefaultExpressionSyntax && indexSyntax is not InterpolatedStringExpressionSyntax)
+        BoundExpression boundIndex = boundIndexOverride;
+        if (boundIndex == null
+            && indexSyntax is not DefaultExpressionSyntax
+            && indexSyntax is not InterpolatedStringExpressionSyntax)
         {
             boundIndex = BindExpression(indexSyntax);
             if (boundIndex is BoundErrorExpression)
@@ -932,21 +937,31 @@ internal sealed partial class ExpressionBinder
         if (target.Type is NullabilityAnnotatedTypeSymbol annotIdx && annotIdx.ClrType is System.Type clrAnnotIdx)
         {
             var idxArgsAnnot = ImmutableArray.Create(BoundIndexArg());
-            if (this.memberLookup.TryResolveClrIndexer(clrAnnotIdx, idxArgsAnnot, out var idxPropAnnot, out var resolvedIdxArgsAnnot))
+            if (this.memberLookup.TryResolveClrIndexer(target.Type, clrAnnotIdx, idxArgsAnnot, out var idxPropAnnot, out var resolvedIdxArgsAnnot))
             {
                 var elemTypeAnnot = annotIdx.GetTypeArgumentSymbolForClrType(idxPropAnnot.PropertyType);
-                return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxPropAnnot, resolvedIdxArgsAnnot, elemTypeAnnot));
+                var convertedIdxArgsAnnot = BindClrIndexerArguments(
+                    target.Type,
+                    idxPropAnnot,
+                    resolvedIdxArgsAnnot,
+                    indexSyntax.Location);
+                return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxPropAnnot, convertedIdxArgsAnnot, elemTypeAnnot));
             }
         }
         else if ((target.Type is ImportedTypeSymbol || target.Type is StructSymbol) && target.Type.ClrType is System.Type clrTarget)
         {
             var idxArgs = ImmutableArray.Create(BoundIndexArg());
-            if (this.memberLookup.TryResolveClrIndexer(clrTarget, idxArgs, out var idxProp, out var resolvedIdxArgs))
+            if (this.memberLookup.TryResolveClrIndexer(target.Type, clrTarget, idxArgs, out var idxProp, out var resolvedIdxArgs))
             {
                 var elementType = target.Type is ImportedTypeSymbol imported
                     ? MapErasedIndexerElementType(imported, idxProp)
                     : ClrNullability.GetPropertyTypeSymbol(idxProp);
-                return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxProp, resolvedIdxArgs, elementType));
+                var convertedIdxArgs = BindClrIndexerArguments(
+                    target.Type,
+                    idxProp,
+                    resolvedIdxArgs,
+                    indexSyntax.Location);
+                return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxProp, convertedIdxArgs, elementType));
             }
         }
 
@@ -1197,18 +1212,43 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
-            BoundExpression sharedSystemIndex = null;
-            if (TryBindSystemIndexValue(indexSyntax, out var boundSystemIndex))
+            BoundExpression sharedIndex = null;
+            if (indexSyntax is FromEndIndexExpressionSyntax)
             {
+                _ = TryBindSystemIndexValue(indexSyntax, out var boundSystemIndex);
                 var indexLocal = DeclareRangeTemp("index", boundSystemIndex.Type, boundSystemIndex, statements);
-                sharedSystemIndex = new BoundVariableExpression(null, indexLocal);
+                sharedIndex = new BoundVariableExpression(null, indexLocal);
             }
 
             var tempRef = new BoundVariableExpression(null, tempVar);
-            var indexRead = BindIndexAgainstTarget(tempRef, indexSyntax, diagnosticLocation, sharedSystemIndex);
+            var indexRead = BindIndexAgainstTarget(tempRef, indexSyntax, diagnosticLocation, sharedIndex);
             if (indexRead is BoundErrorExpression)
             {
                 return indexRead;
+            }
+
+            if (sharedIndex == null
+                && TryCaptureCompoundIndexArgument(ref indexRead, statements, out var capturedIndex))
+            {
+                sharedIndex = capturedIndex;
+            }
+            else if (sharedIndex == null
+                && indexSyntax is not DefaultExpressionSyntax
+                && indexSyntax is not RangeExpressionSyntax)
+            {
+                var boundIndex = BindExpression(indexSyntax);
+                if (boundIndex is BoundErrorExpression)
+                {
+                    return boundIndex;
+                }
+
+                var indexLocal = DeclareRangeTemp("index", boundIndex.Type, boundIndex, statements);
+                sharedIndex = new BoundVariableExpression(null, indexLocal);
+                indexRead = BindIndexAgainstTarget(tempRef, indexSyntax, diagnosticLocation, sharedIndex);
+                if (indexRead is BoundErrorExpression)
+                {
+                    return indexRead;
+                }
             }
 
             var rhsBound = BindExpression(compoundRhsSyntax);
@@ -1238,7 +1278,7 @@ internal sealed partial class ExpressionBinder
                 indexSyntax,
                 combined,
                 diagnosticLocation,
-                sharedSystemIndex);
+                sharedIndex);
         }
         else if (boundValueOverride != null)
         {
@@ -1255,6 +1295,72 @@ internal sealed partial class ExpressionBinder
         }
 
         return new BoundBlockExpression(outerSyntax, statements.ToImmutable(), assignment);
+    }
+
+    private bool TryCaptureCompoundIndexArgument(
+        ref BoundExpression indexRead,
+        ImmutableArray<BoundStatement>.Builder statements,
+        out BoundExpression capturedIndex)
+    {
+        BoundExpression Capture(BoundExpression argument)
+        {
+            var indexLocal = DeclareRangeTemp("index", argument.Type, argument, statements);
+            return new BoundVariableExpression(null, indexLocal);
+        }
+
+        switch (indexRead)
+        {
+            case BoundClrIndexExpression clrIndex when clrIndex.Arguments.Length == 1:
+                capturedIndex = Capture(clrIndex.Arguments[0]);
+                indexRead = new BoundClrIndexExpression(
+                    null,
+                    clrIndex.Target,
+                    clrIndex.Indexer,
+                    ImmutableArray.Create(capturedIndex),
+                    clrIndex.Type);
+                return true;
+
+            case BoundDereferenceExpression { Operand: BoundClrIndexExpression clrRefIndex }
+                when clrRefIndex.Arguments.Length == 1:
+                capturedIndex = Capture(clrRefIndex.Arguments[0]);
+                indexRead = new BoundDereferenceExpression(
+                    null,
+                    new BoundClrIndexExpression(
+                        null,
+                        clrRefIndex.Target,
+                        clrRefIndex.Indexer,
+                        ImmutableArray.Create(capturedIndex),
+                        clrRefIndex.Type));
+                return true;
+
+            case BoundIndexExpression builtInIndex:
+                capturedIndex = Capture(builtInIndex.Index);
+                indexRead = new BoundIndexExpression(
+                    null,
+                    builtInIndex.Target,
+                    capturedIndex,
+                    builtInIndex.Type);
+                return true;
+
+            case BoundUserInstanceCallExpression userIndex when userIndex.Arguments.Length == 1:
+                capturedIndex = Capture(userIndex.Arguments[0]);
+                indexRead = new BoundUserInstanceCallExpression(
+                    null,
+                    userIndex.Receiver,
+                    userIndex.Method,
+                    ImmutableArray.Create(capturedIndex),
+                    userIndex.Type,
+                    userIndex.ConstrainedReceiverTypeParameter,
+                    userIndex.ConstrainedInterfaceType)
+                {
+                    MethodTypeArguments = userIndex.MethodTypeArguments,
+                };
+                return true;
+
+            default:
+                capturedIndex = null;
+                return false;
+        }
     }
 
     private bool TrySplitAtLeftmostNullConditional(
@@ -1306,10 +1412,10 @@ internal sealed partial class ExpressionBinder
         ExpressionSyntax indexSyntax,
         BoundExpression boundValue,
         TextLocation diagnosticLocation,
-        BoundExpression systemIndexOverride = null)
+        BoundExpression boundIndexOverride = null)
     {
         return BindIndexedAssignmentToVariableCore(
-            variable, indexSyntax, valueSyntax: null, boundValueOverride: boundValue, diagnosticLocation, systemIndexOverride);
+            variable, indexSyntax, valueSyntax: null, boundValueOverride: boundValue, diagnosticLocation, boundIndexOverride);
     }
 
     private BoundExpression BindIndexedAssignmentToVariableCore(
@@ -1318,7 +1424,7 @@ internal sealed partial class ExpressionBinder
         ExpressionSyntax valueSyntax,
         BoundExpression boundValueOverride,
         TextLocation diagnosticLocation,
-        BoundExpression systemIndexOverride = null)
+        BoundExpression boundIndexOverride = null)
     {
         BoundExpression BindValue(TypeSymbol elementType)
         {
@@ -1330,15 +1436,30 @@ internal sealed partial class ExpressionBinder
             return conversions.BindConversion(valueSyntax, elementType);
         }
 
-        if (systemIndexOverride != null || TryBindSystemIndexValue(indexSyntax, out systemIndexOverride))
+        if (boundIndexOverride != null
+            && ClrTypeUtilities.AreSame(boundIndexOverride.Type?.ClrType, typeof(System.Index)))
         {
-            return BindSystemIndexAssignment(variable, systemIndexOverride, BindValue, diagnosticLocation);
+            return BindSystemIndexAssignment(variable, boundIndexOverride, BindValue, diagnosticLocation);
         }
+
+        if (boundIndexOverride == null && TryBindSystemIndexValue(indexSyntax, out var systemIndex))
+        {
+            return BindSystemIndexAssignment(variable, systemIndex, BindValue, diagnosticLocation);
+        }
+
+        BoundExpression BindIndexValue() => boundIndexOverride ?? BindExpression(indexSyntax);
+
+        BoundExpression ConvertIndexValue(TypeSymbol targetType) =>
+            boundIndexOverride != null
+                ? conversions.BindConversion(indexSyntax.Location, boundIndexOverride, targetType)
+                : conversions.BindConversion(indexSyntax, targetType);
 
         var element = GetIndexElementType(variable.Type);
         if (element != null)
         {
-            var index = BindArrayElementIndex(indexSyntax);
+            var index = boundIndexOverride != null
+                ? ConvertArrayElementIndex(indexSyntax.Location, boundIndexOverride)
+                : BindArrayElementIndex(indexSyntax);
             var value = BindValue(element);
             return new BoundIndexAssignmentExpression(null, variable, index, value, element);
         }
@@ -1355,7 +1476,7 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
-            var pointerIndex = BindExpression(indexSyntax);
+            var pointerIndex = BindIndexValue();
             if (pointerIndex is BoundErrorExpression)
             {
                 return pointerIndex;
@@ -1363,7 +1484,9 @@ internal sealed partial class ExpressionBinder
 
             if (!IsPointerOffsetType(pointerIndex.Type))
             {
-                pointerIndex = conversions.BindConversion(indexSyntax, TypeSymbol.NInt);
+                pointerIndex = boundIndexOverride != null
+                    ? conversions.BindConversion(indexSyntax.Location, pointerIndex, TypeSymbol.NInt)
+                    : conversions.BindConversion(indexSyntax, TypeSymbol.NInt);
             }
 
             var elementPointer = LowerPointerOffset(new BoundVariableExpression(null, variable), pointerType, pointerIndex, subtract: false);
@@ -1375,7 +1498,7 @@ internal sealed partial class ExpressionBinder
         // value bound to V.
         if (variable.Type is MapTypeSymbol mapType)
         {
-            var keyExpr = conversions.BindConversion(indexSyntax, mapType.KeyType);
+            var keyExpr = ConvertIndexValue(mapType.KeyType);
             var valExpr = BindValue(mapType.ValueType);
             return new BoundIndexAssignmentExpression(null, variable, keyExpr, valExpr, mapType.ValueType);
         }
@@ -1385,8 +1508,8 @@ internal sealed partial class ExpressionBinder
         // Issue #209: honour inner-position nullable flags when present.
         if (variable.Type is NullabilityAnnotatedTypeSymbol annotWr && variable.Type.ClrType is System.Type clrAnnotWr)
         {
-            var idxArgsAnnotWr = ImmutableArray.Create(BindExpression(indexSyntax));
-            if (this.memberLookup.TryResolveClrIndexer(clrAnnotWr, idxArgsAnnotWr, out var idxPropAnnotWr, out var resolvedIdxArgsAnnotWr))
+            var idxArgsAnnotWr = ImmutableArray.Create(BindIndexValue());
+            if (this.memberLookup.TryResolveClrIndexer(variable.Type, clrAnnotWr, idxArgsAnnotWr, out var idxPropAnnotWr, out var resolvedIdxArgsAnnotWr))
             {
                 if (!idxPropAnnotWr.CanWrite)
                 {
@@ -1396,14 +1519,25 @@ internal sealed partial class ExpressionBinder
 
                 var valueTypeAnnotWr = annotWr.GetTypeArgumentSymbolForClrType(idxPropAnnotWr.PropertyType);
                 var boundValueAnnotWr = BindValue(valueTypeAnnotWr);
-                return new BoundClrIndexAssignmentExpression(null, variable, idxPropAnnotWr, resolvedIdxArgsAnnotWr, boundValueAnnotWr, valueTypeAnnotWr);
+                var convertedIdxArgsAnnotWr = BindClrIndexerArguments(
+                    variable.Type,
+                    idxPropAnnotWr,
+                    resolvedIdxArgsAnnotWr,
+                    indexSyntax.Location);
+                return new BoundClrIndexAssignmentExpression(null, variable, idxPropAnnotWr, convertedIdxArgsAnnotWr, boundValueAnnotWr, valueTypeAnnotWr);
             }
         }
         else if ((variable.Type is ImportedTypeSymbol || variable.Type is StructSymbol) && variable.Type.ClrType is System.Type clrTarget)
         {
-            var idxArgs = ImmutableArray.Create(BindExpression(indexSyntax));
-            if (this.memberLookup.TryResolveClrIndexer(clrTarget, idxArgs, out var idxProp, out var resolvedIdxArgs))
+            var idxArgs = ImmutableArray.Create(BindIndexValue());
+            if (this.memberLookup.TryResolveClrIndexer(variable.Type, clrTarget, idxArgs, out var idxProp, out var resolvedIdxArgs))
             {
+                var convertedIdxArgs = BindClrIndexerArguments(
+                    variable.Type,
+                    idxProp,
+                    resolvedIdxArgs,
+                    indexSyntax.Location);
+
                 // ADR-0056 §2: span element write. `Span[T]` has no `set_Item`; its
                 // indexer is a `ref T`-returning getter and writes go through that
                 // managed pointer. Detect the ref-returning getter and store through
@@ -1420,9 +1554,14 @@ internal sealed partial class ExpressionBinder
                             return new BoundErrorExpression(null);
                         }
 
-                        var pointeeType = TypeSymbol.FromClrType(refGetter.ReturnType.GetElementType()!);
+                        var resolvedElementType = variable.Type is ImportedTypeSymbol importedRefReturn
+                            ? MapErasedIndexerElementType(importedRefReturn, idxProp)
+                            : ResolveIndexerElementType(variable.Type, idxProp);
+                        var pointeeType = resolvedElementType is ByRefTypeSymbol byRef
+                            ? byRef.PointeeType
+                            : TypeSymbol.FromClrType(refGetter.ReturnType.GetElementType()!);
                         var refValue = BindValue(pointeeType);
-                        return new BoundClrIndexAssignmentExpression(null, variable, idxProp, resolvedIdxArgs, refValue, pointeeType);
+                        return new BoundClrIndexAssignmentExpression(null, variable, idxProp, convertedIdxArgs, refValue, pointeeType);
                     }
 
                     Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
@@ -1445,7 +1584,7 @@ internal sealed partial class ExpressionBinder
                     ? MapErasedIndexerElementType(imported, idxProp)
                     : ClrNullability.GetPropertyTypeSymbol(idxProp);
                 var boundValue = BindValue(valueType);
-                return new BoundClrIndexAssignmentExpression(null, variable, idxProp, resolvedIdxArgs, boundValue, valueType);
+                return new BoundClrIndexAssignmentExpression(null, variable, idxProp, convertedIdxArgs, boundValue, valueType);
             }
         }
 
@@ -1469,7 +1608,7 @@ internal sealed partial class ExpressionBinder
                 ? Binder.SubstituteType(writeIndexer.Type, writeSubstitution, scope.References.MapClrTypeToReferences)
                 : writeIndexer.Type;
 
-            var indexArg = conversions.BindConversion(indexSyntax, paramType);
+            var indexArg = ConvertIndexValue(paramType);
             var value = BindValue(elementType);
             return new BoundUserInstanceCallExpression(
                 null,
@@ -1499,7 +1638,7 @@ internal sealed partial class ExpressionBinder
                 ? Binder.SubstituteType(writeIfaceIndexer.Type, writeIfaceSubstitution, scope.References.MapClrTypeToReferences)
                 : writeIfaceIndexer.Type;
 
-            var indexArg = conversions.BindConversion(indexSyntax, paramType);
+            var indexArg = ConvertIndexValue(paramType);
             var value = BindValue(elementType);
             return new BoundUserInstanceCallExpression(
                 null,
@@ -1514,6 +1653,22 @@ internal sealed partial class ExpressionBinder
         }
 
         return new BoundErrorExpression(null);
+    }
+
+    private ImmutableArray<BoundExpression> BindClrIndexerArguments(
+        TypeSymbol targetType,
+        PropertyInfo indexer,
+        ImmutableArray<BoundExpression> arguments,
+        TextLocation diagnosticLocation)
+    {
+        var converted = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var parameterType = MemberLookup.GetIndexerParameterTypeSymbol(targetType, indexer, i);
+            converted.Add(conversions.BindConversion(diagnosticLocation, arguments[i], parameterType));
+        }
+
+        return converted.MoveToImmutable();
     }
 
     private static TypeSymbol MapErasedIndexerElementType(ImportedTypeSymbol target, PropertyInfo closedIndexer)
@@ -1537,10 +1692,7 @@ internal sealed partial class ExpressionBinder
         {
             try
             {
-                var openIndexer = ClrTypeUtilities.SafeGetProperty(
-                    openDefinition,
-                    closedIndexer.Name,
-                    BindingFlags.Public | BindingFlags.Instance);
+                var openIndexer = MemberLookup.FindOpenIndexerDefinition(openDefinition, closedIndexer);
                 if (openIndexer?.PropertyType is System.Type openElement)
                 {
                     // ADR-0056 §1/§2: a ref-returning indexer (e.g. `Span[T]`)

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2227,12 +2227,15 @@ internal sealed class MemberLookup
     /// bound the index argument expressions — keeping
     /// <see cref="MemberLookup"/> free of <c>BindExpression</c> side effects.
     /// </summary>
+    /// <param name="targetType">The symbolic receiver type used to recover
+    /// same-compilation generic arguments from the erased CLR shape.</param>
     /// <param name="clrTarget">The CLR receiver type whose indexers to probe.</param>
     /// <param name="boundArguments">The pre-bound index argument expressions.</param>
     /// <param name="indexer">The matching <see cref="PropertyInfo"/>, on success.</param>
     /// <param name="resolvedArguments">The arguments in parameter order, including omitted optional defaults.</param>
     /// <returns><see langword="true"/> when a matching indexer is found.</returns>
     public bool TryResolveClrIndexer(
+        TypeSymbol targetType,
         Type clrTarget,
         ImmutableArray<BoundExpression> boundArguments,
         out PropertyInfo indexer,
@@ -2244,13 +2247,97 @@ internal sealed class MemberLookup
         var properties = ClrTypeUtilities.SafeGetProperties(clrTarget, BindingFlags.Public | BindingFlags.Instance)
             .Where(static property => property.GetMethod != null && property.GetIndexParameters().Length > 0)
             .ToArray();
+        var hasSymbolicArgument = boundArguments.Any(static argument =>
+            argument.Type?.ClrType == null
+            || TypeSymbol.ContainsTypeParameter(argument.Type)
+            || TypeSymbol.ContainsSameCompilationUserType(argument.Type)
+            || argument.Type is ImportedTypeSymbol { HasSubstitutableTypeArgument: true });
+        if (hasSymbolicArgument)
+        {
+            var applicable = new List<(PropertyInfo Property, ImmutableArray<TypeSymbol> ParameterTypes)>();
+            foreach (var property in properties)
+            {
+                var parameters = property.GetIndexParameters();
+                if (parameters.Length != boundArguments.Length)
+                {
+                    continue;
+                }
+
+                var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(parameters.Length);
+                var candidateApplicable = true;
+                for (var i = 0; i < parameters.Length; i++)
+                {
+                    var parameterType = GetIndexerParameterTypeSymbol(targetType, property, i);
+                    parameterTypes.Add(parameterType);
+                    var conversion = ClassifySymbolicIndexerConversion(boundArguments[i].Type, parameterType);
+                    if (!conversion.IsImplicit)
+                    {
+                        candidateApplicable = false;
+                        break;
+                    }
+                }
+
+                if (candidateApplicable)
+                {
+                    applicable.Add((property, parameterTypes.MoveToImmutable()));
+                }
+            }
+
+            if (applicable.Count != 0)
+            {
+                (PropertyInfo Property, ImmutableArray<TypeSymbol> ParameterTypes)? winner = null;
+                foreach (var candidate in applicable)
+                {
+                    var betterThanAll = true;
+                    foreach (var other in applicable)
+                    {
+                        if (ReferenceEquals(candidate.Property, other.Property))
+                        {
+                            continue;
+                        }
+
+                        if (!IsBetterSymbolicIndexerCandidate(candidate.ParameterTypes, other.ParameterTypes, boundArguments))
+                        {
+                            betterThanAll = false;
+                            break;
+                        }
+                    }
+
+                    if (betterThanAll)
+                    {
+                        winner = candidate;
+                        break;
+                    }
+                }
+
+                if (winner.HasValue)
+                {
+                    indexer = winner.Value.Property;
+                    resolvedArguments = boundArguments;
+                    return true;
+                }
+
+                // Do not retry a genuine symbolic ambiguity against the
+                // object-erased CLR shape: doing so can incorrectly prefer an
+                // object overload over a more specific symbolic interface.
+                return false;
+            }
+        }
+
         var argTypes = new Type[boundArguments.Length];
         for (var i = 0; i < boundArguments.Length; i++)
         {
             argTypes[i] = boundArguments[i].Type?.ClrType;
             if (argTypes[i] == null)
             {
-                return false;
+                // Issue #2471: imported generic receivers constructed with a
+                // same-compilation source type use System.Object as the
+                // reflection-time placeholder for that symbolic argument.
+                // Project an index argument with the same not-yet-emitted type
+                // onto that placeholder as well, so overload resolution sees
+                // the erased shape while the original BoundExpression keeps
+                // the real source TypeSymbol for conversion and emit.
+                argTypes[i] = this.binderCtx.References.GetCoreType("System.Object");
             }
         }
 
@@ -2502,6 +2589,253 @@ internal sealed class MemberLookup
     /// alongside <see cref="ClrTypeUtilities.ClearCache"/>.
     /// </summary>
     internal static void ClearCache() => methodsIncludingSelfAndInterfacesCache = new ConditionalWeakTable<Type, System.Collections.Concurrent.ConcurrentDictionary<string, IReadOnlyList<MethodInfo>>>();
+
+    internal static TypeSymbol GetIndexerParameterTypeSymbol(
+        TypeSymbol targetType,
+        PropertyInfo closedIndexer,
+        int parameterIndex)
+    {
+        var closedParameter = closedIndexer.GetIndexParameters()[parameterIndex];
+        if (targetType is ImportedTypeSymbol imported
+            && imported.OpenDefinition is Type openDefinition
+            && !imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            var openIndexer = FindOpenIndexerDefinition(openDefinition, closedIndexer);
+            var openParameters = openIndexer?.GetIndexParameters();
+            if (openParameters != null && parameterIndex < openParameters.Length)
+            {
+                return SubstituteOpenIndexerType(
+                    imported,
+                    openParameters[parameterIndex].ParameterType,
+                    closedParameter.ParameterType);
+            }
+        }
+
+        var closedParameterType = closedParameter.ParameterType;
+        if (closedParameterType.IsConstructedGenericType)
+        {
+            return ImportedTypeSymbol.GetConstructed(
+                closedParameterType,
+                closedParameterType.GetGenericTypeDefinition(),
+                closedParameterType.GetGenericArguments()
+                    .Select(TypeSymbol.FromClrType)
+                    .ToImmutableArray());
+        }
+
+        return ClrNullability.GetParameterTypeSymbol(closedParameter);
+    }
+
+    internal static PropertyInfo FindOpenIndexerDefinition(Type openDefinition, PropertyInfo closedIndexer)
+    {
+        var candidates = ClrTypeUtilities.SafeGetProperties(
+            openDefinition,
+            BindingFlags.Public | BindingFlags.Instance);
+        var token = closedIndexer.MetadataToken;
+        foreach (var candidate in candidates)
+        {
+            if (candidate.MetadataToken == token)
+            {
+                return candidate;
+            }
+        }
+
+        var closedParameters = closedIndexer.GetIndexParameters();
+        foreach (var candidate in candidates)
+        {
+            if (!string.Equals(candidate.Name, closedIndexer.Name, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var openParameters = candidate.GetIndexParameters();
+            if (openParameters.Length != closedParameters.Length)
+            {
+                continue;
+            }
+
+            var matches = true;
+            for (var i = 0; i < openParameters.Length; i++)
+            {
+                var openType = openParameters[i].ParameterType;
+                var closedType = closedParameters[i].ParameterType;
+                if (!openType.IsGenericParameter && !ClrTypeUtilities.AreSame(openType, closedType))
+                {
+                    matches = false;
+                    break;
+                }
+            }
+
+            if (matches)
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    internal static TypeSymbol SubstituteOpenIndexerType(
+        ImportedTypeSymbol target,
+        Type openType,
+        Type closedType)
+    {
+        if (openType.IsGenericParameter
+            && openType.DeclaringMethod == null
+            && openType.GenericParameterPosition < target.TypeArguments.Length)
+        {
+            return target.TypeArguments[openType.GenericParameterPosition];
+        }
+
+        if (openType.IsByRef)
+        {
+            return ByRefTypeSymbol.Get(
+                SubstituteOpenIndexerType(target, openType.GetElementType()!, closedType.GetElementType()!));
+        }
+
+        if (openType.IsArray && openType.GetArrayRank() == 1
+            && closedType.IsArray && closedType.GetArrayRank() == 1)
+        {
+            return SliceTypeSymbol.Get(
+                SubstituteOpenIndexerType(target, openType.GetElementType()!, closedType.GetElementType()!));
+        }
+
+        if (openType.IsGenericType && closedType.IsGenericType)
+        {
+            var openArguments = openType.GetGenericArguments();
+            var closedArguments = closedType.GetGenericArguments();
+            if (openArguments.Length == closedArguments.Length)
+            {
+                var symbolicArguments = ImmutableArray.CreateBuilder<TypeSymbol>(openArguments.Length);
+                for (var i = 0; i < openArguments.Length; i++)
+                {
+                    symbolicArguments.Add(SubstituteOpenIndexerType(target, openArguments[i], closedArguments[i]));
+                }
+
+                return ImportedTypeSymbol.GetConstructed(
+                    closedType,
+                    openType.GetGenericTypeDefinition(),
+                    symbolicArguments.MoveToImmutable());
+            }
+        }
+
+        return TypeSymbol.FromClrType(closedType);
+    }
+
+    private static bool IsBetterSymbolicIndexerCandidate(
+        ImmutableArray<TypeSymbol> candidate,
+        ImmutableArray<TypeSymbol> other,
+        ImmutableArray<BoundExpression> arguments)
+    {
+        var hasBetterConversion = false;
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var source = arguments[i].Type;
+            var candidateConversion = ClassifySymbolicIndexerConversion(source, candidate[i]);
+            var otherConversion = ClassifySymbolicIndexerConversion(source, other[i]);
+            if (candidateConversion.IsIdentity != otherConversion.IsIdentity)
+            {
+                if (!candidateConversion.IsIdentity)
+                {
+                    return false;
+                }
+
+                hasBetterConversion = true;
+                continue;
+            }
+
+            var candidateToOther = ClassifySymbolicIndexerConversion(candidate[i], other[i]).IsImplicit;
+            var otherToCandidate = ClassifySymbolicIndexerConversion(other[i], candidate[i]).IsImplicit;
+            if (candidateToOther == otherToCandidate)
+            {
+                continue;
+            }
+
+            if (!candidateToOther)
+            {
+                return false;
+            }
+
+            hasBetterConversion = true;
+        }
+
+        return hasBetterConversion;
+    }
+
+    private static (bool IsImplicit, bool IsIdentity) ClassifySymbolicIndexerConversion(
+        TypeSymbol source,
+        TypeSymbol target)
+    {
+        if (SameTypeSymbol(source, target))
+        {
+            return (true, true);
+        }
+
+        if (TryClassifyConstructedGenericConversion(source, target, out var constructedImplicit))
+        {
+            return (constructedImplicit, false);
+        }
+
+        var conversion = Conversion.ClassifyNonStructural(source, target);
+        return (conversion.IsImplicit, conversion.IsIdentity);
+    }
+
+    private static bool TryClassifyConstructedGenericConversion(
+        TypeSymbol source,
+        TypeSymbol target,
+        out bool isImplicit)
+    {
+        isImplicit = false;
+        if (source is not ImportedTypeSymbol sourceImported
+            || target is not ImportedTypeSymbol targetImported
+            || sourceImported.OpenDefinition == null
+            || targetImported.OpenDefinition == null
+            || sourceImported.TypeArguments.IsDefaultOrEmpty
+            || targetImported.TypeArguments.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        ImmutableArray<TypeSymbol> sourceArguments;
+        if (ClrTypeUtilities.AreSame(sourceImported.OpenDefinition, targetImported.OpenDefinition))
+        {
+            sourceArguments = sourceImported.TypeArguments;
+        }
+        else if (!TryMapThroughImplemented(sourceImported, targetImported.OpenDefinition, out sourceArguments))
+        {
+            return false;
+        }
+
+        if (sourceArguments.Length != targetImported.TypeArguments.Length)
+        {
+            return true;
+        }
+
+        var genericParameters = targetImported.OpenDefinition.GetGenericArguments();
+        for (var i = 0; i < sourceArguments.Length; i++)
+        {
+            var variance = genericParameters[i].GenericParameterAttributes
+                & GenericParameterAttributes.VarianceMask;
+            var compatible = variance switch
+            {
+                GenericParameterAttributes.Covariant =>
+                    Binder.IsReferenceTypeForConstraint(sourceArguments[i])
+                    && Binder.IsReferenceTypeForConstraint(targetImported.TypeArguments[i])
+                    && ClassifySymbolicIndexerConversion(sourceArguments[i], targetImported.TypeArguments[i]).IsImplicit,
+                GenericParameterAttributes.Contravariant =>
+                    Binder.IsReferenceTypeForConstraint(sourceArguments[i])
+                    && Binder.IsReferenceTypeForConstraint(targetImported.TypeArguments[i])
+                    && ClassifySymbolicIndexerConversion(targetImported.TypeArguments[i], sourceArguments[i]).IsImplicit,
+                _ => SameTypeSymbol(sourceArguments[i], targetImported.TypeArguments[i]),
+            };
+            if (!compatible)
+            {
+                return true;
+            }
+        }
+
+        isImplicit = true;
+        return true;
+    }
 
     /// <summary>
     /// Issue #2375: builds the <see cref="FunctionTypeSymbol"/> shape of a
@@ -2957,6 +3291,39 @@ internal sealed class MemberLookup
         if (a == null || b == null)
         {
             return false;
+        }
+
+        if (a is ImportedTypeSymbol importedA
+            && b is ImportedTypeSymbol importedB
+            && importedA.OpenDefinition != null
+            && importedB.OpenDefinition != null
+            && (!importedA.TypeArguments.IsDefaultOrEmpty || !importedB.TypeArguments.IsDefaultOrEmpty))
+        {
+            if (!ClrTypeUtilities.AreSame(importedA.OpenDefinition, importedB.OpenDefinition)
+                || importedA.TypeArguments.Length != importedB.TypeArguments.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < importedA.TypeArguments.Length; i++)
+            {
+                if (!SameTypeSymbol(importedA.TypeArguments[i], importedB.TypeArguments[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        if (a is SliceTypeSymbol sliceA && b is SliceTypeSymbol sliceB)
+        {
+            return SameTypeSymbol(sliceA.ElementType, sliceB.ElementType);
+        }
+
+        if (a is NullableTypeSymbol nullableA && b is NullableTypeSymbol nullableB)
+        {
+            return SameTypeSymbol(nullableA.UnderlyingType, nullableB.UnderlyingType);
         }
 
         // Constructed user generics are interned (StructSymbol.Construct uses a

--- a/test/Compiler.Tests/Emit/Issue2471DictionaryIndexerSameCompilationTypeTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2471DictionaryIndexerSameCompilationTypeTests.cs
@@ -1,0 +1,684 @@
+// <copyright file="Issue2471DictionaryIndexerSameCompilationTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2471: a CLR indexer on an imported generic type closed over a
+/// same-compilation source type must remain indexable. The original repro used
+/// <c>Dictionary[Key, Value]</c>: ordinary methods such as <c>Add</c> bound,
+/// but <c>cache[key] = value</c> reported GS0116.
+/// </summary>
+public class Issue2471DictionaryIndexerSameCompilationTypeTests
+{
+    private const string CustomIndexerCSharpSource = """
+        using System;
+        using System.Collections.Generic;
+
+        namespace Issue2471.CSharp
+        {
+            public sealed class OverloadedBox<T>
+            {
+                private readonly Dictionary<int, T> values = new();
+
+                public T this[int index]
+                {
+                    get => values[index];
+                    set => values[index] = value;
+                }
+
+                public string this[string name] => "named:" + name;
+
+                public void Put(int index, T value) => values[index] = value;
+            }
+
+            public sealed class RefBox<T>
+            {
+                private readonly T[] values = new T[1];
+
+                public ref T this[int index] => ref values[index];
+
+                public T Read(int index) => values[index];
+            }
+
+            public sealed class GenericKeyBox<T>
+            {
+                public string LastSetter { get; private set; } = "";
+
+                public string this[T key]
+                {
+                    get => "generic";
+                    set => LastSetter = "generic";
+                }
+
+                public string this[object key]
+                {
+                    get => "object";
+                    set => LastSetter = "object";
+                }
+            }
+
+            public sealed class ObjectKeyBox
+            {
+                public string this[object key] => key.GetType().Name;
+            }
+
+            public interface IMarker
+            {
+            }
+
+            public sealed class InterfaceKeyBox
+            {
+                public string this[IMarker key] => "interface";
+
+                public string this[object key] => "object";
+            }
+
+            public sealed class NestedKeyBox<T>
+            {
+                public string this[IEnumerable<T> keys] => "generic";
+
+                public string this[List<object> keys] => "object";
+            }
+
+            public sealed class ArrayKeyBox<T>
+            {
+                public int this[T[] keys] => keys.Length;
+            }
+
+            public sealed class VarianceKeyBox
+            {
+                public string this[IEnumerable<object> keys] => "enumerable";
+
+                public string this[object keys] => "object";
+            }
+
+        }
+        """;
+
+    [Fact]
+    public void DictionaryOfSourceClasses_MethodsAndGetSetIndexers_CompileAndRun()
+    {
+        const string source = """
+            package Issue2471.SourceClasses
+            import System
+            import System.Collections.Generic
+
+            open data class Key2471(Id int32) {}
+            open data class Value2471(Name string) {}
+
+            func Put(cache Dictionary[Key2471, Value2471], key Key2471, value Value2471) {
+                cache.Add(key, Value2471("method-bound"))
+                cache[key] = value
+            }
+
+            let cache = Dictionary[Key2471, Value2471]()
+            let key = Key2471(1)
+            Put(cache, key, Value2471("indexer-bound"))
+            Console.WriteLine(cache[key].Name)
+            """;
+
+        Assert.Equal("indexer-bound\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DictionaryOfSourceStructAndBclValue_GetSetIndexers_CompileAndRun()
+    {
+        const string source = """
+            package Issue2471.SourceStruct
+            import System
+            import System.Collections.Generic
+
+            struct StructKey2471(Id int32) {}
+
+            let cache = Dictionary[StructKey2471, string]()
+            let key = StructKey2471(7)
+            cache.Add(key, "old")
+            cache[key] = "new"
+            Console.WriteLine(cache[key])
+            """;
+
+        Assert.Equal("new\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DictionaryOfSourceInterfaceAndBclStruct_GetSetIndexers_CompileAndRun()
+    {
+        const string source = """
+            package Issue2471.SourceInterface
+            import System
+            import System.Collections.Generic
+
+            interface IKey2471 {
+                func Number() int32;
+            }
+
+            class InterfaceKey2471(NumberValue int32) : IKey2471 {
+                func Number() int32 -> NumberValue
+            }
+
+            let key IKey2471 = InterfaceKey2471(3)
+            let cache = Dictionary[IKey2471, Guid]()
+            let replacement = Guid.Parse("01234567-89ab-cdef-0123-456789abcdef")
+            cache.Add(key, Guid.Empty)
+            cache[key] = replacement
+            Console.WriteLine(cache[key].ToString())
+            """;
+
+        Assert.Equal("01234567-89ab-cdef-0123-456789abcdef\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DictionaryWithNestedImportedGenericValue_GetSetIndexers_CompileAndRun()
+    {
+        const string source = """
+            package Issue2471.Nested
+            import System
+            import System.Collections.Generic
+
+            open data class NestedKey2471(Id int32) {}
+            open data class NestedValue2471(Name string) {}
+
+            let key = NestedKey2471(1)
+            let cache = Dictionary[NestedKey2471, List[NestedValue2471]]()
+            cache.Add(key, List[NestedValue2471]())
+
+            let replacement = List[NestedValue2471]()
+            replacement.Add(NestedValue2471("nested"))
+            cache[key] = replacement
+
+            Console.WriteLine(cache[key][0].Name)
+            """;
+
+        Assert.Equal("nested\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void CompoundAssignment_EvaluatesReceiverIndexAndValueOnce()
+    {
+        const string source = """
+            package Issue2471.SideEffects
+            import System
+            import System.Collections.Generic
+
+            open data class CounterKey2471(Id int32) {}
+
+            class Holder2471(Map Dictionary[CounterKey2471, int32]) {}
+
+            let key = CounterKey2471(1)
+            let cache = Dictionary[CounterKey2471, int32]()
+            cache.Add(key, 10)
+            let holder = Holder2471(cache)
+
+            var receiverCalls = 0
+            var indexCalls = 0
+            var valueCalls = 0
+
+            func GetHolder() Holder2471 {
+                receiverCalls = receiverCalls + 1
+                return holder
+            }
+
+            func GetKey() CounterKey2471 {
+                indexCalls = indexCalls + 1
+                return key
+            }
+
+            func GetValue() int32 {
+                valueCalls = valueCalls + 1
+                return 5
+            }
+
+            GetHolder().Map[GetKey()] += GetValue()
+            Console.WriteLine(cache[key])
+            Console.WriteLine(receiverCalls)
+            Console.WriteLine(indexCalls)
+            Console.WriteLine(valueCalls)
+            """;
+
+        Assert.Equal("15\n1\n1\n1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void CSharpGenericIndexer_OverloadSelection_CompilesAndRuns()
+    {
+        const string gsharpSource = """
+            package Issue2471.CustomIndexers
+            import System
+            import Issue2471.CSharp
+
+            open data class Payload2471(Name string) {}
+
+            let overloaded = OverloadedBox[Payload2471]()
+            overloaded.Put(0, Payload2471("method-bound"))
+            overloaded[0] = Payload2471("setter-bound")
+            Console.WriteLine(overloaded[0].Name)
+            Console.WriteLine(overloaded["key"])
+            """;
+
+        Assert.Equal(
+            "setter-bound\nnamed:key\n",
+            CompileAndRun(gsharpSource, CustomIndexerCSharpSource));
+    }
+
+    [Fact]
+    public void CSharpGenericRefReturnIndexer_GetSet_CompilesAndRuns()
+    {
+        const string gsharpSource = """
+            package Issue2471.RefReturnIndexer
+            import System
+            import Issue2471.CSharp
+
+            open data class Payload2471(Name string) {}
+
+            let byRef = RefBox[Payload2471]()
+            byRef[0] = Payload2471("ref-bound")
+            Console.WriteLine(byRef[0].Name)
+            Console.WriteLine(byRef.Read(0).Name)
+            """;
+
+        Assert.Equal(
+            "ref-bound\nref-bound\n",
+            CompileAndRun(gsharpSource, CustomIndexerCSharpSource));
+    }
+
+    [Fact]
+    public void CSharpGenericIndexer_PrefersSymbolicTypeParameterOverObject()
+    {
+        const string gsharpSource = """
+            package Issue2471.SymbolicOverload
+            import System
+            import Issue2471.CSharp
+
+            open data class Payload2471(Name string) {}
+
+            let key = Payload2471("key")
+            let box = GenericKeyBox[Payload2471]()
+            box[key] = "value"
+            Console.WriteLine(box.LastSetter)
+            Console.WriteLine(box[key])
+            """;
+
+        Assert.Equal(
+            "generic\ngeneric\n",
+            CompileAndRun(gsharpSource, CustomIndexerCSharpSource));
+    }
+
+    [Fact]
+    public void CSharpObjectIndexer_BoxesSourceStructIndex()
+    {
+        const string gsharpSource = """
+            package Issue2471.ObjectIndexer
+            import System
+            import Issue2471.CSharp
+
+            struct ObjectKey2471(Id int32) {}
+
+            let key = ObjectKey2471(1)
+            let box = ObjectKeyBox()
+            Console.WriteLine(box[key])
+            """;
+
+        Assert.Equal(
+            "ObjectKey2471\n",
+            CompileAndRun(gsharpSource, CustomIndexerCSharpSource));
+    }
+
+    [Fact]
+    public void CSharpIndexer_PrefersImplementedInterfaceOverObject()
+    {
+        const string gsharpSource = """
+            package Issue2471.InterfaceOverload
+            import System
+            import Issue2471.CSharp
+
+            class Marker2471() : IMarker {}
+
+            let key = Marker2471()
+            let box = InterfaceKeyBox()
+            Console.WriteLine(box[key])
+            """;
+
+        Assert.Equal(
+            "interface\n",
+            CompileAndRun(gsharpSource, CustomIndexerCSharpSource));
+    }
+
+    [Fact]
+    public void CSharpIndexer_UsesNestedSymbolicArgumentForOverloadResolution()
+    {
+        const string gsharpSource = """
+            package Issue2471.NestedOverload
+            import System
+            import System.Collections.Generic
+            import Issue2471.CSharp
+
+            open data class Payload2471(Name string) {}
+
+            let keys = List[Payload2471]()
+            keys.Add(Payload2471("key"))
+            let box = NestedKeyBox[Payload2471]()
+            Console.WriteLine(box[keys])
+            """;
+
+        Assert.Equal(
+            "generic\n",
+            CompileAndRun(gsharpSource, CustomIndexerCSharpSource));
+    }
+
+    [Fact]
+    public void CSharpGenericArrayIndexer_SubstitutesSourceClassAndStructElements()
+    {
+        const string gsharpSource = """
+            package Issue2471.ArrayIndexer
+            import System
+            import Issue2471.CSharp
+
+            open data class ClassElement2471(Name string) {}
+            struct StructElement2471(Id int32) {}
+
+            let classItems = []ClassElement2471{ClassElement2471("a")}
+            let structItems = []StructElement2471{StructElement2471(1), StructElement2471(2)}
+            let classBox = ArrayKeyBox[ClassElement2471]()
+            let structBox = ArrayKeyBox[StructElement2471]()
+            Console.WriteLine(classBox[classItems])
+            Console.WriteLine(structBox[structItems])
+            """;
+
+        Assert.Equal(
+            "1\n2\n",
+            CompileAndRun(gsharpSource, CustomIndexerCSharpSource));
+    }
+
+    [Fact]
+    public void CSharpIndexer_DoesNotApplyGenericVarianceToSourceStruct()
+    {
+        const string gsharpSource = """
+            package Issue2471.StructVariance
+            import System
+            import System.Collections.Generic
+            import Issue2471.CSharp
+
+            struct StructElement2471(Id int32) {}
+
+            let keys = List[StructElement2471]()
+            keys.Add(StructElement2471(1))
+            let box = VarianceKeyBox()
+            Console.WriteLine(box[keys])
+            """;
+
+        Assert.Equal(
+            "object\n",
+            CompileAndRun(gsharpSource, CustomIndexerCSharpSource));
+    }
+
+    [Fact]
+    public void CompoundAssignment_InterpolatedIndexEvaluatesHolesOnce()
+    {
+        const string source = """
+            package Issue2471.InterpolatedIndex
+            import System
+            import System.Collections.Generic
+
+            let cache = Dictionary[string, int32]()
+            cache.Add("key-1", 10)
+            var calls = 0
+
+            func Next() int32 {
+                calls = calls + 1
+                return calls
+            }
+
+            cache["key-${Next()}"] += 5
+            Console.WriteLine(cache["key-1"])
+            Console.WriteLine(calls)
+            """;
+
+        Assert.Equal("15\n1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EmittedMethodMetadata_PreservesNestedSourceGenericArguments()
+    {
+        const string source = """
+            package Issue2471.Metadata
+            import System.Collections.Generic
+
+            open data class MetadataKey2471(Id int32) {}
+            open data class MetadataValue2471(Name string) {}
+
+            class CacheApi2471 {
+                func Put(
+                    cache Dictionary[MetadataKey2471, List[MetadataValue2471]],
+                    key MetadataKey2471,
+                    values List[MetadataValue2471]) MetadataValue2471 {
+                    cache[key] = values
+                    return cache[key][0]
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var api = assembly.GetType("Issue2471.Metadata.CacheApi2471", throwOnError: true)!;
+        var method = api.GetMethod(
+            "Put",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var parameters = method.GetParameters();
+
+        var dictionaryType = parameters[0].ParameterType;
+        Assert.Equal(typeof(Dictionary<,>), dictionaryType.GetGenericTypeDefinition());
+
+        var dictionaryArguments = dictionaryType.GetGenericArguments();
+        Assert.Equal("MetadataKey2471", dictionaryArguments[0].Name);
+        Assert.Equal(typeof(List<>), dictionaryArguments[1].GetGenericTypeDefinition());
+
+        var valueType = dictionaryArguments[1].GetGenericArguments()[0];
+        Assert.Equal("MetadataValue2471", valueType.Name);
+        Assert.Equal(valueType, parameters[2].ParameterType.GetGenericArguments()[0]);
+        Assert.Equal(valueType, method.ReturnType);
+    }
+
+    [Fact]
+    public void AssignmentToTypeWithoutIndexer_StillReportsGS0116()
+    {
+        const string source = """
+            package Issue2471.NotIndexable
+
+            var value = 1
+            value[0] = 2
+            """;
+
+        var (exitCode, diagnostics) = CompileExpectingFailure(source);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0116", diagnostics);
+        Assert.Contains("not indexable", diagnostics);
+    }
+
+    private static string CompileAndRun(string source, string csharpSource = null)
+    {
+        var workDir = Directory.CreateTempSubdirectory("gs_issue2471_run_").FullName;
+        try
+        {
+            var (exitCode, diagnostics, outPath, references) = Compile(
+                workDir,
+                source,
+                "exe",
+                csharpSource);
+            Assert.True(exitCode == 0, diagnostics);
+
+            IlVerifier.Verify(outPath, additionalReferences: references);
+
+            var runtimeConfig = Path.ChangeExtension(outPath, ".runtimeconfig.json");
+            if (!File.Exists(runtimeConfig))
+            {
+                File.WriteAllText(runtimeConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = workDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(runtimeConfig);
+            psi.ArgumentList.Add(outPath);
+
+            using var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            Assert.True(
+                process.ExitCode == 0,
+                $"dotnet exec failed ({process.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var workDir = Directory.CreateTempSubdirectory("gs_issue2471_metadata_").FullName;
+        try
+        {
+            var (exitCode, diagnostics, outPath, references) = Compile(
+                workDir,
+                source,
+                "library",
+                csharpSource: null);
+            Assert.True(exitCode == 0, diagnostics);
+            IlVerifier.Verify(outPath, additionalReferences: references);
+            return Assembly.Load(File.ReadAllBytes(outPath));
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    private static (int ExitCode, string Diagnostics) CompileExpectingFailure(string source)
+    {
+        var workDir = Directory.CreateTempSubdirectory("gs_issue2471_error_").FullName;
+        try
+        {
+            var (exitCode, diagnostics, _, _) = Compile(
+                workDir,
+                source,
+                "library",
+                csharpSource: null);
+            return (exitCode, diagnostics);
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    private static (int ExitCode, string Diagnostics, string OutPath, string[] References) Compile(
+        string workDir,
+        string source,
+        string target,
+        string csharpSource)
+    {
+        var srcPath = Path.Combine(workDir, "test.gs");
+        var outPath = Path.Combine(workDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var references = csharpSource == null
+            ? Array.Empty<string>()
+            : new[] { EmitCSharpLibrary(workDir, csharpSource) };
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+        foreach (var reference in references)
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        args.Add(srcPath);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(args.ToArray());
+            return (exitCode, stdout.ToString() + stderr, outPath, references);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string EmitCSharpLibrary(string workDir, string source)
+    {
+        var outputPath = Path.Combine(workDir, "Issue2471.CSharp.dll");
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var references = TrustedPlatformAssemblies()
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "Issue2471.CSharp",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return outputPath;
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var value = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        Assert.False(string.IsNullOrWhiteSpace(value));
+        return value!.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- resolve CLR indexers against symbolic same-compilation argument shapes instead of only erased CLR placeholders
- preserve overload specificity, nested generics, variance rules, array parameters, boxing, and generic/ref-return element types
- capture converted compound-assignment indexes so receiver/index/value side effects run once
- add end-to-end runtime, metadata, ILVerify, diagnostic, Dictionary, and custom C# indexer regressions

## Testing
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --no-restore --filter "FullyQualifiedName~Issue2471DictionaryIndexerSameCompilationTypeTests|FullyQualifiedName~Issue674FieldIndexerAssignmentEmitTests.DictionaryField_IndexAssignment_Works|FullyQualifiedName~Issue507MemberIndexAssignmentEmitTests|FullyQualifiedName~Issue418IndexerEmitTests|FullyQualifiedName~Issue968|FullyQualifiedName~Issue1927VarianceConversionAndStringConcatTests" -v:minimal` (40 passed)
- `dotnet build GSharp.sln --no-incremental -m:1 -v:minimal`

Fixes #2471