### PR TITLE
Fix nullable boxed value conversions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -480,6 +480,19 @@ public sealed class Conversion
                     }
                 }
 
+                // Issue #2492: nullable annotations on boxed/reference sources
+                // do not remove C#'s explicit unboxing conversion to a nullable
+                // value type. `object?` / `I?` -> `T?` lowers to
+                // `unbox.any Nullable<T>`: null becomes an empty nullable, a
+                // boxed T becomes a present nullable, and a mismatched box
+                // throws InvalidCastException. Keep this explicit-only and
+                // symbol-aware so primitive/imported/user enum or struct
+                // targets and `[T struct] T?` all share the same rule.
+                if (HasExplicitUnboxingConversion(fromNullable.UnderlyingType, toNullable))
+                {
+                    return Conversion.Explicit;
+                }
+
                 return Conversion.None;
             }
 
@@ -777,8 +790,12 @@ public sealed class Conversion
             return Conversion.Implicit;
         }
 
-        // ADR-0045 explicit unbox: `(T)objectValue` for any value-type T.
-        if (from?.ClrType.IsSameAs(typeof(object)) == true && to?.ClrType != null && to.ClrType.IsValueType)
+        // ADR-0045 / issue #421: explicit unboxing from object, ValueType,
+        // Enum, or a compatible interface to a value type. Issue #2492
+        // includes nullable value-type targets whose real CLR storage is
+        // `Nullable<T>` even when T is a same-compilation symbol without a
+        // ClrType yet.
+        if (HasExplicitUnboxingConversion(from, to))
         {
             return Conversion.Explicit;
         }
@@ -796,17 +813,6 @@ public sealed class Conversion
         // a type parameter. `object?` reaches this via its `object` ClrType.
         // The emitter materialises this with `unbox.any T`.
         if (from?.ClrType.IsSameAs(typeof(object)) == true && to is TypeParameterSymbol)
-        {
-            return Conversion.Explicit;
-        }
-
-        // Issue #421 P2-5: an interface-typed reference holding a boxed
-        // value type unboxes back to that value type via an explicit cast
-        // (`MyStruct(iface)`). On the CLR this lowers to `unbox.any`. We
-        // accept either a user-declared interface (InterfaceSymbol, whose
-        // own ClrType is null) or an imported CLR interface (e.g.
-        // System.IComparable). Mirrors C# §10.3.5.
-        if (IsInterfaceLikeType(from) && to?.ClrType != null && to.ClrType.IsValueType)
         {
             return Conversion.Explicit;
         }
@@ -2343,6 +2349,50 @@ public sealed class Conversion
         {
             return false;
         }
+    }
+
+    private static bool HasExplicitUnboxingConversion(TypeSymbol from, TypeSymbol to)
+    {
+        if (from is NullableTypeSymbol nullableFrom)
+        {
+            from = nullableFrom.UnderlyingType;
+        }
+
+        if (to is NullableTypeSymbol nullableTo)
+        {
+            if (!NullableLifting.IsAnyValueTypeNullable(nullableTo))
+            {
+                return false;
+            }
+
+            to = nullableTo.UnderlyingType;
+        }
+        else if (!IsValueTypeLikeFrom(to))
+        {
+            return false;
+        }
+
+        if (from?.ClrType.IsSameAs(typeof(object)) == true)
+        {
+            return true;
+        }
+
+        if (from?.ClrType.IsSameAs(typeof(System.ValueType)) == true)
+        {
+            return true;
+        }
+
+        if (from?.ClrType.IsSameAs(typeof(System.Enum)) == true)
+        {
+            return IsEnumLikeType(to);
+        }
+
+        // C# only permits interface unboxing when the target value type is
+        // known to implement that interface. Keep unrelated interface/value
+        // pairs as genuine no-conversion diagnostics rather than deferring an
+        // impossible cast to runtime.
+        return IsInterfaceLikeType(from)
+            && IsValueTypeAssignableToInterface(to, from);
     }
 
     private static bool IsValueTypeLikeFrom(TypeSymbol type)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -279,6 +279,7 @@ internal sealed partial class MethodBodyEmitter
         // above (issue #504).
         if (to is NullableTypeSymbol toNullable
             && !ReflectionMetadataEmitter.IsValueTypeNullable(toNullable)
+            && !ReflectionMetadataEmitter.IsValueTypeSymbol(from)
             && IsReferenceCompatible(from, toNullable.UnderlyingType))
         {
             return;
@@ -434,8 +435,15 @@ internal sealed partial class MethodBodyEmitter
         // reference (user-declared `InterfaceSymbol` or any CLR
         // interface), since a boxed value type held in an interface
         // slot needs `unbox.any` to surface as its native value type.
-        if ((from?.ClrType.IsSameAs(typeof(object)) == true || IsInterfaceSourceType(from))
-            && to?.ClrType != null && to.ClrType.IsValueType)
+        // Issue #2492: nullable object/interface annotations are still
+        // reference slots, and a nullable value-type target must retain its
+        // wrapper token so `unbox.any Nullable<T>` propagates null while
+        // preserving checked unboxing semantics for non-null values.
+        if (IsExplicitUnboxingSourceType(from)
+            && ((to is NullableTypeSymbol nullableUnboxTarget
+                    && NullableLifting.IsAnyValueTypeNullable(nullableUnboxTarget))
+                || (to is not NullableTypeSymbol
+                    && ReflectionMetadataEmitter.IsValueTypeSymbol(to))))
         {
             this.il.OpCode(ILOpCode.Unbox_any);
             this.il.Token(this.outer.memberRefs.GetElementTypeToken(to));
@@ -450,7 +458,7 @@ internal sealed partial class MethodBodyEmitter
         // this verifies for any closing instantiation. `GetElementTypeToken`
         // resolves the correct token for both the bare and nullable-wrapped
         // type parameter.
-        if ((from?.ClrType.IsSameAs(typeof(object)) == true || IsInterfaceSourceType(from))
+        if (IsExplicitUnboxingSourceType(from)
             && (to is TypeParameterSymbol
                 || (to is NullableTypeSymbol toNullableTp && toNullableTp.UnderlyingType is TypeParameterSymbol)))
         {

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -501,6 +501,11 @@ internal sealed partial class MethodBodyEmitter
 
     private static bool IsInterfaceTargetType(TypeSymbol type)
     {
+        if (type is NullableTypeSymbol nullable)
+        {
+            type = nullable.UnderlyingType;
+        }
+
         if (type is InterfaceSymbol)
         {
             return true;
@@ -511,12 +516,30 @@ internal sealed partial class MethodBodyEmitter
 
     private static bool IsInterfaceSourceType(TypeSymbol type)
     {
+        if (type is NullableTypeSymbol nullable)
+        {
+            type = nullable.UnderlyingType;
+        }
+
         if (type is InterfaceSymbol)
         {
             return true;
         }
 
         return type?.ClrType != null && type.ClrType.IsInterface;
+    }
+
+    private static bool IsExplicitUnboxingSourceType(TypeSymbol type)
+    {
+        if (type is NullableTypeSymbol nullable)
+        {
+            type = nullable.UnderlyingType;
+        }
+
+        return type?.ClrType.IsSameAs(typeof(object)) == true
+            || type?.ClrType.IsSameAs(typeof(System.ValueType)) == true
+            || type?.ClrType.IsSameAs(typeof(System.Enum)) == true
+            || IsInterfaceSourceType(type);
     }
 
     private static bool IsUnsignedClrType(Type t)

--- a/test/Compiler.Tests/Emit/Issue2492NullableBoxedConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2492NullableBoxedConversionEmitTests.cs
@@ -1,0 +1,299 @@
+// <copyright file="Issue2492NullableBoxedConversionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2492 end-to-end coverage for nullable object/interface sources
+/// explicitly unboxed to nullable value types.
+/// </summary>
+public sealed class Issue2492NullableBoxedConversionEmitTests
+{
+    [Fact]
+    public void NullableObject_ToNullableUInt32_ReflectsUnboxAnySemantics()
+    {
+        const string source = """
+            package issue2492reflection
+
+            func Convert(value object?) uint32? -> uint32?(value)
+            """;
+
+        var assembly = CompileLibrary(source);
+        var method = GetProgramMethod(assembly, "Convert");
+
+        Assert.Equal(typeof(uint?), method.ReturnType);
+        Assert.Null(method.Invoke(null, new object[] { null }));
+        Assert.Equal(2492u, method.Invoke(null, new object[] { 2492u }));
+
+        var exception = Assert.Throws<TargetInvocationException>(
+            () => method.Invoke(null, new object[] { 2492 }));
+        Assert.IsType<InvalidCastException>(exception.InnerException);
+
+        var il = method.GetMethodBody()!.GetILAsByteArray()!;
+        Assert.Contains((byte)0xA5, il); // unbox.any
+    }
+
+    [Fact]
+    public void NullableObject_ToNullableImportedStruct_PropagatesNullAndValue()
+    {
+        const string source = """
+            package issue2492imported
+            import System
+
+            func Convert(value object?) Guid? -> Guid?(value)
+            """;
+
+        var assembly = CompileLibrary(source);
+        var method = GetProgramMethod(assembly, "Convert");
+        var expected = Guid.NewGuid();
+
+        Assert.Equal(typeof(Guid?), method.ReturnType);
+        Assert.Null(method.Invoke(null, new object[] { null }));
+        Assert.Equal(expected, method.Invoke(null, new object[] { expected }));
+    }
+
+    [Fact]
+    public void NullableValueTypeAndEnumBaseSources_UnboxCompatibleNullableTargets()
+    {
+        const string source = """
+            package issue2492boxedbases
+            import System
+
+            func ConvertValue(value ValueType?) Guid? -> Guid?(value)
+            func ConvertEnum(value Enum?) DayOfWeek? -> DayOfWeek?(value)
+            """;
+
+        var assembly = CompileLibrary(source);
+        var convertValue = GetProgramMethod(assembly, "ConvertValue");
+        var convertEnum = GetProgramMethod(assembly, "ConvertEnum");
+        var guid = Guid.NewGuid();
+
+        Assert.Null(convertValue.Invoke(null, new object[] { null }));
+        Assert.Equal(guid, convertValue.Invoke(null, new object[] { guid }));
+        Assert.Null(convertEnum.Invoke(null, new object[] { null }));
+        Assert.Equal(DayOfWeek.Friday, convertEnum.Invoke(null, new object[] { DayOfWeek.Friday }));
+    }
+
+    [Fact]
+    public void SameCompilationStructAndEnum_RoundTripThroughNullableObject()
+    {
+        const string source = """
+            package issue2492user
+            import System
+
+            struct Point2492(Value int32) {}
+            enum Color2492 { Red, Green }
+
+            func Main() {
+                let pointBox object? = Point2492(7)
+                let point Point2492? = Point2492?(pointBox)
+                Console.WriteLine(point!!.Value)
+
+                let colorBox object? = Color2492.Green
+                let color Color2492? = Color2492?(colorBox)
+                Console.WriteLine(int32(color!!))
+
+                let missing object? = nil
+                let noPoint Point2492? = Point2492?(missing)
+                let noColor Color2492? = Color2492?(missing)
+                Console.WriteLine(noPoint == nil)
+                Console.WriteLine(noColor == nil)
+            }
+            """;
+
+        Assert.Equal("7\n1\nTrue\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void StructConstrainedGenericNullableTarget_RoundTrips()
+    {
+        const string source = """
+            package issue2492generic
+            import System
+
+            func Convert[T struct](value object?) T? -> T?(value)
+
+            func Main() {
+                let boxed object? = 42
+                let present int32? = Convert[int32](boxed)
+                Console.WriteLine(present!!)
+
+                let missing object? = nil
+                let absent int32? = Convert[int32](missing)
+                Console.WriteLine(absent == nil)
+            }
+            """;
+
+        Assert.Equal("42\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableImportedAndUserInterfaces_UnboxMatchingValues()
+    {
+        const string source = """
+            package issue2492interfaces
+            import System
+
+            interface IBox2492 {}
+            struct Box2492(Value int32) : IBox2492 {}
+
+            func FromImported(value IComparable?) int32? -> int32?(value)
+            func FromUser(value IBox2492?) Box2492? -> Box2492?(value)
+
+            func Main() {
+                let imported IComparable? = 17
+                Console.WriteLine(FromImported(imported)!!)
+
+                let user IBox2492? = Box2492(23)
+                Console.WriteLine(FromUser(user)!!.Value)
+            }
+            """;
+
+        Assert.Equal("17\n23\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void PatternNarrowedInterfaceSource_UsesCheckedUnboxing()
+    {
+        const string source = """
+            package issue2492pattern
+            import System
+
+            func Convert(value object?) int32? {
+                if value is IComparable {
+                    return int32?(value)
+                }
+
+                return nil
+            }
+
+            func Main() {
+                Console.WriteLine(Convert(31)!!)
+                Console.WriteLine(Convert(nil) == nil)
+            }
+            """;
+
+        Assert.Equal("31\nTrue\n", CompileAndRun(source));
+    }
+
+    private static MethodInfo GetProgramMethod(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        return program.GetMethod(
+            name,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"Method '{name}' was not emitted.");
+    }
+
+    private static Assembly CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2492_lib_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(tempDir, "test.gs");
+            var outputPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            var (exitCode, stdout, stderr) = Compile(sourcePath, outputPath, "library");
+            Assert.True(exitCode == 0, $"gsc failed:\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            IlVerifier.Verify(outputPath);
+            return Assembly.Load(File.ReadAllBytes(outputPath));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2492_exe_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(tempDir, "test.gs");
+            var outputPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            var (exitCode, stdout, stderr) = Compile(sourcePath, outputPath, "exe");
+            Assert.True(exitCode == 0, $"gsc failed:\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            IlVerifier.Verify(outputPath);
+
+            var runtimeConfig = Path.ChangeExtension(outputPath, ".runtimeconfig.json");
+            if (!File.Exists(runtimeConfig))
+            {
+                File.WriteAllText(runtimeConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(runtimeConfig);
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var runtimeOutput = process.StandardOutput.ReadToEnd();
+            var runtimeError = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            Assert.True(
+                process.ExitCode == 0,
+                $"dotnet exec failed ({process.ExitCode}):\nstdout:\n{runtimeOutput}\nstderr:\n{runtimeError}");
+            return runtimeOutput.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) Compile(
+        string sourcePath,
+        string outputPath,
+        string target)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            return (exitCode, stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2492NullableBoxedConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2492NullableBoxedConversionTests.cs
@@ -1,0 +1,114 @@
+// <copyright file="Issue2492NullableBoxedConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2492: explicit object/interface unboxing remains available when the
+/// source and target carry nullable annotations. The conversion is explicit
+/// only and is restricted to interface/value-type pairs that can actually box
+/// and unbox through that interface.
+/// </summary>
+public sealed class Issue2492NullableBoxedConversionTests
+{
+    [Fact]
+    public void ExplicitNullableBoxedSources_ToNullableValueTypes_Compile()
+    {
+        const string source = """
+            package issue2492bindingpositive
+            import System
+
+            interface IBox2492 {}
+            struct Local2492(Value int32) : IBox2492 {}
+            enum Color2492 { Red, Green }
+
+            func Primitive(value object?) uint32? -> uint32?(value)
+            func Imported(value object?) Guid? -> Guid?(value)
+            func ValueTypeSource(value ValueType?) Guid? -> Guid?(value)
+            func EnumBaseSource(value Enum?) DayOfWeek? -> DayOfWeek?(value)
+            func Local(value object?) Local2492? -> Local2492?(value)
+            func EnumValue(value object?) Color2492? -> Color2492?(value)
+            func Generic[T struct](value object?) T? -> T?(value)
+            func ImportedInterface(value IComparable?) int32? -> int32?(value)
+            func UserInterface(value IBox2492?) Local2492? -> Local2492?(value)
+            func NonNullableImportedInterface(value IComparable) int32? -> int32?(value)
+            func NonNullableUserInterface(value IBox2492) Local2492? -> Local2492?(value)
+            func NonNullableObjectControl(value object) uint32? -> uint32?(value)
+            func NonNullableTargetControl(value object?) uint32 -> uint32(value)
+            func AsControl(value object?) uint32? -> value as uint32?
+            """;
+
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void ExplicitCast_AfterInterfacePatternNarrowing_Compiles()
+    {
+        const string source = """
+            package issue2492bindingpattern
+            import System
+
+            func Convert(value object?) int32? {
+                if value is IComparable {
+                    return int32?(value)
+                }
+
+                return nil
+            }
+            """;
+
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void ImplicitNullableObjectToNullableValue_RemainsRejectedAsExplicitOnly()
+    {
+        const string source = """
+            package issue2492bindingimplicit
+
+            func Sink(value int32?) void {}
+            func Return(value object?) int32? -> value
+            func Assign(value object?) void {
+                let converted int32? = value
+                Sink(value)
+            }
+            """;
+
+        var diagnostics = Evaluate(source).Diagnostics;
+        Assert.Equal(2, diagnostics.Count(d => d.Id == "GS0156"));
+        Assert.Single(diagnostics, d => d.Id == "GS0154");
+    }
+
+    [Fact]
+    public void InvalidReferenceAndInterfaceSources_ReportNoConversion()
+    {
+        const string source = """
+            package issue2492bindinginvalid
+            import System
+
+            func FromString(value string?) int32? -> int32?(value)
+            func FromUnrelatedInterface(value IDisposable?) int32? -> int32?(value)
+            func FromEnumBase(value Enum?) int32? -> int32?(value)
+            """;
+
+        var diagnostics = Evaluate(source).Diagnostics;
+        Assert.Equal(3, diagnostics.Count(d => d.Id == "GS0155"));
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree) { IsLibrary = true };
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2492NullableBoxedConversionPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2492NullableBoxedConversionPipelineTests.cs
@@ -1,0 +1,136 @@
+// <copyright file="Issue2492NullableBoxedConversionPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2492: the default SDK-backed migration emits nullable value-type
+/// construction for an explicit cast from <c>object?</c>, and gsc must accept
+/// both the stable minimal repro and the Oahu converter shape.
+/// </summary>
+public sealed class Issue2492NullableBoxedConversionPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_NullableObjectCast_TranslatesAndCompiles()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectDir = Path.Combine(sourceRoot, "src", "Sample");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "Sample.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "Repro.cs"), """
+            namespace Sample;
+
+            public static class Repro
+            {
+                public static uint? Convert(object? value) => (uint?)value;
+            }
+
+            public sealed class ToStringConverterActivationCode
+            {
+                public uint? Convert(object? value)
+                {
+                    uint? ac = (uint?)value;
+                    return ac;
+                }
+            }
+            """);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp("test/NullableBoxedConversion", projectPath, TargetKind.Library);
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+
+        string appRunDir = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.Id));
+        string emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(appRunDir, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains(
+            "func Convert(value object?) uint32? -> uint32?(value)",
+            emitted,
+            StringComparison.Ordinal);
+        Assert.Contains("class ToStringConverterActivationCode", emitted, StringComparison.Ordinal);
+        Assert.Contains("let ac = uint32?(value)", emitted, StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            "Expected default --via-sdk compile to accept nullable boxed conversions. Stages: " +
+                string.Join("; ", appResult.Stages.Select(s => s.Stage + "=" + s.Status)));
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2492",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    dir.FullName,
+                    "out",
+                    "bin",
+                    config,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes #2492

## Summary
- classify explicit unboxing from nullable object, ValueType, Enum, and compatible interface sources to nullable value types
- preserve `unbox.any Nullable<T>` tokens for primitive, enum, imported/user struct, and struct-constrained generic targets
- keep conversions explicit-only and reject unrelated reference/interface sources with the correct diagnostics
- complete nullable-interface boxing needed for matching user/imported interface round trips
- add binding, runtime, reflection, ILVerify, and default `--via-sdk` migration coverage, including the Oahu converter shape

## Validation
- 98 related Core binding tests passed
- 111 related Compiler emit/runtime/ILVerify tests passed
- issue #2492 default `--via-sdk` pipeline regression passed with a fresh local SDK package cache