### PR TITLE
Fix source class constraint declaration ordering

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -5243,9 +5243,9 @@ public sealed class Binder
 
         if (type is TypeParameterSymbol tp)
         {
-            // Propagate: if the source type parameter carries `class`, so
-            // does this substitution.
-            return tp.HasReferenceTypeConstraint;
+            // A class-base constraint proves the parameter is reference-shaped
+            // just as strongly as the explicit `class` flag.
+            return tp.HasReferenceTypeConstraint || tp.ClassConstraint != null;
         }
 
         if (type is StructSymbol structSym)

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -864,47 +864,22 @@ internal sealed partial class DeclarationBinder
     }
 
     /// <summary>
-    /// Binds a type-parameter list without constraint pre-publication. Made
-    /// <c>internal</c> (issue #1886) so <see cref="LambdaBinder"/> can bind the
-    /// <c>[T, U, ...]</c> list on a generic <c>let</c>-bound local function
-    /// declaration (<c>let Name[T] = func (...) ... { ... }</c>) using the exact
-    /// same routine as generic delegate/type declarations.
+    /// Binds a type-parameter list. Made <c>internal</c> (issue #1886) so
+    /// <see cref="LambdaBinder"/> can bind the <c>[T, U, ...]</c> list on a
+    /// generic <c>let</c>-bound local function declaration
+    /// (<c>let Name[T] = func (...) ... { ... }</c>) using the same routine as
+    /// other generic callable declarations.
     /// </summary>
     /// <param name="syntax">The type-parameter list syntax.</param>
     /// <returns>The bound type-parameter symbols.</returns>
     internal ImmutableArray<TypeParameterSymbol> BindTypeParameterList(TypeParameterListSyntax syntax)
-        => BindTypeParameterList(syntax, onBareSymbolsPublished: null);
-
-    /// <summary>
-    /// Binds a type-parameter list. The optional
-    /// <paramref name="onBareSymbolsPublished"/> callback runs after the bare
-    /// type-parameter symbols are created and published into the constraint
-    /// scope but BEFORE any constraint clause is resolved. Issue #1056 uses this
-    /// to register the declaring type's name shell (with its type parameters
-    /// already attached) so a self-referential base-class constraint such as the
-    /// CRTP-style <c>class Box[T Box[T]]</c> / <c>class Box[T Box]</c> resolves
-    /// the type's own name while its constraints are being bound.
-    /// </summary>
-    /// <param name="syntax">The type-parameter list syntax.</param>
-    /// <param name="onBareSymbolsPublished">Optional callback invoked with the bare type-parameter symbols between pass 1 (symbol creation) and pass 2 (constraint resolution).</param>
-    /// <returns>The bound type-parameter symbols.</returns>
-    private ImmutableArray<TypeParameterSymbol> BindTypeParameterList(
-        TypeParameterListSyntax syntax,
-        Action<ImmutableArray<TypeParameterSymbol>> onBareSymbolsPublished)
     {
         if (syntax == null)
         {
-            onBareSymbolsPublished?.Invoke(ImmutableArray<TypeParameterSymbol>.Empty);
             return ImmutableArray<TypeParameterSymbol>.Empty;
         }
 
         var symbols = CreateTypeParameterSymbols(syntax);
-
-        // Publish the bare symbols into the binder's type-parameter scope so the
-        // constraint type clauses bound in pass 2 can see them. Enclosing type
-        // parameters (e.g. for a generic method declared inside a generic type)
-        // remain visible because we copy the previous map.
-        onBareSymbolsPublished?.Invoke(symbols);
         ResolveTypeParameterConstraints(syntax, symbols);
         return symbols;
     }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
@@ -42,52 +42,18 @@ internal sealed partial class DeclarationBinder
             "an interface declaration",
             System.AttributeTargets.Interface));
 
-        // Phase 4.3c / ADR-0020: bind type parameters at declaration time so
-        // method-signature binding (which happens later) can resolve them.
-        //
-        // Issue #1061: register the interface's name shell BETWEEN creating the
-        // bare type parameters and resolving their constraints (mirroring the
-        // class/struct path from #1056). This puts the declaring interface's own
-        // name and arity in scope while its type-parameter constraints are bound,
-        // so a self-referential / CRTP constraint such as
-        // `interface IData[T IData]` or `interface IData[TData IAppleData[TData]]`
-        // resolves the interface being declared instead of failing with GS0113.
-        var registered = false;
-        var registrationFailed = false;
-        var typeParameters = BindTypeParameterList(
-            syntax.TypeParameterList,
-            bareSymbols =>
-            {
-                if (!bareSymbols.IsDefaultOrEmpty)
-                {
-                    interfaceSymbol.SetTypeParameters(bareSymbols);
-                }
-
-                if (!scope.TryDeclareTypeAlias(name, interfaceSymbol))
-                {
-                    Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
-                    registrationFailed = true;
-                    return;
-                }
-
-                registered = true;
-            });
-
-        if (registrationFailed)
-        {
-            return null;
-        }
-
-        // Bind the fully-resolved type parameters (with constraints) onto the
-        // interface symbol; the callback only attached the bare symbols.
+        // Issue #2519: publish bare type parameters with the interface shell
+        // and resolve their constraints only when members are bound, after all
+        // same-compilation aggregate shells exist. This is the interface
+        // counterpart of the aggregate-shell lifecycle and preserves CRTP
+        // because the interface's own shell is visible by then.
+        var typeParameters = CreateTypeParameterSymbols(syntax.TypeParameterList);
         if (!typeParameters.IsDefaultOrEmpty)
         {
             interfaceSymbol.SetTypeParameters(typeParameters);
         }
 
-        // Non-generic interfaces (or the defensive fallback when the callback did
-        // not run) register the name shell here.
-        if (!registered && !scope.TryDeclareTypeAlias(name, interfaceSymbol))
+        if (!scope.TryDeclareTypeAlias(name, interfaceSymbol))
         {
             Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
             return null;
@@ -121,6 +87,7 @@ internal sealed partial class DeclarationBinder
 
         try
         {
+            ResolveTypeParameterConstraints(syntax.TypeParameterList, interfaceSymbol.TypeParameters);
             BindInterfaceMembersCore(syntax, interfaceSymbol, package);
         }
         finally

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -60,6 +60,11 @@ internal sealed partial class DeclarationBinder
                 }
             }
 
+            // Issue #2519: aggregate shells carry bare type parameters so every
+            // same-compilation constraint target can be published first.
+            // Resolve constraints now, with the declaring shell and all sibling
+            // source type shells visible, before binding signatures and members.
+            ResolveTypeParameterConstraints(syntax.TypeParameterList, structSymbol.TypeParameters);
             BindStructDeclarationBodyCore(syntax, package, structSymbol);
         }
         finally

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -723,49 +723,21 @@ internal sealed partial class DeclarationBinder
 
         var accessibility = resolveAccessibility(syntax.AccessibilityModifier);
 
-        // Phase 4.3 / ADR-0020: bind the optional type-parameter list FIRST so
-        // field/parameter types in the body can reference T, U, etc.
-        // Issue #1056: construct and register the struct/class shell BETWEEN
-        // creating the bare type parameters and resolving their constraints, so a
-        // self-referential base-class constraint (CRTP `class Box[T Box[T]]` /
-        // `class Box[T Box]`) can resolve the type's own name and arity.
-        var previousTypeParameters = binderCtx.CurrentTypeParameters;
-        StructSymbol structSymbol = null;
-        ImmutableArray<TypeParameterSymbol> typeParameters = ImmutableArray<TypeParameterSymbol>.Empty;
-        try
-        {
-            if (syntax.TypeParameterList != null)
-            {
-                binderCtx.CurrentTypeParameters = new Dictionary<string, TypeParameterSymbol>();
-
-                // Issue #1537: a nested generic type's own type-parameter
-                // constraints may reference the enclosing type's parameters
-                // (e.g. `struct Middle[T U]` nested in `Outer[U]`), so seed the
-                // enclosing parameters (outermost-first) before binding the
-                // nested type's list.
-                foreach (var tp in CollectEnclosingTypeParameters(containingType))
-                {
-                    binderCtx.CurrentTypeParameters[tp.Name] = tp;
-                }
-
-                typeParameters = BindTypeParameterList(
-                    syntax.TypeParameterList,
-                    bareSymbols =>
-                    {
-                        structSymbol = CreateAndRegisterStructShell(syntax, package, accessibility, name, bareSymbols, containingType);
-                    });
-            }
-        }
-        finally
-        {
-            binderCtx.CurrentTypeParameters = previousTypeParameters;
-        }
-
-        // Non-generic types (or the defensive fallback when the callback did not
-        // run) construct and register the shell here.
-        structSymbol ??= CreateAndRegisterStructShell(syntax, package, accessibility, name, typeParameters, containingType);
-
-        return structSymbol;
+        // Issue #2519: publish the aggregate shell with bare type parameters,
+        // but defer constraint resolution to BindStructDeclarationBody. The
+        // global declaration pass creates every same-compilation type shell
+        // before any body is bound, so a constraint may name a class declared
+        // in a later file without depending on compile-item order. Resolving in
+        // the body phase still preserves CRTP constraints because this shell is
+        // already registered before its own constraints are resolved.
+        var typeParameters = CreateTypeParameterSymbols(syntax.TypeParameterList);
+        return CreateAndRegisterStructShell(
+            syntax,
+            package,
+            accessibility,
+            name,
+            typeParameters,
+            containingType);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -221,6 +221,24 @@ internal sealed partial class ExpressionBinder
                 return new BoundEventSubscriptionExpression(null, boundReceiver, userStruct, ev, userHandler, isAdd);
             }
 
+            // Issue #2519: a class-constrained type parameter exposes the same
+            // instance event surface as its constraint's fields, properties,
+            // and methods. TypeMemberModel walks inherited events; retain the
+            // constraint as the event owner while the receiver remains T.
+            if (isEventCapableOperator
+                && boundReceiver.Type is TypeParameterSymbol { ClassConstraint: StructSymbol classConstraint }
+                && TypeMemberModel.TryGetEvent(classConstraint, eventName, out var constrainedUserEvent))
+            {
+                var constrainedHandler = BindEventSubscriptionHandler(syntax.Value, constrainedUserEvent.Type);
+                return new BoundEventSubscriptionExpression(
+                    null,
+                    boundReceiver,
+                    classConstraint,
+                    constrainedUserEvent,
+                    constrainedHandler,
+                    isAdd);
+            }
+
             // ADR-0149 follow-up (issue #2370): event subscription through an
             // INTERFACE-typed receiver (`b: IFoo; b.Changed += h`). Interfaces
             // could always declare events, but no call-site binding ever
@@ -297,6 +315,19 @@ internal sealed partial class ExpressionBinder
                 {
                     var compoundResult = TryBindChainedCompoundAssignment(
                         compoundStruct, boundReceiver, eventName, eventNameSyntax, syntax, baseOpSyntaxKind);
+                    if (compoundResult != null)
+                    {
+                        return compoundResult;
+                    }
+                }
+
+                // Issue #2519: use the class constraint as the member surface
+                // for `T.member op= value`, matching simple reads/writes and
+                // method/event lookup through the same constrained receiver.
+                if (boundReceiver.Type is TypeParameterSymbol { ClassConstraint: StructSymbol compoundConstraint })
+                {
+                    var compoundResult = TryBindChainedCompoundAssignment(
+                        compoundConstraint, boundReceiver, eventName, eventNameSyntax, syntax, baseOpSyntaxKind);
                     if (compoundResult != null)
                     {
                         return compoundResult;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -543,7 +543,20 @@ internal sealed partial class MethodBodyEmitter
         // ADR-0052: user-defined event subscription — call add_X or remove_X accessor.
         if (node.Receiver != null)
         {
-            this.EmitInstanceReceiver(node.Receiver);
+            if (node.Receiver.Type is TypeParameterSymbol typeParameterReceiver)
+            {
+                // Issue #2519: mirror constrained field/property access. Boxing
+                // a reference-shaped T is a runtime no-op and provides the
+                // verifier with the class-constraint receiver shape expected by
+                // the event accessor.
+                this.EmitExpression(node.Receiver);
+                this.il.OpCode(ILOpCode.Box);
+                this.il.Token(this.outer.memberRefs.GetElementTypeToken(typeParameterReceiver));
+            }
+            else
+            {
+                this.EmitInstanceReceiver(node.Receiver);
+            }
         }
 
         // Issue #503: function-literal handlers default to Action/Func

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -496,6 +496,19 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #2519: box a class-constrained type parameter when widening it
+        // to the constraint, one of its bases, or an implemented interface.
+        // For a reference-type instantiation `box !T` is a runtime no-op, while
+        // giving the verifier the constrained reference shape it requires.
+        if (from is TypeParameterSymbol classConstrainedParameter
+            && classConstrainedParameter.ClassConstraint is TypeSymbol classConstraint
+            && IsReferenceCompatible(classConstraint, to))
+        {
+            this.il.OpCode(ILOpCode.Box);
+            this.il.Token(this.outer.memberRefs.GetElementTypeToken(classConstrainedParameter));
+            return;
+        }
+
         // Phase D: class → interface upcast is a CLR reference-level
         // no-op. The receiver already implements the interface; loading
         // the reference into an interface-typed slot needs no IL.

--- a/test/Compiler.Tests/Emit/Issue2519SourceClassConstraintOrderingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2519SourceClassConstraintOrderingEmitTests.cs
@@ -1,0 +1,163 @@
+// <copyright file="Issue2519SourceClassConstraintOrderingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Compiler;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Runtime and metadata regressions for issue #2519.</summary>
+public sealed class Issue2519SourceClassConstraintOrderingEmitTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SourceClassConstraint_InEitherFileOrder_PreservesMetadataDispatchAndMembers(bool reverse)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue2519_").FullName;
+        try
+        {
+            var sources = WriteSources(directory);
+            if (reverse)
+            {
+                sources.Reverse();
+            }
+
+            var assemblyPath = Path.Combine(directory, "Issue2519.dll");
+            var args = new List<string>
+            {
+                "/out:" + assemblyPath,
+                "/target:library",
+                "/targetframework:net10.0",
+            };
+            args.AddRange(sources);
+
+            Assert.Equal(0, Program.Main(args.ToArray()));
+            IlVerifier.Verify(assemblyPath, additionalReferences: TrustedPlatformAssemblies());
+            VerifyCSharpConsumer(assemblyPath);
+
+            var loadContext = new AssemblyLoadContext("Issue2519", isCollectible: true);
+            try
+            {
+                var assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+                var holderDefinition = assembly.GetType("P.Audio.Holder2519`1", throwOnError: true)!;
+                var entryType = assembly.GetType("P.Entry2519", throwOnError: true)!;
+                var concreteType = assembly.GetType("P.Concrete2519", throwOnError: true)!;
+                var typeParameter = Assert.Single(holderDefinition.GetGenericArguments());
+                Assert.Equal(entryType, Assert.Single(typeParameter.GetGenericParameterConstraints()));
+
+                var holderType = holderDefinition.MakeGenericType(concreteType);
+                var holder = Activator.CreateInstance(holderType);
+                var concrete = Activator.CreateInstance(concreteType);
+                var subscriptions = 0;
+                var handler = new Action(() => subscriptions++);
+                holderType.GetMethod("Subscribe")!.Invoke(holder, new[] { concrete, handler });
+                concreteType.GetMethod("Raise")!.Invoke(concrete, null);
+
+                Assert.Equal(10, holderType.GetMethod("Read")!.Invoke(holder, new[] { concrete }));
+                Assert.Same(concrete, holderType.GetMethod("Upcast")!.Invoke(holder, new[] { concrete }));
+                Assert.Equal(1, subscriptions);
+            }
+            finally
+            {
+                loadContext.Unload();
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static List<string> WriteSources(string directory)
+    {
+        var sources = new[]
+        {
+            ("AHolder.gs", """
+                package P.Audio
+                import P
+                import System
+                public class Holder2519[T Entry2519] {
+                    public func Read(value T) int32 ->
+                        value.Count + value.SamplesInFrame + value.Inherited() + value.VirtualValue()
+                    public func Upcast(value T) Entry2519 -> value
+                    public func Subscribe(value T, handler Action) {
+                        value.Changed += handler
+                    }
+                }
+                """),
+            ("ZEntry.gs", """
+                package P
+                import System
+                public open class Root2519 {
+                    public var SamplesInFrame int32
+                    public func Inherited() int32 -> 3
+                    public event Changed Action
+                    public func Raise() {
+                        Changed()
+                    }
+                }
+                public open class Entry2519 : Root2519 {
+                    public prop Count int32 -> 2
+                    public open func VirtualValue() int32 -> 4
+                }
+                public class Concrete2519 : Entry2519 {
+                    public override func VirtualValue() int32 -> 5
+                }
+                """),
+        };
+
+        var paths = new List<string>(sources.Length);
+        foreach (var (name, source) in sources)
+        {
+            var path = Path.Combine(directory, name);
+            File.WriteAllText(path, source);
+            paths.Add(path);
+        }
+
+        return paths;
+    }
+
+    private static void VerifyCSharpConsumer(string assemblyPath)
+    {
+        const string source = """
+            using P;
+            using P.Audio;
+
+            public static class Consumer2519
+            {
+                public static int Run()
+                {
+                    var value = new Concrete2519();
+                    var holder = new Holder2519<Concrete2519>();
+                    holder.Subscribe(value, () => { });
+                    Entry2519 upcast = holder.Upcast(value);
+                    return holder.Read(value) + (ReferenceEquals(value, upcast) ? 0 : 100);
+                }
+            }
+            """;
+        var compilation = CSharpCompilation.Create(
+            "Issue2519.Consumer",
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            TrustedPlatformAssemblies()
+                .Select(path => MetadataReference.CreateFromFile(path))
+                .Append(MetadataReference.CreateFromFile(assemblyPath)),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static string[] TrustedPlatformAssemblies()
+        => ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))!
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2519SourceClassConstraintOrderingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2519SourceClassConstraintOrderingTests.cs
@@ -1,0 +1,181 @@
+// <copyright file="Issue2519SourceClassConstraintOrderingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>Binding regressions for issue #2519's source class-constraint ordering.</summary>
+public sealed class Issue2519SourceClassConstraintOrderingTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CrossPackageSourceClassConstraint_ExposesCompleteMemberSurfaceInEitherTreeOrder(bool reverse)
+    {
+        var constrained = Parse(
+            """
+            package P.Audio
+            import P
+            import System
+            class Holder2519[T Entry2519] {
+                func Read(value T) int32 ->
+                    value.Count + value.SamplesInFrame + value.Inherited() + value.VirtualValue()
+                func Upcast(value T) Entry2519 -> value
+                func Subscribe(value T, handler Action) {
+                    value.Changed += handler
+                }
+            }
+            """);
+        var constraint = Parse(
+            """
+            package P
+            import System
+            open class Root2519 {
+                public var SamplesInFrame int32
+                public func Inherited() int32 -> 3
+                public event Changed Action
+            }
+            open class Entry2519 : Root2519 {
+                public prop Count int32 -> 2
+                public open func VirtualValue() int32 -> 4
+            }
+            """);
+
+        var trees = reverse
+            ? new[] { constraint, constrained }
+            : new[] { constrained, constraint };
+        var result = new Compilation(trees)
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ExactDecryptConstraintShape_BindsBeforeOrAfterConstraintAndGenericBase(bool reverse)
+    {
+        var multipart = Parse(
+            """
+            package Oahu.Decrypt.FrameFilters.Audio
+            import Oahu.Decrypt
+            import Oahu.Decrypt.FrameFilters
+            import System.Threading.Tasks
+
+            open class MultipartFilterBase2519[
+                TInput FrameEntry2519,
+                TCallback Oahu.Decrypt.INewSplitCallback2519[TCallback]
+            ] : FrameFinalBase2519[TInput] {
+                protected open override func PerformFilteringAsync(input TInput) Task {
+                    if input.Chunk == nil {
+                        input.Notify += () -> { }
+                    }
+                    input.SamplesInFrame += 1
+                    return Task.CompletedTask
+                }
+            }
+            """);
+        var dependencies = Parse(
+            """
+            package Oahu.Decrypt
+            import System
+            interface INewSplitCallback2519[T INewSplitCallback2519[T]] { }
+            open class FrameEntryBase2519 {
+                public var Chunk object?
+                public var SamplesInFrame int32
+                public event Notify Action
+            }
+            open class FrameEntry2519 : FrameEntryBase2519 { }
+            """);
+        var genericBase = Parse(
+            """
+            package Oahu.Decrypt.FrameFilters
+            import System.Threading.Tasks
+            open class FrameFinalBase2519[T] {
+                protected open func PerformFilteringAsync(input T) Task -> Task.CompletedTask
+            }
+            """);
+
+        var trees = reverse
+            ? new[] { genericBase, dependencies, multipart }
+            : new[] { multipart, dependencies, genericBase };
+        var result = new Compilation(trees)
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Message.Contains("FrameEntry2519")
+                || diagnostic.Message.Contains("Chunk")
+                || diagnostic.Message.Contains("SamplesInFrame"));
+    }
+
+    [Fact]
+    public void SameFileConstraintDeclaredLater_ResolvesToPublishedShell()
+    {
+        var tree = Parse(
+            """
+            package P
+            class Holder2519[T Entry2519] {
+                func Read(value T) int32 -> value.Count
+            }
+            class Entry2519 {
+                public prop Count int32 -> 42
+            }
+            """);
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        var holder = Assert.Single(compilation.GlobalScope.Structs.Where(s => s.Name == "Holder2519"));
+        var constraint = Assert.IsType<StructSymbol>(Assert.Single(holder.TypeParameters).ClassConstraint);
+        Assert.Equal("Entry2519", constraint.Name);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ConstructedClassConstraint_OnClassAndInterface_UsesLateGenericMemberProjections(bool reverse)
+    {
+        var consumers = Parse(
+            """
+            package P.Use
+            import P.Model
+            class Holder2519[T GenericEntry2519[int32]] {
+                func Read(value T) int32 -> value.Value + value.BaseValue
+            }
+            interface Reader2519[T GenericEntry2519[int32]] {
+                func Read(value T) int32;
+            }
+            """);
+        var model = Parse(
+            """
+            package P.Model
+            open class GenericBase2519[U] {
+                public prop BaseValue U -> default(U)
+            }
+            class GenericEntry2519[U] : GenericBase2519[U] {
+                public prop Value U -> default(U)
+            }
+            """);
+
+        var trees = reverse
+            ? new[] { model, consumers }
+            : new[] { consumers, model };
+        var result = new Compilation(trees)
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static SyntaxTree Parse(string source)
+        => SyntaxTree.Parse(SourceText.From(source));
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2519SourceClassConstraintOrderingPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2519SourceClassConstraintOrderingPipelineTests.cs
@@ -1,0 +1,186 @@
+// <copyright file="Issue2519SourceClassConstraintOrderingPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>Default SDK-backed Oahu.Decrypt constraint-shape coverage for issue #2519.</summary>
+public sealed class Issue2519SourceClassConstraintOrderingPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_SourceClassConstraintsCompileBeforeTheirDeclarations()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectDir = Path.Combine(sourceRoot, "src", "OahuDecryptConstraintShape");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "OahuDecryptConstraintShape.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        WriteSources(projectDir);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp("test/OahuDecryptConstraintShape2519", projectPath, TargetKind.Library);
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+        string appRunDir = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.Id));
+        string project = File.ReadAllText(Assert.Single(
+            Directory.GetFiles(appRunDir, "*.gsproj", SearchOption.AllDirectories)));
+
+        Assert.Contains("AHolder.gs", project, StringComparison.Ordinal);
+        Assert.Contains("AMultipartFilterBase.gs", project, StringComparison.Ordinal);
+        Assert.Contains("ZEntry.gs", project, StringComparison.Ordinal);
+        Assert.True(
+            project.IndexOf("AHolder.gs", StringComparison.Ordinal)
+                < project.IndexOf("ZEntry.gs", StringComparison.Ordinal));
+        Assert.True(
+            project.IndexOf("AMultipartFilterBase.gs", StringComparison.Ordinal)
+                < project.IndexOf("ZEntry.gs", StringComparison.Ordinal));
+        Assert.True(
+            appResult.Succeeded,
+            "Expected path-ordered default --via-sdk compilation to resolve source class constraints. Stages: " +
+                string.Join("; ", appResult.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+    }
+
+    private static void WriteSources(string projectDir)
+    {
+        File.WriteAllText(Path.Combine(projectDir, "AHolder.cs"), """
+            using P;
+
+            namespace P.Audio;
+
+            public class Holder<T> where T : Entry
+            {
+                public int Read(T value) => value.Count;
+            }
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "AMultipartFilterBase.cs"), """
+            using System.Threading.Tasks;
+
+            namespace Oahu.Decrypt.FrameFilters.Audio;
+
+            public abstract class MultipartFilterBase<TInput, TCallback> : FrameFinalBase<TInput>
+                where TInput : FrameEntry
+                where TCallback : Oahu.Decrypt.INewSplitCallback<TCallback>
+            {
+                protected override Task PerformFilteringAsync(TInput input)
+                {
+                    if (input.Chunk is null)
+                    {
+                        input.Chunk = new object();
+                    }
+
+                    input.SamplesInFrame += 1;
+                    return Task.CompletedTask;
+                }
+            }
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "YFrameFinalBase.cs"), """
+            using System.Threading.Tasks;
+
+            namespace Oahu.Decrypt.FrameFilters.Audio;
+
+            public abstract class FrameFinalBase<T>
+            {
+                protected virtual Task PerformFilteringAsync(T input) => Task.CompletedTask;
+            }
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "ZEntry.cs"), """
+            namespace P
+            {
+                public class Entry
+                {
+                    public int Count { get; set; }
+                }
+            }
+
+            namespace Oahu.Decrypt
+            {
+                public interface INewSplitCallback<T> where T : INewSplitCallback<T>
+                {
+                }
+            }
+
+            namespace Oahu.Decrypt.FrameFilters.Audio
+            {
+                public class FrameEntry
+                {
+                    public object? Chunk { get; set; }
+                    public int SamplesInFrame { get; set; }
+                }
+            }
+            """);
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2519",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    dir.FullName,
+                    "out",
+                    "bin",
+                    config,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- publish aggregate and interface shells with bare type parameters, then resolve constraints only after all same-compilation source type shells exist
- preserve the #2518 lazy constructed-base/member projection lifecycle while making source class constraints independent of file and declaration order
- complete class-constrained event, compound assignment, reference-shape, and base-conversion binding/emission paths exposed by the Decrypt shape

## Root cause
Type-parameter constraints on source classes/interfaces were resolved during shell declaration, unlike delegate signatures and other deferred declaration work. A generic declaration encountered before its source class constraint therefore permanently lost the constraint before body ordering or lazy member projections could help. Resolving constraints in the body/member phase keeps CRTP support while making every source shell visible first.

## Coverage
- same-file, cross-file, cross-package, reversed-order, constructed-generic, inherited-member, override, event, compound assignment, and base-conversion cases
- exact `MultipartFilterBase<TInput : FrameEntry, TCallback : INewSplitCallback<TCallback>>` Decrypt shape
- runtime dispatch/events, reflection constraint metadata, C# consumer compilation, ILVerify, and default `--via-sdk` path ordering
- #1056/#1061/#1235, #2489, and #2517/#2518 regression controls

## Validation
- Release solution build: succeeded, 0 warnings/errors
- related Core regressions: 38 passed
- related Compiler/ILVerify regressions: 15 passed
- issue #2519 SDK pipeline: passed
- issue #2517 SDK pipeline: passed

Fixes #2519
