### PR TITLE
Fix expression-tree lambda null forgiveness

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2496ExpressionTreeArgumentForgivenessPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2496ExpressionTreeArgumentForgivenessPipelineTests.cs
@@ -1,0 +1,228 @@
+// <copyright file="Issue2496ExpressionTreeArgumentForgivenessPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// End-to-end default <c>--via-sdk</c> coverage for issue #2496 using an
+/// oblivious sibling assembly that exposes EF-style expression-tree sinks.
+/// </summary>
+public sealed class Issue2496ExpressionTreeArgumentForgivenessPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_ObliviousExpressionSinks_TranslateAndCompile()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        (string apiProject, string appProject) = WriteFixture(sourceRoot);
+        RunDotnetBuild(apiProject);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(
+            new[] { new CorpusApp("test/ExpressionConsumer", appProject, TargetKind.Library) });
+        AppResult appResult = Assert.Single(result.Apps);
+
+        string appRunDir = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(appResult.AppId));
+        string emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(appRunDir, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains("HasKey((item Item) -> item.Id)", emitted, StringComparison.Ordinal);
+        Assert.Contains("HasIndex((item Item) -> item.Name)", emitted, StringComparison.Ordinal);
+        Assert.Contains("HasForeignKey((item Item) ->", emitted, StringComparison.Ordinal);
+        Assert.Contains("Runtime((item Item) -> item.Name!!)", emitted, StringComparison.Ordinal);
+        Assert.Contains("Selector[Item]((item Item) -> item.Id)", emitted, StringComparison.Ordinal);
+        Assert.Contains("OverloadSink.Select", emitted, StringComparison.Ordinal);
+        Assert.DoesNotContain("item.Id!!", emitted, StringComparison.Ordinal);
+        Assert.DoesNotContain("item.ParentId!!", emitted, StringComparison.Ordinal);
+        Assert.DoesNotContain("child.Name!!", emitted, StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            "Expected default --via-sdk/gsc compilation to accept all expression-tree sinks. Stages: " +
+                string.Join("; ", appResult.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+    }
+
+    private static (string ApiProject, string AppProject) WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+
+        string apiDir = Path.Combine(sourceRoot, "Api");
+        string appDir = Path.Combine(sourceRoot, "ExpressionConsumer");
+        Directory.CreateDirectory(apiDir);
+        Directory.CreateDirectory(appDir);
+
+        string apiProject = Path.Combine(apiDir, "Api.csproj");
+        File.WriteAllText(apiProject, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>disable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(apiDir, "Api.cs"), """
+            using System;
+            using System.Linq.Expressions;
+
+            namespace ExpressionApi;
+
+            public sealed class ModelBuilder
+            {
+                public EntityBuilder<T> Entity<T>() => new();
+            }
+
+            public sealed class EntityBuilder<T>
+            {
+                public EntityBuilder<T> HasKey(Expression<Func<T, object>> selector) => this;
+                public EntityBuilder<T> HasIndex(Expression<Func<T, string>> selector) => this;
+                public EntityBuilder<T> HasForeignKey(Expression<Func<T, object>> selector) => this;
+                public EntityBuilder<T> Runtime(Func<T, string> selector) => this;
+            }
+
+            public sealed class Selector<T>
+            {
+                public Selector(Expression<Func<T, object>> selector) { }
+            }
+
+            public static class OverloadSink
+            {
+                public static void Select<T>(Expression<Func<T, string>> selector) { }
+                public static void Select<T>(Func<T, int> selector) { }
+            }
+            """);
+
+        string appProject = Path.Combine(appDir, "ExpressionConsumer.csproj");
+        File.WriteAllText(appProject, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>disable</Nullable>
+              </PropertyGroup>
+              <ItemGroup>
+                <ProjectReference Include="../Api/Api.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(appDir, "Model.cs"), """
+            using ExpressionApi;
+
+            namespace ExpressionConsumer;
+
+            public sealed class Item
+            {
+                public int Id { get; set; }
+                public int? ParentId { get; set; }
+                public Item Other { get; set; }
+                public string Name => Other?.Name;
+            }
+
+            public sealed class Context
+            {
+                public void Configure(ModelBuilder modelBuilder)
+                {
+                    modelBuilder.Entity<Item>()
+                        .HasKey(item => item.Id)
+                        .HasIndex(item => item.Name)
+                        .HasForeignKey(item => new { item.Id, item.ParentId })
+                        .Runtime(item => item.Name);
+
+                    _ = new Selector<Item>(item => item.Id);
+                    OverloadSink.Select((Item item) => item.Name);
+                    OverloadSink.Select((Item item) => item.Id);
+                }
+            }
+            """);
+
+        return (apiProject, appProject);
+    }
+
+    private static void RunDotnetBuild(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo(
+            "dotnet",
+            $"build \"{projectPath}\" --nologo --verbosity:quiet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+
+        using var process = Process.Start(startInfo);
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(
+            process.ExitCode == 0,
+            "Failed to prebuild expression sink project:\n" + stdout + stderr);
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2496",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    dir.FullName,
+                    "out",
+                    "bin",
+                    config,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2496ExpressionTreeArgumentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2496ExpressionTreeArgumentForgivenessTranslationTests.cs
@@ -1,0 +1,284 @@
+// <copyright file="Issue2496ExpressionTreeArgumentForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2496: nullable-oblivious argument forgiveness must distinguish a
+/// callable value from the value returned by that callable. In particular,
+/// translator-injected runtime <c>!!</c> nodes are forbidden inside lambdas
+/// converted to <c>Expression&lt;TDelegate&gt;</c>.
+/// </summary>
+public sealed class Issue2496ExpressionTreeArgumentForgivenessTranslationTests
+{
+    [Fact]
+    public void ImportedExpressionSinks_AllLambdaShapes_RemainRepresentable()
+    {
+        string printed = TranslateOblivious("""
+            using System;
+            using System.Linq.Expressions;
+
+            namespace Demo;
+
+            public sealed class Item
+            {
+                public int Id { get; set; }
+                public int? ParentId { get; set; }
+                public Item Other { get; set; }
+                public string Name => Other?.Name;
+            }
+
+            public static class Repro
+            {
+                public static void Run(Builder<Item> builder)
+                {
+                    builder
+                        .HasKey(item => item.Id)
+                        .HasIndex((Item item) => item.Name)
+                        .HasForeignKey(item => new { item.ParentId, item.Name })
+                        .HasOptional(item => item.ParentId);
+
+                    _ = new Selector<Item>(item => item.Id);
+                    GenericSink.Accept<Func<Item, string>>(item => item.Name);
+                    builder.Nested(item => child => child.Name);
+                    builder.Quoted(item => GenericSink.Read<Item>(child => child.Name));
+                }
+            }
+            """);
+
+        Assert.Contains("HasKey((item Item) -> item.Id)", printed, StringComparison.Ordinal);
+        Assert.Contains("HasIndex((item Item) -> item.Name)", printed, StringComparison.Ordinal);
+        Assert.Contains("HasForeignKey((item Item) ->", printed, StringComparison.Ordinal);
+        Assert.Contains("ParentId: item.ParentId", printed, StringComparison.Ordinal);
+        Assert.Contains("HasOptional((item Item) -> item.ParentId)", printed, StringComparison.Ordinal);
+        Assert.Contains("Selector[Item]((item Item) -> item.Id)", printed, StringComparison.Ordinal);
+        Assert.Contains("GenericSink.Accept", printed, StringComparison.Ordinal);
+        Assert.Contains("Nested((item Item) -> (child Item) -> child.Name)", printed, StringComparison.Ordinal);
+        Assert.Contains("Read[Item]((child Item) -> child.Name)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("item.Id!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("item.Name!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("item.ParentId!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("child.Name!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OverloadResolution_UsesSemanticExpressionTargetOnly()
+    {
+        string printed = TranslateOblivious("""
+            namespace Demo;
+
+            public sealed class Item
+            {
+                public Item Other { get; set; }
+                public string Name => Other?.Name;
+                public int Id { get; set; }
+            }
+
+            public static class Repro
+            {
+                public static void Run()
+                {
+                    OverloadSink.Select((Item item) => item.Name);
+                    OverloadSink.Select((Item item) => item.Id);
+                }
+            }
+            """);
+
+        Assert.Contains("Select((item Item) -> item.Name)", printed, StringComparison.Ordinal);
+        Assert.Contains("Select((item Item) -> item.Id)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("item.Name!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RuntimeDelegateLambda_ResultForgivenessRemainsAtResultSeam()
+    {
+        string printed = TranslateOblivious("""
+            using System;
+
+            namespace Demo;
+
+            public sealed class Item
+            {
+                public Item Other { get; set; }
+                public string Name => Other?.Name;
+
+                public static string ReadName(Item item) => item.Other?.Name;
+            }
+
+            public static class Repro
+            {
+                public static void Run(RuntimeSink sink)
+                {
+                    sink.Accept((Item item) => item.Name);
+                    sink.AcceptBlock((Item item) => { return item.Name; });
+                    sink.Accept<Item>(Item.ReadName);
+                }
+            }
+            """);
+
+        Assert.Contains("Accept((item Item) -> item.Name!!)", printed, StringComparison.Ordinal);
+        Assert.Contains("return item.Name!!", printed, StringComparison.Ordinal);
+        Assert.Contains("Accept[Item](Item.ReadName)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("ReadName!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UserAuthoredSuppression_InsideExpressionTree_IsPreservedForGscDiagnostic()
+    {
+        string printed = TranslateOblivious("""
+            namespace Demo;
+
+            public sealed class Item
+            {
+                public string Name { get; set; }
+            }
+
+            public static class Repro
+            {
+                public static void Run(Builder<Item> builder) =>
+                    builder.HasIndex(item => item.Name!);
+            }
+            """);
+
+        Assert.Contains("HasIndex((item Item) -> item.Name!!)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NullableEnabledExpressionLambda_RemainsAssertionFree()
+    {
+        string printed = Translate("""
+            #nullable enable
+            using System;
+
+            namespace Demo;
+
+            public sealed class Item
+            {
+                public string Name { get; set; } = "";
+                public string? OptionalName { get; set; }
+            }
+
+            public static class Repro
+            {
+                public static void Run(Builder<Item> builder)
+                {
+                    builder.HasIndex(item => item.Name);
+                    Func<Item, string?> runtime = item => item.OptionalName;
+                }
+            }
+            """, NullableContextOptions.Enable);
+
+        Assert.Contains("HasIndex((item Item) -> item.Name)", printed, StringComparison.Ordinal);
+        Assert.Contains("(item Item) -> item.OptionalName", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("!!", printed, StringComparison.Ordinal);
+    }
+
+    private static string TranslateOblivious(string source) =>
+        Translate(source, NullableContextOptions.Disable);
+
+    private static string Translate(string source, NullableContextOptions nullableContext)
+    {
+        MetadataReference sinks = CreateSinkReference();
+        IReadOnlyList<MetadataReference> references = CSharpProjectLoader.RuntimeReferences()
+            .Concat(new[] { sinks })
+            .ToArray();
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest),
+            path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Issue2496.Consumer",
+            new[] { tree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(nullableContext));
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        CompilationUnit translated = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(translated);
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            roundTrip.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", roundTrip.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    private static MetadataReference CreateSinkReference()
+    {
+        const string source = """
+            using System;
+            using System.Linq.Expressions;
+
+            namespace Demo;
+
+            public sealed class Builder<T>
+            {
+                public Builder<T> HasKey(Expression<Func<T, object>> selector) => this;
+                public Builder<T> HasIndex(Expression<Func<T, string>> selector) => this;
+                public Builder<T> HasForeignKey(Expression<Func<T, object>> selector) => this;
+                public Builder<T> HasOptional(Expression<Func<T, int?>> selector) => this;
+                public Builder<T> Nested(Expression<Func<T, Func<T, string>>> selector) => this;
+                public Builder<T> Quoted(Expression<Func<T, string>> selector) => this;
+            }
+
+            public sealed class Selector<T>
+            {
+                public Selector(Expression<Func<T, object>> selector) { }
+            }
+
+            public sealed class RuntimeSink
+            {
+                public void Accept<T>(Func<T, string> selector) { }
+                public void AcceptBlock<T>(Func<T, string> selector) { }
+            }
+
+            public static class GenericSink
+            {
+                public static void Accept<TDelegate>(Expression<TDelegate> selector)
+                    where TDelegate : Delegate { }
+
+                public static string Read<T>(Expression<Func<T, string>> selector) => "";
+            }
+
+            public static class OverloadSink
+            {
+                public static void Select<T>(Expression<Func<T, string>> selector) { }
+                public static void Select<T>(Func<T, int> selector) { }
+            }
+            """;
+
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest));
+        var compilation = CSharpCompilation.Create(
+            "Issue2496.ExternalSinks",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable));
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return MetadataReference.CreateFromImage(stream.ToArray());
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -777,6 +777,19 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
+            // Issue #2496: `!!` is a runtime-only G# operator and therefore is
+            // never representable inside an expression tree (GS0473). Use the
+            // lambda's semantic converted type rather than call/constructor
+            // syntax so this covers overload-selected Expression<TDelegate>
+            // parameters, generic expression sinks, fluent APIs, and nested
+            // quoted lambdas uniformly. A user-authored C# suppression (`expr!`)
+            // has already returned above and still translates to `!!`, preserving
+            // the compiler's expression-tree restriction diagnostic.
+            if (this.IsWithinExpressionTreeLambda(recv))
+            {
+                return false;
+            }
+
             // Issue #2164: the classic lazy-singleton pattern initializes a
             // nullable static/instance field (or auto-property) under a null
             // guard (`if (F == null) { F = new(); } ... return F;` / `F ??= …;`),
@@ -852,6 +865,16 @@ public sealed partial class CSharpToGSharpTranslator
             // implicitly (oblivious, unchecked), so asserting `!!` here is the
             // minimal bridge, not a widening of the interface contract.
             if (this.IsUnguardedForwardOfTaintedValueInReturnPreservingBody(recv))
+            {
+                return true;
+            }
+
+            // Issue #2496: once callable values stop borrowing their synthesized
+            // method symbol's return taint, a runtime delegate lambda still needs
+            // the old, legitimate bridge at its RESULT seam. Keep that bridge
+            // narrowly target-typed to a non-null delegate return contract. The
+            // expression-tree guard above deliberately excludes quoted lambdas.
+            if (this.IsUnguardedForwardOfTaintedValueAsRuntimeLambdaResult(recv))
             {
                 return true;
             }
@@ -1447,6 +1470,95 @@ public sealed partial class CSharpToGSharpTranslator
 
             return !(parameterDeclaredInThisCompilation
                 && this.ShouldPromoteToNullableReference(parameter));
+        }
+
+        private bool IsUnguardedForwardOfTaintedValueAsRuntimeLambdaResult(ExpressionSyntax use)
+        {
+            if (!this.IsObliviousCompilation()
+                || this.IsWithinExpressionTreeLambda(use)
+                || this.FindResultLambda(use) is not { } lambda
+                || this.GetLambdaTargetDelegateType(lambda) is not { DelegateInvokeMethod: { } invoke }
+                || invoke.ReturnType is not { IsReferenceType: true }
+                || invoke.ReturnType.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                return false;
+            }
+
+            bool returnDeclaredInThisCompilation = invoke.DeclaringSyntaxReferences
+                .Any(reference => this.context.Compilation.ContainsSyntaxTree(reference.SyntaxTree));
+            if (returnDeclaredInThisCompilation
+                && this.ShouldPromoteToNullableReference(invoke))
+            {
+                return false;
+            }
+
+            return this.IsNullablePromotedValue(use)
+                || IsObliviousExternalNullableMember(this.context.GetSymbolInfo(use).Symbol);
+        }
+
+        private AnonymousFunctionExpressionSyntax FindResultLambda(ExpressionSyntax use)
+        {
+            SyntaxNode node = use;
+            while (node.Parent is ParenthesizedExpressionSyntax)
+            {
+                node = node.Parent;
+            }
+
+            if (node.Parent is AnonymousFunctionExpressionSyntax expressionLambda
+                && expressionLambda.Body == node)
+            {
+                return expressionLambda;
+            }
+
+            if (node.Parent is not ReturnStatementSyntax returnStatement)
+            {
+                return null;
+            }
+
+            for (SyntaxNode ancestor = returnStatement.Parent; ancestor != null; ancestor = ancestor.Parent)
+            {
+                if (ancestor is AnonymousFunctionExpressionSyntax lambda)
+                {
+                    return lambda;
+                }
+
+                if (ancestor is LocalFunctionStatementSyntax or BaseMethodDeclarationSyntax)
+                {
+                    return null;
+                }
+            }
+
+            return null;
+        }
+
+        private bool IsWithinExpressionTreeLambda(SyntaxNode node) =>
+            node.AncestorsAndSelf()
+                .OfType<AnonymousFunctionExpressionSyntax>()
+                .Any(lambda => this.IsExpressionTreeLambda(lambda));
+
+        private bool IsExpressionTreeLambda(AnonymousFunctionExpressionSyntax lambda) =>
+            this.context.GetTypeInfo(lambda).ConvertedType is INamedTypeSymbol converted
+                && converted.IsGenericType
+                && converted.OriginalDefinition.MetadataName == "Expression`1"
+                && converted.ContainingNamespace?.ToDisplayString() == "System.Linq.Expressions"
+                && converted.TypeArguments.Length == 1
+                && converted.TypeArguments[0].TypeKind == TypeKind.Delegate;
+
+        private INamedTypeSymbol GetLambdaTargetDelegateType(AnonymousFunctionExpressionSyntax lambda)
+        {
+            if (this.context.GetTypeInfo(lambda).ConvertedType is not INamedTypeSymbol converted)
+            {
+                return null;
+            }
+
+            if (converted.TypeKind == TypeKind.Delegate)
+            {
+                return converted;
+            }
+
+            return this.IsExpressionTreeLambda(lambda)
+                ? converted.TypeArguments[0] as INamedTypeSymbol
+                : null;
         }
 
         // Walks outward from <paramref name="use"/> through parentheses to find

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -309,6 +309,19 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
+            // Issue #2496: an anonymous function or method group is a callable
+            // value, not the value returned when that callable is invoked.
+            // Roslyn binds a lambda to a synthesized IMethodSymbol, so asking the
+            // oblivious-nullability fixpoint about that symbol can otherwise
+            // mistake return-position taint for nullability of the delegate /
+            // Expression<TDelegate> object itself. Keep callable-value
+            // nullability separate; lambda result contracts are handled at the
+            // lambda body seam instead.
+            if (this.IsCallableValueExpression(expression))
+            {
+                return false;
+            }
+
             if (this.IsNullableInitializer(expression))
             {
                 return true;
@@ -330,6 +343,17 @@ public sealed partial class CSharpToGSharpTranslator
                     this.ShouldPromoteToNullableReference(symbol),
                 _ => false,
             };
+        }
+
+        private bool IsCallableValueExpression(ExpressionSyntax expression)
+        {
+            while (expression is ParenthesizedExpressionSyntax parenthesized)
+            {
+                expression = parenthesized.Expression;
+            }
+
+            return expression is AnonymousFunctionExpressionSyntax
+                || this.context.SemanticModel.GetMemberGroup(expression).Length > 0;
         }
 
         // Issue #914 (oblivious sink): promote the arrow (delegate) parameter

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -181,7 +181,17 @@ public sealed partial class CSharpToGSharpTranslator
                 GExpression expressionBody;
                 try
                 {
-                    expressionBody = this.TranslateExpression((ExpressionSyntax)lambda.Body);
+                    // Issue #2496: callable-value nullability is distinct from
+                    // callable-return nullability. Apply forgiveness only at a
+                    // runtime lambda's semantically resolved non-null result
+                    // contract; expression trees and nullable delegate results
+                    // stay assertion-free.
+                    ExpressionSyntax bodyExpression = (ExpressionSyntax)lambda.Body;
+                    expressionBody = this.TranslateExpression(bodyExpression);
+                    if (this.IsUnguardedForwardOfTaintedValueAsRuntimeLambdaResult(bodyExpression))
+                    {
+                        expressionBody = new NonNullAssertionExpression(expressionBody);
+                    }
                 }
                 finally
                 {


### PR DESCRIPTION
## Summary
- separate callable-value nullability from callable return taint
- suppress translator-injected runtime `!!` throughout semantically target-typed expression-tree lambdas, including nested/quoted cases
- preserve targeted result forgiveness for ordinary runtime delegate lambdas
- add translation and live default `--via-sdk`/gsc coverage for fluent, constructor, overload, generic, nullable, and delegate controls

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet build GSharp.sln -c Debug --no-restore`
- 38 focused cs2gs nullability/expression-tree tests passed
- 11 expression-tree restriction controls passed
- live default `--via-sdk` pipeline compiled the oblivious sibling expression sinks successfully

Fixes #2496