### PR TITLE
Fix narrowed inherited assignments

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -1426,6 +1426,33 @@ internal sealed partial class ExpressionBinder
         TextLocation diagnosticLocation,
         BoundExpression boundIndexOverride = null)
     {
+        // Issue #2488: direct indexed writes bypass the ordinary name-expression
+        // read binder, so explicitly reuse its narrowed receiver construction.
+        // Member/indexer lookup sees the effective type while loads still refer
+        // to the original variable slot.
+        var target = BuildNarrowedVariableRead(variable);
+        var targetType = target.Type;
+        var hasNarrowedTarget = target is not BoundVariableExpression targetVariable
+            || targetVariable.NarrowedType != null;
+
+        BoundExpression MakeIndexAssignment(BoundExpression index, BoundExpression value, TypeSymbol elementType)
+        {
+            return hasNarrowedTarget
+                ? BoundIndexAssignmentExpression.WithExpressionTarget(null, target, index, value, elementType)
+                : new BoundIndexAssignmentExpression(null, variable, index, value, elementType);
+        }
+
+        BoundExpression MakeClrIndexAssignment(
+            PropertyInfo indexer,
+            ImmutableArray<BoundExpression> arguments,
+            BoundExpression value,
+            TypeSymbol resultType)
+        {
+            return hasNarrowedTarget
+                ? BoundClrIndexAssignmentExpression.WithExpressionTarget(null, target, indexer, arguments, value, resultType)
+                : new BoundClrIndexAssignmentExpression(null, variable, indexer, arguments, value, resultType);
+        }
+
         BoundExpression BindValue(TypeSymbol elementType)
         {
             if (boundValueOverride != null)
@@ -1439,12 +1466,14 @@ internal sealed partial class ExpressionBinder
         if (boundIndexOverride != null
             && ClrTypeUtilities.AreSame(boundIndexOverride.Type?.ClrType, typeof(System.Index)))
         {
-            return BindSystemIndexAssignment(variable, boundIndexOverride, BindValue, diagnosticLocation);
+            return BindSystemIndexAssignment(
+                variable, target, targetType, hasNarrowedTarget, boundIndexOverride, BindValue, diagnosticLocation);
         }
 
         if (boundIndexOverride == null && TryBindSystemIndexValue(indexSyntax, out var systemIndex))
         {
-            return BindSystemIndexAssignment(variable, systemIndex, BindValue, diagnosticLocation);
+            return BindSystemIndexAssignment(
+                variable, target, targetType, hasNarrowedTarget, systemIndex, BindValue, diagnosticLocation);
         }
 
         BoundExpression BindIndexValue() => boundIndexOverride ?? BindExpression(indexSyntax);
@@ -1454,23 +1483,23 @@ internal sealed partial class ExpressionBinder
                 ? conversions.BindConversion(indexSyntax.Location, boundIndexOverride, targetType)
                 : conversions.BindConversion(indexSyntax, targetType);
 
-        var element = GetIndexElementType(variable.Type);
+        var element = GetIndexElementType(targetType);
         if (element != null)
         {
             var index = boundIndexOverride != null
                 ? ConvertArrayElementIndex(indexSyntax.Location, boundIndexOverride)
                 : BindArrayElementIndex(indexSyntax);
             var value = BindValue(element);
-            return new BoundIndexAssignmentExpression(null, variable, index, value, element);
+            return MakeIndexAssignment(index, value, element);
         }
 
         // ADR-0122 / issue #1014: pointer indexed write `p[i] = v` == `*(p + i) = v`.
-        if (variable.Type is PointerTypeSymbol pointerType)
+        if (targetType is PointerTypeSymbol pointerType)
         {
             // ADR-0122 §3 / issue #1033: a `*void` pointer has no element type,
             // so an indexed write `p[i] = v` is rejected (GS0403); cast to a
             // typed pointer `*T` first.
-            if (TypeSymbol.IsVoidPointer(variable.Type))
+            if (TypeSymbol.IsVoidPointer(targetType))
             {
                 Diagnostics.ReportVoidPointerOperationNotAllowed(diagnosticLocation, "index");
                 return new BoundErrorExpression(null);
@@ -1489,51 +1518,51 @@ internal sealed partial class ExpressionBinder
                     : conversions.BindConversion(indexSyntax, TypeSymbol.NInt);
             }
 
-            var elementPointer = LowerPointerOffset(new BoundVariableExpression(null, variable), pointerType, pointerIndex, subtract: false);
+            var elementPointer = LowerPointerOffset(target, pointerType, pointerIndex, subtract: false);
             var pointerValue = BindValue(pointerType.PointeeType);
             return new BoundIndirectAssignmentExpression(null, elementPointer, pointerValue);
         }
 
         // Phase 3.A.4: map indexed assignment `m[k] = v` — key bound to K,
         // value bound to V.
-        if (variable.Type is MapTypeSymbol mapType)
+        if (targetType is MapTypeSymbol mapType)
         {
             var keyExpr = ConvertIndexValue(mapType.KeyType);
             var valExpr = BindValue(mapType.ValueType);
-            return new BoundIndexAssignmentExpression(null, variable, keyExpr, valExpr, mapType.ValueType);
+            return MakeIndexAssignment(keyExpr, valExpr, mapType.ValueType);
         }
 
         // Phase 4 exit: CLR indexer write on an imported reference type
         // (e.g. `d["k"] = 1` on Dictionary[string, int]).
         // Issue #209: honour inner-position nullable flags when present.
-        if (variable.Type is NullabilityAnnotatedTypeSymbol annotWr && variable.Type.ClrType is System.Type clrAnnotWr)
+        if (targetType is NullabilityAnnotatedTypeSymbol annotWr && targetType.ClrType is System.Type clrAnnotWr)
         {
             var idxArgsAnnotWr = ImmutableArray.Create(BindIndexValue());
-            if (this.memberLookup.TryResolveClrIndexer(variable.Type, clrAnnotWr, idxArgsAnnotWr, out var idxPropAnnotWr, out var resolvedIdxArgsAnnotWr))
+            if (this.memberLookup.TryResolveClrIndexer(targetType, clrAnnotWr, idxArgsAnnotWr, out var idxPropAnnotWr, out var resolvedIdxArgsAnnotWr))
             {
                 if (!idxPropAnnotWr.CanWrite)
                 {
-                    Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
+                    Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
                     return new BoundErrorExpression(null);
                 }
 
                 var valueTypeAnnotWr = annotWr.GetTypeArgumentSymbolForClrType(idxPropAnnotWr.PropertyType);
                 var boundValueAnnotWr = BindValue(valueTypeAnnotWr);
                 var convertedIdxArgsAnnotWr = BindClrIndexerArguments(
-                    variable.Type,
+                    targetType,
                     idxPropAnnotWr,
                     resolvedIdxArgsAnnotWr,
                     indexSyntax.Location);
-                return new BoundClrIndexAssignmentExpression(null, variable, idxPropAnnotWr, convertedIdxArgsAnnotWr, boundValueAnnotWr, valueTypeAnnotWr);
+                return MakeClrIndexAssignment(idxPropAnnotWr, convertedIdxArgsAnnotWr, boundValueAnnotWr, valueTypeAnnotWr);
             }
         }
-        else if ((variable.Type is ImportedTypeSymbol || variable.Type is StructSymbol) && variable.Type.ClrType is System.Type clrTarget)
+        else if ((targetType is ImportedTypeSymbol || targetType is StructSymbol) && targetType.ClrType is System.Type clrTarget)
         {
             var idxArgs = ImmutableArray.Create(BindIndexValue());
-            if (this.memberLookup.TryResolveClrIndexer(variable.Type, clrTarget, idxArgs, out var idxProp, out var resolvedIdxArgs))
+            if (this.memberLookup.TryResolveClrIndexer(targetType, clrTarget, idxArgs, out var idxProp, out var resolvedIdxArgs))
             {
                 var convertedIdxArgs = BindClrIndexerArguments(
-                    variable.Type,
+                    targetType,
                     idxProp,
                     resolvedIdxArgs,
                     indexSyntax.Location);
@@ -1550,21 +1579,21 @@ internal sealed partial class ExpressionBinder
                     {
                         if (IsReadOnlyRefReturn(idxProp, refGetter))
                         {
-                            Diagnostics.ReportCannotAssignReadOnlySpanElement(diagnosticLocation, variable.Type);
+                            Diagnostics.ReportCannotAssignReadOnlySpanElement(diagnosticLocation, targetType);
                             return new BoundErrorExpression(null);
                         }
 
-                        var resolvedElementType = variable.Type is ImportedTypeSymbol importedRefReturn
+                        var resolvedElementType = targetType is ImportedTypeSymbol importedRefReturn
                             ? MapErasedIndexerElementType(importedRefReturn, idxProp)
-                            : ResolveIndexerElementType(variable.Type, idxProp);
+                            : ResolveIndexerElementType(targetType, idxProp);
                         var pointeeType = resolvedElementType is ByRefTypeSymbol byRef
                             ? byRef.PointeeType
                             : TypeSymbol.FromClrType(refGetter.ReturnType.GetElementType()!);
                         var refValue = BindValue(pointeeType);
-                        return new BoundClrIndexAssignmentExpression(null, variable, idxProp, convertedIdxArgs, refValue, pointeeType);
+                        return MakeClrIndexAssignment(idxProp, convertedIdxArgs, refValue, pointeeType);
                     }
 
-                    Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
+                    Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
                     return new BoundErrorExpression(null);
                 }
 
@@ -1580,24 +1609,24 @@ internal sealed partial class ExpressionBinder
                 // real element type (`T`), so the `T` value binds without a
                 // spurious boxing conversion — the WRITE-path counterpart to the
                 // READ-path element-type recovery (issues #313 / #671 / #957).
-                var valueType = variable.Type is ImportedTypeSymbol imported
+                var valueType = targetType is ImportedTypeSymbol imported
                     ? MapErasedIndexerElementType(imported, idxProp)
                     : ClrNullability.GetPropertyTypeSymbol(idxProp);
                 var boundValue = BindValue(valueType);
-                return new BoundClrIndexAssignmentExpression(null, variable, idxProp, convertedIdxArgs, boundValue, valueType);
+                return MakeClrIndexAssignment(idxProp, convertedIdxArgs, boundValue, valueType);
             }
         }
 
         // ADR-0118 / issue #944: index assignment on a user-defined type that
         // declares an indexer member. Binds `obj[i] = v` to a call of the
         // indexer setter (`obj.set_Item(i, v)`).
-        if (variable.Type is StructSymbol userIndexTarget
+        if (targetType is StructSymbol userIndexTarget
             && TryGetUserIndexer(userIndexTarget, out var writeIndexer, out var writeSubstitution)
             && writeIndexer.Parameters.Length == 1)
         {
             if (writeIndexer.SetterSymbol == null)
             {
-                Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
+                Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
                 return new BoundErrorExpression(null);
             }
 
@@ -1612,7 +1641,7 @@ internal sealed partial class ExpressionBinder
             var value = BindValue(elementType);
             return new BoundUserInstanceCallExpression(
                 null,
-                new BoundVariableExpression(null, variable),
+                target,
                 writeIndexer.SetterSymbol,
                 ImmutableArray.Create(indexArg, value));
         }
@@ -1621,13 +1650,13 @@ internal sealed partial class ExpressionBinder
         // INTERFACE-typed receiver — the write-side counterpart of the read
         // branch above. Dispatches via `callvirt` through the interface's own
         // set_Item slot.
-        if (variable.Type is InterfaceSymbol writeIndexIface
+        if (targetType is InterfaceSymbol writeIndexIface
             && TryGetUserIndexer(writeIndexIface, out var writeIfaceIndexer, out var writeIfaceSubstitution)
             && writeIfaceIndexer.Parameters.Length == 1)
         {
             if (writeIfaceIndexer.SetterSymbol == null)
             {
-                Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
+                Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
                 return new BoundErrorExpression(null);
             }
 
@@ -1642,14 +1671,14 @@ internal sealed partial class ExpressionBinder
             var value = BindValue(elementType);
             return new BoundUserInstanceCallExpression(
                 null,
-                new BoundVariableExpression(null, variable),
+                target,
                 writeIfaceIndexer.SetterSymbol,
                 ImmutableArray.Create(indexArg, value));
         }
 
-        if (variable.Type != TypeSymbol.Error)
+        if (targetType != TypeSymbol.Error)
         {
-            Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
+            Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
         }
 
         return new BoundErrorExpression(null);
@@ -2164,24 +2193,29 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression BindSystemIndexAssignment(
         VariableSymbol variable,
+        BoundExpression target,
+        TypeSymbol targetType,
+        bool hasNarrowedTarget,
         BoundExpression indexValue,
         Func<TypeSymbol, BoundExpression> bindValue,
         TextLocation diagnosticLocation)
     {
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
 
-        var element = GetIndexElementType(variable.Type);
+        var element = GetIndexElementType(targetType);
         if (element != null)
         {
             var idx = BuildSystemIndexOffset(
                 indexValue,
-                new BoundLenExpression(null, new BoundVariableExpression(null, variable)),
+                new BoundLenExpression(null, target),
                 statements);
-            var assignment = new BoundIndexAssignmentExpression(null, variable, idx, bindValue(element), element);
+            var assignment = hasNarrowedTarget
+                ? BoundIndexAssignmentExpression.WithExpressionTarget(null, target, idx, bindValue(element), element)
+                : new BoundIndexAssignmentExpression(null, variable, idx, bindValue(element), element);
             return new BoundBlockExpression(null, statements.ToImmutable(), assignment);
         }
 
-        var clrType = variable.Type.ClrType;
+        var clrType = targetType.ClrType;
         if (clrType != null)
         {
             PropertyInfo indexer;
@@ -2194,49 +2228,45 @@ internal sealed partial class ExpressionBinder
             {
                 var lengthExpr = new BoundClrPropertyAccessExpression(
                     null,
-                    new BoundVariableExpression(null, variable),
+                    target,
                     lengthMember,
                     TypeSymbol.Int32);
                 arguments = ImmutableArray.Create(BuildSystemIndexOffset(indexValue, lengthExpr, statements));
             }
             else
             {
-                Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
+                Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
                 return new BoundErrorExpression(null);
             }
 
             var getter = indexer.GetGetMethod(nonPublic: false);
-            var valueType = ResolveIndexerElementType(variable.Type, indexer);
+            var valueType = ResolveIndexerElementType(targetType, indexer);
             if (!indexer.CanWrite)
             {
                 if (getter == null || !getter.ReturnType.IsByRef)
                 {
-                    Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
+                    Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
                     return new BoundErrorExpression(null);
                 }
 
                 if (IsReadOnlyRefReturn(indexer, getter))
                 {
-                    Diagnostics.ReportCannotAssignReadOnlySpanElement(diagnosticLocation, variable.Type);
+                    Diagnostics.ReportCannotAssignReadOnlySpanElement(diagnosticLocation, targetType);
                     return new BoundErrorExpression(null);
                 }
 
                 valueType = valueType is ByRefTypeSymbol byRef ? byRef.PointeeType : valueType;
             }
 
-            return new BoundBlockExpression(
-                null,
-                statements.ToImmutable(),
-                new BoundClrIndexAssignmentExpression(
-                    null,
-                    variable,
-                    indexer,
-                    arguments,
-                    bindValue(valueType),
-                    valueType));
+            var assignment = hasNarrowedTarget
+                ? BoundClrIndexAssignmentExpression.WithExpressionTarget(
+                    null, target, indexer, arguments, bindValue(valueType), valueType)
+                : new BoundClrIndexAssignmentExpression(
+                    null, variable, indexer, arguments, bindValue(valueType), valueType);
+            return new BoundBlockExpression(null, statements.ToImmutable(), assignment);
         }
 
-        if (variable.Type is StructSymbol userTarget
+        if (targetType is StructSymbol userTarget
             && TryGetUserIndexer(userTarget, out var userIndexer, out var substitution)
             && userIndexer.Parameters.Length == 1
             && userIndexer.SetterSymbol != null)
@@ -2251,7 +2281,7 @@ internal sealed partial class ExpressionBinder
                     : userIndexer.Type;
                 return new BoundUserInstanceCallExpression(
                     null,
-                    new BoundVariableExpression(null, variable),
+                    target,
                     userIndexer.SetterSymbol,
                     ImmutableArray.Create(
                         conversions.BindConversion(diagnosticLocation, indexValue, parameterType),
@@ -2259,7 +2289,7 @@ internal sealed partial class ExpressionBinder
             }
         }
 
-        Diagnostics.ReportTypeNotIndexable(diagnosticLocation, variable.Type);
+        Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
         return new BoundErrorExpression(null);
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -681,10 +681,19 @@ internal sealed partial class ExpressionBinder
                 implicitPropReceiver.Property);
         }
 
+        // Issue #2488: classify and bind the write through the same narrowed
+        // receiver view used by reads. The symbol retains its declared nullable
+        // storage type, while the bound receiver carries the effective type
+        // proven by the active if-let/null-guard frame.
+        var assignmentReceiver = implicitFieldReceiverExpr ?? BuildNarrowedVariableRead(variable);
+        var assignmentReceiverType = assignmentReceiver.Type;
+
         // Stream B: instance-CLR receiver → property/field write via reflection.
-        if (variable.Type is not StructSymbol && variable.Type is not NullableTypeSymbol && variable.Type?.ClrType != null)
+        if (assignmentReceiverType is not StructSymbol
+            && assignmentReceiverType is not NullableTypeSymbol
+            && assignmentReceiverType?.ClrType != null)
         {
-            var clrReceiverType = variable.Type.ClrType;
+            var clrReceiverType = assignmentReceiverType.ClrType;
             var fieldName = syntax.FieldIdentifier.Text;
             MemberInfo instanceMember = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, fieldName, BindingFlags.Public | BindingFlags.Instance);
             if (instanceMember is PropertyInfo prop && prop.GetIndexParameters().Length != 0)
@@ -707,16 +716,15 @@ internal sealed partial class ExpressionBinder
 
             _ = instWritable;
             _ = instTargetType;
-            var instReceiver = implicitFieldReceiverExpr ?? new BoundVariableExpression(null, variable);
             var instConverted = conversions.BindConversion(syntax.Value.Location, BindValue(instTargetSymbol), instTargetSymbol);
-            return new BoundClrPropertyAssignmentExpression(null, instReceiver, instanceMember, instConverted, instTargetSymbol);
+            return new BoundClrPropertyAssignmentExpression(null, assignmentReceiver, instanceMember, instConverted, instTargetSymbol);
         }
 
         // Issue #1068: an interface-typed variable receiver (`d.W = v` where
         // d : IDerived) writes the interface property setter (walking base
         // interfaces). Mirrors the read path and the expression-receiver write
         // path; the emitter dispatches via `callvirt set_W`.
-        if (variable.Type is InterfaceSymbol ifaceVarType)
+        if (assignmentReceiverType is InterfaceSymbol ifaceVarType)
         {
             if (TypeMemberModel.TryGetProperty(ifaceVarType, syntax.FieldIdentifier.Text, out var ifaceProp, out _))
             {
@@ -727,9 +735,8 @@ internal sealed partial class ExpressionBinder
                 }
 
                 var ifaceConverted = conversions.BindConversion(syntax.Value.Location, BindValue(ifaceProp.Type), ifaceProp.Type);
-                var ifaceReceiver = implicitFieldReceiverExpr ?? new BoundVariableExpression(null, variable);
-                EnforceInitOnlyAssignment(ifaceProp, ifaceReceiver, syntax.EqualsToken.Location);
-                return new BoundPropertyAssignmentExpression(null, ifaceReceiver, null, ifaceProp, ifaceConverted);
+                EnforceInitOnlyAssignment(ifaceProp, assignmentReceiver, syntax.EqualsToken.Location);
+                return new BoundPropertyAssignmentExpression(null, assignmentReceiver, null, ifaceProp, ifaceConverted);
             }
 
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
@@ -745,7 +752,7 @@ internal sealed partial class ExpressionBinder
         // emitter dispatches via `box !!T; stfld` (fields) or
         // `box !!T; callvirt set_X` (properties) — mirroring the read path's
         // `box !!T; ldfld`/`callvirt get_X`.
-        if (variable.Type is TypeParameterSymbol tpVarType)
+        if (assignmentReceiverType is TypeParameterSymbol tpVarType)
         {
             if (tpVarType.ClassConstraint is StructSymbol tpClassConstraint)
             {
@@ -764,9 +771,8 @@ internal sealed partial class ExpressionBinder
                     }
 
                     var tpPropConverted = conversions.BindConversion(syntax.Value.Location, BindValue(tpProp.Type), tpProp.Type);
-                    var tpPropReceiver = implicitFieldReceiverExpr ?? new BoundVariableExpression(null, variable);
-                    EnforceInitOnlyAssignment(tpProp, tpPropReceiver, syntax.EqualsToken.Location);
-                    return new BoundPropertyAssignmentExpression(null, tpPropReceiver, tpPropDeclaringType, tpProp, tpPropConverted);
+                    EnforceInitOnlyAssignment(tpProp, assignmentReceiver, syntax.EqualsToken.Location);
+                    return new BoundPropertyAssignmentExpression(null, assignmentReceiver, tpPropDeclaringType, tpProp, tpPropConverted);
                 }
             }
 
@@ -782,16 +788,15 @@ internal sealed partial class ExpressionBinder
                 }
 
                 var tpIfaceConverted = conversions.BindConversion(syntax.Value.Location, BindValue(tpIfaceProp.Type), tpIfaceProp.Type);
-                var tpIfaceReceiver = implicitFieldReceiverExpr ?? new BoundVariableExpression(null, variable);
-                EnforceInitOnlyAssignment(tpIfaceProp, tpIfaceReceiver, syntax.EqualsToken.Location);
-                return new BoundPropertyAssignmentExpression(null, tpIfaceReceiver, null, tpIfaceProp, tpIfaceConverted);
+                EnforceInitOnlyAssignment(tpIfaceProp, assignmentReceiver, syntax.EqualsToken.Location);
+                return new BoundPropertyAssignmentExpression(null, assignmentReceiver, null, tpIfaceProp, tpIfaceConverted);
             }
 
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
             return new BoundErrorExpression(null);
         }
 
-        if (!(variable.Type is StructSymbol structSymbol))
+        if (!(assignmentReceiverType is StructSymbol structSymbol))
         {
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
             return new BoundErrorExpression(null);
@@ -820,15 +825,14 @@ internal sealed partial class ExpressionBinder
                 // (a reference-type receiver mutates the heap object and the
                 // enclosing `this` are both exempt via ReceiverVariableIsThis /
                 // ReceiverTypeIsReference).
-                if (variable.IsReadOnly && !ReceiverVariableIsThis(variable) && !ReceiverTypeIsReference(variable.Type))
+                if (variable.IsReadOnly && !ReceiverVariableIsThis(variable) && !ReceiverTypeIsReference(assignmentReceiverType))
                 {
                     Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, receiverName);
                 }
 
                 var propConverted = conversions.BindConversion(syntax.Value.Location, BindValue(prop.Type), prop.Type);
-                var propReceiver = implicitFieldReceiverExpr ?? new BoundVariableExpression(null, variable);
-                EnforceInitOnlyAssignment(prop, propReceiver, syntax.EqualsToken.Location);
-                return new BoundPropertyAssignmentExpression(null, propReceiver, structSymbol, prop, propConverted);
+                EnforceInitOnlyAssignment(prop, assignmentReceiver, syntax.EqualsToken.Location);
+                return new BoundPropertyAssignmentExpression(null, assignmentReceiver, structSymbol, prop, propConverted);
             }
 
             // Issue #319 / #1582: a GSharp class inheriting an imported CLR base
@@ -851,9 +855,8 @@ internal sealed partial class ExpressionBinder
 
                     _ = inhWritable;
                     _ = inhTargetType;
-                    var inhReceiver = implicitFieldReceiverExpr ?? new BoundVariableExpression(null, variable);
                     var inhConverted = conversions.BindConversion(syntax.Value.Location, BindValue(inhTargetSymbol), inhTargetSymbol);
-                    return new BoundClrPropertyAssignmentExpression(null, inhReceiver, clrMember, inhConverted, inhTargetSymbol);
+                    return new BoundClrPropertyAssignmentExpression(null, assignmentReceiver, clrMember, inhConverted, inhTargetSymbol);
                 }
             }
 
@@ -879,7 +882,7 @@ internal sealed partial class ExpressionBinder
         // receiver, `b.Field = v` mutates the heap object, not the binding, so
         // it must be allowed; only value-type receivers (where the field write
         // would mutate the value stored in the read-only slot) stay rejected.
-        if (variable.IsReadOnly && !receiverIsThisField && !ReceiverTypeIsReference(variable.Type))
+        if (variable.IsReadOnly && !receiverIsThisField && !ReceiverTypeIsReference(assignmentReceiverType))
         {
             Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, receiverName);
         }
@@ -898,9 +901,11 @@ internal sealed partial class ExpressionBinder
             $"{structSymbol.Name}.{field.Name}");
 
         var converted = conversions.BindConversion(syntax.Value.Location, BindValue(field.Type), field.Type);
-        if (implicitFieldReceiverExpr != null)
+        if (implicitFieldReceiverExpr != null
+            || (assignmentReceiver is BoundVariableExpression narrowedVariable && narrowedVariable.NarrowedType != null)
+            || assignmentReceiver is BoundUnaryExpression)
         {
-            return BoundFieldAssignmentExpression.WithExpressionReceiver(null, implicitFieldReceiverExpr, structSymbol, field, converted);
+            return BoundFieldAssignmentExpression.WithExpressionReceiver(null, assignmentReceiver, structSymbol, field, converted);
         }
 
         return new BoundFieldAssignmentExpression(null, variable, structSymbol, field, converted);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -615,6 +615,11 @@ internal sealed partial class ExpressionBinder
                 implicitProp.Property);
         }
 
+        return BuildNarrowedVariableRead(variable);
+    }
+
+    private BoundExpression BuildNarrowedVariableRead(VariableSymbol variable)
+    {
         return BuildNarrowedRead(
             new BoundVariableExpression(null, variable),
             variable.Type,

--- a/test/Compiler.Tests/Emit/Issue2488NarrowedInheritedAssignmentTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2488NarrowedInheritedAssignmentTests.cs
@@ -1,0 +1,450 @@
+// <copyright file="Issue2488NarrowedInheritedAssignmentTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2488: assignment binding must use the effective narrowed receiver
+/// type, just like the read path, while the underlying variable keeps its
+/// declared nullable storage type.
+/// </summary>
+public class Issue2488NarrowedInheritedAssignmentTests
+{
+    private const string ImportedTypes = """
+        #nullable enable
+        using System;
+
+        namespace Issue2488.CSharp
+        {
+            public class Base
+            {
+                private readonly int[] values = new int[2];
+
+                public int Field;
+                public int Value { get; set; }
+                public int AddCalls { get; private set; }
+                public int RemoveCalls { get; private set; }
+
+                public event Action Changed
+                {
+                    add => AddCalls++;
+                    remove => RemoveCalls++;
+                }
+
+                public int this[int index]
+                {
+                    get => values[index];
+                    set => values[index] = value;
+                }
+            }
+
+            public sealed class Derived : Base
+            {
+            }
+
+            public static class Factory
+            {
+                public static int Calls;
+
+                public static Derived? Get()
+                {
+                    Calls++;
+                    return new Derived();
+                }
+            }
+        }
+        """;
+
+    [Fact]
+    public void SourceInheritedMembers_NarrowedWritesRunReflectAndVerify()
+    {
+        const string source = """
+            package Issue2488.Source
+
+            open class Base2488 {
+                public var FieldValue int32
+                private var propertyValue int32
+                public var AddCalls int32
+                public var RemoveCalls int32
+
+                prop Value int32 {
+                    get { return propertyValue }
+                    set { propertyValue = value }
+                }
+
+                open event Changed () -> void {
+                    add { AddCalls += 1 }
+                    remove { RemoveCalls += 1 }
+                }
+
+                prop this[index int32] int32 {
+                    get { return propertyValue + index }
+                    set { propertyValue = value + index }
+                }
+            }
+
+            class Derived2488 : Base2488 {
+            }
+
+            public var FactoryCalls = 0
+            public var FieldResult = 0
+            public var PropertyResult = 0
+            public var IndexResult = 0
+            public var AddResult = 0
+            public var RemoveResult = 0
+
+            func GetDerived() Derived2488? {
+                FactoryCalls += 1
+                return Derived2488()
+            }
+
+            if let item = GetDerived() {
+                item.FieldValue = 4
+                item.Value = 10
+                item.Value += 5
+                item.Changed += func() void { }
+                item.Changed -= func() void { }
+                item[2] = 20
+
+                FieldResult = item.FieldValue
+                PropertyResult = item.Value
+                IndexResult = item[2]
+                AddResult = item.AddCalls
+                RemoveResult = item.RemoveCalls
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var derived = assembly.GetType("Issue2488.Source.Derived2488", throwOnError: true)!;
+        Assert.NotNull(derived.GetField("FieldValue"));
+        Assert.NotNull(derived.GetProperty("Value"));
+        Assert.NotNull(derived.GetEvent("Changed"));
+        Assert.NotNull(derived.GetProperty("Item"));
+
+        InvokeEntryPoint(assembly);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        Assert.Equal(1, ReadStaticInt(program, "FactoryCalls"));
+        Assert.Equal(4, ReadStaticInt(program, "FieldResult"));
+        Assert.Equal(22, ReadStaticInt(program, "PropertyResult"));
+        Assert.Equal(24, ReadStaticInt(program, "IndexResult"));
+        Assert.Equal(1, ReadStaticInt(program, "AddResult"));
+        Assert.Equal(1, ReadStaticInt(program, "RemoveResult"));
+    }
+
+    [Fact]
+    public void ImportedInheritedMembers_NarrowedWritesRunOnceAndVerify()
+    {
+        const string source = """
+            package Issue2488.Imported
+            import System
+            import Issue2488.CSharp
+
+            var IndexCalls = 0
+            var ValueCalls = 0
+
+            func NextIndex() int32 {
+                IndexCalls += 1
+                return 1
+            }
+
+            func NextValue() int32 {
+                ValueCalls += 1
+                return 5
+            }
+
+            if let item = Factory.Get() {
+                item.Field = 3
+                item.Value = 4
+                item.Value += 5
+                item.Changed += func() void { }
+                item.Changed -= func() void { }
+                item[1] = 11
+                item[NextIndex()] += NextValue()
+
+                Console.WriteLine(item.Field)
+                Console.WriteLine(item.Value)
+                Console.WriteLine(item[1])
+                Console.WriteLine(item.AddCalls)
+                Console.WriteLine(item.RemoveCalls)
+            }
+
+            Console.WriteLine(Factory.Calls)
+            Console.WriteLine(IndexCalls)
+            Console.WriteLine(ValueCalls)
+            """;
+
+        Assert.Equal("3\n9\n16\n1\n1\n1\n1\n1\n", CompileAndRun(source, ImportedTypes));
+    }
+
+    [Fact]
+    public void UnguardedNullableReceivers_RemainInvalidForEveryWriteKind()
+    {
+        const string source = """
+            package Issue2488.Negative
+
+            open class Base2488 {
+                var FieldValue int32
+                prop Value int32 { get; set; }
+                event Changed () -> void { add { } remove { } }
+                prop this[index int32] int32 { get { return 0 } set { } }
+            }
+
+            class Derived2488 : Base2488 {
+            }
+
+            func GetDerived() Derived2488? {
+                return Derived2488()
+            }
+
+            let item = GetDerived()
+            item.FieldValue = 1
+            item.Value = 2
+            item.Changed += func() void { }
+            item[0] = 3
+            """;
+
+        var (exitCode, diagnostics) = CompileExpectingFailure(source);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0158", diagnostics);
+        Assert.Contains("GS0116", diagnostics);
+    }
+
+    [Fact]
+    public void Narrowing_DoesNotBypassInheritedPrivateAccessChecks()
+    {
+        const string source = """
+            package Issue2488.Access
+
+            open class Base2488 {
+                private var Secret int32
+            }
+
+            class Derived2488 : Base2488 {
+            }
+
+            func GetDerived() Derived2488? {
+                return Derived2488()
+            }
+
+            if let item = GetDerived() {
+                item.Secret = 1
+            }
+            """;
+
+        var (exitCode, diagnostics) = CompileExpectingFailure(source);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0472", diagnostics);
+        Assert.Contains("Secret", diagnostics);
+    }
+
+    [Fact]
+    public void ImportedUnguardedNullableReceiver_RemainsInvalid()
+    {
+        const string source = """
+            package Issue2488.ImportedNegative
+            import Issue2488.CSharp
+
+            let item = Factory.Get()
+            item.Field = 1
+            item.Value = 2
+            item.Changed += func() void { }
+            item[0] = 3
+            """;
+
+        var (exitCode, diagnostics) = CompileExpectingFailure(source, ImportedTypes);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0158", diagnostics);
+        Assert.Contains("GS0116", diagnostics);
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var workDir = Directory.CreateTempSubdirectory("gs_issue2488_reflection_").FullName;
+        try
+        {
+            var (exitCode, diagnostics, outPath, references) = Compile(workDir, source, "exe", csharpSource: null);
+            Assert.True(exitCode == 0, diagnostics);
+            IlVerifier.Verify(outPath, additionalReferences: references);
+            return Assembly.Load(File.ReadAllBytes(outPath));
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    private static string CompileAndRun(string source, string csharpSource)
+    {
+        var workDir = Directory.CreateTempSubdirectory("gs_issue2488_run_").FullName;
+        try
+        {
+            var (exitCode, diagnostics, outPath, references) = Compile(workDir, source, "exe", csharpSource);
+            Assert.True(exitCode == 0, diagnostics);
+            IlVerifier.Verify(outPath, additionalReferences: references);
+
+            var runtimeConfig = Path.ChangeExtension(outPath, ".runtimeconfig.json");
+            if (!File.Exists(runtimeConfig))
+            {
+                File.WriteAllText(runtimeConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = workDir,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(runtimeConfig);
+            startInfo.ArgumentList.Add(outPath);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            Assert.True(
+                process.ExitCode == 0,
+                $"dotnet exec failed ({process.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    private static (int ExitCode, string Diagnostics) CompileExpectingFailure(
+        string source,
+        string csharpSource = null)
+    {
+        var workDir = Directory.CreateTempSubdirectory("gs_issue2488_error_").FullName;
+        try
+        {
+            var (exitCode, diagnostics, _, _) = Compile(workDir, source, "library", csharpSource);
+            return (exitCode, diagnostics);
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    private static (int ExitCode, string Diagnostics, string OutPath, string[] References) Compile(
+        string workDir,
+        string source,
+        string target,
+        string csharpSource)
+    {
+        var sourcePath = Path.Combine(workDir, "test.gs");
+        var outputPath = Path.Combine(workDir, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var references = csharpSource == null
+            ? Array.Empty<string>()
+            : new[] { EmitCSharpLibrary(workDir, csharpSource) };
+
+        var arguments = new List<string>
+        {
+            "/out:" + outputPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+        foreach (var reference in references)
+        {
+            arguments.Add("/reference:" + reference);
+        }
+
+        arguments.Add(sourcePath);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(arguments.ToArray());
+            return (exitCode, stdout.ToString() + stderr, outputPath, references);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string EmitCSharpLibrary(string workDir, string source)
+    {
+        var outputPath = Path.Combine(workDir, "Issue2488.CSharp.dll");
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var references = TrustedPlatformAssemblies().Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "Issue2488.CSharp",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return outputPath;
+    }
+
+    private static void InvokeEntryPoint(Assembly assembly)
+    {
+        var entryPoint = assembly.EntryPoint!;
+        entryPoint.Invoke(
+            null,
+            entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+    }
+
+    private static int ReadStaticInt(Type program, string fieldName)
+    {
+        return (int)program.GetField(fieldName, BindingFlags.Public | BindingFlags.Static)!.GetValue(null)!;
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var value = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        Assert.False(string.IsNullOrWhiteSpace(value));
+        return value!.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- reuse read-path narrowing when binding direct member and index assignments
- resolve inherited source and CLR fields, properties, events, and indexers through the effective receiver type
- preserve nullable diagnostics, access checks, compound assignment semantics, and single evaluation

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Compiler.Tests/Compiler.Tests.csproj --no-restore --filter "FullyQualifiedName~Issue2488NarrowedInheritedAssignmentTests|FullyQualifiedName~Issue1123SmartCastOnAssignmentEmitTests|FullyQualifiedName~Issue1614FieldAssignmentReceiverOnceEmitTests|FullyQualifiedName~Issue2370ExplicitInterfaceEventIndexerEmitTests|FullyQualifiedName~Issue2471DictionaryIndexerSameCompilationTypeTests|FullyQualifiedName~Issue648ChainedMemberAssignmentEmitTests|FullyQualifiedName~Issue944IndexerDeclarationEmitTests" -v:minimal` (63 passed)

Fixes #2488