### PR TITLE
Preserve nullable explicit generic arguments

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2467StaticExtensionConditionalReceiverTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2467StaticExtensionConditionalReceiverTests.cs
@@ -116,7 +116,7 @@ public class Issue2467StaticExtensionConditionalReceiverTests
             }
             """);
 
-        Assert.Contains("(box?.Value).Pick[string](\"fallback\")", printed, StringComparison.Ordinal);
+        Assert.Contains("(box?.Value).Pick[string?](\"fallback\")", printed, StringComparison.Ordinal);
         Assert.Contains("(box?.Value).Pick(\"fallback\")", printed, StringComparison.Ordinal);
         Assert.Contains("(box?.Value).Flow(&x, &y, z)", printed, StringComparison.Ordinal);
         Assert.Contains("(box?.Value).Join()", printed, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2500NullableExplicitGenericArgumentsPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2500NullableExplicitGenericArgumentsPipelineTests.cs
@@ -1,0 +1,149 @@
+// <copyright file="Issue2500NullableExplicitGenericArgumentsPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2500NullableExplicitGenericArgumentsPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_OahuTaskShape_PreservesNullableTypeArgumentsAndCompiles()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectDir = Path.Combine(sourceRoot, "src", "Sample");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "Sample.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "Mp4Operation.cs"), """
+            using System.Runtime.CompilerServices;
+            using System.Threading.Tasks;
+
+            namespace Sample;
+
+            public sealed class Mp4Operation<TOutput>
+            {
+                private readonly Task<TOutput?>? continuation;
+
+                public Mp4Operation(Task<TOutput?>? continuation)
+                {
+                    this.continuation = continuation;
+                }
+
+                public Task<TOutput?> OperationTask =>
+                    continuation ?? Task.FromResult<TOutput?>(default);
+
+                public TaskAwaiter<TOutput?> GetAwaiter() =>
+                    (continuation ?? Task.FromResult<TOutput?>(default)).GetAwaiter();
+
+                public async Task<TOutput?> CompleteAsync() =>
+                    await OperationTask;
+            }
+            """);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp("test/NullableExplicitGenericArguments", projectPath, TargetKind.Library);
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+
+        string appRunDir = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.Id));
+        string emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(appRunDir, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Equal(2, CountOccurrences(emitted, "Task.FromResult[TOutput?](default(TOutput?))"));
+        Assert.Contains("prop OperationTask Task[TOutput?]", emitted, StringComparison.Ordinal);
+        Assert.Contains("async func CompleteAsync() TOutput?", emitted, StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            "Expected default --via-sdk/gsc compilation to accept the Oahu Task.FromResult<TOutput?> shape. Stages: " +
+                string.Join("; ", appResult.Stages.Select(s => s.Stage + "=" + s.Status)));
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2500",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    dir.FullName,
+                    "out",
+                    "bin",
+                    config,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2500NullableExplicitGenericArgumentsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2500NullableExplicitGenericArgumentsTranslationTests.cs
@@ -1,0 +1,234 @@
+// <copyright file="Issue2500NullableExplicitGenericArgumentsTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2500NullableExplicitGenericArgumentsTranslationTests
+{
+    [Fact]
+    public void SemanticTypeArguments_PreserveNullableWrappersAcrossCallAndTypeShapes()
+    {
+        string printed = Translate("""
+            #nullable enable
+            using System;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+
+            namespace Demo;
+
+            public interface IContract
+            {
+            }
+
+            public class Base
+            {
+            }
+
+            public sealed class Host
+            {
+                public TArg Instance<TArg>(TArg value) => value;
+            }
+
+            public static class Extensions
+            {
+                public static TArg Reduced<TArg>(this Host host, TArg value) => value;
+            }
+
+            public sealed class LocalBox<TArg>
+            {
+                public LocalBox(TArg value)
+                {
+                }
+
+                public static LocalBox<TArg> Create(TArg value) => new(value);
+            }
+
+            public static class Repro
+            {
+                private static TArg Same<TArg>(TArg value) => value;
+                private static void Pair<TFirst, TSecond>(TFirst first, TSecond second)
+                {
+                }
+
+                public static void Run<T, TClass, TInterface, TBase, TValue>(Host host)
+                    where TClass : class
+                    where TInterface : IContract
+                    where TBase : Base
+                    where TValue : struct
+                {
+                    T? Factory() => default;
+
+                    _ = Same<T?>(default);
+                    _ = Same<TClass?>(default);
+                    _ = Same<TInterface?>(default);
+                    _ = Same<TBase?>(default);
+                    _ = Same<TValue?>(default);
+                    _ = External.Sink.Echo<T?>(default);
+                    _ = Task.FromResult<T?>(default);
+                    _ = host.Instance<T?>(default);
+                    _ = host.Reduced<T?>(default);
+                    _ = Extensions.Reduced<T?>(host, default);
+                    _ = Same<List<T?>?>(default);
+                    _ = Same<Dictionary<T?, List<T?[]?>?>?>(default);
+                    Pair<T?, List<T?>?>(default, default);
+                    _ = Same<(T?, TClass?)>(default);
+                    _ = Same<T?[]?>(default);
+                    _ = Same<Func<T?>?>(Factory);
+                    _ = new LocalBox<T?>(default);
+                    _ = new External.Box<T?>(default);
+                    _ = LocalBox<T?>.Create(default);
+                    _ = External.Box<T?>.Create(default);
+                }
+
+            #nullable disable
+                public static void Oblivious<T>()
+                {
+                    _ = Same<T>(default);
+                    _ = External.Sink.Echo<T>(default);
+                }
+            #nullable restore
+            }
+            """);
+
+        Assert.Contains("Same[T?](default(T?))", printed, StringComparison.Ordinal);
+        Assert.Contains("Same[TClass?](default(TClass?))", printed, StringComparison.Ordinal);
+        Assert.Contains("Same[TInterface?](default(TInterface?))", printed, StringComparison.Ordinal);
+        Assert.Contains("Same[TBase?](default(TBase?))", printed, StringComparison.Ordinal);
+        Assert.Contains("Same[TValue?](default(TValue?))", printed, StringComparison.Ordinal);
+        Assert.Contains("Echo[T?](default(T?))", printed, StringComparison.Ordinal);
+        Assert.Contains("Task.FromResult[T?](default(T?))", printed, StringComparison.Ordinal);
+        Assert.Contains("host.Instance[T?](default(T?))", printed, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(printed, "host.Reduced[T?](default(T?))"));
+        Assert.Contains("Same[List[T?]?](default(List[T?]?))", printed, StringComparison.Ordinal);
+        Assert.Contains(
+            "Same[Dictionary[T?, List[[]?T?]?]?](default(Dictionary[T?, List[[]?T?]?]?))",
+            printed,
+            StringComparison.Ordinal);
+        Assert.Contains("Pair[T?, List[T?]?](default(T?), default(List[T?]?))", printed, StringComparison.Ordinal);
+        Assert.Contains("Same[(T?, TClass?)](default((T?, TClass?)))", printed, StringComparison.Ordinal);
+        Assert.Contains("Same[[]?T?](default([]?T?))", printed, StringComparison.Ordinal);
+        Assert.Contains("Same[(() -> T?)?](Factory)", printed, StringComparison.Ordinal);
+        Assert.Contains("LocalBox[T?](default(T?))", printed, StringComparison.Ordinal);
+        Assert.Contains("Box[T?](default(T?))", printed, StringComparison.Ordinal);
+        Assert.Contains("LocalBox[T?].Create(default(T?))", printed, StringComparison.Ordinal);
+        Assert.Contains("Box[T?].Create(default(T?))", printed, StringComparison.Ordinal);
+        Assert.Contains("Same[T](default(T))", printed, StringComparison.Ordinal);
+        Assert.Contains("Echo[T](default(T))", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UsingAliases_PreserveNullableSemanticArguments()
+    {
+        string printed = Translate("""
+            #nullable enable
+            using TaskAlias = System.Threading.Tasks.Task;
+            using ExternalAlias = External.Sink;
+            using ClosedBoxAlias = External.Box<string?>;
+
+            namespace Demo;
+
+            public static class Repro
+            {
+                public static void Run<T>()
+                {
+                    _ = TaskAlias.FromResult<T?>(default);
+                    _ = ExternalAlias.Echo<T?>(default);
+                    _ = new ClosedBoxAlias(default);
+                }
+            }
+            """);
+
+        Assert.Contains("TaskAlias.FromResult[T?](default(T?))", printed, StringComparison.Ordinal);
+        Assert.Contains("ExternalAlias.Echo[T?](default(T?))", printed, StringComparison.Ordinal);
+        Assert.Contains("Box[string?](default(string?))", printed, StringComparison.Ordinal);
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
+    }
+
+    private static string Translate(string source)
+    {
+        MetadataReference external = CreateExternalReference();
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest),
+            path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Issue2500.Consumer",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Concat(new[] { external }).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+
+        var document = new LoadedDocument("Snippet.cs", tree, compilation.GetSemanticModel(tree));
+        var context = new TranslationContext(compilation, document.SemanticModel, document.FilePath);
+        return GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static MetadataReference CreateExternalReference()
+    {
+        const string source = """
+            #nullable enable
+
+            namespace External;
+
+            public sealed class Box<T>
+            {
+                public Box(T value)
+                {
+                }
+
+                public static Box<T> Create(T value) => new(value);
+            }
+
+            public static class Sink
+            {
+                public static T Echo<T>(T value) => value;
+            }
+            """;
+
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest),
+            path: "External.cs");
+        var compilation = CSharpCompilation.Create(
+            "Issue2500.External",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+        using var stream = new MemoryStream();
+        var emit = compilation.Emit(stream);
+        Assert.True(
+            emit.Success,
+            "External sink must compile: " + string.Join(Environment.NewLine, emit.Diagnostics));
+        return MetadataReference.CreateFromImage(stream.ToArray());
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -2284,16 +2284,44 @@ public sealed partial class CSharpToGSharpTranslator
 
         private IReadOnlyList<GTypeReference> MapTypeArguments(GenericNameSyntax generic)
         {
+            // Issue #2500: an individual NullableTypeSyntax can bind as its
+            // underlying type parameter and lose the explicit annotation.
+            // Prefer the constructed method/type symbol, whose TypeArguments
+            // retain nullability recursively for every semantic type shape.
+            ImmutableArray<ITypeSymbol> boundTypeArguments = this.GetBoundTypeArguments(generic);
             var result = new List<GTypeReference>();
-            foreach (TypeSyntax argument in generic.TypeArgumentList.Arguments)
+            for (int i = 0; i < generic.TypeArgumentList.Arguments.Count; i++)
             {
-                ITypeSymbol symbol = this.context.GetTypeInfo(argument).Type;
+                TypeSyntax argument = generic.TypeArgumentList.Arguments[i];
+                ITypeSymbol symbol = i < boundTypeArguments.Length
+                    ? boundTypeArguments[i]
+                    : this.context.GetTypeInfo(argument).Type;
                 result.Add(symbol != null
                     ? this.typeMapper.Map(symbol, this.context, argument.GetLocation())
                     : new NamedTypeReference(argument.ToString()));
             }
 
             return result;
+        }
+
+        private ImmutableArray<ITypeSymbol> GetBoundTypeArguments(GenericNameSyntax generic)
+        {
+            ISymbol symbol = this.context.GetSymbolInfo(generic).Symbol;
+            if (symbol == null && generic.Parent is InvocationExpressionSyntax invocation)
+            {
+                symbol = this.context.GetSymbolInfo(invocation).Symbol;
+            }
+
+            ImmutableArray<ITypeSymbol> typeArguments = symbol switch
+            {
+                IMethodSymbol method => method.TypeArguments,
+                INamedTypeSymbol type => type.TypeArguments,
+                _ => ImmutableArray<ITypeSymbol>.Empty,
+            };
+
+            return typeArguments.Length == generic.TypeArgumentList.Arguments.Count
+                ? typeArguments
+                : ImmutableArray<ITypeSymbol>.Empty;
         }
 
         private GExpression TranslateInterpolatedString(InterpolatedStringExpressionSyntax interpolated)


### PR DESCRIPTION
## Summary
- render explicit generic arguments from constructed method/type symbols so recursive nullable annotations are preserved
- cover constrained type parameters, nested types, tuples, arrays, delegates, method groups, constructors, aliases, extensions, and imported/source types
- add default SDK-backed gsc coverage for the Oahu `Task.FromResult<TOutput?>` async shape

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --filter "FullyQualifiedName~Issue2500|FullyQualifiedName~Issue1913AttributeTranslationTests|FullyQualifiedName~BareFormExtensionCallTranslationTests|FullyQualifiedName~GenericStaticReceiverTranslationTests|FullyQualifiedName~Issue2467StaticExtensionConditionalReceiverTests" -v minimal`

Fixes #2500