### PR TITLE
Preserve nullable lambda generic inference

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2882,7 +2882,7 @@ public sealed class Binder
         {
             var clrArgs = new System.Type[syntax.TypeArguments.Count];
             var symbolicArgs = ImmutableArray.CreateBuilder<TypeSymbol>(syntax.TypeArguments.Count);
-            var hasTypeParameterArg = false;
+            var hasSymbolicArg = false;
             for (var i = 0; i < syntax.TypeArguments.Count; i++)
             {
                 var ta = BindTypeClause(syntax.TypeArguments[i]);
@@ -2911,9 +2911,9 @@ public sealed class Binder
                 // CLR shape so member / index / conversion resolution keeps
                 // working, while the symbolic `[T]` is preserved on the result
                 // for inference, substitution, and erased emit.
-                if (TypeSymbol.ContainsTypeParameter(ta) || TypeSymbol.ContainsSameCompilationUserType(ta))
+                if (TypeSymbol.RequiresSymbolicProjection(ta))
                 {
-                    hasTypeParameterArg = true;
+                    hasSymbolicArg = true;
 
                     // Issue #2391: source enums use Int32 as their established
                     // CLR ride-through. Preserve that surrogate when closing
@@ -2921,8 +2921,17 @@ public sealed class Binder
                     // struct-constrained interface leaves Nullable<T> member
                     // signatures unconstructable and hides parameterized
                     // methods from overload resolution.
-                    var erasedArgument = ta is EnumSymbol ? typeof(int) : typeof(object);
-                    clrArgs[i] = scope.References.MapClrTypeToReferences(erasedArgument);
+                    if (TypeSymbol.ContainsTypeParameter(ta) || TypeSymbol.ContainsSameCompilationUserType(ta))
+                    {
+                        var erasedArgument = ta is EnumSymbol ? typeof(int) : typeof(object);
+                        clrArgs[i] = scope.References.MapClrTypeToReferences(erasedArgument);
+                    }
+                    else
+                    {
+                        clrArgs[i] = ResolveClrTypeForGenericArg(ta)
+                            ?? scope.References.MapClrTypeToReferences(ta.ClrType);
+                    }
+
                     continue;
                 }
 
@@ -2938,7 +2947,7 @@ public sealed class Binder
             try
             {
                 var closed = clrOpenType.MakeGenericType(clrArgs);
-                if (hasTypeParameterArg)
+                if (hasSymbolicArg)
                 {
                     // #313 / #671: keep the symbolic type arguments alongside
                     // the type-erased closed CLR shape so call-site inference,
@@ -3701,7 +3710,7 @@ public sealed class Binder
 
         var clrArgs = new Type[targetArity];
         var symbolicArgs = ImmutableArray.CreateBuilder<TypeSymbol>(targetArity);
-        var hasTypeParameterArg = false;
+        var hasSymbolicArg = false;
         for (var i = 0; i < targetArity; i++)
         {
             var ta = BindTypeClause(syntax.TypeArguments[i]);
@@ -3725,7 +3734,7 @@ public sealed class Binder
             // formed while the symbolic argument is preserved alongside.
             if (TypeSymbol.ContainsTypeParameter(ta))
             {
-                hasTypeParameterArg = true;
+                hasSymbolicArg = true;
                 clrArgs[i] = scope.References.MapClrTypeToReferences(typeof(object));
                 continue;
             }
@@ -3734,7 +3743,7 @@ public sealed class Binder
             // System.Object (same as type parameters above).
             if (ta.ClrType == null)
             {
-                hasTypeParameterArg = true;
+                hasSymbolicArg = true;
                 clrArgs[i] = scope.References.MapClrTypeToReferences(typeof(object));
                 continue;
             }
@@ -3745,7 +3754,7 @@ public sealed class Binder
         try
         {
             var closed = clrType.MakeGenericType(clrArgs);
-            if (hasTypeParameterArg)
+            if (hasSymbolicArg)
             {
                 return ImportedTypeSymbol.GetConstructed(closed, clrType, symbolicArgs.MoveToImmutable());
             }
@@ -3950,7 +3959,7 @@ public sealed class Binder
 
         var clrArgs = new Type[argSyntaxes.Count];
         var symbolicArgs = ImmutableArray.CreateBuilder<TypeSymbol>(argSyntaxes.Count);
-        var hasTypeParameterArg = false;
+        var hasSymbolicArg = false;
         for (var i = 0; i < argSyntaxes.Count; i++)
         {
             var ta = BindTypeClause(argSyntaxes[i]);
@@ -3970,10 +3979,15 @@ public sealed class Binder
 
             // #313 / #671: in-scope type parameters and user types without a
             // ClrType project onto System.Object under the type-erased model.
-            if (TypeSymbol.ContainsTypeParameter(ta) || TypeSymbol.ContainsSameCompilationUserType(ta) || ta.ClrType == null)
+            if (TypeSymbol.RequiresSymbolicProjection(ta) || ta.ClrType == null)
             {
-                hasTypeParameterArg = true;
-                clrArgs[i] = scope.References.MapClrTypeToReferences(typeof(object));
+                hasSymbolicArg = true;
+                clrArgs[i] = TypeSymbol.ContainsTypeParameter(ta)
+                    || TypeSymbol.ContainsSameCompilationUserType(ta)
+                    || ta.ClrType == null
+                        ? scope.References.MapClrTypeToReferences(typeof(object))
+                        : ResolveClrTypeForGenericArg(ta)
+                            ?? scope.References.MapClrTypeToReferences(ta.ClrType);
                 continue;
             }
 
@@ -3983,7 +3997,7 @@ public sealed class Binder
         try
         {
             var closed = nestedDef.MakeGenericType(clrArgs);
-            if (hasTypeParameterArg)
+            if (hasSymbolicArg)
             {
                 return ImportedTypeSymbol.GetConstructed(closed, nestedDef, symbolicArgs.MoveToImmutable());
             }
@@ -4325,9 +4339,14 @@ public sealed class Binder
                 return;
             }
 
-            // First seen value wins. Cross-arg consistency is verified later
-            // by the post-substitution argument-type check.
-            if (!substitution.ContainsKey(tp))
+            // Join compatible nullable-reference evidence across arguments.
+            // The post-substitution applicability check still rejects genuine
+            // type conflicts.
+            if (substitution.TryGetValue(tp, out var existing))
+            {
+                substitution[tp] = MemberLookup.MergeInferredTypeArgument(existing, argumentType);
+            }
+            else
             {
                 substitution[tp] = argumentType;
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -1681,13 +1681,7 @@ internal sealed partial class ExpressionBinder
         // (e.g. `outer[0]` on `List[List[MyGs]]` -> `List[MyGs]`); without
         // this the element would type-erase to `List<object>` and downstream
         // member access on the result would emit against the wrong parent.
-        var hasSubstitutableArgs = !target.TypeArguments.IsDefaultOrEmpty
-            && (target.HasTypeParameterArgument
-                || target.TypeArguments.Any(static a => a.ClrType == null
-                    || (a is ImportedTypeSymbol nested
-                        && nested.OpenDefinition != null
-                        && !nested.TypeArguments.IsDefaultOrEmpty)));
-        if (hasSubstitutableArgs
+        if (target.HasSubstitutableTypeArgument
             && target.OpenDefinition is System.Type openDefinition)
         {
             try

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -531,9 +531,8 @@ internal sealed partial class ExpressionBinder
     // struct/enum. Build the symbolic awaiter type (`TaskAwaiter[U]`) so the
     // emitted awaiter pool field and `GetAwaiter()`/`GetResult()` call sites
     // agree on `!!0`/`!0` instead of the erased `object`.
-    private static bool IsAwaiterTypeArgumentCandidate(TypeSymbol a) =>
-        a is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol
-        || (a is NullableTypeSymbol nt && nt.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol);
+    private static bool IsAwaiterTypeArgumentCandidate(TypeSymbol a)
+        => TypeSymbol.RequiresSymbolicProjection(a);
 
     private static TypeSymbol TryGetAwaiterTypeSymbol(TypeSymbol awaitableType)
     {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -369,7 +369,7 @@ internal sealed partial class ExpressionBinder
         // open `T` return to the user `Entry` symbol (whose `ClrType` is null
         // while being emitted). Without this the result type-erases to `object`
         // and an `Entry`-typed target fails to bind (GS0155).
-        return TypeSymbol.ContainsTypeParameter(mapped) || TypeSymbol.ContainsSameCompilationUserType(mapped)
+        return TypeSymbol.RequiresSymbolicProjection(mapped)
             ? mapped
             : null;
     }
@@ -427,7 +427,7 @@ internal sealed partial class ExpressionBinder
         }
 
         var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openPointee, imp.OpenDefinition, imp.TypeArguments);
-        return TypeSymbol.ContainsTypeParameter(mapped) || TypeSymbol.ContainsSameCompilationUserType(mapped)
+        return TypeSymbol.RequiresSymbolicProjection(mapped)
             ? mapped
             : null;
     }
@@ -858,8 +858,7 @@ internal sealed partial class ExpressionBinder
 
         var methodHasSymbolicArgs = closedMethod.IsGenericMethod
             && !symbolicMethodTypeArgs.IsDefaultOrEmpty
-            && symbolicMethodTypeArgs.Any(s => s != null
-                && (TypeSymbol.ContainsTypeParameter(s) || TypeSymbol.ContainsSameCompilationUserType(s)));
+            && symbolicMethodTypeArgs.Any(TypeSymbol.RequiresSymbolicProjection);
 
         Type receiverOpenDef = null;
         ImmutableArray<TypeSymbol> receiverTypeArgs = default;
@@ -870,8 +869,7 @@ internal sealed partial class ExpressionBinder
         }
 
         var receiverHasSymbolicArgs = receiverOpenDef != null
-            && receiverTypeArgs.Any(s => s != null
-                && (TypeSymbol.ContainsTypeParameter(s) || TypeSymbol.ContainsSameCompilationUserType(s)));
+            && receiverTypeArgs.Any(TypeSymbol.RequiresSymbolicProjection);
 
         if (!methodHasSymbolicArgs && !receiverHasSymbolicArgs)
         {
@@ -950,8 +948,8 @@ internal sealed partial class ExpressionBinder
         // Only override the erased target when the recovered shape actually
         // carries a type parameter or same-compilation user type; otherwise the
         // ordinary closed-CLR delegate target is already correct.
-        var carries = (returnType != null && (TypeSymbol.ContainsTypeParameter(returnType) || TypeSymbol.ContainsSameCompilationUserType(returnType)))
-            || parameterTypes.Any(p => p != null && (TypeSymbol.ContainsTypeParameter(p) || TypeSymbol.ContainsSameCompilationUserType(p)));
+        var carries = TypeSymbol.RequiresSymbolicProjection(returnType)
+            || parameterTypes.Any(TypeSymbol.RequiresSymbolicProjection);
         if (!carries)
         {
             return false;

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1550,12 +1550,12 @@ internal sealed class LambdaBinder
 
         if (left == TypeSymbol.Null)
         {
-            return right;
+            return right is NullableTypeSymbol ? right : NullableTypeSymbol.Get(right);
         }
 
         if (right == TypeSymbol.Null)
         {
-            return left;
+            return left is NullableTypeSymbol ? left : NullableTypeSymbol.Get(left);
         }
 
         var leftToRight = Conversion.Classify(left, right);
@@ -1573,8 +1573,10 @@ internal sealed class LambdaBinder
 
         if (leftToRight.IsImplicit && rightToLeft.IsImplicit)
         {
-            // Pick the left arm deterministically when both sides convert.
-            return left;
+            // Issue #2498: mutually convertible nullable/non-nullable
+            // references must union their annotations independent of return
+            // statement order.
+            return MemberLookup.MergeInferredTypeArgument(left, right);
         }
 
         return null;

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -862,8 +862,7 @@ internal sealed class MemberLookup
             // symbolic slice here the call's return would collapse to the
             // erased `object[]` and fail to convert to `[]Foo` (GS0155). Mirror
             // the generic-type branch below, which already honours #903.
-            if (TypeSymbol.ContainsTypeParameter(mappedElement)
-                || TypeSymbol.ContainsSameCompilationUserType(mappedElement))
+            if (TypeSymbol.RequiresSymbolicProjection(mappedElement))
             {
                 return SliceTypeSymbol.Get(mappedElement);
             }
@@ -878,8 +877,7 @@ internal sealed class MemberLookup
         {
             var openPointee = openClr.GetElementType();
             var mappedPointee = MapOpenClrTypeToSymbolic(openPointee, openDefinition, typeArguments, openMethodDefinition, methodTypeArguments);
-            if (TypeSymbol.ContainsTypeParameter(mappedPointee)
-                || TypeSymbol.ContainsSameCompilationUserType(mappedPointee))
+            if (TypeSymbol.RequiresSymbolicProjection(mappedPointee))
             {
                 return ByRefTypeSymbol.Get(mappedPointee);
             }
@@ -904,8 +902,7 @@ internal sealed class MemberLookup
                 openMethodDefinition,
                 methodTypeArguments);
 
-            if (TypeSymbol.ContainsTypeParameter(mappedUnderlying)
-                || TypeSymbol.ContainsSameCompilationUserType(mappedUnderlying))
+            if (TypeSymbol.RequiresSymbolicProjection(mappedUnderlying))
             {
                 return NullableTypeSymbol.Get(mappedUnderlying);
             }
@@ -931,8 +928,7 @@ internal sealed class MemberLookup
                 // receiver keep the `Check` element identity instead of
                 // collapsing to the type-erased `IEnumerable<object>` (which
                 // for a value-type element is not even a legal up-cast).
-                if (TypeSymbol.ContainsTypeParameter(mapped)
-                    || TypeSymbol.ContainsSameCompilationUserType(mapped))
+                if (TypeSymbol.RequiresSymbolicProjection(mapped))
                 {
                     anyParam = true;
                 }
@@ -1102,7 +1098,7 @@ internal sealed class MemberLookup
         // erased `TSource` to `object`, so a generic return like `Single() →
         // TSource` would otherwise surface as `object` and lose the `Check`
         // identity (breaking `net.Id`). The symbolic projection recovers it.
-        return TypeSymbol.ContainsTypeParameter(mapped) || TypeSymbol.ContainsSameCompilationUserType(mapped)
+        return TypeSymbol.RequiresSymbolicProjection(mapped)
             ? mapped
             : null;
     }
@@ -1162,8 +1158,7 @@ internal sealed class MemberLookup
             // recovered from a `List[Check]` receiver) does too — the closed
             // CLR method erased it to `object`, so without the symbolic vector
             // the call's return type / lambda parameter type would be `object`.
-            if (inferred[i] != null
-                && (TypeSymbol.ContainsTypeParameter(inferred[i]) || TypeSymbol.ContainsSameCompilationUserType(inferred[i])))
+            if (TypeSymbol.RequiresSymbolicProjection(inferred[i]))
             {
                 anySymbolic = true;
                 break;
@@ -3087,6 +3082,9 @@ internal sealed class MemberLookup
         return TypeSymbol.FromClrType(closedType);
     }
 
+    internal static TypeSymbol MergeInferredTypeArgument(TypeSymbol existing, TypeSymbol incoming)
+        => MergeRecoveredTypeArgument(existing, incoming);
+
     private static bool IsBetterSymbolicIndexerCandidate(
         ImmutableArray<TypeSymbol> candidate,
         ImmutableArray<TypeSymbol> other,
@@ -3853,6 +3851,26 @@ internal sealed class MemberLookup
             return;
         }
 
+        // A direct MVar match must observe the complete symbolic actual before
+        // nullable-reference wrappers are removed for outer structural
+        // matching. Multiple inference sources join compatible nullable
+        // evidence instead of depending on argument order.
+        if (openClr.IsGenericParameter && openClr.DeclaringMethod != null)
+        {
+            if (ReferenceEquals(openClr.DeclaringMethod, openMethod)
+                || openClr.DeclaringMethod.MetadataToken == openMethod.MetadataToken)
+            {
+                var pos = openClr.GenericParameterPosition;
+                if ((uint)pos < (uint)result.Length)
+                {
+                    var recovered = NormalizeRecoveredNullability(actual);
+                    result[pos] = MergeInferredTypeArgument(result[pos], recovered);
+                }
+            }
+
+            return;
+        }
+
         // Reference-type nullability is a source annotation and does not add a
         // CLR wrapper. Unify through it so a nullable reference receiver such as
         // IEnumerable<Choice>? still recovers TSource = Choice. Preserve real
@@ -3861,22 +3879,6 @@ internal sealed class MemberLookup
             && !NullableLifting.IsAnyValueTypeNullable(nullableActual))
         {
             actual = nullableActual.UnderlyingType;
-        }
-
-        // Open MVar(i) → record the actual symbolic shape (first wins).
-        if (openClr.IsGenericParameter && openClr.DeclaringMethod != null)
-        {
-            if (ReferenceEquals(openClr.DeclaringMethod, openMethod)
-                || openClr.DeclaringMethod.MetadataToken == openMethod.MetadataToken)
-            {
-                var pos = openClr.GenericParameterPosition;
-                if ((uint)pos < (uint)result.Length && result[pos] == null)
-                {
-                    result[pos] = NormalizeRecoveredNullability(actual);
-                }
-            }
-
-            return;
         }
 
         // T[] / []T (open array element).
@@ -4045,6 +4047,112 @@ internal sealed class MemberLookup
         }
 
         return t;
+    }
+
+    private static TypeSymbol MergeRecoveredTypeArgument(TypeSymbol existing, TypeSymbol incoming)
+    {
+        if (existing == null)
+        {
+            return incoming;
+        }
+
+        if (incoming == null || ReferenceEquals(existing, incoming))
+        {
+            return existing;
+        }
+
+        var existingNullable = existing is NullableTypeSymbol en
+            && !NullableLifting.IsAnyValueTypeNullable(en);
+        var incomingNullable = incoming is NullableTypeSymbol inn
+            && !NullableLifting.IsAnyValueTypeNullable(inn);
+        if (existingNullable || incomingNullable)
+        {
+            var existingUnderlying = existingNullable ? ((NullableTypeSymbol)existing).UnderlyingType : existing;
+            var incomingUnderlying = incomingNullable ? ((NullableTypeSymbol)incoming).UnderlyingType : incoming;
+            if (DeclarationBinder.TypeSignaturesEquivalent(existingUnderlying, incomingUnderlying))
+            {
+                return NullableTypeSymbol.Get(
+                    MergeRecoveredTypeArgument(existingUnderlying, incomingUnderlying));
+            }
+        }
+
+        if (existing is ImportedTypeSymbol existingImported
+            && incoming is ImportedTypeSymbol incomingImported
+            && existingImported.OpenDefinition != null
+            && incomingImported.OpenDefinition != null
+            && ClrTypeUtilities.AreSame(existingImported.OpenDefinition, incomingImported.OpenDefinition)
+            && existingImported.TypeArguments.Length == incomingImported.TypeArguments.Length)
+        {
+            var merged = ImmutableArray.CreateBuilder<TypeSymbol>(existingImported.TypeArguments.Length);
+            var changed = false;
+            for (var i = 0; i < existingImported.TypeArguments.Length; i++)
+            {
+                var left = existingImported.TypeArguments[i];
+                var right = incomingImported.TypeArguments[i];
+                if (!DeclarationBinder.TypeSignaturesEquivalent(left, right))
+                {
+                    return existing;
+                }
+
+                var item = MergeRecoveredTypeArgument(left, right);
+                changed |= !ReferenceEquals(item, left);
+                merged.Add(item);
+            }
+
+            if (changed)
+            {
+                return ImportedTypeSymbol.GetConstructed(
+                    existingImported.ClrType,
+                    existingImported.OpenDefinition,
+                    merged.MoveToImmutable());
+            }
+        }
+
+        if (existing is SliceTypeSymbol existingSlice
+            && incoming is SliceTypeSymbol incomingSlice
+            && DeclarationBinder.TypeSignaturesEquivalent(existingSlice.ElementType, incomingSlice.ElementType))
+        {
+            return SliceTypeSymbol.Get(
+                MergeRecoveredTypeArgument(existingSlice.ElementType, incomingSlice.ElementType));
+        }
+
+        if (existing is ArrayTypeSymbol existingArray
+            && incoming is ArrayTypeSymbol incomingArray
+            && existingArray.Length == incomingArray.Length
+            && DeclarationBinder.TypeSignaturesEquivalent(existingArray.ElementType, incomingArray.ElementType))
+        {
+            return ArrayTypeSymbol.Get(
+                MergeRecoveredTypeArgument(existingArray.ElementType, incomingArray.ElementType),
+                existingArray.Length);
+        }
+
+        if (existing is TupleTypeSymbol existingTuple
+            && incoming is TupleTypeSymbol incomingTuple
+            && existingTuple.ElementTypes.Length == incomingTuple.ElementTypes.Length)
+        {
+            var merged = ImmutableArray.CreateBuilder<TypeSymbol>(existingTuple.ElementTypes.Length);
+            for (var i = 0; i < existingTuple.ElementTypes.Length; i++)
+            {
+                if (!DeclarationBinder.TypeSignaturesEquivalent(
+                    existingTuple.ElementTypes[i],
+                    incomingTuple.ElementTypes[i]))
+                {
+                    return existing;
+                }
+
+                merged.Add(MergeRecoveredTypeArgument(
+                    existingTuple.ElementTypes[i],
+                    incomingTuple.ElementTypes[i]));
+            }
+
+            return TupleTypeSymbol.Get(merged.MoveToImmutable());
+        }
+
+        return !TypeSymbol.ContainsReferenceNullableAnnotation(existing)
+            && TypeSymbol.ContainsReferenceNullableAnnotation(incoming)
+            && DeclarationBinder.TypeSignaturesEquivalent(existing, incoming)
+                ? incoming
+                : existing;
     }
 
     private static TypeSymbol TryGetElementType(TypeSymbol t)

--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -150,6 +150,16 @@ internal sealed class ImportedMemberRefFactory
             return this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
         }
 
+        // Issue #2498: nullable-reference annotations do not change the CLR
+        // element token. Forward same-compilation classes/interfaces/delegates
+        // through their underlying symbol just as imported nullable references
+        // already flow through the shared CLR Type.
+        if (element is NullableTypeSymbol nullableReferenceElement
+            && !NullableLifting.IsAnyValueTypeNullable(nullableReferenceElement))
+        {
+            return this.GetElementTypeToken(nullableReferenceElement.UnderlyingType);
+        }
+
         if (element == TypeSymbol.Int32)
         {
             return this.GetTypeReference(this.emitCtx.CoreInt32Type);
@@ -184,7 +194,7 @@ internal sealed class ImportedMemberRefFactory
         if (element is ImportedTypeSymbol symbolicImported
             && !symbolicImported.TypeArguments.IsDefaultOrEmpty
             && !symbolicImported.HasTypeParameterArgument
-            && symbolicImported.TypeArguments.Any(ReflectionMetadataEmitter.ArgIsSymbolicUserDefined))
+            && symbolicImported.TypeArguments.Any(TypeSymbol.RequiresSymbolicProjection))
         {
             var sigBlob = new BlobBuilder();
             this.signatures.EncodeTypeSymbol(new BlobEncoder(sigBlob).TypeSpecificationSignature(), symbolicImported);
@@ -817,7 +827,7 @@ internal sealed class ImportedMemberRefFactory
             {
                 if (!typeArgSymbols.IsDefaultOrEmpty
                     && i < typeArgSymbols.Length
-                    && ReflectionMetadataEmitter.ArgIsSymbolicUserDefined(typeArgSymbols[i]))
+                    && TypeSymbol.RequiresSymbolicProjection(typeArgSymbols[i]))
                 {
                     this.signatures.EncodeTypeSymbol(symbolicArgsEncoder.AddArgument(), typeArgSymbols[i]);
                 }
@@ -842,7 +852,7 @@ internal sealed class ImportedMemberRefFactory
         // the same generic method was referenced multiple times with the same
         // user-type generic args.
         var hasSymbolArgs = !typeArgSymbols.IsDefaultOrEmpty
-            && typeArgSymbols.Any(ReflectionMetadataEmitter.ArgIsSymbolicUserDefined);
+            && typeArgSymbols.Any(TypeSymbol.RequiresSymbolicProjection);
         if (!hasSymbolArgs)
         {
             if (this.cache.MethodSpecs.TryGetValue(method, out var existing))
@@ -874,7 +884,7 @@ internal sealed class ImportedMemberRefFactory
             // collapsing to System.Object at the placeholder.
             if (!typeArgSymbols.IsDefaultOrEmpty
                 && i < typeArgSymbols.Length
-                && ReflectionMetadataEmitter.ArgIsSymbolicUserDefined(typeArgSymbols[i]))
+                && TypeSymbol.RequiresSymbolicProjection(typeArgSymbols[i]))
             {
                 this.signatures.EncodeTypeSymbol(argsEncoder.AddArgument(), typeArgSymbols[i]);
             }
@@ -906,7 +916,7 @@ internal sealed class ImportedMemberRefFactory
         if (method == null
             || !TryNormalizeToSymbolicContainer(containingTypeSymbol, out var openDefinition, out var typeArguments)
             || typeArguments.IsDefaultOrEmpty
-            || !(typeArguments.Any(TypeSymbol.ContainsTypeParameter) || typeArguments.Any(ReflectionMetadataEmitter.ArgIsSymbolicUserDefined)))
+            || !typeArguments.Any(TypeSymbol.RequiresSymbolicProjection))
         {
             return false;
         }

--- a/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
@@ -311,7 +311,7 @@ internal sealed class SignatureEncoder
             && !symbolicImported.TypeArguments.IsDefaultOrEmpty
             && !symbolicImported.HasTypeParameterArgument
             && symbolicImported.OpenDefinition != null
-            && symbolicImported.TypeArguments.Any(ReflectionMetadataEmitter.ArgIsSymbolicUserDefined))
+            && symbolicImported.TypeArguments.Any(TypeSymbol.RequiresSymbolicProjection))
         {
             var genericInst = encoder.GenericInstantiation(
                 this.outer.memberRefs.GetTypeReference(symbolicImported.OpenDefinition),

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -1964,7 +1964,7 @@ internal sealed class UserTokenResolver
         if (property == null
             || !ImportedMemberRefFactory.TryNormalizeToSymbolicContainer(receiverType, out var openDef, out var typeArguments)
             || typeArguments.IsDefaultOrEmpty
-            || !(typeArguments.Any(TypeSymbol.ContainsTypeParameter) || typeArguments.Any(ReflectionMetadataEmitter.ArgIsSymbolicUserDefined)))
+            || !typeArguments.Any(TypeSymbol.RequiresSymbolicProjection))
         {
             return false;
         }
@@ -2007,7 +2007,7 @@ internal sealed class UserTokenResolver
         if (method == null
             || !ImportedMemberRefFactory.TryNormalizeToSymbolicContainer(receiverType, out var openDef, out var typeArguments)
             || typeArguments.IsDefaultOrEmpty
-            || !(typeArguments.Any(TypeSymbol.ContainsTypeParameter) || typeArguments.Any(ReflectionMetadataEmitter.ArgIsSymbolicUserDefined)))
+            || !typeArguments.Any(TypeSymbol.RequiresSymbolicProjection))
         {
             return false;
         }

--- a/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
@@ -86,11 +86,12 @@ public sealed class ImportedTypeSymbol : TypeSymbol
     /// </summary>
     public bool HasSubstitutableTypeArgument =>
         !TypeArguments.IsDefaultOrEmpty
-        && (HasTypeParameterArgument
-            || TypeArguments.Any(static a => a.ClrType == null
-                || (a is ImportedTypeSymbol nested
-                    && nested.OpenDefinition != null
-                    && !nested.TypeArguments.IsDefaultOrEmpty)));
+        && TypeArguments.Any(static a =>
+            a.ClrType == null
+            || TypeSymbol.RequiresSymbolicProjection(a)
+            || (a is ImportedTypeSymbol nested
+                && nested.OpenDefinition != null
+                && !nested.TypeArguments.IsDefaultOrEmpty));
 
     /// <summary>
     /// Gets or creates the imported type symbol for the given CLR type.

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -653,6 +653,49 @@ public class TypeSymbol : Symbol
     }
 
     /// <summary>
+    /// Issue #2498: returns <c>true</c> when <paramref name="type"/> carries a
+    /// nullable-reference annotation at any structural position. Unlike CLR
+    /// <c>Nullable&lt;T&gt;</c>, reference nullability has no distinct runtime
+    /// <see cref="Type"/> shape, so reflection-only generic substitution cannot
+    /// reproduce it after inference.
+    /// </summary>
+    /// <param name="type">The type to inspect.</param>
+    /// <returns><c>true</c> when a nullable-reference wrapper is present.</returns>
+    public static bool ContainsReferenceNullableAnnotation(TypeSymbol type)
+    {
+        if (type is NullableTypeSymbol nullable)
+        {
+            if (!NullableLifting.IsAnyValueTypeNullable(nullable))
+            {
+                return true;
+            }
+
+            return ContainsReferenceNullableAnnotation(nullable.UnderlyingType);
+        }
+
+        foreach (var inner in GetWrappedTypes(type))
+        {
+            if (ContainsReferenceNullableAnnotation(inner))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when a symbolic type projection contains information
+    /// that its CLR <see cref="Type"/> cannot faithfully represent.
+    /// </summary>
+    /// <param name="type">The type to inspect.</param>
+    /// <returns><c>true</c> when symbolic substitution must be retained.</returns>
+    public static bool RequiresSymbolicProjection(TypeSymbol type)
+        => ContainsTypeParameter(type)
+            || ContainsSameCompilationUserType(type)
+            || ContainsReferenceNullableAnnotation(type);
+
+    /// <summary>
     /// Returns true when <paramref name="type"/> — after unwrapping nullable,
     /// slice and array wrappers — is itself a same-compilation user-defined
     /// type (struct/class/enum/interface/delegate with a null <c>ClrType</c>).

--- a/test/Compiler.Tests/Emit/Issue2498NullableLambdaGenericInferenceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2498NullableLambdaGenericInferenceEmitTests.cs
@@ -1,0 +1,311 @@
+// <copyright file="Issue2498NullableLambdaGenericInferenceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Compiler;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Runtime, metadata, C# consumer, and ILVerify coverage for issue #2498.
+/// </summary>
+public sealed class Issue2498NullableLambdaGenericInferenceEmitTests
+{
+    [Fact]
+    public void OahuIteratorShape_SelectToArray_RunsAndVerifies()
+    {
+        const string source = """
+            package Issue2498.Iterator
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            func Build2498[T](source []IEnumerable[T]) []IEnumerator[T]? {
+                let values = source
+                    .Select((enumerable IEnumerable[T]) -> enumerable.GetEnumerator())
+                    .Select((enumerator IEnumerator[T]) ->
+                        if enumerator.MoveNext() {
+                            enumerator
+                        } else {
+                            default(IEnumerator[T]?)
+                        })
+                    .ToArray()
+                values[0] = nil
+                return values
+            }
+
+            func Main() {
+                let source = []IEnumerable[int32]{
+                    []int32{1},
+                    []int32{},
+                }
+                let values = Build2498[int32](source)
+                Console.WriteLine(values[0] == nil)
+                Console.WriteLine(values[1] == nil)
+            }
+            """;
+
+        Assert.Equal("True\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GeneralizedImportedAndSourceGenericShapes_RunAndVerify()
+    {
+        const string source = """
+            package Issue2498.Runtime
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            func Maybe2498(value string) string? ->
+                if value.Length > 0 { value } else { nil }
+
+            func Project2498[A, B](source []A, selector (A) -> B) []B ->
+                source.Select(selector).ToArray()
+
+            func MaybeComparable2498(value string) IComparable? -> Maybe2498(value)
+
+            func MaybeList2498(value string) List[IComparable?] {
+                let result = List[IComparable?]()
+                result.Add(MaybeComparable2498(value))
+                return result
+            }
+
+            func Main() {
+                let source = []string{"value", ""}
+
+                let array = source.Select((value string) -> Maybe2498(value)).ToArray()
+                array[0] = nil
+                Console.WriteLine(array[0] == nil)
+                Console.WriteLine(array[1] == nil)
+
+                let list = source.Select(Maybe2498).ToList()
+                list[0] = nil
+                Console.WriteLine(list[0] == nil)
+
+                let nested = source.Select((value string) -> MaybeList2498(value)).ToArray()
+                nested[0][0] = nil
+                Console.WriteLine(nested[0][0] == nil)
+
+                let projected = Project2498(source, (value string) -> Maybe2498(value))
+                projected[0] = nil
+                Console.WriteLine(projected[0] == nil)
+
+                let groups = source.GroupBy((value string) -> Maybe2498(value)).ToArray()
+                Console.WriteLine(groups[1].Key == nil)
+            }
+            """;
+
+        Assert.Equal("True\nTrue\nTrue\nTrue\nTrue\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EmittedNullability_RoundTripsAndCSharpConsumerAcceptsNullWrites()
+    {
+        const string source = """
+            package Issue2498.Metadata
+            import System.Collections.Generic
+            import System.Linq
+
+            func Maybe2498Metadata(value string) string? ->
+                if value.Length > 0 { value } else { nil }
+
+            class Api2498 {
+                shared {
+                    func Build(source []string) []string? ->
+                        source.Select((value string) -> Maybe2498Metadata(value)).ToArray()
+
+                    func BuildList(source []string) List[string?] ->
+                        source.Select((value string) -> Maybe2498Metadata(value)).ToList()
+
+                    func BuildNested(source []string) []List[string?] ->
+                        source.Select((value string) -> {
+                            let result = List[string?]()
+                            result.Add(Maybe2498Metadata(value))
+                            return result
+                        }).ToArray()
+                }
+            }
+            """;
+
+        WithCompiledLibrary(source, (dllPath, references) =>
+        {
+            var assembly = Assembly.Load(File.ReadAllBytes(dllPath));
+            var api = assembly.GetType("Issue2498.Metadata.Api2498", throwOnError: true)!;
+            var nullability = new NullabilityInfoContext();
+
+            var build = nullability.Create(GetMethod(api, "Build").ReturnParameter);
+            Assert.Equal(NullabilityState.Nullable, build.ElementType!.ReadState);
+
+            var buildList = nullability.Create(GetMethod(api, "BuildList").ReturnParameter);
+            Assert.Equal(NullabilityState.Nullable, buildList.GenericTypeArguments[0].ReadState);
+
+            var buildNested = nullability.Create(GetMethod(api, "BuildNested").ReturnParameter);
+            Assert.Equal(
+                NullabilityState.Nullable,
+                buildNested.ElementType!.GenericTypeArguments[0].ReadState);
+
+            const string consumerSource = """
+                #nullable enable
+                using Issue2498.Metadata;
+
+                public static class Consumer2498
+                {
+                    public static void WriteNulls()
+                    {
+                        Api2498.Build(["x"])[0] = null;
+                        Api2498.BuildList(["x"])[0] = null;
+                        Api2498.BuildNested(["x"])[0][0] = null;
+                    }
+                }
+                """;
+
+            var compilation = CSharpCompilation.Create(
+                "Issue2498.Consumer",
+                new[] { CSharpSyntaxTree.ParseText(consumerSource) },
+                TrustedPlatformAssemblies()
+                    .Select(path => MetadataReference.CreateFromFile(path))
+                    .Append(MetadataReference.CreateFromFile(dllPath)),
+                new CSharpCompilationOptions(
+                    OutputKind.DynamicallyLinkedLibrary,
+                    nullableContextOptions: NullableContextOptions.Enable,
+                    generalDiagnosticOption: ReportDiagnostic.Error));
+            using var stream = new MemoryStream();
+            var result = compilation.Emit(stream);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        });
+    }
+
+    private static MethodInfo GetMethod(Type type, string name)
+        => type.GetMethod(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"Method '{name}' was not emitted.");
+
+    private static string CompileAndRun(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue2498_run_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+            var (exitCode, stdout, stderr) = Compile(sourcePath, outputPath, "exe");
+            Assert.True(exitCode == 0, $"gsc failed:\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            IlVerifier.Verify(outputPath);
+
+            var runtimeConfig = Path.ChangeExtension(outputPath, ".runtimeconfig.json");
+            File.WriteAllText(runtimeConfig, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(runtimeConfig);
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var runtimeOutput = process.StandardOutput.ReadToEnd();
+            var runtimeError = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            Assert.True(
+                process.ExitCode == 0,
+                $"dotnet exec failed ({process.ExitCode}):\nstdout:\n{runtimeOutput}\nstderr:\n{runtimeError}");
+            return runtimeOutput.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            TryDelete(directory);
+        }
+    }
+
+    private static void WithCompiledLibrary(
+        string source,
+        Action<string, IReadOnlyList<string>> assertion)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue2498_lib_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+            var (exitCode, stdout, stderr) = Compile(sourcePath, outputPath, "library");
+            Assert.True(exitCode == 0, $"gsc failed:\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            var references = TrustedPlatformAssemblies().ToArray();
+            IlVerifier.Verify(outputPath, additionalReferences: references);
+            assertion(outputPath, references);
+        }
+        finally
+        {
+            TryDelete(directory);
+        }
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) Compile(
+        string sourcePath,
+        string outputPath,
+        string target)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            return (exitCode, stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var value = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        return string.IsNullOrWhiteSpace(value)
+            ? Array.Empty<string>()
+            : value.Split(Path.PathSeparator).Where(File.Exists);
+    }
+
+    private static void TryDelete(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2498NullableLambdaGenericInferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2498NullableLambdaGenericInferenceTests.cs
@@ -1,0 +1,253 @@
+// <copyright file="Issue2498NullableLambdaGenericInferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2498: nullable-reference lambda results must survive generic method
+/// inference and every symbolic projection built from the inferred argument.
+/// </summary>
+public sealed class Issue2498NullableLambdaGenericInferenceTests
+{
+    [Fact]
+    public void Select_ToArrayAndToList_PreserveNullableElements()
+    {
+        AssertBinds("""
+            import System.Collections.Generic
+            import System.Linq
+
+            func Build[T](source []IEnumerator[T]) {
+                let array = source.Select((item IEnumerator[T]) ->
+                    if item.MoveNext() { item } else { default(IEnumerator[T]?) }).ToArray()
+                array[0] = nil
+
+                let list = source.Select((item IEnumerator[T]) ->
+                    if item.MoveNext() { item } else { default(IEnumerator[T]?) }).ToList()
+                list[0] = nil
+            }
+            """);
+    }
+
+    [Fact]
+    public void LambdaResultForms_MethodGroupsAndExplicitArguments_PreserveNullability()
+    {
+        AssertBinds("""
+            import System.Collections.Generic
+            import System.Linq
+
+            class Holder2498Forms {
+                prop Value string? { get; init; }
+            }
+
+            func Maybe2498(value string) string? ->
+                if value.Length > 0 { value } else { nil }
+
+            func Run2498Forms(source []string, holders []Holder2498Forms) {
+                let conditional = source.Select((value string) ->
+                    if value.Length > 0 { value } else { default(string?) }).ToArray()
+                conditional[0] = nil
+
+                let switched = source.Select((value string) ->
+                    switch value { case "": default(string?) default: value }).ToArray()
+                switched[0] = nil
+
+                let directNil = source.Select((value string) -> {
+                    if value.Length > 0 {
+                        return value
+                    }
+                    return nil
+                }).ToArray()
+                directNil[0] = nil
+
+                let coalesced = holders.Select((holder Holder2498Forms) ->
+                    holder.Value ?? default(string?)).ToArray()
+                coalesced[0] = nil
+
+                let called = source.Select((value string) -> Maybe2498(value)).ToArray()
+                called[0] = nil
+
+                let member = holders.Select((holder Holder2498Forms) -> holder.Value).ToArray()
+                member[0] = nil
+
+                let methodGroup = source.Select(Maybe2498).ToArray()
+                methodGroup[0] = nil
+
+                let explicit = source.Select[string, string?](
+                    (value string) -> Maybe2498(value)).ToArray()
+                explicit[0] = nil
+            }
+            """);
+    }
+
+    [Fact]
+    public void NestedGenericsArraysAndNullableReferenceKinds_PreserveAnnotations()
+    {
+        AssertBinds("""
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            class Holder2498Shapes {
+                prop Value string? { get; init; }
+                prop Callback Func[int32]? { get; init; }
+            }
+
+            func MaybeText2498(value string) string? ->
+                if value.Length > 0 { value } else { nil }
+
+            func MaybeList2498(value string) List[string?] {
+                let result = List[string?]()
+                result.Add(MaybeText2498(value))
+                return result
+            }
+
+            func MaybeArray2498(value string) []string? ->
+                []string?{MaybeText2498(value)}
+
+            func MaybeHolder2498(value Holder2498Shapes) Holder2498Shapes? ->
+                if value.Value != nil { value } else { nil }
+
+            func MaybeComparable2498(value string) IComparable? -> value
+
+            func Run2498Shapes(source []string, holders []Holder2498Shapes) {
+                let nested = source.Select((value string) -> MaybeList2498(value)).ToArray()
+                nested[0][0] = nil
+
+                let arrays = source.Select((value string) -> MaybeArray2498(value)).ToArray()
+                arrays[0][0] = nil
+
+                let tuples = source.Select(
+                    (value string) -> (MaybeText2498(value), 1)).ToArray()
+                var tupleValue = tuples[0].Item1
+                tupleValue = nil
+
+                let classes = holders.Select(
+                    (holder Holder2498Shapes) -> MaybeHolder2498(holder)).ToArray()
+                classes[0] = nil
+
+                let interfaces = source.Select(
+                    (value string) -> MaybeComparable2498(value)).ToArray()
+                interfaces[0] = nil
+
+                let delegates = holders.Select(
+                    (holder Holder2498Shapes) -> holder.Callback).ToArray()
+                delegates[0] = nil
+            }
+            """);
+    }
+
+    [Fact]
+    public void MultipleLambdasImportedContinuationsAndSourceGenerics_PreserveNullability()
+    {
+        AssertBinds("""
+            import System.Collections.Generic
+            import System.Linq
+            import System.Threading.Tasks
+
+            class Holder2498Apis {
+                prop Value string? { get; init; }
+            }
+
+            func Maybe2498Apis(value string) string? ->
+                if value.Length > 0 { value } else { nil }
+
+            func SourceProject2498[A, B](source []A, selector (A) -> B) []B ->
+                source.Select(selector).ToArray()
+
+            func SourceChoose2498[B](first () -> B, second () -> B) B -> second()
+
+            func Run2498Apis(source []string, holders []Holder2498Apis) {
+                let sourceGeneric = SourceProject2498(
+                    source, (value string) -> Maybe2498Apis(value))
+                sourceGeneric[0] = nil
+
+                var sourceJoined = SourceChoose2498(
+                    () -> "value",
+                    () -> default(string?))
+                sourceJoined = nil
+
+                let flattened = holders.SelectMany(
+                    (holder Holder2498Apis) -> []string?{holder.Value},
+                    (holder Holder2498Apis, value string?) -> value).ToArray()
+                flattened[0] = nil
+
+                let groups = holders.GroupBy(
+                    (holder Holder2498Apis) -> holder.Value).ToArray()
+                let groupKey string? = groups[0].Key
+
+                let joined = source.Join(
+                    source,
+                    (outer string) -> Maybe2498Apis(outer),
+                    (inner string) -> inner,
+                    (outer string, inner string) -> outer).ToArray()
+
+                let continued = Task.FromResult("x").ContinueWith(
+                    (task Task[string]) -> Maybe2498Apis(task.Result))
+                var continuationResult = continued.Result
+                continuationResult = nil
+            }
+            """);
+    }
+
+    [Fact]
+    public void NullableReceiverAndNonNullableAndValueNullableControlsRemainStable()
+    {
+        AssertBinds("""
+            import System.Collections.Generic
+            import System.Linq
+
+            func Count2498(values IEnumerable[string]?) int32 -> values!!.Count()
+
+            func Controls2498(source []string) {
+                let nullableValues = source.Select((value string) -> default(int32?)).ToArray()
+                nullableValues[0] = nil
+
+                let plain = source.Select((value string) -> value).ToArray()
+                let text string = plain[0]
+            }
+            """);
+
+        var diagnostics = Bind("""
+            import System.Linq
+
+            let plain = []string{"x"}.Select((value string) -> value).ToArray()
+            plain[0] = nil
+            """);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0155");
+    }
+
+    private static void AssertBinds(string source)
+    {
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.IsError);
+    }
+
+    private static ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
+    {
+        var paths = new List<string>();
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (!string.IsNullOrEmpty(tpa))
+        {
+            paths.AddRange(tpa.Split(Path.PathSeparator).Where(File.Exists));
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(paths);
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), resolver);
+        var program = Binder.BindProgram(globalScope, resolver);
+        return globalScope.Diagnostics.AddRange(program.Diagnostics);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2498NullableLambdaGenericInferencePipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2498NullableLambdaGenericInferencePipelineTests.cs
@@ -1,0 +1,142 @@
+// <copyright file="Issue2498NullableLambdaGenericInferencePipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Default SDK-backed migration coverage for issue #2498.
+/// </summary>
+public sealed class Issue2498NullableLambdaGenericInferencePipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_NullableLambdaProjection_TranslatesAndCompiles()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectDir = Path.Combine(sourceRoot, "src", "Sample");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "Sample.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "Repro.cs"), """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            namespace Sample;
+
+            public static class Repro
+            {
+                public static IEnumerator<T>?[] Build<T>(IEnumerable<T>[] source)
+                {
+                    IEnumerator<T>?[] values = source
+                        .Select(item => item.GetEnumerator())
+                        .Select(item => item.MoveNext() ? item : null)
+                        .ToArray();
+                    values[0] = null;
+                    return values;
+                }
+
+                public static List<string?> BuildList(string[] source)
+                {
+                    List<string?> values = source
+                        .Select(value => value.Length > 0 ? value : null)
+                        .ToList();
+                    values[0] = null;
+                    return values;
+                }
+            }
+            """);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp("test/NullableLambdaInference", projectPath, TargetKind.Library);
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+
+        string appRunDir = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.Id));
+        string emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(appRunDir, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains("default(IEnumerator[T]?)", emitted, StringComparison.Ordinal);
+        Assert.Contains("values[0] = nil", emitted, StringComparison.Ordinal);
+        Assert.Contains("List[string?]", emitted, StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            "Expected default --via-sdk/gsc compilation to preserve nullable lambda projections. Stages: " +
+                string.Join("; ", appResult.Stages.Select(s => s.Stage + "=" + s.Status)));
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2498",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    dir.FullName,
+                    "out",
+                    "bin",
+                    config,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes #2498

## Summary
- preserve nullable-reference lambda returns before direct method-type-parameter unification unwraps structural containers
- carry symbolic nullability through source/imported inference, nested generic/array/list materialization, bound returns, member refs, MethodSpecs, and emitted signatures
- union compatible nullable evidence across conditional/direct-nil and multiple-lambda inference sources
- add binder, runtime, reflection/C# consumer, ILVerify, and default `cs2gs --via-sdk` regressions

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --nologo` (6500 passed, 1 skipped)
- targeted Compiler.Tests: issue #2498, #1518, and enum inference control (14 passed)
- isolated default `--via-sdk` issue #2498 pipeline test (passed)
- full Compiler.Tests was sampled but stopped after unrelated missing `Gsharp.Extensions.dll` environment failures; focused compiler coverage is green