### PR TITLE
Fix named delegate return taint synchronization

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2423InterfaceMethodContractTaintTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2423InterfaceMethodContractTaintTests.cs
@@ -198,12 +198,11 @@ namespace Demo
     }
 
     [Fact]
-    public void OverrideOfAbstractBase_IsNotSyncedByThisFix()
+    public void OverrideOfAbstractBase_ReturnContractConverges()
     {
-        // Negative/documentation control: base-class virtual/abstract
-        // contracts are NOT interfaces, so CollectInterfaceMethodEdges (like
-        // its pre-existing property counterpart) does not create any edge for
-        // them - only the override's own tainted body is promoted.
+        // Issue #2504 generalizes callable return contracts to base methods too:
+        // a method group bound through the base contract must expose the same
+        // promoted return shape as its nullable override.
         string printed = TranslateOblivious(@"
 namespace Demo
 {
@@ -218,7 +217,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("open func Get() string;", printed);
+        Assert.Contains("open func Get() string?;", printed);
         Assert.Contains("override func Get() string? -> nil", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2504NamedDelegateReturnTaintPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2504NamedDelegateReturnTaintPipelineTests.cs
@@ -1,0 +1,181 @@
+// <copyright file="Issue2504NamedDelegateReturnTaintPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Default SDK-backed/gsc sink coverage for issue #2504, including the
+/// cross-project delegate-declaration/producer shape used by real corpora.
+/// </summary>
+public sealed class Issue2504NamedDelegateReturnTaintPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_CrossProjectNamedDelegateReturn_TranslatesAndCompiles()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        (string contractsProject, string producerProject) = WriteFixture(sourceRoot);
+        string outputRoot = NewDirectory("pipeline-tests");
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("test/Contracts", contractsProject, TargetKind.Library),
+            new CorpusApp("test/Producer", producerProject, TargetKind.Library),
+        });
+
+        Assert.All(
+            result.Apps,
+            app => Assert.True(
+                app.Succeeded,
+                $"Expected default --via-sdk/gsc compilation to succeed for {app.AppId}. Stages: " +
+                    string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status))));
+
+        string contracts = ReadAppOutput(outputRoot, result.RunId, "test_Contracts");
+        string producer = ReadAppOutput(outputRoot, result.RunId, "test_Producer");
+        Assert.Contains("class Result", contracts, StringComparison.Ordinal);
+        Assert.Contains("type Callback = delegate func(enforce bool = false) Result?", producer, StringComparison.Ordinal);
+        Assert.Contains("callback ((bool) -> Result?)?", producer, StringComparison.Ordinal);
+        Assert.Contains("func Produce(enforce bool) Result? -> nil", producer, StringComparison.Ordinal);
+        Assert.Contains("Holder(Produce)", producer, StringComparison.Ordinal);
+        Assert.DoesNotContain("Produce!!", producer, StringComparison.Ordinal);
+    }
+
+    private static (string ContractsProject, string ProducerProject) WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+
+        string contractsDir = Path.Combine(sourceRoot, "Contracts");
+        Directory.CreateDirectory(contractsDir);
+        string contractsProject = Path.Combine(contractsDir, "Contracts.csproj");
+        File.WriteAllText(contractsProject, ProjectFile(projectReference: null));
+        File.WriteAllText(Path.Combine(contractsDir, "Contracts.cs"), """
+            namespace Contracts;
+
+            public sealed class Result { }
+            """);
+
+        string producerDir = Path.Combine(sourceRoot, "Producer");
+        Directory.CreateDirectory(producerDir);
+        string producerProject = Path.Combine(producerDir, "Producer.csproj");
+        File.WriteAllText(
+            producerProject,
+            ProjectFile(Path.GetRelativePath(producerDir, contractsProject)));
+        File.WriteAllText(Path.Combine(producerDir, "Repro.cs"), """
+            using Contracts;
+
+            namespace Producer;
+
+            public delegate Result Callback(bool enforce = false);
+
+            public sealed class Holder
+            {
+                private readonly Callback callback;
+
+                public Holder(Callback callback) => this.callback = callback;
+
+                public Result Run(bool enforce = false) => callback?.Invoke(enforce);
+            }
+
+            public static class Repro
+            {
+                private static Result Produce(bool enforce) => null;
+
+                public static Holder Create() => new Holder(Produce);
+            }
+            """);
+
+        return (contractsProject, producerProject);
+    }
+
+    private static string ProjectFile(string projectReference) =>
+        projectReference is null
+            ? """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """
+            : $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <ProjectReference Include="{projectReference}" />
+                  </ItemGroup>
+                </Project>
+                """;
+
+    private static string ReadAppOutput(string outputRoot, string runId, string appDirectory)
+    {
+        string directory = Path.Combine(outputRoot, runId, appDirectory);
+        return string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(directory, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2504",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2504NamedDelegateReturnTaintTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2504NamedDelegateReturnTaintTranslationTests.cs
@@ -1,0 +1,397 @@
+// <copyright file="Issue2504NamedDelegateReturnTaintTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2504: source named-delegate return contracts participate in the
+/// oblivious callable-return taint graph without borrowing callable-envelope
+/// nullability or changing delegate parameter variance.
+/// </summary>
+public sealed class Issue2504NamedDelegateReturnTaintTranslationTests
+{
+    [Fact]
+    public void MinimalMethodGroup_ConstructorAndConditionalInvoke_ConvergeBothDimensions()
+    {
+        string printed = TranslateOblivious("""
+            namespace Demo;
+
+            public sealed class Result { }
+            public delegate Result Callback();
+
+            public sealed class Holder
+            {
+                private readonly Callback callback;
+
+                public Holder(Callback callback) => this.callback = callback;
+
+                public Result Run() => callback?.Invoke();
+            }
+
+            public static class Repro
+            {
+                private static Result Produce() => null;
+
+                public static Holder Create() => new Holder(Produce);
+            }
+            """);
+
+        Assert.Contains("type Callback = delegate func() Result?", printed, StringComparison.Ordinal);
+        Assert.Contains("callback (() -> Result?)?", printed, StringComparison.Ordinal);
+        Assert.Contains("func Produce() Result? -> nil", printed, StringComparison.Ordinal);
+        Assert.Contains("Holder(Produce)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Produce!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EveryConversionSeam_MethodGroupsAndLambdas_JoinOneContract()
+    {
+        string printed = TranslateOblivious("""
+            namespace Demo;
+
+            public sealed class Result { }
+            public delegate Result Callback(bool enforce = false);
+
+            public static class Repro
+            {
+                private static Callback field = Clean;
+                public static Callback Property { get; } = _ => null;
+                public static event Callback Changed;
+
+                private static Result Clean(bool enforce) => new Result();
+                private static Result Produce(bool enforce) => null;
+
+                public static void Accept(Callback callback) { }
+                public static Callback Return() => Produce;
+
+                public static void Wire()
+                {
+                    Callback local = Clean;
+                    local = Produce;
+                    Accept(value => value ? null : new Result());
+                    Changed += Produce;
+                }
+            }
+            """);
+
+        Assert.Contains("type Callback = delegate func(enforce bool = false) Result?", printed, StringComparison.Ordinal);
+        Assert.Contains("func Clean(enforce bool) Result?", printed, StringComparison.Ordinal);
+        Assert.Contains("func Produce(enforce bool) Result?", printed, StringComparison.Ordinal);
+        Assert.Contains("func Accept(callback (bool) -> Result?)", printed, StringComparison.Ordinal);
+        Assert.Contains("func Return() (bool) -> Result?", printed, StringComparison.Ordinal);
+        Assert.Contains("event Changed Callback", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CallableEnvelopeAndReturnNullability_RemainIndependent()
+    {
+        string printed = TranslateOblivious("""
+            namespace Demo;
+
+            public sealed class Result { }
+            public delegate Result CleanCallback();
+            public delegate Result NullableResultCallback();
+            public delegate Result OptionalNullableResultCallback();
+
+            public static class Repro
+            {
+                private static CleanCallback clean = () => new Result();
+                private static CleanCallback optionalClean = () => new Result();
+                private static NullableResultCallback nullableResult = () => null;
+                private static OptionalNullableResultCallback optionalNullableResult = () => null;
+
+                public static Result RunOptionalClean() => optionalClean?.Invoke();
+                public static Result RunOptionalNullable() => optionalNullableResult?.Invoke();
+            }
+            """);
+
+        Assert.Contains("type CleanCallback = delegate func() Result", printed, StringComparison.Ordinal);
+        Assert.Contains("type NullableResultCallback = delegate func() Result?", printed, StringComparison.Ordinal);
+        Assert.Contains("type OptionalNullableResultCallback = delegate func() Result?", printed, StringComparison.Ordinal);
+        Assert.Contains("optionalClean (() -> Result)?", printed, StringComparison.Ordinal);
+        Assert.Contains("nullableResult () -> Result?", printed, StringComparison.Ordinal);
+        Assert.Contains("optionalNullableResult (() -> Result?)?", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GenericAndStructuredReturns_ReuseExistingReturnShapePromotion()
+    {
+        string printed = TranslateOblivious("""
+            using System.Threading.Tasks;
+
+            namespace Demo;
+
+            public sealed class Result { }
+            public sealed class Box<T> { }
+
+            public delegate T GenericCallback<T>() where T : class;
+            public delegate Task<Result> TaskCallback();
+            public delegate ValueTask<Result> ValueTaskCallback();
+            public delegate (Result First, Result Second) TupleCallback();
+            public delegate (Result First, Result Second) LambdaTupleCallback();
+            public delegate Result[] ArrayCallback();
+            public delegate Box<Result> NestedCallback();
+
+            public static class Repro
+            {
+                private static T GenericProduce<T>() where T : class => null;
+                private static async Task<Result> TaskProduce() => null;
+                private static async ValueTask<Result> ValueTaskProduce() => null;
+                private static (Result, Result) TupleProduce()
+                {
+                    Result first = null;
+                    return (first, new Result());
+                }
+                private static Result[] ArrayProduce() => null;
+                private static Box<Result> NestedProduce() => null;
+
+                private static GenericCallback<Result> generic = GenericProduce<Result>;
+                private static TaskCallback task = TaskProduce;
+                private static ValueTaskCallback valueTask = ValueTaskProduce;
+                private static TupleCallback tuple = TupleProduce;
+                private static LambdaTupleCallback lambdaTuple = () =>
+                {
+                    Result first = null;
+                    return (first, new Result());
+                };
+                private static ArrayCallback array = ArrayProduce;
+                private static NestedCallback nested = NestedProduce;
+            }
+            """);
+
+        Assert.Contains("delegate func() T?", printed, StringComparison.Ordinal);
+        Assert.Contains("type TaskCallback = delegate func() Task[Result?]", printed, StringComparison.Ordinal);
+        Assert.Contains("type ValueTaskCallback = delegate func() ValueTask[Result?]", printed, StringComparison.Ordinal);
+        Assert.Contains("type TupleCallback = delegate func() (Result?, Result)", printed, StringComparison.Ordinal);
+        Assert.Contains("type LambdaTupleCallback = delegate func() (Result?, Result)", printed, StringComparison.Ordinal);
+        Assert.Contains("type ArrayCallback = delegate func() []?Result", printed, StringComparison.Ordinal);
+        Assert.Contains("type NestedCallback = delegate func() Box[Result]?", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InterfaceBaseAndParameterVariance_ConvergeOnlyReturnContracts()
+    {
+        string printed = TranslateOblivious("""
+            namespace Demo;
+
+            public sealed class Result { }
+            public delegate Result Callback();
+            public delegate Result Variant(string value);
+
+            public interface IProducer
+            {
+                Result Get();
+            }
+
+            public sealed class InterfaceProducer : IProducer
+            {
+                public Result Get() => null;
+            }
+
+            public abstract class BaseProducer
+            {
+                public abstract Result Get();
+            }
+
+            public sealed class DerivedProducer : BaseProducer
+            {
+                public override Result Get() => null;
+            }
+
+            public static class Repro
+            {
+                private static Result VariantProduce(object value) => null;
+
+                public static Callback FromInterface(IProducer producer) => producer.Get;
+                public static Callback FromBase(BaseProducer producer) => producer.Get;
+                public static Variant Contravariant() => VariantProduce;
+            }
+            """);
+
+        Assert.Contains("func Get() Result?;", printed, StringComparison.Ordinal);
+        Assert.Contains("open func Get() Result?;", printed, StringComparison.Ordinal);
+        Assert.Contains("type Callback = delegate func() Result?", printed, StringComparison.Ordinal);
+        Assert.Contains("type Variant = delegate func(value string) Result?", printed, StringComparison.Ordinal);
+        Assert.Contains("func VariantProduce(value object) Result?", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CrossProjectProducer_PromotesDelegateInDeclaringProject()
+    {
+        CSharpCompilation contracts = CreateCompilation(
+            "Contracts",
+            """
+            namespace Contracts;
+
+            public sealed class Result { }
+            public delegate Result Callback();
+            """,
+            references: null,
+            NullableContextOptions.Disable);
+        CSharpCompilation producer = CreateCompilation(
+            "Producer",
+            """
+            using Contracts;
+
+            namespace Producer;
+
+            public static class Factory
+            {
+                private static Result Produce() => null;
+                public static Callback Create() => Produce;
+            }
+            """,
+            new[] { contracts.ToMetadataReference() },
+            NullableContextOptions.Disable);
+
+        string printed = TranslateCompilation(contracts, new[] { contracts, producer });
+
+        Assert.Contains("type Callback = delegate func() Result?", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReferencedProjectProducer_PromotesConsumerDelegateWithoutCallableAssertion()
+    {
+        CSharpCompilation producer = CreateCompilation(
+            "Producer",
+            """
+            namespace Producer;
+
+            public sealed class Result { }
+
+            public static class Factory
+            {
+                public static Result Produce() => null;
+            }
+            """,
+            references: null,
+            NullableContextOptions.Disable);
+        CSharpCompilation consumer = CreateCompilation(
+            "Consumer",
+            """
+            using Producer;
+
+            namespace Consumer;
+
+            public delegate Result Callback();
+
+            public static class Repro
+            {
+                public static Callback Create() => Factory.Produce;
+            }
+            """,
+            new[] { producer.ToMetadataReference() },
+            NullableContextOptions.Disable);
+
+        string printed = TranslateCompilation(consumer, new[] { producer, consumer });
+
+        Assert.Contains("type Callback = delegate func() Result?", printed, StringComparison.Ordinal);
+        Assert.Contains("Factory.Produce", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Factory.Produce!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NullableEnabledSource_RemainsAnnotationDriven()
+    {
+        string printed = Translate(
+            """
+            #nullable enable
+            namespace Demo;
+
+            public sealed class Result { }
+            public delegate Result Callback();
+            public delegate Result? NullableCallback();
+
+            public static class Repro
+            {
+                private static Result Clean() => new Result();
+                private static Result? Maybe() => null;
+
+                public static Callback First() => Clean;
+                public static NullableCallback Second() => Maybe;
+            }
+            """,
+            NullableContextOptions.Enable);
+
+        Assert.Contains("type Callback = delegate func() Result", printed, StringComparison.Ordinal);
+        Assert.Contains("type NullableCallback = delegate func() Result?", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Clean() Result?", printed, StringComparison.Ordinal);
+    }
+
+    private static string TranslateOblivious(string source) =>
+        Translate(source, NullableContextOptions.Disable);
+
+    private static string Translate(string source, NullableContextOptions nullableContext)
+    {
+        CSharpCompilation compilation = CreateCompilation(
+            "Issue2504",
+            source,
+            references: null,
+            nullableContext);
+        return TranslateCompilation(compilation, siblingCompilations: null);
+    }
+
+    private static CSharpCompilation CreateCompilation(
+        string assemblyName,
+        string source,
+        IEnumerable<MetadataReference> references,
+        NullableContextOptions nullableContext)
+    {
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest),
+            path: assemblyName + ".cs");
+        var allReferences = CSharpProjectLoader.RuntimeReferences()
+            .Concat(references ?? Array.Empty<MetadataReference>());
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { tree },
+            allReferences,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(nullableContext));
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        return compilation;
+    }
+
+    private static string TranslateCompilation(
+        CSharpCompilation compilation,
+        IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        var printed = new List<string>();
+        foreach (SyntaxTree tree in compilation.SyntaxTrees)
+        {
+            SemanticModel model = compilation.GetSemanticModel(tree);
+            var document = new LoadedDocument(tree.FilePath, tree, model);
+            var context = new TranslationContext(
+                compilation,
+                model,
+                document.FilePath,
+                siblingCompilations);
+            CompilationUnit translated = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+            string text = GSharpPrinter.Print(translated);
+            RoundTripResult roundTrip = GSharpRoundTrip.Validate(text);
+            Assert.True(
+                roundTrip.Success,
+                "Translated G# must round-trip. Errors:\n" +
+                    string.Join("\n", roundTrip.Errors) + "\n\nPrinted:\n" + text);
+            printed.Add(text);
+        }
+
+        return string.Join(Environment.NewLine, printed);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -790,6 +790,15 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
+            // Issue #2504/#2496: a method group or lambda is the callable value
+            // itself, never the nullable value produced by invoking it. External
+            // oblivious-return forgiveness belongs at the callable's result
+            // contract, not as `MethodGroup!!` on the delegate conversion seam.
+            if (this.IsCallableValueExpression(recv))
+            {
+                return false;
+            }
+
             // Issue #2164: the classic lazy-singleton pattern initializes a
             // nullable static/instance field (or auto-property) under a null
             // guard (`if (F == null) { F = new(); } ... return F;` / `F ??= …;`),

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -597,8 +597,8 @@ public sealed partial class CSharpToGSharpTranslator
             IMethodSymbol invoke = symbol?.DelegateInvokeMethod;
 
             List<Parameter> parameters = this.MapParameterList(node.ParameterList);
-            GTypeReference returnType = invoke != null && invoke.ReturnsVoid
-                ? null
+            GTypeReference returnType = invoke != null
+                ? this.MapDelegateLikeReturnType(invoke, isAsync: false, node.ReturnType.GetLocation())
                 : this.MapTypeSyntax(node.ReturnType);
             List<TypeParameter> typeParameters = this.MapTypeParameters(symbol);
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -246,9 +246,21 @@ public sealed partial class CSharpToGSharpTranslator
             // Issue #914 (oblivious sink): local-function/lambda return
             // promotion uses the same shared symbol-position decision as a
             // top-level method return.
-            return this.PromoteReturnIfTainted(
-                this.typeMapper.Map(returnType, this.context, location),
-                symbol);
+            GTypeReference mapped = this.typeMapper.Map(returnType, this.context, location);
+            mapped = this.PromoteTupleDeclarationIfTainted(mapped, returnType, symbol);
+
+            if (returnType is INamedTypeSymbol { IsGenericType: true } taskLike
+                && taskLike.TypeArguments.Length == 1
+                && taskLike.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks"
+                && taskLike.Name is "Task" or "ValueTask")
+            {
+                return this.PromoteTaskEnvelopeReturnIfTainted(
+                    mapped,
+                    taskLike.TypeArguments[0],
+                    symbol);
+            }
+
+            return this.PromoteReturnIfTainted(mapped, symbol);
         }
 
         private Parameter MapLambdaParameter(ParameterSyntax parameter)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -998,7 +998,8 @@ public sealed class CSharpTypeMapper
             .Select(p => this.Map(p.Type, context, location))
             .ToList();
 
-        ITypeSymbol returnType = invoke.ReturnType;
+        ITypeSymbol declaredReturnType = invoke.ReturnType;
+        ITypeSymbol returnType = declaredReturnType;
         bool isAsync = false;
 
         // A delegate returning Task / Task<T> maps to the async arrow form
@@ -1014,10 +1015,98 @@ public sealed class CSharpTypeMapper
         var returns = new List<GTypeReference>();
         if (returnType != null && returnType.SpecialType != SpecialType.System_Void)
         {
-            returns.Add(this.Map(returnType, context, location));
+            GTypeReference mappedReturn = this.Map(returnType, context, location);
+
+            // Issue #2504: every structural projection of a source named
+            // delegate must consume the same Invoke-return taint as the named
+            // declaration itself. Task<T> arrows expose the unwrapped T result;
+            // ValueTask<T> remains an explicit envelope in the existing mapper,
+            // so promote its inner result in place.
+            if (declaredReturnType is INamedTypeSymbol { IsGenericType: true, TypeArguments.Length: 1 } taskLike
+                && taskLike.Name == "ValueTask"
+                && taskLike.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks"
+                && mappedReturn is NamedTypeReference { TypeArguments.Count: 1 } valueTaskMapped)
+            {
+                GTypeReference promotedInner = this.PromoteDelegateReturnPosition(
+                    valueTaskMapped.TypeArguments[0],
+                    taskLike.TypeArguments[0],
+                    invoke,
+                    context,
+                    new List<int>());
+                mappedReturn = ReferenceEquals(promotedInner, valueTaskMapped.TypeArguments[0])
+                    ? mappedReturn
+                    : new NamedTypeReference(valueTaskMapped.Name, new[] { promotedInner });
+            }
+            else
+            {
+                mappedReturn = this.PromoteDelegateReturnPosition(
+                    mappedReturn,
+                    returnType,
+                    invoke,
+                    context,
+                    new List<int>());
+            }
+
+            returns.Add(mappedReturn);
         }
 
         return new ArrowTypeReference(parameters, returns, isAsync);
+    }
+
+    private GTypeReference PromoteDelegateReturnPosition(
+        GTypeReference mapped,
+        ITypeSymbol returnType,
+        IMethodSymbol invoke,
+        TranslationContext context,
+        List<int> tuplePath)
+    {
+        if (context.Compilation.Options.NullableContextOptions != NullableContextOptions.Disable)
+        {
+            return mapped;
+        }
+
+        if (mapped is TupleTypeReference mappedTuple
+            && returnType is INamedTypeSymbol { IsTupleType: true } tupleType
+            && mappedTuple.ElementTypes.Count == tupleType.TupleElements.Length)
+        {
+            bool changed = false;
+            var elements = new List<GTypeReference>(mappedTuple.ElementTypes.Count);
+            for (int index = 0; index < mappedTuple.ElementTypes.Count; index++)
+            {
+                tuplePath.Add(index);
+                GTypeReference element = this.PromoteDelegateReturnPosition(
+                    mappedTuple.ElementTypes[index],
+                    tupleType.TupleElements[index].Type,
+                    invoke,
+                    context,
+                    tuplePath);
+                tuplePath.RemoveAt(tuplePath.Count - 1);
+                changed |= !ReferenceEquals(element, mappedTuple.ElementTypes[index]);
+                elements.Add(element);
+            }
+
+            return changed
+                ? new TupleTypeReference(elements) { IsNullable = mappedTuple.IsNullable }
+                : mapped;
+        }
+
+        bool tainted = tuplePath.Count == 0
+            ? ObliviousNullabilityAnalyzer.IsTainted(
+                context.Compilation,
+                invoke,
+                context.SiblingCompilations)
+            : ObliviousNullabilityAnalyzer.IsTupleElementTainted(
+                context.Compilation,
+                invoke,
+                tuplePath,
+                context.SiblingCompilations);
+
+        return tainted
+            && !mapped.IsNullable
+            && returnType is { IsReferenceType: true }
+            && returnType.NullableAnnotation != NullableAnnotation.Annotated
+                ? WithNullable(mapped, true)
+                : mapped;
     }
 }
 

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -59,6 +59,7 @@ internal static class ObliviousNullabilityAnalyzer
     // a fresh entry and stale ones are collectible — same pattern as the
     // subclassed-base-types / partial-type-parts caches in the translator.
     private static readonly ConditionalWeakTable<Compilation, TaintResult> Cache = new();
+    private static readonly ConditionalWeakTable<Compilation, SourceAssemblySet> SourceAssemblies = new();
 
     // Which source expressions a transitive return/forwarding edge follows.
     private enum SourceScope
@@ -102,6 +103,7 @@ internal static class ObliviousNullabilityAnalyzer
             return false;
         }
 
+        RegisterSourceAssemblies(compilation, null);
         return Cache.GetValue(compilation, Compute).Tainted.Contains(Canonical(symbol));
     }
 
@@ -130,8 +132,10 @@ internal static class ObliviousNullabilityAnalyzer
     /// <para>
     /// Deliberately scoped to <paramref name="symbol"/> ITSELF (plus its
     /// remapped counterpart in each sibling) — never a same-compilation
-    /// backward walk through <paramref name="compilation"/>'s own assignment
-    /// edges to some OTHER, indirectly-connected declaration. Issue #2412's
+    /// backward walk through ordinary assignment edges to some OTHER,
+    /// indirectly-connected declaration. The sole exception is issue #2504's
+    /// explicitly tracked named-delegate return-contract edge, whose source
+    /// callable may be declared in a referenced sibling. Issue #2412's
     /// own worked example is explicit that the fix must insert `!!`
     /// forgiveness AT THE CONSUMPTION SITE while leaving the consuming
     /// project's OWN declarations (e.g. an object-initializer target
@@ -167,6 +171,7 @@ internal static class ObliviousNullabilityAnalyzer
             return false;
         }
 
+        RegisterSourceAssemblies(compilation, siblingCompilations);
         return IsTaintedCore(
             compilation,
             Canonical(symbol),
@@ -200,6 +205,7 @@ internal static class ObliviousNullabilityAnalyzer
             return false;
         }
 
+        RegisterSourceAssemblies(compilation, siblingCompilations);
         return IsTupleElementTaintedCore(
             compilation,
             Canonical(symbol),
@@ -232,6 +238,7 @@ internal static class ObliviousNullabilityAnalyzer
             return false;
         }
 
+        RegisterSourceAssemblies(compilation, siblingCompilations);
         return IsTupleElementTaintedCore(
             compilation,
             source.Symbol,
@@ -267,6 +274,20 @@ internal static class ObliviousNullabilityAnalyzer
                     compilation,
                     source.Symbol,
                     source.Path,
+                    siblingCompilations,
+                    scalarVisited,
+                    tupleVisited))
+            {
+                return true;
+            }
+        }
+
+        foreach ((ISymbol target, ISymbol source) in result.DelegateReturnEdges)
+        {
+            if (SymbolEqualityComparer.Default.Equals(target, query.Symbol)
+                && IsTaintedCore(
+                    compilation,
+                    source,
                     siblingCompilations,
                     scalarVisited,
                     tupleVisited))
@@ -487,6 +508,7 @@ internal static class ObliviousNullabilityAnalyzer
         var tupleEdges = new List<(TupleElementKey Target, TupleElementKey Source)>();
         var tupleScalarEdges = new List<(TupleElementKey Target, ISymbol Source)>();
         var scalarTupleEdges = new List<(ISymbol Target, TupleElementKey Source)>();
+        var delegateReturnEdges = new List<(ISymbol Target, ISymbol Source)>();
 
         foreach (SyntaxTree tree in compilation.SyntaxTrees)
         {
@@ -514,6 +536,15 @@ internal static class ObliviousNullabilityAnalyzer
                 tupleEdges,
                 tupleScalarEdges,
                 scalarTupleEdges);
+            CollectDelegateReturnContractEdges(
+                compilation,
+                root,
+                model,
+                tainted,
+                edges,
+                delegateReturnEdges,
+                tupleTainted,
+                tupleEdges);
         }
 
         // Issue #2285: an interface member and every member that implements it
@@ -522,7 +553,7 @@ internal static class ObliviousNullabilityAnalyzer
         // parameter) to `T?` while leaving the other (the interface property it
         // satisfies) non-null `T` — see <see cref="CollectInterfaceImplementationEdges"/>.
         CollectInterfaceImplementationEdges(compilation, edges);
-        CollectOverrideParameterEdges(compilation, edges);
+        CollectOverrideContractEdges(compilation, edges);
         CollectTupleContractEdges(compilation, tupleTainted, tupleEdges);
 
         // Fixpoint: propagate taint along the edge set until it stabilizes.
@@ -572,7 +603,8 @@ internal static class ObliviousNullabilityAnalyzer
             tupleTainted,
             tupleEdges,
             tupleScalarEdges,
-            scalarTupleEdges);
+            scalarTupleEdges,
+            delegateReturnEdges);
     }
 
     // Seeds direct null evidence for a value declaration symbol (field /
@@ -833,6 +865,17 @@ internal static class ObliviousNullabilityAnalyzer
                         model.GetDeclaredSymbol(localFunction),
                         localFunction.ExpressionBody?.Expression,
                         localFunction.Body,
+                        model,
+                        tupleTainted,
+                        tupleEdges,
+                        tupleScalarEdges);
+                    break;
+
+                case AnonymousFunctionExpressionSyntax lambda:
+                    CollectTupleReturnFlows(
+                        model.GetSymbolInfo(lambda).Symbol as IMethodSymbol,
+                        lambda.Body as ExpressionSyntax,
+                        lambda.Body as BlockSyntax,
                         model,
                         tupleTainted,
                         tupleEdges,
@@ -1676,6 +1719,17 @@ internal static class ObliviousNullabilityAnalyzer
                         scalarTupleEdges);
                     break;
 
+                case AnonymousFunctionExpressionSyntax lambda:
+                    SeedMethodLikeReturnTaint(
+                        model.GetSymbolInfo(lambda).Symbol,
+                        lambda.Body as ExpressionSyntax,
+                        lambda.Body as BlockSyntax,
+                        model,
+                        tainted,
+                        edges,
+                        scalarTupleEdges);
+                    break;
+
                 // Property / indexer getters: the "return type" is the
                 // property's own type and the taint TARGET is the property
                 // symbol itself. A getter whose expression body / `get` accessor
@@ -2018,21 +2072,12 @@ internal static class ObliviousNullabilityAnalyzer
             return;
         }
 
-        ITypeSymbol effectiveReturnType = UnwrapAwaitedType(interfaceMethod.ReturnType);
-        if (!interfaceMethod.ReturnsVoid
-            && effectiveReturnType is { IsReferenceType: true }
-            && effectiveReturnType.NullableAnnotation != NullableAnnotation.Annotated)
-        {
-            ISymbol interfaceCanonical = Canonical(interfaceMethod);
-            ISymbol implCanonical = Canonical(implementingMethod);
-            edges.Add((interfaceCanonical, implCanonical));
-            edges.Add((implCanonical, interfaceCanonical));
-        }
+        AddReturnContractEdges(interfaceMethod, implementingMethod, edges);
 
         AddParameterContractEdges(interfaceMethod.Parameters, implementingMethod.Parameters, edges);
     }
 
-    private static void CollectOverrideParameterEdges(
+    private static void CollectOverrideContractEdges(
         Compilation compilation,
         List<(ISymbol Target, ISymbol Source)> edges)
     {
@@ -2043,6 +2088,7 @@ internal static class ObliviousNullabilityAnalyzer
                 if (method.MethodKind == MethodKind.Ordinary
                     && method.OverriddenMethod is IMethodSymbol overridden)
                 {
+                    AddReturnContractEdges(method, overridden, edges);
                     AddParameterContractEdges(method.Parameters, overridden.Parameters, edges);
                 }
             }
@@ -2055,6 +2101,26 @@ internal static class ObliviousNullabilityAnalyzer
                 }
             }
         }
+    }
+
+    private static void AddReturnContractEdges(
+        IMethodSymbol first,
+        IMethodSymbol second,
+        List<(ISymbol Target, ISymbol Source)> edges)
+    {
+        ITypeSymbol effectiveReturnType = UnwrapAwaitedType(first.ReturnType);
+        if (first.ReturnsVoid
+            || second.ReturnsVoid
+            || effectiveReturnType is not { IsReferenceType: true }
+            || effectiveReturnType.NullableAnnotation == NullableAnnotation.Annotated)
+        {
+            return;
+        }
+
+        ISymbol firstCanonical = Canonical(first);
+        ISymbol secondCanonical = Canonical(second);
+        edges.Add((firstCanonical, secondCanonical));
+        edges.Add((secondCanonical, firstCanonical));
     }
 
     private static void AddParameterContractEdges(
@@ -2157,6 +2223,123 @@ internal static class ObliviousNullabilityAnalyzer
             string.Empty,
             tupleTainted,
             tupleEdges);
+    }
+
+    // Issue #2504: a source named delegate's Invoke return is a declaration
+    // contract just like an interface/base method return. Roslyn exposes the
+    // selected method group or synthesized lambda method and the converted
+    // delegate type at every conversion seam, independent of whether that seam
+    // is an initializer, assignment, argument, return, or multicast update.
+    private static void CollectDelegateReturnContractEdges(
+        Compilation compilation,
+        SyntaxNode root,
+        SemanticModel model,
+        HashSet<ISymbol> tainted,
+        List<(ISymbol Target, ISymbol Source)> edges,
+        List<(ISymbol Target, ISymbol Source)> delegateReturnEdges,
+        HashSet<TupleElementKey> tupleTainted,
+        List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges)
+    {
+        foreach (ExpressionSyntax expression in root.DescendantNodes().OfType<ExpressionSyntax>())
+        {
+            bool isLambda = expression is AnonymousFunctionExpressionSyntax;
+            if (!isLambda && model.GetMemberGroup(expression).IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            if (model.GetTypeInfo(expression).ConvertedType is not INamedTypeSymbol delegateType
+                || delegateType.TypeKind != TypeKind.Delegate
+                || !IsSourceDelegateType(compilation, delegateType)
+                || delegateType.DelegateInvokeMethod is not IMethodSymbol invoke
+                || invoke.ReturnsVoid)
+            {
+                continue;
+            }
+
+            IMethodSymbol source = model.GetSymbolInfo(expression).Symbol as IMethodSymbol;
+            if (source == null || source.ReturnsVoid)
+            {
+                continue;
+            }
+
+            if (TryGetTupleType(invoke, out INamedTypeSymbol invokeTuple)
+                && TryGetTupleType(source, out INamedTypeSymbol sourceTuple))
+            {
+                AddTupleContractPair(
+                    invoke,
+                    invokeTuple,
+                    source,
+                    sourceTuple,
+                    tupleTainted,
+                    tupleEdges);
+                continue;
+            }
+
+            if (!IsEligibleScalarTarget(invoke))
+            {
+                continue;
+            }
+
+            ISymbol invokeCanonical = Canonical(invoke);
+            ISymbol sourceCanonical = Canonical(source);
+            edges.Add((invokeCanonical, sourceCanonical));
+            edges.Add((sourceCanonical, invokeCanonical));
+            delegateReturnEdges.Add((invokeCanonical, sourceCanonical));
+            delegateReturnEdges.Add((sourceCanonical, invokeCanonical));
+
+            if (UnwrapAwaitedType(source.ReturnType).NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                tainted.Add(invokeCanonical);
+            }
+        }
+    }
+
+    private static bool IsSourceDelegateType(Compilation compilation, INamedTypeSymbol delegateType)
+    {
+        SourceAssemblySet assemblies = SourceAssemblies.GetValue(
+            compilation,
+            static current => new SourceAssemblySet(current.Assembly.Identity.GetDisplayName()));
+        lock (assemblies.Names)
+        {
+            return assemblies.Names.Contains(delegateType.ContainingAssembly.Identity.GetDisplayName());
+        }
+    }
+
+    private static void RegisterSourceAssemblies(
+        CSharpCompilation compilation,
+        IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        var compilations = new List<CSharpCompilation> { compilation };
+        if (siblingCompilations != null)
+        {
+            compilations.AddRange(siblingCompilations.Where(candidate => candidate != null));
+        }
+
+        string[] names = compilations
+            .Select(candidate => candidate.Assembly.Identity.GetDisplayName())
+            .Distinct(System.StringComparer.Ordinal)
+            .ToArray();
+
+        foreach (CSharpCompilation candidate in compilations)
+        {
+            SourceAssemblySet assemblies = SourceAssemblies.GetValue(
+                candidate,
+                static current => new SourceAssemblySet(current.Assembly.Identity.GetDisplayName()));
+            bool changed = false;
+            lock (assemblies.Names)
+            {
+                foreach (string name in names)
+                {
+                    changed |= assemblies.Names.Add(name);
+                }
+            }
+
+            if (changed)
+            {
+                Cache.Remove(candidate);
+            }
+        }
     }
 
     // Unwraps a (non-generic-parameter) `System.Threading.Tasks.Task<T>` or
@@ -2336,6 +2519,15 @@ internal static class ObliviousNullabilityAnalyzer
             return;
         }
 
+        // Issue #2504/#2496: assigning or returning a lambda/method group moves
+        // the callable object, not the value produced by invoking it. Its result
+        // taint is wired separately to the converted named delegate's Invoke
+        // contract; it must never make the delegate envelope itself nullable.
+        if (IsCallableValueExpression(value, model))
+        {
+            return;
+        }
+
         if (IsDirectlyNullable(value, model))
         {
             tainted.Add(target);
@@ -2387,6 +2579,17 @@ internal static class ObliviousNullabilityAnalyzer
         }
 
         AddEdges(target, value, model, edges, scope);
+    }
+
+    private static bool IsCallableValueExpression(ExpressionSyntax expression, SemanticModel model)
+    {
+        while (expression is ParenthesizedExpressionSyntax parenthesized)
+        {
+            expression = parenthesized.Expression;
+        }
+
+        return expression is AnonymousFunctionExpressionSyntax
+            || !model.GetMemberGroup(expression).IsDefaultOrEmpty;
     }
 
     private static IEnumerable<ISymbol> ResolveSources(
@@ -2775,13 +2978,15 @@ internal static class ObliviousNullabilityAnalyzer
             HashSet<TupleElementKey> tupleTainted,
             List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges,
             List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges,
-            List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges)
+            List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges,
+            List<(ISymbol Target, ISymbol Source)> delegateReturnEdges)
         {
             this.Tainted = tainted;
             this.TupleTainted = tupleTainted;
             this.TupleEdges = tupleEdges;
             this.TupleScalarEdges = tupleScalarEdges;
             this.ScalarTupleEdges = scalarTupleEdges;
+            this.DelegateReturnEdges = delegateReturnEdges;
         }
 
         public HashSet<ISymbol> Tainted { get; }
@@ -2793,5 +2998,17 @@ internal static class ObliviousNullabilityAnalyzer
         public List<(TupleElementKey Target, ISymbol Source)> TupleScalarEdges { get; }
 
         public List<(ISymbol Target, TupleElementKey Source)> ScalarTupleEdges { get; }
+
+        public List<(ISymbol Target, ISymbol Source)> DelegateReturnEdges { get; }
+    }
+
+    private sealed class SourceAssemblySet
+    {
+        public SourceAssemblySet(string currentAssembly)
+        {
+            this.Names = new HashSet<string>(System.StringComparer.Ordinal) { currentAssembly };
+        }
+
+        public HashSet<string> Names { get; }
     }
 }


### PR DESCRIPTION
Fixes #2504.

## Summary
- connect named delegate Invoke returns to converted method groups, local functions, and lambdas in the oblivious nullability graph
- synchronize structural delegate projections, task/value-task and tuple result shapes, base/interface contracts, and cross-project evidence without conflating callable envelopes
- add focused translation coverage plus a live default `--via-sdk`/gsc sink regression

## Validation
- 72 focused oblivious-nullability tests passed
- 24 delegate compatibility controls passed
- 23 final issue/interface/lambda tests passed with `MSBUILDDISABLENODEREUSE=1`