### PR TITLE
gsc expression trees: lower lifted same-compilation operators

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
@@ -27,6 +27,7 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
     private static readonly TypeSymbol BindingFlagsTypeSymbol = TypeSymbol.FromClrType(typeof(BindingFlags));
     private static readonly TypeSymbol ReflectionConstructorInfoTypeSymbol = TypeSymbol.FromClrType(typeof(ConstructorInfo));
     private static readonly TypeSymbol ReflectionFieldInfoTypeSymbol = TypeSymbol.FromClrType(typeof(FieldInfo));
+    private static readonly TypeSymbol ReflectionMethodInfoTypeSymbol = TypeSymbol.FromClrType(typeof(MethodInfo));
     private static readonly TypeSymbol ReflectionPropertyInfoTypeSymbol = TypeSymbol.FromClrType(typeof(PropertyInfo));
     private static readonly TypeSymbol ReflectionMemberInfoTypeSymbol = TypeSymbol.FromClrType(typeof(MemberInfo));
     private static readonly TypeSymbol ExpressionTypeSymbol = TypeSymbol.FromClrType(typeof(System.Linq.Expressions.Expression));
@@ -185,6 +186,14 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
         nameof(Type.GetField),
         typeof(string),
         typeof(BindingFlags));
+    private static readonly MethodInfo TypeGetMethodByParameterTypesMethod = GetRequiredMethod(
+        typeof(Type),
+        nameof(Type.GetMethod),
+        typeof(string),
+        typeof(BindingFlags),
+        typeof(System.Reflection.Binder),
+        typeof(Type[]),
+        typeof(ParameterModifier[]));
     private static readonly MethodInfo TypeGetPropertyMethod = GetRequiredMethod(
         typeof(Type),
         nameof(Type.GetProperty),
@@ -885,22 +894,6 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
         BoundClrBinaryOperatorExpression expression,
         Dictionary<VariableSymbol, LocalVariableSymbol> parameterMap)
     {
-        // Issue #2388: the nullable-lifted same-compilation struct operator
-        // shape (Function set, Method null) has no reflection MethodInfo
-        // available at lowering time (the declaring struct's operator is
-        // still TypeBuilder-backed) — the `Expression.Equal`/`Expression.Add`
-        // etc. factories all require an actual MethodInfo for a user-defined
-        // operator overload, so this shape cannot yet be lowered into an
-        // expression tree. The imported-CLR-type shape (Method set) is
-        // unaffected: `Expression.Equal(nullableLeft, nullableRight, false,
-        // method)` already performs the Nullable<T> unwrap/lift itself at
-        // expression-tree-compile time, so no change is needed there.
-        if (expression.Method == null)
-        {
-            throw new NotSupportedException(
-                "Expression trees do not yet support a nullable-lifted same-compilation user operator call (issue #2388).");
-        }
-
         var methodName = expression.OperatorKind switch
         {
             SyntaxKind.PlusToken => nameof(System.Linq.Expressions.Expression.Add),
@@ -927,6 +920,13 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
         var leftExpr = UpcastToExpression(this.TranslateExpression(expression.Left, parameterMap));
         var rightExpr = UpcastToExpression(this.TranslateExpression(expression.Right, parameterMap));
         var resultType = TypeSymbol.FromClrType(typeof(System.Linq.Expressions.BinaryExpression));
+
+        // Issue #2398: same-compilation operators have no MethodInfo until the
+        // emitted declaring type exists. Resolve it at runtime from the exact
+        // closed owner and substituted parameter signature.
+        var operatorMethod = expression.Method != null
+            ? BuildMethodInfoConstant(expression.Method)
+            : BuildUserOperatorMethodInfoLookup(expression);
 
         // Issue #2373: unlike the arithmetic/bitwise/shift/logical factories,
         // the six relational/equality factories do NOT expose a 3-arg
@@ -956,7 +956,7 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
                     leftExpr,
                     rightExpr,
                     new BoundLiteralExpression(null, false, TypeSymbol.Bool),
-                    BuildMethodInfoConstant(expression.Method)));
+                    operatorMethod));
         }
 
         var factory = GetRequiredMethod(
@@ -973,7 +973,7 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
             ImmutableArray.Create<BoundExpression>(
                 leftExpr,
                 rightExpr,
-                BuildMethodInfoConstant(expression.Method)));
+                operatorMethod));
     }
 
     private BoundExpression BuildClrUnaryOperatorExpression(
@@ -1168,7 +1168,33 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
     }
 
     private static BoundExpression BuildMethodInfoConstant(MethodInfo method)
-        => new BoundLiteralExpression(null, method, TypeSymbol.FromClrType(typeof(MethodInfo)));
+        => new BoundLiteralExpression(null, method, ReflectionMethodInfoTypeSymbol);
+
+    private static BoundExpression BuildUserOperatorMethodInfoLookup(BoundClrBinaryOperatorExpression expression)
+    {
+        var function = expression.Function
+            ?? throw new NotSupportedException("A same-compilation expression-tree operator requires a function symbol.");
+        var ownerType = expression.FunctionOwnerType ?? function.StaticOwnerType as StructSymbol
+            ?? throw new NotSupportedException($"Operator '{function.Name}' has no same-compilation declaring type.");
+
+        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(function.Parameters.Length);
+        foreach (var parameter in function.Parameters)
+        {
+            parameterTypes.Add(ownerType.SubstituteMemberType(parameter.Type));
+        }
+
+        return new BoundImportedInstanceCallExpression(
+            expression.Syntax,
+            CreateTypeOf(ownerType),
+            TypeGetMethodByParameterTypesMethod,
+            ReflectionMethodInfoTypeSymbol,
+            ImmutableArray.Create<BoundExpression>(
+                new BoundLiteralExpression(null, function.Name, TypeSymbol.String),
+                BuildBindingFlagsConstant(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static),
+                new BoundLiteralExpression(null, null, TypeSymbol.Null),
+                BuildTypeArray(parameterTypes.MoveToImmutable()),
+                new BoundLiteralExpression(null, null, TypeSymbol.Null)));
+    }
 
     private static BoundExpression BuildMemberInfoConstant(MemberInfo member)
         => new BoundLiteralExpression(null, member, ReflectionMemberInfoTypeSymbol);

--- a/test/Compiler.Tests/Emit/Issue2398ExpressionTreeLiftedUserOperatorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2398ExpressionTreeLiftedUserOperatorEmitTests.cs
@@ -1,0 +1,185 @@
+// <copyright file="Issue2398ExpressionTreeLiftedUserOperatorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.Loader;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2398: nullable same-compilation user operators represented by a
+/// FunctionSymbol must lower to expression-tree binary nodes with the emitted
+/// operator MethodInfo and the same lifted metadata as C#.
+/// </summary>
+public class Issue2398ExpressionTreeLiftedUserOperatorEmitTests
+{
+    [Fact]
+    public void SameCompilationEquality_UsesOperatorMethodAndLiftedBooleanSemantics()
+    {
+        var source = """
+            package Issue2398Equality
+            import System
+            import System.Linq.Expressions
+
+            struct Token(Value int32) {
+            }
+
+            func (left Token) operator ==(right Token) bool -> left.Value == right.Value
+            func (left Token) operator !=(right Token) bool -> left.Value != right.Value
+
+            func Predicate() Expression[Func[Token?, Token?, bool]] {
+                return (left Token?, right Token?) -> left == right
+            }
+            """;
+
+        var (assembly, loadContext) = CompileToAssembly(source, nameof(SameCompilationEquality_UsesOperatorMethodAndLiftedBooleanSemantics));
+        try
+        {
+            var lambda = GetLambda(assembly, "Predicate");
+            var binary = Assert.IsAssignableFrom<BinaryExpression>(lambda.Body);
+            var tokenType = assembly.GetTypes().Single(t => t.Name == "Token");
+
+            Assert.Equal(ExpressionType.Equal, binary.NodeType);
+            Assert.True(binary.IsLifted);
+            Assert.False(binary.IsLiftedToNull);
+            Assert.Equal(typeof(bool), binary.Type);
+            Assert.Equal("op_Equality", binary.Method?.Name);
+            Assert.Equal(tokenType, binary.Method?.DeclaringType);
+
+            var compiled = lambda.Compile();
+            var present = Activator.CreateInstance(tokenType);
+            Assert.True((bool)compiled.DynamicInvoke(present, present)!);
+            Assert.False((bool)compiled.DynamicInvoke(present, null)!);
+            Assert.True((bool)compiled.DynamicInvoke(null, null)!);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    [Fact]
+    public void SameCompilationArithmetic_IsLiftedToNullAndUsesOperatorMethod()
+    {
+        var source = """
+            package Issue2398Arithmetic
+            import System
+            import System.Linq.Expressions
+
+            struct Count(Value int32) {
+            }
+
+            func (left Count) operator +(right Count) Count {
+                return Count{ Value: left.Value + right.Value }
+            }
+
+            func Sum() Expression[Func[Count?, Count?, Count?]] {
+                return (left Count?, right Count?) -> left + right
+            }
+            """;
+
+        var (assembly, loadContext) = CompileToAssembly(source, nameof(SameCompilationArithmetic_IsLiftedToNullAndUsesOperatorMethod));
+        try
+        {
+            var lambda = GetLambda(assembly, "Sum");
+            var binary = Assert.IsAssignableFrom<BinaryExpression>(lambda.Body);
+            var countType = assembly.GetTypes().Single(t => t.Name == "Count");
+
+            Assert.Equal(ExpressionType.Add, binary.NodeType);
+            Assert.True(binary.IsLifted);
+            Assert.True(binary.IsLiftedToNull);
+            Assert.Equal("op_Addition", binary.Method?.Name);
+            Assert.Equal(countType, binary.Method?.DeclaringType);
+            Assert.Equal(typeof(Nullable<>).MakeGenericType(countType), binary.Type);
+
+            var compiled = lambda.Compile();
+            var present = Activator.CreateInstance(countType);
+            var result = compiled.DynamicInvoke(present, present);
+            Assert.NotNull(result);
+            Assert.Equal(countType, result!.GetType());
+            Assert.Null(compiled.DynamicInvoke(present, null));
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    [Fact]
+    public void ClosedGenericEquality_ResolvesMethodOnClosedDeclaringType()
+    {
+        var source = """
+            package Issue2398Generic
+            import System
+            import System.Linq.Expressions
+
+            struct Box[T] {
+                var Value T
+                var Rank int32
+            }
+
+            func (left Box[T]) operator ==(right Box[T]) bool -> left.Rank == right.Rank
+            func (left Box[T]) operator !=(right Box[T]) bool -> left.Rank != right.Rank
+
+            func Predicate() Expression[Func[Box[string]?, Box[string]?, bool]] {
+                return (left Box[string]?, right Box[string]?) -> left == right
+            }
+            """;
+
+        var (assembly, loadContext) = CompileToAssembly(source, nameof(ClosedGenericEquality_ResolvesMethodOnClosedDeclaringType));
+        try
+        {
+            var lambda = GetLambda(assembly, "Predicate");
+            var binary = Assert.IsAssignableFrom<BinaryExpression>(lambda.Body);
+            var method = Assert.IsAssignableFrom<MethodInfo>(binary.Method);
+            var declaringType = Assert.IsAssignableFrom<Type>(method.DeclaringType);
+
+            Assert.True(binary.IsLifted);
+            Assert.False(binary.IsLiftedToNull);
+            Assert.Equal("op_Equality", method.Name);
+            Assert.True(declaringType.IsConstructedGenericType);
+            Assert.Equal(typeof(string), declaringType.GetGenericArguments().Single());
+            Assert.All(method.GetParameters(), p => Assert.Equal(declaringType, p.ParameterType));
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static LambdaExpression GetLambda(Assembly assembly, string methodName)
+    {
+        var programType = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var method = programType.GetMethod(methodName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return Assert.IsAssignableFrom<LambdaExpression>(method!.Invoke(null, null));
+    }
+
+    private static (Assembly Assembly, AssemblyLoadContext LoadContext) CompileToAssembly(string source, string caseName)
+    {
+        var outputDirectory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2398ExpressionTreeLiftedUserOperatorEmitTests));
+        Directory.CreateDirectory(outputDirectory);
+        var assemblyPath = Path.Combine(outputDirectory, caseName + ".dll");
+        var compilation = new GsCompilation(GsSyntaxTree.Parse(SourceText.From(source))) { IsLibrary = true };
+
+        using (var peStream = File.Create(assemblyPath))
+        {
+            var result = compilation.Emit(peStream, pdbStream: null, refStream: null, assemblyName: caseName);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        IlVerifier.Verify(assemblyPath);
+
+        var loadContext = new AssemblyLoadContext(caseName, isCollectible: true);
+        return (loadContext.LoadFromAssemblyPath(assemblyPath), loadContext);
+    }
+}


### PR DESCRIPTION
## Summary
- resolve same-compilation operator `MethodInfo` values at runtime from the exact emitted owner and substituted parameter signature
- feed that method into the existing expression-tree operator factories so equality/ordering remain lifted-to-bool while arithmetic remains lifted-to-null
- cover non-generic equality, arithmetic, and closed-generic operator metadata/runtime behavior

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Compiler.Tests/Compiler.Tests.csproj --no-restore --filter 'FullyQualifiedName~Issue2373ExpressionTreeClrComparisonEmitTests|FullyQualifiedName~Issue2398ExpressionTreeLiftedUserOperatorEmitTests' --verbosity minimal` — 16 passed

Built on the lifted same-compilation operator support merged in #2481.

Fixes #2398