### PR TITLE
Fix imported interface constraint member access

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -5555,7 +5555,9 @@ public sealed class Binder
         }
 
         var openDefName = constraintClr.GetGenericTypeDefinition().FullName;
-        var constraintArgs = (constraint as ImportedTypeSymbol)?.TypeArguments ?? ImmutableArray<TypeSymbol>.Empty;
+        var constraintArgs = MemberLookup.GetImportedTypeSymbol(constraint)?.TypeArguments
+            ?? ImmutableArray<TypeSymbol>.Empty;
+        var constraintClrArgs = constraintClr.GetGenericArguments();
 
         foreach (var candidate in EnumerateSelfAndInterfaces(typeArgClr))
         {
@@ -5565,7 +5567,12 @@ public sealed class Binder
                 continue;
             }
 
-            if (GenericConstraintArgumentsMatch(candidate.GetGenericArguments(), constraintArgs, tp, typeArgClr))
+            if (GenericConstraintArgumentsMatch(
+                candidate.GetGenericArguments(),
+                constraintArgs,
+                constraintClrArgs,
+                tp,
+                typeArgClr))
             {
                 return true;
             }
@@ -5590,10 +5597,14 @@ public sealed class Binder
     private static bool GenericConstraintArgumentsMatch(
         Type[] candidateArgs,
         ImmutableArray<TypeSymbol> constraintArgs,
+        Type[] constraintClrArgs,
         TypeParameterSymbol tp,
         Type typeArgClr)
     {
-        if (constraintArgs.IsDefaultOrEmpty || candidateArgs.Length != constraintArgs.Length)
+        var expectedCount = !constraintArgs.IsDefaultOrEmpty
+            ? constraintArgs.Length
+            : constraintClrArgs?.Length ?? 0;
+        if (expectedCount == 0 || candidateArgs.Length != expectedCount)
         {
             return false;
         }
@@ -5603,9 +5614,11 @@ public sealed class Binder
             // A self-referential constraint argument (the constrained parameter
             // itself) is expected to be the type argument; any other argument is
             // matched against its own resolved CLR type.
-            var expectedName = constraintArgs[i] is TypeParameterSymbol cArgTp && ReferenceEquals(cArgTp, tp)
-                ? typeArgClr.FullName
-                : constraintArgs[i].ClrType?.FullName;
+            var expectedName = !constraintArgs.IsDefaultOrEmpty
+                ? (constraintArgs[i] is TypeParameterSymbol cArgTp && ReferenceEquals(cArgTp, tp)
+                    ? typeArgClr.FullName
+                    : constraintArgs[i].ClrType?.FullName)
+                : constraintClrArgs[i].FullName;
 
             if (expectedName == null
                 || !string.Equals(candidateArgs[i].FullName, expectedName, StringComparison.Ordinal))

--- a/src/Core/CodeAnalysis/Binding/BoundClrEventSubscriptionExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrEventSubscriptionExpression.cs
@@ -19,13 +19,22 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrEventSubscriptionExpression : BoundExpression
 {
-    public BoundClrEventSubscriptionExpression(SyntaxNode syntax, BoundExpression receiver, EventInfo eventInfo, BoundExpression handler, bool isAdd)
+    public BoundClrEventSubscriptionExpression(
+        SyntaxNode syntax,
+        BoundExpression receiver,
+        EventInfo eventInfo,
+        BoundExpression handler,
+        bool isAdd,
+        TypeParameterSymbol constrainedReceiverTypeParameter = null,
+        TypeSymbol constrainedInterfaceType = null)
         : base(syntax)
     {
         Receiver = receiver;
         Event = eventInfo;
         Handler = handler;
         IsAdd = isAdd;
+        ConstrainedReceiverTypeParameter = constrainedReceiverTypeParameter;
+        ConstrainedInterfaceType = constrainedInterfaceType;
     }
 
     public BoundExpression Receiver { get; }
@@ -35,6 +44,12 @@ public sealed class BoundClrEventSubscriptionExpression : BoundExpression
     public BoundExpression Handler { get; }
 
     public bool IsAdd { get; }
+
+    public TypeParameterSymbol ConstrainedReceiverTypeParameter { get; }
+
+    public TypeSymbol ConstrainedInterfaceType { get; }
+
+    public bool IsConstrainedTypeParameterAccess => ConstrainedReceiverTypeParameter != null;
 
     public override TypeSymbol Type => TypeSymbol.Void;
 

--- a/src/Core/CodeAnalysis/Binding/BoundClrIndexAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrIndexAssignmentExpression.cs
@@ -22,7 +22,15 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrIndexAssignmentExpression : BoundExpression
 {
-    public BoundClrIndexAssignmentExpression(SyntaxNode syntax, VariableSymbol target, PropertyInfo indexer, ImmutableArray<BoundExpression> arguments, BoundExpression value, TypeSymbol resultType)
+    public BoundClrIndexAssignmentExpression(
+        SyntaxNode syntax,
+        VariableSymbol target,
+        PropertyInfo indexer,
+        ImmutableArray<BoundExpression> arguments,
+        BoundExpression value,
+        TypeSymbol resultType,
+        TypeParameterSymbol constrainedReceiverTypeParameter = null,
+        TypeSymbol constrainedInterfaceType = null)
         : base(syntax)
     {
         Target = target;
@@ -30,9 +38,19 @@ public sealed class BoundClrIndexAssignmentExpression : BoundExpression
         Arguments = arguments;
         Value = value;
         Type = resultType;
+        ConstrainedReceiverTypeParameter = constrainedReceiverTypeParameter;
+        ConstrainedInterfaceType = constrainedInterfaceType;
     }
 
-    private BoundClrIndexAssignmentExpression(SyntaxNode syntax, BoundExpression targetExpression, PropertyInfo indexer, ImmutableArray<BoundExpression> arguments, BoundExpression value, TypeSymbol resultType)
+    private BoundClrIndexAssignmentExpression(
+        SyntaxNode syntax,
+        BoundExpression targetExpression,
+        PropertyInfo indexer,
+        ImmutableArray<BoundExpression> arguments,
+        BoundExpression value,
+        TypeSymbol resultType,
+        TypeParameterSymbol constrainedReceiverTypeParameter,
+        TypeSymbol constrainedInterfaceType)
         : base(syntax)
     {
         TargetExpression = targetExpression;
@@ -40,6 +58,8 @@ public sealed class BoundClrIndexAssignmentExpression : BoundExpression
         Arguments = arguments;
         Value = value;
         Type = resultType;
+        ConstrainedReceiverTypeParameter = constrainedReceiverTypeParameter;
+        ConstrainedInterfaceType = constrainedInterfaceType;
     }
 
     public VariableSymbol Target { get; }
@@ -58,6 +78,12 @@ public sealed class BoundClrIndexAssignmentExpression : BoundExpression
 
     public BoundExpression Value { get; }
 
+    public TypeParameterSymbol ConstrainedReceiverTypeParameter { get; }
+
+    public TypeSymbol ConstrainedInterfaceType { get; }
+
+    public bool IsConstrainedTypeParameterAccess => ConstrainedReceiverTypeParameter != null;
+
     public override TypeSymbol Type { get; }
 
     public override BoundNodeKind Kind => BoundNodeKind.ClrIndexAssignmentExpression;
@@ -73,6 +99,8 @@ public sealed class BoundClrIndexAssignmentExpression : BoundExpression
     /// <param name="arguments">The indexer argument expressions.</param>
     /// <param name="value">The value to assign.</param>
     /// <param name="resultType">The result type of the assignment expression.</param>
+    /// <param name="constrainedReceiverTypeParameter">The constrained receiver type parameter, if any.</param>
+    /// <param name="constrainedInterfaceType">The imported interface declaring the constrained indexer, if any.</param>
     /// <returns>A new <see cref="BoundClrIndexAssignmentExpression"/> with an expression target.</returns>
     public static BoundClrIndexAssignmentExpression WithExpressionTarget(
         SyntaxNode syntax,
@@ -80,8 +108,18 @@ public sealed class BoundClrIndexAssignmentExpression : BoundExpression
         PropertyInfo indexer,
         ImmutableArray<BoundExpression> arguments,
         BoundExpression value,
-        TypeSymbol resultType)
+        TypeSymbol resultType,
+        TypeParameterSymbol constrainedReceiverTypeParameter = null,
+        TypeSymbol constrainedInterfaceType = null)
     {
-        return new BoundClrIndexAssignmentExpression(syntax, targetExpression, indexer, arguments, value, resultType);
+        return new BoundClrIndexAssignmentExpression(
+            syntax,
+            targetExpression,
+            indexer,
+            arguments,
+            value,
+            resultType,
+            constrainedReceiverTypeParameter,
+            constrainedInterfaceType);
     }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundClrIndexExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrIndexExpression.cs
@@ -19,13 +19,22 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrIndexExpression : BoundExpression
 {
-    public BoundClrIndexExpression(SyntaxNode syntax, BoundExpression target, PropertyInfo indexer, ImmutableArray<BoundExpression> arguments, TypeSymbol resultType)
+    public BoundClrIndexExpression(
+        SyntaxNode syntax,
+        BoundExpression target,
+        PropertyInfo indexer,
+        ImmutableArray<BoundExpression> arguments,
+        TypeSymbol resultType,
+        TypeParameterSymbol constrainedReceiverTypeParameter = null,
+        TypeSymbol constrainedInterfaceType = null)
         : base(syntax)
     {
         Target = target;
         Indexer = indexer;
         Arguments = arguments;
         Type = resultType;
+        ConstrainedReceiverTypeParameter = constrainedReceiverTypeParameter;
+        ConstrainedInterfaceType = constrainedInterfaceType;
     }
 
     public BoundExpression Target { get; }
@@ -33,6 +42,12 @@ public sealed class BoundClrIndexExpression : BoundExpression
     public PropertyInfo Indexer { get; }
 
     public ImmutableArray<BoundExpression> Arguments { get; }
+
+    public TypeParameterSymbol ConstrainedReceiverTypeParameter { get; }
+
+    public TypeSymbol ConstrainedInterfaceType { get; }
+
+    public bool IsConstrainedTypeParameterAccess => ConstrainedReceiverTypeParameter != null;
 
     public override TypeSymbol Type { get; }
 

--- a/src/Core/CodeAnalysis/Binding/BoundClrPropertyAccessExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrPropertyAccessExpression.cs
@@ -20,13 +20,22 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrPropertyAccessExpression : BoundExpression
 {
-    public BoundClrPropertyAccessExpression(SyntaxNode syntax, BoundExpression receiver, MemberInfo member, TypeSymbol resultType, TypeSymbol staticContainerType = null)
+    public BoundClrPropertyAccessExpression(
+        SyntaxNode syntax,
+        BoundExpression receiver,
+        MemberInfo member,
+        TypeSymbol resultType,
+        TypeSymbol staticContainerType = null,
+        TypeParameterSymbol constrainedReceiverTypeParameter = null,
+        TypeSymbol constrainedInterfaceType = null)
         : base(syntax)
     {
         Receiver = receiver;
         Member = member;
         Type = resultType;
         StaticContainerType = staticContainerType;
+        ConstrainedReceiverTypeParameter = constrainedReceiverTypeParameter;
+        ConstrainedInterfaceType = constrainedInterfaceType;
     }
 
     public BoundExpression Receiver { get; }
@@ -44,6 +53,15 @@ public sealed class BoundClrPropertyAccessExpression : BoundExpression
     /// instance member access.
     /// </summary>
     public TypeSymbol StaticContainerType { get; }
+
+    /// <summary>Gets the type parameter used for constrained interface dispatch, if any.</summary>
+    public TypeParameterSymbol ConstrainedReceiverTypeParameter { get; }
+
+    /// <summary>Gets the imported interface that owns the constrained member reference, if any.</summary>
+    public TypeSymbol ConstrainedInterfaceType { get; }
+
+    /// <summary>Gets a value indicating whether this access dispatches through a type-parameter constraint.</summary>
+    public bool IsConstrainedTypeParameterAccess => ConstrainedReceiverTypeParameter != null;
 
     public override TypeSymbol Type { get; }
 

--- a/src/Core/CodeAnalysis/Binding/BoundClrPropertyAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrPropertyAssignmentExpression.cs
@@ -20,13 +20,22 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrPropertyAssignmentExpression : BoundExpression
 {
-    public BoundClrPropertyAssignmentExpression(SyntaxNode syntax, BoundExpression receiver, MemberInfo member, BoundExpression value, TypeSymbol resultType)
+    public BoundClrPropertyAssignmentExpression(
+        SyntaxNode syntax,
+        BoundExpression receiver,
+        MemberInfo member,
+        BoundExpression value,
+        TypeSymbol resultType,
+        TypeParameterSymbol constrainedReceiverTypeParameter = null,
+        TypeSymbol constrainedInterfaceType = null)
         : base(syntax)
     {
         Receiver = receiver;
         Member = member;
         Value = value;
         Type = resultType;
+        ConstrainedReceiverTypeParameter = constrainedReceiverTypeParameter;
+        ConstrainedInterfaceType = constrainedInterfaceType;
     }
 
     public BoundExpression Receiver { get; }
@@ -34,6 +43,12 @@ public sealed class BoundClrPropertyAssignmentExpression : BoundExpression
     public MemberInfo Member { get; }
 
     public BoundExpression Value { get; }
+
+    public TypeParameterSymbol ConstrainedReceiverTypeParameter { get; }
+
+    public TypeSymbol ConstrainedInterfaceType { get; }
+
+    public bool IsConstrainedTypeParameterAccess => ConstrainedReceiverTypeParameter != null;
 
     public override TypeSymbol Type { get; }
 

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1648,7 +1648,16 @@ public abstract class BoundTreeRewriter
         }
 
         var receiver = RewriteExpression(node.Receiver);
-        return receiver == node.Receiver ? node : new BoundClrPropertyAccessExpression(null, receiver, node.Member, node.Type);
+        return receiver == node.Receiver
+            ? node
+            : new BoundClrPropertyAccessExpression(
+                null,
+                receiver,
+                node.Member,
+                node.Type,
+                node.StaticContainerType,
+                node.ConstrainedReceiverTypeParameter,
+                node.ConstrainedInterfaceType);
     }
 
     /// <summary>Rewrites a CLR property/field write (static or instance).</summary>
@@ -1663,7 +1672,14 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundClrPropertyAssignmentExpression(null, receiver, node.Member, value, node.Type);
+        return new BoundClrPropertyAssignmentExpression(
+            null,
+            receiver,
+            node.Member,
+            value,
+            node.Type,
+            node.ConstrainedReceiverTypeParameter,
+            node.ConstrainedInterfaceType);
     }
 
     /// <summary>Rewrites a CLR event subscription (Stream B′).</summary>
@@ -1678,7 +1694,14 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundClrEventSubscriptionExpression(null, receiver, node.Event, handler, node.IsAdd);
+        return new BoundClrEventSubscriptionExpression(
+            null,
+            receiver,
+            node.Event,
+            handler,
+            node.IsAdd,
+            node.ConstrainedReceiverTypeParameter,
+            node.ConstrainedInterfaceType);
     }
 
     /// <summary>Rewrites a user-defined event subscription expression (ADR-0052).</summary>
@@ -1776,7 +1799,14 @@ public abstract class BoundTreeRewriter
         }
 
         var args = builder?.ToImmutable() ?? node.Arguments;
-        return new BoundClrIndexExpression(null, target, node.Indexer, args, node.Type);
+        return new BoundClrIndexExpression(
+            null,
+            target,
+            node.Indexer,
+            args,
+            node.Type,
+            node.ConstrainedReceiverTypeParameter,
+            node.ConstrainedInterfaceType);
     }
 
     /// <summary>Rewrites a CLR indexer write.</summary>
@@ -1814,10 +1844,26 @@ public abstract class BoundTreeRewriter
         var args = builder?.ToImmutable() ?? node.Arguments;
         if (targetExpr != null)
         {
-            return BoundClrIndexAssignmentExpression.WithExpressionTarget(null, targetExpr, node.Indexer, args, value, node.Type);
+            return BoundClrIndexAssignmentExpression.WithExpressionTarget(
+                null,
+                targetExpr,
+                node.Indexer,
+                args,
+                value,
+                node.Type,
+                node.ConstrainedReceiverTypeParameter,
+                node.ConstrainedInterfaceType);
         }
 
-        return new BoundClrIndexAssignmentExpression(null, node.Target, node.Indexer, args, value, node.Type);
+        return new BoundClrIndexAssignmentExpression(
+            null,
+            node.Target,
+            node.Indexer,
+            args,
+            value,
+            node.Type,
+            node.ConstrainedReceiverTypeParameter,
+            node.ConstrainedInterfaceType);
     }
 
     /// <summary>Rewrites an instance-method call on a user-defined class.</summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -934,7 +934,45 @@ internal sealed partial class ExpressionBinder
         // matches the single argument by assignability).
         // Issue #209: when the target carries inner-position nullable flags,
         // use them to type the element correctly (e.g., `list[0]` on `List<string?>` → `string?`).
-        if (target.Type is NullabilityAnnotatedTypeSymbol annotIdx && annotIdx.ClrType is System.Type clrAnnotIdx)
+        if (target.Type is TypeParameterSymbol tpIndexTarget
+            && tpIndexTarget.ClrInterfaceConstraint is TypeSymbol clrIndexConstraint
+            && clrIndexConstraint.ClrType is System.Type clrConstraintType)
+        {
+            var idxArgs = ImmutableArray.Create(BoundIndexArg());
+            if (this.memberLookup.TryResolveClrIndexer(
+                clrIndexConstraint,
+                clrConstraintType,
+                idxArgs,
+                out var idxProp,
+                out var resolvedIdxArgs))
+            {
+                if (idxProp.GetGetMethod(nonPublic: false) == null)
+                {
+                    Diagnostics.ReportTypeNotIndexable(targetLocation, target.Type);
+                    return new BoundErrorExpression(null);
+                }
+
+                var elementType = MemberLookup.GetClrPropertyTypeSymbol(clrIndexConstraint, idxProp);
+                var declaringInterface = MemberLookup.GetClrMemberDeclaringTypeSymbol(
+                    clrIndexConstraint,
+                    idxProp);
+                var convertedIdxArgs = BindClrIndexerArguments(
+                    clrIndexConstraint,
+                    idxProp,
+                    resolvedIdxArgs,
+                    indexSyntax.Location);
+                return ConversionClassifier.AutoDereferenceRefReturn(
+                    new BoundClrIndexExpression(
+                        null,
+                        target,
+                        idxProp,
+                        convertedIdxArgs,
+                        elementType,
+                        tpIndexTarget,
+                        declaringInterface));
+            }
+        }
+        else if (target.Type is NullabilityAnnotatedTypeSymbol annotIdx && annotIdx.ClrType is System.Type clrAnnotIdx)
         {
             var idxArgsAnnot = ImmutableArray.Create(BoundIndexArg());
             if (this.memberLookup.TryResolveClrIndexer(target.Type, clrAnnotIdx, idxArgsAnnot, out var idxPropAnnot, out var resolvedIdxArgsAnnot))
@@ -1446,11 +1484,29 @@ internal sealed partial class ExpressionBinder
             PropertyInfo indexer,
             ImmutableArray<BoundExpression> arguments,
             BoundExpression value,
-            TypeSymbol resultType)
+            TypeSymbol resultType,
+            TypeParameterSymbol constrainedReceiverTypeParameter = null,
+            TypeSymbol constrainedInterfaceType = null)
         {
             return hasNarrowedTarget
-                ? BoundClrIndexAssignmentExpression.WithExpressionTarget(null, target, indexer, arguments, value, resultType)
-                : new BoundClrIndexAssignmentExpression(null, variable, indexer, arguments, value, resultType);
+                ? BoundClrIndexAssignmentExpression.WithExpressionTarget(
+                    null,
+                    target,
+                    indexer,
+                    arguments,
+                    value,
+                    resultType,
+                    constrainedReceiverTypeParameter,
+                    constrainedInterfaceType)
+                : new BoundClrIndexAssignmentExpression(
+                    null,
+                    variable,
+                    indexer,
+                    arguments,
+                    value,
+                    resultType,
+                    constrainedReceiverTypeParameter,
+                    constrainedInterfaceType);
         }
 
         BoundExpression BindValue(TypeSymbol elementType)
@@ -1535,7 +1591,44 @@ internal sealed partial class ExpressionBinder
         // Phase 4 exit: CLR indexer write on an imported reference type
         // (e.g. `d["k"] = 1` on Dictionary[string, int]).
         // Issue #209: honour inner-position nullable flags when present.
-        if (targetType is NullabilityAnnotatedTypeSymbol annotWr && targetType.ClrType is System.Type clrAnnotWr)
+        if (targetType is TypeParameterSymbol tpIndexTarget
+            && tpIndexTarget.ClrInterfaceConstraint is TypeSymbol clrIndexConstraint
+            && clrIndexConstraint.ClrType is System.Type clrConstraintType)
+        {
+            var idxArgs = ImmutableArray.Create(BindIndexValue());
+            if (this.memberLookup.TryResolveClrIndexer(
+                clrIndexConstraint,
+                clrConstraintType,
+                idxArgs,
+                out var idxProp,
+                out var resolvedIdxArgs))
+            {
+                if (idxProp.GetSetMethod(nonPublic: false) == null)
+                {
+                    Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
+                    return new BoundErrorExpression(null);
+                }
+
+                var elementType = MemberLookup.GetClrPropertyTypeSymbol(clrIndexConstraint, idxProp);
+                var declaringInterface = MemberLookup.GetClrMemberDeclaringTypeSymbol(
+                    clrIndexConstraint,
+                    idxProp);
+                var value = BindValue(elementType);
+                var convertedArgs = BindClrIndexerArguments(
+                    clrIndexConstraint,
+                    idxProp,
+                    resolvedIdxArgs,
+                    indexSyntax.Location);
+                return MakeClrIndexAssignment(
+                    idxProp,
+                    convertedArgs,
+                    value,
+                    elementType,
+                    tpIndexTarget,
+                    declaringInterface);
+            }
+        }
+        else if (targetType is NullabilityAnnotatedTypeSymbol annotWr && targetType.ClrType is System.Type clrAnnotWr)
         {
             var idxArgsAnnotWr = ImmutableArray.Create(BindIndexValue());
             if (this.memberLookup.TryResolveClrIndexer(targetType, clrAnnotWr, idxArgsAnnotWr, out var idxPropAnnotWr, out var resolvedIdxArgsAnnotWr))
@@ -1702,6 +1795,12 @@ internal sealed partial class ExpressionBinder
 
     private static TypeSymbol MapErasedIndexerElementType(ImportedTypeSymbol target, PropertyInfo closedIndexer)
     {
+        var symbolicType = MemberLookup.GetClrPropertyTypeSymbol(target, closedIndexer);
+        if (TypeSymbol.RequiresSymbolicProjection(symbolicType))
+        {
+            return symbolicType;
+        }
+
         // Issue #313 (HasTypeParameterArgument): substitute the open indexer's
         // generic-parameter result back through the target's symbolic type
         // arguments so `list[i]` on `List[T]` is typed as `T`.
@@ -3083,6 +3182,37 @@ internal sealed partial class ExpressionBinder
                 }
 
                 return new BoundPropertyAccessExpression(null, receiver, null, ifaceProp);
+            }
+        }
+
+        if (tpRecv.ClrInterfaceConstraint is TypeSymbol clrInterfaceConstraint
+            && clrInterfaceConstraint.ClrType is Type clrInterface
+            && clrInterface.IsInterface)
+        {
+            var clrProperty = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(
+                clrInterface,
+                memberName,
+                BindingFlags.Public | BindingFlags.Instance);
+            if (clrProperty != null && clrProperty.GetIndexParameters().Length == 0)
+            {
+                if (clrProperty.GetGetMethod(nonPublic: false) == null)
+                {
+                    Diagnostics.ReportCannotAssign(ne.Location, memberName);
+                    return new BoundErrorExpression(null);
+                }
+
+                var propertyType = MemberLookup.GetClrPropertyTypeSymbol(clrInterfaceConstraint, clrProperty);
+                var declaringInterface = MemberLookup.GetClrMemberDeclaringTypeSymbol(
+                    clrInterfaceConstraint,
+                    clrProperty);
+                return ConversionClassifier.AutoDereferenceRefReturn(
+                    new BoundClrPropertyAccessExpression(
+                        null,
+                        receiver,
+                        clrProperty,
+                        propertyType,
+                        constrainedReceiverTypeParameter: tpRecv,
+                        constrainedInterfaceType: declaringInterface));
             }
         }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -1795,12 +1795,6 @@ internal sealed partial class ExpressionBinder
 
     private static TypeSymbol MapErasedIndexerElementType(ImportedTypeSymbol target, PropertyInfo closedIndexer)
     {
-        var symbolicType = MemberLookup.GetClrPropertyTypeSymbol(target, closedIndexer);
-        if (TypeSymbol.RequiresSymbolicProjection(symbolicType))
-        {
-            return symbolicType;
-        }
-
         // Issue #313 (HasTypeParameterArgument): substitute the open indexer's
         // generic-parameter result back through the target's symbolic type
         // arguments so `list[i]` on `List[T]` is typed as `T`.

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -792,6 +792,41 @@ internal sealed partial class ExpressionBinder
                 return new BoundPropertyAssignmentExpression(null, assignmentReceiver, null, tpIfaceProp, tpIfaceConverted);
             }
 
+            if (tpVarType.ClrInterfaceConstraint is TypeSymbol clrInterfaceConstraint
+                && clrInterfaceConstraint.ClrType is Type clrInterface
+                && clrInterface.IsInterface)
+            {
+                var clrProperty = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(
+                    clrInterface,
+                    syntax.FieldIdentifier.Text,
+                    BindingFlags.Public | BindingFlags.Instance);
+                if (clrProperty != null && clrProperty.GetIndexParameters().Length == 0)
+                {
+                    if (clrProperty.GetSetMethod(nonPublic: false) == null)
+                    {
+                        Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.Text);
+                        return new BoundErrorExpression(null);
+                    }
+
+                    var propertyType = MemberLookup.GetClrPropertyTypeSymbol(clrInterfaceConstraint, clrProperty);
+                    var declaringInterface = MemberLookup.GetClrMemberDeclaringTypeSymbol(
+                        clrInterfaceConstraint,
+                        clrProperty);
+                    var constrainedConverted = conversions.BindConversion(
+                        syntax.Value.Location,
+                        BindValue(propertyType),
+                        propertyType);
+                    return new BoundClrPropertyAssignmentExpression(
+                        null,
+                        assignmentReceiver,
+                        clrProperty,
+                        constrainedConverted,
+                        propertyType,
+                        tpVarType,
+                        declaringInterface);
+                }
+            }
+
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
             return new BoundErrorExpression(null);
         }
@@ -1988,6 +2023,45 @@ internal sealed partial class ExpressionBinder
                 var ifaceConverted = conversions.BindConversion(syntax.Value.Location, BindValue(ifaceProp.Type), ifaceProp.Type);
                 EnforceInitOnlyAssignment(ifaceProp, receiver, syntax.EqualsToken.Location);
                 return new BoundPropertyAssignmentExpression(null, receiver, null, ifaceProp, ifaceConverted);
+            }
+
+            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
+            return new BoundErrorExpression(null);
+        }
+
+        if (receiverType is TypeParameterSymbol tpReceiver
+            && tpReceiver.ClrInterfaceConstraint is TypeSymbol clrInterfaceConstraint
+            && clrInterfaceConstraint.ClrType is Type constraintClrType
+            && constraintClrType.IsInterface)
+        {
+            var clrProperty = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(
+                constraintClrType,
+                fieldName,
+                BindingFlags.Public | BindingFlags.Instance);
+            if (clrProperty != null && clrProperty.GetIndexParameters().Length == 0)
+            {
+                if (clrProperty.GetSetMethod(nonPublic: false) == null)
+                {
+                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
+                    return new BoundErrorExpression(null);
+                }
+
+                var propertyType = MemberLookup.GetClrPropertyTypeSymbol(clrInterfaceConstraint, clrProperty);
+                var declaringInterface = MemberLookup.GetClrMemberDeclaringTypeSymbol(
+                    clrInterfaceConstraint,
+                    clrProperty);
+                var constrainedConverted = conversions.BindConversion(
+                    syntax.Value.Location,
+                    BindValue(propertyType),
+                    propertyType);
+                return new BoundClrPropertyAssignmentExpression(
+                    null,
+                    receiver,
+                    clrProperty,
+                    constrainedConverted,
+                    propertyType,
+                    tpReceiver,
+                    declaringInterface);
             }
 
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -238,6 +238,53 @@ internal sealed partial class ExpressionBinder
                 return new BoundEventSubscriptionExpression(null, boundReceiver, userIface, ifaceEv, ifaceHandler, isAdd);
             }
 
+            if (isEventCapableOperator
+                && boundReceiver.Type is TypeParameterSymbol tpReceiver
+                && tpReceiver.ClrInterfaceConstraint is TypeSymbol clrInterfaceConstraint
+                && clrInterfaceConstraint.ClrType is Type clrInterface
+                && clrInterface.IsInterface)
+            {
+                var constrainedEvent = ClrTypeUtilities.SafeGetEventIncludingInterfaces(
+                    clrInterface,
+                    eventName,
+                    BindingFlags.Public | BindingFlags.Instance);
+                if (constrainedEvent != null)
+                {
+                    var constrainedHandlerType = constrainedEvent.EventHandlerType;
+                    var constrainedHandlerTypeSymbol = MemberLookup.GetClrEventHandlerTypeSymbol(
+                        clrInterfaceConstraint,
+                        constrainedEvent);
+                    var constrainedBoundHandler = BindEventSubscriptionHandler(syntax.Value, constrainedHandlerTypeSymbol);
+                    BoundExpression constrainedConvertedHandler;
+                    if (constrainedBoundHandler is BoundFunctionLiteralExpression
+                        || constrainedBoundHandler is BoundMethodGroupExpression
+                        || constrainedBoundHandler is BoundClrMethodGroupExpression
+                        || (constrainedBoundHandler.Type is FunctionTypeSymbol constrainedFunction
+                            && IsSignatureCompatibleWithDelegate(constrainedFunction, constrainedHandlerType)))
+                    {
+                        constrainedConvertedHandler = constrainedBoundHandler;
+                    }
+                    else
+                    {
+                        constrainedConvertedHandler = conversions.BindConversion(
+                            syntax.Value.Location,
+                            constrainedBoundHandler,
+                            constrainedHandlerTypeSymbol);
+                    }
+
+                    return new BoundClrEventSubscriptionExpression(
+                        null,
+                        boundReceiver,
+                        constrainedEvent,
+                        constrainedConvertedHandler,
+                        isAdd,
+                        tpReceiver,
+                        MemberLookup.GetClrMemberDeclaringTypeSymbol(
+                            clrInterfaceConstraint,
+                            constrainedEvent));
+                }
+            }
+
             receiverClrType = boundReceiver.Type?.ClrType;
             if (receiverClrType == null)
             {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -2653,8 +2653,10 @@ internal sealed partial class ExpressionBinder
         // recovered by projecting through the constructed constraint interface;
         // a concrete return (e.g. IComparable.CompareTo -> int32) falls back to
         // the direct CLR mapping.
-        var returnType = ResolveInstanceReturnTypeFromReceiver(constraintInterface, method)
-            ?? MapClrMethodReturnType(method);
+        var returnType = MemberLookup.GetClrMethodReturnTypeSymbol(constraintInterface, method);
+        var declaringInterface = MemberLookup.GetClrMemberDeclaringTypeSymbol(
+            constraintInterface,
+            method);
 
         // Issue #1852: re-lower each interpolated-string argument whose
         // resolved parameter is IFormattable/FormattableString-shaped to
@@ -2690,7 +2692,7 @@ internal sealed partial class ExpressionBinder
             refKinds,
             default,
             constrainedReceiverTypeParameter: tp,
-            constrainedInterfaceType: constraintInterface);
+            constrainedInterfaceType: declaringInterface);
         return true;
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -1642,6 +1642,46 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
+            if (tp.ClrInterfaceConstraint is TypeSymbol clrInterfaceConstraint
+                && clrInterfaceConstraint.ClrType is Type clrInterface
+                && clrInterface.IsInterface)
+            {
+                var clrProperty = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(
+                    clrInterface,
+                    memberName,
+                    BindingFlags.Public | BindingFlags.Instance);
+                if (clrProperty != null && clrProperty.GetIndexParameters().Length == 0)
+                {
+                    if (clrProperty.GetSetMethod(nonPublic: false) == null)
+                    {
+                        Diagnostics.ReportCannotAssign(initSyntax.FieldIdentifier.Location, memberName);
+                        _ = BindExpression(initSyntax.Value);
+                        continue;
+                    }
+
+                    var propertyType = MemberLookup.GetClrPropertyTypeSymbol(clrInterfaceConstraint, clrProperty);
+                    var declaringInterface = MemberLookup.GetClrMemberDeclaringTypeSymbol(
+                        clrInterfaceConstraint,
+                        clrProperty);
+                    var propertyValue = BindExpression(initSyntax.Value);
+                    var converted = conversions.BindConversion(
+                        initSyntax.Value.Location,
+                        propertyValue,
+                        propertyType);
+                    statements.Add(new BoundExpressionStatement(
+                        initSyntax,
+                        new BoundClrPropertyAssignmentExpression(
+                            initSyntax,
+                            receiverExpr,
+                            clrProperty,
+                            converted,
+                            propertyType,
+                            tp,
+                            declaringInterface)));
+                    continue;
+                }
+            }
+
             Diagnostics.ReportUnableToFindMember(initSyntax.FieldIdentifier.Location, memberName);
             _ = BindExpression(initSyntax.Value);
         }

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -928,12 +928,7 @@ internal sealed class MemberLookup
                 // receiver keep the `Check` element identity instead of
                 // collapsing to the type-erased `IEnumerable<object>` (which
                 // for a value-type element is not even a legal up-cast).
-                // A type parameter can substitute to a concrete symbol (for
-                // example Action<T> on IBase<string>). The original open CLR
-                // shape still cannot be used as the projected member type, so
-                // reconstruct it even when the mapped argument itself does
-                // not require symbolic projection.
-                if (TypeSymbol.RequiresSymbolicProjection(mapped) || a.ContainsGenericParameters)
+                if (TypeSymbol.RequiresSymbolicProjection(mapped))
                 {
                     anyParam = true;
                 }
@@ -2610,7 +2605,10 @@ internal sealed class MemberLookup
         indexer = null;
         resolvedArguments = default;
 
-        var properties = EnumerateSelfAndInterfaces(clrTarget)
+        var declaringTypes = clrTarget.IsInterface
+            ? EnumerateSelfAndInterfaces(clrTarget)
+            : new[] { clrTarget };
+        var properties = declaringTypes
             .SelectMany(type => ClrTypeUtilities.SafeGetProperties(
                 type,
                 BindingFlags.Public | BindingFlags.Instance))
@@ -2967,9 +2965,10 @@ internal sealed class MemberLookup
         int parameterIndex)
     {
         var closedParameter = closedIndexer.GetIndexParameters()[parameterIndex];
-        if (GetImportedTypeSymbol(targetType) is ImportedTypeSymbol imported
+        if (GetImportedTypeSymbol(targetType) is ImportedTypeSymbol importedInterface
+            && importedInterface.ClrType?.IsInterface == true
             && TryGetSymbolicDeclaringContext(
-                imported,
+                importedInterface,
                 closedIndexer.DeclaringType,
                 out var openDefinition,
                 out var declaringTypeArguments))
@@ -2982,6 +2981,20 @@ internal sealed class MemberLookup
                     openParameters[parameterIndex].ParameterType,
                     openDefinition,
                     declaringTypeArguments);
+            }
+        }
+        else if (targetType is ImportedTypeSymbol imported
+            && imported.OpenDefinition is Type importedOpenDefinition
+            && !imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            var openIndexer = FindOpenIndexerDefinition(importedOpenDefinition, closedIndexer);
+            var openParameters = openIndexer?.GetIndexParameters();
+            if (openParameters != null && parameterIndex < openParameters.Length)
+            {
+                return SubstituteOpenIndexerType(
+                    imported,
+                    openParameters[parameterIndex].ParameterType,
+                    closedParameter.ParameterType);
             }
         }
 
@@ -3047,10 +3060,14 @@ internal sealed class MemberLookup
                 .FirstOrDefault(candidate => candidate.Name == closedEvent.Name);
             if (openEvent?.EventHandlerType != null)
             {
-                return MapOpenClrTypeToSymbolic(
+                var mapped = MapOpenClrTypeToSymbolic(
                     openEvent.EventHandlerType,
                     openDefinition,
                     declaringTypeArguments);
+                if (mapped.ClrType?.ContainsGenericParameters != true)
+                {
+                    return mapped;
+                }
             }
         }
 

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -928,7 +928,12 @@ internal sealed class MemberLookup
                 // receiver keep the `Check` element identity instead of
                 // collapsing to the type-erased `IEnumerable<object>` (which
                 // for a value-type element is not even a legal up-cast).
-                if (TypeSymbol.RequiresSymbolicProjection(mapped))
+                // A type parameter can substitute to a concrete symbol (for
+                // example Action<T> on IBase<string>). The original open CLR
+                // shape still cannot be used as the projected member type, so
+                // reconstruct it even when the mapped argument itself does
+                // not require symbolic projection.
+                if (TypeSymbol.RequiresSymbolicProjection(mapped) || a.ContainsGenericParameters)
                 {
                     anyParam = true;
                 }
@@ -2605,8 +2610,13 @@ internal sealed class MemberLookup
         indexer = null;
         resolvedArguments = default;
 
-        var properties = ClrTypeUtilities.SafeGetProperties(clrTarget, BindingFlags.Public | BindingFlags.Instance)
+        var properties = EnumerateSelfAndInterfaces(clrTarget)
+            .SelectMany(type => ClrTypeUtilities.SafeGetProperties(
+                type,
+                BindingFlags.Public | BindingFlags.Instance))
             .Where(static property => property.GetMethod != null && property.GetIndexParameters().Length > 0)
+            .GroupBy(static property => (property.Module, property.MetadataToken))
+            .Select(static group => group.First())
             .ToArray();
         var hasSymbolicArgument = boundArguments.Any(static argument =>
             argument.Type?.ClrType == null
@@ -2957,18 +2967,21 @@ internal sealed class MemberLookup
         int parameterIndex)
     {
         var closedParameter = closedIndexer.GetIndexParameters()[parameterIndex];
-        if (targetType is ImportedTypeSymbol imported
-            && imported.OpenDefinition is Type openDefinition
-            && !imported.TypeArguments.IsDefaultOrEmpty)
+        if (GetImportedTypeSymbol(targetType) is ImportedTypeSymbol imported
+            && TryGetSymbolicDeclaringContext(
+                imported,
+                closedIndexer.DeclaringType,
+                out var openDefinition,
+                out var declaringTypeArguments))
         {
             var openIndexer = FindOpenIndexerDefinition(openDefinition, closedIndexer);
             var openParameters = openIndexer?.GetIndexParameters();
             if (openParameters != null && parameterIndex < openParameters.Length)
             {
-                return SubstituteOpenIndexerType(
-                    imported,
+                return MapOpenClrTypeToSymbolic(
                     openParameters[parameterIndex].ParameterType,
-                    closedParameter.ParameterType);
+                    openDefinition,
+                    declaringTypeArguments);
             }
         }
 
@@ -2985,6 +2998,191 @@ internal sealed class MemberLookup
 
         return ClrNullability.GetParameterTypeSymbol(closedParameter);
     }
+
+    /// <summary>
+    /// Resolves a CLR property's type through a symbolic imported receiver,
+    /// including properties declared on inherited generic interfaces.
+    /// </summary>
+    /// <param name="targetType">The symbolic imported receiver type.</param>
+    /// <param name="closedProperty">The reflected property selected from the erased receiver.</param>
+    /// <returns>The property type after symbolic receiver substitution.</returns>
+    internal static TypeSymbol GetClrPropertyTypeSymbol(TypeSymbol targetType, PropertyInfo closedProperty)
+    {
+        if (GetImportedTypeSymbol(targetType) is ImportedTypeSymbol imported
+            && TryGetSymbolicDeclaringContext(
+                imported,
+                closedProperty.DeclaringType,
+                out var openDefinition,
+                out var declaringTypeArguments))
+        {
+            var openProperty = FindOpenIndexerDefinition(openDefinition, closedProperty);
+            if (openProperty != null)
+            {
+                return MapOpenClrTypeToSymbolic(
+                    openProperty.PropertyType,
+                    openDefinition,
+                    declaringTypeArguments);
+            }
+        }
+
+        return ClrNullability.GetPropertyTypeSymbol(closedProperty);
+    }
+
+    /// <summary>Resolves an imported event handler type through a symbolic receiver/interface hierarchy.</summary>
+    /// <param name="targetType">The symbolic imported receiver type.</param>
+    /// <param name="closedEvent">The reflected event selected from the erased receiver.</param>
+    /// <returns>The event handler type after symbolic receiver substitution.</returns>
+    internal static TypeSymbol GetClrEventHandlerTypeSymbol(TypeSymbol targetType, EventInfo closedEvent)
+    {
+        if (GetImportedTypeSymbol(targetType) is ImportedTypeSymbol imported
+            && TryGetSymbolicDeclaringContext(
+                imported,
+                closedEvent.DeclaringType,
+                out var openDefinition,
+                out var declaringTypeArguments))
+        {
+            var openEvent = ClrTypeUtilities.SafeGetEvents(
+                    openDefinition,
+                    BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(candidate => candidate.Name == closedEvent.Name);
+            if (openEvent?.EventHandlerType != null)
+            {
+                return MapOpenClrTypeToSymbolic(
+                    openEvent.EventHandlerType,
+                    openDefinition,
+                    declaringTypeArguments);
+            }
+        }
+
+        return TypeSymbol.FromClrType(closedEvent.EventHandlerType);
+    }
+
+    /// <summary>
+    /// Reconstructs the symbolic imported interface that actually declares a
+    /// reflected member reached through a possibly derived constraint.
+    /// </summary>
+    /// <param name="targetType">The symbolic imported receiver type.</param>
+    /// <param name="member">The reflected member reached through the receiver.</param>
+    /// <returns>The symbolic declaring interface used to parent the emitted member reference.</returns>
+    internal static TypeSymbol GetClrMemberDeclaringTypeSymbol(
+        TypeSymbol targetType,
+        MemberInfo member)
+    {
+        if (GetImportedTypeSymbol(targetType) is ImportedTypeSymbol imported
+            && TryGetSymbolicDeclaringContext(
+                imported,
+                member?.DeclaringType,
+                out var openDefinition,
+                out var declaringTypeArguments))
+        {
+            return openDefinition.IsGenericTypeDefinition
+                ? ImportedTypeSymbol.GetConstructed(
+                    member.DeclaringType,
+                    openDefinition,
+                    declaringTypeArguments)
+                : ImportedTypeSymbol.Get(openDefinition);
+        }
+
+        return targetType;
+    }
+
+    /// <summary>Resolves an imported method return through a symbolic receiver/interface hierarchy.</summary>
+    /// <param name="targetType">The symbolic imported receiver type.</param>
+    /// <param name="closedMethod">The reflected method selected from the erased receiver.</param>
+    /// <returns>The method return type after symbolic receiver substitution.</returns>
+    internal static TypeSymbol GetClrMethodReturnTypeSymbol(
+        TypeSymbol targetType,
+        MethodInfo closedMethod)
+    {
+        if (GetImportedTypeSymbol(targetType) is ImportedTypeSymbol imported
+            && TryGetSymbolicDeclaringContext(
+                imported,
+                closedMethod?.DeclaringType,
+                out var openDefinition,
+                out var declaringTypeArguments))
+        {
+            var openMethod = TryGetOpenMethodOnDeclaringType(openDefinition, closedMethod);
+            if (openMethod != null)
+            {
+                return MapOpenClrTypeToSymbolic(
+                    openMethod.ReturnType,
+                    openDefinition,
+                    declaringTypeArguments);
+            }
+        }
+
+        return TypeSymbol.FromClrType(closedMethod.ReturnType);
+    }
+
+    /// <summary>Finds the symbolic generic context for a reflected declaring type.</summary>
+    /// <param name="imported">The symbolic imported receiver.</param>
+    /// <param name="declaringType">The reflected member's declaring type.</param>
+    /// <param name="openDefinition">The open declaring type definition.</param>
+    /// <param name="typeArguments">The receiver-projected declaring type arguments.</param>
+    /// <returns><see langword="true"/> when a symbolic declaring context was found.</returns>
+    internal static bool TryGetSymbolicDeclaringContext(
+        ImportedTypeSymbol imported,
+        Type declaringType,
+        out Type openDefinition,
+        out ImmutableArray<TypeSymbol> typeArguments)
+    {
+        openDefinition = null;
+        typeArguments = default;
+        if (imported?.ClrType == null || declaringType == null)
+        {
+            return false;
+        }
+
+        var receiverOpenDefinition = imported.OpenDefinition
+            ?? (imported.ClrType.IsGenericType
+                ? imported.ClrType.GetGenericTypeDefinition()
+                : imported.ClrType);
+        var receiverTypeArguments = !imported.TypeArguments.IsDefaultOrEmpty
+            ? imported.TypeArguments
+            : (imported.ClrType.IsGenericType
+                ? imported.ClrType.GetGenericArguments()
+                    .Select(TypeSymbol.FromClrType)
+                    .ToImmutableArray()
+                : ImmutableArray<TypeSymbol>.Empty);
+
+        openDefinition = declaringType.IsGenericType
+            ? declaringType.GetGenericTypeDefinition()
+            : declaringType;
+        if (ClrTypeUtilities.AreSame(receiverOpenDefinition, openDefinition))
+        {
+            typeArguments = receiverTypeArguments;
+            return true;
+        }
+
+        if (imported.OpenDefinition != null
+            && !imported.TypeArguments.IsDefaultOrEmpty
+            && TryMapThroughImplemented(imported, openDefinition, out typeArguments))
+        {
+            return true;
+        }
+
+        if (declaringType.IsGenericType)
+        {
+            typeArguments = declaringType.GetGenericArguments()
+                .Select(TypeSymbol.FromClrType)
+                .ToImmutableArray();
+            return true;
+        }
+
+        typeArguments = ImmutableArray<TypeSymbol>.Empty;
+        return true;
+    }
+
+    /// <summary>Unwraps an imported type from an optional CLR nullability annotation.</summary>
+    /// <param name="type">The type symbol to unwrap.</param>
+    /// <returns>The imported type symbol, or <c>null</c> for another symbol kind.</returns>
+    internal static ImportedTypeSymbol GetImportedTypeSymbol(TypeSymbol type)
+        => type switch
+        {
+            ImportedTypeSymbol imported => imported,
+            NullabilityAnnotatedTypeSymbol { BaseType: ImportedTypeSymbol imported } => imported,
+            _ => null,
+        };
 
     internal static PropertyInfo FindOpenIndexerDefinition(Type openDefinition, PropertyInfo closedIndexer)
     {

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -490,7 +490,11 @@ internal sealed partial class MethodBodyEmitter
         var isStatic = subscription.Receiver == null;
         var receiverIsValueType = !isStatic && ReflectionMetadataEmitter.IsValueTypeSymbol(subscription.Receiver.Type);
 
-        if (!isStatic)
+        if (subscription.IsConstrainedTypeParameterAccess)
+        {
+            this.EmitConstrainedTypeParameterReceiver(subscription.Receiver);
+        }
+        else if (!isStatic)
         {
             this.EmitInstanceReceiver(subscription.Receiver);
         }
@@ -518,8 +522,20 @@ internal sealed partial class MethodBodyEmitter
                 $"Event '{subscription.Event.DeclaringType?.FullName}.{subscription.Event.Name}' has no public {(subscription.IsAdd ? "add" : "remove")} accessor.");
         }
 
-        this.il.OpCode(isStatic || receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(accessor));
+        if (subscription.IsConstrainedTypeParameterAccess)
+        {
+            this.il.OpCode(ILOpCode.Constrained);
+            this.il.Token(this.outer.memberRefs.GetElementTypeToken(subscription.ConstrainedReceiverTypeParameter));
+            this.il.OpCode(ILOpCode.Callvirt);
+            this.il.Token(this.outer.memberRefs.GetMethodEntityHandle(
+                accessor,
+                subscription.ConstrainedInterfaceType));
+        }
+        else
+        {
+            this.il.OpCode(isStatic || receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
+            this.il.Token(this.outer.memberRefs.GetMethodReference(accessor));
+        }
     }
 
     private void EmitUserEventSubscription(BoundEventSubscriptionExpression node)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -959,6 +959,28 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitClrPropertyAccess(BoundClrPropertyAccessExpression access)
     {
+        if (access.IsConstrainedTypeParameterAccess)
+        {
+            if (access.Member is not PropertyInfo constrainedProperty)
+            {
+                throw new NotSupportedException("Imported interface constraints cannot expose instance fields.");
+            }
+
+            var constrainedGetter = ImportedMemberRefFactory.GetTypeBuilderSafePropertyAccessor(
+                constrainedProperty,
+                wantSetter: false)
+                ?? throw new InvalidOperationException(
+                    $"Property '{constrainedProperty.DeclaringType?.FullName}.{constrainedProperty.Name}' has no public getter.");
+            this.EmitConstrainedTypeParameterReceiver(access.Receiver);
+            this.il.OpCode(ILOpCode.Constrained);
+            this.il.Token(this.outer.memberRefs.GetElementTypeToken(access.ConstrainedReceiverTypeParameter));
+            this.il.OpCode(ILOpCode.Callvirt);
+            this.il.Token(this.outer.memberRefs.GetMethodEntityHandle(
+                constrainedGetter,
+                access.ConstrainedInterfaceType));
+            return;
+        }
+
         // Phase 4 / Stream B: property or field read on a CLR receiver.
         // Properties dispatch to their `get_X` accessor (callvirt for
         // reference types, call for value types); fields use `ldfld`.
@@ -1060,6 +1082,32 @@ internal sealed partial class MethodBodyEmitter
                 + "Check AssignmentValueSpillCollector and its ancestor walker.");
         }
 
+        if (assn.IsConstrainedTypeParameterAccess)
+        {
+            if (assn.Member is not PropertyInfo constrainedProperty)
+            {
+                throw new NotSupportedException("Imported interface constraints cannot expose instance fields.");
+            }
+
+            var constrainedSetter = ImportedMemberRefFactory.GetTypeBuilderSafePropertyAccessor(
+                constrainedProperty,
+                wantSetter: true)
+                ?? throw new InvalidOperationException(
+                    $"Property '{constrainedProperty.DeclaringType?.FullName}.{constrainedProperty.Name}' has no public setter.");
+            this.EmitConstrainedTypeParameterReceiver(assn.Receiver);
+            this.EmitExpression(assn.Value);
+            this.il.OpCode(ILOpCode.Dup);
+            this.il.StoreLocal(valueSlot);
+            this.il.OpCode(ILOpCode.Constrained);
+            this.il.Token(this.outer.memberRefs.GetElementTypeToken(assn.ConstrainedReceiverTypeParameter));
+            this.il.OpCode(ILOpCode.Callvirt);
+            this.il.Token(this.outer.memberRefs.GetMethodEntityHandle(
+                constrainedSetter,
+                assn.ConstrainedInterfaceType));
+            this.il.LoadLocal(valueSlot);
+            return;
+        }
+
         if (!isStatic)
         {
             this.EmitInstanceReceiver(assn.Receiver);
@@ -1104,6 +1152,28 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitClrIndex(BoundClrIndexExpression idx)
     {
+        if (idx.IsConstrainedTypeParameterAccess)
+        {
+            var constrainedGetter = ImportedMemberRefFactory.GetTypeBuilderSafePropertyAccessor(
+                idx.Indexer,
+                wantSetter: false)
+                ?? throw new InvalidOperationException(
+                    $"Indexer on '{idx.Indexer.DeclaringType?.FullName}' has no public getter.");
+            this.EmitConstrainedTypeParameterReceiver(idx.Target);
+            foreach (var arg in idx.Arguments)
+            {
+                this.EmitExpression(arg);
+            }
+
+            this.il.OpCode(ILOpCode.Constrained);
+            this.il.Token(this.outer.memberRefs.GetElementTypeToken(idx.ConstrainedReceiverTypeParameter));
+            this.il.OpCode(ILOpCode.Callvirt);
+            this.il.Token(this.outer.memberRefs.GetMethodEntityHandle(
+                constrainedGetter,
+                idx.ConstrainedInterfaceType));
+            return;
+        }
+
         // #313: indexing an erased generic over a type parameter (e.g.
         // `items[0]` where `items: List[T]`, or `map["k"]` where
         // `map: Dictionary[string, T]`). At runtime the receiver is a closed
@@ -1194,6 +1264,36 @@ internal sealed partial class MethodBodyEmitter
     private void EmitClrIndexAssignment(BoundClrIndexAssignmentExpression ixa)
     {
         var setter = ImportedMemberRefFactory.GetTypeBuilderSafePropertyAccessor(ixa.Indexer, wantSetter: true);
+
+        if (ixa.IsConstrainedTypeParameterAccess)
+        {
+            if (setter == null)
+            {
+                throw new InvalidOperationException(
+                    $"Indexer on '{ixa.Indexer.DeclaringType?.FullName}' has no public setter.");
+            }
+
+            BoundExpression constrainedReceiver = ixa.TargetExpression
+                ?? new BoundVariableExpression(null, ixa.Target);
+            var constrainedValueSlot = this.indexAssignmentValueSlots[ixa];
+            this.EmitConstrainedTypeParameterReceiver(constrainedReceiver);
+            foreach (var arg in ixa.Arguments)
+            {
+                this.EmitExpression(arg);
+            }
+
+            this.EmitExpression(ixa.Value);
+            this.il.OpCode(ILOpCode.Dup);
+            this.il.StoreLocal(constrainedValueSlot);
+            this.il.OpCode(ILOpCode.Constrained);
+            this.il.Token(this.outer.memberRefs.GetElementTypeToken(ixa.ConstrainedReceiverTypeParameter));
+            this.il.OpCode(ILOpCode.Callvirt);
+            this.il.Token(this.outer.memberRefs.GetMethodEntityHandle(
+                setter,
+                ixa.ConstrainedInterfaceType));
+            this.il.LoadLocal(constrainedValueSlot);
+            return;
+        }
 
         // ADR-0056 §2: span element write. `Span[T]` has no setter; its
         // indexer getter returns `ref T`. Obtain the managed pointer via

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -636,6 +636,36 @@ public static class ClrTypeUtilities
     public static EventInfo SafeGetEvent(Type type, string name, BindingFlags flags)
         => SafeGetMember(type, name, flags, (t, f) => t.GetEvent(name, f), SafeGetEvents);
 
+    /// <summary>Looks up an event by name across an interface and its inherited interfaces.</summary>
+    /// <param name="type">The interface type to search.</param>
+    /// <param name="name">The event name.</param>
+    /// <param name="flags">The binding flags controlling visibility.</param>
+    /// <returns>The matching event, or <c>null</c> when none is found.</returns>
+    public static EventInfo SafeGetEventIncludingInterfaces(Type type, string name, BindingFlags flags)
+    {
+        var direct = SafeGetEvent(type, name, flags);
+        if (direct != null)
+        {
+            return direct;
+        }
+
+        if (type is null)
+        {
+            return null;
+        }
+
+        foreach (var iface in SafeGetInterfaces(type))
+        {
+            var inherited = SafeGetEvent(iface, name, flags);
+            if (inherited != null)
+            {
+                return inherited;
+            }
+        }
+
+        return null;
+    }
+
     /// <summary>
     /// Issues #529 / #572: looks up a property by name, walking the transitive
     /// interface hierarchy. For interface types this surfaces inherited

--- a/test/Compiler.Tests/Emit/Issue2514ImportedInterfaceConstraintMemberTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2514ImportedInterfaceConstraintMemberTests.cs
@@ -1,0 +1,550 @@
+// <copyright file="Issue2514ImportedInterfaceConstraintMemberTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2514: imported interface constraints expose their complete accessible
+/// instance contract through type-parameter receivers.
+/// </summary>
+public sealed class Issue2514ImportedInterfaceConstraintMemberTests
+{
+    private const string ContractsSource = """
+        using System;
+
+        namespace Issue2514.Contracts
+        {
+            public interface IBase<T>
+            {
+                T Value { get; set; }
+                T this[int index] { get; set; }
+                event EventHandler Changed;
+                event Action<T> ItemChanged;
+                T Echo(T value);
+                string ReadOnly { get; }
+                string WriteOnly { set; }
+            }
+
+            public interface IContract<T> : IBase<T>
+            {
+                string Name { get; set; }
+                string Echo(string prefix, int value);
+            }
+
+            public interface ISelf<T> where T : ISelf<T>
+            {
+                T Next { get; }
+            }
+
+            public interface IStaticContract
+            {
+                static abstract int Code { get; }
+            }
+
+            public sealed class RefContract : IContract<string>
+            {
+                private readonly string[] values = new string[4];
+                private string name = "Ada";
+                private string contractValue = "seed";
+
+                public string Value
+                {
+                    get => contractValue;
+                    set
+                    {
+                        contractValue = value;
+                        ItemChanged?.Invoke(value);
+                    }
+                }
+                public string ReadOnly => "read-only";
+                public string WriteOnly { set => Value = value; }
+                public string Name
+                {
+                    get => name;
+                    set
+                    {
+                        name = value;
+                        Changed?.Invoke(this, EventArgs.Empty);
+                    }
+                }
+
+                public string this[int index]
+                {
+                    get => values[index] ?? "";
+                    set => values[index] = value;
+                }
+
+                public event EventHandler? Changed;
+                public event Action<string>? ItemChanged;
+                public string Echo(string value) => value + "!";
+                public string Echo(string prefix, int value) => prefix + value;
+            }
+
+            public struct ValueContract : IContract<int>
+            {
+                private int value;
+
+                public int Value { readonly get => value; set => this.value = value; }
+                public readonly string ReadOnly => "value";
+                public string WriteOnly { set => this.value = value.Length; }
+                public string Name { readonly get => "struct"; set { } }
+                public int this[int index]
+                {
+                    readonly get => value + index;
+                    set => this.value = value - index;
+                }
+
+                public event EventHandler? Changed;
+                public event Action<int>? ItemChanged;
+                public readonly int Echo(int value) => value + 1;
+                public readonly string Echo(string prefix, int value) => prefix + value;
+            }
+
+            public sealed class Node : ISelf<Node>
+            {
+                public int Id => 2514;
+                public Node Next => this;
+            }
+
+            public sealed class StaticContract : IStaticContract
+            {
+                public static int Code => 2514;
+            }
+        }
+        """;
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(
+        () => TrustedPlatformAssemblies().ToArray());
+
+    [Fact]
+    public void ImportedConstraintMembers_RunVerifyReflectAndWorkFromCSharp()
+    {
+        const string source = """
+            package Issue2514
+            import System
+            import Issue2514.Contracts
+
+            class Api {
+                shared {
+                    func ReadName[T IContract[string]](value T) string -> value.Name
+                    func WriteName[T IContract[string]](value T, name string) { value.Name = name }
+                    func ReadValue[T IContract[string]](value T) string -> value.Value
+                    func WriteValue[T IContract[string]](value T, text string) { value.Value = text }
+                    func ReadIndex[T IContract[string]](value T, index int32) string -> value[index]
+                    func WriteIndex[T IContract[string]](value T, index int32, text string) string {
+                        value[index] = text
+                        return value[index]
+                    }
+                    func Echo[T IContract[string]](value T, text string) string -> value.Echo(text)
+                    func EchoNumber[T IContract[string]](value T, number int32) string -> value.Echo("number:", number)
+                    func ReadNext[T ISelf[T]](value T) T -> value.Next
+                    func SubscribeAndWrite[T IContract[string]](value T, name string, handler EventHandler) {
+                        value.Changed += handler
+                        value.Name = name
+                        value.Changed -= handler
+                    }
+                    func SubscribeItem[T IContract[string]](value T, handler Action[string]) {
+                        value.ItemChanged += handler
+                        value.Value = "item"
+                        value.ItemChanged -= handler
+                    }
+                    func Make[T IContract[string] init()]() T -> T{Name: "made", Value: "created"}
+                    func StructRoundtrip[T IContract[int32]](value T) int32 {
+                        value.Value = 40
+                        value[2] = 50
+                        return value.Value + value[2] + value.Echo(1)
+                    }
+                }
+            }
+
+            func Main() {
+                var person = RefContract()
+                Console.WriteLine(Api.ReadName(person))
+                Api.WriteName(person, "Grace")
+                Console.WriteLine(Api.ReadName(person))
+                Api.WriteValue(person, "value")
+                Console.WriteLine(Api.ReadValue(person))
+                Console.WriteLine(Api.WriteIndex(person, 1, "indexed"))
+                Console.WriteLine(Api.Echo(person, "echo"))
+                Console.WriteLine(Api.EchoNumber(person, 7))
+                Console.WriteLine(Api.ReadNext(Node()).Id)
+                Console.WriteLine(Api.StructRoundtrip(ValueContract()))
+                var made = Api.Make[RefContract]()
+                Console.WriteLine(made.Name + ":" + made.Value)
+            }
+            """;
+
+        using var result = Compile(source, "exe");
+        Assert.Equal(
+            "Ada\nGrace\nvalue\nindexed\necho!\nnumber:7\n2514\n100\nmade:created\n",
+            Run(result.OutputPath));
+        IlVerifier.Verify(result.OutputPath, additionalReferences: new[] { result.ContractsPath });
+
+        var assembly = Assembly.LoadFrom(result.OutputPath);
+        var api = assembly.GetType("Issue2514.Api")!;
+        var readNameParameter = api.GetMethod("ReadName")!.GetGenericArguments().Single();
+        Assert.Contains(
+            readNameParameter.GetGenericParameterConstraints(),
+            constraint => constraint.IsGenericType
+                && constraint.GetGenericTypeDefinition().FullName == "Issue2514.Contracts.IContract`1"
+                && constraint.GetGenericArguments()[0] == typeof(string));
+
+        var makeParameter = api.GetMethod("Make")!.GetGenericArguments().Single();
+        Assert.True(
+            (makeParameter.GenericParameterAttributes & GenericParameterAttributes.DefaultConstructorConstraint) != 0);
+
+        var consumerPath = EmitCSharpConsumer(result.DirectoryPath, result.OutputPath, result.ContractsPath);
+        Assert.Equal(
+            "CSharp\nconsumer\nconsumer!\nnumber:8\n2514\n100\nmade:created\n1\nitem\n",
+            Run(consumerPath));
+    }
+
+    [Theory]
+    [InlineData(
+        "func Bad[T IContract[string]](value T) string -> value.Missing",
+        "GS0158")]
+    [InlineData(
+        "func Bad[T IContract[string]](value T) { value.ReadOnly = \"x\" }",
+        "GS0127")]
+    [InlineData(
+        "func Bad[T IContract[string]](value T) string -> value.WriteOnly",
+        "GS0127")]
+    [InlineData(
+        "func Bad[T IStaticContract]() int32 -> T.Code",
+        "GS0333")]
+    [InlineData(
+        "func Bad(value Node) string -> ReadName[Node](value)",
+        "GS0152")]
+    public void InvalidConstraintMemberUsesRetainSpecificDiagnostics(string member, string diagnosticId)
+    {
+        var source = $$"""
+            package Issue2514Negative
+            import Issue2514.Contracts
+
+            func ReadName[T IContract[string]](value T) string -> value.Name
+            {{member}}
+            """;
+
+        using var result = Compile(source, "library", expectSuccess: false);
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains(diagnosticId, result.Stdout + result.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SiblingGSharpInterfaceConstraint_PropertiesBindAndRun()
+    {
+        const string contracts = """
+            package Issue2514.Sibling
+
+            interface ISourceContract {
+                prop Name string { get; set; }
+            }
+
+            class SourcePerson : ISourceContract {
+                prop Name string { get; set; }
+                init() { Name = "source" }
+            }
+            """;
+        const string consumer = """
+            package Issue2514.SiblingConsumer
+            import System
+            import Issue2514.Sibling
+
+            func Read[T ISourceContract](value T) string -> value.Name
+            func Write[T ISourceContract](value T, name string) { value.Name = name }
+
+            func Main() {
+                var person = SourcePerson()
+                Console.WriteLine(Read(person))
+                Write(person, "sibling")
+                Console.WriteLine(Read(person))
+            }
+            """;
+
+        var directory = CreateArtifactDirectory();
+        try
+        {
+            var contractsPath = CompileGSharpFile(
+                directory,
+                "contracts.gs",
+                contracts,
+                "Issue2514.Sibling.dll",
+                "library");
+            var consumerPath = CompileGSharpFile(
+                directory,
+                "consumer.gs",
+                consumer,
+                "consumer.dll",
+                "exe",
+                contractsPath);
+            IlVerifier.Verify(consumerPath, additionalReferences: new[] { contractsPath });
+            Assert.Equal("source\nsibling\n", Run(consumerPath));
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    private static CompilationResult Compile(string source, string target, bool expectSuccess = true)
+    {
+        var directory = CreateArtifactDirectory();
+        var contractsPath = EmitContracts(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "Issue2514.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + outputPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/reference:" + contractsPath,
+            "/nowarn:GS9100",
+        };
+        args.AddRange(BclReferences.Value.Select(reference => "/reference:" + reference));
+        args.Add(sourcePath);
+
+        var execution = RunCompiler(args);
+        if (expectSuccess)
+        {
+            Assert.True(
+                execution.ExitCode == 0,
+                $"compile failed ({execution.ExitCode})\nstdout:\n{execution.Stdout}\nstderr:\n{execution.Stderr}");
+        }
+
+        return new CompilationResult(
+            directory,
+            outputPath,
+            contractsPath,
+            execution.ExitCode,
+            execution.Stdout,
+            execution.Stderr);
+    }
+
+    private static string CompileGSharpFile(
+        string directory,
+        string fileName,
+        string source,
+        string outputName,
+        string target,
+        params string[] references)
+    {
+        var sourcePath = Path.Combine(directory, fileName);
+        var outputPath = Path.Combine(directory, outputName);
+        File.WriteAllText(sourcePath, source);
+        var args = new List<string>
+        {
+            "/out:" + outputPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+        args.AddRange(references.Select(reference => "/reference:" + reference));
+        args.AddRange(BclReferences.Value.Select(reference => "/reference:" + reference));
+        args.Add(sourcePath);
+        var result = RunCompiler(args);
+        Assert.True(
+            result.ExitCode == 0,
+            $"compile failed ({result.ExitCode})\nstdout:\n{result.Stdout}\nstderr:\n{result.Stderr}");
+        return outputPath;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunCompiler(List<string> args)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        return (exitCode, stdout.ToString(), stderr.ToString());
+    }
+
+    private static string EmitContracts(string directory)
+    {
+        var outputPath = Path.Combine(directory, "Issue2514.Contracts.dll");
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            ContractsSource,
+            new CSharpParseOptions(LanguageVersion.Latest));
+        var references = TrustedPlatformAssemblies()
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "Issue2514.Contracts",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return outputPath;
+    }
+
+    private static string EmitCSharpConsumer(
+        string directory,
+        string gsharpAssembly,
+        string contractsAssembly)
+    {
+        const string source = """
+            using System;
+            using Issue2514;
+            using Issue2514.Contracts;
+
+            internal static class Program
+            {
+                private static void Main()
+                {
+                    var person = new RefContract();
+                    Api.WriteName(person, "CSharp");
+                    Console.WriteLine(Api.ReadName(person));
+                    Console.WriteLine(Api.WriteIndex(person, 0, "consumer"));
+                    Console.WriteLine(Api.Echo(person, "consumer"));
+                    Console.WriteLine(Api.EchoNumber(person, 8));
+                    Console.WriteLine(Api.ReadNext(new Node()).Id);
+                    Console.WriteLine(Api.StructRoundtrip(new ValueContract()));
+                    var made = Api.Make<RefContract>();
+                    Console.WriteLine(made.Name + ":" + made.Value);
+                    var count = 0;
+                    EventHandler handler = (_, _) => count++;
+                    Api.SubscribeAndWrite(person, "event", handler);
+                    Console.WriteLine(count);
+                    string? item = null;
+                    Action<string> itemHandler = value => item = value;
+                    Api.SubscribeItem(person, itemHandler);
+                    Console.WriteLine(item);
+                }
+            }
+            """;
+        var outputPath = Path.Combine(directory, "consumer.dll");
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
+        var references = TrustedPlatformAssemblies()
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .Concat(new[]
+            {
+                MetadataReference.CreateFromFile(gsharpAssembly),
+                MetadataReference.CreateFromFile(contractsAssembly),
+            });
+        var compilation = CSharpCompilation.Create(
+            "Issue2514.Consumer",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.ConsoleApplication));
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        File.Copy(
+            Path.ChangeExtension(gsharpAssembly, ".runtimeconfig.json"),
+            Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+            overwrite: true);
+        return outputPath;
+    }
+
+    private static string Run(string assemblyPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath)!,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n");
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var value = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        return string.IsNullOrEmpty(value)
+            ? Enumerable.Empty<string>()
+            : value.Split(Path.PathSeparator);
+    }
+
+    private static string CreateArtifactDirectory()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2514-artifacts",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void DeleteDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+
+    private sealed class CompilationResult : IDisposable
+    {
+        public CompilationResult(
+            string directoryPath,
+            string outputPath,
+            string contractsPath,
+            int exitCode,
+            string stdout,
+            string stderr)
+        {
+            DirectoryPath = directoryPath;
+            OutputPath = outputPath;
+            ContractsPath = contractsPath;
+            ExitCode = exitCode;
+            Stdout = stdout;
+            Stderr = stderr;
+        }
+
+        public string DirectoryPath { get; }
+
+        public string OutputPath { get; }
+
+        public string ContractsPath { get; }
+
+        public int ExitCode { get; }
+
+        public string Stdout { get; }
+
+        public string Stderr { get; }
+
+        public void Dispose() => DeleteDirectory(DirectoryPath);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2514ImportedInterfaceConstraintMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2514ImportedInterfaceConstraintMemberTests.cs
@@ -1,0 +1,88 @@
+// <copyright file="Issue2514ImportedInterfaceConstraintMemberTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>Binder coverage for imported interface constraint member lookup.</summary>
+public sealed class Issue2514ImportedInterfaceConstraintMemberTests
+{
+    [Fact]
+    public void InheritedPropertyMethodAndIndexer_BindWithGenericSubstitution()
+    {
+        const string source = """
+            import System.Collections.Generic
+
+            func ReadCount[T IList[string]](value T) int32 -> value.Count
+            func Read[T IList[string]](value T, index int32) string -> value[index]
+            func Write[T IList[string]](value T, index int32, text string) {
+                value[index] = text
+            }
+            func Find[T IList[string]](value T, text string) int32 -> value.IndexOf(text)
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void ConstructorFlag_CombinesWithImportedInterfaceConstraint()
+    {
+        const string source = """
+            import System
+
+            func Compare[T IComparable[T] init()](value T) int32 -> value.CompareTo(value)
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void SourceInterfaceConstraint_ControlRemainsGreen()
+    {
+        const string source = """
+            interface ISource {
+                prop Name string { get; set; }
+            }
+
+            func Use[T ISource](value T) string {
+                value.Name = "ok"
+                return value.Name
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void UnknownImportedConstraintMember_StillReportsGS0158()
+    {
+        const string source = """
+            import System.Collections.Generic
+
+            func Bad[T IList[string]](value T) int32 -> value.Missing
+            """;
+
+        Assert.Contains(Bind(source), diagnostic => diagnostic.Id == "GS0158");
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>())
+            .Diagnostics
+            .ToList();
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2514ImportedInterfaceConstraintPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2514ImportedInterfaceConstraintPipelineTests.cs
@@ -1,0 +1,179 @@
+// <copyright file="Issue2514ImportedInterfaceConstraintPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>Default SDK-backed regression for imported constraint properties.</summary>
+public sealed class Issue2514ImportedInterfaceConstraintPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_ImportedConstraintReadsWritesAndCalls_Compile()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        (string contractsProject, string consumerProject) = WriteFixture(sourceRoot);
+        string outputRoot = NewDirectory("pipeline-tests");
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("test/Contracts", contractsProject, TargetKind.Library),
+            new CorpusApp("test/Consumer", consumerProject, TargetKind.Library),
+        });
+
+        Assert.All(
+            result.Apps,
+            app => Assert.True(
+                app.Succeeded,
+                app.AppId + " should compile through default --via-sdk/gsc. Stages: "
+                    + string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status))));
+
+        AppResult consumer = result.Apps.Single(app => app.AppId == "test/Consumer");
+        string runDirectory = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(consumer.AppId));
+        string emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(runDirectory, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains("func Read[T IPerson](value T) string -> value.Name", emitted, StringComparison.Ordinal);
+        Assert.Contains("value.Name = name", emitted, StringComparison.Ordinal);
+        Assert.Contains("value.Books.Add(book)", emitted, StringComparison.Ordinal);
+    }
+
+    private static (string ContractsProject, string ConsumerProject) WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+
+        string contractsDirectory = Path.Combine(sourceRoot, "Contracts");
+        Directory.CreateDirectory(contractsDirectory);
+        string contractsProject = Path.Combine(contractsDirectory, "Contracts.csproj");
+        File.WriteAllText(contractsProject, ProjectFile(null));
+        File.WriteAllText(Path.Combine(contractsDirectory, "Contracts.cs"), """
+            using System.Collections.Generic;
+
+            namespace Issue2514.Contracts;
+
+            public interface IPerson
+            {
+                string Name { get; set; }
+                IList<string> Books { get; }
+            }
+
+            public sealed class Author : IPerson
+            {
+                public string Name { get; set; } = "Ada";
+                public IList<string> Books { get; } = new List<string>();
+            }
+            """);
+
+        string consumerDirectory = Path.Combine(sourceRoot, "Consumer");
+        Directory.CreateDirectory(consumerDirectory);
+        string consumerProject = Path.Combine(consumerDirectory, "Consumer.csproj");
+        File.WriteAllText(consumerProject, ProjectFile("../Contracts/Contracts.csproj"));
+        File.WriteAllText(Path.Combine(consumerDirectory, "Repro.cs"), """
+            using Issue2514.Contracts;
+
+            namespace Issue2514.Consumer;
+
+            public static class Repro
+            {
+                public static string Read<T>(T value) where T : IPerson => value.Name;
+
+                public static void Write<T>(T value, string name, string book) where T : IPerson
+                {
+                    value.Name = name;
+                    value.Books.Add(book);
+                }
+
+                public static string Test(Author value) => Read(value);
+            }
+            """);
+
+        return (contractsProject, consumerProject);
+    }
+
+    private static string ProjectFile(string projectReference)
+    {
+        string reference = projectReference is null
+            ? string.Empty
+            : $"""
+
+                <ItemGroup>
+                  <ProjectReference Include="{projectReference}" />
+                </ItemGroup>
+              """;
+        return $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>disable</Nullable>
+              </PropertyGroup>{reference}
+            </Project>
+            """;
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2514",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirectoryName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirectoryName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes #2514

## Summary
- generalize constrained type-parameter lookup for imported interface properties, indexers, events, and inherited methods
- preserve symbolic generic substitution and declaring-interface metadata through binding and constrained callvirt emission
- cover reference/value implementations, accessors, overloads, sibling G# assemblies, SDK translation, reflection, C# consumption, ILVerify, and negative diagnostics

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet build GSharp.sln --no-restore -v:minimal`
- issue-focused Core tests (4 passed)
- issue-focused Compiler runtime/reflection/C# consumer/ILVerify tests (7 passed)
- issue-focused default via-SDK pipeline test (1 passed)