### PR TITLE
gsc: support lifted generic same-compilation user-defined operators

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundClrBinaryOperatorExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrBinaryOperatorExpression.cs
@@ -37,16 +37,36 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 public sealed class BoundClrBinaryOperatorExpression : BoundExpression
 {
     public BoundClrBinaryOperatorExpression(SyntaxNode syntax, SyntaxKind operatorKind, BoundExpression left, BoundExpression right, MethodInfo method, TypeSymbol resultType)
-        : this(syntax, operatorKind, left, right, method, null, resultType)
+        : this(syntax, operatorKind, left, right, method, null, null, resultType)
     {
     }
 
     public BoundClrBinaryOperatorExpression(SyntaxNode syntax, SyntaxKind operatorKind, BoundExpression left, BoundExpression right, Symbols.FunctionSymbol function, TypeSymbol resultType)
-        : this(syntax, operatorKind, left, right, null, function, resultType)
+        : this(syntax, operatorKind, left, right, function, function?.StaticOwnerType as StructSymbol, resultType)
     {
     }
 
-    private BoundClrBinaryOperatorExpression(SyntaxNode syntax, SyntaxKind operatorKind, BoundExpression left, BoundExpression right, MethodInfo method, Symbols.FunctionSymbol function, TypeSymbol resultType)
+    public BoundClrBinaryOperatorExpression(
+        SyntaxNode syntax,
+        SyntaxKind operatorKind,
+        BoundExpression left,
+        BoundExpression right,
+        Symbols.FunctionSymbol function,
+        StructSymbol functionOwnerType,
+        TypeSymbol resultType)
+        : this(syntax, operatorKind, left, right, null, function, functionOwnerType, resultType)
+    {
+    }
+
+    private BoundClrBinaryOperatorExpression(
+        SyntaxNode syntax,
+        SyntaxKind operatorKind,
+        BoundExpression left,
+        BoundExpression right,
+        MethodInfo method,
+        Symbols.FunctionSymbol function,
+        StructSymbol functionOwnerType,
+        TypeSymbol resultType)
         : base(syntax)
     {
         OperatorKind = operatorKind;
@@ -54,6 +74,7 @@ public sealed class BoundClrBinaryOperatorExpression : BoundExpression
         Right = right;
         Method = method;
         Function = function;
+        FunctionOwnerType = functionOwnerType;
         Type = resultType;
     }
 
@@ -73,6 +94,14 @@ public sealed class BoundClrBinaryOperatorExpression : BoundExpression
     /// (imported-CLR-type or non-nullable Stream D) shape.
     /// </summary>
     public Symbols.FunctionSymbol Function { get; }
+
+    /// <summary>
+    /// Gets the same-compilation operator's declaring type in the call-site
+    /// construction (issue #2400), or <see langword="null"/> for imported CLR
+    /// operators. The emitter uses this to parent calls on a closed generic
+    /// TypeSpec rather than the open declaring TypeDef.
+    /// </summary>
+    public StructSymbol FunctionOwnerType { get; }
 
     public override TypeSymbol Type { get; }
 

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1712,7 +1712,7 @@ public abstract class BoundTreeRewriter
         // Function (nullable-lifted same-compilation struct operator) the
         // original node carried — exactly one is non-null.
         return node.Function != null
-            ? new BoundClrBinaryOperatorExpression(null, node.OperatorKind, left, right, node.Function, node.Type)
+            ? new BoundClrBinaryOperatorExpression(null, node.OperatorKind, left, right, node.Function, node.FunctionOwnerType, node.Type)
             : new BoundClrBinaryOperatorExpression(null, node.OperatorKind, left, right, node.Method, node.Type);
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -1573,13 +1573,18 @@ internal sealed partial class ExpressionBinder
                 : right.Type as StructSymbol;
 
             FunctionSymbol userOp = null;
-            if (leftStructType != null && TypeMemberModel.TryGetStaticMethodIncludingInherited(leftStructType, userOpName, out var leftOp))
+            StructSymbol userOpOwner = null;
+            if (leftStructType != null
+                && TypeMemberModel.TryGetStaticMethodIncludingInherited(leftStructType, userOpName, out var leftOp, out var leftOwner))
             {
                 userOp = leftOp;
+                userOpOwner = leftOwner;
             }
-            else if (rightStructType != null && TypeMemberModel.TryGetStaticMethodIncludingInherited(rightStructType, userOpName, out var rightOp))
+            else if (rightStructType != null
+                && TypeMemberModel.TryGetStaticMethodIncludingInherited(rightStructType, userOpName, out var rightOp, out var rightOwner))
             {
                 userOp = rightOp;
+                userOpOwner = rightOwner;
             }
             else if (left.Type != null && scope.TryLookupExtensionFunction(left.Type, userOpName, out var leftExt))
             {
@@ -1592,14 +1597,38 @@ internal sealed partial class ExpressionBinder
 
             if (userOp != null && userOp.Parameters.Length == 2)
             {
-                if (TryLiftNullableClrOperatorOperands(opKind, ref left, ref right, leftLocation, rightLocation, userOp.Type, out var liftedResultType))
+                // Issue #2400: StaticMethods on a constructed generic struct
+                // intentionally expose the definition's FunctionSymbol. Close
+                // its parameter/result types in the declaring construction so
+                // overload applicability and the bound call use Box[int32],
+                // not the open Box[T] signature.
+                var leftParameterType = userOpOwner?.SubstituteMemberType(userOp.Parameters[0].Type)
+                    ?? userOp.Parameters[0].Type;
+                var rightParameterType = userOpOwner?.SubstituteMemberType(userOp.Parameters[1].Type)
+                    ?? userOp.Parameters[1].Type;
+                var resultType = userOpOwner?.SubstituteMemberType(userOp.Type) ?? userOp.Type;
+
+                if (CanApplyLiftedUserOperator(left.Type, leftParameterType)
+                    && CanApplyLiftedUserOperator(right.Type, rightParameterType)
+                    && TryLiftNullableClrOperatorOperands(opKind, ref left, ref right, leftLocation, rightLocation, resultType, out var liftedResultType))
                 {
-                    return new BoundClrBinaryOperatorExpression(null, opKind, left, right, userOp, liftedResultType);
+                    return new BoundClrBinaryOperatorExpression(null, opKind, left, right, userOp, userOpOwner, liftedResultType);
                 }
 
-                var convertedLeft = conversions.BindConversion(leftLocation, left, userOp.Parameters[0].Type);
-                var convertedRight = conversions.BindConversion(rightLocation, right, userOp.Parameters[1].Type);
-                return new BoundCallExpression(null, userOp, ImmutableArray.Create(convertedLeft, convertedRight));
+                var convertedLeft = conversions.BindConversion(leftLocation, left, leftParameterType);
+                var convertedRight = conversions.BindConversion(rightLocation, right, rightParameterType);
+                return new BoundCallExpression(
+                    null,
+                    userOp,
+                    ImmutableArray.Create(convertedLeft, convertedRight),
+                    resultType)
+                {
+                    StaticGenericOwnerType = userOpOwner != null
+                        && (!userOpOwner.TypeArguments.IsDefaultOrEmpty
+                            || !(userOpOwner.Definition ?? userOpOwner).TypeParameters.IsDefaultOrEmpty)
+                        ? userOpOwner
+                        : null,
+                };
             }
         }
 
@@ -1639,6 +1668,15 @@ internal sealed partial class ExpressionBinder
         }
 
         return null;
+    }
+
+    private static bool CanApplyLiftedUserOperator(TypeSymbol operandType, TypeSymbol parameterType)
+    {
+        var underlyingOperand = operandType is NullableTypeSymbol nullable
+            ? nullable.UnderlyingType
+            : operandType;
+        var conversion = Conversion.Classify(underlyingOperand, parameterType);
+        return conversion.Exists && conversion.IsImplicit;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -1743,21 +1743,6 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
-        // Arithmetic / bitwise: produces Nullable<R>. The same-compilation
-        // Function-carrying case has no runtime CLR Type for the result
-        // underlying, so constructing Nullable<R> symbolically (mirroring
-        // GetNullableCtorMemberRefForUserValueType) is deferred — reported
-        // as a known limitation. Imported-CLR arithmetic operators
-        // (op.Method, e.g. DateTime.op_Subtraction) are fully supported.
-        if (op.Function != null)
-        {
-            throw new NotSupportedException(
-                $"Lifted same-compilation arithmetic/bitwise operator '{op.OperatorKind}' on "
-                + $"'{op.Function.Name}' is not yet supported (issue #2388 scoped equality/ordering "
-                + "lifting; symbolic Nullable<R> construction for a same-compilation result type is "
-                + "deferred follow-up work).");
-        }
-
         this.EmitLiftedClrArithmetic(op, lhsSlot, rhsSlot, slots.ResultSlot, leftNullable, rightNullable);
     }
 
@@ -1830,18 +1815,14 @@ internal sealed partial class MethodBodyEmitter
         var getHasValueLhs = this.GetNullableHasValueRef(leftNullable);
         var getHasValueRhs = this.GetNullableHasValueRef(rightNullable);
 
-        var resultUnderlyingClr = op.Method.ReturnType;
-        if (!NullableLifting.TryConstructNullable(this.outer.emitCtx.References, resultUnderlyingClr, out var nullableClr))
+        if (op.Type is not NullableTypeSymbol resultNullable)
         {
             throw new InvalidOperationException(
-                $"Cannot construct Nullable<{resultUnderlyingClr.FullName}>: System.Nullable`1 is not resolvable in the reference set.");
+                $"Lifted CLR/user binary operator '{op.OperatorKind}' must produce a nullable result.");
         }
 
-        var nullableInnerArg = nullableClr.GetGenericArguments()[0];
-        var ctor = nullableClr.GetConstructor(new[] { nullableInnerArg })
-            ?? throw new InvalidOperationException(
-                $"Nullable<{nullableInnerArg.FullName}> has no single-arg constructor.");
-        var nullableToken = this.outer.memberRefs.GetTypeHandleForMember(nullableClr);
+        var nullableToken = this.outer.memberRefs.GetElementTypeToken(resultNullable);
+        var nullableCtor = this.GetNullableResultConstructor(resultNullable);
 
         var nullBranch = this.il.DefineLabel();
         var end = this.il.DefineLabel();
@@ -1859,7 +1840,7 @@ internal sealed partial class MethodBodyEmitter
         this.EmitUnwrappedNullableValue(rhsSlot, rightNullable);
         this.EmitCallResolvedClrOrFunctionOperator(op);
         this.il.OpCode(ILOpCode.Newobj);
-        this.il.Token(this.outer.memberRefs.GetCtorReference(ctor));
+        this.il.Token(nullableCtor);
         this.il.Branch(ILOpCode.Br, end);
 
         this.il.MarkLabel(nullBranch);
@@ -1869,6 +1850,35 @@ internal sealed partial class MethodBodyEmitter
         this.il.LoadLocal(resultSlot);
 
         this.il.MarkLabel(end);
+    }
+
+    private EntityHandle GetNullableResultConstructor(NullableTypeSymbol nullable)
+    {
+        if (NullableLifting.IsUserValueTypeNullable(nullable))
+        {
+            return this.outer.memberRefs.GetNullableCtorMemberRefForUserValueType(nullable);
+        }
+
+        if (nullable.UnderlyingType is TypeParameterSymbol typeParameter
+            && typeParameter.HasValueTypeConstraint)
+        {
+            return this.outer.memberRefs.GetNullableCtorMemberRefForOpenTypeParameter(nullable);
+        }
+
+        var resultUnderlyingClr = nullable.UnderlyingType?.ClrType
+            ?? throw new InvalidOperationException(
+                $"Lifted operator result '{nullable.UnderlyingType?.Name}' has no runtime or symbolic value-type representation.");
+        if (!NullableLifting.TryConstructNullable(this.outer.emitCtx.References, resultUnderlyingClr, out var nullableClr))
+        {
+            throw new InvalidOperationException(
+                $"Cannot construct Nullable<{resultUnderlyingClr.FullName}>: System.Nullable`1 is not resolvable in the reference set.");
+        }
+
+        var nullableInnerArg = nullableClr.GetGenericArguments()[0];
+        var ctor = nullableClr.GetConstructor(new[] { nullableInnerArg })
+            ?? throw new InvalidOperationException(
+                $"Nullable<{nullableInnerArg.FullName}> has no single-arg constructor.");
+        return this.outer.memberRefs.GetCtorReference(ctor);
     }
 
     // Issue #2388: HasValue/Value accessors on Nullable<T> need different
@@ -1904,18 +1914,29 @@ internal sealed partial class MethodBodyEmitter
     // operator, e.g. Meters.op_Equality) via the ordinary
     // FunctionHandles/MethodHandles cache — mirroring the two-cache
     // fallback used by every other same-compilation call site
-    // (EmitFunctionPointerFromMethod, BoundCallExpression emission).
-    // Generic same-compilation operator functions are out of scope for
-    // this lifted path (deferred follow-up).
+    // (EmitFunctionPointerFromMethod, BoundCallExpression emission). Issue
+    // #2400 additionally routes a closed generic FunctionOwnerType through a
+    // TypeSpec-parented MemberRef instead of calling the open MethodDef.
     private void EmitCallResolvedClrOrFunctionOperator(BoundClrBinaryOperatorExpression op)
     {
         if (op.Function != null)
         {
-            if (!this.outer.cache.FunctionHandles.TryGetValue(op.Function, out var fnHandle)
-                && !this.outer.cache.MethodHandles.TryGetValue(op.Function, out fnHandle))
+            EntityHandle fnHandle;
+            if (op.FunctionOwnerType != null
+                && ReflectionMetadataEmitter.IsUserGenericTypeReference(op.FunctionOwnerType))
             {
-                throw new InvalidOperationException(
-                    $"Lifted same-compilation operator '{op.Function.Name}' has no emitted MethodDef.");
+                fnHandle = this.outer.userTokens.ResolveUserStaticMethodToken(op.FunctionOwnerType, op.Function);
+            }
+            else
+            {
+                if (!this.outer.cache.FunctionHandles.TryGetValue(op.Function, out var definitionHandle)
+                    && !this.outer.cache.MethodHandles.TryGetValue(op.Function, out definitionHandle))
+                {
+                    throw new InvalidOperationException(
+                        $"Lifted same-compilation operator '{op.Function.Name}' has no emitted MethodDef.");
+                }
+
+                fnHandle = definitionHandle;
             }
 
             if (op.Function.IsGeneric && !op.Function.TypeParameters.IsDefaultOrEmpty)

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -1421,18 +1421,57 @@ public sealed partial class Evaluator
 
     private object EvaluateClrBinaryOperatorExpression(BoundClrBinaryOperatorExpression node)
     {
-        // Issue #2388: the nullable-lifted same-compilation struct operator
-        // shape (Function set, Method null) needs the same HasValue-branch
-        // lifting semantics as the IL emitter's EmitLiftedNullableClrBinary;
-        // the tree-walking interpreter does not implement that lifting, so
-        // fail loudly rather than silently invoking the unlifted operator on
-        // a boxed Nullable<T>. The compiled (gsc-emitted) path is unaffected
-        // — this only affects direct BoundTree interpretation via Evaluator.
         if (node.Function != null)
         {
-            throw new NotSupportedException(
-                "Evaluator: nullable-lifted same-compilation user operator calls (issue #2388) are not supported by "
-                + "the tree-walking interpreter; compile and run instead.");
+            var leftValue = EvaluateExpression(node.Left);
+            var rightValue = EvaluateExpression(node.Right);
+            var leftPresent = leftValue != null;
+            var rightPresent = rightValue != null;
+
+            if (node.OperatorKind == SyntaxKind.EqualsEqualsToken)
+            {
+                if (leftPresent != rightPresent)
+                {
+                    return false;
+                }
+
+                if (!leftPresent)
+                {
+                    return true;
+                }
+            }
+            else if (node.OperatorKind == SyntaxKind.BangEqualsToken)
+            {
+                if (leftPresent != rightPresent)
+                {
+                    return true;
+                }
+
+                if (!leftPresent)
+                {
+                    return false;
+                }
+            }
+            else if (!leftPresent || !rightPresent)
+            {
+                if (node.OperatorKind is SyntaxKind.LessToken
+                    or SyntaxKind.LessOrEqualsToken
+                    or SyntaxKind.GreaterToken
+                    or SyntaxKind.GreaterOrEqualsToken)
+                {
+                    return false;
+                }
+
+                return null;
+            }
+
+            var locals = new ConcurrentDictionary<VariableSymbol, object>();
+            locals[node.Function.Parameters[0]] = leftValue;
+            locals[node.Function.Parameters[1]] = rightValue;
+            using (PushFrame(locals))
+            {
+                return EvaluateFunctionBody(program.Functions[node.Function]);
+            }
         }
 
         var left = EvaluateExpression(node.Left);

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -510,7 +510,7 @@ public static class SpillSequenceSpiller
                         clrBinary.Left,
                         clrBinary.Right,
                         (l, r) => clrBinary.Function != null
-                            ? new BoundClrBinaryOperatorExpression(null, clrBinary.OperatorKind, l, r, clrBinary.Function, clrBinary.Type)
+                            ? new BoundClrBinaryOperatorExpression(null, clrBinary.OperatorKind, l, r, clrBinary.Function, clrBinary.FunctionOwnerType, clrBinary.Type)
                             : new BoundClrBinaryOperatorExpression(null, clrBinary.OperatorKind, l, r, clrBinary.Method, clrBinary.Type));
                 case BoundClrUnaryOperatorExpression clrUnary:
                     return SpillOneOperand(

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -1627,6 +1627,22 @@ public sealed class StructSymbol : TypeSymbol
         ConstructedNestedGenericCache.Clear();
     }
 
+    /// <summary>
+    /// Substitutes this constructed type's arguments through a member type
+    /// declared on its generic definition.
+    /// </summary>
+    /// <param name="type">The open member type to close.</param>
+    /// <returns>The member type in this construction's context.</returns>
+    internal TypeSymbol SubstituteMemberType(TypeSymbol type)
+    {
+        if (type == null || Definition == null || ReferenceEquals(Definition, this))
+        {
+            return type;
+        }
+
+        return SubstituteTypeForConstruction(type, GetSubstitutionMap(), mapClrType);
+    }
+
     private static TypeArgsKey BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments) => new(typeArguments);
 
     private static TypeSymbol EnclosingTypeOf(TypeSymbol type) => type switch

--- a/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
@@ -494,6 +494,22 @@ public static class TypeMemberModel
     /// <param name="method">The found method on success.</param>
     /// <returns>True if found.</returns>
     public static bool TryGetStaticMethodIncludingInherited(TypeSymbol type, string name, out FunctionSymbol method)
+        => TryGetStaticMethodIncludingInherited(type, name, out method, out _);
+
+    /// <summary>
+    /// Tries to find the first static method named <paramref name="name"/> and
+    /// returns the constructed type level that supplied it.
+    /// </summary>
+    /// <param name="type">The type to resolve against.</param>
+    /// <param name="name">The method name.</param>
+    /// <param name="method">The found method on success.</param>
+    /// <param name="declaringType">The matching type level in the receiver's constructed base chain.</param>
+    /// <returns>True if found.</returns>
+    public static bool TryGetStaticMethodIncludingInherited(
+        TypeSymbol type,
+        string name,
+        out FunctionSymbol method,
+        out StructSymbol declaringType)
     {
         if (type is StructSymbol structSymbol)
         {
@@ -501,12 +517,14 @@ public static class TypeMemberModel
             {
                 if (c.TryGetStaticMethod(name, out method))
                 {
+                    declaringType = c;
                     return true;
                 }
             }
         }
 
         method = null;
+        declaringType = null;
         return false;
     }
 

--- a/test/Compiler.Tests/Emit/Issue2388NullableCustomEqualityEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2388NullableCustomEqualityEmitTests.cs
@@ -231,6 +231,85 @@ public class Issue2388NullableCustomEqualityEmitTests
     }
 
     [Fact]
+    public void ClosedGenericSameCompilationStruct_LiftedComparison_RunsAndVerifies()
+    {
+        var source = """
+            package GenericComparisonPkg
+
+            struct Box[T] {
+                var Value T
+                var Rank int32
+            }
+
+            func (left Box[T]) operator ==(right Box[T]) bool -> left.Rank == right.Rank
+            func (left Box[T]) operator <(right Box[T]) bool -> left.Rank < right.Rank
+
+            let low Box[string]? = Box[string]{Value: "low", Rank: 1}
+            let same Box[string]? = Box[string]{Value: "same", Rank: 1}
+            let high Box[string]? = Box[string]{Value: "high", Rank: 2}
+            let missing Box[string]? = nil
+
+            Console.WriteLine(low == same)
+            Console.WriteLine(low == missing)
+            Console.WriteLine(missing == missing)
+            Console.WriteLine(low < high)
+            Console.WriteLine(low < missing)
+            """;
+
+        Assert.Equal("True\nFalse\nTrue\nTrue\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ClosedGenericSameCompilationStruct_LiftedArithmeticReturningPrimitive_RunsAndVerifies()
+    {
+        var source = """
+            package GenericPrimitiveArithmeticPkg
+
+            struct Box[T] {
+                var Value T
+                var Rank int32
+            }
+
+            func (left Box[T]) operator +(right Box[T]) int32 -> left.Rank + right.Rank
+
+            let left Box[string]? = Box[string]{Value: "left", Rank: 20}
+            let right Box[string]? = Box[string]{Value: "right", Rank: 22}
+            let missing Box[string]? = nil
+            Console.WriteLine((left + right)!!)
+            Console.WriteLine(left!! + right!!)
+            Console.WriteLine(left + missing == nil)
+            """;
+
+        Assert.Equal("42\n42\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ClosedGenericSameCompilationStruct_LiftedArithmeticReturningGenericStruct_RunsAndVerifies()
+    {
+        var source = """
+            package GenericStructArithmeticPkg
+
+            struct Box[T] {
+                var Value T
+                var Rank int32
+            }
+
+            func (left Box[T]) operator +(right Box[T]) Box[T] {
+                return Box[T]{Value: left.Value, Rank: left.Rank + right.Rank}
+            }
+
+            let left Box[string]? = Box[string]{Value: "kept", Rank: 20}
+            let right Box[string]? = Box[string]{Value: "ignored", Rank: 22}
+            let missing Box[string]? = nil
+            Console.WriteLine((left + right)!!.Value)
+            Console.WriteLine((left + right)!!.Rank)
+            Console.WriteLine(left + missing == nil)
+            """;
+
+        Assert.Equal("kept\n42\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
     public void SameCompilationStruct_WithoutUserOperator_NullableEquality_StillReportsGS0129()
     {
         var (exitCode, stdout, _) = TryCompile("""

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2388NullableCustomEqualityBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2388NullableCustomEqualityBinderTests.cs
@@ -28,11 +28,10 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// lifts them) while a same-compilation struct WITHOUT a user operator still
 /// correctly reports GS0129 (proving the fix does not make every value type
 /// universally nullable-comparable). Method bodies are bound but never
-/// invoked — this is pure binder coverage, independent of the tree-walking
-/// Evaluator (which does not implement nullable-lifting semantics for the
-/// same-compilation Function-carrying node shape; see
-/// Issue2388NullableCustomEqualityEmitTests for the compiled/run/ILVerify
-/// coverage that exercises the actual lifted comparisons).
+/// invoked — this is pure binder coverage. Issue #2400 adds tree-walking
+/// Evaluator coverage for the same-compilation Function-carrying shape, while
+/// Issue2388NullableCustomEqualityEmitTests covers compiled/run/ILVerify
+/// behavior.
 /// </summary>
 public class Issue2388NullableCustomEqualityBinderTests
 {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2400LiftedGenericOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2400LiftedGenericOperatorTests.cs
@@ -1,0 +1,144 @@
+// <copyright file="Issue2400LiftedGenericOperatorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public class Issue2400LiftedGenericOperatorTests
+{
+    [Fact]
+    public void ClosedGenericNullableEquality_EvaluatesLiftedNullSemantics()
+    {
+        var result = Evaluate(
+            """
+            struct Box[T] {
+                var Value T
+                var Rank int32
+            }
+
+            func (left Box[T]) operator ==(right Box[T]) bool -> left.Rank == right.Rank
+
+            let present Box[string]? = Box[string]{Value: "a", Rank: 7}
+            let same Box[string]? = Box[string]{Value: "b", Rank: 7}
+            let missing Box[string]? = nil
+            present == same && !(present == missing) && missing == missing
+            """);
+
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.True((bool)result.Value);
+    }
+
+    [Fact]
+    public void ClosedGenericNullableOrdering_EvaluatesPresentAndMissingOperands()
+    {
+        var result = Evaluate(
+            """
+            struct Box[T] {
+                var Value T
+                var Rank int32
+            }
+
+            func (left Box[T]) operator <(right Box[T]) bool -> left.Rank < right.Rank
+
+            let low Box[int32]? = Box[int32]{Value: 1, Rank: 1}
+            let high Box[int32]? = Box[int32]{Value: 2, Rank: 2}
+            let missing Box[int32]? = nil
+            low < high && !(low < missing)
+            """);
+
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.True((bool)result.Value);
+    }
+
+    [Fact]
+    public void ClosedGenericNullableArithmetic_EvaluatesAndPropagatesNil()
+    {
+        var present = Evaluate(
+            """
+            struct Box[T] {
+                var Value T
+                var Rank int32
+            }
+
+            func (left Box[T]) operator +(right Box[T]) int32 -> left.Rank + right.Rank
+
+            let left Box[string]? = Box[string]{Value: "a", Rank: 20}
+            let right Box[string]? = Box[string]{Value: "b", Rank: 22}
+            (left + right)!!
+            """);
+        Assert.Empty(present.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(42, present.Value);
+
+        var missing = Evaluate(
+            """
+            struct Box[T] {
+                var Value T
+                var Rank int32
+            }
+
+            func (left Box[T]) operator +(right Box[T]) int32 -> left.Rank + right.Rank
+
+            let left Box[string]? = Box[string]{Value: "a", Rank: 20}
+            let missing Box[string]? = nil
+            left + missing
+            """);
+        Assert.Empty(missing.Diagnostics.Where(d => d.IsError));
+        Assert.Null(missing.Value);
+    }
+
+    [Fact]
+    public void ClosedGenericNonNullableOperator_UsesSubstitutedSignature()
+    {
+        var result = Evaluate(
+            """
+            struct Box[T] {
+                var Value T
+                var Rank int32
+            }
+
+            func (left Box[T]) operator +(right Box[T]) int32 -> left.Rank + right.Rank
+
+            let left = Box[string]{Value: "a", Rank: 20}
+            let right = Box[string]{Value: "b", Rank: 22}
+            left + right
+            """);
+
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void DifferentClosedGenericOperands_DoNotBindToOneInstantiation()
+    {
+        var result = Evaluate(
+            """
+            struct Box[T] {
+                var Value T
+            }
+
+            func (left Box[T]) operator ==(right Box[T]) bool -> true
+
+            let text Box[string]? = Box[string]{Value: "a"}
+            let number Box[int32]? = Box[int32]{Value: 1}
+            text == number
+            """);
+
+        Assert.Contains(result.Diagnostics, d => d.IsError);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary
- close generic same-compilation operator parameter and result shapes during binding
- emit TypeSpec-parented operator calls and symbolic nullable results for closed generic value types
- execute lifted equality, ordering, and arithmetic operators in the evaluator
- preserve generic owner information through bound-tree rewriting and async spilling
- add positive runtime/ILVerify regressions plus mismatched-instantiation diagnostics coverage

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --filter 'FullyQualifiedName~Issue2388NullableCustomEqualityBinderTests|FullyQualifiedName~Issue2400LiftedGenericOperatorTests'` — 17 passed
- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Compiler.Tests/Compiler.Tests.csproj --no-restore --filter FullyQualifiedName~Issue2388NullableCustomEqualityEmitTests` — 18 passed
- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --filter FullyQualifiedName~Issue2402GenericOperatorDeclarationTests` — 6 passed

## Scope
Same-compilation lifted operators in expression trees remain deferred to #2398.

Fixes #2400
