### PR TITLE
Fix override resolution declaration-order dependency

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -892,8 +892,69 @@ public sealed class Binder
             }
         }
 
-        foreach (var (structSyntax, structSymbol) in declaredStructs)
+        // Issue #2489: shells make base types resolvable up front, but override
+        // validation also needs the base type's members. Bind same-compilation
+        // base classes before their derived classes, independent of tree/source
+        // order.
+        var declarationsByName = declaredStructs
+            .Select((declaration, index) => (declaration.Symbol.Name, Index: index))
+            .GroupBy(entry => entry.Name, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.Select(entry => entry.Index).ToList(), StringComparer.Ordinal);
+        var bindingState = new byte[declaredStructs.Count];
+        var bindingOrder = new List<int>(declaredStructs.Count);
+
+        void AddBaseFirst(int index)
         {
+            if (bindingState[index] == 2)
+            {
+                return;
+            }
+
+            if (bindingState[index] == 1)
+            {
+                return;
+            }
+
+            bindingState[index] = 1;
+            var (syntax, symbol) = declaredStructs[index];
+            TypeClauseSyntax baseType = syntax.BaseTypeClauses.Count > 0
+                ? syntax.BaseTypeClauses[0]
+                : syntax.BaseTypeIdentifier == null
+                    ? null
+                    : new TypeClauseSyntax(syntax.SyntaxTree, syntax.BaseTypeIdentifier);
+            var baseName = baseType?.QualifierIdentifierTokens.LastOrDefault()?.Text
+                ?? baseType?.Identifier?.Text;
+            if (symbol.IsClass && baseName != null && declarationsByName.TryGetValue(baseName, out var candidates))
+            {
+                var requestedPackage = baseType.HasQualifier
+                    ? baseType.DottedName[..^(baseName.Length + 1)]
+                    : symbol.PackageName;
+                var matchingPackage = candidates.Where(candidate =>
+                    declaredStructs[candidate].Symbol.IsClass &&
+                    declaredStructs[candidate].Symbol.PackageName == requestedPackage).ToList();
+                var baseIndex = matchingPackage.Count == 1
+                    ? matchingPackage[0]
+                    : candidates.Count(candidate => declaredStructs[candidate].Symbol.IsClass) == 1
+                        ? candidates.Single(candidate => declaredStructs[candidate].Symbol.IsClass)
+                        : -1;
+                if (baseIndex >= 0)
+                {
+                    AddBaseFirst(baseIndex);
+                }
+            }
+
+            bindingState[index] = 2;
+            bindingOrder.Add(index);
+        }
+
+        for (var i = 0; i < declaredStructs.Count; i++)
+        {
+            AddBaseFirst(i);
+        }
+
+        foreach (var index in bindingOrder)
+        {
+            var (structSyntax, structSymbol) = declaredStructs[index];
             var owningPackage = packageByTree[structSyntax.SyntaxTree];
             RunWithPackage(owningPackage, structSyntax.SyntaxTree, () => binder.declarations.BindStructDeclarationBody(structSyntax, owningPackage, structSymbol));
         }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -566,8 +566,8 @@ internal sealed partial class DeclarationBinder
         // Phase 3.B.3 sub-step 3 + 3.B.4: resolve the optional `: X, Y, Z` clause.
         // Each identifier is either the (single) base class or an interface
         // implemented by this class. A base class, if present, must be the
-        // first identifier. Declaration order rules apply: base/interfaces
-        // must be declared before this type.
+        // first identifier. All same-compilation type shells are already
+        // declared, and the global binder orders class bodies base-first.
         StructSymbol baseClassSymbol = null;
         TypeSymbol importedBaseType = null;
         var implementedInterfaces = ImmutableArray.CreateBuilder<InterfaceSymbol>();

--- a/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
@@ -377,6 +377,45 @@ b.F()
     }
 
     [Fact]
+    public void Override_DerivedDeclaredBeforeBase_Dispatches()
+    {
+        var source = @"
+class B : A {
+    override func F() int32 { return 2 }
+}
+open class A {
+    open func F() int32 { return 1 }
+}
+var b = B{}
+b.F()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(2, result.Value);
+    }
+
+    [Fact]
+    public void Override_DerivedTreeBeforeBaseTree_Binds()
+    {
+        var derived = SyntaxTree.Parse(SourceText.From(@"
+package Demo
+class B : A {
+    override func F() int32 { return 2 }
+}
+"));
+        var baseType = SyntaxTree.Parse(SourceText.From(@"
+package Demo
+open class A {
+    open func F() int32 { return 1 }
+}
+"));
+        var result = new Compilation(derived, baseType)
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
     public void Override_OfNonOpenMethod_Diagnoses()
     {
         var source = @"

--- a/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
@@ -400,12 +400,14 @@ b.F()
         var derived = SyntaxTree.Parse(SourceText.From(@"
 package Demo
 class B : A {
+    init() : base(1) {}
     override func F() int32 { return 2 }
 }
 "));
         var baseType = SyntaxTree.Parse(SourceText.From(@"
 package Demo
 open class A {
+    init(value int32) {}
     open func F() int32 { return 1 }
 }
 "));

--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -40,7 +40,7 @@ public sealed class CompileStage : IMigrationStage
         string outputName = Path.GetFileNameWithoutExtension(context.App.ProjectPath) + ".dll";
         string outputPath = Path.Combine(context.AppRunDir, outputName);
 
-        IReadOnlyList<string> gsFiles = OrderForCompilation(context.EmittedFiles)
+        IReadOnlyList<string> gsFiles = context.EmittedFiles
             .Select(f => f.GsPath)
             .ToList();
         IReadOnlyList<string> references =
@@ -249,103 +249,6 @@ public sealed class CompileStage : IMigrationStage
         return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
             .OrderBy(p => p, StringComparer.Ordinal)
             .ToList();
-    }
-
-    /// <summary>
-    /// Orders emitted files so that a file declaring a base class is compiled
-    /// before any file declaring its subclasses. gsc currently resolves a
-    /// <c>: base(...)</c> constructor chain against the base class's explicit
-    /// <c>init</c> only when the base type has already been bound, so a derived
-    /// class that appears before its base reports a spurious GS0214 "no
-    /// accessible constructor" (and cascading GS0183/GS0187). A stable
-    /// topological sort on the class-inheritance graph avoids that; cycles (which
-    /// the inheritance graph cannot contain, but file-level grouping might) fall
-    /// back to the original order.
-    /// </summary>
-    private static IReadOnlyList<EmittedGsFile> OrderForCompilation(IReadOnlyList<EmittedGsFile> files)
-    {
-        if (files.Count <= 1)
-        {
-            return files;
-        }
-
-        // Map each declared type's simple name to the file that declares it.
-        var typeToFile = new Dictionary<string, int>(StringComparer.Ordinal);
-        for (int i = 0; i < files.Count; i++)
-        {
-            foreach (string typeName in files[i].DeclaredTypeNames)
-            {
-                typeToFile.TryAdd(typeName, i);
-            }
-        }
-
-        // Edges: a file depends on (must come after) every file that declares one
-        // of its base classes.
-        var dependencies = new List<HashSet<int>>(files.Count);
-        var dependentCount = new int[files.Count];
-        for (int i = 0; i < files.Count; i++)
-        {
-            dependencies.Add(new HashSet<int>());
-        }
-
-        for (int i = 0; i < files.Count; i++)
-        {
-            foreach (string baseName in files[i].BaseClassNames)
-            {
-                if (typeToFile.TryGetValue(baseName, out int baseFile) &&
-                    baseFile != i &&
-                    dependencies[i].Add(baseFile))
-                {
-                    dependentCount[i]++;
-                }
-            }
-        }
-
-        // Kahn's algorithm with stable tie-breaking by original index.
-        var ordered = new List<EmittedGsFile>(files.Count);
-        var emitted = new bool[files.Count];
-        int remaining = files.Count;
-        while (remaining > 0)
-        {
-            int picked = -1;
-            for (int i = 0; i < files.Count; i++)
-            {
-                if (!emitted[i] && dependentCount[i] == 0)
-                {
-                    picked = i;
-                    break;
-                }
-            }
-
-            if (picked < 0)
-            {
-                // Cycle in the file-level graph: emit the remaining files in their
-                // original order to make progress.
-                for (int i = 0; i < files.Count; i++)
-                {
-                    if (!emitted[i])
-                    {
-                        ordered.Add(files[i]);
-                        emitted[i] = true;
-                    }
-                }
-
-                break;
-            }
-
-            ordered.Add(files[picked]);
-            emitted[picked] = true;
-            remaining--;
-            for (int i = 0; i < files.Count; i++)
-            {
-                if (!emitted[i] && dependencies[i].Remove(picked))
-                {
-                    dependentCount[i]--;
-                }
-            }
-        }
-
-        return ordered;
     }
 
     private static EmittedGsFile MatchEmittedFile(IReadOnlyList<EmittedGsFile> files, string diagnosticFile)

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -181,34 +181,11 @@ public sealed class EmittedGsFile
     /// <param name="csFilePath">The originating C# file path.</param>
     /// <param name="gsharpSource">The emitted G# source text.</param>
     public EmittedGsFile(string gsPath, string relativeGsPath, string csFilePath, string gsharpSource)
-        : this(gsPath, relativeGsPath, csFilePath, gsharpSource, null, null)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="EmittedGsFile"/> class with
-    /// type-graph metadata used to order files for whole-app compilation.
-    /// </summary>
-    /// <param name="gsPath">The absolute path of the written <c>.gs</c> file.</param>
-    /// <param name="relativeGsPath">The run-relative path of the <c>.gs</c> file (for artifacts).</param>
-    /// <param name="csFilePath">The originating C# file path.</param>
-    /// <param name="gsharpSource">The emitted G# source text.</param>
-    /// <param name="declaredTypeNames">Simple names of the types declared in this file.</param>
-    /// <param name="baseClassNames">Simple names of the base classes those types extend.</param>
-    public EmittedGsFile(
-        string gsPath,
-        string relativeGsPath,
-        string csFilePath,
-        string gsharpSource,
-        IReadOnlyList<string> declaredTypeNames,
-        IReadOnlyList<string> baseClassNames)
     {
         this.GsPath = gsPath;
         this.RelativeGsPath = relativeGsPath;
         this.CsFilePath = csFilePath;
         this.GSharpSource = gsharpSource;
-        this.DeclaredTypeNames = declaredTypeNames ?? System.Array.Empty<string>();
-        this.BaseClassNames = baseClassNames ?? System.Array.Empty<string>();
     }
 
     /// <summary>Gets the absolute path of the written <c>.gs</c> file.</summary>
@@ -222,17 +199,6 @@ public sealed class EmittedGsFile
 
     /// <summary>Gets the emitted G# source text.</summary>
     public string GSharpSource { get; }
-
-    /// <summary>Gets the simple names of the types declared in this file.</summary>
-    public IReadOnlyList<string> DeclaredTypeNames { get; }
-
-    /// <summary>
-    /// Gets the simple names of the base classes extended by the types in this
-    /// file. Used to order files so a base class is compiled before its
-    /// subclasses (works around an order-dependent <c>: base(...)</c> resolution
-    /// limitation in gsc).
-    /// </summary>
-    public IReadOnlyList<string> BaseClassNames { get; }
 
     /// <summary>
     /// Gets or sets a value indicating whether this file was emitted from a

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -265,19 +265,13 @@ public sealed class TranslateStage : IMigrationStage
                 Directory.CreateDirectory(Path.GetDirectoryName(gsPath));
                 File.WriteAllText(gsPath, printed);
 
-                var declaredTypeNames = new List<string>();
-                var baseClassNames = new List<string>();
-                CollectTypeGraph(unit.Members, declaredTypeNames, baseClassNames);
-
                 string relativeGsPath = MigrationPipeline.SanitizeAppId(context.App.Id) + "/" +
                     gsRelativePath.Replace(Path.DirectorySeparatorChar, '/');
                 var emitted = new EmittedGsFile(
                     gsPath,
                     relativeGsPath,
                     document.FilePath,
-                    printed,
-                    declaredTypeNames,
-                    baseClassNames)
+                    printed)
                 {
                     IsFromReferencedProject = isReferencedProject,
                 };
@@ -339,8 +333,6 @@ public sealed class TranslateStage : IMigrationStage
                     continue;
                 }
 
-                string className = Path.GetFileNameWithoutExtension(resxPath);
-
                 string gsRelativePath = OutputPathForResx(
                     resxPath,
                     currentProject,
@@ -356,9 +348,7 @@ public sealed class TranslateStage : IMigrationStage
                     gsPath,
                     relativeGsPath,
                     resxPath,
-                    generated,
-                    new[] { className },
-                    Array.Empty<string>())
+                    generated)
                 {
                     IsFromReferencedProject = isReferencedProject,
                 };
@@ -742,59 +732,5 @@ public sealed class TranslateStage : IMigrationStage
                 privateAssets ?? "all",
                 includeAssets));
         }
-    }
-
-    /// <summary>
-    /// Walks the emitted declarations of one file, recording the simple names of
-    /// the types declared (including nested types) and the simple names of the
-    /// base classes they extend. This drives the base-before-subclass compile
-    /// ordering in <see cref="CompileStage"/>.
-    /// </summary>
-    private static void CollectTypeGraph(
-        IReadOnlyList<GNode> members,
-        List<string> declaredTypeNames,
-        List<string> baseClassNames)
-    {
-        if (members is null)
-        {
-            return;
-        }
-
-        foreach (GNode member in members)
-        {
-            if (member is TypeDeclaration type)
-            {
-                declaredTypeNames.Add(type.Name);
-                if (type.BaseType is NamedTypeReference baseRef)
-                {
-                    baseClassNames.Add(SimpleName(baseRef.Name));
-                }
-
-                // Implemented interfaces are dependencies too: gsc's interface-
-                // satisfaction binding is order-sensitive, so a type must be
-                // compiled after the interfaces it declares (CompileStage ordering).
-                foreach (GTypeReference iface in type.Interfaces)
-                {
-                    if (iface is NamedTypeReference ifaceRef)
-                    {
-                        baseClassNames.Add(SimpleName(ifaceRef.Name));
-                    }
-                }
-
-                CollectTypeGraph(type.Members, declaredTypeNames, baseClassNames);
-            }
-        }
-    }
-
-    /// <summary>Returns the last dotted segment of a (possibly qualified) name.</summary>
-    private static string SimpleName(string name)
-    {
-        if (string.IsNullOrEmpty(name))
-        {
-            return name;
-        }
-
-        int dot = name.LastIndexOf('.');
-        return dot >= 0 ? name.Substring(dot + 1) : name;
     }
 }


### PR DESCRIPTION
## Summary
- bind same-compilation base class bodies before derived class bodies
- make override and explicit base-constructor resolution independent of declaration and syntax-tree order
- remove cs2gs simple-name file-ordering workaround and metadata
- add regressions for same-file and cross-file ordering

## Testing
- ClassTests: 49 passed
- cross-file override and explicit base constructor regression: passed
- Cs2Gs.Tests: 1,616 passed; 9 unrelated existing SDK/toolchain failures

Closes #2489
