### PR TITLE
Fix nullable-oblivious index argument forgiveness

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessPipelineTests.cs
@@ -1,0 +1,271 @@
+// <copyright file="Issue2511NullableIndexArgumentForgivenessPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Default <c>--via-sdk</c>/gsc sink coverage for issue #2511, covering the
+/// minimal dictionary repro plus source and imported/cross-project custom
+/// indexers.
+/// </summary>
+public sealed class Issue2511NullableIndexArgumentForgivenessPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_IndexArgumentForgiveness_TranslatesAndCompiles()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        (string apiProject, string appProject) = WriteFixture(sourceRoot);
+        RunDotnetBuild(apiProject);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(
+            new[] { new CorpusApp("test/Issue2511", appProject, TargetKind.Library) });
+        AppResult appResult = Assert.Single(result.Apps);
+
+        string emitted = ReadAppOutput(outputRoot, result.RunId, appResult.AppId);
+        AssertMatches(emitted, @"items\[[^\]]*key!![^\]]*\]\s*=\s*""value""");
+        AssertMatches(emitted, @"items\[[^\]]*key!![^\]]*\]");
+        AssertMatches(emitted, @"imported\[[^\]]*key!![^\]]*\]");
+        AssertMatches(emitted, @"generic\[[^\]]*key!![^\]]*\]");
+        AssertMatches(emitted, @"counts\[[^\]]*key!![^\]]*\]\s*\+=\s*1");
+        Assert.Contains("local[key] = second", emitted, StringComparison.Ordinal);
+        Assert.DoesNotContain("local[key!!]", emitted, StringComparison.Ordinal);
+        Assert.Contains("nullable[key] = second", emitted, StringComparison.Ordinal);
+        Assert.DoesNotContain("nullable[key!!]", emitted, StringComparison.Ordinal);
+        Assert.Contains("array[i]", emitted, StringComparison.Ordinal);
+        Assert.Contains("span[i]", emitted, StringComparison.Ordinal);
+        Assert.Contains("text[i]", emitted, StringComparison.Ordinal);
+        Assert.Contains("array[^1]", emitted, StringComparison.Ordinal);
+        Assert.Contains("text[1..^1]", emitted, StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            "Expected default --via-sdk/gsc compilation to accept nullable-oblivious index arguments. Stages: " +
+                string.Join("; ", appResult.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+    }
+
+    private static (string ApiProject, string AppProject) WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+
+        string apiDir = Path.Combine(sourceRoot, "Api");
+        string appDir = Path.Combine(sourceRoot, "Issue2511");
+        Directory.CreateDirectory(apiDir);
+        Directory.CreateDirectory(appDir);
+
+        string apiProject = Path.Combine(apiDir, "Api.csproj");
+        File.WriteAllText(apiProject, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(apiDir, "Api.cs"), """
+            #nullable disable
+            namespace ExternalApi;
+
+            public sealed class ImportedLookup
+            {
+                public string this[string key]
+                {
+                    get => key ?? "";
+                    set { }
+                }
+            }
+
+            public sealed class GenericLookup<TKey>
+                where TKey : class
+            {
+                public string this[TKey key] => key.ToString();
+            }
+
+            public static class ImportedUsage
+            {
+                private static string FindKey() =>
+                    System.Environment.GetEnvironmentVariable("SIBLING_KEY");
+
+                public static string Read(ImportedLookup lookup)
+                {
+                    string key = FindKey();
+                    return lookup[key];
+                }
+            }
+
+            #nullable enable
+            public sealed class NullableLookup
+            {
+                public string this[string? key]
+                {
+                    get => key ?? "";
+                    set { }
+                }
+            }
+            """);
+
+        string appProject = Path.Combine(appDir, "Issue2511.csproj");
+        File.WriteAllText(appProject, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>disable</Nullable>
+              </PropertyGroup>
+              <ItemGroup>
+                <ProjectReference Include="../Api/Api.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(appDir, "Repro.cs"), """
+            using System;
+            using System.Collections.Generic;
+            using ExternalApi;
+
+            namespace Issue2511;
+
+            public sealed class LocalLookup
+            {
+                public string this[string key]
+                {
+                    get => key ?? "";
+                    set { }
+                }
+            }
+
+            public static class Repro
+            {
+                private static string FindKey(bool ok) => ok ? "key" : null;
+
+                public static string Run(
+                    Dictionary<string, string> items,
+                    Dictionary<string, int> counts,
+                    LocalLookup local,
+                    ImportedLookup imported,
+                    GenericLookup<string> generic,
+                    NullableLookup nullable,
+                    int[] array,
+                    string text,
+                    int i,
+                    bool ok)
+                {
+                    string key = FindKey(ok);
+                    items[key] = "value";
+                    string first = items[key];
+                    string second = imported[key];
+                    local[key] = second;
+                    string third = local[key];
+                    string fourth = generic[key];
+                    counts[key] += 1;
+                    nullable[key] = second;
+                    Span<int> span = array;
+                    return fourth + first + third + nullable[key]
+                        + (array[i] + span[i] + text[i] + array[^1] + text[1..^1].Length).ToString();
+                }
+            }
+            """);
+
+        return (apiProject, appProject);
+    }
+
+    private static void RunDotnetBuild(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo(
+            "dotnet",
+            $"build \"{projectPath}\" --nologo --verbosity:quiet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+
+        using var process = Process.Start(startInfo);
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(
+            process.ExitCode == 0,
+            "Failed to prebuild API project:\n" + stdout + stderr);
+    }
+
+    private static string ReadAppOutput(string outputRoot, string runId, string appId)
+    {
+        string directory = Path.Combine(
+            outputRoot,
+            runId,
+            MigrationPipeline.SanitizeAppId(appId));
+        return string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(directory, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2511",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private static void AssertMatches(string text, string pattern) =>
+        Assert.Matches(new Regex(pattern, RegexOptions.Singleline | RegexOptions.CultureInvariant), text);
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessTranslationTests.cs
@@ -1,0 +1,372 @@
+// <copyright file="Issue2511NullableIndexArgumentForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression coverage for issue #2511: nullable-oblivious values used as
+/// index arguments need the same minimal, target-aware forgiveness as ordinary
+/// call arguments.
+/// </summary>
+public sealed class Issue2511NullableIndexArgumentForgivenessTranslationTests
+{
+    [Fact]
+    public void ObliviousDictionaryIndexes_ForgiveReadsWritesAndCompoundAssignments()
+    {
+        string printed = TranslateOblivious("""
+            using System;
+            using System.Collections.Generic;
+
+            namespace Demo;
+
+            public static class Repro
+            {
+                private static string FindKey() => Environment.GetEnvironmentVariable("KEY");
+
+                public static string Run(
+                    Dictionary<string, string> items,
+                    Dictionary<string, int> counts)
+                {
+                    string key = FindKey();
+                    items[key] = "value";
+                    string value = items[key];
+                    counts[key] += 1;
+                    counts[key]++;
+                    items[FindKey()] ??= value;
+                    Dictionary<string, string> initialized = new()
+                    {
+                        [key] = value,
+                    };
+                    return items[key];
+                }
+            }
+            """);
+
+        Assert.Contains("items[key!!] = \"value\"", printed, StringComparison.Ordinal);
+        Assert.Contains("let value = items[key!!]", printed, StringComparison.Ordinal);
+        Assert.Contains("counts[key!!] += 1", printed, StringComparison.Ordinal);
+        Assert.Contains("counts[key!!]++", printed, StringComparison.Ordinal);
+        Assert.Contains("items[Repro.FindKey()!!] ??= value", printed, StringComparison.Ordinal);
+        Assert.Contains("[key!!] = value", printed, StringComparison.Ordinal);
+        Assert.Contains("return items[key!!]", printed, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(printed, "items[Repro.FindKey()!!]"));
+    }
+
+    [Fact]
+    public void ImportedGenericAndConditionalIndexes_AreForgivenWithoutDoubleAssertion()
+    {
+        string printed = TranslateObliviousWithIndexerLibrary("""
+            using System;
+
+            namespace Demo;
+
+            public static class Repro
+            {
+                private static string FindKey() => Environment.GetEnvironmentVariable("KEY");
+
+                public static string Run(
+                    ImportedLookup imported,
+                    GenericLookup<string> generic,
+                    bool useConditional)
+                {
+                    string key = FindKey();
+                    imported[key] = "value";
+                    string first = imported[key];
+                    string second = generic[key];
+                    string third = imported[key!];
+                    string fourth = useConditional ? imported?[key] : "";
+                    return first + second + third + fourth;
+                }
+            }
+            """);
+
+        Assert.Contains("imported!![key!!] = \"value\"", printed, StringComparison.Ordinal);
+        Assert.Contains("let first = imported!![key!!]", printed, StringComparison.Ordinal);
+        Assert.Contains("let second = generic[key!!]", printed, StringComparison.Ordinal);
+        Assert.Contains("let third = imported!![key!!]", printed, StringComparison.Ordinal);
+        Assert.Contains("imported?[key!!]", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("key!!!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ObliviousIndexArgumentShapes_ReuseValueForgiveness()
+    {
+        string printed = TranslateOblivious("""
+            using System;
+            using System.Collections.Generic;
+
+            namespace Demo;
+
+            public sealed class Holder
+            {
+                public string Key { get; set; }
+            }
+
+            public static class Repro
+            {
+                private static string Field = Environment.GetEnvironmentVariable("FIELD");
+                private static string Property => Environment.GetEnvironmentVariable("PROPERTY");
+                private static string FindKey() => Environment.GetEnvironmentVariable("METHOD");
+
+                public static void Run(
+                    Dictionary<string, string> items,
+                    string parameter,
+                    Holder holder,
+                    bool choose)
+                {
+                    parameter = Environment.GetEnvironmentVariable("PARAMETER");
+                    items[Field] = "field";
+                    items[Property] = "property";
+                    items[FindKey()] = "method";
+                    items[parameter] = "parameter";
+                    items[choose ? Field : Property] = "conditional";
+                    items[holder?.Key] = "conditional-access";
+                    items[Environment.GetEnvironmentVariable("DIRECT")] = "external";
+                }
+            }
+            """);
+
+        Assert.Contains("items[Repro.Field!!] = \"field\"", printed, StringComparison.Ordinal);
+        Assert.Contains("items[Repro.Property!!] = \"property\"", printed, StringComparison.Ordinal);
+        Assert.Contains("items[Repro.FindKey()!!] = \"method\"", printed, StringComparison.Ordinal);
+        Assert.Contains("items[parameter!!] = \"parameter\"", printed, StringComparison.Ordinal);
+        Assert.Contains("if choose { Repro.Field } else { Repro.Property }", printed, StringComparison.Ordinal);
+        Assert.Contains("Repro.Property })!!] = \"conditional\"", printed, StringComparison.Ordinal);
+        Assert.Contains("items[(holder?.Key)!!] = \"conditional-access\"", printed, StringComparison.Ordinal);
+        Assert.Contains(
+            "items[Environment.GetEnvironmentVariable(\"DIRECT\")!!] = \"external\"",
+            printed,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExplicitNullableSourcePromotedAndNullableEnabledContracts_RemainAssertionFree()
+    {
+        string oblivious = TranslateObliviousWithIndexerLibrary("""
+            using System;
+
+            namespace Demo;
+
+            public sealed class SourceLookup
+            {
+                public string this[string key]
+                {
+                    get => key;
+                    set { }
+                }
+            }
+
+            public static class Repro
+            {
+                private static string FindKey() => Environment.GetEnvironmentVariable("KEY");
+
+                public static string Run(
+                    NullableLookup nullable,
+                    SourceLookup source)
+                {
+                    string key = FindKey();
+                    nullable[key] = "value";
+                    source[key] = "value";
+                    NullableLookup initialized = new()
+                    {
+                        [key] = "value",
+                    };
+                    return nullable[key] + source[key];
+                }
+            }
+            """);
+
+        Assert.Contains("nullable[key] = \"value\"", oblivious, StringComparison.Ordinal);
+        Assert.Contains("nullable[key] + source[key]", oblivious, StringComparison.Ordinal);
+        Assert.DoesNotContain("nullable[key!!]", oblivious, StringComparison.Ordinal);
+        Assert.DoesNotContain("source[key!!]", oblivious, StringComparison.Ordinal);
+        Assert.DoesNotContain("[key!!] = \"value\"", oblivious, StringComparison.Ordinal);
+
+        string enabled = Translate(
+            """
+            #nullable enable
+            using System.Collections.Generic;
+
+            namespace Demo;
+
+            public static class Repro
+            {
+                public static string Run(Dictionary<string, string> items, string? key)
+                {
+                    if (key is null)
+                    {
+                        return "";
+                    }
+
+                    return items[key];
+                }
+            }
+            """,
+            NullableContextOptions.Enable);
+
+        Assert.Contains("return items[key]", enabled, StringComparison.Ordinal);
+        Assert.DoesNotContain("key!!", enabled, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuardsExpressionTreesAndNumericIndexPaths_RemainUnchanged()
+    {
+        string printed = TranslateOblivious("""
+            using System;
+            using System.Collections.Generic;
+            using System.Linq.Expressions;
+
+            namespace Demo;
+
+            public static class Repro
+            {
+                private static string FindKey() => Environment.GetEnvironmentVariable("KEY");
+
+                public static int Run(
+                    Dictionary<string, string> items,
+                    int[] array,
+                    int[,] grid,
+                    string text,
+                    int i,
+                    int row,
+                    int column)
+                {
+                    string key = FindKey();
+                    if (key != null)
+                    {
+                        _ = items[key];
+                    }
+
+                    items[key != null ? key : "fallback"] = "guarded";
+                    Expression<Func<Dictionary<string, string>, string>> read =
+                        dictionary => dictionary[key];
+                    Span<int> span = array;
+                    return array[i] + span[i] + text[i] + array[^1]
+                        + text[1..^1].Length + grid[row, column];
+                }
+            }
+            """);
+
+        Assert.Contains("items[key]", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("key!!", printed, StringComparison.Ordinal);
+        Assert.Contains("dictionary[key]", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("dictionary[key!!]", printed, StringComparison.Ordinal);
+        Assert.Contains("array[i]", printed, StringComparison.Ordinal);
+        Assert.Contains("span[i]", printed, StringComparison.Ordinal);
+        Assert.Contains("text[i]", printed, StringComparison.Ordinal);
+        Assert.Contains("array[^1]", printed, StringComparison.Ordinal);
+        Assert.Contains("text[1..^1]", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("row!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("column!!", printed, StringComparison.Ordinal);
+    }
+
+    private static string TranslateOblivious(string source) =>
+        Translate(source, NullableContextOptions.Disable);
+
+    private static string Translate(
+        string source,
+        NullableContextOptions nullableContext,
+        params MetadataReference[] additionalReferences)
+    {
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest),
+            path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Issue2511.Consumer",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Concat(additionalReferences),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(nullableContext)
+                .WithAllowUnsafe(true));
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        CompilationUnit translated = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(translated);
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            roundTrip.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", roundTrip.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    private static string TranslateObliviousWithIndexerLibrary(string source) =>
+        Translate(source, NullableContextOptions.Disable, CompileIndexerLibrary());
+
+    private static MetadataReference CompileIndexerLibrary()
+    {
+        const string source = """
+            #nullable disable
+            public sealed class ImportedLookup
+            {
+                public string this[string key]
+                {
+                    get => key;
+                    set { }
+                }
+            }
+
+            public sealed class GenericLookup<TKey>
+                where TKey : class
+            {
+                public string this[TKey key] => key.ToString();
+            }
+
+            #nullable enable
+            public sealed class NullableLookup
+            {
+                public string this[string? key]
+                {
+                    get => key ?? "";
+                    set { }
+                }
+            }
+            """;
+
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest));
+        var compilation = CSharpCompilation.Create(
+            "Issue2511.IndexerLibrary",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+        using var stream = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return MetadataReference.CreateFromImage(stream.ToArray());
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        int count = 0;
+        for (int index = text.IndexOf(value, StringComparison.Ordinal);
+            index >= 0;
+            index = text.IndexOf(value, index + value.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -758,6 +758,101 @@ public sealed partial class CSharpToGSharpTranslator
             return translated;
         }
 
+        // Issue #2511: element-access arguments are call-like value sinks too.
+        // Apply the established forgiveness predicate only when Roslyn bound the
+        // argument to a non-null reference parameter that cs2gs will keep
+        // non-null. Arrays and numeric/string/span indices therefore stay on
+        // their existing paths, explicitly nullable indexer contracts remain
+        // untouched, and nullable-enabled projects receive no new assertions.
+        // A genuinely null oblivious key follows the existing `!!` bridge
+        // policy and fails at runtime before the index operation.
+        private GExpression TranslateIndexArgumentWithNullForgiveness(ArgumentSyntax argument)
+        {
+            GExpression translated = this.TranslateExpression(argument.Expression);
+            if (!this.IsObliviousCompilation()
+                || !this.IndexArgumentTargetsNonNullableReference(argument)
+                || !this.IndexArgumentValueNeedsNullForgiveness(argument.Expression))
+            {
+                return translated;
+            }
+
+            GExpression assertionOperand = argument.Expression is ConditionalExpressionSyntax
+                or SwitchExpressionSyntax
+                or ConditionalAccessExpressionSyntax
+                    ? new ParenthesizedExpression(translated)
+                    : translated;
+            return new NonNullAssertionExpression(assertionOperand);
+        }
+
+        private bool IndexArgumentValueNeedsNullForgiveness(ExpressionSyntax value)
+        {
+            if (value is PostfixUnaryExpressionSyntax
+                    { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
+                || this.IsWithinExpressionTreeLambda(value))
+            {
+                return false;
+            }
+
+            if (this.ReceiverNeedsNullForgiveness(value))
+            {
+                return true;
+            }
+
+            switch (value)
+            {
+                case ParenthesizedExpressionSyntax parenthesized:
+                    return this.IndexArgumentValueNeedsNullForgiveness(parenthesized.Expression);
+
+                case ConditionalExpressionSyntax conditional:
+                    return this.IndexArgumentValueNeedsNullForgiveness(conditional.WhenTrue)
+                        || this.IndexArgumentValueNeedsNullForgiveness(conditional.WhenFalse);
+
+                case SwitchExpressionSyntax switchExpression:
+                    return switchExpression.Arms.Any(arm =>
+                        this.IndexArgumentValueNeedsNullForgiveness(arm.Expression));
+
+                case ConditionalAccessExpressionSyntax:
+                    return true;
+            }
+
+            ISymbol symbol = this.context.GetSymbolInfo(value).Symbol;
+            return symbol is IFieldSymbol or IPropertySymbol or ILocalSymbol or IParameterSymbol or IMethodSymbol
+                && this.IsNullablePromotedValue(value)
+                && !this.IsDominatedByNullCheckGuard(value, symbol);
+        }
+
+        private bool IndexArgumentTargetsNonNullableReference(ArgumentSyntax argument)
+        {
+            if (this.context.SemanticModel.GetOperation(argument) is not IArgumentOperation
+                {
+                    Parameter: { } parameter,
+                })
+            {
+                return false;
+            }
+
+            return this.ParameterWillRemainNonNullableReference(parameter);
+        }
+
+        private bool ParameterWillRemainNonNullableReference(IParameterSymbol parameter)
+        {
+            if (parameter.Type is not { IsReferenceType: true } parameterType
+                || parameterType.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                return false;
+            }
+
+            bool parameterDeclaredInThisCompilation = parameter.DeclaringSyntaxReferences
+                .Any(reference => this.context.Compilation.ContainsSyntaxTree(reference.SyntaxTree));
+
+            // Only a parameter declaration translated by this compilation can
+            // have its rendered signature widened. Project-reference and CLR
+            // metadata parameters keep the contract gsc binds at this call site,
+            // even when sibling analysis records nullable flow for their source.
+            return !(parameterDeclaredInThisCompilation
+                && this.ShouldPromoteToNullableReference(parameter));
+        }
+
         /// <summary>
         /// Determines whether <paramref name="recv"/> needs a G# <c>!!</c>
         /// assertion because it is either a declared-nullable reference narrowed
@@ -1555,13 +1650,6 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            ITypeSymbol parameterType = parameter.Type;
-            if (parameterType is not { IsReferenceType: true }
-                || parameterType.NullableAnnotation == NullableAnnotation.Annotated)
-            {
-                return false;
-            }
-
             // If cs2gs will ALSO promote the bound parameter to nullable (the
             // ordinary same-project method case above), the argument already
             // widens `T? -> T?` with no `!!` required — forcing one here would
@@ -1587,11 +1675,7 @@ public sealed partial class CSharpToGSharpTranslator
             // symbol category entirely and leaves the same-project method
             // case (whose parameter genuinely has a declaring syntax node
             // here) unaffected.
-            bool parameterDeclaredInThisCompilation = parameter.DeclaringSyntaxReferences
-                .Any(reference => this.context.Compilation.ContainsSyntaxTree(reference.SyntaxTree));
-
-            return !(parameterDeclaredInThisCompilation
-                && this.ShouldPromoteToNullableReference(parameter));
+            return this.ParameterWillRemainNonNullableReference(parameter);
         }
 
         private bool IsUnguardedForwardOfTaintedValueAsRuntimeLambdaResult(ExpressionSyntax use)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1773,7 +1773,8 @@ public sealed partial class CSharpToGSharpTranslator
                         indexerSymbol);
 
                     elements.Add(new CollectionInitializerElement(
-                        this.TranslateExpression(indexAccess.ArgumentList.Arguments[0].Expression),
+                        this.TranslateIndexArgumentWithNullForgiveness(
+                            indexAccess.ArgumentList.Arguments[0]),
                         indexedValue,
                         indexed: true));
                 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -198,7 +198,8 @@ public sealed partial class CSharpToGSharpTranslator
                     GExpression index = elementAccess.ArgumentList.Arguments.Count > 0
                         ? this.CoerceIndexToInt32(
                             elementAccess,
-                            this.TranslateExpression(elementAccess.ArgumentList.Arguments[0].Expression))
+                            this.TranslateIndexArgumentWithNullForgiveness(
+                                elementAccess.ArgumentList.Arguments[0]))
                         : new IdentifierExpression("nil");
                     return new IndexExpression(
                         this.TranslateReceiverWithNullForgiveness(elementAccess.Expression),
@@ -282,7 +283,8 @@ public sealed partial class CSharpToGSharpTranslator
 
                 case ElementBindingExpressionSyntax elementBinding:
                     GExpression bindingIndex = elementBinding.ArgumentList.Arguments.Count > 0
-                        ? this.TranslateExpression(elementBinding.ArgumentList.Arguments[0].Expression)
+                        ? this.TranslateIndexArgumentWithNullForgiveness(
+                            elementBinding.ArgumentList.Arguments[0])
                         : new IdentifierExpression("nil");
                     return new IndexExpression(new ConditionalReceiverExpression(), bindingIndex);
 


### PR DESCRIPTION
## Summary
- route element, conditional-element, and indexed-initializer keys through target-aware nullable-oblivious forgiveness
- preserve nullable/source-promoted contracts, guards, expression trees, conditional access, numeric/range paths, and single evaluation
- add focused translator plus default `--via-sdk`/gsc coverage for dictionary/custom/generic/cross-project indexers

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --filter "FullyQualifiedName~Issue2511|FullyQualifiedName~Issue2425|FullyQualifiedName~Issue2427|FullyQualifiedName~Issue2429|FullyQualifiedName~Issue2434|FullyQualifiedName~Issue2496" --nologo --verbosity:minimal`
- 79 passed

Fixes #2511