### PR TITLE
Fix tuple-element nullability forwarding into scalar sinks

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2469TupleElementNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2469TupleElementNullabilityTranslationTests.cs
@@ -45,7 +45,7 @@ public static class Parser
         Assert.Contains(
             "func Parse(text string) (string?, string?, Dictionary[string, string]?)",
             printed);
-        Assert.Contains("let method = parsed.Item2", printed);
+        Assert.Contains("let method string? = parsed.Item2", printed);
         Assert.DoesNotContain("nil!!", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2490TupleScalarNullabilityPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2490TupleScalarNullabilityPipelineTests.cs
@@ -1,0 +1,157 @@
+// <copyright file="Issue2490TupleScalarNullabilityPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2490TupleScalarNullabilityPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_TupleElementForwarding_TranslatesAndCompiles()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectDir = Path.Combine(sourceRoot, "src", "Sample");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "Sample.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>disable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "Repro.cs"), """
+            using System.Collections.Generic;
+
+            namespace Sample;
+
+            public sealed class Statistics
+            {
+            }
+
+            public static class Repro
+            {
+                public static int Run(bool ok)
+                {
+                    var result = Gather(ok);
+                    return Cleanup(result.Items, result.Stats);
+                }
+
+                private static (List<string> Items, Statistics Stats) Gather(bool ok)
+                {
+                    if (!ok)
+                        return default;
+
+                    return (new List<string>(), new Statistics());
+                }
+
+                private static int Cleanup(List<string> items, Statistics stats) =>
+                    CleanupCore(items);
+
+                private static int CleanupCore(List<string> items)
+                {
+                    if (items is null)
+                        return 0;
+
+                    return items.Count;
+                }
+            }
+            """);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp("test/TupleScalar", projectPath, TargetKind.Library);
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+
+        string appRunDir = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.Id));
+        string emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(appRunDir, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains(
+            "func Gather(ok bool) (List[string]?, Statistics?)",
+            emitted,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "func Cleanup(items List[string]?, stats Statistics?) int32",
+            emitted,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "func CleanupCore(items List[string]?) int32",
+            emitted,
+            StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            "Expected the default --via-sdk compile to accept tuple-element forwarding. Stages: " +
+                string.Join("; ", appResult.Stages.Select(s => s.Stage + "=" + s.Status)));
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2490",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    dir.FullName,
+                    "out",
+                    "bin",
+                    config,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2490TupleScalarNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2490TupleScalarNullabilityTranslationTests.cs
@@ -1,0 +1,400 @@
+// <copyright file="Issue2490TupleScalarNullabilityTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public class Issue2490TupleScalarNullabilityTranslationTests
+{
+    [Fact]
+    public void DirectNamedTupleElement_PromotesWrapperAndCoreParameters()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+
+public static class Repro
+{
+    public static int Run(bool ok)
+    {
+        var result = Gather(ok);
+        if (ok)
+            Count(new List<string>());
+
+        return Count(items: result.Items);
+    }
+
+    private static (List<string> Items, int Value) Gather(bool ok)
+    {
+        if (!ok)
+            return default;
+
+        return (new List<string>(), 0);
+    }
+
+    private static int Count(List<string> items) => CountCore(items);
+
+    private static List<string> Read(bool ok)
+    {
+        return Gather(ok).Items;
+    }
+
+    private static int CountCore(List<string> items)
+    {
+        if (items is null)
+            return 0;
+
+        return items.Count;
+    }
+}");
+
+        Assert.Contains("func Gather(ok bool) (List[string]?, int32)", printed);
+        Assert.Contains("func Count(items List[string]?) int32", printed);
+        Assert.Contains("func CountCore(items List[string]?) int32", printed);
+        Assert.Contains("func Read(ok bool) List[string]?", printed);
+    }
+
+    [Fact]
+    public void NestedTupleLocalsConditionalsConstructorsAndIndexers_PreserveLeafPrecision()
+    {
+        string printed = TranslateOblivious(@"
+public sealed class Box
+{
+    public Box(string value)
+    {
+    }
+
+    public Box((string Maybe, int Keep) payload)
+        : this(payload.Maybe)
+    {
+    }
+}
+
+public sealed class Lookup
+{
+    public string this[string key] => ""value"";
+}
+
+public static class Repro
+{
+    public static string Run(bool missing, Lookup lookup)
+    {
+        var result = Gather(missing);
+        var direct = result.Names.Maybe;
+        var (keep, deconstructed) = result.Names;
+        string assigned = ""initial"";
+        assigned = missing ? result.Names.Maybe : direct;
+        var box = new Box((result.Names.Maybe, result.Count));
+        var indexed = lookup[result.Names.Maybe];
+        return Echo(missing ? deconstructed : direct);
+    }
+
+    private static ((string Keep, string Maybe) Names, int Count) Gather(bool missing)
+    {
+        if (missing)
+            return ((""keep"", null), 1);
+
+        return ((""keep"", ""value""), 2);
+    }
+
+    private static string Echo(string value) => value;
+}");
+
+        Assert.Contains("func Gather(missing bool) ((string, string?), int32)", printed);
+        Assert.Contains("var assigned string? =", printed);
+        Assert.Contains("init(value string?)", printed);
+        Assert.Contains("prop this[key string?] string", printed);
+        Assert.Contains("func Echo(value string?) string?", printed);
+        Assert.DoesNotContain("((string?, string?), int32)", printed);
+    }
+
+    [Fact]
+    public void ScalarFieldsAndProperties_ReceiveTupleElementEvidence()
+    {
+        string printed = TranslateOblivious(@"
+public static class Repro
+{
+    private static (string Maybe, string Keep) Source
+    {
+        get
+        {
+            return (null, ""keep"");
+        }
+    }
+
+    public static string Field = Source.Maybe;
+
+    public static string Property { get; set; } = Source.Maybe;
+
+    public static void Reset()
+    {
+        Field = Source.Maybe;
+        Property = Source.Maybe;
+    }
+}");
+
+        Assert.Contains("prop Source (string?, string)", printed);
+        Assert.Contains("var Field string?", printed);
+        Assert.Contains("var Property string?", printed);
+        Assert.DoesNotContain("prop Source (string?, string?)", printed);
+    }
+
+    [Fact]
+    public void DelegateGenericLocalFunctionAndAsyncForwarding_PropagateTupleEvidence()
+    {
+        string printed = TranslateOblivious(@"
+using System.Threading.Tasks;
+
+public delegate int Counter(string value);
+
+public static class Repro
+{
+    public static int Invoke(Counter counter, bool missing)
+    {
+        var result = Gather(missing);
+        return counter(result.Item);
+    }
+
+    public static async Task<string> RunAsync(bool missing)
+    {
+        var result = await GatherAsync(missing);
+        return Forward(result.Item);
+    }
+
+    private static T Forward<T>(T value) where T : class
+    {
+        T Core(T item) => item;
+        return Core(value);
+    }
+
+    private static (string Item, int Keep) Gather(bool missing)
+    {
+        if (missing)
+            return (null, 1);
+
+        return (""value"", 2);
+    }
+
+    private static async Task<(string Item, int Keep)> GatherAsync(bool missing)
+    {
+        await Task.Yield();
+        return Gather(missing);
+    }
+}");
+
+        Assert.Contains("type Counter = delegate func(value string?) int32", printed);
+        Assert.Contains("func Forward[T class](value T?) T?", printed);
+        Assert.Contains("let Core = func (item T?) T?", printed);
+        Assert.Contains("async func RunAsync(missing bool) string?", printed);
+        Assert.Contains("async func GatherAsync(missing bool) (string?, int32)", printed);
+    }
+
+    [Fact]
+    public void InterfaceAndOverrideParameterContracts_StayInLockstep()
+    {
+        string printed = TranslateOblivious(@"
+public interface ISink
+{
+    void Put(string value);
+}
+
+public abstract class SinkBase
+{
+    public abstract void Put(string value);
+}
+
+public sealed class Sink : SinkBase, ISink
+{
+    public override void Put(string value) => PutCore(value);
+
+    private static void PutCore(string value)
+    {
+    }
+}
+
+public static class Repro
+{
+    public static void Run(ISink sink, bool missing)
+    {
+        var result = Gather(missing);
+        sink.Put(result.Item);
+    }
+
+    private static (string Item, int Keep) Gather(bool missing)
+    {
+        if (missing)
+            return (null, 1);
+
+        return (""value"", 2);
+    }
+}");
+
+        Assert.Contains("func Put(value string?);", printed);
+        Assert.Contains("open func Put(value string?);", printed);
+        Assert.Contains("override func Put(value string?)", printed);
+        Assert.Contains("func PutCore(value string?)", printed);
+    }
+
+    [Fact]
+    public void CrossProjectTupleElement_PromotesConsumerScalarParameter()
+    {
+        const string sourceB = @"
+namespace LibB
+{
+    public static class Provider
+    {
+        public static (string Item, int Keep) Gather(bool missing)
+        {
+            if (missing)
+                return (null, 1);
+
+            return (""value"", 2);
+        }
+    }
+}";
+        const string sourceA = @"
+using LibB;
+
+namespace LibA
+{
+    public static class Consumer
+    {
+        public static int Run(bool missing) => Count(Provider.Gather(missing).Item);
+
+        private static int Count(string value) => value is null ? 0 : value.Length;
+    }
+}";
+
+        LoadedCSharpProject projectB = LoadOblivious(sourceB, "LibB");
+        LoadedCSharpProject projectA = LoadOblivious(
+            sourceA,
+            "LibA",
+            new MetadataReference[] { projectB.Compilation.ToMetadataReference() });
+        var siblings = new[] { projectA.Compilation, projectB.Compilation };
+
+        string printedB = TranslateProject(projectB, siblings);
+        string printedA = TranslateProject(projectA, siblings);
+
+        Assert.Contains("func Gather(missing bool) (string?, int32)", printedB);
+        Assert.Contains("func Count(value string?) int32", printedA);
+    }
+
+    [Fact]
+    public void NullableEnabledCompilation_PreservesAnnotatedAndNonNullParameters()
+    {
+        string printed = TranslateEnabled(@"
+#nullable enable
+
+public static class Repro
+{
+    public static void Run(bool missing)
+    {
+        var result = Gather(missing);
+        Accept(result.Maybe);
+        Keep(result.Required);
+    }
+
+    private static (string Required, string? Maybe) Gather(bool missing)
+    {
+        if (missing)
+            return (""required"", null);
+
+        return (""required"", ""value"");
+    }
+
+    private static void Accept(string? value)
+    {
+    }
+
+    private static void Keep(string value)
+    {
+    }
+}");
+
+        Assert.Contains("func Gather(missing bool) (string, string?)", printed);
+        Assert.Contains("func Accept(value string?)", printed);
+        Assert.Contains("func Keep(value string)", printed);
+        Assert.DoesNotContain("func Keep(value string?)", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = LoadOblivious(source, "Snippet");
+        return TranslateProject(project, new[] { project.Compilation });
+    }
+
+    private static string TranslateEnabled(string source)
+    {
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest),
+            path: "Snippet.cs");
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "Snippet",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+
+        var document = new LoadedDocument("Snippet.cs", tree, compilation.GetSemanticModel(tree));
+        var project = new LoadedCSharpProject(compilation, new[] { document }, Array.Empty<Diagnostic>());
+        return TranslateProject(project, new[] { compilation });
+    }
+
+    private static LoadedCSharpProject LoadOblivious(
+        string source,
+        string assemblyName,
+        IReadOnlyList<MetadataReference> extraReferences = null)
+    {
+        IReadOnlyList<MetadataReference> references = extraReferences is null
+            ? CSharpProjectLoader.RuntimeReferences()
+            : CSharpProjectLoader.RuntimeReferences().Concat(extraReferences).ToList();
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { (assemblyName + ".cs", source) },
+            references,
+            assemblyName);
+        Assert.True(
+            project.BoundWithoutErrors,
+            $"{assemblyName} should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+        return project;
+    }
+
+    private static string TranslateProject(
+        LoadedCSharpProject project,
+        IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath,
+            siblingCompilations);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/ObliviousPromotionSinkCompilationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ObliviousPromotionSinkCompilationTests.cs
@@ -146,6 +146,61 @@ namespace Demo
         Assert.DoesNotContain("string?", printed);
     }
 
+    [Fact]
+    public void TupleElementPromotion_ScalarCallSinksCompileWithGsc()
+    {
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public delegate int Counter(string value);
+
+    public sealed class Box
+    {
+        public Box(string value)
+        {
+        }
+    }
+
+    public sealed class Lookup
+    {
+        public int this[string key] => 1;
+    }
+
+    public static class Repro
+    {
+        public static int Run(bool missing, Counter counter, Lookup lookup)
+        {
+            var result = Gather(missing);
+            var value = result.Payload.Maybe;
+            var box = new Box(result.Payload.Maybe);
+            return Count(value) + counter(result.Payload.Maybe) + lookup[result.Payload.Maybe];
+        }
+
+        private static ((string Keep, string Maybe) Payload, int Count) Gather(bool missing)
+        {
+            if (missing)
+                return ((""keep"", null), 0);
+
+            return ((""keep"", ""value""), 1);
+        }
+
+        private static int Count(string value)
+        {
+            if (value is null)
+                return 0;
+
+            return value.Length;
+        }
+    }
+}");
+
+        Assert.Contains("type Counter = delegate func(value string?) int32", printed);
+        Assert.Contains("init(value string?)", printed);
+        Assert.Contains("prop this[key string?] int32", printed);
+        Assert.Contains("func Count(value string?) int32", printed);
+        CompileWithGsc(printed);
+    }
+
     private static string TranslateOblivious(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -900,7 +900,7 @@ public sealed partial class CSharpToGSharpTranslator
                     ITypeSymbol awaitedType = task.TypeArguments[0];
                     GTypeReference awaitedMapped = this.typeMapper.Map(
                         awaitedType, this.context, node.ReturnType.GetLocation());
-                    awaitedMapped = this.PromoteTupleReturnIfTainted(awaitedMapped, awaitedType, symbol);
+                    awaitedMapped = this.PromoteTupleDeclarationIfTainted(awaitedMapped, awaitedType, symbol);
                     return this.PromoteAwaitedReturnIfTainted(awaitedMapped, awaitedType, symbol);
                 }
 
@@ -914,7 +914,7 @@ public sealed partial class CSharpToGSharpTranslator
                 // Issue #2469: promote tuple return leaves independently from
                 // the analyzer's element-path evidence graph. Applied before
                 // scalar promotion, which is a no-op for tuple value types.
-                mapped = this.PromoteTupleReturnIfTainted(mapped, returnType, symbol);
+                mapped = this.PromoteTupleDeclarationIfTainted(mapped, returnType, symbol);
 
                 // Issue #2423: a NON-async declaration (a C# interface member —
                 // interfaces cannot declare `async` members — or a synchronous

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -121,7 +121,21 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GTypeReference PromoteIfUsedAsNullable(GTypeReference type, ISymbol symbol)
         {
-            if (type == null || type.IsNullable)
+            if (type == null)
+            {
+                return type;
+            }
+
+            ITypeSymbol declaredType = symbol switch
+            {
+                IPropertySymbol property => property.Type,
+                IFieldSymbol field => field.Type,
+                ILocalSymbol local => local.Type,
+                IParameterSymbol parameter => parameter.Type,
+                _ => null,
+            };
+            type = this.PromoteTupleDeclarationIfTainted(type, declaredType, symbol);
+            if (type.IsNullable)
             {
                 return type;
             }
@@ -204,7 +218,7 @@ public sealed partial class CSharpToGSharpTranslator
                 return envelope;
             }
 
-            GTypeReference promotedInner = this.PromoteTupleReturnIfTainted(
+            GTypeReference promotedInner = this.PromoteTupleDeclarationIfTainted(
                 named.TypeArguments[0], awaitedType, symbol);
             promotedInner = this.PromoteAwaitedReturnIfTainted(
                 promotedInner, awaitedType, symbol);
@@ -214,15 +228,15 @@ public sealed partial class CSharpToGSharpTranslator
                 : new NamedTypeReference(named.Name, new[] { promotedInner });
         }
 
-        // Issue #2469: tuple return leaves are independent declaration sinks.
+        // Issue #2469/#2490: tuple leaves are independent declaration sinks.
         // Their evidence lives in ObliviousNullabilityAnalyzer's element-path
-        // graph so tuple literals, forwarded tuple values, nested tuples,
-        // conditionals/switches, async envelopes, and contracts all converge on
-        // the same per-position answer.
-        private GTypeReference PromoteTupleReturnIfTainted(
+        // graph so tuple returns, parameters, locals, fields/properties, nested
+        // tuples, async envelopes, and contracts all converge on the same
+        // per-position answer.
+        private GTypeReference PromoteTupleDeclarationIfTainted(
             GTypeReference mapped,
             ITypeSymbol returnType,
-            IMethodSymbol symbol)
+            ISymbol symbol)
         {
             if (!this.IsObliviousCompilation()
                 || mapped is not TupleTypeReference tuple
@@ -238,7 +252,7 @@ public sealed partial class CSharpToGSharpTranslator
         private GTypeReference PromoteTupleElements(
             TupleTypeReference tuple,
             INamedTypeSymbol tupleType,
-            IMethodSymbol symbol,
+            ISymbol symbol,
             List<int> path)
         {
             var elements = new List<GTypeReference>(tuple.ElementTypes.Count);
@@ -296,6 +310,15 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             if (this.IsNullableInitializer(expression))
+            {
+                return true;
+            }
+
+            if (ObliviousNullabilityAnalyzer.IsTupleElementTainted(
+                this.context.Compilation,
+                expression,
+                this.context.SemanticModel,
+                this.context.SiblingCompilations))
             {
                 return true;
             }

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -160,48 +160,19 @@ internal static class ObliviousNullabilityAnalyzer
         ISymbol symbol,
         IReadOnlyList<CSharpCompilation> siblingCompilations)
     {
-        if (IsTainted(compilation, symbol))
-        {
-            return true;
-        }
-
-        if (symbol == null || siblingCompilations == null)
+        if (symbol == null
+            || compilation == null
+            || compilation.Options.NullableContextOptions != NullableContextOptions.Disable)
         {
             return false;
         }
 
-        foreach (CSharpCompilation sibling in siblingCompilations)
-        {
-            if (sibling == null || ReferenceEquals(sibling, compilation))
-            {
-                continue;
-            }
-
-            // A symbol resolved through one compilation's semantic model and
-            // the "same" declaration resolved directly in the compilation that
-            // actually owns it are NOT `SymbolEqualityComparer.Default`-equal
-            // across two independently-bound `CSharpCompilation`s linked only
-            // by a `CompilationReference` (confirmed empirically: two separate
-            // `CSharpCompilation.Create` calls each mint their own distinct
-            // `IAssemblySymbol` wrapper for the "same" referenced assembly, so
-            // even `ContainingAssembly` differs) — this is true of the exact
-            // `LoadProjectWithReferencesAsync` shape too (a separate
-            // `BuildLoadedProjectAsync`/`GetCompilationAsync` call per project).
-            // So `IsTainted(sibling, symbol)` alone would only ever match a
-            // symbol whose OWN declaring compilation happens to be `sibling`
-            // itself — remap `symbol` to ITS OWN symbol in `sibling`'s symbol
-            // table (by stable metadata identity: containing type's fully
-            // qualified metadata name + member name/arity, not object/CLR
-            // symbol identity) and test that remapped symbol against
-            // `sibling`'s own cached result instead.
-            ISymbol remapped = RemapToCompilation(sibling, symbol);
-            if (remapped != null && IsTainted(sibling, remapped))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return IsTaintedCore(
+            compilation,
+            Canonical(symbol),
+            siblingCompilations,
+            new HashSet<ScalarQuery>(ScalarQueryComparer.Instance),
+            new HashSet<TupleElementQuery>(TupleElementQueryComparer.Instance));
     }
 
     /// <summary>
@@ -234,7 +205,104 @@ internal static class ObliviousNullabilityAnalyzer
             Canonical(symbol),
             EncodeTuplePath(elementPath),
             siblingCompilations,
+            new HashSet<ScalarQuery>(ScalarQueryComparer.Instance),
             new HashSet<TupleElementQuery>(TupleElementQueryComparer.Instance));
+    }
+
+    /// <summary>
+    /// Whether <paramref name="expression"/> reads a null-tainted tuple leaf.
+    /// </summary>
+    /// <param name="compilation">The compilation containing the expression.</param>
+    /// <param name="expression">A named or positional tuple-member expression.</param>
+    /// <param name="model">The semantic model for the expression.</param>
+    /// <param name="siblingCompilations">Other compilations loaded in the same translation run.</param>
+    /// <returns><see langword="true"/> when the selected tuple leaf is null-tainted.</returns>
+    public static bool IsTupleElementTainted(
+        CSharpCompilation compilation,
+        ExpressionSyntax expression,
+        SemanticModel model,
+        IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        if (compilation == null
+            || expression == null
+            || model == null
+            || compilation.Options.NullableContextOptions != NullableContextOptions.Disable
+            || !TryResolveTupleElementSource(expression, model, out TupleElementKey source))
+        {
+            return false;
+        }
+
+        return IsTupleElementTaintedCore(
+            compilation,
+            source.Symbol,
+            source.Path,
+            siblingCompilations,
+            new HashSet<ScalarQuery>(ScalarQueryComparer.Instance),
+            new HashSet<TupleElementQuery>(TupleElementQueryComparer.Instance));
+    }
+
+    private static bool IsTaintedCore(
+        CSharpCompilation compilation,
+        ISymbol symbol,
+        IReadOnlyList<CSharpCompilation> siblingCompilations,
+        HashSet<ScalarQuery> scalarVisited,
+        HashSet<TupleElementQuery> tupleVisited)
+    {
+        var query = new ScalarQuery(compilation, Canonical(symbol));
+        if (!scalarVisited.Add(query))
+        {
+            return false;
+        }
+
+        TaintResult result = Cache.GetValue(compilation, Compute);
+        if (result.Tainted.Contains(query.Symbol))
+        {
+            return true;
+        }
+
+        foreach ((ISymbol target, TupleElementKey source) in result.ScalarTupleEdges)
+        {
+            if (SymbolEqualityComparer.Default.Equals(target, query.Symbol)
+                && IsTupleElementTaintedCore(
+                    compilation,
+                    source.Symbol,
+                    source.Path,
+                    siblingCompilations,
+                    scalarVisited,
+                    tupleVisited))
+            {
+                return true;
+            }
+        }
+
+        if (siblingCompilations != null)
+        {
+            foreach (CSharpCompilation sibling in siblingCompilations)
+            {
+                if (sibling == null
+                    || ReferenceEquals(sibling, compilation)
+                    || sibling.Options.NullableContextOptions != NullableContextOptions.Disable)
+                {
+                    continue;
+                }
+
+                // Remap independently-bound symbols by stable metadata identity
+                // before testing the sibling compilation's own cached graph.
+                ISymbol remapped = RemapToCompilation(sibling, query.Symbol);
+                if (remapped != null
+                    && IsTaintedCore(
+                        sibling,
+                        Canonical(remapped),
+                        siblingCompilations,
+                        scalarVisited,
+                        tupleVisited))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private static bool IsTupleElementTaintedCore(
@@ -242,10 +310,11 @@ internal static class ObliviousNullabilityAnalyzer
         ISymbol symbol,
         string path,
         IReadOnlyList<CSharpCompilation> siblingCompilations,
-        HashSet<TupleElementQuery> visited)
+        HashSet<ScalarQuery> scalarVisited,
+        HashSet<TupleElementQuery> tupleVisited)
     {
         var key = new TupleElementKey(symbol, path);
-        if (!visited.Add(new TupleElementQuery(compilation, key)))
+        if (!tupleVisited.Add(new TupleElementQuery(compilation, key)))
         {
             return false;
         }
@@ -259,7 +328,12 @@ internal static class ObliviousNullabilityAnalyzer
         foreach ((TupleElementKey target, ISymbol source) in result.TupleScalarEdges)
         {
             if (TupleElementKeyComparer.Instance.Equals(target, key)
-                && IsTainted(compilation, source, siblingCompilations))
+                && IsTaintedCore(
+                    compilation,
+                    source,
+                    siblingCompilations,
+                    scalarVisited,
+                    tupleVisited))
             {
                 return true;
             }
@@ -273,7 +347,8 @@ internal static class ObliviousNullabilityAnalyzer
                     source.Symbol,
                     source.Path,
                     siblingCompilations,
-                    visited))
+                    scalarVisited,
+                    tupleVisited))
             {
                 return true;
             }
@@ -297,7 +372,8 @@ internal static class ObliviousNullabilityAnalyzer
                         Canonical(remapped),
                         path,
                         siblingCompilations,
-                        visited))
+                        scalarVisited,
+                        tupleVisited))
                 {
                     return true;
                 }
@@ -420,7 +496,7 @@ internal static class ObliviousNullabilityAnalyzer
             foreach (SyntaxNode node in root.DescendantNodes())
             {
                 SeedDirectTaint(node, model, tainted);
-                CollectEdges(node, model, tainted, edges);
+                CollectEdges(node, model, tainted, edges, scalarTupleEdges);
             }
 
             // Method / accessor / local-function RETURN taint: a `return null`,
@@ -428,7 +504,7 @@ internal static class ObliviousNullabilityAnalyzer
             // enclosing member's return symbol; a non-directly-null `return`
             // records a transitive edge from the return symbol to the returned
             // value's source.
-            SeedReturnTaint(root, model, tainted, edges);
+            SeedReturnTaint(root, model, tainted, edges, scalarTupleEdges);
             CollectTupleFlows(
                 root,
                 model,
@@ -446,6 +522,7 @@ internal static class ObliviousNullabilityAnalyzer
         // parameter) to `T?` while leaving the other (the interface property it
         // satisfies) non-null `T` — see <see cref="CollectInterfaceImplementationEdges"/>.
         CollectInterfaceImplementationEdges(compilation, edges);
+        CollectOverrideParameterEdges(compilation, edges);
         CollectTupleContractEdges(compilation, tupleTainted, tupleEdges);
 
         // Fixpoint: propagate taint along the edge set until it stabilizes.
@@ -494,7 +571,8 @@ internal static class ObliviousNullabilityAnalyzer
             tainted,
             tupleTainted,
             tupleEdges,
-            tupleScalarEdges);
+            tupleScalarEdges,
+            scalarTupleEdges);
     }
 
     // Seeds direct null evidence for a value declaration symbol (field /
@@ -587,7 +665,8 @@ internal static class ObliviousNullabilityAnalyzer
         SyntaxNode node,
         SemanticModel model,
         HashSet<ISymbol> tainted,
-        List<(ISymbol Target, ISymbol Source)> edges)
+        List<(ISymbol Target, ISymbol Source)> edges,
+        List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges)
     {
         // Interprocedural parameter taint: an argument that is directly null or
         // reads a (possibly tainted) declaration flows to the bound parameter, so
@@ -607,9 +686,11 @@ internal static class ObliviousNullabilityAnalyzer
         // through the same argument→parameter edge collection.
         if (node is InvocationExpressionSyntax
             or ObjectCreationExpressionSyntax
-            or ConstructorInitializerSyntax)
+            or ConstructorInitializerSyntax
+            or ElementAccessExpressionSyntax
+            or ElementBindingExpressionSyntax)
         {
-            CollectArgumentEdges(node, model, tainted, edges);
+            CollectArgumentEdges(node, model, tainted, edges, scalarTupleEdges);
         }
 
         switch (node)
@@ -627,14 +708,13 @@ internal static class ObliviousNullabilityAnalyzer
                     // non-null (issue #2167, the `var` local-join case). A
                     // directly-nullable RHS taints immediately; any other RHS
                     // records a transitive edge so a nullable source propagates.
-                    if (IsDirectlyNullable(assign.Right, model))
-                    {
-                        tainted.Add(assignTarget);
-                    }
-                    else
-                    {
-                        AddEdges(assignTarget, assign.Right, model, edges);
-                    }
+                    CollectScalarValueFlow(
+                        assignTarget,
+                        assign.Right,
+                        model,
+                        tainted,
+                        edges,
+                        scalarTupleEdges);
                 }
 
                 break;
@@ -642,20 +722,30 @@ internal static class ObliviousNullabilityAnalyzer
             case VariableDeclaratorSyntax declarator
                 when declarator.Initializer != null:
                 if (model.GetDeclaredSymbol(declarator) is ISymbol declared
-                    && IsValueDeclarationSymbol(declared)
-                    && !IsDirectlyNullable(declarator.Initializer.Value, model))
+                    && IsValueDeclarationSymbol(declared))
                 {
-                    AddEdges(Canonical(declared), declarator.Initializer.Value, model, edges);
+                    CollectScalarValueFlow(
+                        Canonical(declared),
+                        declarator.Initializer.Value,
+                        model,
+                        tainted,
+                        edges,
+                        scalarTupleEdges);
                 }
 
                 break;
 
             case PropertyDeclarationSyntax property
                 when property.Initializer != null:
-                if (model.GetDeclaredSymbol(property) is IPropertySymbol propertySymbol
-                    && !IsDirectlyNullable(property.Initializer.Value, model))
+                if (model.GetDeclaredSymbol(property) is IPropertySymbol propertySymbol)
                 {
-                    AddEdges(Canonical(propertySymbol), property.Initializer.Value, model, edges);
+                    CollectScalarValueFlow(
+                        Canonical(propertySymbol),
+                        property.Initializer.Value,
+                        model,
+                        tainted,
+                        edges,
+                        scalarTupleEdges);
                 }
 
                 break;
@@ -669,14 +759,10 @@ internal static class ObliviousNullabilityAnalyzer
         SyntaxNode call,
         SemanticModel model,
         HashSet<ISymbol> tainted,
-        List<(ISymbol Target, ISymbol Source)> edges)
+        List<(ISymbol Target, ISymbol Source)> edges,
+        List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges)
     {
-        ImmutableArray<IArgumentOperation> arguments = model.GetOperation(call) switch
-        {
-            IInvocationOperation invocation => invocation.Arguments,
-            IObjectCreationOperation creation => creation.Arguments,
-            _ => default,
-        };
+        ImmutableArray<IArgumentOperation> arguments = GetCallArguments(call, model);
 
         if (arguments.IsDefaultOrEmpty)
         {
@@ -692,16 +778,26 @@ internal static class ObliviousNullabilityAnalyzer
             }
 
             ISymbol parameterSymbol = Canonical(parameter);
-            if (IsDirectlyNullable(value, model))
-            {
-                tainted.Add(parameterSymbol);
-            }
-            else
-            {
-                AddEdges(parameterSymbol, value, model, edges);
-            }
+            CollectScalarValueFlow(
+                parameterSymbol,
+                value,
+                model,
+                tainted,
+                edges,
+                scalarTupleEdges);
         }
     }
+
+    private static ImmutableArray<IArgumentOperation> GetCallArguments(
+        SyntaxNode call,
+        SemanticModel model) =>
+        model.GetOperation(call) switch
+        {
+            IInvocationOperation invocation => invocation.Arguments,
+            IObjectCreationOperation creation => creation.Arguments,
+            IPropertyReferenceOperation property => property.Arguments,
+            _ => default,
+        };
 
     // Issue #2469: tuple-valued declarations need the same direct/transitive
     // evidence graph as scalar declarations, but keyed by an element path.
@@ -838,7 +934,9 @@ internal static class ObliviousNullabilityAnalyzer
 
                 case InvocationExpressionSyntax
                     or ObjectCreationExpressionSyntax
-                    or ConstructorInitializerSyntax:
+                    or ConstructorInitializerSyntax
+                    or ElementAccessExpressionSyntax
+                    or ElementBindingExpressionSyntax:
                     CollectTupleArgumentFlows(
                         node,
                         model,
@@ -958,12 +1056,7 @@ internal static class ObliviousNullabilityAnalyzer
         List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges,
         List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges)
     {
-        ImmutableArray<IArgumentOperation> arguments = model.GetOperation(call) switch
-        {
-            IInvocationOperation invocation => invocation.Arguments,
-            IObjectCreationOperation creation => creation.Arguments,
-            _ => default,
-        };
+        ImmutableArray<IArgumentOperation> arguments = GetCallArguments(call, model);
 
         if (arguments.IsDefaultOrEmpty)
         {
@@ -1194,7 +1287,7 @@ internal static class ObliviousNullabilityAnalyzer
 
         if (value is TupleExpressionSyntax declarationTupleValue
             && targetPattern is DeclarationExpressionSyntax
-                { Designation: ParenthesizedVariableDesignationSyntax declarationPattern }
+            { Designation: ParenthesizedVariableDesignationSyntax declarationPattern }
             && declarationPattern.Variables.Count == declarationTupleValue.Arguments.Count)
         {
             for (int i = 0; i < declarationPattern.Variables.Count; i++)
@@ -1440,15 +1533,15 @@ internal static class ObliviousNullabilityAnalyzer
             int index = TupleElementIndex(receiverTuple, field);
             if (index >= 0)
             {
-                if (TryResolveTupleSource(member.Expression, model, out ISymbol symbol, out _))
-                {
-                    source = new TupleElementKey(symbol, index.ToString(System.Globalization.CultureInfo.InvariantCulture));
-                    return true;
-                }
-
                 if (TryResolveTupleElementSource(member.Expression, model, out TupleElementKey parent))
                 {
                     source = new TupleElementKey(parent.Symbol, AppendTuplePath(parent.Path, index));
+                    return true;
+                }
+
+                if (TryResolveTupleSource(member.Expression, model, out ISymbol symbol, out _))
+                {
+                    source = new TupleElementKey(symbol, index.ToString(System.Globalization.CultureInfo.InvariantCulture));
                     return true;
                 }
             }
@@ -1495,6 +1588,22 @@ internal static class ObliviousNullabilityAnalyzer
         type is { IsReferenceType: true }
             && type.NullableAnnotation != NullableAnnotation.Annotated;
 
+    private static bool IsEligibleScalarTarget(ISymbol symbol)
+    {
+        ITypeSymbol type = symbol switch
+        {
+            IMethodSymbol method => UnwrapAwaitedType(method.ReturnType),
+            IPropertySymbol property => property.Type,
+            IFieldSymbol field => field.Type,
+            ILocalSymbol local => local.Type,
+            IParameterSymbol parameter => parameter.Type,
+            _ => null,
+        };
+
+        return type is { IsReferenceType: true }
+            && type.NullableAnnotation != NullableAnnotation.Annotated;
+    }
+
     private static bool IsDefaultTupleValue(ExpressionSyntax expression, SemanticModel model) =>
         expression is DefaultExpressionSyntax
             || (expression is LiteralExpressionSyntax literal
@@ -1538,7 +1647,8 @@ internal static class ObliviousNullabilityAnalyzer
         SyntaxNode root,
         SemanticModel model,
         HashSet<ISymbol> tainted,
-        List<(ISymbol Target, ISymbol Source)> edges)
+        List<(ISymbol Target, ISymbol Source)> edges,
+        List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges)
     {
         foreach (SyntaxNode node in root.DescendantNodes())
         {
@@ -1551,7 +1661,8 @@ internal static class ObliviousNullabilityAnalyzer
                         method.Body,
                         model,
                         tainted,
-                        edges);
+                        edges,
+                        scalarTupleEdges);
                     break;
 
                 case LocalFunctionStatementSyntax localFunction:
@@ -1561,7 +1672,8 @@ internal static class ObliviousNullabilityAnalyzer
                         localFunction.Body,
                         model,
                         tainted,
-                        edges);
+                        edges,
+                        scalarTupleEdges);
                     break;
 
                 // Property / indexer getters: the "return type" is the
@@ -1576,7 +1688,8 @@ internal static class ObliviousNullabilityAnalyzer
                         property.AccessorList,
                         model,
                         tainted,
-                        edges);
+                        edges,
+                        scalarTupleEdges);
                     break;
 
                 case IndexerDeclarationSyntax indexer:
@@ -1586,7 +1699,8 @@ internal static class ObliviousNullabilityAnalyzer
                         indexer.AccessorList,
                         model,
                         tainted,
-                        edges);
+                        edges,
+                        scalarTupleEdges);
                     break;
             }
         }
@@ -1598,7 +1712,8 @@ internal static class ObliviousNullabilityAnalyzer
         BlockSyntax body,
         SemanticModel model,
         HashSet<ISymbol> tainted,
-        List<(ISymbol Target, ISymbol Source)> edges)
+        List<(ISymbol Target, ISymbol Source)> edges,
+        List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges)
     {
         if (returnSymbol is not IMethodSymbol { ReturnsVoid: false })
         {
@@ -1609,14 +1724,28 @@ internal static class ObliviousNullabilityAnalyzer
 
         if (arrowBody != null)
         {
-            ApplyReturnValue(canonicalReturn, arrowBody, model, tainted, edges, transitive: true);
+            ApplyReturnValue(
+                canonicalReturn,
+                arrowBody,
+                model,
+                tainted,
+                edges,
+                scalarTupleEdges,
+                transitive: true);
         }
 
         foreach (ReturnStatementSyntax statement in EnumerateOwnReturns(body))
         {
             if (statement.Expression != null)
             {
-                ApplyReturnValue(canonicalReturn, statement.Expression, model, tainted, edges, transitive: true);
+                ApplyReturnValue(
+                    canonicalReturn,
+                    statement.Expression,
+                    model,
+                    tainted,
+                    edges,
+                    scalarTupleEdges,
+                    transitive: true);
             }
         }
     }
@@ -1627,7 +1756,8 @@ internal static class ObliviousNullabilityAnalyzer
         AccessorListSyntax accessorList,
         SemanticModel model,
         HashSet<ISymbol> tainted,
-        List<(ISymbol Target, ISymbol Source)> edges)
+        List<(ISymbol Target, ISymbol Source)> edges,
+        List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges)
     {
         // Only reference-typed, not-already-nullable property/indexer types are
         // governed by this analysis; value types and `T?` declarations are left
@@ -1674,7 +1804,15 @@ internal static class ObliviousNullabilityAnalyzer
         // `Prop => expr;`
         if (propertyArrowBody != null)
         {
-            ApplyReturnValue(canonicalReturn, propertyArrowBody, model, tainted, edges, transitive, SourceScope.CallsAndNonPropertyDeclarations);
+            ApplyReturnValue(
+                canonicalReturn,
+                propertyArrowBody,
+                model,
+                tainted,
+                edges,
+                scalarTupleEdges,
+                transitive,
+                SourceScope.CallsAndNonPropertyDeclarations);
         }
 
         // Only the `get` accessor produces the property value; `set`/`init`
@@ -1689,7 +1827,15 @@ internal static class ObliviousNullabilityAnalyzer
         // `get => expr;`
         if (getter.ExpressionBody?.Expression is ExpressionSyntax getterArrow)
         {
-            ApplyReturnValue(canonicalReturn, getterArrow, model, tainted, edges, transitive, SourceScope.CallsAndNonPropertyDeclarations);
+            ApplyReturnValue(
+                canonicalReturn,
+                getterArrow,
+                model,
+                tainted,
+                edges,
+                scalarTupleEdges,
+                transitive,
+                SourceScope.CallsAndNonPropertyDeclarations);
         }
 
         // `get { ... return x; }`
@@ -1697,7 +1843,15 @@ internal static class ObliviousNullabilityAnalyzer
         {
             if (statement.Expression != null)
             {
-                ApplyReturnValue(canonicalReturn, statement.Expression, model, tainted, edges, transitive, SourceScope.CallsAndNonPropertyDeclarations);
+                ApplyReturnValue(
+                    canonicalReturn,
+                    statement.Expression,
+                    model,
+                    tainted,
+                    edges,
+                    scalarTupleEdges,
+                    transitive,
+                    SourceScope.CallsAndNonPropertyDeclarations);
             }
         }
     }
@@ -1803,29 +1957,28 @@ internal static class ObliviousNullabilityAnalyzer
         IPropertySymbol interfaceProperty,
         List<(ISymbol Target, ISymbol Source)> edges)
     {
-        if (interfaceProperty.Type is not { IsReferenceType: true }
-            || interfaceProperty.Type.NullableAnnotation == NullableAnnotation.Annotated)
-        {
-            return;
-        }
-
         if (type.FindImplementationForInterfaceMember(interfaceProperty) is not IPropertySymbol implementingProperty)
         {
             return;
         }
 
-        ISymbol interfaceCanonical = Canonical(interfaceProperty);
-        ISymbol implCanonical = Canonical(implementingProperty);
-        edges.Add((interfaceCanonical, implCanonical));
-        edges.Add((implCanonical, interfaceCanonical));
-
-        IParameterSymbol positionalParameter = FindPositionalRecordParameter(compilation, implementingProperty);
-        if (positionalParameter != null)
+        if (IsEligibleScalarTarget(interfaceProperty))
         {
-            ISymbol paramCanonical = Canonical(positionalParameter);
-            edges.Add((interfaceCanonical, paramCanonical));
-            edges.Add((paramCanonical, interfaceCanonical));
+            ISymbol interfaceCanonical = Canonical(interfaceProperty);
+            ISymbol implCanonical = Canonical(implementingProperty);
+            edges.Add((interfaceCanonical, implCanonical));
+            edges.Add((implCanonical, interfaceCanonical));
+
+            IParameterSymbol positionalParameter = FindPositionalRecordParameter(compilation, implementingProperty);
+            if (positionalParameter != null)
+            {
+                ISymbol paramCanonical = Canonical(positionalParameter);
+                edges.Add((interfaceCanonical, paramCanonical));
+                edges.Add((paramCanonical, interfaceCanonical));
+            }
         }
+
+        AddParameterContractEdges(interfaceProperty.Parameters, implementingProperty.Parameters, edges);
     }
 
     // Issue #2423: the method-return analog of
@@ -1859,27 +2012,69 @@ internal static class ObliviousNullabilityAnalyzer
         IMethodSymbol interfaceMethod,
         List<(ISymbol Target, ISymbol Source)> edges)
     {
-        if (interfaceMethod.MethodKind != MethodKind.Ordinary || interfaceMethod.ReturnsVoid)
+        if (interfaceMethod.MethodKind != MethodKind.Ordinary
+            || type.FindImplementationForInterfaceMember(interfaceMethod) is not IMethodSymbol implementingMethod)
         {
             return;
         }
 
         ITypeSymbol effectiveReturnType = UnwrapAwaitedType(interfaceMethod.ReturnType);
-        if (effectiveReturnType is not { IsReferenceType: true }
-            || effectiveReturnType.NullableAnnotation == NullableAnnotation.Annotated)
+        if (!interfaceMethod.ReturnsVoid
+            && effectiveReturnType is { IsReferenceType: true }
+            && effectiveReturnType.NullableAnnotation != NullableAnnotation.Annotated)
         {
-            return;
+            ISymbol interfaceCanonical = Canonical(interfaceMethod);
+            ISymbol implCanonical = Canonical(implementingMethod);
+            edges.Add((interfaceCanonical, implCanonical));
+            edges.Add((implCanonical, interfaceCanonical));
         }
 
-        if (type.FindImplementationForInterfaceMember(interfaceMethod) is not IMethodSymbol implementingMethod)
-        {
-            return;
-        }
+        AddParameterContractEdges(interfaceMethod.Parameters, implementingMethod.Parameters, edges);
+    }
 
-        ISymbol interfaceCanonical = Canonical(interfaceMethod);
-        ISymbol implCanonical = Canonical(implementingMethod);
-        edges.Add((interfaceCanonical, implCanonical));
-        edges.Add((implCanonical, interfaceCanonical));
+    private static void CollectOverrideParameterEdges(
+        Compilation compilation,
+        List<(ISymbol Target, ISymbol Source)> edges)
+    {
+        foreach (INamedTypeSymbol type in EnumerateSourceNamedTypes(compilation))
+        {
+            foreach (IMethodSymbol method in type.GetMembers().OfType<IMethodSymbol>())
+            {
+                if (method.MethodKind == MethodKind.Ordinary
+                    && method.OverriddenMethod is IMethodSymbol overridden)
+                {
+                    AddParameterContractEdges(method.Parameters, overridden.Parameters, edges);
+                }
+            }
+
+            foreach (IPropertySymbol property in type.GetMembers().OfType<IPropertySymbol>())
+            {
+                if (property.OverriddenProperty is IPropertySymbol overridden)
+                {
+                    AddParameterContractEdges(property.Parameters, overridden.Parameters, edges);
+                }
+            }
+        }
+    }
+
+    private static void AddParameterContractEdges(
+        ImmutableArray<IParameterSymbol> first,
+        ImmutableArray<IParameterSymbol> second,
+        List<(ISymbol Target, ISymbol Source)> edges)
+    {
+        int count = System.Math.Min(first.Length, second.Length);
+        for (int i = 0; i < count; i++)
+        {
+            if (!IsEligibleScalarTarget(first[i]) || !IsEligibleScalarTarget(second[i]))
+            {
+                continue;
+            }
+
+            ISymbol firstCanonical = Canonical(first[i]);
+            ISymbol secondCanonical = Canonical(second[i]);
+            edges.Add((firstCanonical, secondCanonical));
+            edges.Add((secondCanonical, firstCanonical));
+        }
     }
 
     private static void CollectTupleContractEdges(
@@ -2057,6 +2252,7 @@ internal static class ObliviousNullabilityAnalyzer
         SemanticModel model,
         HashSet<ISymbol> tainted,
         List<(ISymbol Target, ISymbol Source)> edges,
+        List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges,
         bool transitive,
         SourceScope scope = SourceScope.AllSources)
     {
@@ -2066,7 +2262,14 @@ internal static class ObliviousNullabilityAnalyzer
         }
         else if (transitive)
         {
-            AddEdges(returnSymbol, value, model, edges, scope);
+            CollectScalarValueFlow(
+                returnSymbol,
+                value,
+                model,
+                tainted,
+                edges,
+                scalarTupleEdges,
+                scope);
         }
     }
 
@@ -2112,6 +2315,78 @@ internal static class ObliviousNullabilityAnalyzer
         {
             edges.Add((target, source));
         }
+    }
+
+    // Issue #2490: a scalar declaration/return/parameter can receive one
+    // independently-tainted leaf from the tuple graph introduced for #2469.
+    // Preserve the scalar expression-shape rules used by ResolveSources while
+    // recording tuple-member reads as element-path edges instead of collapsing
+    // them to the synthesized ValueTuple field symbol.
+    private static void CollectScalarValueFlow(
+        ISymbol target,
+        ExpressionSyntax value,
+        SemanticModel model,
+        HashSet<ISymbol> tainted,
+        List<(ISymbol Target, ISymbol Source)> edges,
+        List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges,
+        SourceScope scope = SourceScope.AllSources)
+    {
+        if (!IsEligibleScalarTarget(target))
+        {
+            return;
+        }
+
+        if (IsDirectlyNullable(value, model))
+        {
+            tainted.Add(target);
+            return;
+        }
+
+        switch (value)
+        {
+            case ParenthesizedExpressionSyntax parenthesized:
+                CollectScalarValueFlow(target, parenthesized.Expression, model, tainted, edges, scalarTupleEdges, scope);
+                return;
+
+            case AwaitExpressionSyntax awaitExpression:
+                CollectScalarValueFlow(target, awaitExpression.Expression, model, tainted, edges, scalarTupleEdges, scope);
+                return;
+
+            case PostfixUnaryExpressionSyntax suppress
+                when suppress.IsKind(SyntaxKind.SuppressNullableWarningExpression):
+                return;
+
+            case BinaryExpressionSyntax coalesce
+                when coalesce.IsKind(SyntaxKind.CoalesceExpression):
+                CollectScalarValueFlow(target, coalesce.Right, model, tainted, edges, scalarTupleEdges, scope);
+                return;
+
+            case ConditionalExpressionSyntax conditional:
+                CollectScalarValueFlow(target, conditional.WhenTrue, model, tainted, edges, scalarTupleEdges, scope);
+                CollectScalarValueFlow(target, conditional.WhenFalse, model, tainted, edges, scalarTupleEdges, scope);
+                return;
+
+            case SwitchExpressionSyntax switchExpression:
+                foreach (SwitchExpressionArmSyntax arm in switchExpression.Arms)
+                {
+                    CollectScalarValueFlow(target, arm.Expression, model, tainted, edges, scalarTupleEdges, scope);
+                }
+
+                return;
+
+            case CastExpressionSyntax cast:
+                CollectScalarValueFlow(target, cast.Expression, model, tainted, edges, scalarTupleEdges, scope);
+                return;
+        }
+
+        if (scope != SourceScope.CallsOnly
+            && TryResolveTupleElementSource(value, model, out TupleElementKey tupleSource))
+        {
+            scalarTupleEdges.Add((target, tupleSource));
+            return;
+        }
+
+        AddEdges(target, value, model, edges, scope);
     }
 
     private static IEnumerable<ISymbol> ResolveSources(
@@ -2417,6 +2692,19 @@ internal static class ObliviousNullabilityAnalyzer
         public string Path { get; }
     }
 
+    private readonly struct ScalarQuery
+    {
+        public ScalarQuery(CSharpCompilation compilation, ISymbol symbol)
+        {
+            this.Compilation = compilation;
+            this.Symbol = Canonical(symbol);
+        }
+
+        public CSharpCompilation Compilation { get; }
+
+        public ISymbol Symbol { get; }
+    }
+
     private readonly struct TupleElementQuery
     {
         public TupleElementQuery(CSharpCompilation compilation, TupleElementKey key)
@@ -2447,6 +2735,25 @@ internal static class ObliviousNullabilityAnalyzer
         }
     }
 
+    private sealed class ScalarQueryComparer : IEqualityComparer<ScalarQuery>
+    {
+        public static ScalarQueryComparer Instance { get; } = new();
+
+        public bool Equals(ScalarQuery x, ScalarQuery y) =>
+            ReferenceEquals(x.Compilation, y.Compilation)
+                && SymbolEqualityComparer.Default.Equals(x.Symbol, y.Symbol);
+
+        public int GetHashCode(ScalarQuery obj)
+        {
+            int symbolHash = obj.Symbol == null
+                ? 0
+                : SymbolEqualityComparer.Default.GetHashCode(obj.Symbol);
+            return System.HashCode.Combine(
+                System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj.Compilation),
+                symbolHash);
+        }
+    }
+
     private sealed class TupleElementQueryComparer : IEqualityComparer<TupleElementQuery>
     {
         public static TupleElementQueryComparer Instance { get; } = new();
@@ -2467,12 +2774,14 @@ internal static class ObliviousNullabilityAnalyzer
             HashSet<ISymbol> tainted,
             HashSet<TupleElementKey> tupleTainted,
             List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges,
-            List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges)
+            List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges,
+            List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges)
         {
             this.Tainted = tainted;
             this.TupleTainted = tupleTainted;
             this.TupleEdges = tupleEdges;
             this.TupleScalarEdges = tupleScalarEdges;
+            this.ScalarTupleEdges = scalarTupleEdges;
         }
 
         public HashSet<ISymbol> Tainted { get; }
@@ -2482,5 +2791,7 @@ internal static class ObliviousNullabilityAnalyzer
         public List<(TupleElementKey Target, TupleElementKey Source)> TupleEdges { get; }
 
         public List<(TupleElementKey Target, ISymbol Source)> TupleScalarEdges { get; }
+
+        public List<(ISymbol Target, TupleElementKey Source)> ScalarTupleEdges { get; }
     }
 }


### PR DESCRIPTION
## Summary
- connect tuple-element taint to scalar declarations, returns, and call/constructor/indexer/delegate parameters
- preserve element precision across nested tuples, sibling compilations, and interface/override parameter contracts
- apply tuple leaf promotion consistently to tuple-valued declarations and delegate invocation shapes
- add focused translation, gsc sink, and default via-SDK pipeline regressions

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-restore --filter 'FullyQualifiedName~Issue2490|FullyQualifiedName~Issue2469TupleElementNullabilityTranslationTests|FullyQualifiedName~Issue2167TransitiveNullabilityTranslationTests|FullyQualifiedName~Issue2423InterfaceMethodContractTaintTests|FullyQualifiedName~Issue2285InterfaceImplementationNullabilityTests|FullyQualifiedName~ObliviousPromotionSinkCompilationTests' --nologo --verbosity:minimal` (36 passed)\n\nFixes #2490