### PR TITLE
Fix implicit System.Object override resolution

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/ExternalClrOverrideResolver.cs
@@ -26,9 +26,9 @@ internal static class ExternalClrOverrideResolver
         Accessibility accessibility)
     {
         bool sawName = false;
-        var importedBase = FindImportedBaseType(derivedType);
-        var typeArguments = GetSymbolicTypeArguments(importedBase);
-        foreach (var method in EnumerateMethods(GetReflectionBaseType(importedBase), name))
+        var externalBase = FindExternalBaseType(derivedType);
+        var typeArguments = GetSymbolicTypeArguments(externalBase);
+        foreach (var method in EnumerateMethods(GetReflectionBaseType(externalBase), name))
         {
             if (!IsAccessibleOverrideTarget(method, accessibility))
             {
@@ -45,13 +45,13 @@ internal static class ExternalClrOverrideResolver
 
             if (!method.IsVirtual || method.IsFinal)
             {
-                return new MatchResult<MethodInfo>(null, importedBase, sawName, IsSealed: true);
+                return new MatchResult<MethodInfo>(null, externalBase, sawName, IsSealed: true);
             }
 
-            return new MatchResult<MethodInfo>(method, importedBase, sawName, IsSealed: false);
+            return new MatchResult<MethodInfo>(method, externalBase, sawName, IsSealed: false);
         }
 
-        return new MatchResult<MethodInfo>(null, importedBase, sawName, IsSealed: false);
+        return new MatchResult<MethodInfo>(null, externalBase, sawName, IsSealed: false);
     }
 
     internal static MatchResult<PropertyInfo> FindProperty(
@@ -64,9 +64,9 @@ internal static class ExternalClrOverrideResolver
         Accessibility accessibility)
     {
         bool sawName = false;
-        var importedBase = FindImportedBaseType(derivedType);
-        var typeArguments = GetSymbolicTypeArguments(importedBase);
-        foreach (var property in EnumerateProperties(GetReflectionBaseType(importedBase), name))
+        var externalBase = FindExternalBaseType(derivedType);
+        var typeArguments = GetSymbolicTypeArguments(externalBase);
+        foreach (var property in EnumerateProperties(GetReflectionBaseType(externalBase), name))
         {
             var getter = property.GetGetMethod(nonPublic: true);
             var setter = property.GetSetMethod(nonPublic: true);
@@ -90,13 +90,13 @@ internal static class ExternalClrOverrideResolver
             if ((getter != null && (!getter.IsVirtual || getter.IsFinal))
                 || (setter != null && (!setter.IsVirtual || setter.IsFinal)))
             {
-                return new MatchResult<PropertyInfo>(null, importedBase, sawName, IsSealed: true);
+                return new MatchResult<PropertyInfo>(null, externalBase, sawName, IsSealed: true);
             }
 
-            return new MatchResult<PropertyInfo>(property, importedBase, sawName, IsSealed: false);
+            return new MatchResult<PropertyInfo>(property, externalBase, sawName, IsSealed: false);
         }
 
-        return new MatchResult<PropertyInfo>(null, importedBase, sawName, IsSealed: false);
+        return new MatchResult<PropertyInfo>(null, externalBase, sawName, IsSealed: false);
     }
 
     internal static MatchResult<EventInfo> FindEvent(
@@ -106,9 +106,9 @@ internal static class ExternalClrOverrideResolver
         Accessibility accessibility)
     {
         bool sawName = false;
-        var importedBase = FindImportedBaseType(derivedType);
-        var typeArguments = GetSymbolicTypeArguments(importedBase);
-        foreach (var eventInfo in EnumerateEvents(GetReflectionBaseType(importedBase), name))
+        var externalBase = FindExternalBaseType(derivedType);
+        var typeArguments = GetSymbolicTypeArguments(externalBase);
+        foreach (var eventInfo in EnumerateEvents(GetReflectionBaseType(externalBase), name))
         {
             var add = eventInfo.GetAddMethod(nonPublic: true);
             var remove = eventInfo.GetRemoveMethod(nonPublic: true);
@@ -127,16 +127,16 @@ internal static class ExternalClrOverrideResolver
             if ((add != null && (!add.IsVirtual || add.IsFinal))
                 || (remove != null && (!remove.IsVirtual || remove.IsFinal)))
             {
-                return new MatchResult<EventInfo>(null, importedBase, sawName, IsSealed: true);
+                return new MatchResult<EventInfo>(null, externalBase, sawName, IsSealed: true);
             }
 
-            return new MatchResult<EventInfo>(eventInfo, importedBase, sawName, IsSealed: false);
+            return new MatchResult<EventInfo>(eventInfo, externalBase, sawName, IsSealed: false);
         }
 
-        return new MatchResult<EventInfo>(null, importedBase, sawName, IsSealed: false);
+        return new MatchResult<EventInfo>(null, externalBase, sawName, IsSealed: false);
     }
 
-    private static TypeSymbol FindImportedBaseType(StructSymbol type)
+    private static TypeSymbol FindExternalBaseType(StructSymbol type)
     {
         for (var current = type; current != null; current = current.BaseClass)
         {
@@ -144,9 +144,16 @@ internal static class ExternalClrOverrideResolver
             {
                 return current.ImportedBaseType;
             }
+
+            if (current.IsAttributeClass)
+            {
+                // Attribute sugar emits System.Attribute rather than the CLR
+                // implicit Object base handled by this fallback.
+                return null;
+            }
         }
 
-        return null;
+        return type?.IsClass == true ? TypeSymbol.Object : null;
     }
 
     private static Type GetReflectionBaseType(TypeSymbol importedBase)

--- a/test/Compiler.Tests/Emit/Issue2443ExternalClrOverrideEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2443ExternalClrOverrideEmitTests.cs
@@ -23,6 +23,143 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
     private static readonly Lazy<string> ExternalBaseAssembly = new(EmitExternalBaseAssembly);
 
     [Fact]
+    public void ImplicitObjectOverrides_SourceChainsAndGenericClasses_DispatchAndReflectBaseSlots()
+    {
+        const string Source = """
+            package Issue2486
+            import System
+
+            open class Root[T] {
+            }
+
+            class Derived : Root[int32] {
+                override func ToString() string -> "derived"
+                override func GetHashCode() int32 -> 2486
+                override func Equals(value object) bool -> true
+            }
+
+            open class OpenImplicit {
+                override func ToString() string -> "open"
+            }
+
+            class Generic[T] {
+                override func ToString() string -> "generic"
+            }
+
+            func Main() {
+                let value object = Derived()
+                Console.WriteLine(value.ToString())
+                Console.WriteLine(value.GetHashCode())
+                Console.WriteLine(value.Equals(Derived()))
+            }
+            """;
+
+        var result = Compile(Source, target: "exe");
+        try
+        {
+            Assert.Equal("derived\n2486\nTrue\n", Run(result.OutputPath));
+            IlVerifier.Verify(result.OutputPath);
+
+            var assembly = Assembly.LoadFrom(result.OutputPath);
+            var derived = assembly.GetType("Issue2486.Derived")!;
+            AssertOverrideSlot(
+                derived.GetMethod("ToString", BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!,
+                typeof(object).GetMethod("ToString")!);
+            AssertOverrideSlot(
+                derived.GetMethod("GetHashCode", BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!,
+                typeof(object).GetMethod("GetHashCode")!);
+            AssertOverrideSlot(
+                derived.GetMethod("Equals", BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!,
+                typeof(object).GetMethod("Equals", new[] { typeof(object) })!);
+
+            var openImplicit = assembly.GetType("Issue2486.OpenImplicit")!;
+            Assert.False(openImplicit.IsSealed);
+            AssertOverrideSlot(openImplicit.GetMethod("ToString")!, typeof(object).GetMethod("ToString")!);
+
+            var generic = assembly.GetType("Issue2486.Generic`1")!;
+            Assert.True(generic.IsSealed);
+            AssertOverrideSlot(generic.GetMethod("ToString")!, typeof(object).GetMethod("ToString")!);
+
+            var consumerPath = EmitImplicitObjectConsumer(result.DirectoryPath, result.OutputPath);
+            Assert.Equal("derived\n2486\nTrue\ngeneric\n", Run(consumerPath));
+        }
+        finally
+        {
+            result.Dispose();
+        }
+    }
+
+    [Fact]
+    public void MatchingImplicitObjectVirtualWithoutOverride_RemainsAnAcceptedShadow()
+    {
+        const string Source = """
+            package Issue2486
+
+            class Shadow {
+                func ToString() string -> "shadow"
+            }
+            """;
+
+        var result = Compile(Source, target: "library");
+        try
+        {
+            IlVerifier.Verify(result.OutputPath);
+
+            var assembly = Assembly.LoadFrom(result.OutputPath);
+            var type = assembly.GetType("Issue2486.Shadow")!;
+            var instance = Activator.CreateInstance(type);
+            var shadow = type.GetMethod("ToString", BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!;
+
+            Assert.True((shadow.Attributes & MethodAttributes.NewSlot) != 0);
+            Assert.Equal("shadow", shadow.Invoke(instance, null));
+            Assert.Equal("Issue2486.Shadow", typeof(object).GetMethod("ToString")!.Invoke(instance, null));
+        }
+        finally
+        {
+            result.Dispose();
+        }
+    }
+
+    [Theory]
+    [InlineData("""
+        package Issue2486
+        class Bad {
+            override func ToString(value int32) string -> "bad"
+        }
+        """, "GS0185")]
+    [InlineData("""
+        package Issue2486
+        class Bad {
+            protected override func MemberwiseClone() object -> this
+        }
+        """, "GS0184")]
+    [InlineData("""
+        package Issue2486
+        class Bad {
+            override func Missing() string -> "bad"
+        }
+        """, "GS0183")]
+    [InlineData("""
+        package Issue2486
+        struct Bad {
+            override func ToString() string -> "bad"
+        }
+        """, "GS0183")]
+    public void ImplicitObjectOverride_InvalidShapesRetainSpecificDiagnostics(string source, string diagnosticId)
+    {
+        var result = TryCompile(source, "library");
+        try
+        {
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.Contains(diagnosticId, result.Stdout + result.Stderr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            result.Dispose();
+        }
+    }
+
+    [Fact]
     public void BclObjectOverride_DispatchesAndReflectsBaseSlot()
     {
         const string Source = """
@@ -368,6 +505,37 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
             OutputKind.ConsoleApplication,
             gsharpAssembly,
             baseAssembly);
+        return outputPath;
+    }
+
+    private static string EmitImplicitObjectConsumer(string directory, string gsharpAssembly)
+    {
+        var outputPath = Path.Combine(directory, "Issue2486Consumer.dll");
+        const string Source = """
+            using System;
+            using Issue2486;
+
+            internal static class Program
+            {
+                private static void Main()
+                {
+                    object value = new Derived();
+                    Console.WriteLine(value.ToString());
+                    Console.WriteLine(value.GetHashCode());
+                    Console.WriteLine(value.Equals(new Derived()));
+
+                    object generic = new Generic<string>();
+                    Console.WriteLine(generic.ToString());
+                }
+            }
+            """;
+
+        EmitCSharpAssembly(
+            outputPath,
+            "Issue2486Consumer",
+            Source,
+            OutputKind.ConsoleApplication,
+            gsharpAssembly);
         return outputPath;
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2486ImplicitObjectOverridePipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2486ImplicitObjectOverridePipelineTests.cs
@@ -1,0 +1,143 @@
+// <copyright file="Issue2486ImplicitObjectOverridePipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2486: ordinary C# classes do not spell an <c>object</c> base, so the
+/// default SDK-backed migration path must compile their preserved overrides
+/// against gsc's implicit <see cref="object"/> base.
+/// </summary>
+public sealed class Issue2486ImplicitObjectOverridePipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_ImplicitObjectOverrides_TranslateAndCompile()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null || repoRoot is null ||
+            GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectDir = Path.Combine(sourceRoot, "src", "Sample");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "Sample.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <OutputType>Exe</OutputType>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "Program.cs"), """
+            using System;
+
+            namespace Sample;
+
+            public sealed class Widget
+            {
+                public override string ToString() => "widget";
+
+                public override int GetHashCode() => 2486;
+
+                public override bool Equals(object? value) => true;
+            }
+
+            public static class Program
+            {
+                public static void Main()
+                {
+                    object value = new Widget();
+                    Console.WriteLine(value.ToString());
+                    Console.WriteLine(value.GetHashCode());
+                    Console.WriteLine(value.Equals(new Widget()));
+                }
+            }
+            """);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp("test/ImplicitObject", projectPath, TargetKind.Exe);
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+
+        string appRunDir = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.Id));
+        string emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(appRunDir, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains("class Widget", emitted, StringComparison.Ordinal);
+        Assert.DoesNotContain("class Widget : Object", emitted, StringComparison.Ordinal);
+        Assert.Contains("override func ToString", emitted, StringComparison.Ordinal);
+        Assert.Contains("override func GetHashCode", emitted, StringComparison.Ordinal);
+        Assert.Contains("override func Equals", emitted, StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            "Expected the default --via-sdk compile to accept implicit Object overrides. Stages: " +
+                string.Join("; ", appResult.Stages.Select(s => s.Stage + "=" + s.Status)));
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2486",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    dir.FullName,
+                    "out",
+                    "bin",
+                    config,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- fall back to the implicit `System.Object` base when external override resolution reaches the root of a source class hierarchy
- keep structs, attribute-sugar classes, explicit/imported bases, and non-override shadowing on their existing paths
- cover `ToString`, `GetHashCode`, and `Equals(object)` with runtime, reflection, C# consumer, ILVerify, diagnostics, generic/source-chain, and default `--via-sdk` migration tests

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter FullyQualifiedName~Issue2443ExternalClrOverrideEmitTests --no-restore --verbosity minimal` (11 passed)
- `MSBUILDDISABLENODEREUSE=1 dotnet build src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj -c Release --no-restore --verbosity minimal`
- `NUGET_PACKAGES=$PWD/out/nuget-packages-issue2486 MSBUILDDISABLENODEREUSE=1 dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --filter FullyQualifiedName~Issue2486ImplicitObjectOverridePipelineTests --no-restore --verbosity minimal` (1 passed)

Fixes #2486