### PR TITLE
Preserve source enum identity in LINQ Min/Max

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -1123,7 +1123,13 @@ internal sealed partial class ExpressionBinder
             extensionArgumentNames = withReceiver;
         }
 
-        var candidates = this.memberLookup.CollectImportedExtensionMethods(methodName);
+        var extensionSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(
+            receiver?.Type,
+            ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
+        var candidates = MemberLookup.ExcludeErasureOnlyEnumCandidates(
+            this.memberLookup.CollectImportedExtensionMethods(methodName),
+            extensionSymbolicArgs,
+            extensionArgumentNames).ToList();
         if (candidates.Count == 0)
         {
             return false;
@@ -1189,7 +1195,6 @@ internal sealed partial class ExpressionBinder
         // method-type-args may then surface a symbolic return like
         // `[]T` from `[]T{}.ToArray()` instead of the erased
         // `object[]`.
-        var extensionSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(receiver?.Type, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
         var extensionSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(best, typeArgSymbols, extensionSymbolicArgs);
         var extensionTypeArgSymbolsForCall = !extensionSymbolicTypeArgs.IsDefault ? extensionSymbolicTypeArgs : typeArgSymbols;
         var returnOverride = ResolveImportedGenericReturnType(best, typeArgSymbols)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2458,7 +2458,14 @@ internal sealed partial class ExpressionBinder
         // methods declared on a base interface (e.g.
         // IEnumerable<T>.GetEnumerator() surfaced through
         // IReadOnlyList<T>) are found.
-        var candidates = new List<MethodInfo>(MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(clrType, methodName));
+        var instSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(
+            receiverType: null,
+            ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
+        var candidates = MemberLookup.ExcludeErasureOnlyEnumCandidates(
+            MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(clrType, methodName),
+            instSymbolicArgs,
+            argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
+            effectiveReceiverType).ToList();
 
         if (candidates.Count > 0)
         {
@@ -2570,7 +2577,6 @@ internal sealed partial class ExpressionBinder
                         // never unified and the call collapsed to `<object>`. The
                         // receiver still drives return-type Var substitution via
                         // `ResolveCallReturnTypeFromSymbolicTypeArgs` below.
-                        var instSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(null, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
                         var instSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(resolution.Best, typeArgSymbols, instSymbolicArgs);
                         var instTypeArgSymbolsForCall = !instSymbolicTypeArgs.IsDefault ? instSymbolicTypeArgs : typeArgSymbols;
                         var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols)

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1213,6 +1213,322 @@ internal sealed class MemberLookup
     }
 
     /// <summary>
+    /// Issue #2494: removes imported method candidates that are applicable only
+    /// because a same-compilation enum was projected to its temporary CLR
+    /// <c>int32</c> representation. The projection is a lookup aid; it is not a
+    /// source-language enum-to-integer conversion. Open generic parameter
+    /// positions remain eligible so the existing symbolic substitution path can
+    /// recover the enum identity for the selected method and its return type.
+    /// </summary>
+    /// <param name="candidates">The imported candidates to filter.</param>
+    /// <param name="symbolicArgTypes">Symbolic argument types in candidate parameter order.</param>
+    /// <param name="argumentNames">Optional source argument names aligned with <paramref name="symbolicArgTypes"/>.</param>
+    /// <param name="symbolicReceiverType">The symbolic instance receiver, used to reopen an erased constructed declaring type.</param>
+    /// <returns>Candidates that do not require an enum-erasure-only match.</returns>
+    public static IEnumerable<MethodInfo> ExcludeErasureOnlyEnumCandidates(
+        IEnumerable<MethodInfo> candidates,
+        ImmutableArray<TypeSymbol> symbolicArgTypes,
+        IReadOnlyList<string> argumentNames = null,
+        TypeSymbol symbolicReceiverType = null)
+    {
+        if (candidates == null || symbolicArgTypes.IsDefaultOrEmpty)
+        {
+            return candidates ?? Enumerable.Empty<MethodInfo>();
+        }
+
+        return candidates.Where(candidate => !HasErasureOnlyEnumParameterMatch(
+            candidate,
+            symbolicArgTypes,
+            argumentNames,
+            symbolicReceiverType));
+
+        static bool HasErasureOnlyEnumParameterMatch(
+            MethodInfo candidate,
+            ImmutableArray<TypeSymbol> symbolicArgTypes,
+            IReadOnlyList<string> argumentNames,
+            TypeSymbol symbolicReceiverType)
+        {
+            if (candidate == null)
+            {
+                return false;
+            }
+
+            MethodInfo openCandidate = candidate.IsGenericMethod && !candidate.IsGenericMethodDefinition
+                ? candidate.GetGenericMethodDefinition()
+                : candidate;
+            Type declaringType = openCandidate.DeclaringType;
+            if (declaringType?.IsConstructedGenericType == true
+                && symbolicReceiverType is ImportedTypeSymbol symbolicReceiver
+                && symbolicReceiver.OpenDefinition != null)
+            {
+                var declaringDefinition = declaringType.GetGenericTypeDefinition();
+                var receiverCarriesSymbolicType = ClrTypeUtilities.AreSame(
+                        symbolicReceiver.OpenDefinition,
+                        declaringDefinition)
+                    && TypeSymbol.ContainsSameCompilationUserType(symbolicReceiverType);
+                if (!receiverCarriesSymbolicType
+                    && TryMapThroughImplemented(
+                        symbolicReceiver,
+                        declaringDefinition,
+                        out var liftedReceiverArguments))
+                {
+                    receiverCarriesSymbolicType = liftedReceiverArguments.Any(
+                        TypeSymbol.ContainsSameCompilationUserType);
+                }
+
+                if (receiverCarriesSymbolicType)
+                {
+                    MethodInfo reopened = TryGetOpenMethodOnDeclaringType(
+                        declaringDefinition,
+                        openCandidate);
+                    if (reopened != null)
+                    {
+                        openCandidate = reopened;
+                    }
+                }
+            }
+
+            ParameterInfo[] parameters;
+            try
+            {
+                parameters = openCandidate.GetParameters();
+            }
+            catch
+            {
+                return false;
+            }
+
+            var hasParams = parameters.Length > 0
+                && OverloadResolution.IsParamsArrayParameter(parameters[parameters.Length - 1]);
+            var nextPositionalParameter = 0;
+            for (var i = 0; i < symbolicArgTypes.Length; i++)
+            {
+                var argumentName = argumentNames != null && i < argumentNames.Count
+                    ? argumentNames[i]
+                    : null;
+                var parameterIndex = -1;
+                if (!string.IsNullOrEmpty(argumentName))
+                {
+                    for (var p = 0; p < parameters.Length; p++)
+                    {
+                        if (string.Equals(parameters[p].Name, argumentName, StringComparison.Ordinal))
+                        {
+                            parameterIndex = p;
+                            break;
+                        }
+                    }
+                }
+                else if (nextPositionalParameter < parameters.Length)
+                {
+                    parameterIndex = nextPositionalParameter++;
+                }
+                else if (hasParams)
+                {
+                    parameterIndex = parameters.Length - 1;
+                }
+
+                if (parameterIndex < 0 || parameterIndex >= parameters.Length)
+                {
+                    continue;
+                }
+
+                var parameterType = parameters[parameterIndex].ParameterType;
+                if (hasParams
+                    && parameterIndex == parameters.Length - 1
+                    && string.IsNullOrEmpty(argumentName)
+                    && parameterType.IsArray
+                    && symbolicArgTypes[i] is not SliceTypeSymbol
+                    && symbolicArgTypes[i] is not ArrayTypeSymbol)
+                {
+                    parameterType = parameterType.GetElementType();
+                    nextPositionalParameter = parameterIndex;
+                }
+
+                if (IsErasureOnlyEnumMatch(parameterType, symbolicArgTypes[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        static bool IsErasureOnlyEnumMatch(Type openParameterType, TypeSymbol symbolicArgumentType)
+        {
+            if (openParameterType == null || symbolicArgumentType == null)
+            {
+                return false;
+            }
+
+            if (openParameterType.IsByRef)
+            {
+                openParameterType = openParameterType.GetElementType();
+            }
+
+            if (symbolicArgumentType is ByRefTypeSymbol byRefArgument)
+            {
+                symbolicArgumentType = byRefArgument.PointeeType;
+            }
+
+            // A generic slot captures the symbolic enum and is repaired downstream
+            // by BuildSymbolicMethodTypeArgs/ResolveCallReturnTypeFromSymbolicTypeArgs.
+            if (openParameterType == null || openParameterType.IsGenericParameter)
+            {
+                return false;
+            }
+
+            if (symbolicArgumentType is EnumSymbol)
+            {
+                return string.Equals(openParameterType.FullName, typeof(int).FullName, StringComparison.Ordinal);
+            }
+
+            if (symbolicArgumentType is NullableTypeSymbol nullable)
+            {
+                if (TryGetNullableTypeArgument(openParameterType, out var nullableParameter))
+                {
+                    return IsErasureOnlyEnumMatch(nullableParameter, nullable.UnderlyingType);
+                }
+
+                // Reference-type nullability is an annotation, not a distinct
+                // CLR generic wrapper. Continue matching the underlying symbolic
+                // shape against the same formal parameter.
+                return IsErasureOnlyEnumMatch(openParameterType, nullable.UnderlyingType);
+            }
+
+            if (symbolicArgumentType is FunctionTypeSymbol functionType)
+            {
+                MethodInfo invoke;
+                try
+                {
+                    invoke = openParameterType.GetMethod("Invoke");
+                }
+                catch
+                {
+                    return false;
+                }
+
+                if (invoke == null)
+                {
+                    return false;
+                }
+
+                var invokeParameters = invoke.GetParameters();
+                var parameterCount = Math.Min(invokeParameters.Length, functionType.ParameterTypes.Length);
+                for (var i = 0; i < parameterCount; i++)
+                {
+                    if (IsErasureOnlyEnumMatch(invokeParameters[i].ParameterType, functionType.ParameterTypes[i]))
+                    {
+                        return true;
+                    }
+                }
+
+                return !FunctionTypeSymbol.IsVoidReturn(functionType.ReturnType)
+                    && IsErasureOnlyEnumMatch(invoke.ReturnType, functionType.ReturnType);
+            }
+
+            if (symbolicArgumentType is TupleTypeSymbol tuple
+                && openParameterType.IsGenericType)
+            {
+                var tupleDefinition = openParameterType.GetGenericTypeDefinition();
+                var tupleArguments = openParameterType.GetGenericArguments();
+                if (tupleDefinition.FullName?.StartsWith("System.ValueTuple`", StringComparison.Ordinal) == true
+                    && tupleArguments.Length == tuple.ElementTypes.Length)
+                {
+                    for (var i = 0; i < tupleArguments.Length; i++)
+                    {
+                        if (IsErasureOnlyEnumMatch(tupleArguments[i], tuple.ElementTypes[i]))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+            }
+
+            if (openParameterType.IsArray && openParameterType.GetArrayRank() == 1)
+            {
+                TypeSymbol symbolicElement = TryGetElementType(symbolicArgumentType);
+                return symbolicElement != null
+                    && IsErasureOnlyEnumMatch(openParameterType.GetElementType(), symbolicElement);
+            }
+
+            if (openParameterType.IsGenericType)
+            {
+                var openArguments = openParameterType.GetGenericArguments();
+                if (symbolicArgumentType is ImportedTypeSymbol implemented
+                    && TryMapThroughImplemented(
+                        implemented,
+                        openParameterType.GetGenericTypeDefinition(),
+                        out var liftedArguments)
+                    && liftedArguments.Length == openArguments.Length)
+                {
+                    for (var i = 0; i < openArguments.Length; i++)
+                    {
+                        if (IsErasureOnlyEnumMatch(openArguments[i], liftedArguments[i]))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                if (openArguments.Length == 1)
+                {
+                    TypeSymbol symbolicElement = TryGetElementType(symbolicArgumentType);
+                    if (symbolicElement != null)
+                    {
+                        return IsErasureOnlyEnumMatch(openArguments[0], symbolicElement);
+                    }
+                }
+
+                if (symbolicArgumentType is ImportedTypeSymbol imported
+                    && !imported.TypeArguments.IsDefaultOrEmpty
+                    && imported.TypeArguments.Length == openArguments.Length)
+                {
+                    for (var i = 0; i < openArguments.Length; i++)
+                    {
+                        if (IsErasureOnlyEnumMatch(openArguments[i], imported.TypeArguments[i]))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        static bool TryGetNullableTypeArgument(Type type, out Type argument)
+        {
+            argument = null;
+            if (type == null || !type.IsGenericType)
+            {
+                return false;
+            }
+
+            Type definition;
+            try
+            {
+                definition = type.GetGenericTypeDefinition();
+            }
+            catch
+            {
+                return false;
+            }
+
+            if (!string.Equals(definition.FullName, typeof(Nullable<>).FullName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            argument = type.GetGenericArguments()[0];
+            return true;
+        }
+    }
+
+    /// <summary>
     /// Issue #833: projects a <see cref="TypeSymbol"/> that may contain
     /// open type/method parameters to a CLR <see cref="System.Type"/>
     /// using <c>object</c> as the erasure placeholder. This lets
@@ -1284,7 +1600,31 @@ internal sealed class MemberLookup
 
                 return false;
             case NullableTypeSymbol nullable when nullable.UnderlyingType != null:
-                return TryProjectErasedClrType(nullable.UnderlyingType, out erased);
+                if (!TryProjectErasedClrType(nullable.UnderlyingType, out var erasedUnderlying))
+                {
+                    return false;
+                }
+
+                if (!erasedUnderlying.IsValueType || Nullable.GetUnderlyingType(erasedUnderlying) != null)
+                {
+                    erased = erasedUnderlying;
+                    return true;
+                }
+
+                try
+                {
+                    var nullableDefinition = erasedUnderlying.Assembly == typeof(object).Assembly
+                        ? typeof(Nullable<>)
+                        : erasedUnderlying.Assembly.GetType(typeof(Nullable<>).FullName, throwOnError: false);
+                    erased = nullableDefinition?.MakeGenericType(erasedUnderlying) ?? erasedUnderlying;
+                    return true;
+                }
+                catch
+                {
+                    erased = erasedUnderlying;
+                    return true;
+                }
+
             case FunctionTypeSymbol fn:
                 // Issue #932: a func/arrow literal whose natural delegate type
                 // closes over a same-compilation user class (whose ClrType is
@@ -3513,6 +3853,16 @@ internal sealed class MemberLookup
             return;
         }
 
+        // Reference-type nullability is a source annotation and does not add a
+        // CLR wrapper. Unify through it so a nullable reference receiver such as
+        // IEnumerable<Choice>? still recovers TSource = Choice. Preserve real
+        // Nullable<T> value shapes (including same-compilation enums/structs).
+        if (actual is NullableTypeSymbol nullableActual
+            && !NullableLifting.IsAnyValueTypeNullable(nullableActual))
+        {
+            actual = nullableActual.UnderlyingType;
+        }
+
         // Open MVar(i) → record the actual symbolic shape (first wins).
         if (openClr.IsGenericParameter && openClr.DeclaringMethod != null)
         {
@@ -3561,6 +3911,18 @@ internal sealed class MemberLookup
         {
             var openDef = openClr.GetGenericTypeDefinition();
             var openArgs = openClr.GetGenericArguments();
+
+            if (actual is TupleTypeSymbol tuple
+                && openDef.FullName?.StartsWith("System.ValueTuple`", StringComparison.Ordinal) == true
+                && openArgs.Length == tuple.ElementTypes.Length)
+            {
+                for (var i = 0; i < openArgs.Length; i++)
+                {
+                    UnifyForMethodTypeArgs(openArgs[i], tuple.ElementTypes[i], openMethod, result);
+                }
+
+                return;
+            }
 
             // Pattern A: actual is an ImportedTypeSymbol whose OpenDefinition matches exactly.
             if (actual is ImportedTypeSymbol imp

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -324,6 +324,11 @@ public sealed class ImportedClassSymbol : Symbol
         var symbolicArgVector = MemberLookup.BuildSymbolicArgTypeVector(
             receiverType: null,
             ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
+        nameMatches = MemberLookup.ExcludeErasureOnlyEnumCandidates(
+            nameMatches,
+            symbolicArgVector,
+            argumentNames,
+            SymbolicReceiver).ToList();
         var result = OverloadResolution.Resolve(
             nameMatches,
             argTypes,

--- a/test/Compiler.Tests/Emit/Issue2494EnumLinqExtremaEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2494EnumLinqExtremaEmitTests.cs
@@ -1,0 +1,505 @@
+// <copyright file="Issue2494EnumLinqExtremaEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// End-to-end regression coverage for issue #2494. Imported generic LINQ
+/// extrema and sibling generic-return paths must retain a same-compilation
+/// enum in binding, emitted signatures, MethodSpecs, and runtime values rather
+/// than exposing the enum's temporary <c>int32</c> lookup projection.
+/// </summary>
+public sealed class Issue2494EnumLinqExtremaEmitTests
+{
+    private const string ImportedEnumsCSharpSource = """
+        namespace Issue2494.Imported;
+
+        public enum SByteChoice : sbyte { Low, High }
+        public enum ByteChoice : byte { Low, High }
+        public enum Int16Choice : short { Low, High }
+        public enum UInt16Choice : ushort { Low, High }
+        public enum Int32Choice : int { Low, High }
+        public enum UInt32Choice : uint { Low, High }
+        public enum Int64Choice : long { Low, High }
+        public enum UInt64Choice : ulong { Low, High }
+        """;
+
+    [Fact]
+    public void SourceEnum_AllReceiverAndGenericReturnShapes_CompileRunAndIlVerify()
+    {
+        const string source = """
+            package Issue2494.SourceRuntime
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            enum Choice2494 { Low, Middle, High }
+            data class Item2494(State Choice2494, Optional Choice2494?) {}
+
+            func GenericMin[T](values IEnumerable[T]) T -> values.Min()
+            func GenericMax[T](values IEnumerable[T]) T -> values.Max()
+            func ArrayMin(values []Choice2494) Choice2494 -> values.Min()
+            func ArrayMax(values []Choice2494) Choice2494 -> values.Max()
+            func EnumerableMin(values IEnumerable[Choice2494]) Choice2494 -> values.Min()
+            func EnumerableMax(values IEnumerable[Choice2494]) Choice2494 -> values.Max()
+            func ListMin(values List[Choice2494]) Choice2494 -> values.Min()
+            func ListMax(values List[Choice2494]) Choice2494 -> values.Max()
+            func StaticMin(values []Choice2494) Choice2494 -> Enumerable.Min(values)
+            func StaticMax(values []Choice2494) Choice2494 -> Enumerable.Max(values)
+            func DictionaryValuesMin(values Dictionary[string, Choice2494]) Choice2494 ->
+                values.Values.Min()
+            func PipelineMin(values []Choice2494) Choice2494 ->
+                values.Select((value Choice2494) -> value).Distinct().Min()
+            func PipelineMax(values []Choice2494) Choice2494 ->
+                values.Select((value Choice2494) -> value).Distinct().Max()
+            func NullableMin(values []Choice2494?) Choice2494? -> values.Min()
+            func NullableMax(values []Choice2494?) Choice2494? -> values.Max()
+            func SelectorMin(values []Item2494) Choice2494 ->
+                values.Min((item Item2494) -> item.State)
+            func SelectorMax(values []Item2494) Choice2494 ->
+                values.Max((item Item2494) -> item.State)
+            func NullableSelectorMin(values []Item2494) Choice2494? ->
+                values.Min((item Item2494) -> item.Optional)
+            func NullableSelectorMax(values []Item2494) Choice2494? ->
+                values.Max((item Item2494) -> item.Optional)
+
+            func main() {
+                let array = []Choice2494{Choice2494.Low, Choice2494.Middle, Choice2494.High}
+                let enumerable IEnumerable[Choice2494] = array
+                let list = List[Choice2494]()
+                list.Add(Choice2494.High)
+                list.Add(Choice2494.Low)
+
+                Console.WriteLine(ArrayMin(array) == Choice2494.Low)
+                Console.WriteLine(ArrayMax(array) == Choice2494.High)
+                Console.WriteLine(EnumerableMin(enumerable) == Choice2494.Low)
+                Console.WriteLine(EnumerableMax(enumerable) == Choice2494.High)
+                Console.WriteLine(ListMin(list) == Choice2494.Low)
+                Console.WriteLine(ListMax(list) == Choice2494.High)
+                Console.WriteLine(StaticMin(array) == Choice2494.Low)
+                Console.WriteLine(StaticMax(array) == Choice2494.High)
+                let dictionary = Dictionary[string, Choice2494]()
+                dictionary.Add("high", Choice2494.High)
+                dictionary.Add("low", Choice2494.Low)
+                Console.WriteLine(DictionaryValuesMin(dictionary) == Choice2494.Low)
+                Console.WriteLine(PipelineMin(array) == Choice2494.Low)
+                Console.WriteLine(PipelineMax(array) == Choice2494.High)
+
+                let nullable = []Choice2494?{nil, Choice2494.High, Choice2494.Low}
+                Console.WriteLine(NullableMin(nullable) == Choice2494.Low)
+                Console.WriteLine(NullableMax(nullable) == Choice2494.High)
+
+                let items = []Item2494{
+                    Item2494(Choice2494.Middle, Choice2494.High),
+                    Item2494(Choice2494.High, nil),
+                    Item2494(Choice2494.Low, Choice2494.Low),
+                }
+                Console.WriteLine(SelectorMin(items) == Choice2494.Low)
+                Console.WriteLine(SelectorMax(items) == Choice2494.High)
+                Console.WriteLine(NullableSelectorMin(items) == Choice2494.Low)
+                Console.WriteLine(NullableSelectorMax(items) == Choice2494.High)
+
+                Console.WriteLine(GenericMin[Choice2494](array) == Choice2494.Low)
+                Console.WriteLine(GenericMax[Choice2494](array) == Choice2494.High)
+
+                Console.WriteLine(array.First() == Choice2494.Low)
+                Console.WriteLine(array.FirstOrDefault() == Choice2494.Low)
+                Console.WriteLine([]Choice2494{Choice2494.Middle}.Single() == Choice2494.Middle)
+                Console.WriteLine(array.ElementAt(2) == Choice2494.High)
+                Console.WriteLine(array.Last() == Choice2494.High)
+            }
+
+            main()
+            """;
+
+        Assert.Equal(
+            string.Concat(Enumerable.Repeat("True\n", 24)),
+            CompileAndRun(source));
+    }
+
+    [Fact]
+    public void SourceEnum_ReflectedReturnTypes_RemainTheEmittedEnum()
+    {
+        const string source = """
+            package Issue2494.Reflection
+            import System.Collections.Generic
+            import System.Linq
+
+            enum Choice2494 { Low, Middle, High }
+            data class Item2494(State Choice2494, Optional Choice2494?) {}
+
+            func GenericMin[T](values IEnumerable[T]) T -> values.Min()
+
+            class ExtremaApi2494 {
+                func ArrayMin(values []Choice2494) Choice2494 -> values.Min()
+                func ListMax(values List[Choice2494]) Choice2494 -> values.Max()
+                func NullableMin(values []Choice2494?) Choice2494? -> values.Min()
+                func SelectorMax(values []Item2494) Choice2494 ->
+                    values.Max((item Item2494) -> item.State)
+                func WrappedMin(values []Choice2494) Choice2494 ->
+                    GenericMin[Choice2494](values)
+                func FirstValue(values []Choice2494) Choice2494 -> values.First()
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var enumType = assembly.GetType("Issue2494.Reflection.Choice2494", throwOnError: true)!;
+        var apiType = assembly.GetType("Issue2494.Reflection.ExtremaApi2494", throwOnError: true)!;
+
+        Assert.Equal(enumType, GetMethod(apiType, "ArrayMin").ReturnType);
+        Assert.Equal(enumType, GetMethod(apiType, "ListMax").ReturnType);
+        Assert.Equal(enumType, GetMethod(apiType, "SelectorMax").ReturnType);
+        Assert.Equal(enumType, GetMethod(apiType, "WrappedMin").ReturnType);
+        Assert.Equal(enumType, GetMethod(apiType, "FirstValue").ReturnType);
+
+        var nullableReturn = GetMethod(apiType, "NullableMin").ReturnType;
+        Assert.Equal(typeof(Nullable<>), nullableReturn.GetGenericTypeDefinition());
+        Assert.Equal(enumType, nullableReturn.GetGenericArguments()[0]);
+    }
+
+    [Fact]
+    public void SourceEnum_CSharpConsumer_SeesEnumTypedExtremaApi()
+    {
+        const string source = """
+            package Issue2494.Consumer
+            import System.Linq
+
+            enum Choice2494 { Low, Middle, High }
+
+            class ExtremaApi2494 {
+                shared {
+                    func Min(values []Choice2494) Choice2494 -> values.Min()
+                    func Max(values []Choice2494) Choice2494 -> values.Max()
+                }
+            }
+            """;
+        const string consumerSource = """
+            using Issue2494.Consumer;
+
+            public static class Consumer2494
+            {
+                public static bool Verify()
+                {
+                    Choice2494[] values = [Choice2494.High, Choice2494.Low];
+                    Choice2494 min = ExtremaApi2494.Min(values);
+                    Choice2494 max = ExtremaApi2494.Max(values);
+                    return min == Choice2494.Low && max == Choice2494.High;
+                }
+            }
+            """;
+
+        var workDir = Directory.CreateTempSubdirectory("gs_issue2494_consumer_").FullName;
+        try
+        {
+            var (exitCode, diagnostics, outPath, references) = Compile(
+                workDir,
+                source,
+                target: "library",
+                csharpSource: null);
+            Assert.True(exitCode == 0, diagnostics);
+            IlVerifier.Verify(outPath, additionalReferences: references);
+
+            var compilation = CSharpCompilation.Create(
+                "Issue2494.ConsumerProbe",
+                new[] { CSharpSyntaxTree.ParseText(consumerSource) },
+                TrustedPlatformAssemblies()
+                    .Select(path => MetadataReference.CreateFromFile(path))
+                    .Append(MetadataReference.CreateFromFile(outPath)),
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            using var stream = new MemoryStream();
+            var result = compilation.Emit(stream);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    [Fact]
+    public void ImportedEnums_AllIntegralUnderlyingTypes_MinMaxRemainEnumTyped()
+    {
+        const string source = """
+            package Issue2494.ImportedRuntime
+            import System
+            import System.Collections.Generic
+            import System.Linq
+            import Issue2494.Imported
+
+            func GenericMin[T](values IEnumerable[T]) T -> values.Min()
+            func GenericMax[T](values IEnumerable[T]) T -> values.Max()
+
+            func PrintExtrema[T](values []T) {
+                Console.WriteLine(GenericMin[T](values))
+                Console.WriteLine(GenericMax[T](values))
+            }
+
+            PrintExtrema[SByteChoice]([]SByteChoice{SByteChoice.High, SByteChoice.Low})
+            PrintExtrema[ByteChoice]([]ByteChoice{ByteChoice.High, ByteChoice.Low})
+            PrintExtrema[Int16Choice]([]Int16Choice{Int16Choice.High, Int16Choice.Low})
+            PrintExtrema[UInt16Choice]([]UInt16Choice{UInt16Choice.High, UInt16Choice.Low})
+            PrintExtrema[Int32Choice]([]Int32Choice{Int32Choice.High, Int32Choice.Low})
+            PrintExtrema[UInt32Choice]([]UInt32Choice{UInt32Choice.High, UInt32Choice.Low})
+            PrintExtrema[Int64Choice]([]Int64Choice{Int64Choice.High, Int64Choice.Low})
+            PrintExtrema[UInt64Choice]([]UInt64Choice{UInt64Choice.High, UInt64Choice.Low})
+            """;
+
+        Assert.Equal(
+            string.Concat(Enumerable.Repeat("Low\nHigh\n", 8)),
+            CompileAndRun(source, ImportedEnumsCSharpSource));
+    }
+
+    [Fact]
+    public void PrimitiveNumericOverloads_ContinueReturningConcreteNumericTypes()
+    {
+        const string source = """
+            package Issue2494.NumericControls
+            import System
+            import System.Linq
+
+            let ints = []int32{7, -2, 11}
+            Console.WriteLine(ints.Min())
+            Console.WriteLine(ints.Max())
+
+            let longs = []int64{int64(9), int64(-4), int64(12)}
+            Console.WriteLine(longs.Min())
+            Console.WriteLine(longs.Max())
+
+            let doubles = []float64{3.5, -1.25, 8.0}
+            Console.WriteLine(doubles.Min())
+            Console.WriteLine(doubles.Max())
+
+            let decimals = []decimal{3.5M, -1.25M, 8M}
+            Console.WriteLine(decimals.Min())
+            Console.WriteLine(decimals.Max())
+            """;
+
+        Assert.Equal(
+            "-2\n11\n-4\n12\n-1.25\n8\n-1.25\n8\n",
+            CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EnumErasure_DoesNotDistortNamedParamsOrConcreteGenericReceiverOverloads()
+    {
+        const string importedSource = """
+            namespace Issue2494.ImportedOverloads;
+
+            public static class ParamsProbe
+            {
+                public static int Pick(params int[] values) => values[0];
+                public static T Pick<T>(params T[] values) => values[0];
+            }
+
+            public sealed class Box<T>
+            {
+                public string Pick(T value) => "typed";
+                public string Pick(object value) => "object";
+            }
+
+            public static class NamedProbe
+            {
+                public static string Pick(int index, object value) => "named";
+            }
+
+            public static class ByRefProbe
+            {
+                public static int Read(ref int value) => value;
+                public static T Read<T>(ref T value) => value;
+            }
+
+            public static class TupleProbe
+            {
+                public static int First((int, int) value) => value.Item1;
+                public static T1 First<T1, T2>((T1, T2) value) => value.Item1;
+            }
+            """;
+        const string source = """
+            package Issue2494.OverloadControls
+            import System
+            import Issue2494.ImportedOverloads
+
+            enum Choice2494 { Low, High }
+
+            Console.WriteLine(
+                ParamsProbe.Pick(Choice2494.Low, Choice2494.High) == Choice2494.Low)
+
+            let box = Box[int32]()
+            Console.WriteLine(box.Pick(Choice2494.Low))
+
+            Console.WriteLine(NamedProbe.Pick(value: Choice2494.Low, index: 0))
+
+            var choice = Choice2494.High
+            Console.WriteLine(ByRefProbe.Read(ref choice) == Choice2494.High)
+
+            let pair = (Choice2494.Low, 7)
+            Console.WriteLine(TupleProbe.First(pair) == Choice2494.Low)
+            """;
+
+        Assert.Equal("True\nobject\nnamed\nTrue\nTrue\n", CompileAndRun(source, importedSource));
+    }
+
+    private static MethodInfo GetMethod(Type type, string name)
+        => type.GetMethod(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"Method '{name}' was not found on '{type}'.");
+
+    private static string CompileAndRun(string source, string csharpSource = null)
+    {
+        var workDir = Directory.CreateTempSubdirectory("gs_issue2494_run_").FullName;
+        try
+        {
+            var (exitCode, diagnostics, outPath, references) = Compile(
+                workDir,
+                source,
+                target: "exe",
+                csharpSource);
+            Assert.True(exitCode == 0, diagnostics);
+
+            IlVerifier.Verify(outPath, additionalReferences: references);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = workDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            Assert.True(
+                process.ExitCode == 0,
+                $"dotnet exec failed ({process.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var workDir = Directory.CreateTempSubdirectory("gs_issue2494_reflection_").FullName;
+        try
+        {
+            var (exitCode, diagnostics, outPath, references) = Compile(
+                workDir,
+                source,
+                target: "library",
+                csharpSource: null);
+            Assert.True(exitCode == 0, diagnostics);
+            IlVerifier.Verify(outPath, additionalReferences: references);
+            return Assembly.Load(File.ReadAllBytes(outPath));
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    private static (
+        int ExitCode,
+        string Diagnostics,
+        string OutPath,
+        string[] References) Compile(
+        string workDir,
+        string source,
+        string target,
+        string csharpSource)
+    {
+        var sourcePath = Path.Combine(workDir, "test.gs");
+        var outPath = Path.Combine(workDir, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var references = csharpSource == null
+            ? Array.Empty<string>()
+            : new[] { EmitCSharpLibrary(workDir, csharpSource) };
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+        foreach (var reference in references)
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        args.Add(sourcePath);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(args.ToArray());
+            return (exitCode, stdout.ToString() + stderr, outPath, references);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string EmitCSharpLibrary(string workDir, string source)
+    {
+        var outputPath = Path.Combine(workDir, "Issue2494.Imported.dll");
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var references = TrustedPlatformAssemblies()
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "Issue2494.Imported",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return outputPath;
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var value = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        Assert.False(string.IsNullOrWhiteSpace(value));
+        return value!.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2494EnumLinqExtremaTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2494EnumLinqExtremaTests.cs
@@ -1,0 +1,265 @@
+// <copyright file="Issue2494EnumLinqExtremaTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2494: imported generic LINQ methods must preserve a symbolic
+/// same-compilation enum type. In particular, the enum's temporary
+/// <c>int32</c> CLR projection may help imported-member lookup, but it must
+/// not make the concrete numeric <c>Min</c>/<c>Max</c> overloads semantically
+/// applicable or leak <c>int32</c> into the bound result.
+/// </summary>
+public sealed class Issue2494EnumLinqExtremaTests
+{
+    [Fact]
+    public void MinMax_SourceEnumReceiverShapes_BindAsSourceEnum()
+    {
+        const string source = """
+            package issue2494bindingreceivers
+            import System.Collections.Generic
+            import System.Linq
+
+            enum Choice2494 { Low, Middle, High }
+
+            func ArrayMin(values []Choice2494) Choice2494 -> values.Min()
+            func ArrayMax(values []Choice2494) Choice2494 -> values.Max()
+            func EnumerableMin(values IEnumerable[Choice2494]) Choice2494 -> values.Min()
+            func EnumerableMax(values IEnumerable[Choice2494]) Choice2494 -> values.Max()
+            func NullableEnumerableMin(values IEnumerable[Choice2494]?) Choice2494 -> values.Min()
+            func ListMin(values List[Choice2494]) Choice2494 -> values.Min()
+            func ListMax(values List[Choice2494]) Choice2494 -> values.Max()
+            func StaticMin(values []Choice2494) Choice2494 -> Enumerable.Min(values)
+            func StaticMax(values []Choice2494) Choice2494 -> Enumerable.Max(values)
+            func DictionaryValuesMin(values Dictionary[string, Choice2494]) Choice2494 ->
+                values.Values.Min()
+            func PipelineMin(values []Choice2494) Choice2494 ->
+                values.Select((value Choice2494) -> value).Distinct().Min()
+            func PipelineMax(values []Choice2494) Choice2494 ->
+                values.Select((value Choice2494) -> value).Distinct().Max()
+            """;
+
+        var compilation = Compile(source);
+
+        AssertGenericSourceEnumCall(FindCall(compilation, "ArrayMin", "Min"), "Choice2494");
+        AssertGenericSourceEnumCall(FindCall(compilation, "ArrayMax", "Max"), "Choice2494");
+        AssertGenericSourceEnumCall(FindCall(compilation, "EnumerableMin", "Min"), "Choice2494");
+        AssertGenericSourceEnumCall(FindCall(compilation, "EnumerableMax", "Max"), "Choice2494");
+        AssertGenericSourceEnumCall(
+            FindCall(compilation, "NullableEnumerableMin", "Min"),
+            "Choice2494");
+        AssertGenericSourceEnumCall(FindCall(compilation, "ListMin", "Min"), "Choice2494");
+        AssertGenericSourceEnumCall(FindCall(compilation, "ListMax", "Max"), "Choice2494");
+        AssertGenericSourceEnumCall(FindCall(compilation, "StaticMin", "Min"), "Choice2494");
+        AssertGenericSourceEnumCall(FindCall(compilation, "StaticMax", "Max"), "Choice2494");
+        AssertGenericSourceEnumCall(
+            FindCall(compilation, "DictionaryValuesMin", "Min"),
+            "Choice2494");
+        AssertGenericSourceEnumCall(FindCall(compilation, "PipelineMin", "Min"), "Choice2494");
+        AssertGenericSourceEnumCall(FindCall(compilation, "PipelineMax", "Max"), "Choice2494");
+        AssertNoErrors(compilation);
+    }
+
+    [Fact]
+    public void MinMax_NullableEnumAndSelectorOverloads_PreserveProjectedEnumType()
+    {
+        const string source = """
+            package issue2494bindingselectors
+            import System.Linq
+
+            enum Choice2494 { Low, Middle, High }
+            data class Item2494(State Choice2494, Optional Choice2494?) {}
+
+            func NullableMin(values []Choice2494?) Choice2494? -> values.Min()
+            func NullableMax(values []Choice2494?) Choice2494? -> values.Max()
+            func SelectorMin(values []Item2494) Choice2494 ->
+                values.Min((item Item2494) -> item.State)
+            func SelectorMax(values []Item2494) Choice2494 ->
+                values.Max((item Item2494) -> item.State)
+            func NullableSelectorMin(values []Item2494) Choice2494? ->
+                values.Min((item Item2494) -> item.Optional)
+            func NullableSelectorMax(values []Item2494) Choice2494? ->
+                values.Max((item Item2494) -> item.Optional)
+            """;
+
+        var compilation = Compile(source);
+
+        AssertNoErrors(compilation);
+        AssertNullableSourceEnum(
+            FindCall(compilation, "NullableMin", "Min").Type,
+            "Choice2494");
+        AssertNullableSourceEnum(
+            FindCall(compilation, "NullableMax", "Max").Type,
+            "Choice2494");
+        AssertSourceEnum(
+            FindCall(compilation, "SelectorMin", "Min").Type,
+            "Choice2494");
+        AssertSourceEnum(
+            FindCall(compilation, "SelectorMax", "Max").Type,
+            "Choice2494");
+        AssertNullableSourceEnum(
+            FindCall(compilation, "NullableSelectorMin", "Min").Type,
+            "Choice2494");
+        AssertNullableSourceEnum(
+            FindCall(compilation, "NullableSelectorMax", "Max").Type,
+            "Choice2494");
+    }
+
+    [Fact]
+    public void GenericWrappersAndSiblingGenericReturnLinq_PreserveSourceEnumIdentity()
+    {
+        const string source = """
+            package issue2494bindinggeneric
+            import System.Collections.Generic
+            import System.Linq
+
+            enum Choice2494 { Low, Middle, High }
+
+            func GenericMin[T](values IEnumerable[T]) T -> values.Min()
+            func GenericMax[T](values IEnumerable[T]) T -> values.Max()
+
+            func WrappedMin(values []Choice2494) Choice2494 ->
+                GenericMin[Choice2494](values)
+            func WrappedMax(values []Choice2494) Choice2494 ->
+                GenericMax[Choice2494](values)
+            func FirstValue(values []Choice2494) Choice2494 -> values.First()
+            func FirstOrDefaultValue(values []Choice2494) Choice2494 -> values.FirstOrDefault()
+            func SingleValue(values []Choice2494) Choice2494 -> values.Single()
+            func ElementAtValue(values []Choice2494) Choice2494 -> values.ElementAt(0)
+            func LastValue(values []Choice2494) Choice2494 -> values.Last()
+            func ContainsValue(values IList[Choice2494]) bool -> values.Contains(Choice2494.Low)
+            """;
+
+        var compilation = Compile(source);
+
+        Assert.IsType<TypeParameterSymbol>(FindCall(compilation, "GenericMin", "Min").Type);
+        Assert.IsType<TypeParameterSymbol>(FindCall(compilation, "GenericMax", "Max").Type);
+        AssertSourceEnum(FindCall(compilation, "WrappedMin", "GenericMin").Type, "Choice2494");
+        AssertSourceEnum(FindCall(compilation, "WrappedMax", "GenericMax").Type, "Choice2494");
+        AssertSourceEnum(FindCall(compilation, "FirstValue", "First").Type, "Choice2494");
+        AssertSourceEnum(
+            FindCall(compilation, "FirstOrDefaultValue", "FirstOrDefault").Type,
+            "Choice2494");
+        AssertSourceEnum(FindCall(compilation, "SingleValue", "Single").Type, "Choice2494");
+        AssertSourceEnum(FindCall(compilation, "ElementAtValue", "ElementAt").Type, "Choice2494");
+        AssertSourceEnum(FindCall(compilation, "LastValue", "Last").Type, "Choice2494");
+        AssertNoErrors(compilation);
+    }
+
+    [Fact]
+    public void ImportedEnumAndPrimitiveNumericControls_KeepTheirEstablishedTypes()
+    {
+        const string source = """
+            package issue2494bindingcontrols
+            import System
+            import System.Linq
+
+            func ImportedMin(values []DayOfWeek) DayOfWeek -> values.Min()
+            func ImportedMax(values []DayOfWeek) DayOfWeek -> values.Max()
+            func IntMin(values []int32) int32 -> values.Min()
+            func LongMax(values []int64) int64 -> values.Max()
+            """;
+
+        var compilation = Compile(source);
+
+        AssertNoErrors(compilation);
+        var importedMin = Assert.IsType<ImportedTypeSymbol>(
+            FindCall(compilation, "ImportedMin", "Min").Type);
+        var importedMax = Assert.IsType<ImportedTypeSymbol>(
+            FindCall(compilation, "ImportedMax", "Max").Type);
+        Assert.Equal(typeof(System.DayOfWeek), importedMin.ClrType);
+        Assert.Equal(typeof(System.DayOfWeek), importedMax.ClrType);
+
+        Assert.Equal(TypeSymbol.Int32, FindCall(compilation, "IntMin", "Min").Type);
+        Assert.Equal(TypeSymbol.Int64, FindCall(compilation, "LongMax", "Max").Type);
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree) { IsLibrary = true };
+    }
+
+    private static BoundExpression FindCall(
+        Compilation compilation,
+        string functionName,
+        string methodName)
+    {
+        var function = compilation.BoundProgram.Functions.Keys.Single(f => f.Name == functionName);
+        var collector = new CallCollector(methodName);
+        collector.Visit(compilation.BoundProgram.Functions[function]);
+        return Assert.Single(collector.Calls);
+    }
+
+    private static void AssertSourceEnum(TypeSymbol type, string expectedName)
+    {
+        var enumType = Assert.IsType<EnumSymbol>(type);
+        Assert.Equal(expectedName, enumType.Name);
+        Assert.NotEqual(TypeSymbol.Int32, enumType);
+    }
+
+    private static void AssertGenericSourceEnumCall(BoundExpression expression, string expectedName)
+    {
+        AssertSourceEnum(expression.Type, expectedName);
+        var call = Assert.IsType<BoundImportedCallExpression>(expression);
+        Assert.True(call.Function.Method.IsGenericMethod);
+        Assert.Contains(
+            call.TypeArgumentSymbols,
+            argument => argument is EnumSymbol enumType && enumType.Name == expectedName);
+    }
+
+    private static void AssertNullableSourceEnum(TypeSymbol type, string expectedName)
+    {
+        var nullable = Assert.IsType<NullableTypeSymbol>(type);
+        AssertSourceEnum(nullable.UnderlyingType, expectedName);
+    }
+
+    private static void AssertNoErrors(Compilation compilation)
+    {
+        Assert.DoesNotContain(compilation.GlobalScope.Diagnostics, d => d.IsError);
+        Assert.DoesNotContain(compilation.BoundProgram.Diagnostics, d => d.IsError);
+    }
+
+    private sealed class CallCollector : BoundTreeWalker
+    {
+        private readonly string methodName;
+
+        public CallCollector(string methodName)
+        {
+            this.methodName = methodName;
+        }
+
+        public List<BoundExpression> Calls { get; } = new();
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            switch (node)
+            {
+                case BoundCallExpression call when call.Function.Name == this.methodName:
+                    Calls.Add(call);
+                    break;
+                case BoundImportedInstanceCallExpression call when call.Method.Name == this.methodName:
+                    Calls.Add(call);
+                    break;
+                case BoundImportedCallExpression call when call.Function.Name == this.methodName:
+                    Calls.Add(call);
+                    break;
+                case BoundClrStaticCallExpression call when call.Method.Name == this.methodName:
+                    Calls.Add(call);
+                    break;
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2494EnumLinqExtremaPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2494EnumLinqExtremaPipelineTests.cs
@@ -1,0 +1,156 @@
+// <copyright file="Issue2494EnumLinqExtremaPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2494: the default SDK-backed migration must compile both the minimal
+/// enum-array Min shape and the Select/Distinct/Min pipeline that exposed the
+/// same symbolic enum erasure in Oahu.
+/// </summary>
+public sealed class Issue2494EnumLinqExtremaPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_SourceEnumMinShapes_TranslateAndCompile()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectDir = Path.Combine(sourceRoot, "src", "Sample");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "Sample.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "Repro.cs"), """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            namespace Sample;
+
+            public enum Choice { Low, High }
+            public enum EConversionState { None, Partial, Complete }
+
+            public sealed class Conversion
+            {
+                public EConversionState ApplicableState() => EConversionState.Complete;
+            }
+
+            public sealed class Component
+            {
+                public required Conversion Conversion { get; init; }
+            }
+
+            public sealed class Book
+            {
+                public required List<Component> Components { get; init; }
+            }
+
+            public static class Repro
+            {
+                public static Choice Pick() =>
+                    new[] { Choice.Low, Choice.High }.Min();
+
+                public static EConversionState ApplicableState(Book book)
+                {
+                    var state = book.Components
+                        .Select(c => c.Conversion.ApplicableState())
+                        .Distinct()
+                        .Min();
+                    return state;
+                }
+            }
+            """);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp("test/EnumLinqExtrema", projectPath, TargetKind.Library);
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+
+        string appRunDir = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.Id));
+        string emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(appRunDir, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains("func Pick() Choice", emitted, StringComparison.Ordinal);
+        Assert.Contains("[]Choice{Choice.Low, Choice.High}.Min()", emitted, StringComparison.Ordinal);
+        Assert.Contains("func ApplicableState(book Book) EConversionState", emitted, StringComparison.Ordinal);
+        Assert.Contains(".Distinct().Min()", emitted, StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            "Expected default --via-sdk compile to preserve source enum identity through Min. Stages: " +
+                string.Join("; ", appResult.Stages.Select(s => s.Stage + "=" + s.Status)));
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2494",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    dir.FullName,
+                    "out",
+                    "bin",
+                    config,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- reject imported concrete numeric overloads that only match through same-compilation enum erasure
- preserve symbolic generic substitutions through nullable, selector, collection/interface, tuple, by-ref, static, instance, and extension call shapes
- keep nullable enum CLR projections structurally nullable and retain existing imported-enum/numeric behavior

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet build GSharp.sln --no-incremental -graph`
- 38 related Core binding tests
- 43 related Compiler runtime/reflection/ILVerify tests
- default `--via-sdk` cs2gs migration regression for the minimal and ApplicableState pipeline shapes

Fixes #2494