### PR TITLE
Fix inherited static member lookup

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3278,12 +3278,20 @@ public sealed class Binder
             // references. Issue #1506: each segment now drives its own preferred
             // arity from its own type-argument list.
             var preferredArity = syntax.SegmentHasTypeArguments(i) ? syntax.GetSegmentTypeArguments(i).Count : -1;
-            if (!scope.TryLookupNestedTypeAlias(definitions[i - 1], segmentTexts[i], preferredArity, out var nested))
+            if (scope.TryLookupNestedTypeAlias(definitions[i - 1], segmentTexts[i], preferredArity, out var nested))
+            {
+                definitions[i] = nested;
+            }
+            else if (definitions[i - 1] is StructSymbol containerStruct
+                && scope.TryLookupNestedTypeAliasIncludingInherited(containerStruct, segmentTexts[i], preferredArity, out var inheritedNested, out var declaringContainer))
+            {
+                definitions[i - 1] = declaringContainer;
+                definitions[i] = inheritedNested;
+            }
+            else
             {
                 return null;
             }
-
-            definitions[i] = nested;
         }
 
         // The chain resolved to a user nested type. Construct generic segments

--- a/src/Core/CodeAnalysis/Binding/BoundEventSubscriptionExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundEventSubscriptionExpression.cs
@@ -21,7 +21,8 @@ public sealed class BoundEventSubscriptionExpression : BoundExpression
         TypeSymbol structType,
         EventSymbol eventSymbol,
         BoundExpression handler,
-        bool isAdd)
+        bool isAdd,
+        TypeSymbol eventType = null)
         : base(syntax)
     {
         Receiver = receiver;
@@ -29,6 +30,7 @@ public sealed class BoundEventSubscriptionExpression : BoundExpression
         Event = eventSymbol;
         Handler = handler;
         IsAdd = isAdd;
+        EventType = eventType ?? eventSymbol.Type;
     }
 
     public BoundExpression Receiver { get; }
@@ -47,6 +49,8 @@ public sealed class BoundEventSubscriptionExpression : BoundExpression
     public BoundExpression Handler { get; }
 
     public bool IsAdd { get; }
+
+    public TypeSymbol EventType { get; }
 
     public override TypeSymbol Type => TypeSymbol.Void;
 

--- a/src/Core/CodeAnalysis/Binding/BoundFieldAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFieldAssignmentExpression.cs
@@ -18,13 +18,14 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundFieldAssignmentExpression : BoundExpression
 {
-    public BoundFieldAssignmentExpression(SyntaxNode syntax, VariableSymbol receiver, StructSymbol structType, FieldSymbol field, BoundExpression value)
+    public BoundFieldAssignmentExpression(SyntaxNode syntax, VariableSymbol receiver, StructSymbol structType, FieldSymbol field, BoundExpression value, TypeSymbol resultType = null)
         : base(syntax)
     {
         Receiver = receiver;
         StructType = structType;
         Field = field;
         Value = value;
+        ResultType = resultType;
     }
 
     /// <summary>
@@ -49,13 +50,20 @@ public sealed class BoundFieldAssignmentExpression : BoundExpression
         Value = value;
     }
 
-    private BoundFieldAssignmentExpression(SyntaxNode syntax, BoundExpression receiverExpression, StructSymbol structType, FieldSymbol field, BoundExpression value)
+    private BoundFieldAssignmentExpression(
+        SyntaxNode syntax,
+        BoundExpression receiverExpression,
+        StructSymbol structType,
+        FieldSymbol field,
+        BoundExpression value,
+        TypeSymbol resultType)
         : base(syntax)
     {
         ReceiverExpression = receiverExpression;
         StructType = structType;
         Field = field;
         Value = value;
+        ResultType = resultType;
     }
 
     public VariableSymbol Receiver { get; }
@@ -83,7 +91,9 @@ public sealed class BoundFieldAssignmentExpression : BoundExpression
 
     public BoundExpression Value { get; }
 
-    public override TypeSymbol Type => Field.Type;
+    public TypeSymbol ResultType { get; }
+
+    public override TypeSymbol Type => ResultType ?? Field.Type;
 
     public override BoundNodeKind Kind => BoundNodeKind.FieldAssignmentExpression;
 
@@ -97,14 +107,16 @@ public sealed class BoundFieldAssignmentExpression : BoundExpression
     /// <param name="structType">The declaring struct/class type.</param>
     /// <param name="field">The field to write.</param>
     /// <param name="value">The value to assign.</param>
+    /// <param name="resultType">The substituted assignment result type, or null.</param>
     /// <returns>A new <see cref="BoundFieldAssignmentExpression"/> with an expression receiver.</returns>
     public static BoundFieldAssignmentExpression WithExpressionReceiver(
         SyntaxNode syntax,
         BoundExpression receiverExpression,
         StructSymbol structType,
         FieldSymbol field,
-        BoundExpression value)
+        BoundExpression value,
+        TypeSymbol resultType = null)
     {
-        return new BoundFieldAssignmentExpression(syntax, receiverExpression, structType, field, value);
+        return new BoundFieldAssignmentExpression(syntax, receiverExpression, structType, field, value, resultType);
     }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundMethodGroupExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundMethodGroupExpression.cs
@@ -33,21 +33,42 @@ public sealed class BoundMethodGroupExpression : BoundExpression
     }
 
     public BoundMethodGroupExpression(SyntaxNode syntax, BoundExpression receiver, FunctionSymbol function, FunctionTypeSymbol type)
+        : this(syntax, receiver, function, type, staticOwnerType: null)
+    {
+    }
+
+    public BoundMethodGroupExpression(
+        SyntaxNode syntax,
+        BoundExpression receiver,
+        FunctionSymbol function,
+        FunctionTypeSymbol type,
+        StructSymbol staticOwnerType)
         : base(syntax)
     {
         Receiver = receiver;
         Function = function;
         FunctionType = type;
         Candidates = ImmutableArray.Create(function);
+        StaticOwnerType = staticOwnerType;
     }
 
     public BoundMethodGroupExpression(SyntaxNode syntax, BoundExpression receiver, ImmutableArray<FunctionSymbol> candidates)
+        : this(syntax, receiver, candidates, staticOwnerType: null)
+    {
+    }
+
+    public BoundMethodGroupExpression(
+        SyntaxNode syntax,
+        BoundExpression receiver,
+        ImmutableArray<FunctionSymbol> candidates,
+        StructSymbol staticOwnerType)
         : base(syntax)
     {
         Receiver = receiver;
         Function = candidates.IsDefaultOrEmpty ? null : candidates[0];
         FunctionType = null;
         Candidates = candidates;
+        StaticOwnerType = staticOwnerType;
     }
 
     /// <summary>
@@ -67,6 +88,9 @@ public sealed class BoundMethodGroupExpression : BoundExpression
     /// <c>[Function]</c> when there is a single candidate.
     /// </summary>
     public ImmutableArray<FunctionSymbol> Candidates { get; }
+
+    /// <summary>Gets the type used to qualify a static method group.</summary>
+    public StructSymbol StaticOwnerType { get; }
 
     public override TypeSymbol Type => FunctionType ?? (TypeSymbol)TypeSymbol.Error;
 

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -1226,6 +1226,52 @@ public sealed class BoundScope
     }
 
     /// <summary>
+    /// Resolves a nested type through a source class and its base-class chain,
+    /// returning the effective base construction that declares it.
+    /// </summary>
+    /// <param name="container">The source class used to qualify the nested type.</param>
+    /// <param name="simpleName">The nested type's simple name.</param>
+    /// <param name="preferredArity">The preferred generic arity.</param>
+    /// <param name="type">The nested type definition.</param>
+    /// <param name="declaringContainer">The effective declaring construction.</param>
+    /// <returns>Whether a nested type was found.</returns>
+    public bool TryLookupNestedTypeAliasIncludingInherited(
+        StructSymbol container,
+        string simpleName,
+        int preferredArity,
+        out TypeSymbol type,
+        out StructSymbol declaringContainer)
+    {
+        for (var c = container.BaseClass; c != null; c = c.BaseClass)
+        {
+            var definition = c.Definition ?? c;
+            if (!TryLookupNestedTypeAlias(definition, simpleName, preferredArity, out type))
+            {
+                if (TypeMemberModel.DeclaresAnyStaticMember(c, simpleName))
+                {
+                    break;
+                }
+
+                continue;
+            }
+
+            if (!ReferenceEquals(c, container) && IsPrivateNestedType(type))
+            {
+                type = null;
+                declaringContainer = null;
+                return false;
+            }
+
+            declaringContainer = TypeMemberModel.ResolveStaticMemberOwner(container, c);
+            return true;
+        }
+
+        type = null;
+        declaringContainer = null;
+        return false;
+    }
+
+    /// <summary>
     /// Gets the set of declared type aliases.
     /// </summary>
     /// <returns>The map of alias names to underlying types.</returns>
@@ -2633,4 +2679,12 @@ public sealed class BoundScope
 
         return true;
     }
+
+    private static bool IsPrivateNestedType(TypeSymbol type) => type switch
+    {
+        StructSymbol s => s.Accessibility == Accessibility.Private,
+        InterfaceSymbol i => i.Accessibility == Accessibility.Private,
+        EnumSymbol e => e.Accessibility == Accessibility.Private,
+        _ => false,
+    };
 }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1693,7 +1693,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundEventSubscriptionExpression(null, receiver, node.StructType, node.Event, handler, node.IsAdd);
+        return new BoundEventSubscriptionExpression(null, receiver, node.StructType, node.Event, handler, node.IsAdd, node.EventType);
     }
 
     /// <summary>Rewrites a CLR binary operator call (Stream C).</summary>
@@ -1975,7 +1975,7 @@ public abstract class BoundTreeRewriter
                 return node;
             }
 
-            return BoundFieldAssignmentExpression.WithExpressionReceiver(null, receiverExpr, node.StructType, node.Field, value);
+            return BoundFieldAssignmentExpression.WithExpressionReceiver(null, receiverExpr, node.StructType, node.Field, value, node.ResultType);
         }
 
         if (value == node.Value)
@@ -1991,7 +1991,7 @@ public abstract class BoundTreeRewriter
         // static routing and mis-codegen/crash.
         return node.InterfaceType != null
             ? new BoundFieldAssignmentExpression(null, node.Field, node.InterfaceType, value)
-            : new BoundFieldAssignmentExpression(null, node.Receiver, node.StructType, node.Field, value);
+            : new BoundFieldAssignmentExpression(null, node.Receiver, node.StructType, node.Field, value, node.ResultType);
     }
 
     /// <summary>Rewrites a property read (ADR-0051).</summary>
@@ -2092,8 +2092,8 @@ public abstract class BoundTreeRewriter
         }
 
         return node.FunctionType != null
-            ? new BoundMethodGroupExpression(node.Syntax, receiver, node.Function, node.FunctionType)
-            : new BoundMethodGroupExpression(node.Syntax, receiver, node.Candidates);
+            ? new BoundMethodGroupExpression(node.Syntax, receiver, node.Function, node.FunctionType, node.StaticOwnerType)
+            : new BoundMethodGroupExpression(node.Syntax, receiver, node.Candidates, node.StaticOwnerType);
     }
 
     /// <summary>Rewrites a CLR method-group expression (issue #337).</summary>

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1470,8 +1470,12 @@ internal sealed class ConversionClassifier
         }
 
         FunctionSymbol pick = null;
+        StructSymbol pickOwner = null;
         foreach (var candidate in group.Candidates)
         {
+            var candidateOwner = group.StaticOwnerType != null && candidate.StaticOwnerType is StructSymbol declaredOwner
+                ? TypeMemberModel.ResolveStaticMemberOwner(group.StaticOwnerType, declaredOwner)
+                : null;
             var parameterOffset = candidate.IsExtension && group.Receiver != null ? 1 : 0;
             if (candidate.Parameters.Length - parameterOffset != targetParameterTypes.Length)
             {
@@ -1481,7 +1485,9 @@ internal sealed class ConversionClassifier
             var paramsMatch = true;
             for (var i = 0; i < targetParameterTypes.Length; i++)
             {
-                if (!ReferenceEquals(candidate.Parameters[i + parameterOffset].Type, targetParameterTypes[i]))
+                var candidateParameterType = candidateOwner?.SubstituteMemberType(candidate.Parameters[i + parameterOffset].Type)
+                    ?? candidate.Parameters[i + parameterOffset].Type;
+                if (!ReferenceEquals(candidateParameterType, targetParameterTypes[i]))
                 {
                     paramsMatch = false;
                     break;
@@ -1493,7 +1499,7 @@ internal sealed class ConversionClassifier
                 continue;
             }
 
-            var candidateReturn = candidate.Type ?? TypeSymbol.Void;
+            var candidateReturn = candidateOwner?.SubstituteMemberType(candidate.Type) ?? candidate.Type ?? TypeSymbol.Void;
             if (!ReferenceEquals(candidateReturn, targetReturnType))
             {
                 continue;
@@ -1501,11 +1507,25 @@ internal sealed class ConversionClassifier
 
             if (pick != null)
             {
+                var pickDefinition = pick.StaticOwnerType is StructSymbol pickDeclared
+                    ? pickDeclared.Definition ?? pickDeclared
+                    : null;
+                var candidateDefinition = candidate.StaticOwnerType is StructSymbol candidateDeclared
+                    ? candidateDeclared.Definition ?? candidateDeclared
+                    : null;
+                if (pickDefinition != null
+                    && candidateDefinition != null
+                    && !ReferenceEquals(pickDefinition, candidateDefinition))
+                {
+                    continue;
+                }
+
                 Diagnostics.ReportCannotConvertMethodGroup(diagnosticLocation, groupName, targetType);
                 return new BoundErrorExpression(null);
             }
 
             pick = candidate;
+            pickOwner = candidateOwner;
         }
 
         if (pick == null)
@@ -1518,11 +1538,12 @@ internal sealed class ConversionClassifier
         var pickParams = ImmutableArray.CreateBuilder<TypeSymbol>(pick.Parameters.Length - pickParameterOffset);
         for (var i = pickParameterOffset; i < pick.Parameters.Length; i++)
         {
-            pickParams.Add(pick.Parameters[i].Type);
+            pickParams.Add(pickOwner?.SubstituteMemberType(pick.Parameters[i].Type) ?? pick.Parameters[i].Type);
         }
 
-        var pickFnType = FunctionTypeSymbol.Get(pickParams.MoveToImmutable(), pick.Type ?? TypeSymbol.Void);
-        var resolvedGroup = new BoundMethodGroupExpression(group.Syntax, group.Receiver, pick, pickFnType);
+        var pickReturn = pickOwner?.SubstituteMemberType(pick.Type) ?? pick.Type ?? TypeSymbol.Void;
+        var pickFnType = FunctionTypeSymbol.Get(pickParams.MoveToImmutable(), pickReturn);
+        var resolvedGroup = new BoundMethodGroupExpression(group.Syntax, group.Receiver, pick, pickFnType, pickOwner);
 
         // If the target is the native function type matching the pick exactly,
         // identity-convert; otherwise let the regular conversion machinery turn

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -523,6 +523,12 @@ internal sealed partial class ExpressionBinder
                     break;
             }
         }
+        else if (leftPart is AccessorExpressionSyntax inheritedImportedNestedType
+            && !inheritedImportedNestedType.IsNullConditional
+            && TryResolveInheritedImportedNestedType(inheritedImportedNestedType, out var inheritedImportedNestedSymbol))
+        {
+            classSymbol = inheritedImportedNestedSymbol;
+        }
         else if (leftPart is IndexExpressionSyntax nestedTypeIndex
             && !nestedTypeIndex.IsNullConditional
             && TryResolveUserNestedTypeExpression(nestedTypeIndex, out var nestedTypeIndexSymbol))
@@ -572,6 +578,81 @@ internal sealed partial class ExpressionBinder
         }
 
         return BindAccessorStep(receiver, classSymbol, rightPart);
+    }
+
+    private bool TryResolveInheritedImportedNestedType(
+        AccessorExpressionSyntax syntax,
+        out ImportedClassSymbol nestedClassSymbol)
+    {
+        nestedClassSymbol = null;
+        StructSymbol sourceType = null;
+        if (syntax.LeftPart is NameExpressionSyntax sourceName
+            && scope.TryLookupTypeAlias(sourceName.IdentifierToken.Text, out var sourceAlias)
+            && sourceAlias is StructSymbol namedSourceType)
+        {
+            sourceType = namedSourceType;
+        }
+        else if (syntax.LeftPart is IndexExpressionSyntax constructedSource
+            && TryResolveConstructedGenericTypeReceiver(
+                constructedSource,
+                out var constructedStruct,
+                out _,
+                out _))
+        {
+            sourceType = constructedStruct;
+        }
+        else if (syntax.LeftPart is GenericNameExpressionSyntax genericSource
+            && TryResolveConstructedGenericTypeReceiver(
+                genericSource,
+                out var genericStruct,
+                out _,
+                out _))
+        {
+            sourceType = genericStruct;
+        }
+
+        if (sourceType == null
+            || TypeMemberModel.GetNearestImportedBase(sourceType)?.ClrType is not Type importedBase)
+        {
+            return false;
+        }
+
+        var importedBaseSymbol = new ImportedClassSymbol(importedBase, syntax.LeftPart, references: scope.References);
+        if (!TryResolveNestedTypeFromAccessorLeft(importedBaseSymbol, syntax.RightPart, out nestedClassSymbol))
+        {
+            return false;
+        }
+
+        nestedClassSymbol = CloseImportedNestedType(importedBase, nestedClassSymbol, syntax.RightPart);
+        return true;
+    }
+
+    private ImportedClassSymbol CloseImportedNestedType(
+        Type constructedOuter,
+        ImportedClassSymbol nested,
+        ExpressionSyntax syntax)
+    {
+        var nestedType = nested?.ClassType;
+        if (constructedOuter?.IsConstructedGenericType != true
+            || nestedType?.ContainsGenericParameters != true)
+        {
+            return nested;
+        }
+
+        var outerArguments = constructedOuter.GetGenericArguments();
+        if (nestedType.GetGenericArguments().Length != outerArguments.Length)
+        {
+            return nested;
+        }
+
+        try
+        {
+            return new ImportedClassSymbol(nestedType.MakeGenericType(outerArguments), syntax, references: scope.References);
+        }
+        catch (ArgumentException)
+        {
+            return nested;
+        }
     }
 
     /// <summary>
@@ -797,12 +878,20 @@ internal sealed partial class ExpressionBinder
         {
             var containerDef = (definitions[i - 1] as StructSymbol)?.Definition ?? definitions[i - 1];
             var arity = segments[i].Args.IsDefaultOrEmpty ? -1 : segments[i].Args.Length;
-            if (!scope.TryLookupNestedTypeAlias(containerDef, segments[i].Name, arity, out var nested))
+            if (scope.TryLookupNestedTypeAlias(containerDef, segments[i].Name, arity, out var nested))
+            {
+                definitions[i] = nested;
+            }
+            else if (definitions[i - 1] is StructSymbol containerStruct
+                && scope.TryLookupNestedTypeAliasIncludingInherited(containerStruct, segments[i].Name, arity, out var inheritedNested, out var declaringContainer))
+            {
+                definitions[i - 1] = declaringContainer;
+                definitions[i] = inheritedNested;
+            }
+            else
             {
                 return false;
             }
-
-            definitions[i] = nested;
         }
 
         // Thread the flattened enclosing construction's arguments (the own
@@ -826,13 +915,23 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            if (segments[i].Args.IsDefaultOrEmpty || segments[i].Args.Length != ownParams.Length)
+            var constructionArgs = definitions[i] is StructSymbol constructedStruct
+                && !constructedStruct.TypeArguments.IsDefaultOrEmpty
+                ? constructedStruct.TypeArguments
+                : segments[i].Args;
+            if (constructionArgs.IsDefaultOrEmpty || constructionArgs.Length != ownParams.Length)
             {
                 enclosingBuilder = null;
                 break;
             }
 
-            enclosingBuilder.AddRange(segments[i].Args);
+            if (definitions[i] is StructSymbol nestedConstruction
+                && !nestedConstruction.EnclosingTypeArguments.IsDefaultOrEmpty)
+            {
+                enclosingBuilder.AddRange(nestedConstruction.EnclosingTypeArguments);
+            }
+
+            enclosingBuilder.AddRange(constructionArgs);
         }
 
         var enclosingArgs = enclosingBuilder != null && enclosingBuilder.Count > 0
@@ -1611,13 +1710,15 @@ internal sealed partial class ExpressionBinder
         // ADR-0112: route through the canonical member-resolution layer.
         if (isCall)
         {
-            return !TypeMemberModel.GetMethods(structSym, headName, MemberQuery.Static(MemberKinds.Method)).IsEmpty;
+            return !TypeMemberModel.GetMethods(structSym, headName, MemberQuery.InheritedStatic(MemberKinds.Method)).IsEmpty
+                || ClrTypeExposesStaticMember(TypeMemberModel.GetNearestImportedBase(structSym)?.ClrType, headName);
         }
 
         return TypeMemberModel.LookupMember(
             structSym,
             headName,
-            MemberQuery.Static(MemberKinds.Field | MemberKinds.Property)) != null;
+            MemberQuery.InheritedStatic(MemberKinds.Field | MemberKinds.Property)) != null
+            || ClrTypeExposesStaticMember(TypeMemberModel.GetNearestImportedBase(structSym)?.ClrType, headName);
     }
 
     private BoundExpression BindEnumAccessorStep(EnumSymbol enumSymbol, ExpressionSyntax rightPart)
@@ -1674,6 +1775,16 @@ internal sealed partial class ExpressionBinder
                 if (TryResolveNestedTypeChainUnderReceiver(structSym, nested.LeftPart, out var innerReceiver))
                 {
                     return BindUserTypeStaticAccessorStep(innerReceiver, nested.RightPart);
+                }
+
+                if (TypeMemberModel.GetNearestImportedBase(structSym)?.ClrType is Type importedBase)
+                {
+                    var importedBaseSymbol = new ImportedClassSymbol(importedBase, nested.LeftPart, references: scope.References);
+                    if (TryResolveNestedTypeFromAccessorLeft(importedBaseSymbol, nested.LeftPart, out var importedNested))
+                    {
+                        importedNested = CloseImportedNestedType(importedBase, importedNested, nested.LeftPart);
+                        return BindAccessorStep(receiver: null, importedNested, nested.RightPart);
+                    }
                 }
 
                 var head = BindUserTypeStaticAccessorStep(structSym, nested.LeftPart);
@@ -1751,8 +1862,21 @@ internal sealed partial class ExpressionBinder
     {
         var container = outerConstructed.Definition ?? outerConstructed;
         var literalArity = structLiteral.TypeArgumentList != null ? structLiteral.TypeArgumentList.Arguments.Count : -1;
-        if (!scope.TryLookupNestedTypeAlias(container, structLiteral.TypeIdentifier.Text, literalArity, out var nestedType)
-            || nestedType is not StructSymbol nestedStructDef)
+        TypeSymbol nestedType;
+        StructSymbol declaringContainer = outerConstructed;
+        if (!scope.TryLookupNestedTypeAlias(container, structLiteral.TypeIdentifier.Text, literalArity, out nestedType)
+            && !scope.TryLookupNestedTypeAliasIncludingInherited(
+                outerConstructed,
+                structLiteral.TypeIdentifier.Text,
+                literalArity,
+                out nestedType,
+                out declaringContainer))
+        {
+            Diagnostics.ReportUnableToFindType(structLiteral.TypeIdentifier.Location, structLiteral.TypeIdentifier.Text);
+            return new BoundErrorExpression(null);
+        }
+
+        if (nestedType is not StructSymbol nestedStructDef)
         {
             Diagnostics.ReportUnableToFindType(structLiteral.TypeIdentifier.Location, structLiteral.TypeIdentifier.Text);
             return new BoundErrorExpression(null);
@@ -1761,7 +1885,7 @@ internal sealed partial class ExpressionBinder
         // The enclosing construction already flattens its own enclosing chain in
         // EnclosingTypeArguments; append its own TypeArguments so the nested
         // type sees the full outermost-first vector.
-        var enclosingArgs = FlattenConstructedEnclosingArguments(outerConstructed);
+        var enclosingArgs = FlattenConstructedEnclosingArguments(declaringContainer);
         return BindStructLiteralExpression(structLiteral, nestedStructDef.Definition ?? nestedStructDef, enclosingArgs);
     }
 
@@ -1795,9 +1919,19 @@ internal sealed partial class ExpressionBinder
         {
             var arity = segments[i].Args.IsDefaultOrEmpty ? -1 : segments[i].Args.Length;
             var lookupContainer = (containerDef as StructSymbol)?.Definition ?? containerDef;
-            if (!scope.TryLookupNestedTypeAlias(lookupContainer, segments[i].Name, arity, out var nested))
+            TypeSymbol nested;
+            if (!scope.TryLookupNestedTypeAlias(lookupContainer, segments[i].Name, arity, out nested))
             {
-                return false;
+                if (containerDef is StructSymbol containerStruct
+                    && scope.TryLookupNestedTypeAliasIncludingInherited(containerStruct, segments[i].Name, arity, out var inheritedNested, out var inheritedOwner))
+                {
+                    nested = inheritedNested;
+                    enclosingArgs = FlattenConstructedEnclosingArguments(inheritedOwner);
+                }
+                else
+                {
+                    return false;
+                }
             }
 
             if (i < segments.Count - 1)
@@ -2588,33 +2722,50 @@ internal sealed partial class ExpressionBinder
     /// <param name="name">The member name.</param>
     /// <returns><c>true</c> when a matching static member exists.</returns>
     private static bool ImportedTypeExposesStaticMember(StructSymbol structSym, string name)
-        => TypeMemberModel.TryGetStaticField(structSym, name, out _)
-            || TypeMemberModel.TryGetStaticProperty(structSym, name, out _)
-            || !TypeMemberModel.GetMethods(structSym, name, MemberQuery.Static(MemberKinds.Method)).IsDefaultOrEmpty;
+        => TypeMemberModel.TryGetStaticFieldIncludingInherited(structSym, name, out _, out _)
+            || TypeMemberModel.TryGetStaticPropertyIncludingInherited(structSym, name, out _, out _)
+            || !TypeMemberModel.GetMethods(structSym, name, MemberQuery.InheritedStatic(MemberKinds.Method)).IsDefaultOrEmpty;
 
     private BoundExpression BindUserTypeStaticMemberAccess(StructSymbol structSym, NameExpressionSyntax ne)
     {
         var memberName = ne.IdentifierToken.Text;
 
         // ADR-0112: static field/property lookups go through the canonical layer.
-        if (TypeMemberModel.TryGetStaticField(structSym, memberName, out var field))
+        if (TypeMemberModel.TryGetStaticFieldIncludingInherited(structSym, memberName, out var field, out var fieldOwner))
         {
-            return new BoundFieldAccessExpression(null, receiver: null, structSym, field);
+            if (!AccessibilityChecker.IsAccessible(field.Accessibility, fieldOwner, function))
+            {
+                Diagnostics.ReportMemberInaccessible(ne.Location, field.Name, fieldOwner.Name, field.Accessibility);
+            }
+
+            var fieldType = fieldOwner.SubstituteMemberType(field.Type);
+            return new BoundFieldAccessExpression(null, receiver: null, fieldOwner, field, fieldType);
         }
 
-        if (TypeMemberModel.TryGetStaticProperty(structSym, memberName, out var prop))
+        if (TypeMemberModel.TryGetStaticPropertyIncludingInherited(structSym, memberName, out var prop, out var propertyOwner))
         {
-            return new BoundPropertyAccessExpression(null, receiver: null, structSym, prop);
+            if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propertyOwner, function))
+            {
+                Diagnostics.ReportMemberInaccessible(ne.Location, prop.Name, propertyOwner.Name, prop.Accessibility);
+            }
+
+            return new BoundPropertyAccessExpression(null, receiver: null, propertyOwner, prop);
         }
 
         // ADR-0112: a static (shared) method named here in non-call position is a
         // method group with a null receiver. Overload selection (when more than
         // one shared overload shares the name) is deferred to the conversion
         // classifier, driven by the target delegate signature.
-        var staticMethods = TypeMemberModel.GetMethods(structSym, memberName, MemberQuery.Static(MemberKinds.Method));
-        if (TryBuildUserMethodGroup(receiver: null, staticMethods, out var staticGroup))
+        var staticMethods = TypeMemberModel.GetMethods(structSym, memberName, MemberQuery.InheritedStatic(MemberKinds.Method));
+        if (TryBuildUserMethodGroup(receiver: null, staticMethods, out var staticGroup, staticOwnerType: structSym))
         {
             return staticGroup;
+        }
+
+        if (TypeMemberModel.GetNearestImportedBase(structSym)?.ClrType is System.Type importedBase)
+        {
+            var imported = new ImportedClassSymbol(importedBase, ne, references: scope.References);
+            return BindAccessorStep(receiver: null, imported, ne);
         }
 
         Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
@@ -2642,13 +2793,6 @@ internal sealed partial class ExpressionBinder
     {
         var structSym = ownerType as StructSymbol;
         var ifaceSym = ownerType as InterfaceSymbol;
-        var ownerDefinition = structSym?.Definition ?? (TypeSymbol)ifaceSym?.Definition;
-        var ownerDefTypeParameters = structSym?.Definition?.TypeParameters
-            ?? ifaceSym?.Definition?.TypeParameters
-            ?? ImmutableArray<TypeParameterSymbol>.Empty;
-        var ownerTypeArguments = structSym?.TypeArguments
-            ?? ifaceSym?.TypeArguments
-            ?? ImmutableArray<TypeSymbol>.Empty;
 
         var methodName = ce.Identifier.Text;
 
@@ -2688,14 +2832,36 @@ internal sealed partial class ExpressionBinder
         // for instance methods). A single-candidate group is returned unchanged
         // so the legacy per-position arity/optional/variadic diagnostics below
         // still apply (e.g. genuine arity mismatch on a non-overloaded method).
-        var staticMethodGroup = TypeMemberModel.GetMethods(ownerType, methodName, MemberQuery.Static(MemberKinds.Method));
+        var staticMethodGroup = TypeMemberModel.GetMethods(
+            ownerType,
+            methodName,
+            structSym != null ? MemberQuery.InheritedStatic(MemberKinds.Method) : MemberQuery.Static(MemberKinds.Method));
         if (!staticMethodGroup.IsDefaultOrEmpty)
         {
-            var method = overloads.SelectInstanceOverloadOrReport(staticMethodGroup, arguments, ce, methodName, argumentNames: default);
+            var selectionGroup = BuildConstructedStaticOverloadGroup(structSym, staticMethodGroup, out var originalMethods);
+            var method = overloads.SelectInstanceOverloadOrReport(selectionGroup, arguments, ce, methodName, argumentNames: default);
             if (method == null)
             {
                 return new BoundErrorExpression(null);
             }
+
+            if (originalMethods != null && originalMethods.TryGetValue(method, out var originalMethod))
+            {
+                method = originalMethod;
+            }
+
+            var effectiveOwnerType = structSym != null && method.StaticOwnerType is StructSymbol declaredOwner
+                ? TypeMemberModel.ResolveStaticMemberOwner(structSym, declaredOwner)
+                : ownerType;
+            var effectiveStructOwner = effectiveOwnerType as StructSymbol;
+            var effectiveInterfaceOwner = effectiveOwnerType as InterfaceSymbol;
+            var ownerDefinition = effectiveStructOwner?.Definition ?? (TypeSymbol)effectiveInterfaceOwner?.Definition;
+            var ownerDefTypeParameters = effectiveStructOwner?.Definition?.TypeParameters
+                ?? effectiveInterfaceOwner?.Definition?.TypeParameters
+                ?? ImmutableArray<TypeParameterSymbol>.Empty;
+            var ownerTypeArguments = effectiveStructOwner?.TypeArguments
+                ?? effectiveInterfaceOwner?.TypeArguments
+                ?? ImmutableArray<TypeSymbol>.Empty;
 
             // Issue #2071: enforce `protected`/`private` accessibility on static
             // (`shared`) method calls, mirroring the instance-call check in
@@ -3017,8 +3183,8 @@ internal sealed partial class ExpressionBinder
             // constructed generic INTERFACE owner; it is carried separately
             // because the emitter resolves interface- and struct-declared
             // statics through different TypeSpec helpers.
-            var staticGenericOwner = structSym?.Definition != null ? structSym : null;
-            var staticGenericInterfaceOwner = ifaceSym?.Definition != null ? ifaceSym : null;
+            var staticGenericOwner = effectiveStructOwner?.Definition != null ? effectiveStructOwner : null;
+            var staticGenericInterfaceOwner = effectiveInterfaceOwner?.Definition != null ? effectiveInterfaceOwner : null;
 
             // Issue #1931: stash the method's own (explicit or inferred) type
             // arguments on the bound node so the emitter's MethodSpec
@@ -3072,7 +3238,98 @@ internal sealed partial class ExpressionBinder
             return MakeStaticGenericCall(null);
         }
 
+        if (structSym != null
+            && TypeMemberModel.GetNearestImportedBase(structSym)?.ClrType is System.Type importedBase)
+        {
+            var imported = new ImportedClassSymbol(importedBase, ce, references: scope.References);
+            return BindAccessorCall(receiver: null, imported, ce);
+        }
+
         Diagnostics.ReportUnableToFindMember(ce.Location, methodName);
         return new BoundErrorExpression(null);
+    }
+
+    private static ImmutableArray<FunctionSymbol> BuildConstructedStaticOverloadGroup(
+        StructSymbol lookupType,
+        ImmutableArray<FunctionSymbol> methods,
+        out Dictionary<FunctionSymbol, FunctionSymbol> originalMethods)
+    {
+        originalMethods = null;
+        if (lookupType == null || methods.Length <= 1)
+        {
+            return methods;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<FunctionSymbol>(methods.Length);
+        foreach (var method in methods)
+        {
+            var owner = method.StaticOwnerType is StructSymbol declaredOwner
+                ? TypeMemberModel.ResolveStaticMemberOwner(lookupType, declaredOwner)
+                : null;
+            if (owner == null || owner.Definition == null)
+            {
+                if (!builder.Any(existing => BoundScope.FunctionSignaturesEqual(existing, method)))
+                {
+                    builder.Add(method);
+                }
+
+                continue;
+            }
+
+            var changed = false;
+            var parameters = ImmutableArray.CreateBuilder<ParameterSymbol>(method.Parameters.Length);
+            foreach (var parameter in method.Parameters)
+            {
+                var parameterType = owner.SubstituteMemberType(parameter.Type);
+                changed |= !ReferenceEquals(parameterType, parameter.Type);
+                var constructedParameter = new ParameterSymbol(
+                    parameter.Name,
+                    parameterType,
+                    parameter.IsVariadic,
+                    parameter.DeclaringSyntax,
+                    parameter.IsScoped,
+                    parameter.RefKind);
+                if (parameter.HasExplicitDefaultValue)
+                {
+                    constructedParameter.SetExplicitDefaultValue(parameter.ExplicitDefaultValue);
+                }
+
+                parameters.Add(constructedParameter);
+            }
+
+            var returnType = owner.SubstituteMemberType(method.Type);
+            changed |= !ReferenceEquals(returnType, method.Type);
+            if (!changed)
+            {
+                if (!builder.Any(existing => BoundScope.FunctionSignaturesEqual(existing, method)))
+                {
+                    builder.Add(method);
+                }
+
+                continue;
+            }
+
+            var constructedMethod = new FunctionSymbol(
+                method.Name,
+                parameters.MoveToImmutable(),
+                returnType,
+                method.Declaration,
+                method.Package,
+                method.Accessibility)
+            {
+                IsStatic = method.IsStatic,
+                StaticOwnerType = owner,
+                TypeParameters = method.TypeParameters,
+                ReturnRefKind = method.ReturnRefKind,
+            };
+            if (!builder.Any(existing => BoundScope.FunctionSignaturesEqual(existing, constructedMethod)))
+            {
+                originalMethods ??= new Dictionary<FunctionSymbol, FunctionSymbol>();
+                originalMethods.Add(constructedMethod, method);
+                builder.Add(constructedMethod);
+            }
+        }
+
+        return builder.ToImmutable();
     }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -95,7 +95,11 @@ internal sealed partial class ExpressionBinder
     /// variadic) are filtered out; the group is only produced when at least one
     /// usable candidate remains.
     /// </summary>
-    private bool TryBuildUserMethodGroup(BoundExpression receiver, ImmutableArray<FunctionSymbol> methods, out BoundExpression methodGroup)
+    private bool TryBuildUserMethodGroup(
+        BoundExpression receiver,
+        ImmutableArray<FunctionSymbol> methods,
+        out BoundExpression methodGroup,
+        StructSymbol staticOwnerType = null)
     {
         methodGroup = null;
 
@@ -135,7 +139,10 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        methodGroup = BuildInstanceMethodGroup(receiver, usable.ToImmutable());
+        var usableMethods = usable.ToImmutable();
+        methodGroup = staticOwnerType == null
+            ? BuildInstanceMethodGroup(receiver, usableMethods)
+            : new BoundMethodGroupExpression(null, receiver, usableMethods, staticOwnerType);
         return true;
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -527,21 +527,32 @@ internal sealed partial class ExpressionBinder
         if (scope.TryLookupTypeAlias(receiverName, out var typeAlias) && typeAlias is StructSymbol userStruct)
         {
             var fieldName = syntax.FieldIdentifier.Text;
-            if (TypeMemberModel.TryGetStaticField(userStruct, fieldName, out var staticField))
+            if (TypeMemberModel.TryGetStaticFieldIncludingInherited(userStruct, fieldName, out var staticField, out var fieldOwner))
             {
+                if (!AccessibilityChecker.IsAccessible(staticField.Accessibility, fieldOwner, function))
+                {
+                    Diagnostics.ReportMemberInaccessible(syntax.FieldIdentifier.Location, staticField.Name, fieldOwner.Name, staticField.Accessibility);
+                }
+
                 if (staticField.IsReadOnly)
                 {
                     Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
                 }
 
-                var staticValue = BindAssignmentRhs(syntax.Value, staticField.Type);
-                var staticConverted = conversions.BindConversion(syntax.Value.Location, staticValue, staticField.Type);
-                return new BoundFieldAssignmentExpression(null, null, userStruct, staticField, staticConverted);
+                var fieldType = fieldOwner.SubstituteMemberType(staticField.Type);
+                var staticValue = BindAssignmentRhs(syntax.Value, fieldType);
+                var staticConverted = conversions.BindConversion(syntax.Value.Location, staticValue, fieldType);
+                return new BoundFieldAssignmentExpression(null, null, fieldOwner, staticField, staticConverted, fieldType);
             }
 
             // Issue #263: static property assignment.
-            if (TypeMemberModel.TryGetStaticProperty(userStruct, fieldName, out var prop))
+            if (TypeMemberModel.TryGetStaticPropertyIncludingInherited(userStruct, fieldName, out var prop, out var propertyOwner))
             {
+                if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propertyOwner, function))
+                {
+                    Diagnostics.ReportMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propertyOwner.Name, prop.Accessibility);
+                }
+
                 if (!prop.HasSetter)
                 {
                     Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
@@ -550,7 +561,19 @@ internal sealed partial class ExpressionBinder
 
                 var staticValue = BindAssignmentRhs(syntax.Value, prop.Type);
                 var propConverted = conversions.BindConversion(syntax.Value.Location, staticValue, prop.Type);
-                return new BoundPropertyAssignmentExpression(null, receiver: null, userStruct, prop, propConverted);
+                return new BoundPropertyAssignmentExpression(null, receiver: null, propertyOwner, prop, propConverted);
+            }
+
+            if (TypeMemberModel.GetNearestImportedBase(userStruct)?.ClrType is Type importedBaseClr)
+            {
+                var importedBase = new ImportedClassSymbol(importedBaseClr, syntax, references: scope.References);
+                if (importedBase.TryLookupMember(fieldName, ne: null, out var inheritedStaticMember)
+                    && TryGetWritableClrMember(inheritedStaticMember, out _, out var inheritedTarget, out _))
+                {
+                    var inheritedValue = BindAssignmentRhs(syntax.Value, inheritedTarget);
+                    var inheritedConverted = conversions.BindConversion(syntax.Value.Location, inheritedValue, inheritedTarget);
+                    return new BoundClrPropertyAssignmentExpression(null, receiver: null, inheritedStaticMember, inheritedConverted, inheritedTarget);
+                }
             }
 
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
@@ -1110,9 +1133,15 @@ internal sealed partial class ExpressionBinder
         var memberName = memberNameSyntax.IdentifierToken.Text;
         var boundRhs = BindExpression(syntax.Value);
 
-        if (TypeMemberModel.TryGetStaticField(staticStruct, memberName, out var staticField))
+        if (TypeMemberModel.TryGetStaticFieldIncludingInherited(staticStruct, memberName, out var staticField, out var fieldOwner))
         {
-            var leftRead = new BoundFieldAccessExpression(null, receiver: null, staticStruct, staticField);
+            if (!AccessibilityChecker.IsAccessible(staticField.Accessibility, fieldOwner, function))
+            {
+                Diagnostics.ReportMemberInaccessible(memberNameSyntax.Location, staticField.Name, fieldOwner.Name, staticField.Accessibility);
+            }
+
+            var fieldType = fieldOwner.SubstituteMemberType(staticField.Type);
+            var leftRead = new BoundFieldAccessExpression(null, receiver: null, fieldOwner, staticField, fieldType);
             var binary = TryBindCompoundBinaryOperation(baseOpSyntaxKind, leftRead, boundRhs, syntax.Value.Location);
             if (binary == null)
             {
@@ -1126,13 +1155,18 @@ internal sealed partial class ExpressionBinder
                 Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, memberName);
             }
 
-            var converted = conversions.BindConversion(syntax.Value.Location, binary, staticField.Type);
-            result = new BoundFieldAssignmentExpression(null, null, staticStruct, staticField, converted);
+            var converted = conversions.BindConversion(syntax.Value.Location, binary, fieldType);
+            result = new BoundFieldAssignmentExpression(null, null, fieldOwner, staticField, converted, fieldType);
             return true;
         }
 
-        if (TypeMemberModel.TryGetStaticProperty(staticStruct, memberName, out var prop))
+        if (TypeMemberModel.TryGetStaticPropertyIncludingInherited(staticStruct, memberName, out var prop, out var propertyOwner))
         {
+            if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propertyOwner, function))
+            {
+                Diagnostics.ReportMemberInaccessible(memberNameSyntax.Location, prop.Name, propertyOwner.Name, prop.Accessibility);
+            }
+
             if (!prop.HasGetter || !prop.HasSetter)
             {
                 Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, memberName);
@@ -1140,7 +1174,7 @@ internal sealed partial class ExpressionBinder
                 return true;
             }
 
-            var leftRead = new BoundPropertyAccessExpression(null, receiver: null, staticStruct, prop);
+            var leftRead = new BoundPropertyAccessExpression(null, receiver: null, propertyOwner, prop);
             var binary = TryBindCompoundBinaryOperation(baseOpSyntaxKind, leftRead, boundRhs, syntax.Value.Location);
             if (binary == null)
             {
@@ -1150,7 +1184,7 @@ internal sealed partial class ExpressionBinder
             }
 
             var converted = conversions.BindConversion(syntax.Value.Location, binary, prop.Type);
-            result = new BoundPropertyAssignmentExpression(null, receiver: null, staticStruct, prop, converted);
+            result = new BoundPropertyAssignmentExpression(null, receiver: null, propertyOwner, prop, converted);
             return true;
         }
 
@@ -2014,19 +2048,30 @@ internal sealed partial class ExpressionBinder
         // User class/struct → static field or static property write.
         if (constructedStruct != null)
         {
-            if (TypeMemberModel.TryGetStaticField(constructedStruct, fieldName, out var staticField))
+            if (TypeMemberModel.TryGetStaticFieldIncludingInherited(constructedStruct, fieldName, out var staticField, out var fieldOwner))
             {
+                if (!AccessibilityChecker.IsAccessible(staticField.Accessibility, fieldOwner, function))
+                {
+                    Diagnostics.ReportMemberInaccessible(syntax.FieldIdentifier.Location, staticField.Name, fieldOwner.Name, staticField.Accessibility);
+                }
+
                 if (staticField.IsReadOnly)
                 {
                     Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
                 }
 
-                var staticConverted = conversions.BindConversion(syntax.Value.Location, BindValue(staticField.Type), staticField.Type);
-                return new BoundFieldAssignmentExpression(null, null, constructedStruct, staticField, staticConverted);
+                var fieldType = fieldOwner.SubstituteMemberType(staticField.Type);
+                var staticConverted = conversions.BindConversion(syntax.Value.Location, BindValue(fieldType), fieldType);
+                return new BoundFieldAssignmentExpression(null, null, fieldOwner, staticField, staticConverted, fieldType);
             }
 
-            if (TypeMemberModel.TryGetStaticProperty(constructedStruct, fieldName, out var prop))
+            if (TypeMemberModel.TryGetStaticPropertyIncludingInherited(constructedStruct, fieldName, out var prop, out var propertyOwner))
             {
+                if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propertyOwner, function))
+                {
+                    Diagnostics.ReportMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propertyOwner.Name, prop.Accessibility);
+                }
+
                 if (!prop.HasSetter)
                 {
                     Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
@@ -2034,7 +2079,7 @@ internal sealed partial class ExpressionBinder
                 }
 
                 var propConverted = conversions.BindConversion(syntax.Value.Location, BindValue(prop.Type), prop.Type);
-                return new BoundPropertyAssignmentExpression(null, receiver: null, constructedStruct, prop, propConverted);
+                return new BoundPropertyAssignmentExpression(null, receiver: null, propertyOwner, prop, propConverted);
             }
 
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -92,10 +92,17 @@ internal sealed partial class ExpressionBinder
             // reporting an immediate "unable to find member". Non-+/-
             // operators (issue #2154) can never be an event, so skip straight
             // to the compound-assignment fallback.
-            if (isEventCapableOperator && TypeMemberModel.TryGetStaticEvent(staticStruct, eventName, out var ev))
+            if (isEventCapableOperator
+                && TypeMemberModel.TryGetStaticEventIncludingInherited(staticStruct, eventName, out var ev, out var eventOwner))
             {
-                var userHandler = BindEventSubscriptionHandler(syntax.Value, ev.Type);
-                return new BoundEventSubscriptionExpression(null, receiver: null, staticStruct, ev, userHandler, isAdd);
+                if (!AccessibilityChecker.IsAccessible(ev.Accessibility, eventOwner, function))
+                {
+                    Diagnostics.ReportMemberInaccessible(eventNameSyntax.Location, ev.Name, eventOwner.Name, ev.Accessibility);
+                }
+
+                var eventType = eventOwner.SubstituteMemberType(ev.Type);
+                var userHandler = BindEventSubscriptionHandler(syntax.Value, eventType);
+                return new BoundEventSubscriptionExpression(null, receiver: null, eventOwner, ev, userHandler, isAdd, eventType);
             }
 
             // ADR-0053: `Type.StaticField op= rhs` / `Type.StaticProp op= rhs`.
@@ -106,8 +113,16 @@ internal sealed partial class ExpressionBinder
                 return compoundResult;
             }
 
-            Diagnostics.ReportUnableToFindMember(eventNameSyntax.Location, eventName);
-            return new BoundErrorExpression(null);
+            if (TypeMemberModel.GetNearestImportedBase(staticStruct)?.ClrType is Type importedBaseClr)
+            {
+                receiverClrType = importedBaseClr;
+                flags = BindingFlags.Public | BindingFlags.Static;
+            }
+            else
+            {
+                Diagnostics.ReportUnableToFindMember(eventNameSyntax.Location, eventName);
+                return new BoundErrorExpression(null);
+            }
         }
         else if (accessor.LeftPart is NameExpressionSyntax ifaceLeftName
             && scope.TryLookupTypeAlias(ifaceLeftName.IdentifierToken.Text, out var ifaceTypeAlias)
@@ -143,7 +158,20 @@ internal sealed partial class ExpressionBinder
             // TYPE, resolved to the constructed symbol (mirroring the READ /
             // simple-write paths) rather than bound as element access, and the
             // carried construction drives per-construction emit/storage.
-            _ = ctorImported;
+            if (ctorStruct != null
+                && isEventCapableOperator
+                && TypeMemberModel.TryGetStaticEventIncludingInherited(ctorStruct, eventName, out var ctorEvent, out var ctorEventOwner))
+            {
+                if (!AccessibilityChecker.IsAccessible(ctorEvent.Accessibility, ctorEventOwner, function))
+                {
+                    Diagnostics.ReportMemberInaccessible(eventNameSyntax.Location, ctorEvent.Name, ctorEventOwner.Name, ctorEvent.Accessibility);
+                }
+
+                var eventType = ctorEventOwner.SubstituteMemberType(ctorEvent.Type);
+                var handler = BindEventSubscriptionHandler(syntax.Value, eventType);
+                return new BoundEventSubscriptionExpression(null, receiver: null, ctorEventOwner, ctorEvent, handler, isAdd, eventType);
+            }
+
             if (ctorStruct != null
                 && TryBindUserTypeStaticCompoundAssignment(ctorStruct, eventNameSyntax, syntax, baseOpSyntaxKind, out var ctorStructCompound))
             {
@@ -156,8 +184,22 @@ internal sealed partial class ExpressionBinder
                 return ctorCompound;
             }
 
-            Diagnostics.ReportUnableToFindMember(eventNameSyntax.Location, eventName);
-            return new BoundErrorExpression(null);
+            if (ctorStruct != null
+                && TypeMemberModel.GetNearestImportedBase(ctorStruct)?.ClrType is Type constructedImportedBase)
+            {
+                receiverClrType = constructedImportedBase;
+                flags = BindingFlags.Public | BindingFlags.Static;
+            }
+            else if (ctorImported != null)
+            {
+                receiverClrType = ctorImported.ClassType;
+                flags = BindingFlags.Public | BindingFlags.Static;
+            }
+            else
+            {
+                Diagnostics.ReportUnableToFindMember(eventNameSyntax.Location, eventName);
+                return new BoundErrorExpression(null);
+            }
         }
         else
         {

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -432,6 +432,13 @@ internal sealed partial class MethodBodyEmitter
         // function token (ilverify `DelegateCtor`). Re-resolve through the
         // receiver's type.
         EntityHandle ftnToken = staticHandle;
+        if (methodGroup.Receiver == null
+            && methodGroup.StaticOwnerType != null
+            && ReflectionMetadataEmitter.IsUserGenericTypeReference(methodGroup.StaticOwnerType))
+        {
+            ftnToken = this.outer.userTokens.ResolveUserStaticMethodToken(methodGroup.StaticOwnerType, methodGroup.Function);
+        }
+
         if (methodGroup.Receiver?.Type is StructSymbol receiverStruct
             && ReflectionMetadataEmitter.IsUserGenericTypeReference(receiverStruct)
             && this.outer.cache.MethodHandles.ContainsKey(methodGroup.Function))
@@ -534,9 +541,9 @@ internal sealed partial class MethodBodyEmitter
         // and non-capturing lambdas both flow through the closure builder
         // with the correct target delegate ctor (object, IntPtr).
         if (node.Handler is BoundFunctionLiteralExpression literalHandler
-            && node.Event.Type?.ClrType != null)
+            && node.EventType?.ClrType != null)
         {
-            var mappedDelegateType = this.outer.signatures.MapToReferenceClrType(node.Event.Type.ClrType);
+            var mappedDelegateType = this.outer.signatures.MapToReferenceClrType(node.EventType.ClrType);
             this.EmitFunctionLiteral(literalHandler, mappedDelegateType);
         }
         else
@@ -547,6 +554,18 @@ internal sealed partial class MethodBodyEmitter
         if (this.outer.cache.EventAccessorHandles.TryGetValue(node.Event, out var accessorHandles))
         {
             var accessorMethodSymbol = node.IsAdd ? node.Event.AddMethodSymbol : node.Event.RemoveMethodSymbol;
+            var accessorHandle = node.IsAdd ? accessorHandles.Add : accessorHandles.Remove;
+
+            if (node.Receiver == null
+                && node.StructType is StructSymbol staticOwner
+                && ReflectionMetadataEmitter.IsUserGenericTypeReference(staticOwner)
+                && accessorMethodSymbol != null)
+            {
+                var accessorToken = this.outer.userTokens.ResolveUserStaticMethodToken(staticOwner, accessorMethodSymbol, accessorHandle);
+                this.il.OpCode(ILOpCode.Call);
+                this.il.Token(accessorToken);
+                return;
+            }
 
             // ADR-0149 follow-up (issue #2370): a generic-interface-typed
             // receiver (`b: IWatchable[int32]; b.Changed += h`) must reach
@@ -564,7 +583,6 @@ internal sealed partial class MethodBodyEmitter
                 return;
             }
 
-            var accessorHandle = node.IsAdd ? accessorHandles.Add : accessorHandles.Remove;
             bool isStatic = node.Receiver == null;
             bool isVirtual = !isStatic && (node.StructType is InterfaceSymbol || node.Event.IsVirtual || node.Event.IsOverride);
             this.il.OpCode(isVirtual ? ILOpCode.Callvirt : ILOpCode.Call);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -464,7 +464,7 @@ internal sealed partial class MethodBodyEmitter
         {
             this.il.OpCode(ILOpCode.Ldsfld);
             this.il.Token(fieldHandle);
-            this.EmitNarrowingCastIfNeeded(fa.Field.Type, fa.NarrowedType);
+            this.EmitNarrowingCastIfNeeded(GetEffectiveFieldType(fa), fa.NarrowedType);
             return;
         }
 
@@ -481,7 +481,7 @@ internal sealed partial class MethodBodyEmitter
             this.il.Token(this.outer.memberRefs.GetElementTypeToken(fieldReceiverTp));
             this.il.OpCode(ILOpCode.Ldfld);
             this.il.Token(fieldHandle);
-            this.EmitNarrowingCastIfNeeded(fa.Field.Type, fa.NarrowedType);
+            this.EmitNarrowingCastIfNeeded(GetEffectiveFieldType(fa), fa.NarrowedType);
             return;
         }
 
@@ -514,8 +514,13 @@ internal sealed partial class MethodBodyEmitter
 
         this.il.OpCode(ILOpCode.Ldfld);
         this.il.Token(fieldHandle);
-        this.EmitNarrowingCastIfNeeded(fa.Field.Type, fa.NarrowedType);
+        this.EmitNarrowingCastIfNeeded(GetEffectiveFieldType(fa), fa.NarrowedType);
     }
+
+    private static TypeSymbol GetEffectiveFieldType(BoundFieldAccessExpression access)
+        => access.StructType is StructSymbol owner
+            ? owner.SubstituteMemberType(access.Field.Type)
+            : access.Field.Type;
 
     private void EmitFieldAssignment(BoundFieldAssignmentExpression fas)
     {

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -1441,6 +1441,21 @@ internal sealed class UserTokenResolver
         return this.GetUserStructMethodRef(containingType, openDef, method.Name, this.EncodeOpenMethodSignature(method));
     }
 
+    /// <summary>Resolves a generic static accessor whose MethodDef is tracked outside the method caches.</summary>
+    /// <param name="containingType">The effective generic owner.</param>
+    /// <param name="method">The accessor method symbol.</param>
+    /// <param name="openDef">The accessor's emitted MethodDef.</param>
+    /// <returns>The MethodDef or TypeSpec-parented MemberRef token.</returns>
+    internal EntityHandle ResolveUserStaticMethodToken(StructSymbol containingType, FunctionSymbol method, EntityHandle openDef)
+    {
+        if (!ReflectionMetadataEmitter.IsUserGenericTypeReference(containingType))
+        {
+            return openDef;
+        }
+
+        return this.GetUserStructMethodRef(containingType, openDef, method.Name, this.EncodeOpenMethodSignature(method));
+    }
+
     /// <summary>
     /// Issue #1433: resolves the token for a call to a user <c>shared</c>
     /// (static) method whose declaring type is a user-declared INTERFACE

--- a/src/Core/CodeAnalysis/Symbols/MemberQuery.cs
+++ b/src/Core/CodeAnalysis/Symbols/MemberQuery.cs
@@ -56,6 +56,12 @@ public readonly struct MemberQuery
     public static MemberQuery Static(MemberKinds kinds = MemberKinds.All)
         => new(includeInstance: false, includeStatic: true, includeInherited: false, kinds);
 
+    /// <summary>Gets a query matching static members of the given kinds, walking the base-class chain.</summary>
+    /// <param name="kinds">The member-kind mask.</param>
+    /// <returns>The configured query.</returns>
+    public static MemberQuery InheritedStatic(MemberKinds kinds = MemberKinds.All)
+        => new(includeInstance: false, includeStatic: true, includeInherited: true, kinds);
+
     /// <summary>Returns a copy of this query with the kind mask replaced.</summary>
     /// <param name="kinds">The new kind mask.</param>
     /// <returns>The adjusted query.</returns>

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -48,6 +48,7 @@ public sealed class StructSymbol : TypeSymbol
     private ImmutableArray<FieldSymbol> fieldsStore = ImmutableArray<FieldSymbol>.Empty;
     private ImmutableArray<PropertySymbol> propertiesStore = ImmutableArray<PropertySymbol>.Empty;
     private ImmutableArray<PropertySymbol> staticPropertiesStore = ImmutableArray<PropertySymbol>.Empty;
+    private ImmutableArray<EventSymbol> staticEventsStore = ImmutableArray<EventSymbol>.Empty;
 
     // Issue #1341: memoized substitution of the definition's instance-member
     // tables (whose member types may mention the type parameters) for a
@@ -408,7 +409,11 @@ public sealed class StructSymbol : TypeSymbol
     }
 
     /// <summary>Gets the static events declared inside a <c>shared</c> block (ADR-0053). Populated by the binder; defaults to empty.</summary>
-    public ImmutableArray<EventSymbol> StaticEvents { get; private set; } = ImmutableArray<EventSymbol>.Empty;
+    public ImmutableArray<EventSymbol> StaticEvents
+    {
+        get => Definition != null && !ReferenceEquals(Definition, this) ? Definition.StaticEvents : staticEventsStore;
+        private set => staticEventsStore = value;
+    }
 
     /// <summary>Gets the bound initializer expressions for static fields with non-default values (Issue #262). Keyed by field symbol.</summary>
     public ImmutableDictionary<FieldSymbol, BoundExpression> StaticFieldInitializers { get; private set; } = ImmutableDictionary<FieldSymbol, BoundExpression>.Empty;

--- a/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
@@ -93,7 +93,7 @@ public static class TypeMemberModel
 
                 if (query.IncludeStatic)
                 {
-                    AddMethodsDeduped(ref builder, c.StaticMethods, name);
+                    AddMethodsDeduped(ref builder, c.StaticMethods, name, skipPrivate: !ReferenceEquals(c, structSymbol));
                 }
 
                 if (!query.IncludeInherited)
@@ -212,6 +212,11 @@ public static class TypeMemberModel
 
                 if (query.IncludeStatic && c.TryGetStaticField(name, out field))
                 {
+                    if (!ReferenceEquals(c, structSymbol) && field.Accessibility == Accessibility.Private)
+                    {
+                        break;
+                    }
+
                     declaringType = c;
                     return true;
                 }
@@ -241,6 +246,42 @@ public static class TypeMemberModel
         }
 
         field = null;
+        return false;
+    }
+
+    /// <summary>Tries to find an inherited static field and its effective declaring type.</summary>
+    /// <param name="type">The source type used to qualify the field.</param>
+    /// <param name="name">The field name.</param>
+    /// <param name="field">The declared field.</param>
+    /// <param name="declaringType">The effective declaring construction.</param>
+    /// <returns>Whether a field was found.</returns>
+    public static bool TryGetStaticFieldIncludingInherited(
+        StructSymbol type,
+        string name,
+        out FieldSymbol field,
+        out StructSymbol declaringType)
+    {
+        for (var c = type; c != null; c = c.BaseClass)
+        {
+            if (c.TryGetStaticField(name, out field))
+            {
+                if (!ReferenceEquals(c, type) && field.Accessibility == Accessibility.Private)
+                {
+                    break;
+                }
+
+                declaringType = ResolveStaticMemberOwner(type, c);
+                return true;
+            }
+
+            if (DeclaresAnyStaticMember(c, name))
+            {
+                break;
+            }
+        }
+
+        field = null;
+        declaringType = null;
         return false;
     }
 
@@ -373,6 +414,43 @@ public static class TypeMemberModel
         return false;
     }
 
+    /// <summary>Tries to find an inherited static property and its effective declaring type.</summary>
+    /// <param name="type">The source type used to qualify the property.</param>
+    /// <param name="name">The property name.</param>
+    /// <param name="property">The property in the effective owner context.</param>
+    /// <param name="declaringType">The effective declaring construction.</param>
+    /// <returns>Whether a property was found.</returns>
+    public static bool TryGetStaticPropertyIncludingInherited(
+        StructSymbol type,
+        string name,
+        out PropertySymbol property,
+        out StructSymbol declaringType)
+    {
+        for (var c = type; c != null; c = c.BaseClass)
+        {
+            var effective = ResolveStaticMemberOwner(type, c);
+            if (TryGetStaticProperty(effective, name, out property))
+            {
+                if (!ReferenceEquals(c, type) && property.Accessibility == Accessibility.Private)
+                {
+                    break;
+                }
+
+                declaringType = effective;
+                return true;
+            }
+
+            if (DeclaresAnyStaticMember(c, name))
+            {
+                break;
+            }
+        }
+
+        property = null;
+        declaringType = null;
+        return false;
+    }
+
     /// <summary>Tries to find an instance event named <paramref name="name"/> on <paramref name="type"/>, walking the base chain.</summary>
     /// <param name="type">The type to resolve against.</param>
     /// <param name="name">The event name.</param>
@@ -450,6 +528,91 @@ public static class TypeMemberModel
         return false;
     }
 
+    /// <summary>Tries to find an inherited static event and its effective declaring type.</summary>
+    /// <param name="type">The source type used to qualify the event.</param>
+    /// <param name="name">The event name.</param>
+    /// <param name="event">The declared event.</param>
+    /// <param name="declaringType">The effective declaring construction.</param>
+    /// <returns>Whether an event was found.</returns>
+    public static bool TryGetStaticEventIncludingInherited(
+        StructSymbol type,
+        string name,
+        out EventSymbol @event,
+        out StructSymbol declaringType)
+    {
+        for (var c = type; c != null; c = c.BaseClass)
+        {
+            var effective = ResolveStaticMemberOwner(type, c);
+            if (TryGetStaticEvent(effective, name, out @event))
+            {
+                if (!ReferenceEquals(c, type) && @event.Accessibility == Accessibility.Private)
+                {
+                    break;
+                }
+
+                declaringType = effective;
+                return true;
+            }
+
+            if (DeclaresAnyStaticMember(c, name))
+            {
+                break;
+            }
+        }
+
+        @event = null;
+        declaringType = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves the base-class construction that owns a static member found
+    /// through <paramref name="lookupType"/>.
+    /// </summary>
+    /// <param name="lookupType">The source type used to qualify the member.</param>
+    /// <param name="declaredOwner">The member's declared owner.</param>
+    /// <returns>The owner construction in the lookup type's base chain.</returns>
+    public static StructSymbol ResolveStaticMemberOwner(StructSymbol lookupType, StructSymbol declaredOwner)
+    {
+        if (lookupType == null || declaredOwner == null)
+        {
+            return declaredOwner;
+        }
+
+        var declaredDefinition = declaredOwner.Definition ?? declaredOwner;
+        if (!declaredDefinition.TypeParameters.IsDefaultOrEmpty)
+        {
+            return lookupType.FindConstructedGenericBase(
+                candidate => ReferenceEquals(candidate, declaredDefinition)) ?? declaredOwner;
+        }
+
+        for (var c = lookupType; c != null; c = c.BaseClass)
+        {
+            if (ReferenceEquals(c.Definition ?? c, declaredDefinition))
+            {
+                return c;
+            }
+        }
+
+        return declaredOwner;
+    }
+
+    /// <summary>Finds the nearest imported CLR base under a source class chain.</summary>
+    /// <param name="type">The source class whose chain is searched.</param>
+    /// <returns>The imported base, or null.</returns>
+    public static TypeSymbol GetNearestImportedBase(StructSymbol type)
+    {
+        for (var c = type; c != null; c = c.BaseClass)
+        {
+            if (c.ImportedBaseType?.ClrType != null)
+            {
+                return c.ImportedBaseType;
+            }
+        }
+
+        return null;
+    }
+
     /// <summary>
     /// ADR-0112: tries to find the FIRST instance method named <paramref name="name"/>
     /// on <paramref name="type"/>, walking the base chain this-first (declaration order
@@ -525,6 +688,40 @@ public static class TypeMemberModel
 
         method = null;
         declaringType = null;
+        return false;
+    }
+
+    internal static bool DeclaresAnyStaticMember(StructSymbol type, string name)
+    {
+        if (type.TryGetStaticField(name, out _))
+        {
+            return true;
+        }
+
+        foreach (var property in type.StaticProperties)
+        {
+            if (property.Name == name)
+            {
+                return true;
+            }
+        }
+
+        foreach (var @event in type.StaticEvents)
+        {
+            if (@event.Name == name)
+            {
+                return true;
+            }
+        }
+
+        foreach (var method in type.StaticMethods)
+        {
+            if (method.Name == name)
+            {
+                return true;
+            }
+        }
+
         return false;
     }
 
@@ -801,7 +998,11 @@ public static class TypeMemberModel
         return false;
     }
 
-    private static void AddMethodsDeduped(ref ImmutableArray<FunctionSymbol>.Builder builder, ImmutableArray<FunctionSymbol> source, string name)
+    private static void AddMethodsDeduped(
+        ref ImmutableArray<FunctionSymbol>.Builder builder,
+        ImmutableArray<FunctionSymbol> source,
+        string name,
+        bool skipPrivate = false)
     {
         if (source.IsDefaultOrEmpty)
         {
@@ -810,7 +1011,7 @@ public static class TypeMemberModel
 
         foreach (var m in source)
         {
-            if (m.Name != name)
+            if (m.Name != name || (skipPrivate && m.Accessibility == Accessibility.Private))
             {
                 continue;
             }

--- a/test/Compiler.Tests/Emit/Issue2502InheritedStaticMembersEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2502InheritedStaticMembersEmitTests.cs
@@ -1,0 +1,299 @@
+// <copyright file="Issue2502InheritedStaticMembersEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Compiler;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Issue #2502 end-to-end coverage for inherited static members.</summary>
+public sealed class Issue2502InheritedStaticMembersEmitTests
+{
+    [Fact]
+    public void SourceGenericBase_AllMemberKinds_VerifyReflectAndWorkFromCSharp()
+    {
+        const string Source = """
+            package Issue2502Source
+            import System
+
+            open class Base2502[T] {
+                public class Nested2502 {
+                    shared { func Value() int32 -> 9 }
+                }
+                shared {
+                    var Field T
+                    prop Prop T { get -> Field; set { Field = value } }
+                    event Changed () -> void
+                    func Echo(value T) T -> value
+                    func Pick(value T) string -> "generic"
+                    func Pick(value int32) string -> "int"
+                }
+            }
+
+            open class Mid2502[U] : Base2502[U] { }
+            class Derived2502 : Mid2502[string] { }
+
+            class Probe2502 {
+                shared {
+                    func Run() string {
+                        Derived2502.Field = "field"
+                        Derived2502.Field += "!"
+                        Derived2502.Prop = Derived2502.Field
+                        Derived2502.Prop += "?"
+                        let handler () -> void = () -> { }
+                        Derived2502.Changed += handler
+                        Derived2502.Changed -= handler
+                        let echo (string) -> string = Derived2502.Echo
+                        return Derived2502.Prop + "|" + echo("group") + "|" + Derived2502.Pick(1) + "|" + Derived2502.Nested2502.Value().ToString()
+                    }
+                }
+            }
+            """;
+
+        var directory = CreateTestDirectory();
+        try
+        {
+            var library = CompileGSharp(directory, "Issue2502Source", Source, "library");
+            IlVerifier.Verify(library);
+
+            var assembly = Assembly.LoadFrom(library);
+            var derived = assembly.GetType("Issue2502Source.Derived2502")!;
+            var closedBase = assembly.GetType("Issue2502Source.Base2502`1")!.MakeGenericType(typeof(string));
+            Assert.Equal(closedBase, derived.BaseType!.BaseType);
+            Assert.Equal(closedBase, derived.GetMethod("Echo", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)!.DeclaringType);
+            Assert.Equal(closedBase, derived.GetField("Field", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)!.DeclaringType);
+            Assert.Equal(closedBase, derived.GetProperty("Prop", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)!.DeclaringType);
+            Assert.Equal(closedBase, derived.GetEvent("Changed", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)!.DeclaringType);
+
+            var consumer = Path.Combine(directory, "Issue2502Consumer.dll");
+            const string ConsumerSource = """
+                using System;
+                using Issue2502Source;
+
+                Console.WriteLine(Probe2502.Run());
+                Derived2502.Field = "cs-field";
+                Derived2502.Prop = "cs-prop";
+                Console.WriteLine(Derived2502.Field);
+                Console.WriteLine(Derived2502.Prop);
+                Console.WriteLine(Derived2502.Echo("cs-method"));
+                Func<string, string> echo = Derived2502.Echo;
+                Console.WriteLine(echo("cs-group"));
+                Action handler = () => { };
+                Derived2502.Changed += handler;
+                Derived2502.Changed -= handler;
+                Console.WriteLine("event-ok");
+                """;
+            EmitCSharpAssembly(consumer, "Issue2502Consumer", ConsumerSource, OutputKind.ConsoleApplication, library);
+
+            Assert.Equal(
+                "field!?|group|int|9\ncs-prop\ncs-prop\ncs-method\ncs-group\nevent-ok\n",
+                Run(consumer));
+        }
+        finally
+        {
+            TryDelete(directory);
+        }
+    }
+
+    [Fact]
+    public void ImportedClosedGenericBase_AllMemberKinds_VerifyAndRun()
+    {
+        var directory = CreateTestDirectory();
+        try
+        {
+            var importedBase = Path.Combine(directory, "Issue2502ImportedBase.dll");
+            const string ImportedSource = """
+                using System;
+
+                namespace Issue2502ImportedBase;
+
+                public class Base<T>
+                {
+                    public static T Field = default!;
+                    public static T Prop { get; set; } = default!;
+                    public static event Action? Changed;
+                    public static T Echo(T value) => value;
+                    public static void Raise() => Changed?.Invoke();
+
+                    public class Nested
+                    {
+                        public static int Value() => 12;
+                    }
+                }
+                """;
+            EmitCSharpAssembly(importedBase, "Issue2502ImportedBase", ImportedSource, OutputKind.DynamicallyLinkedLibrary);
+
+            const string Source = """
+                package Issue2502Imported
+                import System
+                import Issue2502ImportedBase
+
+                class Derived2502Imported : Base[string] { }
+
+                func Main() {
+                    Derived2502Imported.Field = "field"
+                    Console.WriteLine(Derived2502Imported.Field)
+                    Derived2502Imported.Prop = "prop"
+                    Console.WriteLine(Derived2502Imported.Prop)
+                    Console.WriteLine(Derived2502Imported.Echo("method"))
+                    Derived2502Imported.Changed += () -> Console.WriteLine("event")
+                    Derived2502Imported.Raise()
+                    Console.WriteLine(Derived2502Imported.Nested.Value())
+                }
+                """;
+
+            var executable = CompileGSharp(directory, "Issue2502Imported", Source, "exe", importedBase);
+            IlVerifier.Verify(executable, additionalReferences: new[] { importedBase });
+            Assert.Equal("field\nprop\nmethod\nevent\n12\n", Run(executable));
+        }
+        finally
+        {
+            TryDelete(directory);
+        }
+    }
+
+    private static string CompileGSharp(
+        string directory,
+        string assemblyName,
+        string source,
+        string target,
+        params string[] references)
+    {
+        var sourcePath = Path.Combine(directory, assemblyName + ".gs");
+        var outputPath = Path.Combine(directory, assemblyName + ".dll");
+        File.WriteAllText(sourcePath, source);
+        var args = new List<string>
+        {
+            "/out:" + outputPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+        foreach (var reference in references.Concat(BclReferences.Value))
+        {
+            args.Add("/r:" + reference);
+        }
+
+        args.Add(sourcePath);
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(exitCode == 0, $"gsc failed:\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return outputPath;
+    }
+
+    private static void EmitCSharpAssembly(
+        string outputPath,
+        string assemblyName,
+        string source,
+        OutputKind outputKind,
+        params string[] additionalReferences)
+    {
+        var references = TrustedPlatformReferences()
+            .Concat(additionalReferences.Select(path => MetadataReference.CreateFromFile(path)))
+            .ToArray();
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(outputKind));
+
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static string Run(string assemblyPath)
+    {
+        File.WriteAllText(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"), """
+            {
+              "runtimeOptions": {
+                "tfm": "net10.0",
+                "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+              }
+            }
+            """);
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath)!,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add(assemblyPath);
+        using var process = Process.Start(startInfo)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(process.ExitCode == 0, $"exit {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static string CreateTestDirectory()
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2502", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void TryDelete(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+
+    private static IEnumerable<MetadataReference> TrustedPlatformReferences()
+        => ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+            ?.Split(Path.PathSeparator)
+            ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => MetadataReference.CreateFromFile(path));
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDirectory) || !Directory.Exists(runtimeDirectory))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDirectory, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(path =>
+            {
+                var name = Path.GetFileName(path);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToArray();
+    });
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2502InheritedStaticMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2502InheritedStaticMemberTests.cs
@@ -1,0 +1,142 @@
+// <copyright file="Issue2502InheritedStaticMemberTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>Issue #2502 binding coverage for inherited source static members.</summary>
+public class Issue2502InheritedStaticMemberTests
+{
+    [Fact]
+    public void ClosedGenericMultiLevelBase_AllStaticMemberPathsBind()
+    {
+        const string Source = """
+            open class Base2502[T] {
+                class Nested2502 { shared { func Value() int32 -> 9 } }
+                shared {
+                    var Field T
+                    prop Prop T { get -> Field; set { Field = value } }
+                    event Changed () -> void
+                    func Echo(value T) T -> value
+                    func Pick(value T) string -> "generic"
+                    func Pick(value int32) string -> "int"
+                }
+            }
+            open class Mid2502[U] : Base2502[U] { }
+            class Derived2502 : Mid2502[string] { }
+            class Use2502 {
+                func Run() {
+                    Derived2502.Field = "a"
+                    Derived2502.Field += "b"
+                    Derived2502.Prop = Derived2502.Field
+                    Derived2502.Prop += "c"
+                    Derived2502.Changed += () -> { }
+                    Derived2502.Changed -= () -> { }
+                    let echo (string) -> string = Derived2502.Echo
+                    let a string = Derived2502.Pick("x")
+                    let b string = Derived2502.Pick(1)
+                    let c int32 = Derived2502.Nested2502.Value()
+                }
+            }
+            0
+            """;
+
+        Assert.Empty(Evaluate(Source).Diagnostics);
+    }
+
+    [Fact]
+    public void SubstitutedSignature_DerivedMethodHidesBaseMethod()
+    {
+        const string Source = """
+            open class Base2502Hide[T] {
+                shared { func Pick(value T) string -> "base" }
+            }
+            class Derived2502Hide : Base2502Hide[string] {
+                shared { func Pick(value string) string -> "derived" }
+            }
+            class Use2502Hide {
+                func Run() {
+                    let direct string = Derived2502Hide.Pick("x")
+                    let group (string) -> string = Derived2502Hide.Pick
+                    let indirect string = group("x")
+                }
+            }
+            0
+            """;
+
+        Assert.Empty(Evaluate(Source).Diagnostics);
+    }
+
+    [Fact]
+    public void ProtectedInheritedStatic_IsAccessibleOnlyFromDerivedContext()
+    {
+        const string Source = """
+            open class Base2502Protected {
+                shared { protected func Guarded() int32 -> 7 }
+            }
+            class Derived2502Protected : Base2502Protected {
+                func Allowed() int32 -> Derived2502Protected.Guarded()
+            }
+            class Other2502Protected {
+                func Rejected() int32 -> Derived2502Protected.Guarded()
+            }
+            0
+            """;
+
+        var diagnostics = Evaluate(Source).Diagnostics;
+        Assert.Single(diagnostics, d => d.Id == "GS0379");
+    }
+
+    [Fact]
+    public void PrivateAndInstanceMembers_AreNotInheritedStaticCandidates()
+    {
+        const string Source = """
+            open class Base2502Negative {
+                func InstanceOnly() int32 -> 1
+                shared { private func Secret() int32 -> 2 }
+            }
+            class Derived2502Negative : Base2502Negative { }
+            class Use2502Negative {
+                func A() int32 -> Derived2502Negative.Secret()
+                func B() int32 -> Derived2502Negative.InstanceOnly()
+            }
+            0
+            """;
+
+        var diagnostics = Evaluate(Source).Diagnostics;
+        Assert.Contains(diagnostics, d => d.Id is "GS0158" or "GS0472");
+        Assert.True(diagnostics.Length >= 2);
+    }
+
+    [Fact]
+    public void ClosedGenericBase_RejectsWrongSubstitutedArgument()
+    {
+        const string Source = """
+            open class Base2502Wrong[T] {
+                shared { func Echo(value T) T -> value }
+            }
+            class Derived2502Wrong : Base2502Wrong[string] { }
+            class Use2502Wrong {
+                func Run() string -> Derived2502Wrong.Echo(1)
+            }
+            0
+            """;
+
+        Assert.NotEmpty(Evaluate(Source).Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2502InheritedStaticPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2502InheritedStaticPipelineTests.cs
@@ -1,0 +1,139 @@
+// <copyright file="Issue2502InheritedStaticPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>Default SDK-backed migration coverage for issue #2502.</summary>
+public sealed class Issue2502InheritedStaticPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_InheritedGenericStaticCalls_TranslateAndCompile()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectDir = Path.Combine(sourceRoot, "src", "Sample");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "Sample.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "Repro.cs"), """
+            namespace Sample;
+
+            public class Factory<T>
+            {
+                public static T Create() => default!;
+            }
+
+            public sealed class Product : Factory<Product>
+            {
+            }
+
+            public abstract class Serialization<T>
+            {
+                public static T Deserialize(string json) => default!;
+            }
+
+            public sealed class LicenseResponse : Serialization<LicenseResponse>
+            {
+            }
+
+            public static class Repro
+            {
+                public static Product Make() => Product.Create();
+
+                public static LicenseResponse Parse(string response) =>
+                    LicenseResponse.Deserialize(response);
+            }
+            """);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp("test/InheritedStatic2502", projectPath, TargetKind.Library);
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+        string appRunDir = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.Id));
+        string emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(appRunDir, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains("Product.Create()", emitted, StringComparison.Ordinal);
+        Assert.Contains("LicenseResponse.Deserialize(response)", emitted, StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            "Expected default --via-sdk/gsc compilation to bind inherited generic statics. Stages: " +
+                string.Join("; ", appResult.Stages.Select(s => s.Stage + "=" + s.Status)));
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2502",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    dir.FullName,
+                    "out",
+                    "bin",
+                    config,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add inherited-static source member lookup while preserving non-inherited completion queries
- carry effective constructed base owners through calls, reads/writes, events, method groups, nested types, and emitted TypeSpec tokens
- support multi-level closed generic source bases and imported CLR bases with hiding, accessibility, overload, and private/instance controls
- add binding, runtime, reflection, C# consumer, ILVerify, and default via-SDK cs2gs regressions, including the Oahu Serialization<T>.Deserialize shape

## Validation
- Core binding/regression tests: 35 passed
- Compiler static/generic/nested/interop tests: 41 passed
- cs2gs default via-SDK regression: passed
- local Gsharp.NET.Sdk package build: passed

Fixes #2502