### PR TITLE
Fix imported initializer target forgiveness

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2521ImportedInitializerTargetContractPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2521ImportedInitializerTargetContractPipelineTests.cs
@@ -1,0 +1,435 @@
+// <copyright file="Issue2521ImportedInitializerTargetContractPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Default <c>--via-sdk</c>/gsc coverage for issue #2521 across a prebuilt,
+/// multi-level project-reference graph.
+/// </summary>
+public sealed class Issue2521ImportedInitializerTargetContractPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_ImportedInitializerSinks_CompileDeterministically()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        Fixture fixture = WriteFixture(sourceRoot);
+
+        // Prebuild the middle project so both it and the leaf target assembly
+        // exist on disk before MSBuildWorkspace loads the consumer.
+        RunDotnetBuild(fixture.BridgeProject);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        RunResult first = await RunPipeline(outputRoot, sourceRoot, compiler, fixture);
+        string firstConsumer = AssertSuccessfulAndRead(
+            first,
+            outputRoot,
+            "test/Consumer",
+            "Consumer.cs");
+        string firstEnabled = AssertSuccessfulAndRead(
+            first,
+            outputRoot,
+            "test/EnabledConsumer",
+            "EnabledConsumer.cs");
+        AssertExpectedSinks(firstConsumer, firstEnabled);
+
+        RunResult second = await RunPipeline(outputRoot, sourceRoot, compiler, fixture);
+        string secondConsumer = AssertSuccessfulAndRead(
+            second,
+            outputRoot,
+            "test/Consumer",
+            "Consumer.cs");
+        string secondEnabled = AssertSuccessfulAndRead(
+            second,
+            outputRoot,
+            "test/EnabledConsumer",
+            "EnabledConsumer.cs");
+
+        Assert.Equal(Compact(firstConsumer), Compact(secondConsumer));
+        Assert.Equal(Compact(firstEnabled), Compact(secondEnabled));
+        AssertExpectedSinks(secondConsumer, secondEnabled);
+    }
+
+    private static async Task<RunResult> RunPipeline(
+        string outputRoot,
+        string sourceRoot,
+        string compiler,
+        Fixture fixture)
+    {
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        return await pipeline.RunAsync(
+            new[]
+            {
+                new CorpusApp("test/Target", fixture.TargetProject, TargetKind.Library),
+                new CorpusApp("test/Bridge", fixture.BridgeProject, TargetKind.Library),
+                new CorpusApp("test/Consumer", fixture.ConsumerProject, TargetKind.Library),
+                new CorpusApp("test/EnabledConsumer", fixture.EnabledConsumerProject, TargetKind.Library),
+            });
+    }
+
+    private static void AssertExpectedSinks(string consumer, string enabledConsumer)
+    {
+        string compact = Compact(consumer);
+        Assert.Contains(
+            "Target{Value: source.Value!!, InitValue: source.Value!!, Field: source.Value!!}",
+            compact);
+        Assert.Contains("Target(1){Value = source.Value!!}", compact);
+        Assert.Contains("Nested: Target{Value: source.Value!!}", compact);
+        Assert.Contains("T{Value: source.Value!!}", compact);
+        Assert.Contains("List[string]{ source.Value!! }", compact);
+        Assert.Contains("Holder{Values: { source.Value!! }}", compact);
+        Assert.Contains("Holder(1){Values = { source.Value!! }}", compact);
+        Assert.Contains("\"key\": source.Value!!", compact);
+        Assert.Contains("[\"key\"] = source.Value!!", compact);
+        Assert.Contains("Target{Value: value!!}", compact);
+
+        Assert.Contains("LocalTarget{Value: source.Value}", compact);
+        Assert.DoesNotContain("LocalTarget{Value: source.Value!!}", compact);
+        Assert.Contains("NullableTarget{Value: source.Value}", compact);
+        Assert.DoesNotContain("NullableTarget{Value: source.Value!!}", compact);
+
+        string enabledCompact = Compact(enabledConsumer);
+        Assert.Contains("Target{Value: source.Value!!}", enabledCompact);
+        Assert.Contains("NullableTarget{Value: source.Value}", enabledCompact);
+    }
+
+    private static Fixture WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+
+        string targetDir = Path.Combine(sourceRoot, "Target");
+        string bridgeDir = Path.Combine(sourceRoot, "Bridge");
+        string consumerDir = Path.Combine(sourceRoot, "Consumer");
+        string enabledDir = Path.Combine(sourceRoot, "EnabledConsumer");
+        Directory.CreateDirectory(targetDir);
+        Directory.CreateDirectory(bridgeDir);
+        Directory.CreateDirectory(consumerDir);
+        Directory.CreateDirectory(enabledDir);
+
+        string targetProject = Path.Combine(targetDir, "Target.csproj");
+        File.WriteAllText(targetProject, ProjectFile(nullable: "disable"));
+        File.WriteAllText(Path.Combine(targetDir, "Target.cs"), """
+            #nullable disable
+            namespace Imported;
+
+            public interface ITarget
+            {
+                string Value { get; set; }
+            }
+
+            public sealed class Target : ITarget
+            {
+                public Target() { }
+
+                public Target(int id) { }
+
+                public string Value { get; set; }
+
+                public string InitValue { get; init; }
+
+                public string Field;
+            }
+
+            public sealed class Holder
+            {
+                public Holder() { }
+
+                public Holder(int id) { }
+
+                public System.Collections.Generic.List<string> Values { get; } = new();
+            }
+
+            #nullable enable
+            public sealed class NullableTarget
+            {
+                public string? Value { get; set; }
+            }
+            """);
+
+        string bridgeProject = Path.Combine(bridgeDir, "Bridge.csproj");
+        File.WriteAllText(
+            bridgeProject,
+            ProjectFile(nullable: "disable", "../Target/Target.csproj"));
+        File.WriteAllText(Path.Combine(bridgeDir, "Bridge.cs"), """
+            using Imported;
+
+            namespace Bridge;
+
+            public sealed class TargetFactory
+            {
+                public Target Create() => new Target();
+            }
+            """);
+
+        string consumerProject = Path.Combine(consumerDir, "Consumer.csproj");
+        File.WriteAllText(
+            consumerProject,
+            ProjectFile(
+                nullable: "disable",
+                "../Bridge/Bridge.csproj",
+                "../Target/Target.csproj"));
+        File.WriteAllText(Path.Combine(consumerDir, "Consumer.cs"), """
+            #nullable disable
+            using System.Collections.Generic;
+            using Imported;
+
+            namespace Consumer;
+
+            public interface ISource
+            {
+                string Value { get; set; }
+            }
+
+            public sealed class Wrapper
+            {
+                public Target Nested { get; set; }
+            }
+
+            public sealed class LocalTarget
+            {
+                public string Value { get; set; }
+
+                public bool HasValue => Value is not null;
+            }
+
+            public static class Repro
+            {
+                public static bool SourceMayBeNull(ISource source) => source.Value is null;
+
+                public static Target Property(ISource source) =>
+                    new Target
+                    {
+                        Value = source.Value,
+                        InitValue = source.Value,
+                        Field = source.Value,
+                    };
+
+                public static Target ConstructorSuffix(ISource source) =>
+                    new Target(1) { Value = source.Value };
+
+                public static Wrapper Nested(ISource source) =>
+                    new Wrapper { Nested = new Target { Value = source.Value } };
+
+                public static T GenericConstraint<T>(ISource source)
+                    where T : class, ITarget, new() =>
+                    new T { Value = source.Value };
+
+                public static List<string> BareAdd(ISource source) =>
+                    new List<string> { source.Value };
+
+                public static Holder NestedCollection(ISource source) =>
+                    new Holder { Values = { source.Value } };
+
+                public static Holder SuffixNestedCollection(ISource source) =>
+                    new Holder(1) { Values = { source.Value } };
+
+                public static Dictionary<string, string> KeyedAdd(ISource source) =>
+                    new Dictionary<string, string> { { "key", source.Value } };
+
+                public static Dictionary<string, string> Indexed(ISource source) =>
+                    new Dictionary<string, string> { ["key"] = source.Value };
+
+                public static Target Parameter(string value)
+                {
+                    if (value is null)
+                        value = "fallback";
+
+                    return new Target { Value = value };
+                }
+
+                public static Target Local(ISource source)
+                {
+                    string value = source.Value;
+                    if (value is null)
+                        value = "fallback";
+
+                    return new Target { Value = value };
+                }
+
+                public static LocalTarget SameCompilationTarget(ISource source) =>
+                    new LocalTarget { Value = source.Value };
+
+                public static NullableTarget ReferencedNullableTarget(ISource source) =>
+                    new NullableTarget { Value = source.Value };
+            }
+            """);
+
+        string enabledConsumerProject = Path.Combine(enabledDir, "EnabledConsumer.csproj");
+        File.WriteAllText(
+            enabledConsumerProject,
+            ProjectFile(
+                nullable: "enable",
+                "../Bridge/Bridge.csproj",
+                "../Target/Target.csproj"));
+        File.WriteAllText(Path.Combine(enabledDir, "EnabledConsumer.cs"), """
+            using Imported;
+
+            namespace EnabledConsumer;
+
+            public interface ISource
+            {
+                string? Value { get; }
+            }
+
+            public static class Repro
+            {
+                public static Target Create(ISource source) =>
+                    new Target { Value = source.Value! };
+
+                public static NullableTarget CreateNullable(ISource source) =>
+                    new NullableTarget { Value = source.Value };
+            }
+            """);
+
+        return new Fixture(
+            targetProject,
+            bridgeProject,
+            consumerProject,
+            enabledConsumerProject);
+    }
+
+    private static string ProjectFile(string nullable, params string[] projectReferences)
+    {
+        string itemGroup = projectReferences.Length == 0
+            ? string.Empty
+            : $"""
+                <ItemGroup>
+                {string.Join(
+                    Environment.NewLine,
+                    projectReferences.Select(reference => $"  <ProjectReference Include=\"{reference}\" />"))}
+                </ItemGroup>
+              """;
+        return $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>{nullable}</Nullable>
+              </PropertyGroup>
+              {itemGroup}
+            </Project>
+            """;
+    }
+
+    private static string AssertSuccessfulAndRead(
+        RunResult result,
+        string outputRoot,
+        string appId,
+        string fileName)
+    {
+        AppResult app = result.Apps.Single(candidate => candidate.AppId == appId);
+        Assert.True(
+            app.Succeeded,
+            $"Expected default --via-sdk/gsc compilation to succeed for {appId}. Stages: " +
+                string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+
+        string appDirectory = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(appId));
+        string[] matches = Directory.GetFiles(
+            appDirectory,
+            fileName.Replace(".cs", ".gs", StringComparison.Ordinal),
+            SearchOption.AllDirectories);
+        Assert.Single(matches);
+        return File.ReadAllText(matches[0]);
+    }
+
+    private static void RunDotnetBuild(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo(
+            "dotnet",
+            $"build \"{projectPath}\" --nologo --verbosity:quiet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+
+        using Process process = Process.Start(startInfo);
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(
+            process.ExitCode == 0,
+            "Failed to prebuild multi-level fixture:\n" + stdout + stderr);
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2521",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private static string Compact(string printed) =>
+        string.Join(
+            " ",
+            printed.Split(
+                new[] { ' ', '\t', '\r', '\n' },
+                StringSplitOptions.RemoveEmptyEntries));
+
+    private sealed record Fixture(
+        string TargetProject,
+        string BridgeProject,
+        string ConsumerProject,
+        string EnabledConsumerProject);
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2521ImportedInitializerTargetContractTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2521ImportedInitializerTargetContractTranslationTests.cs
@@ -1,0 +1,441 @@
+// <copyright file="Issue2521ImportedInitializerTargetContractTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression coverage for issue #2521: consumer-side taint may describe a
+/// referenced target symbol as promoted even though its independently emitted
+/// G# contract remains non-null. Initializer sinks must use that effective
+/// emitted contract while preserving real same-compilation promotion.
+/// </summary>
+public sealed class Issue2521ImportedInitializerTargetContractTranslationTests
+{
+    private const string TargetSource = """
+        #nullable disable
+        using System.Collections;
+        using System.Collections.Generic;
+
+        namespace Imported;
+
+        public interface ITarget
+        {
+            string Value { get; set; }
+        }
+
+        public class TargetBase
+        {
+            public string BaseValue;
+        }
+
+        public sealed class Target : TargetBase, ITarget
+        {
+            public Target() { }
+
+            public Target(int id) { }
+
+            public string Value { get; set; }
+
+            public string InitValue { get; init; }
+        }
+
+        public sealed class GenericTarget<T>
+            where T : class
+        {
+            public T Value { get; set; }
+        }
+
+        public sealed class ImportedBag : IEnumerable<string>
+        {
+            private readonly List<string> values = new();
+
+            public void Add(string value) => values.Add(value);
+
+            public IEnumerator<string> GetEnumerator() => values.GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        public sealed class ImportedHolder
+        {
+            public ImportedHolder() { }
+
+            public ImportedHolder(int id) { }
+
+            public List<string> Values { get; } = new();
+        }
+
+        public sealed class ImportedMap : IEnumerable<KeyValuePair<string, string>>
+        {
+            private readonly Dictionary<string, string> values = new();
+
+            public string this[string key]
+            {
+                get => values[key];
+                set => values[key] = value;
+            }
+
+            public void Add(string key, string value) => values.Add(key, value);
+
+            public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => values.GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        #nullable enable
+        public sealed class NullableTarget
+        {
+            public string? Value { get; set; }
+        }
+        """;
+
+    private const string ConsumerSource = """
+        #nullable disable
+        using Imported;
+
+        namespace Consumer;
+
+        public interface ISource
+        {
+            string Value { get; set; }
+        }
+
+        public sealed class Wrapper
+        {
+            public Target Nested { get; set; }
+        }
+
+        public sealed class LocalTarget
+        {
+            public string Value { get; set; }
+
+            public bool HasValue => Value is not null;
+        }
+
+        public sealed class LocalGenericTarget<T>
+            where T : class
+        {
+            public T Value { get; set; }
+
+            public bool HasValue => Value is not null;
+        }
+
+        public sealed class LocalBag : System.Collections.Generic.IEnumerable<string>
+        {
+            public void Add(string value)
+            {
+                if (value is null)
+                    return;
+            }
+
+            public System.Collections.Generic.IEnumerator<string> GetEnumerator() =>
+                System.Linq.Enumerable.Empty<string>().GetEnumerator();
+
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        public sealed class LocalMap : System.Collections.Generic.IEnumerable<
+            System.Collections.Generic.KeyValuePair<string, string>>
+        {
+            public string this[string key]
+            {
+                get => "";
+                set { }
+            }
+
+            public bool IsMissing(string key) => this[key] is null;
+
+            public System.Collections.Generic.IEnumerator<
+                System.Collections.Generic.KeyValuePair<string, string>> GetEnumerator() =>
+                System.Linq.Enumerable.Empty<
+                    System.Collections.Generic.KeyValuePair<string, string>>().GetEnumerator();
+
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        public static class Repro
+        {
+            public static string StaticValue { get; set; }
+
+            public static bool SourceMayBeNull(ISource source) => source.Value is null;
+
+            public static bool StaticMayBeNull() => StaticValue is null;
+
+            public static Target Property(ISource source) =>
+                new Target
+                {
+                    Value = source.Value,
+                    InitValue = source.Value,
+                    BaseValue = source.Value,
+                };
+
+            public static Target StaticProperty() =>
+                new Target { Value = StaticValue };
+
+            public static Target ConstructorSuffix(ISource source) =>
+                new Target(1) { Value = source.Value };
+
+            public static Wrapper Nested(ISource source) =>
+                new Wrapper { Nested = new Target { Value = source.Value } };
+
+            public static T GenericConstraint<T>(ISource source)
+                where T : class, ITarget, new() =>
+                new T { Value = source.Value };
+
+            public static GenericTarget<string> GenericMember(ISource source) =>
+                new GenericTarget<string> { Value = source.Value };
+
+            public static ImportedBag BareAdd(ISource source) =>
+                new ImportedBag { source.Value };
+
+            public static ImportedHolder NestedCollection(ISource source) =>
+                new ImportedHolder { Values = { source.Value } };
+
+            public static ImportedHolder SuffixNestedCollection(ISource source) =>
+                new ImportedHolder(1) { Values = { source.Value } };
+
+            public static ImportedMap KeyedAdd(ISource source) =>
+                new ImportedMap { { "key", source.Value } };
+
+            public static ImportedMap Indexed(ISource source) =>
+                new ImportedMap { ["key"] = source.Value };
+
+            public static Target Parameter(string value)
+            {
+                if (value is null)
+                    value = "fallback";
+
+                return new Target { Value = value };
+            }
+
+            public static Target Local(ISource source)
+            {
+                string value = source.Value;
+                if (value is null)
+                    value = "fallback";
+
+                return new Target { Value = value };
+            }
+
+            public static LocalTarget SameCompilationTarget(ISource source) =>
+                new LocalTarget { Value = source.Value };
+
+            public static LocalGenericTarget<string> SameCompilationGenericTarget(ISource source) =>
+                new LocalGenericTarget<string> { Value = source.Value };
+
+            public static LocalBag SameCompilationAdd(ISource source) =>
+                new LocalBag { source.Value };
+
+            public static LocalMap SameCompilationIndexer(ISource source) =>
+                new LocalMap { ["key"] = source.Value };
+
+            public static NullableTarget ReferencedNullableTarget(ISource source) =>
+                new NullableTarget { Value = source.Value };
+        }
+        """;
+
+    [Fact]
+    public void ImportedTargets_UseAlreadyEmittedContracts_ForAllInitializerSinks()
+    {
+        LoadedCSharpProject target = LoadProject(TargetSource, "Issue2521.Target");
+        LoadedCSharpProject consumer = LoadProject(
+            ConsumerSource,
+            "Issue2521.Consumer",
+            target.Compilation.ToMetadataReference());
+
+        string printed = Translate(
+            consumer,
+            new[] { consumer.Compilation, target.Compilation });
+        string compact = Compact(printed);
+
+        Assert.Contains(
+            "Target{Value: source.Value!!, InitValue: source.Value!!, BaseValue: source.Value!!}",
+            compact);
+        Assert.Contains("StaticValue!!", compact);
+        Assert.Contains("Target(1){Value = source.Value!!}", compact);
+        Assert.Contains("Nested: Target{Value: source.Value!!}", compact);
+        Assert.Contains("T{Value: source.Value!!}", compact);
+        Assert.Contains("GenericTarget[string]{Value: source.Value!!}", compact);
+        Assert.Contains("ImportedBag(){ source.Value!! }", compact);
+        Assert.Contains("ImportedHolder{Values: { source.Value!! }}", compact);
+        Assert.Contains("ImportedHolder(1){Values = { source.Value!! }}", compact);
+        Assert.Contains("\"key\": source.Value!!", compact);
+        Assert.Contains("[\"key\"] = source.Value!!", compact);
+        Assert.Contains("Target{Value: value!!}", compact);
+
+        Assert.Contains("LocalTarget{Value: source.Value}", compact);
+        Assert.DoesNotContain("LocalTarget{Value: source.Value!!}", compact);
+        Assert.Contains("LocalGenericTarget[string]{Value: source.Value}", compact);
+        Assert.DoesNotContain("LocalGenericTarget[string]{Value: source.Value!!}", compact);
+        Assert.Contains("LocalBag(){ source.Value }", compact);
+        Assert.DoesNotContain("LocalBag(){ source.Value!! }", compact);
+        Assert.Contains("LocalMap(){ [\"key\"] = source.Value }", compact);
+        Assert.DoesNotContain("LocalMap(){ [\"key\"] = source.Value!! }", compact);
+        Assert.Contains("NullableTarget{Value: source.Value}", compact);
+        Assert.DoesNotContain("NullableTarget{Value: source.Value!!}", compact);
+    }
+
+    [Fact]
+    public void PrebuiltMetadataTarget_ConsumerTaintStillCannotPromoteItsContract()
+    {
+        MetadataReference targetReference = CompileReference(TargetSource, "Issue2521.PrebuiltTarget");
+        LoadedCSharpProject consumer = LoadProject(
+            ConsumerSource,
+            "Issue2521.PrebuiltConsumer",
+            targetReference);
+
+        string compact = Compact(Translate(consumer, new[] { consumer.Compilation }));
+
+        Assert.Contains(
+            "Target{Value: source.Value!!, InitValue: source.Value!!, BaseValue: source.Value!!}",
+            compact);
+        Assert.Contains("T{Value: source.Value!!}", compact);
+        Assert.Contains("ImportedBag(){ source.Value!! }", compact);
+        Assert.Contains("[\"key\"] = source.Value!!", compact);
+    }
+
+    [Fact]
+    public async Task ReferencedTargetTranslation_IsDeterministicAcrossParallelConsumers()
+    {
+        LoadedCSharpProject target = LoadProject(TargetSource, "Issue2521.ParallelTarget");
+        LoadedCSharpProject consumer = LoadProject(
+            ConsumerSource,
+            "Issue2521.ParallelConsumer",
+            target.Compilation.ToMetadataReference());
+        var siblings = new[] { consumer.Compilation, target.Compilation };
+
+        string sequential = Translate(consumer, siblings);
+        string[] parallel = await Task.WhenAll(
+            Enumerable.Range(0, 8)
+                .Select(_ => Task.Run(() => Translate(consumer, siblings))));
+
+        Assert.All(parallel, result => Assert.Equal(sequential, result));
+        Assert.Contains("Target{Value: source.Value!!", Compact(sequential));
+    }
+
+    [Fact]
+    public void NullableEnabledConsumer_PreservesAnnotationDrivenSemantics()
+    {
+        const string EnabledConsumer = """
+            #nullable enable
+            using Imported;
+
+            namespace EnabledConsumer;
+
+            public interface ISource
+            {
+                string? Value { get; }
+            }
+
+            public static class Repro
+            {
+                public static Target Create(ISource source) =>
+                    new Target { Value = source.Value! };
+
+                public static NullableTarget CreateNullable(ISource source) =>
+                    new NullableTarget { Value = source.Value };
+            }
+            """;
+
+        LoadedCSharpProject target = LoadProject(TargetSource, "Issue2521.EnabledTarget");
+        LoadedCSharpProject consumer = LoadProject(
+            EnabledConsumer,
+            "Issue2521.EnabledConsumer",
+            target.Compilation.ToMetadataReference(),
+            NullableContextOptions.Enable);
+
+        string compact = Compact(Translate(
+            consumer,
+            new[] { consumer.Compilation, target.Compilation }));
+
+        Assert.Contains("Target{Value: source.Value!!}", compact);
+        Assert.Contains("NullableTarget{Value: source.Value}", compact);
+    }
+
+    private static LoadedCSharpProject LoadProject(
+        string source,
+        string assemblyName,
+        MetadataReference extraReference = null,
+        NullableContextOptions nullableContext = NullableContextOptions.Disable)
+    {
+        IReadOnlyList<MetadataReference> references = extraReference is null
+            ? CSharpProjectLoader.RuntimeReferences()
+            : CSharpProjectLoader.RuntimeReferences().Append(extraReference).ToList();
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest),
+            path: assemblyName + ".cs");
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { tree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(nullableContext)
+                .WithAllowUnsafe(true));
+        Diagnostic[] errors = compilation.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+        Assert.Empty(errors);
+        var document = new LoadedDocument(
+            tree.FilePath,
+            tree,
+            compilation.GetSemanticModel(tree));
+        return new LoadedCSharpProject(
+            compilation,
+            new[] { document },
+            Array.Empty<Diagnostic>());
+    }
+
+    private static MetadataReference CompileReference(string source, string assemblyName)
+    {
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest));
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable));
+        using var stream = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        stream.Position = 0;
+        return MetadataReference.CreateFromStream(stream);
+    }
+
+    private static string Translate(
+        LoadedCSharpProject project,
+        IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath,
+            siblingCompilations);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+
+    private static string Compact(string printed) =>
+        string.Join(
+            " ",
+            printed.Split(
+                new[] { ' ', '\t', '\r', '\n' },
+                StringSplitOptions.RemoveEmptyEntries));
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -836,21 +836,7 @@ public sealed partial class CSharpToGSharpTranslator
 
         private bool ParameterWillRemainNonNullableReference(IParameterSymbol parameter)
         {
-            if (parameter.Type is not { IsReferenceType: true } parameterType
-                || parameterType.NullableAnnotation == NullableAnnotation.Annotated)
-            {
-                return false;
-            }
-
-            bool parameterDeclaredInThisCompilation = parameter.DeclaringSyntaxReferences
-                .Any(reference => this.context.Compilation.ContainsSyntaxTree(reference.SyntaxTree));
-
-            // Only a parameter declaration translated by this compilation can
-            // have its rendered signature widened. Project-reference and CLR
-            // metadata parameters keep the contract gsc binds at this call site,
-            // even when sibling analysis records nullable flow for their source.
-            return !(parameterDeclaredInThisCompilation
-                && this.ShouldPromoteToNullableReference(parameter));
+            return this.TargetWillRemainNonNullableReference(parameter.Type, parameter);
         }
 
         /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1460,14 +1460,12 @@ public sealed partial class CSharpToGSharpTranslator
         //    an external oblivious type).
         // Both are forgiven identically here: the TARGET position (member/
         // Add-parameter/indexer-value) is what decides whether forgiveness is
-        // needed — gated to a target whose OWN type is a non-annotated,
-        // non-promoted reference type (i.e. one that genuinely expects
-        // non-null), so an ALREADY-nullable/promoted target (which accepts a
-        // `T?` value unchanged) and a nullable-enabled compilation (real
-        // annotations) are both left byte-identical. This is deliberately blind
-        // to whether the TARGET is an imported/metadata type or a source type —
-        // only the target's resolved type/promotion state matters, exactly like
-        // every other forgiveness sink in this file.
+        // needed. Issue #2521 requires that decision to use the EFFECTIVE
+        // emitted contract: a same-compilation declaration may genuinely widen
+        // to `T?`, but consumer-side taint cannot retroactively widen a project-
+        // reference or CLR-metadata member that was already emitted as `T`.
+        // An already-nullable target and a nullable-enabled compilation remain
+        // byte-identical.
         //
         // Deliberately NOT narrowed to exclude PREBUILT SIBLING projects (an
         // earlier version of this bridge tried exactly that, gating
@@ -1499,14 +1497,9 @@ public sealed partial class CSharpToGSharpTranslator
         {
             if (!this.IsObliviousCompilation()
                 || translatedValue is NonNullAssertionExpression
-                || targetType is not { IsReferenceType: true }
-                || targetType.NullableAnnotation == NullableAnnotation.Annotated)
-            {
-                return translatedValue;
-            }
-
-            if (targetSymbolForPromotionCheck != null
-                && this.ShouldPromoteToNullableReference(targetSymbolForPromotionCheck))
+                || !this.TargetWillRemainNonNullableReference(
+                    targetType,
+                    targetSymbolForPromotionCheck))
             {
                 return translatedValue;
             }
@@ -1795,10 +1788,11 @@ public sealed partial class CSharpToGSharpTranslator
                     // initializer symbol API — a plain `GetSymbolInfo` on the
                     // element has nothing to bind to, it is not itself a call
                     // syntax) so each argument's target parameter type decides
-                    // whether that argument needs forgiveness. `Add` parameters
-                    // are never tracked by the taint fixpoint (they're not a
-                    // symbol with its own declaration to promote), so no
-                    // promotion-check symbol is passed.
+                    // whether that argument needs forgiveness. Issue #2521 also
+                    // passes the parameter symbol so a same-compilation
+                    // promotion is honored while an imported parameter's
+                    // already-emitted contract cannot be widened by consumer
+                    // taint.
                     IMethodSymbol addMethod =
                         this.context.SemanticModel.GetCollectionInitializerSymbolInfo(complex).Symbol as IMethodSymbol;
                     GExpression keyValue = this.TranslateExpression(complex.Expressions[0]);
@@ -1806,9 +1800,9 @@ public sealed partial class CSharpToGSharpTranslator
                     if (addMethod is { Parameters.Length: 2 })
                     {
                         keyValue = this.ForgiveInitializerElementValue(
-                            complex.Expressions[0], keyValue, addMethod.Parameters[0].Type, targetSymbolForPromotionCheck: null);
+                            complex.Expressions[0], keyValue, addMethod.Parameters[0].Type, addMethod.Parameters[0]);
                         pairValue = this.ForgiveInitializerElementValue(
-                            complex.Expressions[1], pairValue, addMethod.Parameters[1].Type, targetSymbolForPromotionCheck: null);
+                            complex.Expressions[1], pairValue, addMethod.Parameters[1].Type, addMethod.Parameters[1]);
                     }
 
                     elements.Add(new CollectionInitializerElement(keyValue, pairValue, indexed: false));
@@ -1824,7 +1818,7 @@ public sealed partial class CSharpToGSharpTranslator
                     if (addMethod is { Parameters.Length: 1 })
                     {
                         bareValue = this.ForgiveInitializerElementValue(
-                            element, bareValue, addMethod.Parameters[0].Type, targetSymbolForPromotionCheck: null);
+                            element, bareValue, addMethod.Parameters[0].Type, addMethod.Parameters[0]);
                     }
 
                     elements.Add(new CollectionInitializerElement(bareValue));

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -627,6 +627,26 @@ public sealed partial class CSharpToGSharpTranslator
                 : this.IsUsedAsNullable(symbol, this.GetNullabilityScope(symbol));
         }
 
+        // Issue #2521: sink lowering must use the target contract that G# will
+        // actually bind, not consumer-side taint recorded for an imported
+        // symbol. Only declarations emitted by this compilation can have their
+        // contract widened by this compilation's promotion result. Project
+        // references and CLR metadata retain their already-emitted contract.
+        private bool TargetWillRemainNonNullableReference(ITypeSymbol targetType, ISymbol targetSymbol)
+        {
+            if (targetType is not { IsReferenceType: true }
+                || targetType.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                return false;
+            }
+
+            bool targetDeclaredInThisCompilation = targetSymbol?.DeclaringSyntaxReferences
+                .Any(reference => this.context.Compilation.ContainsSyntaxTree(reference.SyntaxTree)) == true;
+
+            return !(targetDeclaredInThisCompilation
+                && this.ShouldPromoteToNullableReference(targetSymbol));
+        }
+
         // The syntax region a symbol's null usage is searched in: the whole
         // enclosing method for a parameter, the whole declaring type for a field,
         // and the enclosing method body block for a local.


### PR DESCRIPTION
Fixes #2521

## Summary
- decide initializer forgiveness from the target contract actually emitted by the current compilation
- preserve same-compilation target promotion while ignoring consumer-only taint on imported members and Add parameters
- cover object, nested, constructor-suffix, collection, indexer, generic-constraint, metadata, multi-project, nullable, and parallel cases

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet build GSharp.sln --nologo --verbosity:minimal`
- `MSBUILDDISABLENODEREUSE=1 dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-restore --filter 'FullyQualifiedName~Issue2202|FullyQualifiedName~Issue2412|FullyQualifiedName~Issue2425|FullyQualifiedName~Issue2427|FullyQualifiedName~Issue2429|FullyQualifiedName~Issue2511|FullyQualifiedName~Issue2514|FullyQualifiedName~Issue2521' --nologo --verbosity:minimal` (109 passed)