### PR TITLE
Fix collision-aware constraint type qualification

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2509ConstraintTypeQualificationPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2509ConstraintTypeQualificationPipelineTests.cs
@@ -1,0 +1,220 @@
+// <copyright file="Issue2509ConstraintTypeQualificationPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Default SDK-backed/gsc sink coverage for issue #2509's cross-project
+/// constraint collision and a negative control proving constraint enforcement
+/// remains active.
+/// </summary>
+public sealed class Issue2509ConstraintTypeQualificationPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_CrossProjectConstraintCollision_TranslatesAndCompiles()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        (string contractsProject, string consumerProject) = WriteFixture(sourceRoot);
+        string outputRoot = NewDirectory("pipeline-tests");
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("test/Contracts", contractsProject, TargetKind.Library),
+            new CorpusApp("test/Consumer", consumerProject, TargetKind.Library),
+        });
+
+        Assert.All(
+            result.Apps,
+            app => Assert.True(
+                app.Succeeded,
+                app.AppId + " should compile through default --via-sdk/gsc. Stages: " +
+                    string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status))));
+
+        AppResult consumer = result.Apps.Single(app => app.AppId == "test/Consumer");
+        string appRunDir = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(consumer.AppId));
+        string emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(appRunDir, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains("func Add[T A.IPerson class init()]() T", emitted, StringComparison.Ordinal);
+        Assert.Contains("func Test() Author -> Add[Author]()", emitted, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ViaSdk_GenuinelyUnsatisfiedConstraint_StillReportsGs0152()
+    {
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (repoRoot is null || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string workDir = NewDirectory("negative-control");
+        string sourcePath = Path.Combine(workDir, "Negative.gs");
+        File.WriteAllText(sourcePath, """
+            package Negative
+
+            interface IContract {
+            }
+
+            class Wrong {
+            }
+
+            class Repro {
+                shared {
+                    func Add[T IContract]() {
+                    }
+
+                    func Test() -> Add[Wrong]()
+                }
+            }
+            """);
+
+        SdkCompileResult result = new SdkCompileRunner().Compile(
+            workDir,
+            "Negative",
+            new[] { sourcePath },
+            TargetKind.Library,
+            Array.Empty<string>(),
+            Array.Empty<string>(),
+            Array.Empty<string>(),
+            rootNamespace: null,
+            config: "Release");
+
+        Assert.True(result.IsAvailable, result.UnavailableReason);
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Errors, diagnostic => diagnostic.Id == "GS0152");
+    }
+
+    private static (string ContractsProject, string ConsumerProject) WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+
+        string contractsDir = Path.Combine(sourceRoot, "Contracts");
+        Directory.CreateDirectory(contractsDir);
+        string contractsProject = Path.Combine(contractsDir, "Contracts.csproj");
+        File.WriteAllText(contractsProject, ProjectFile(null));
+        File.WriteAllText(Path.Combine(contractsDir, "Contracts.cs"), """
+            namespace A;
+
+            public interface IPerson { }
+
+            public sealed class Author : IPerson
+            {
+            }
+            """);
+
+        string consumerDir = Path.Combine(sourceRoot, "Consumer");
+        Directory.CreateDirectory(consumerDir);
+        string consumerProject = Path.Combine(consumerDir, "Consumer.csproj");
+        File.WriteAllText(consumerProject, ProjectFile("../Contracts/Contracts.csproj"));
+        File.WriteAllText(Path.Combine(consumerDir, "Repro.cs"), """
+            using A;
+
+            namespace B
+            {
+                public interface IPerson { }
+            }
+
+            namespace App
+            {
+                public static class Repro
+                {
+                    public static T Add<T>() where T : class, IPerson, new() => new T();
+                    public static B.IPerson GetOther() => null;
+                    public static Author Test() => Add<Author>();
+                }
+            }
+            """);
+
+        return (contractsProject, consumerProject);
+    }
+
+    private static string ProjectFile(string projectReference)
+    {
+        string reference = projectReference is null
+            ? string.Empty
+            : $"""
+
+                <ItemGroup>
+                  <ProjectReference Include="{projectReference}" />
+                </ItemGroup>
+              """;
+        return $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>disable</Nullable>
+              </PropertyGroup>{reference}
+            </Project>
+            """;
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2509",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2509ConstraintTypeQualificationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2509ConstraintTypeQualificationTranslationTests.cs
@@ -1,0 +1,341 @@
+// <copyright file="Issue2509ConstraintTypeQualificationTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2509: every class/interface constraint type must use the same
+/// semantic, collision-aware type mapper as generic constraints and ordinary
+/// type positions.
+/// </summary>
+public sealed class Issue2509ConstraintTypeQualificationTranslationTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SourceHomonyms_AllDeclarationKinds_KeepExactConstraintIdentity(bool reverseTypeFileOrder)
+    {
+        (string FileName, string Source) first = ("A.cs", """
+            namespace A
+            {
+                public interface IContract { }
+                public interface IGeneric<T> { }
+                public class Base { }
+                public static class Outer
+                {
+                    public interface IContract { }
+                }
+            }
+            """);
+        (string FileName, string Source) second = ("B.cs", """
+            namespace B
+            {
+                public interface IContract { }
+                public interface IGeneric<T> { }
+                public class Base { }
+                public static class Outer
+                {
+                    public interface IContract { }
+                }
+            }
+            """);
+        var sources = reverseTypeFileOrder
+            ? new[] { second, first, ("Caller.cs", CallerSource) }
+            : new[] { first, second, ("Caller.cs", CallerSource) };
+
+        (string printed, TranslationContext context) = TranslateInMemory(sources, "Caller.cs");
+
+        Assert.Contains("class BaseHost[T A.Base]", printed, StringComparison.Ordinal);
+        Assert.Contains("interface InterfaceHost[T A.IContract]", printed, StringComparison.Ordinal);
+        Assert.Contains("type Handler[T A.IContract] = delegate", printed, StringComparison.Ordinal);
+        Assert.Contains("func Generic[T A.IGeneric[T]]", printed, StringComparison.Ordinal);
+        Assert.Contains("func Nested[T A.Outer.IContract]", printed, StringComparison.Ordinal);
+        Assert.Contains("func Multiple[T A.Base init()]", printed, StringComparison.Ordinal);
+        Assert.Contains(
+            context.Diagnostics,
+            diagnostic => diagnostic.Message.Contains(
+                "multiple constraint types; only the first ('A.Base')",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void MetadataConstraint_WithSourceHomonym_UsesQualifiedSemanticIdentity()
+    {
+        MetadataReference contractReference = CompileLibrary(
+            """
+            namespace A
+            {
+                public interface IContract { }
+            }
+            """,
+            "Issue2509MetadataA");
+
+        const string SourceHomonym = """
+            namespace B
+            {
+                public interface IContract { }
+            }
+            """;
+        const string Caller = """
+            using Contract = A.IContract;
+
+            namespace App
+            {
+                public static class Repro
+                {
+                    public static void Add<T>() where T : class, Contract, new() { }
+                    public static B.IContract GetOther() => null;
+                }
+            }
+            """;
+
+        string printed = TranslateWithReferences(
+            new[] { ("B.cs", SourceHomonym), ("Caller.cs", Caller) },
+            "Caller.cs",
+            contractReference);
+
+        Assert.Contains("func Add[T A.IContract class init()]", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MetadataConstraint_WithMetadataHomonym_UsesQualifiedSemanticIdentity()
+    {
+        MetadataReference first = CompileLibrary(
+            """
+            namespace A
+            {
+                public interface IContract { }
+            }
+            """,
+            "Issue2509MetadataFirst");
+        MetadataReference second = CompileLibrary(
+            """
+            namespace B
+            {
+                public interface IContract { }
+            }
+            """,
+            "Issue2509MetadataSecond");
+
+        const string Caller = """
+            using A;
+
+            namespace App
+            {
+                public static class Repro
+                {
+                    public static void Add<T>() where T : IContract { }
+                    public static B.IContract GetOther() => null;
+                }
+            }
+            """;
+
+        string printed = TranslateWithReferences(
+            new[] { ("Caller.cs", Caller) },
+            "Caller.cs",
+            first,
+            second);
+
+        Assert.Contains("func Add[T A.IContract]", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NestedMetadataConstraint_WithCollidingOutermostTypes_UsesNamespaceQualification()
+    {
+        MetadataReference first = CompileLibrary(
+            """
+            namespace A
+            {
+                public static class Outer
+                {
+                    public interface IContract { }
+                }
+            }
+            """,
+            "Issue2509NestedMetadataFirst");
+        MetadataReference second = CompileLibrary(
+            """
+            namespace B
+            {
+                public static class Outer
+                {
+                    public interface IContract { }
+                }
+            }
+            """,
+            "Issue2509NestedMetadataSecond");
+
+        const string Caller = """
+            using A;
+
+            namespace App
+            {
+                public static class Repro
+                {
+                    public static void Add<T>() where T : Outer.IContract { }
+                    public static B.Outer.IContract GetOther() => null;
+                }
+            }
+            """;
+
+        string printed = TranslateWithReferences(
+            new[] { ("Caller.cs", Caller) },
+            "Caller.cs",
+            first,
+            second);
+
+        Assert.Contains("func Add[T A.Outer.IContract]", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NullableConstraintAnnotation_IsAuditedAndDroppedFromUnsupportedConstraintSlot()
+    {
+        (string printed, TranslationContext context) = TranslateInMemory(
+            new[]
+            {
+                ("Caller.cs", """
+                    #nullable enable
+                    namespace Solo
+                    {
+                        public interface IContract { }
+                        public sealed class Holder<T> where T : IContract? { }
+                    }
+                    """),
+            },
+            "Caller.cs");
+
+        Assert.Contains("class Holder[T IContract]", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("IContract?", printed, StringComparison.Ordinal);
+        Assert.Contains(
+            context.Diagnostics,
+            diagnostic => diagnostic.Message.Contains(
+                "generic-constraint slot has no nullable form",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void NoCollision_NonGenericConstraint_RemainsShort()
+    {
+        (string printed, TranslationContext _) = TranslateInMemory(
+            new[]
+            {
+                ("Caller.cs", """
+                    namespace Solo
+                    {
+                        public interface IContract { }
+                        public sealed class Holder<T> where T : IContract { }
+                    }
+                    """),
+            },
+            "Caller.cs");
+
+        Assert.Contains("class Holder[T IContract]", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Solo.IContract", printed, StringComparison.Ordinal);
+    }
+
+    private const string CallerSource = """
+        using A;
+        using Contract = A.IContract;
+
+        namespace App
+        {
+            public class BaseHost<T> where T : Base { }
+            public interface InterfaceHost<T> where T : Contract { }
+            public delegate void Handler<T>() where T : IContract;
+
+            public static class Repro
+            {
+                public static void Generic<T>() where T : IGeneric<T> { }
+                public static void Nested<T>() where T : Outer.IContract { }
+                public static void Multiple<T>() where T : Base, IContract, new() { }
+
+                public static B.IContract GetOther() => null;
+                public static B.IGeneric<int> GetOtherGeneric() => null;
+                public static B.Base GetOtherBase() => null;
+                public static B.Outer.IContract GetOtherNested() => null;
+            }
+        }
+        """;
+
+    private static (string Printed, TranslationContext Context) TranslateInMemory(
+        (string FileName, string Source)[] sources,
+        string targetFile)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(sources);
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Inline C# should bind without errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = project.Documents.Single(
+            candidate => candidate.FilePath.EndsWith(targetFile, StringComparison.Ordinal));
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return (PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context)), context);
+    }
+
+    private static string TranslateWithReferences(
+        (string FileName, string Source)[] sources,
+        string targetFile,
+        params MetadataReference[] additionalReferences)
+    {
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree[] trees = sources
+            .Select(source => CSharpSyntaxTree.ParseText(source.Source, parseOptions, path: source.FileName))
+            .ToArray();
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue2509.ConstraintQualification",
+            trees,
+            CSharpProjectLoader.RuntimeReferences().Concat(additionalReferences).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+
+        SyntaxTree target = trees.Single(tree => tree.FilePath.EndsWith(targetFile, StringComparison.Ordinal));
+        SemanticModel model = compilation.GetSemanticModel(target);
+        var document = new LoadedDocument(target.FilePath, target, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            roundTrip.Success,
+            string.Join(Environment.NewLine, roundTrip.Errors) + Environment.NewLine + printed);
+        return printed;
+    }
+
+    private static MetadataReference CompileLibrary(string source, string assemblyName)
+    {
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest));
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var stream = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult emit = compilation.Emit(stream);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        stream.Position = 0;
+        return MetadataReference.CreateFromStream(stream);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -619,21 +619,16 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 ITypeSymbol primary = tp.ConstraintTypes[0];
 
-                // Issue #943: a constructed generic-interface constraint
-                // (`where T : IComparable<T>`) now has a canonical G# form —
-                // `[T IComparable[T]]` — which parses, binds, emits verifiable
-                // IL, and is enforced. Render the constraint type (including its
-                // type arguments, e.g. the self-referential `T`) into the legacy
-                // constraint slot via the type mapper + printer.
-                if (primary is INamedTypeSymbol { IsGenericType: true })
-                {
-                    GTypeReference constraintRef = this.typeMapper.Map(primary, this.context, tp.Locations.FirstOrDefault());
-                    legacy = GSharpPrinter.RenderTypeReference(constraintRef);
-                }
-                else
-                {
-                    legacy = primary.Name;
-                }
+                // Issues #943 and #2509: every selected class/interface
+                // constraint uses the canonical semantic type mapper. The old
+                // non-generic branch emitted only `primary.Name`, discarding
+                // namespace/nesting identity and allowing a synthesized import
+                // containing a homonym to rebind the constraint.
+                GTypeReference constraintRef = this.typeMapper.MapConstraintType(
+                    primary,
+                    this.context,
+                    tp.Locations.FirstOrDefault());
+                legacy = GSharpPrinter.RenderTypeReference(constraintRef);
 
                 if (tp.ConstraintTypes.Length > 1)
                 {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -122,6 +122,14 @@ public sealed class CSharpTypeMapper
     private HashSet<string> importedNamespaceNames;
 
     /// <summary>
+    /// Issue #2509: constraint slots must disambiguate metadata/metadata
+    /// homonyms as well as source collisions. Ordinary type positions retain
+    /// the existing source-authored collision policy to avoid gratuitously
+    /// qualifying framework types that share a name across BCL namespaces.
+    /// </summary>
+    private bool qualifyMetadataImportCollisions;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="CSharpTypeMapper"/> class
     /// with a private, unshared anonymous-type registry (every prior call
     /// site's behavior — used by standalone/single-file callers such as
@@ -298,6 +306,48 @@ public sealed class CSharpTypeMapper
             && (type.IsReferenceType || type is ITypeParameterSymbol);
         GTypeReference mapped = this.MapCore(type, context, location);
         return nullableReference ? WithNullable(mapped, true) : mapped;
+    }
+
+    /// <summary>
+    /// Maps a type used in G#'s legacy generic-constraint slot. The slot uses
+    /// the canonical semantic name/type arguments but does not accept an outer
+    /// nullable marker, so a C# nullable constraint annotation is reported and
+    /// dropped while nested nullable type arguments remain intact.
+    /// </summary>
+    /// <param name="type">The bound C# constraint type.</param>
+    /// <param name="context">The translation context that accumulates diagnostics.</param>
+    /// <param name="location">The originating C# constraint location.</param>
+    /// <returns>The canonical G# constraint type reference.</returns>
+    public GTypeReference MapConstraintType(
+        ITypeSymbol type,
+        TranslationContext context,
+        Location location)
+    {
+        bool previous = this.qualifyMetadataImportCollisions;
+        this.qualifyMetadataImportCollisions = true;
+        GTypeReference mapped;
+        try
+        {
+            mapped = this.Map(type, context, location);
+        }
+        finally
+        {
+            this.qualifyMetadataImportCollisions = previous;
+        }
+
+        if (!mapped.IsNullable)
+        {
+            return mapped;
+        }
+
+        string message = $"constraint type '{type.ToDisplayString()}' has a nullable annotation; " +
+            "G#'s generic-constraint slot has no nullable form, so the outer annotation is dropped.";
+        context.Report(new TranslationDiagnostic(
+            nameof(SyntaxKind.TypeParameterConstraintClause),
+            message,
+            location,
+            TranslationSeverity.Info));
+        return WithNullable(mapped, false);
     }
 
     /// <summary>
@@ -706,7 +756,9 @@ public sealed class CSharpTypeMapper
     // simple key — so the nested type must be qualified `Container.Nested` to
     // resolve correctly. This is now safe to emit in every position (generic
     // arguments, type clauses, struct literals) thanks to the issue #1174
-    // language fix, so the qualified form round-trips under gsc.
+    // language fix, so the qualified form round-trips under gsc. Issue #2509
+    // additionally prefixes the namespace when the OUTERMOST containing type
+    // itself collides across imported packages.
     private string QualifiedTypeName(INamedTypeSymbol named, TranslationContext context)
     {
         if (named.ContainingType == null)
@@ -725,15 +777,14 @@ public sealed class CSharpTypeMapper
             // the reference to the right type instead of whichever homonym
             // happens to resolve first.
             //
-            // The imported-namespace scan is gated on `named` itself being
-            // SOURCE-declared: a pure-BCL/metadata reference (e.g. `List<T>`)
-            // must never trip it — the runtime ships the same forwarded type
-            // across several referenced assemblies (facade + implementation),
-            // which otherwise looks like a spurious homonym and would qualify
-            // every common framework type. Only a type this project actually
-            // AUTHORS can be the accidental collision the issue describes.
+            // Constraint mapping also enables this scan for metadata/metadata
+            // collisions (issue #2509). Ordinary positions retain the
+            // source-authored gate so common framework types are not qualified
+            // spuriously.
+            bool scanImportedNamespaces = named.Locations.Any(l => l.IsInSource)
+                || this.qualifyMetadataImportCollisions;
             bool ambiguous = this.HasSourceHomonym(named, context)
-                || (named.Locations.Any(l => l.IsInSource) && this.HasImportedNamespaceHomonym(named, context));
+                || (scanImportedNamespaces && this.HasImportedNamespaceHomonym(named, context));
             if (!ambiguous)
             {
                 return simpleName;
@@ -760,7 +811,15 @@ public sealed class CSharpTypeMapper
         }
 
         this.TrackShortenedNamespace(outermost);
-        return string.Join(".", parts);
+        string nestedName = string.Join(".", parts);
+        bool scanOutermostImports = outermost.Locations.Any(l => l.IsInSource)
+            || this.qualifyMetadataImportCollisions;
+        bool outermostAmbiguous = this.HasSourceHomonym(outermost, context)
+            || (scanOutermostImports && this.HasImportedNamespaceHomonym(outermost, context));
+        return outermostAmbiguous
+            && outermost.ContainingNamespace is { IsGlobalNamespace: false } outerNamespace
+                ? $"{outerNamespace.ToDisplayString()}.{nestedName}"
+                : nestedName;
     }
 
     /// <summary>
@@ -809,7 +868,9 @@ public sealed class CSharpTypeMapper
     /// compilation-wide source-only census, this walks only the namespaces
     /// this file actually imports — cheap even when a referenced assembly
     /// (e.g. a translated sibling project) is huge — and covers a homonym
-    /// declared in metadata rather than source.
+    /// declared in metadata rather than source. Issue #2509 extends this to a
+    /// metadata type colliding with a different metadata type; symbols in the
+    /// same namespace/package are not import collisions.
     /// </summary>
     private bool HasImportedNamespaceHomonym(INamedTypeSymbol named, TranslationContext context)
     {
@@ -828,10 +889,23 @@ public sealed class CSharpTypeMapper
             // original definitions so `Box<Label>` correctly matches `Box<T>`.
             foreach (INamedTypeSymbol candidate in candidateNamespace.GetTypeMembers(named.Name))
             {
-                if (!SymbolEqualityComparer.Default.Equals(candidate.OriginalDefinition, named.OriginalDefinition))
+                if (SymbolEqualityComparer.Default.Equals(candidate.OriginalDefinition, named.OriginalDefinition))
                 {
-                    return true;
+                    continue;
                 }
+
+                // Types in the same namespace/package are not an import
+                // collision. This also filters facade/implementation symbols
+                // for the same forwarded metadata type, and same-namespace
+                // generic-arity overloads such as IComparable/IComparable<T>
+                // that the type arguments already disambiguate.
+                if (candidate.ContainingNamespace?.ToDisplayString()
+                    == named.ContainingNamespace?.ToDisplayString())
+                {
+                    continue;
+                }
+
+                return true;
             }
         }
 


### PR DESCRIPTION
Fixes #2509

## Summary
- route every selected class/interface constraint through the canonical semantic type mapper
- qualify source/metadata and metadata/metadata constraint homonyms, including nested containing-type collisions
- preserve existing multiple-constraint policy and report unsupported outer nullable constraint annotations
- add focused translation plus default `--via-sdk`/gsc positive and GS0152 negative coverage

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter FullyQualifiedName~Issue2509ConstraintTypeQualification --no-restore`
- qualification regression set (22 tests)
- `MSBUILDDISABLENODEREUSE=1 dotnet build GSharp.sln -c Release --no-restore`