### PR TITLE
Fix promoted call receiver null forgiveness

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessPipelineTests.cs
@@ -1,0 +1,168 @@
+// <copyright file="Issue2506PromotedCallReceiverForgivenessPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Default <c>--via-sdk</c>/gsc sink coverage for the minimal issue #2506
+/// promoted-call receiver and the Oahu <c>FromCountryCode(...).Domain</c>
+/// extension-call shape.
+/// </summary>
+public sealed class Issue2506PromotedCallReceiverForgivenessPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_PromotedSameProjectCallReceivers_TranslateAndCompile()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectPath = WriteFixture(sourceRoot);
+        string outputRoot = NewDirectory("pipeline-tests");
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(
+            new[] { new CorpusApp("test/Issue2506", projectPath, TargetKind.Library) });
+        AppResult appResult = Assert.Single(result.Apps);
+
+        string appRunDir = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(appResult.AppId));
+        string emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(appRunDir, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains("Repro.Find(false)!!.Name", emitted, StringComparison.Ordinal);
+        Assert.Contains(
+            "Locale.FromCountryCode(region)!!.Domain",
+            emitted,
+            StringComparison.Ordinal);
+        Assert.Contains("Repro.FindFactory()!!().Name", emitted, StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            "Expected default --via-sdk/gsc compilation to accept promoted same-project call receivers. Stages: " +
+                string.Join("; ", appResult.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+    }
+
+    private static string WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+        string projectDir = Path.Combine(sourceRoot, "Issue2506");
+        Directory.CreateDirectory(projectDir);
+
+        string projectPath = Path.Combine(projectDir, "Issue2506.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>disable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "Repro.cs"), """
+            using System;
+
+            namespace Issue2506;
+
+            public sealed class Item
+            {
+                public string Name { get; } = "item";
+            }
+
+            public enum ERegion
+            {
+                Unknown,
+            }
+
+            public interface ILocale
+            {
+                string Domain { get; }
+            }
+
+            public sealed class LocaleValue : ILocale
+            {
+                public string Domain { get; } = "example.test";
+            }
+
+            public static class Locale
+            {
+                public static ILocale FromCountryCode(this ERegion region) => null;
+            }
+
+            public static class Repro
+            {
+                private static Item Find(bool found) => found ? new Item() : null;
+                private static Func<Item> FindFactory() => null;
+
+                public static string Read() => Find(false).Name;
+                public static string ReadFactory() => FindFactory()().Name;
+                public static string ReadDomain(ERegion region) =>
+                    Locale.FromCountryCode(region).Domain;
+            }
+            """);
+
+        return projectPath;
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2506",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
@@ -1,0 +1,354 @@
+// <copyright file="Issue2506PromotedCallReceiverForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression coverage for issue #2506: in a nullable-oblivious compilation,
+/// a same-project method or local-function return promoted to <c>T?</c> must be
+/// forgiven when its call is used as an ordinary receiver. The assertion
+/// preserves C#'s throw-on-null behavior and must not spread into null-tolerant
+/// or expression-tree contexts.
+/// </summary>
+public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
+{
+    [Fact]
+    public void PromotedCalls_OrdinaryReceiverShapes_AssertAtEachReceiver()
+    {
+        string printed = Translate("""
+            using System;
+            using System.Collections.Generic;
+
+            namespace Demo;
+
+            public class Item
+            {
+                public string Name => "item";
+                public string Read() => Name;
+                public string this[int index] => Name;
+                public Item Next() => null;
+            }
+
+            public static class ItemExtensions
+            {
+                public static string ExtensionName(this Item item) => item.Name;
+                public static Item NextExtension(this Item item) => null;
+            }
+
+            public sealed class Holder
+            {
+                public Item Child => null;
+                public Item this[int index] => null;
+            }
+
+            public static class Repro
+            {
+                private static Item Find() => null;
+                private static Item Always() => new();
+                private static IEnumerable<Item> FindMany() => null;
+                private static Func<Item> FindFactory() => null;
+                private static Holder GetHolder() => new();
+                private static T FindGeneric<T>() where T : class => null;
+
+                public static string Property() => Find().Name;
+                public static string Method() => Find().Read();
+                public static string Indexer() => Find()[0];
+                public static string Extension() => Find().ExtensionName();
+                public static string ExtensionResult() => Find().NextExtension().Name;
+                public static string Chain() => Find().Next().Name;
+                public static string PropertyResult() => GetHolder().Child.Name;
+                public static string IndexerResult() => GetHolder()[0].Name;
+                public static string GenericResult() => FindGeneric<Item>().Name;
+                public static string DelegateInvoke() => FindFactory().Invoke().Name;
+                public static string DirectDelegateInvoke() => FindFactory()().Name;
+                public static string Parenthesized() => (Find()).Name;
+                public static string Cast() => ((Item)Find()).Name;
+                public static string Conditional(bool condition) =>
+                    (condition ? Find() : Always()).Name;
+
+                public static string LocalFunction()
+                {
+                    Item LocalFind() => null;
+                    return LocalFind().Name;
+                }
+
+                public static int Enumerate()
+                {
+                    var count = 0;
+                    foreach (var item in FindMany())
+                        count++;
+                    return count;
+                }
+            }
+            """);
+
+        Assert.Contains("Repro.Find()!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("Repro.Find()!!.Read()", printed, StringComparison.Ordinal);
+        Assert.Contains("Repro.Find()!![0]", printed, StringComparison.Ordinal);
+        Assert.Contains("Repro.Find().ExtensionName()", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Repro.Find()!!.ExtensionName()", printed, StringComparison.Ordinal);
+        Assert.Contains("Repro.Find().NextExtension()!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("Repro.Find()!!.Next()!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("Repro.GetHolder().Child!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("Repro.GetHolder()[0]!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("FindGeneric[Item]()!!.Name", printed, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(printed, "Repro.FindFactory()!!().Name"));
+        Assert.Contains("(Repro.Find())!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("(Item(Repro.Find()!!)).Name", printed, StringComparison.Ordinal);
+        Assert.Contains(
+            "(if condition { Repro.Find() } else { Repro.Always() })!!.Name",
+            printed,
+            StringComparison.Ordinal);
+        Assert.Contains("LocalFind()!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("for item in Repro.FindMany()!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PromotedDirectCall_AssertsAndEvaluatesOnce()
+    {
+        string printed = Translate("""
+            namespace Demo;
+
+            public sealed class Item
+            {
+                public string Name => "item";
+            }
+
+            public static class Repro
+            {
+                private static Item Find() => null;
+
+                public static string Direct() => Find().Name;
+            }
+            """);
+
+        Assert.Contains("Repro.Find()!!.Name", printed, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(printed, "Repro.Find()"));
+    }
+
+    [Fact]
+    public void PromotedLocal_ControlExistingLocalReceiverForgiveness()
+    {
+        string printed = Translate("""
+            namespace Demo;
+
+            public sealed class Item
+            {
+                public string Name => "item";
+            }
+
+            public static class Repro
+            {
+                private static Item Find() => null;
+
+                public static string ThroughLocal()
+                {
+                    var item = Find();
+                    return item.Name;
+                }
+            }
+            """);
+
+        Assert.Contains("item!!.Name", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AwaitedPromotedResult_AssertsBeforeMemberAccess()
+    {
+        string printed = Translate("""
+            using System.Threading.Tasks;
+
+            namespace Demo;
+
+            public sealed class Item
+            {
+                public string Name => "item";
+            }
+
+            public static class Repro
+            {
+                private static async Task<Item> FindAsync() => null;
+
+                public static async Task<string> Awaited() => (await FindAsync()).Name;
+                public static string Envelope() => FindAsync().ToString();
+            }
+            """);
+
+        Assert.Contains("(await Repro.FindAsync())!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("Repro.FindAsync().ToString()", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Repro.FindAsync()!!.ToString()", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UsingPromotedResource_ControlRemainsNullTolerant()
+    {
+        string printed = Translate("""
+            using System;
+
+            namespace Demo;
+
+            public sealed class Resource : IDisposable
+            {
+                public void Dispose() { }
+            }
+
+            public static class Repro
+            {
+                private static Resource Open() => null;
+
+                public static void Use()
+                {
+                    using (Open())
+                    {
+                    }
+                }
+            }
+            """);
+
+        Assert.Contains("using let __using = Repro.Open()", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Repro.Open()!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConditionalAccessNullableEnabledFlowAndExpressionTrees_AvoidObliviousOverAssertion()
+    {
+        string oblivious = Translate("""
+            using System;
+            using System.Linq.Expressions;
+
+            namespace Demo;
+
+            public sealed class Item
+            {
+                public string Name => "item";
+            }
+
+            public static class Repro
+            {
+                private static Item Find() => null;
+
+                public static string Conditional() => Find()?.Name;
+                public static Expression<Func<string>> Tree() => () => Find().Name;
+            }
+            """);
+
+        Assert.Contains("Repro.Find()?.Name", oblivious, StringComparison.Ordinal);
+        Assert.DoesNotContain("Repro.Find()!!?.Name", oblivious, StringComparison.Ordinal);
+        Assert.Contains("Repro.Find().Name", oblivious, StringComparison.Ordinal);
+        Assert.DoesNotContain("() -> Repro.Find()!!.Name", oblivious, StringComparison.Ordinal);
+
+        string enabled = Translate("""
+            #nullable enable
+            namespace Demo;
+
+            public sealed class Item
+            {
+                public string Name => "item";
+            }
+
+            public static class Repro
+            {
+                private static Item? ExplicitMaybe() => null;
+                private static Item Always() => new();
+
+                public static string ExplicitContract() => ExplicitMaybe().Name;
+                public static string SuppressedContract() => ExplicitMaybe()!.Name;
+                public static string NonNullContract() => Always().Name;
+
+                public static string Guarded()
+                {
+                    var item = ExplicitMaybe();
+                    if (item is null)
+                        return "";
+                    return item.Name;
+                }
+            }
+            """);
+
+        Assert.Contains("Repro.ExplicitMaybe().Name", enabled, StringComparison.Ordinal);
+        Assert.Contains("Repro.ExplicitMaybe()!!.Name", enabled, StringComparison.Ordinal);
+        Assert.Contains("Repro.Always().Name", enabled, StringComparison.Ordinal);
+        Assert.DoesNotContain("Repro.Always()!!.Name", enabled, StringComparison.Ordinal);
+        Assert.Contains("item!!.Name", enabled, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InterfaceBaseAndGenericContracts_ForgivePromotedCallResults()
+    {
+        string printed = Translate("""
+            namespace Demo;
+
+            public class Item
+            {
+                public string Name => "item";
+            }
+
+            public interface IProvider
+            {
+                Item Find();
+            }
+
+            public abstract class ProviderBase
+            {
+                public abstract Item Find();
+            }
+
+            public sealed class Provider : ProviderBase, IProvider
+            {
+                public override Item Find() => null;
+            }
+
+            public static class Repro
+            {
+                public static string ViaInterface(IProvider provider) => provider.Find().Name;
+                public static string ViaBase(ProviderBase provider) => provider.Find().Name;
+                public static string ViaGeneric<T>(T provider) where T : IProvider => provider.Find().Name;
+            }
+            """);
+
+        Assert.Equal(3, CountOccurrences(printed, "provider.Find()!!.Name"));
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        int count = 0;
+        for (int index = text.IndexOf(value, StringComparison.Ordinal);
+            index >= 0;
+            index = text.IndexOf(value, index + value.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -527,7 +527,7 @@ public sealed partial class CSharpToGSharpTranslator
         {
             GExpression translated = this.TranslateExpression(recv);
 
-            if (this.ReceiverNeedsNullForgiveness(recv)
+            if (this.ReceiverNeedsNullForgiveness(recv, isDereferenceReceiver: true)
                 || this.ReceiverIsNullableReferenceFieldOrProperty(recv))
             {
                 translated = new NonNullAssertionExpression(translated);
@@ -713,9 +713,10 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         // True when <paramref name="member"/> binds to an extension method whose
-        // (reduced) `this` parameter is nullable-annotated (`this T? x`). Such a
-        // method is designed to accept a null receiver, so the translated call must
-        // keep the declared-nullable receiver rather than forgive it to non-null.
+        // (reduced) `this` parameter is nullable-annotated (`this T? x`) or was
+        // promoted nullable by oblivious analysis. Such a method is designed to
+        // accept a null receiver, so the translated call must keep that nullable
+        // receiver rather than forgive it to non-null.
         private bool MemberBindsToNullableThisExtension(MemberAccessExpressionSyntax member)
         {
             if (this.context.GetSymbolInfo(member).Symbol is not IMethodSymbol method)
@@ -732,6 +733,7 @@ public sealed partial class CSharpToGSharpTranslator
             IParameterSymbol thisParameter = unreduced.Parameters[0];
             return thisParameter.Type.IsReferenceType
                 ? thisParameter.NullableAnnotation == NullableAnnotation.Annotated
+                    || this.ShouldPromoteToNullableReference(thisParameter)
                 : thisParameter.Type.OriginalDefinition?.SpecialType == SpecialType.System_Nullable_T;
         }
 
@@ -757,12 +759,15 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         /// <summary>
-        /// Determines whether <paramref name="recv"/> is a declared-nullable
-        /// reference receiver that Roslyn's flow analysis has narrowed to non-null,
-        /// and therefore needs a G# <c>!!</c> assertion (see
+        /// Determines whether <paramref name="recv"/> needs a G# <c>!!</c>
+        /// assertion because it is either a declared-nullable reference narrowed
+        /// non-null by flow or an ordinary dereference receiver whose declaration
+        /// was promoted nullable by oblivious analysis (see
         /// <see cref="TranslateReceiverWithNullForgiveness"/>).
         /// </summary>
-        private bool ReceiverNeedsNullForgiveness(ExpressionSyntax recv)
+        private bool ReceiverNeedsNullForgiveness(
+            ExpressionSyntax recv,
+            bool isDereferenceReceiver = false)
         {
             // `expr!` already lowers to a `NonNullAssertionExpression`; never
             // double-assert. `this`/`base`, a null literal, and a `?.` conditional
@@ -797,6 +802,18 @@ public sealed partial class CSharpToGSharpTranslator
             if (this.IsCallableValueExpression(recv))
             {
                 return false;
+            }
+
+            // Issue #2506: the oblivious analysis promotes a same-project
+            // method/property/indexer declaration when its VALUE can be null.
+            // An ordinary C# dereference of that value still means
+            // throw-on-null, so the corresponding G# receiver needs one `!!`.
+            // Keep this receiver-only: a method group is the callable value
+            // rather than its return, and a promoted call forwarded as a return
+            // or argument must remain `T?` instead of being blanket-forgiven.
+            if (isDereferenceReceiver && this.ReceiverValueIsPromotedNullable(recv))
+            {
+                return true;
             }
 
             // Issue #2164: the classic lazy-singleton pattern initializes a
@@ -988,6 +1005,102 @@ public sealed partial class CSharpToGSharpTranslator
             // too, so its flow-proven uses need the same assertion for consistency.
             return declared.NullableAnnotation == NullableAnnotation.Annotated
                 || this.ShouldPromoteToNullableReference(symbol);
+        }
+
+        private bool ReceiverValueIsPromotedNullable(ExpressionSyntax expression)
+        {
+            if (!this.IsObliviousCompilation())
+            {
+                return false;
+            }
+
+            switch (expression)
+            {
+                case ParenthesizedExpressionSyntax parenthesized:
+                    return this.ReceiverValueIsPromotedNullable(parenthesized.Expression);
+
+                case CastExpressionSyntax cast:
+                    ITypeSymbol castTarget = this.context.GetTypeInfo(cast.Type).Type;
+                    ITypeSymbol castSource = this.context.GetTypeInfo(cast.Expression).Type;
+                    return castTarget != null
+                        && castSource != null
+                        && this.context.Compilation.ClassifyConversion(castSource, castTarget).IsReference
+                        && this.ReceiverValueIsPromotedNullable(cast.Expression);
+
+                case AwaitExpressionSyntax awaited:
+                    return this.AwaitedReceiverValueIsPromotedNullable(awaited.Expression);
+
+                case ConditionalExpressionSyntax conditional:
+                    return this.ReceiverValueIsPromotedNullable(conditional.WhenTrue)
+                        || this.ReceiverValueIsPromotedNullable(conditional.WhenFalse);
+
+                case SwitchExpressionSyntax switchExpression:
+                    return switchExpression.Arms.Any(arm =>
+                        this.ReceiverValueIsPromotedNullable(arm.Expression));
+
+                // `a ?? b` is non-null whenever `b` is non-null; only the
+                // fallback value can make the coalesced receiver nullable.
+                case BinaryExpressionSyntax coalesce
+                    when coalesce.IsKind(SyntaxKind.CoalesceExpression):
+                    return this.ReceiverValueIsPromotedNullable(coalesce.Right);
+
+                case InvocationExpressionSyntax invocation
+                    when this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol method:
+                    // Method-return taint on Task<T>/ValueTask<T> widens the
+                    // awaited T, not the non-null task envelope itself.
+                    return !IsTaskLikeEnvelope(method.ReturnType)
+                        && this.ShouldPromoteToNullableReference(method);
+
+                case ElementAccessExpressionSyntax elementAccess:
+                    return this.context.GetSymbolInfo(elementAccess).Symbol is IPropertySymbol indexer
+                        && this.ShouldPromoteToNullableReference(indexer);
+
+                case IdentifierNameSyntax:
+                case MemberAccessExpressionSyntax:
+                    ISymbol symbol = this.context.GetSymbolInfo(expression).Symbol;
+                    return symbol is IFieldSymbol or IPropertySymbol or ILocalSymbol or IParameterSymbol
+                        && this.ShouldPromoteToNullableReference(symbol);
+
+                default:
+                    return false;
+            }
+        }
+
+        private bool AwaitedReceiverValueIsPromotedNullable(ExpressionSyntax expression)
+        {
+            switch (expression)
+            {
+                case ParenthesizedExpressionSyntax parenthesized:
+                    return this.AwaitedReceiverValueIsPromotedNullable(parenthesized.Expression);
+
+                case CastExpressionSyntax cast:
+                    return this.AwaitedReceiverValueIsPromotedNullable(cast.Expression);
+
+                case ConditionalExpressionSyntax conditional:
+                    return this.AwaitedReceiverValueIsPromotedNullable(conditional.WhenTrue)
+                        || this.AwaitedReceiverValueIsPromotedNullable(conditional.WhenFalse);
+
+                case InvocationExpressionSyntax invocation
+                    when this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol method:
+                    return IsTaskLikeEnvelope(method.ReturnType)
+                        && this.ShouldPromoteToNullableReference(method);
+
+                default:
+                    return false;
+            }
+        }
+
+        private static bool IsTaskLikeEnvelope(ITypeSymbol type)
+        {
+            if (type is not INamedTypeSymbol named
+                || !named.IsGenericType
+                || named.TypeArguments.Length != 1
+                || named.Name is not ("Task" or "ValueTask"))
+            {
+                return false;
+            }
+
+            return named.ContainingNamespace.ToDisplayString() == "System.Threading.Tasks";
         }
 
         // Issue #2164: true when <paramref name="recv"/> reads a nullable

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -244,22 +244,18 @@ public sealed partial class CSharpToGSharpTranslator
 
             var arguments = this.TranslateCallArguments(invocation, invocation.ArgumentList.Arguments);
 
-            // Directly invoking a nullable-reference delegate field/property
-            // (`handler(args)` where `handler` is `((T) -> R)?`) needs a `!!`
-            // assertion on the callee: G# smart-casts only locals, never a
-            // field/property chain, so an unforgiven nullable delegate field is
-            // "not a function" (GS0131) even inside an `if handler != nil` guard.
-            // This is the invocation-callee analog of the receiver `!!` pass
-            // (#1594). It is restricted to a field/property callee: a `!!`-asserted
-            // callee only parses as `recv!!.member`, never as a standalone `recv!!`
-            // invocation target, so a nullable LOCAL/PARAMETER delegate callee is
-            // NOT forgiven here — gsc smart-casts those from an `if d != nil` guard
-            // instead (the promotion that made them `T?` comes from #2113).
+            // Directly invoking a nullable delegate value needs the same receiver
+            // forgiveness as `.Invoke(...)`: fields/properties retain #1594's
+            // behavior, while issue #2506 adds promoted method/property/indexer
+            // results such as `FindFactory()()`. Keep the decision receiver-only
+            // so callable-return taint is asserted on the produced delegate value,
+            // never on a method group.
             if (this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol
                     { MethodKind: MethodKind.DelegateInvoke }
-                && this.context.GetSymbolInfo(invocation.Expression).Symbol
-                    is IFieldSymbol or IPropertySymbol
-                && this.ReceiverIsNullableReferenceFieldOrProperty(invocation.Expression))
+                && (this.ReceiverNeedsNullForgiveness(
+                        invocation.Expression,
+                        isDereferenceReceiver: true)
+                    || this.ReceiverIsNullableReferenceFieldOrProperty(invocation.Expression)))
             {
                 target = new NonNullAssertionExpression(target);
             }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -1866,7 +1866,7 @@ public sealed partial class CSharpToGSharpTranslator
                     GExpression qualifiedReceiver = new MemberAccessExpression(
                         qualifier, SanitizeIdentifier(receiverId.Identifier.Text));
 
-                    if (this.ReceiverNeedsNullForgiveness(receiverId) ||
+                    if (this.ReceiverNeedsNullForgiveness(receiverId, isDereferenceReceiver: true) ||
                         this.ReceiverIsNullableReferenceFieldOrProperty(receiverId))
                     {
                         qualifiedReceiver = new NonNullAssertionExpression(qualifiedReceiver);
@@ -1876,7 +1876,7 @@ public sealed partial class CSharpToGSharpTranslator
                         qualifiedReceiver, SanitizeIdentifier(member.Name.Identifier.Text));
                 }
 
-                if (this.ReceiverNeedsNullForgiveness(member.Expression) ||
+                if (this.ReceiverNeedsNullForgiveness(member.Expression, isDereferenceReceiver: true) ||
                     this.ReceiverIsNullableReferenceFieldOrProperty(member.Expression) ||
                     (member.Expression is IdentifierNameSyntax hoistedId &&
                      this.context.GetSymbolInfo(hoistedId).Symbol is { } hoistedSymbol &&


### PR DESCRIPTION
## Summary
- add receiver-only null forgiveness for same-project promoted method, property, indexer, local-function, awaited, and delegate-call results
- preserve conditional access, expression-tree restrictions, nullable contracts, flow behavior, task envelopes, nullable extension receivers, and single evaluation
- cover direct/default `--via-sdk` + gsc compilation for the minimal repro, delegate invocation, and Oahu `FromCountryCode(...).Domain` shape

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-restore --filter 'FullyQualifiedName~Issue2506PromotedCallReceiverForgiveness'` (8 passed)\n- related nullability/receiver regression selection (73 passed)\n- tests active during an unrelated full-suite testhost abort rerun directly (15 passed)\n\nFixes #2506