### PR TITLE
Fix constructed generic base cache lifecycle

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Syntax;
 
@@ -85,6 +86,17 @@ public sealed class StructSymbol : TypeSymbol
     private ImmutableArray<PropertySymbol> substitutedStaticProperties;
     private ImmutableArray<PropertySymbol> substitutedStaticPropertiesSource;
     private bool substitutedStaticPropertiesComputed;
+    private ImmutableArray<ParameterSymbol> primaryConstructorParametersStore = ImmutableArray<ParameterSymbol>.Empty;
+    private ImmutableArray<InterfaceSymbol> interfacesStore = ImmutableArray<InterfaceSymbol>.Empty;
+    private ImmutableArray<TypeSymbol> implementedClrInterfacesStore = ImmutableArray<TypeSymbol>.Empty;
+    private ImmutableArray<EventSymbol> eventsStore = ImmutableArray<EventSymbol>.Empty;
+    private TypeSymbol importedBaseTypeStore;
+    private StructSymbol baseClassStore;
+    private BaseClassSnapshot substitutedBaseClass;
+    private ParameterArraySnapshot substitutedPrimaryConstructorParameters;
+    private InterfaceArraySnapshot substitutedInterfaces;
+    private TypeArraySnapshot substitutedImplementedClrInterfaces;
+    private TypeSnapshot substitutedImportedBaseType;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="StructSymbol"/> class.
@@ -245,10 +257,10 @@ public sealed class StructSymbol : TypeSymbol
         IsData = isData;
         IsInline = isInline;
         IsClass = isClass;
-        PrimaryConstructorParameters = primaryConstructorParameters;
+        primaryConstructorParametersStore = primaryConstructorParameters;
         IsOpen = isOpen;
-        BaseClass = baseClass;
-        Interfaces = ImmutableArray<InterfaceSymbol>.Empty;
+        baseClassStore = baseClass;
+        interfacesStore = ImmutableArray<InterfaceSymbol>.Empty;
         Definition = this;
     }
 
@@ -290,7 +302,13 @@ public sealed class StructSymbol : TypeSymbol
     public bool IsClass { get; }
 
     /// <summary>Gets the Kotlin-style primary constructor parameters (Phase 3.B.3 sub-step 2). Each entry corresponds 1:1 to a field of the same name and type on this class; empty when no primary constructor was declared (default parameterless ctor).</summary>
-    public ImmutableArray<ParameterSymbol> PrimaryConstructorParameters { get; private set; }
+    public ImmutableArray<ParameterSymbol> PrimaryConstructorParameters
+    {
+        get => Definition != null && !ReferenceEquals(Definition, this)
+            ? GetSubstitutedPrimaryConstructorParameters()
+            : primaryConstructorParametersStore;
+        private set => primaryConstructorParametersStore = value;
+    }
 
     /// <summary>Gets a value indicating whether this type carries an explicit primary constructor (Phase 3.B.3 sub-step 2).</summary>
     public bool HasPrimaryConstructor => !PrimaryConstructorParameters.IsDefaultOrEmpty;
@@ -325,10 +343,27 @@ public sealed class StructSymbol : TypeSymbol
     }
 
     /// <summary>Gets the immediate base class (Phase 3.B.3 sub-step 3), or <c>null</c> when this class derives directly from <c>System.Object</c>. Always null for structs.</summary>
-    public StructSymbol BaseClass { get; private set; }
+    public StructSymbol BaseClass
+    {
+        get
+        {
+            if (Definition == null || ReferenceEquals(Definition, this))
+            {
+                return Volatile.Read(ref baseClassStore);
+            }
+
+            return GetSubstitutedBaseClass();
+        }
+    }
 
     /// <summary>Gets the interfaces this type implements (Phase 3.B.4). Populated by the binder after the symbol is constructed; defaults to empty.</summary>
-    public ImmutableArray<InterfaceSymbol> Interfaces { get; private set; }
+    public ImmutableArray<InterfaceSymbol> Interfaces
+    {
+        get => Definition != null && !ReferenceEquals(Definition, this)
+            ? GetSubstitutedInterfaces()
+            : interfacesStore;
+        private set => interfacesStore = value;
+    }
 
     /// <summary>
     /// Gets the imported (CLR) interfaces this class implements (issue #525).
@@ -339,7 +374,13 @@ public sealed class StructSymbol : TypeSymbol
     /// the resulting class is a real CLR implementer (<c>Type.GetInterfaces()</c>
     /// surfaces the interface and dispatch through interface receivers works).
     /// </summary>
-    public ImmutableArray<TypeSymbol> ImplementedClrInterfaces { get; private set; } = ImmutableArray<TypeSymbol>.Empty;
+    public ImmutableArray<TypeSymbol> ImplementedClrInterfaces
+    {
+        get => Definition != null && !ReferenceEquals(Definition, this)
+            ? GetSubstitutedImplementedClrInterfaces()
+            : implementedClrInterfacesStore;
+        private set => implementedClrInterfacesStore = value;
+    }
 
     /// <summary>Gets the methods declared inside the class body (Phase 3.B.3 sub-step 2b). Populated by the binder after the symbol is constructed; defaults to empty.</summary>
     /// <remarks>
@@ -368,7 +409,11 @@ public sealed class StructSymbol : TypeSymbol
     }
 
     /// <summary>Gets the events declared on this type (ADR-0052). Populated by the binder after the symbol is constructed; defaults to empty.</summary>
-    public ImmutableArray<EventSymbol> Events { get; private set; } = ImmutableArray<EventSymbol>.Empty;
+    public ImmutableArray<EventSymbol> Events
+    {
+        get => Definition != null && !ReferenceEquals(Definition, this) ? Definition.Events : eventsStore;
+        private set => eventsStore = value;
+    }
 
     /// <summary>Gets the static fields declared inside a <c>shared</c> block (ADR-0053). Populated by the binder; defaults to empty.</summary>
     /// <remarks>Issue #1341: forwarded from <see cref="Definition"/> on a constructed instance (static members are shared by identity per issue #1209) so reads are order-independent.</remarks>
@@ -499,7 +544,12 @@ public sealed class StructSymbol : TypeSymbol
     /// <c>.ctor()</c>; member lookup walks into this type so inherited CLR
     /// members are accessible on instances of the derived GSharp class.
     /// </summary>
-    public TypeSymbol ImportedBaseType { get; private set; }
+    public TypeSymbol ImportedBaseType
+    {
+        get => Definition != null && !ReferenceEquals(Definition, this)
+            ? GetSubstitutedImportedBaseType()
+            : Volatile.Read(ref importedBaseTypeStore);
+    }
 
     /// <summary>
     /// Gets the explicit base-constructor initializer (<c>: Base(args)</c>) declared
@@ -599,7 +649,7 @@ public sealed class StructSymbol : TypeSymbol
     /// <param name="importedBaseType">The imported CLR base type symbol.</param>
     public void SetImportedBaseType(TypeSymbol importedBaseType)
     {
-        ImportedBaseType = importedBaseType;
+        Volatile.Write(ref importedBaseTypeStore, importedBaseType);
     }
 
     /// <summary>Sets <see cref="BaseConstructorInitializer"/> after binding the base-constructor argument list (issue #306).</summary>
@@ -677,7 +727,7 @@ public sealed class StructSymbol : TypeSymbol
     /// <param name="baseClass">The resolved base class symbol, or <c>null</c>.</param>
     public void SetBaseClass(StructSymbol baseClass)
     {
-        BaseClass = baseClass;
+        Volatile.Write(ref baseClassStore, baseClass);
     }
 
     /// <summary>
@@ -1707,31 +1757,6 @@ public sealed class StructSymbol : TypeSymbol
         constructed.Definition = definition;
         constructed.TypeArguments = typeArguments;
         constructed.mapClrType = mapClrType;
-        if (!definition.Interfaces.IsDefaultOrEmpty)
-        {
-            var substitutedIfaces = ImmutableArray.CreateBuilder<InterfaceSymbol>(definition.Interfaces.Length);
-            foreach (var iface in definition.Interfaces)
-            {
-                substitutedIfaces.Add((InterfaceSymbol)SubstituteTypeForConstruction(iface, subst, mapClrType));
-            }
-
-            constructed.SetInterfaces(substitutedIfaces.MoveToImmutable());
-        }
-        else
-        {
-            constructed.SetInterfaces(definition.Interfaces);
-        }
-
-        if (!definition.ImplementedClrInterfaces.IsDefaultOrEmpty)
-        {
-            var substitutedClrIfaces = ImmutableArray.CreateBuilder<TypeSymbol>(definition.ImplementedClrInterfaces.Length);
-            foreach (var iface in definition.ImplementedClrInterfaces)
-            {
-                substitutedClrIfaces.Add(SubstituteTypeForConstruction(iface, subst, mapClrType));
-            }
-
-            constructed.SetImplementedClrInterfaces(substitutedClrIfaces.MoveToImmutable());
-        }
 
         // Issue #1341: Methods and the static-member tables below are
         // generically erased (ADR-0004) and shared with the definition by
@@ -1762,11 +1787,6 @@ public sealed class StructSymbol : TypeSymbol
         // definition is emitted; the external accessor call is parented at the
         // constructed TypeSpec by the emitter, and inside-the-type access lowers
         // against the definition).
-        if (definition.ImportedBaseType != null)
-        {
-            constructed.SetImportedBaseType(definition.ImportedBaseType);
-        }
-
         return constructed;
     }
 
@@ -1798,17 +1818,6 @@ public sealed class StructSymbol : TypeSymbol
         constructed.EnclosingTypeArguments = enclosingTypeArguments;
         constructed.mapClrType = mapClrType;
         constructed.ContainingType = definition.ContainingType;
-        constructed.SetInterfaces(definition.Interfaces);
-        if (!definition.ImplementedClrInterfaces.IsDefaultOrEmpty)
-        {
-            constructed.SetImplementedClrInterfaces(definition.ImplementedClrInterfaces);
-        }
-
-        if (definition.ImportedBaseType != null)
-        {
-            constructed.SetImportedBaseType(definition.ImportedBaseType);
-        }
-
         return constructed;
     }
 
@@ -1854,17 +1863,6 @@ public sealed class StructSymbol : TypeSymbol
         // argument no matter when it is first computed.
         constructed.nestedOwnTypeParameters = definition.TypeParameters;
         constructed.ContainingType = definition.ContainingType;
-        constructed.SetInterfaces(definition.Interfaces);
-        if (!definition.ImplementedClrInterfaces.IsDefaultOrEmpty)
-        {
-            constructed.SetImplementedClrInterfaces(definition.ImplementedClrInterfaces);
-        }
-
-        if (definition.ImportedBaseType != null)
-        {
-            constructed.SetImportedBaseType(definition.ImportedBaseType);
-        }
-
         return constructed;
     }
 
@@ -1874,9 +1872,10 @@ public sealed class StructSymbol : TypeSymbol
     // a construction's type arguments are fixed, so the map is cached.
     private Dictionary<TypeParameterSymbol, TypeSymbol> GetSubstitutionMap()
     {
-        if (substitutionMap != null)
+        var existing = Volatile.Read(ref substitutionMap);
+        if (existing != null)
         {
-            return substitutionMap;
+            return existing;
         }
 
         var def = Definition;
@@ -1915,8 +1914,136 @@ public sealed class StructSymbol : TypeSymbol
             }
         }
 
-        substitutionMap = map;
-        return map;
+        return Interlocked.CompareExchange(ref substitutionMap, map, null) ?? map;
+    }
+
+    private StructSymbol GetSubstitutedBaseClass()
+    {
+        var source = Definition.BaseClass;
+        var snapshot = Volatile.Read(ref substitutedBaseClass);
+        if (snapshot != null && ReferenceEquals(snapshot.Source, source))
+        {
+            return snapshot.Value;
+        }
+
+        var value = source == null
+            ? null
+            : SubstituteTypeForConstruction(source, GetSubstitutionMap(), mapClrType) as StructSymbol;
+        Volatile.Write(ref substitutedBaseClass, new BaseClassSnapshot(source, value));
+        return value;
+    }
+
+    private ImmutableArray<ParameterSymbol> GetSubstitutedPrimaryConstructorParameters()
+    {
+        var source = Definition.PrimaryConstructorParameters;
+        var snapshot = Volatile.Read(ref substitutedPrimaryConstructorParameters);
+        if (snapshot != null && snapshot.Source.Equals(source))
+        {
+            return snapshot.Value;
+        }
+
+        ImmutableArray<ParameterSymbol> value;
+        if (source.IsDefaultOrEmpty)
+        {
+            value = source;
+        }
+        else
+        {
+            var builder = ImmutableArray.CreateBuilder<ParameterSymbol>(source.Length);
+            foreach (var parameter in source)
+            {
+                builder.Add(new ParameterSymbol(
+                    parameter.Name,
+                    SubstituteTypeForConstruction(parameter.Type, GetSubstitutionMap(), mapClrType),
+                    isVariadic: parameter.IsVariadic,
+                    isScoped: parameter.IsScoped,
+                    refKind: parameter.RefKind));
+            }
+
+            value = builder.MoveToImmutable();
+        }
+
+        Volatile.Write(
+            ref substitutedPrimaryConstructorParameters,
+            new ParameterArraySnapshot(source, value));
+        return value;
+    }
+
+    private ImmutableArray<InterfaceSymbol> GetSubstitutedInterfaces()
+    {
+        var source = Definition.Interfaces;
+        var snapshot = Volatile.Read(ref substitutedInterfaces);
+        if (snapshot != null && snapshot.Source.Equals(source))
+        {
+            return snapshot.Value;
+        }
+
+        ImmutableArray<InterfaceSymbol> value;
+        if (source.IsDefaultOrEmpty)
+        {
+            value = source;
+        }
+        else
+        {
+            var builder = ImmutableArray.CreateBuilder<InterfaceSymbol>(source.Length);
+            foreach (var iface in source)
+            {
+                builder.Add((InterfaceSymbol)SubstituteTypeForConstruction(
+                    iface,
+                    GetSubstitutionMap(),
+                    mapClrType));
+            }
+
+            value = builder.MoveToImmutable();
+        }
+
+        Volatile.Write(ref substitutedInterfaces, new InterfaceArraySnapshot(source, value));
+        return value;
+    }
+
+    private ImmutableArray<TypeSymbol> GetSubstitutedImplementedClrInterfaces()
+    {
+        var source = Definition.ImplementedClrInterfaces;
+        var snapshot = Volatile.Read(ref substitutedImplementedClrInterfaces);
+        if (snapshot != null && snapshot.Source.Equals(source))
+        {
+            return snapshot.Value;
+        }
+
+        ImmutableArray<TypeSymbol> value;
+        if (source.IsDefaultOrEmpty)
+        {
+            value = source;
+        }
+        else
+        {
+            var builder = ImmutableArray.CreateBuilder<TypeSymbol>(source.Length);
+            foreach (var iface in source)
+            {
+                builder.Add(SubstituteTypeForConstruction(iface, GetSubstitutionMap(), mapClrType));
+            }
+
+            value = builder.MoveToImmutable();
+        }
+
+        Volatile.Write(
+            ref substitutedImplementedClrInterfaces,
+            new TypeArraySnapshot(source, value));
+        return value;
+    }
+
+    private TypeSymbol GetSubstitutedImportedBaseType()
+    {
+        var source = Definition.ImportedBaseType;
+        var snapshot = Volatile.Read(ref substitutedImportedBaseType);
+        if (snapshot != null && ReferenceEquals(snapshot.Source, source))
+        {
+            return snapshot.Value;
+        }
+
+        var value = SubstituteTypeForConstruction(source, GetSubstitutionMap(), mapClrType);
+        Volatile.Write(ref substitutedImportedBaseType, new TypeSnapshot(source, value));
+        return value;
     }
 
     // Issue #1341: lazily substitutes the definition's instance fields for this
@@ -2374,5 +2501,76 @@ public sealed class StructSymbol : TypeSymbol
         }
 
         return type;
+    }
+
+    private sealed class BaseClassSnapshot
+    {
+        public BaseClassSnapshot(StructSymbol source, StructSymbol value)
+        {
+            Source = source;
+            Value = value;
+        }
+
+        public StructSymbol Source { get; }
+
+        public StructSymbol Value { get; }
+    }
+
+    private sealed class ParameterArraySnapshot
+    {
+        public ParameterArraySnapshot(
+            ImmutableArray<ParameterSymbol> source,
+            ImmutableArray<ParameterSymbol> value)
+        {
+            Source = source;
+            Value = value;
+        }
+
+        public ImmutableArray<ParameterSymbol> Source { get; }
+
+        public ImmutableArray<ParameterSymbol> Value { get; }
+    }
+
+    private sealed class InterfaceArraySnapshot
+    {
+        public InterfaceArraySnapshot(
+            ImmutableArray<InterfaceSymbol> source,
+            ImmutableArray<InterfaceSymbol> value)
+        {
+            Source = source;
+            Value = value;
+        }
+
+        public ImmutableArray<InterfaceSymbol> Source { get; }
+
+        public ImmutableArray<InterfaceSymbol> Value { get; }
+    }
+
+    private sealed class TypeArraySnapshot
+    {
+        public TypeArraySnapshot(
+            ImmutableArray<TypeSymbol> source,
+            ImmutableArray<TypeSymbol> value)
+        {
+            Source = source;
+            Value = value;
+        }
+
+        public ImmutableArray<TypeSymbol> Source { get; }
+
+        public ImmutableArray<TypeSymbol> Value { get; }
+    }
+
+    private sealed class TypeSnapshot
+    {
+        public TypeSnapshot(TypeSymbol source, TypeSymbol value)
+        {
+            Source = source;
+            Value = value;
+        }
+
+        public TypeSymbol Source { get; }
+
+        public TypeSymbol Value { get; }
     }
 }

--- a/test/Compiler.Tests/Emit/Issue2517ConstructedBaseOrderingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2517ConstructedBaseOrderingEmitTests.cs
@@ -1,0 +1,150 @@
+// <copyright file="Issue2517ConstructedBaseOrderingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Compiler;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Runtime, reflection, C# consumer, and ILVerify coverage for issue #2517.</summary>
+public sealed class Issue2517ConstructedBaseOrderingEmitTests
+{
+    [Fact]
+    public void EarlyCrossPackageSignature_PreservesConstructedBaseMetadataAndDispatch()
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue2517_").FullName;
+        try
+        {
+            var sources = WriteSources(directory);
+            var assemblyPath = Path.Combine(directory, "Issue2517.dll");
+            var args = new List<string>
+            {
+                "/out:" + assemblyPath,
+                "/target:library",
+                "/targetframework:net10.0",
+            };
+            args.AddRange(sources);
+
+            var exitCode = Program.Main(args.ToArray());
+            Assert.Equal(0, exitCode);
+            IlVerifier.Verify(assemblyPath, additionalReferences: TrustedPlatformAssemblies());
+            VerifyCSharpConsumer(assemblyPath);
+
+            var loadContext = new AssemblyLoadContext("Issue2517", isCollectible: true);
+            try
+            {
+                var assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+                var derived = assembly.GetType("P.Audio.Derived2517", throwOnError: true)!;
+                var middle = assembly.GetType("P.Middle2517`2", throwOnError: true)!;
+                var baseType = assembly.GetType("P.Base2517`1", throwOnError: true)!;
+
+                Assert.Equal(middle, derived.BaseType!.GetGenericTypeDefinition());
+                Assert.Equal(baseType, derived.BaseType.BaseType!.GetGenericTypeDefinition());
+                Assert.Equal(
+                    "P.Entry2517",
+                    Assert.Single(derived.BaseType.BaseType.GenericTypeArguments).FullName);
+
+                var sizeGetter = derived.GetProperty(
+                    "Size",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!.GetMethod!;
+                Assert.Equal(
+                    baseType,
+                    sizeGetter.GetBaseDefinition().DeclaringType!.GetGenericTypeDefinition());
+
+                var instance = Activator.CreateInstance(derived);
+                var read = derived.GetMethod("Read", BindingFlags.Instance | BindingFlags.Public)!;
+                Assert.Equal(101, read.Invoke(instance, null));
+            }
+            finally
+            {
+                loadContext.Unload();
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static IReadOnlyList<string> WriteSources(string directory)
+    {
+        var sources = new[]
+        {
+            ("0Early.gs", """
+                package Other
+                import P
+                public class Early2517 {
+                    public func Get() Middle2517[Entry2517,Entry2517]? -> default(Middle2517[Entry2517,Entry2517]?)
+                }
+                """),
+            ("ADerived.gs", """
+                package P.Audio
+                import P
+                public open class Derived2517 : Middle2517[Entry2517,Entry2517] {
+                    public open override prop Size int32 -> 100
+                    public func Read() int32 -> Size + Inherited()
+                }
+                """),
+            ("Entry.gs", """
+                package P
+                public class Entry2517 { }
+                """),
+            ("YMiddle.gs", """
+                package P
+                public open class Middle2517[TInput,TOutput] : Base2517[TInput] { }
+                """),
+            ("ZBase.gs", """
+                package P
+                public open class Base2517[T] {
+                    public open prop Size int32 { get; }
+                    protected func Inherited() int32 -> 1
+                }
+                """),
+        };
+
+        var paths = new List<string>(sources.Length);
+        foreach (var (name, source) in sources)
+        {
+            var path = Path.Combine(directory, name);
+            File.WriteAllText(path, source);
+            paths.Add(path);
+        }
+
+        return paths;
+    }
+
+    private static void VerifyCSharpConsumer(string assemblyPath)
+    {
+        const string source = """
+            using P.Audio;
+
+            public static class Consumer2517
+            {
+                public static int Run() => new Derived2517().Read();
+            }
+            """;
+        var compilation = CSharpCompilation.Create(
+            "Issue2517.Consumer",
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            TrustedPlatformAssemblies()
+                .Select(path => MetadataReference.CreateFromFile(path))
+                .Append(MetadataReference.CreateFromFile(assemblyPath)),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static string[] TrustedPlatformAssemblies()
+        => ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))!
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2517ConstructedBaseOrderingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2517ConstructedBaseOrderingTests.cs
@@ -1,0 +1,106 @@
+// <copyright file="Issue2517ConstructedBaseOrderingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>Binding regressions for issue #2517's early generic construction ordering.</summary>
+public sealed class Issue2517ConstructedBaseOrderingTests
+{
+    [Fact]
+    public void EarlyReturnSignature_BeforeGenericBaseDefinition_PreservesOverrideAndInheritedMembers()
+    {
+        var early = Parse(
+            """
+            package Other
+            import P
+            class Early2517 {
+                func Get() Middle2517[Entry2517,Entry2517]? -> default(Middle2517[Entry2517,Entry2517]?)
+            }
+            """);
+        var derived = Parse(
+            """
+            package P.Audio
+            import P
+            open class Derived2517 : Middle2517[Entry2517,Entry2517] {
+                protected open override prop Size int32 -> 100
+                func Read() int32 -> Size + Inherited()
+            }
+            """);
+        var entry = Parse(
+            """
+            package P
+            class Entry2517 { }
+            """);
+        var middle = Parse(
+            """
+            package P
+            open class Middle2517[TInput,TOutput] : Base2517[TInput] { }
+            """);
+        var baseType = Parse(
+            """
+            package P
+            open class Base2517[T] {
+                protected open prop Size int32 { get; }
+                protected func Inherited() int32 -> 1
+            }
+            """);
+
+        var result = new Compilation(early, derived, entry, middle, baseType)
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void MultiLevelGenericBase_WithExplicitBaseConstructor_IsTreeOrderIndependent(bool reverse)
+    {
+        var early = Parse(
+            """
+            package Other2517
+            import Layers2517
+            class EarlyCtor2517 {
+                var Value Layer2517[int32]?
+            }
+            """);
+        var derived = Parse(
+            """
+            package Layers2517
+            class Final2517 : Layer2517[int32] {
+                init() : base(41) { }
+                override func Read() int32 -> 42
+            }
+            """);
+        var layers = Parse(
+            """
+            package Layers2517
+            open class Root2517[T] {
+                init(value T) { }
+                open func Read() int32 -> 1
+            }
+            open class Layer2517[T] : Root2517[T] {
+                init(value T) : base(value) { }
+            }
+            """);
+
+        var trees = reverse
+            ? new[] { layers, derived, early }
+            : new[] { early, derived, layers };
+        var result = new Compilation(trees)
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static SyntaxTree Parse(string source)
+        => SyntaxTree.Parse(SourceText.From(source));
+}

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue2517ConstructedBaseCacheTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue2517ConstructedBaseCacheTests.cs
@@ -1,0 +1,150 @@
+// <copyright file="Issue2517ConstructedBaseCacheTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>Regression coverage for issue #2517's constructed generic base cache.</summary>
+public sealed class Issue2517ConstructedBaseCacheTests
+{
+    [Fact]
+    public void ConstructionCreatedBeforeBaseBinding_ObservesSubstitutedBaseAfterBinding()
+    {
+        var baseType = GenericClass("Base2517", out _);
+        var middle = GenericClass("Middle2517", out var middleParameter);
+
+        var constructed = StructSymbol.Construct(
+            middle,
+            ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+        Assert.Null(constructed.BaseClass);
+
+        middle.SetBaseClass(StructSymbol.Construct(
+            baseType,
+            ImmutableArray.Create<TypeSymbol>(middleParameter)));
+
+        var closedBase = Assert.IsType<StructSymbol>(constructed.BaseClass);
+        Assert.Same(baseType, closedBase.Definition);
+        Assert.Same(TypeSymbol.Int32, Assert.Single(closedBase.TypeArguments));
+
+        var secondConstruction = StructSymbol.Construct(
+            middle,
+            ImmutableArray.Create<TypeSymbol>(TypeSymbol.String));
+        Assert.Same(baseType, secondConstruction.BaseClass.Definition);
+        Assert.Same(TypeSymbol.String, Assert.Single(secondConstruction.BaseClass.TypeArguments));
+    }
+
+    [Fact]
+    public void RecursiveConstructedBase_RecomputesWithoutDeadlockOrCrossDefinitionLeakage()
+    {
+        var root = GenericClass("Root2517", out _);
+        var node = GenericClass("Node2517", out var nodeParameter);
+        var sibling = GenericClass("Node2517", out var siblingParameter);
+
+        var closedNode = StructSymbol.Construct(
+            node,
+            ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+        var closedSibling = StructSymbol.Construct(
+            sibling,
+            ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+
+        node.SetBaseClass(StructSymbol.Construct(
+            root,
+            ImmutableArray.Create<TypeSymbol>(
+                StructSymbol.Construct(node, ImmutableArray.Create<TypeSymbol>(nodeParameter)))));
+        sibling.SetBaseClass(StructSymbol.Construct(
+            root,
+            ImmutableArray.Create<TypeSymbol>(siblingParameter)));
+
+        Parallel.For(0, 64, _ =>
+        {
+            var recursiveBase = closedNode.BaseClass;
+            Assert.Same(root, recursiveBase.Definition);
+            var recursiveArgument = Assert.IsType<StructSymbol>(Assert.Single(recursiveBase.TypeArguments));
+            Assert.Same(node, recursiveArgument.Definition);
+            Assert.Same(TypeSymbol.Int32, Assert.Single(recursiveArgument.TypeArguments));
+
+            Assert.Same(root, closedSibling.BaseClass.Definition);
+            Assert.Same(TypeSymbol.Int32, Assert.Single(closedSibling.BaseClass.TypeArguments));
+        });
+
+        Assert.NotSame(closedNode, closedSibling);
+        Assert.NotSame(node, sibling);
+    }
+
+    [Fact]
+    public void OtherLateBoundConstructedMetadata_RemainsLiveAndSubstituted()
+    {
+        var container = GenericClass("Container2517", out var containerParameter);
+        var iface = new InterfaceSymbol(
+            "IValue2517",
+            Accessibility.Public,
+            declaration: null,
+            packageName: "Issue2517");
+        var ifaceParameter = new TypeParameterSymbol(
+            "T",
+            0,
+            TypeParameterConstraint.Any,
+            TypeParameterVariance.None);
+        iface.SetTypeParameters(ImmutableArray.Create(ifaceParameter));
+
+        var constructed = StructSymbol.Construct(
+            container,
+            ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+        Assert.Empty(constructed.PrimaryConstructorParameters);
+        Assert.Empty(constructed.Interfaces);
+        Assert.Empty(constructed.Events);
+
+        container.SetInstanceFieldsAndPrimaryConstructorParameters(
+            ImmutableArray<FieldSymbol>.Empty,
+            ImmutableArray.Create(new ParameterSymbol("value", containerParameter)));
+        container.SetInterfaces(ImmutableArray.Create(
+            InterfaceSymbol.Construct(
+                iface,
+                ImmutableArray.Create<TypeSymbol>(containerParameter))));
+        var changed = new EventSymbol(
+            "Changed",
+            containerParameter,
+            Accessibility.Public,
+            isFieldLike: true,
+            isVirtual: false,
+            isOverride: false);
+        container.SetEvents(ImmutableArray.Create(changed));
+        containerParameter.ClassConstraint = GenericClass("Constraint2517", out _);
+
+        Assert.Same(
+            TypeSymbol.Int32,
+            Assert.Single(constructed.PrimaryConstructorParameters).Type);
+        var closedInterface = Assert.Single(constructed.Interfaces);
+        Assert.Same(iface, closedInterface.Definition);
+        Assert.Same(TypeSymbol.Int32, Assert.Single(closedInterface.TypeArguments));
+        Assert.Same(changed, Assert.Single(constructed.Events));
+        Assert.Same(
+            containerParameter.ClassConstraint,
+            Assert.Single(constructed.Definition.TypeParameters).ClassConstraint);
+    }
+
+    private static StructSymbol GenericClass(string name, out TypeParameterSymbol parameter)
+    {
+        parameter = new TypeParameterSymbol(
+            "T",
+            ordinal: 0,
+            TypeParameterConstraint.Any,
+            TypeParameterVariance.None);
+        var type = new StructSymbol(
+            name,
+            ImmutableArray<FieldSymbol>.Empty,
+            Accessibility.Public,
+            declaration: null,
+            packageName: "Issue2517",
+            isData: false,
+            isInline: false,
+            isClass: true);
+        type.SetTypeParameters(ImmutableArray.Create(parameter));
+        return type;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2517ConstructedBaseOrderingPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2517ConstructedBaseOrderingPipelineTests.cs
@@ -1,0 +1,175 @@
+// <copyright file="Issue2517ConstructedBaseOrderingPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>Default SDK-backed Oahu.Decrypt ordering-shape coverage for issue #2517.</summary>
+public sealed class Issue2517ConstructedBaseOrderingPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_EarlyGenericSignatureAndOahuFilterShape_CompileInPathOrder()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectDir = Path.Combine(sourceRoot, "src", "OahuDecryptShape");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "OahuDecryptShape.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        WriteSources(projectDir);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp("test/OahuDecryptShape2517", projectPath, TargetKind.Library);
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+        string appRunDir = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.Id));
+        string project = File.ReadAllText(Assert.Single(
+            Directory.GetFiles(appRunDir, "*.gsproj", SearchOption.AllDirectories)));
+
+        Assert.True(project.IndexOf("0Early.gs", StringComparison.Ordinal) >= 0);
+        Assert.True(
+            project.IndexOf("0Early.gs", StringComparison.Ordinal)
+                < project.IndexOf("ADerived.gs", StringComparison.Ordinal));
+        Assert.True(
+            project.IndexOf("ADerived.gs", StringComparison.Ordinal)
+                < project.IndexOf("YMiddle.gs", StringComparison.Ordinal));
+        Assert.True(
+            project.IndexOf("YMiddle.gs", StringComparison.Ordinal)
+                < project.IndexOf("ZBase.gs", StringComparison.Ordinal));
+        Assert.True(
+            appResult.Succeeded,
+            "Expected path-ordered default --via-sdk compilation to preserve the constructed generic base. Stages: " +
+                string.Join("; ", appResult.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+    }
+
+    private static void WriteSources(string projectDir)
+    {
+        File.WriteAllText(Path.Combine(projectDir, "0Early.cs"), """
+            using Oahu.Decrypt;
+
+            namespace Other;
+
+            public sealed class Early
+            {
+                public Middle<Entry, Entry>? Get() => null;
+            }
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "ADerived.cs"), """
+            using Oahu.Decrypt;
+
+            namespace Oahu.Decrypt.FrameFilters.Audio;
+
+            public sealed class AacValidateFilter : Middle<Entry, Entry>
+            {
+                public AacValidateFilter() : base(1) { }
+
+                protected override int InputBufferSize => 100;
+
+                public int Inspect() =>
+                    InputBufferSize + SamplesInFrame + (Disposed ? 0 : 1) + (Chunk is null ? 1 : 0);
+
+                public void Report() => OnProgressUpdate();
+            }
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "Entry.cs"), """
+            namespace Oahu.Decrypt;
+
+            public sealed class Entry { }
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "YMiddle.cs"), """
+            namespace Oahu.Decrypt;
+
+            public abstract class Middle<TInput, TOutput> : Base<TInput>
+            {
+                protected Middle(int seed) : base(seed) { }
+            }
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "ZBase.cs"), """
+            namespace Oahu.Decrypt;
+
+            public abstract class Base<T>
+            {
+                protected Base(int seed) => SamplesInFrame = seed;
+
+                protected abstract int InputBufferSize { get; }
+                protected bool Disposed { get; }
+                protected T? Chunk { get; }
+                protected int SamplesInFrame { get; }
+                protected void OnProgressUpdate() { }
+            }
+            """);
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2517",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    dir.FullName,
+                    "out",
+                    "bin",
+                    config,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- make constructed `StructSymbol` base relationships lazily recompute from the current generic definition after base binding completes
- apply the same lifecycle-safe substitution to primary constructors, implemented interfaces, CLR interfaces, imported bases, and events while preserving constructed-symbol identity
- publish substitution maps and relation snapshots atomically for concurrent cache readers
- preserve #2513 base-first declaration ordering and fix arbitrary early signature construction forward

## Coverage
- exact early-signature/path-order regression and reversed ordering
- multi-level, recursive, cross-package, base-constructor, inherited-member, override, and sibling-definition cache cases
- runtime dispatch, reflection base/override metadata, C# consumer compilation, and ILVerify
- default `--via-sdk` Oahu.Decrypt filter shape with the canonical `InputBufferSize`/inherited-member cascade

## Validation
- Release solution build: succeeded, 0 warnings/errors
- Core related regressions: 80 passed
- Compiler generic-base/ILVerify regressions: 14 passed
- cs2gs default SDK Oahu shape: 1 passed

Fixes #2517