### PR TITLE
Fix nullable imported generic base conversions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -402,6 +402,29 @@ public sealed class Conversion
             return Conversion.Identity;
         }
 
+        // Issue #2523: a constructed imported reference type may carry
+        // symbolic arguments that its erased CLR shape cannot represent. For
+        // example, imported generic inference can surface
+        // IIncludableQueryable<TEntity, TProperty?> symbolically while its
+        // reflection probe shape is IIncludableQueryable<object, object>.
+        // Testing that erased shape against IQueryable<TEntity> loses the
+        // declared base-interface substitution and rejects a valid upcast.
+        //
+        // Project the source's open interface/base hierarchy through its
+        // symbolic arguments, then classify the resulting constructed target
+        // with ordinary CLR variance rules. This is framework-independent and
+        // applies equally to imported interfaces/classes, inferred or explicit
+        // method arguments, nested generic arguments, and cross-context CLR
+        // identities.
+        if (from is ImportedTypeSymbol fromConstructedReference
+            && to is ImportedTypeSymbol toConstructedReference
+            && TryClassifyConstructedImportedReferenceConversion(
+                fromConstructedReference,
+                toConstructedReference))
+        {
+            return Conversion.Implicit;
+        }
+
         // Phase 3.C.1 / ADR-0001: T → T? is an implicit widening; T? → T?
         // when underlyings match is identity. T? → T requires the bang
         // operator (Phase 3.C.3) and is not implicit here.
@@ -1712,6 +1735,81 @@ public sealed class Conversion
         for (var i = 0; i < from.TypeArguments.Length; i++)
         {
             if (!AreTypeArgumentsEquivalent(from.TypeArguments[i], to.TypeArguments[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #2523: classifies a reference conversion between constructed
+    /// imported generic types from their symbolic open-definition hierarchy
+    /// instead of their possibly-erased CLR probe types.
+    /// </summary>
+    private static bool TryClassifyConstructedImportedReferenceConversion(
+        ImportedTypeSymbol from,
+        ImportedTypeSymbol to)
+    {
+        if (from?.OpenDefinition == null
+            || from.TypeArguments.IsDefaultOrEmpty
+            || from.OpenDefinition.IsValueType
+            || !TryGetConstructedGenericShape(to, out var targetOpen, out var targetArguments)
+            || targetOpen == null
+            || targetOpen.IsValueType)
+        {
+            return false;
+        }
+
+        ImmutableArray<TypeSymbol> sourceArguments;
+        if (ClrTypeUtilities.AreSame(from.OpenDefinition, targetOpen))
+        {
+            sourceArguments = from.TypeArguments;
+        }
+        else if (!MemberLookup.TryMapConstructedTypeArgumentsThroughHierarchy(
+                     from,
+                     targetOpen,
+                     out sourceArguments))
+        {
+            return false;
+        }
+
+        if (sourceArguments.Length != targetArguments.Length)
+        {
+            return false;
+        }
+
+        var genericParameters = targetOpen.GetGenericArguments();
+        if (genericParameters.Length != sourceArguments.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < sourceArguments.Length; i++)
+        {
+            var sourceArgument = sourceArguments[i];
+            var targetArgument = targetArguments[i];
+            if (AreTypeArgumentsEquivalent(sourceArgument, targetArgument))
+            {
+                continue;
+            }
+
+            var variance = genericParameters[i].GenericParameterAttributes
+                & System.Reflection.GenericParameterAttributes.VarianceMask;
+            var compatible = variance switch
+            {
+                System.Reflection.GenericParameterAttributes.Covariant =>
+                    Binder.IsReferenceTypeForConstraint(sourceArgument)
+                    && Binder.IsReferenceTypeForConstraint(targetArgument)
+                    && Classify(sourceArgument, targetArgument) is { Exists: true, IsImplicit: true },
+                System.Reflection.GenericParameterAttributes.Contravariant =>
+                    Binder.IsReferenceTypeForConstraint(sourceArgument)
+                    && Binder.IsReferenceTypeForConstraint(targetArgument)
+                    && Classify(targetArgument, sourceArgument) is { Exists: true, IsImplicit: true },
+                _ => false,
+            };
+            if (!compatible)
             {
                 return false;
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -1048,6 +1048,27 @@ internal sealed partial class ExpressionBinder
             }
         }
 
+        // Issue #2523: a symbolic imported generic return keeps an erased CLR
+        // probe shape for binding (for example,
+        // IChain<object, object>) even when every symbolic argument now has a
+        // concrete CLR type. Reify that shape before extension-method generic
+        // inference so the receiver contributes its real base/interface
+        // substitutions (IQuery<TEntity>) rather than conflicting `object`
+        // evidence. Reification already preserves real Nullable<T> value
+        // arguments and erases only reference nullability, matching CLR type
+        // identity; it safely falls back to the cached probe shape for
+        // same-compilation/open arguments that cannot yet be closed.
+        if (receiver.Type is ImportedTypeSymbol symbolicImportedReceiver
+            && symbolicImportedReceiver.OpenDefinition != null
+            && !symbolicImportedReceiver.TypeArguments.IsDefaultOrEmpty)
+        {
+            var reifiedReceiver = symbolicImportedReceiver.ReifyClosedClrType();
+            if (reifiedReceiver != null && !reifiedReceiver.ContainsGenericParameters)
+            {
+                receiverClrType = reifiedReceiver;
+            }
+        }
+
         // Issue #1423: a user class that implements a generic collection
         // interface (e.g. `class EntryList : IReadOnlyCollection[Entry]`, which
         // extends `IEnumerable[Entry]`) erases to `System.Object` via
@@ -1133,6 +1154,44 @@ internal sealed partial class ExpressionBinder
         if (candidates.Count == 0)
         {
             return false;
+        }
+
+        // Issue #2523: when a symbolic imported receiver's own reconstructed
+        // CLR type is still unavailable, project it onto a candidate's declared
+        // generic receiver interface/base. This gives generic inference the
+        // subset of source arguments that the extension actually consumes
+        // (for example IIncludableQueryable<TEntity, TProperty?> ->
+        // IQueryable<TEntity>) without letting unrelated nullable or invariant
+        // source slots collapse that receiver to object.
+        if (receiver.Type is ImportedTypeSymbol symbolicReceiver)
+        {
+            foreach (var candidate in candidates)
+            {
+                var candidateParameters = candidate.GetParameters();
+                if (candidateParameters.Length == 0)
+                {
+                    continue;
+                }
+
+                var candidateReceiver = candidateParameters[0].ParameterType;
+                if (!candidateReceiver.IsGenericType)
+                {
+                    continue;
+                }
+
+                var candidateReceiverOpen = candidateReceiver.IsGenericTypeDefinition
+                    ? candidateReceiver
+                    : candidateReceiver.GetGenericTypeDefinition();
+                if (MemberLookup.TryProjectConstructedHierarchyClrType(
+                    symbolicReceiver,
+                    candidateReceiverOpen,
+                    out var projectedReceiver))
+                {
+                    receiverClrType = projectedReceiver;
+                    argTypes[0] = projectedReceiver;
+                    break;
+                }
+            }
         }
 
         // OverloadResolution.Resolve infers type arguments for open generic

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -3300,6 +3300,54 @@ internal sealed class MemberLookup
     internal static TypeSymbol MergeInferredTypeArgument(TypeSymbol existing, TypeSymbol incoming)
         => MergeRecoveredTypeArgument(existing, incoming);
 
+    internal static bool TryMapConstructedTypeArgumentsThroughHierarchy(
+        ImportedTypeSymbol source,
+        Type targetOpenDefinition,
+        out ImmutableArray<TypeSymbol> mappedArguments)
+        => TryMapThroughImplemented(source, targetOpenDefinition, out mappedArguments);
+
+    internal static bool TryProjectConstructedHierarchyClrType(
+        ImportedTypeSymbol source,
+        Type targetOpenDefinition,
+        out Type projectedType)
+    {
+        projectedType = null;
+        if (source == null
+            || targetOpenDefinition == null
+            || !targetOpenDefinition.IsGenericTypeDefinition
+            || !TryMapThroughImplemented(source, targetOpenDefinition, out var mappedArguments)
+            || mappedArguments.Any(TypeSymbol.RequiresSymbolicProjection))
+        {
+            return false;
+        }
+
+        var contextObject = ResolveErasedObjectInContext(targetOpenDefinition);
+        var erasedArguments = Enumerable.Repeat(
+            contextObject,
+            targetOpenDefinition.GetGenericArguments().Length).ToArray();
+        Type erased;
+        try
+        {
+            erased = targetOpenDefinition.MakeGenericType(erasedArguments);
+        }
+        catch
+        {
+            return false;
+        }
+
+        var projected = ImportedTypeSymbol.GetConstructed(
+            erased,
+            targetOpenDefinition,
+            mappedArguments).ReifyClosedClrType();
+        if (projected == null || projected.ContainsGenericParameters)
+        {
+            return false;
+        }
+
+        projectedType = projected;
+        return true;
+    }
+
     private static bool IsBetterSymbolicIndexerCandidate(
         ImmutableArray<TypeSymbol> candidate,
         ImmutableArray<TypeSymbol> other,
@@ -4141,16 +4189,26 @@ internal sealed class MemberLookup
                 return;
             }
 
-            // Pattern A: actual is an ImportedTypeSymbol whose OpenDefinition matches exactly.
+            // Pattern A: actual is an imported constructed generic whose open
+            // definition matches exactly. Issue #2523 extends this from
+            // explicitly-symbolic constructions to ordinary fully-closed CLR
+            // returns as well: a non-nullable Include result can legitimately
+            // surface as plain IIncludableQueryable<Book, List<Component>>,
+            // and a following ThenInclude must still recover TEntity=Book from
+            // that receiver before a nullable selector result forces the next
+            // return back into symbolic form.
             if (actual is ImportedTypeSymbol imp
-                && imp.OpenDefinition != null
-                && ClrTypeUtilities.AreSame(imp.OpenDefinition, openDef)
-                && !imp.TypeArguments.IsDefaultOrEmpty
-                && imp.TypeArguments.Length == openArgs.Length)
+                && TryGetConstructedImportedProjection(imp, out var projectedImp)
+                && ClrTypeUtilities.AreSame(projectedImp.OpenDefinition, openDef)
+                && projectedImp.TypeArguments.Length == openArgs.Length)
             {
                 for (int j = 0; j < openArgs.Length; j++)
                 {
-                    UnifyForMethodTypeArgs(openArgs[j], imp.TypeArguments[j], openMethod, result);
+                    UnifyForMethodTypeArgs(
+                        openArgs[j],
+                        projectedImp.TypeArguments[j],
+                        openMethod,
+                        result);
                 }
 
                 return;
@@ -4229,9 +4287,10 @@ internal sealed class MemberLookup
             // Pattern C: actual is an ImportedTypeSymbol whose OpenDefinition is
             // a derived/implementing shape (e.g. List<T> formal-matched against
             // IEnumerable<TSource>). Walk the actual's interfaces/base.
-            if (actual is ImportedTypeSymbol imp2 && imp2.OpenDefinition != null && !imp2.TypeArguments.IsDefaultOrEmpty)
+            if (actual is ImportedTypeSymbol imp2
+                && TryGetConstructedImportedProjection(imp2, out var projectedImp2))
             {
-                if (TryMapThroughImplemented(imp2, openDef, out var liftedArgs))
+                if (TryMapThroughImplemented(projectedImp2, openDef, out var liftedArgs))
                 {
                     for (int j = 0; j < openArgs.Length && j < liftedArgs.Length; j++)
                     {
@@ -4240,6 +4299,33 @@ internal sealed class MemberLookup
                 }
             }
         }
+    }
+
+    private static bool TryGetConstructedImportedProjection(
+        ImportedTypeSymbol imported,
+        out ImportedTypeSymbol projected)
+    {
+        projected = null;
+        if (imported?.OpenDefinition != null
+            && !imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            projected = imported;
+            return true;
+        }
+
+        var clr = imported?.ClrType;
+        if (clr == null || !clr.IsGenericType || clr.IsGenericTypeDefinition)
+        {
+            return false;
+        }
+
+        projected = ImportedTypeSymbol.GetConstructed(
+            clr,
+            clr.GetGenericTypeDefinition(),
+            clr.GetGenericArguments()
+                .Select(TypeSymbol.FromClrType)
+                .ToImmutableArray());
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -802,6 +802,27 @@ internal sealed partial class MethodBodyEmitter
             return true;
         }
 
+        // Issue #2523: constructed imported reference types can preserve their
+        // real generic arguments only symbolically while carrying an erased CLR
+        // probe shape. The binder classifies their declared imported
+        // interface/base conversion from that symbolic hierarchy; the emitted
+        // representation is still an ordinary CLR reference upcast and
+        // therefore requires no instruction. Reuse the binder classification
+        // instead of repeating nullable substitution, variance, and
+        // cross-context identity logic here.
+        if (a is ImportedTypeSymbol importedReference
+            && importedReference.OpenDefinition?.IsValueType == false
+            && !importedReference.TypeArguments.IsDefaultOrEmpty
+            && b is ImportedTypeSymbol
+            && Conversion.ClassifyNonStructural(a, b) is
+            {
+                Exists: true,
+                IsImplicit: true,
+            })
+        {
+            return true;
+        }
+
         // Issue #521: standard CLR reference upcast. A reference-typed
         // value of CLR type `a` widens to any base class or implemented
         // CLR interface `b` as a no-op at the IL level (the reference

--- a/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
@@ -174,6 +174,10 @@ public sealed class ImportedTypeSymbol : TypeSymbol
             return ClrType;
         }
 
+        var contextObject = OpenDefinition.GetGenericArguments()
+            .Select(static parameter => parameter.BaseType)
+            .FirstOrDefault(static baseType =>
+                string.Equals(baseType?.FullName, "System.Object", StringComparison.Ordinal));
         var args = new Type[TypeArguments.Length];
         for (var i = 0; i < args.Length; i++)
         {
@@ -193,7 +197,7 @@ public sealed class ImportedTypeSymbol : TypeSymbol
                 return ClrType;
             }
 
-            args[i] = argClr;
+            args[i] = RemapHostCoreTypeToContext(argClr, contextObject);
         }
 
         try
@@ -399,6 +403,56 @@ public sealed class ImportedTypeSymbol : TypeSymbol
         var baseName = StripGenericArity(type.Name);
         var args = type.GetGenericArguments().Select(BuildAggregateDisplayName);
         return $"{baseName}[{string.Join(", ", args)}]";
+    }
+
+    private static Type RemapHostCoreTypeToContext(Type type, Type contextObject)
+    {
+        if (type == null
+            || contextObject == null
+            || ReferenceEquals(contextObject.Assembly, typeof(object).Assembly))
+        {
+            return type;
+        }
+
+        if (type.IsByRef)
+        {
+            return RemapHostCoreTypeToContext(type.GetElementType(), contextObject).MakeByRefType();
+        }
+
+        if (type.IsPointer)
+        {
+            return RemapHostCoreTypeToContext(type.GetElementType(), contextObject).MakePointerType();
+        }
+
+        if (type.IsArray)
+        {
+            var element = RemapHostCoreTypeToContext(type.GetElementType(), contextObject);
+            return type.IsSZArray
+                ? element.MakeArrayType()
+                : element.MakeArrayType(type.GetArrayRank());
+        }
+
+        if (type.IsConstructedGenericType
+            && ReferenceEquals(type.GetGenericTypeDefinition().Assembly, typeof(object).Assembly))
+        {
+            var open = contextObject.Assembly.GetType(
+                type.GetGenericTypeDefinition().FullName,
+                throwOnError: false);
+            if (open != null)
+            {
+                return open.MakeGenericType(
+                    type.GetGenericArguments()
+                        .Select(argument => RemapHostCoreTypeToContext(argument, contextObject))
+                        .ToArray());
+            }
+        }
+
+        if (ReferenceEquals(type.Assembly, typeof(object).Assembly))
+        {
+            return contextObject.Assembly.GetType(type.FullName, throwOnError: false) ?? type;
+        }
+
+        return type;
     }
 
     private static string StripGenericArity(string name)

--- a/test/Compiler.Tests/Emit/Issue2523NullableImportedGenericBaseConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2523NullableImportedGenericBaseConversionEmitTests.cs
@@ -1,0 +1,280 @@
+// <copyright file="Issue2523NullableImportedGenericBaseConversionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Compiler;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Runtime, reflection, C# consumer, and ILVerify coverage for issue #2523.
+/// </summary>
+public sealed class Issue2523NullableImportedGenericBaseConversionEmitTests
+{
+    [Fact]
+    public void ImportedGenericReturnBaseConversionsRunAndPreserveMetadata()
+    {
+        var directory = NewDirectory();
+        try
+        {
+            var fixturePath = Path.Combine(directory, "Issue2523.Metadata.dll");
+            EmitFixture(fixturePath);
+
+            const string source = """
+                package Issue2523.Emit
+                import System
+                import Issue2523.Metadata
+
+                class Api2523 {
+                    shared {
+                        func Build(
+                            source IQuery2523[MetadataEntity2523])
+                            IQuery2523[MetadataEntity2523] ->
+                            QueryExtensions2523.Include2523(
+                                source,
+                                    (entity MetadataEntity2523) -> entity.Child)
+                                .Include2523(
+                                    (entity MetadataEntity2523) -> entity.Other)
+
+                        func BuildChain(
+                            source IQuery2523[MetadataEntity2523])
+                            IChain2523[
+                                MetadataEntity2523,
+                                MetadataChild2523?,
+                                string,
+                                string] ->
+                            QueryExtensions2523.Include2523(
+                                source,
+                                (entity MetadataEntity2523) -> entity.Child)
+                    }
+                }
+
+                func Main() {
+                    let source = Query2523[MetadataEntity2523](1)
+                    Console.WriteLine(Api2523.Build(source).Count)
+                    Console.WriteLine(Api2523.BuildChain(source).Count)
+                }
+                """;
+
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "Issue2523.Emit.dll");
+            File.WriteAllText(sourcePath, source);
+            var (exitCode, output) = Compile(sourcePath, outputPath, fixturePath);
+            Assert.True(exitCode == 0, output);
+
+            var references = TrustedPlatformAssemblies().Append(fixturePath).ToArray();
+            IlVerifier.Verify(outputPath, additionalReferences: references);
+            Assert.Equal("3\n2\n", Run(outputPath));
+
+            var fixture = Assembly.LoadFrom(fixturePath);
+            var emitted = Assembly.LoadFrom(outputPath);
+            var api = emitted.GetType("Issue2523.Emit.Api2523", throwOnError: true)!;
+            var buildChain = api.GetMethod(
+                "BuildChain",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
+            var nullability = new NullabilityInfoContext().Create(buildChain.ReturnParameter);
+            Assert.Equal(NullabilityState.Nullable, nullability.GenericTypeArguments[1].ReadState);
+
+            const string consumerSource = """
+                #nullable enable
+                using Issue2523.Emit;
+                using Issue2523.Metadata;
+
+                public static class Consumer2523
+                {
+                    public static IQuery2523<MetadataEntity2523> Build()
+                    {
+                        var source = new Query2523<MetadataEntity2523>(1);
+                        IChain2523<
+                            MetadataEntity2523,
+                            MetadataChild2523?,
+                            string,
+                            string> chain = Api2523.BuildChain(source);
+                        return chain;
+                    }
+                }
+                """;
+            var consumer = CSharpCompilation.Create(
+                "Issue2523.Consumer",
+                new[] { CSharpSyntaxTree.ParseText(consumerSource) },
+                TrustedPlatformAssemblies()
+                    .Select(path => MetadataReference.CreateFromFile(path))
+                    .Append(MetadataReference.CreateFromFile(fixturePath))
+                    .Append(MetadataReference.CreateFromFile(outputPath)),
+                new CSharpCompilationOptions(
+                    OutputKind.DynamicallyLinkedLibrary,
+                    nullableContextOptions: NullableContextOptions.Enable,
+                    generalDiagnosticOption: ReportDiagnostic.Error));
+            using var consumerPe = new MemoryStream();
+            var consumerResult = consumer.Emit(consumerPe);
+            Assert.True(
+                consumerResult.Success,
+                string.Join(Environment.NewLine, consumerResult.Diagnostics));
+
+            GC.KeepAlive(fixture);
+        }
+        finally
+        {
+            TryDelete(directory);
+        }
+    }
+
+    private static void EmitFixture(string outputPath)
+    {
+        const string fixtureSource = """
+            #nullable enable
+            using System;
+            using System.Linq.Expressions;
+
+            namespace Issue2523.Metadata;
+
+            public interface IQuery2523<out TEntity>
+            {
+                int Count { get; }
+            }
+
+            public interface IChain2523<out TEntity, out TProperty, in TInput, TInvariant>
+                : IQuery2523<TEntity>
+            {
+            }
+
+            public sealed class Query2523<TEntity> : IQuery2523<TEntity>
+            {
+                public Query2523(int count) => Count = count;
+                public int Count { get; }
+            }
+
+            public sealed class Chain2523<TEntity, TProperty, TInput, TInvariant>
+                : IChain2523<TEntity, TProperty, TInput, TInvariant>
+            {
+                public Chain2523(int count) => Count = count;
+                public int Count { get; }
+            }
+
+            public sealed class MetadataEntity2523
+            {
+                public MetadataChild2523? Child { get; set; }
+                public MetadataOther2523? Other { get; set; }
+            }
+
+            public sealed class MetadataChild2523 { }
+            public sealed class MetadataOther2523 { }
+
+            public static class QueryExtensions2523
+            {
+                public static IChain2523<TEntity, TProperty, string, string>
+                    Include2523<TEntity, TProperty>(
+                        this IQuery2523<TEntity> source,
+                        Expression<Func<TEntity, TProperty>> selector)
+                    => new Chain2523<TEntity, TProperty, string, string>(
+                        source.Count + 1);
+            }
+            """;
+
+        var compilation = CSharpCompilation.Create(
+            "Issue2523.Metadata",
+            new[] { CSharpSyntaxTree.ParseText(fixtureSource) },
+            TrustedPlatformAssemblies().Select(path => MetadataReference.CreateFromFile(path)),
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+        using var pe = File.Create(outputPath);
+        var result = compilation.Emit(pe);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static (int ExitCode, string Output) Compile(
+        string sourcePath,
+        string outputPath,
+        string fixturePath)
+    {
+        var args = new List<string>
+        {
+            "/out:" + outputPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            "/reference:" + fixturePath,
+        };
+        args.AddRange(TrustedPlatformAssemblies().Select(path => "/reference:" + path));
+        args.Add(sourcePath);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return (Program.Main(args.ToArray()), stdout.ToString() + stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string Run(string outputPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(outputPath)!,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(outputPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start issue #2523 executable.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "Issue #2523 executable timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"dotnet exec failed ({process.ExitCode}):\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n");
+    }
+
+    private static string NewDirectory()
+    {
+        var root = Path.Combine(Environment.CurrentDirectory, "TestArtifacts", "Issue2523");
+        var directory = Path.Combine(root, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var value = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        return string.IsNullOrWhiteSpace(value)
+            ? Array.Empty<string>()
+            : value.Split(Path.PathSeparator).Where(File.Exists);
+    }
+
+    private static void TryDelete(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2523NullableImportedGenericBaseConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2523NullableImportedGenericBaseConversionTests.cs
@@ -1,0 +1,335 @@
+// <copyright file="Issue2523NullableImportedGenericBaseConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding
+{
+    /// <summary>
+    /// Issue #2523: symbolic nullable arguments on an imported generic return
+    /// must not erase the return's declared generic base interfaces.
+    /// </summary>
+    public sealed class Issue2523NullableImportedGenericBaseConversionTests
+    {
+        [Fact]
+        public void InferredExplicitReducedAndChainedCallsKeepImportedBaseConversions()
+        {
+            AssertBinds(
+                """
+                import System.Collections.Generic
+                import GSharp.Core.Tests.CodeAnalysis.Binding.Issue2523Fixtures
+
+                class LocalChild2523 {
+                    prop Name string { get; init; }
+                }
+
+                class LocalOther2523 {
+                }
+
+                class LocalEntity2523 {
+                    prop Child LocalChild2523? { get; init; }
+                    prop Other LocalOther2523? { get; init; }
+                    prop MetadataChild MetadataChild2523? { get; init; }
+                }
+
+                func Consume2523(value IQuery2523[LocalEntity2523]) { }
+
+                func Return2523(source IQuery2523[LocalEntity2523]) IQuery2523[LocalEntity2523] {
+                    let first = source.Include2523(
+                        (entity LocalEntity2523) -> entity.Child)
+                    let assigned IQuery2523[LocalEntity2523] = first
+                    Consume2523(first)
+
+                    let consecutive = first.Include2523(
+                        (entity LocalEntity2523) -> entity.Other)
+                    let components = source.Include2523(
+                        (entity LocalEntity2523) ->
+                            List[LocalChild2523]())
+                    let thenIncluded = components.ThenInclude2523(
+                        (child LocalChild2523) -> child.Name)
+                    let resumed = thenIncluded.Include2523(
+                        (entity LocalEntity2523) -> entity.MetadataChild)
+
+                    let explicit = source.Include2523[
+                        LocalEntity2523, LocalChild2523?](
+                        (entity LocalEntity2523) -> entity.Child)
+                    let explicitBase IQuery2523[LocalEntity2523] = explicit
+
+                    let nested = source.Include2523(
+                        (entity LocalEntity2523) ->
+                            List[LocalChild2523?]())
+                    let nestedBase IQuery2523[LocalEntity2523] = nested
+
+                    let joined = source.IncludePair2523(
+                        (entity LocalEntity2523) -> LocalChild2523(),
+                        (entity LocalEntity2523) -> entity.Child)
+                    let joinedBase IQuery2523[LocalEntity2523] = joined
+
+                    let valueNullable = source.Include2523(
+                        (entity LocalEntity2523) -> default(int32?))
+                    let valueBase IQuery2523[LocalEntity2523] = valueNullable
+
+                    return resumed
+                }
+                """);
+        }
+
+        [Fact]
+        public void SourceAndMetadataEntityNavigationCombinationsKeepBaseConversions()
+        {
+            AssertBinds(
+                """
+                import GSharp.Core.Tests.CodeAnalysis.Binding.Issue2523Fixtures
+
+                class LocalEntity2523Mix {
+                }
+
+                class LocalNavigation2523Mix {
+                }
+
+                func Run2523Mix(
+                    local IQuery2523[LocalEntity2523Mix],
+                    metadata IQuery2523[MetadataEntity2523]) {
+                    let sourceSource = local.Include2523(
+                        (entity LocalEntity2523Mix) ->
+                            default(LocalNavigation2523Mix?))
+                    let sourceSourceBase IQuery2523[LocalEntity2523Mix] = sourceSource
+
+                    let sourceMetadata = local.Include2523(
+                        (entity LocalEntity2523Mix) ->
+                            default(MetadataChild2523?))
+                    let sourceMetadataBase IQuery2523[LocalEntity2523Mix] = sourceMetadata
+
+                    let metadataSource = metadata.Include2523(
+                        (entity MetadataEntity2523) ->
+                            default(LocalNavigation2523Mix?))
+                    let metadataSourceBase IQuery2523[MetadataEntity2523] = metadataSource
+
+                    let metadataMetadata = metadata.Include2523(
+                        (entity MetadataEntity2523) -> entity.Child)
+                    let metadataMetadataBase IQuery2523[MetadataEntity2523] = metadataMetadata
+                }
+                """);
+        }
+
+        [Fact]
+        public void EntityFrameworkIncludeThenIncludeAndIncludeChainBinds()
+        {
+            AssertBinds(
+                """
+                import System.Collections.Generic
+                import System.Linq
+                import Microsoft.EntityFrameworkCore
+
+                class EfChild2523 {
+                    prop Detail EfDetail2523? { get; init; }
+                }
+
+                class EfDetail2523 {
+                }
+
+                class EfOther2523 {
+                }
+
+                class EfEntity2523 {
+                    prop Child EfChild2523? { get; init; }
+                    prop Children List[EfChild2523] { get; init; }
+                    prop Other EfOther2523? { get; init; }
+                }
+
+                func BuildEf2523(source IQueryable[EfEntity2523]) IQueryable[EfEntity2523] ->
+                    source
+                        .Include((entity EfEntity2523) -> entity.Child)
+                        .Include((entity EfEntity2523) -> entity.Children)
+                        .ThenInclude((child EfChild2523) -> child.Detail)
+                        .Include((entity EfEntity2523) -> entity.Other)
+                """,
+                typeof(Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions).Assembly.Location);
+        }
+
+        [Fact]
+        public void SymbolicHierarchySubstitutionHandlesNestedAndUnrelatedVarianceSlots()
+        {
+            var chainOpen = typeof(Issue2523Fixtures.IChain2523<,,,>);
+            var queryOpen = typeof(Issue2523Fixtures.IQuery2523<>);
+            var nestedOpen = typeof(Issue2523Fixtures.INested2523<>);
+            var projectionOpen = typeof(Issue2523Fixtures.IProjection2523<>);
+
+            var entity = ImportedTypeSymbol.Get(typeof(Issue2523Fixtures.MetadataEntity2523));
+            var child = ImportedTypeSymbol.Get(typeof(Issue2523Fixtures.MetadataChild2523));
+            var nullableChild = NullableTypeSymbol.Get(child);
+            var nestedProjection = ImportedTypeSymbol.GetConstructed(
+                projectionOpen.MakeGenericType(typeof(object)),
+                projectionOpen,
+                ImmutableArray.Create<TypeSymbol>(nullableChild));
+            var source = ImportedTypeSymbol.GetConstructed(
+                chainOpen.MakeGenericType(typeof(object), typeof(object), typeof(object), typeof(object)),
+                chainOpen,
+                ImmutableArray.Create<TypeSymbol>(
+                    entity,
+                    nullableChild,
+                    NullableTypeSymbol.Get(TypeSymbol.String),
+                    ImportedTypeSymbol.GetConstructed(
+                        typeof(List<object>),
+                        typeof(List<>),
+                        ImmutableArray.Create<TypeSymbol>(nullableChild))));
+
+            var queryTarget = ImportedTypeSymbol.GetConstructed(
+                queryOpen.MakeGenericType(typeof(Issue2523Fixtures.MetadataEntity2523)),
+                queryOpen,
+                ImmutableArray.Create<TypeSymbol>(entity));
+            var nestedTarget = ImportedTypeSymbol.GetConstructed(
+                nestedOpen.MakeGenericType(projectionOpen.MakeGenericType(typeof(object))),
+                nestedOpen,
+                ImmutableArray.Create<TypeSymbol>(nestedProjection));
+
+            Assert.True(Conversion.Classify(source, queryTarget).IsImplicit);
+            Assert.True(Conversion.Classify(source, nestedTarget).IsImplicit);
+
+            var wrongQueryTarget = ImportedTypeSymbol.GetConstructed(
+                queryOpen.MakeGenericType(typeof(Issue2523Fixtures.MetadataChild2523)),
+                queryOpen,
+                ImmutableArray.Create<TypeSymbol>(child));
+            Assert.False(Conversion.Classify(source, wrongQueryTarget).Exists);
+        }
+
+        [Fact]
+        public void SeparateMetadataLoadContextsStillRecognizeProjectedBaseInterface()
+        {
+            var reference = typeof(Issue2523Fixtures.IChain2523<,,,>).Assembly.Location;
+            using var resolverA = ReferenceResolver.WithReferences(new[] { reference });
+            using var resolverB = ReferenceResolver.WithReferences(new[] { reference });
+
+            Assert.True(
+                resolverA.TryResolveType(
+                    "GSharp.Core.Tests.CodeAnalysis.Binding.Issue2523Fixtures.IChain2523`4",
+                    out var chainOpen));
+            Assert.True(
+                resolverB.TryResolveType(
+                    "GSharp.Core.Tests.CodeAnalysis.Binding.Issue2523Fixtures.IQuery2523`1",
+                    out var queryOpen));
+            Assert.True(
+                resolverA.TryResolveType(
+                    "GSharp.Core.Tests.CodeAnalysis.Binding.Issue2523Fixtures.MetadataEntity2523",
+                    out var entityA));
+            Assert.True(
+                resolverB.TryResolveType(
+                    "GSharp.Core.Tests.CodeAnalysis.Binding.Issue2523Fixtures.MetadataEntity2523",
+                    out var entityB));
+            Assert.True(
+                resolverA.TryResolveType(
+                    "GSharp.Core.Tests.CodeAnalysis.Binding.Issue2523Fixtures.MetadataChild2523",
+                    out var childA));
+
+            var entitySymbolA = ImportedTypeSymbol.Get(entityA);
+            var entitySymbolB = ImportedTypeSymbol.Get(entityB);
+            var contextObject = chainOpen.GetGenericArguments()[0].BaseType!;
+            var source = ImportedTypeSymbol.GetConstructed(
+                chainOpen.MakeGenericType(
+                    contextObject,
+                    contextObject,
+                    contextObject,
+                    contextObject),
+                chainOpen,
+                ImmutableArray.Create<TypeSymbol>(
+                    entitySymbolA,
+                    NullableTypeSymbol.Get(ImportedTypeSymbol.Get(childA)),
+                    TypeSymbol.String,
+                    TypeSymbol.String));
+            var target = ImportedTypeSymbol.GetConstructed(
+                queryOpen.MakeGenericType(entityB),
+                queryOpen,
+                ImmutableArray.Create<TypeSymbol>(entitySymbolB));
+
+            Assert.False(ReferenceEquals(chainOpen.Assembly, queryOpen.Assembly));
+            Assert.True(Conversion.Classify(source, target).IsImplicit);
+        }
+
+        private static void AssertBinds(string source, params string[] additionalReferences)
+        {
+            var paths = TrustedPlatformAssemblies().ToList();
+            paths.Add(typeof(Issue2523Fixtures.IChain2523<,,,>).Assembly.Location);
+            paths.AddRange(additionalReferences);
+
+            using var resolver = ReferenceResolver.WithReferences(paths);
+            var tree = SyntaxTree.Parse(SourceText.From(source));
+            var global = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), resolver);
+            var program = Binder.BindProgram(global, resolver);
+            var diagnostics = global.Diagnostics.AddRange(program.Diagnostics);
+            Assert.True(
+                diagnostics.All(diagnostic => !diagnostic.IsError),
+                string.Join(Environment.NewLine, diagnostics));
+        }
+
+        private static IEnumerable<string> TrustedPlatformAssemblies()
+        {
+            var value = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+            return string.IsNullOrWhiteSpace(value)
+                ? Array.Empty<string>()
+                : value.Split(Path.PathSeparator).Where(File.Exists);
+        }
+    }
+}
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding.Issue2523Fixtures
+{
+    public interface IQuery2523<out TEntity>
+    {
+    }
+
+    public interface IProjection2523<out TValue>
+    {
+    }
+
+    public interface INested2523<out TValue>
+    {
+    }
+
+    public interface IChain2523<out TEntity, out TProperty, in TInput, TInvariant>
+        : IQuery2523<TEntity>,
+          IProjection2523<TProperty>,
+          INested2523<IProjection2523<TProperty>>
+    {
+    }
+
+    public sealed class MetadataEntity2523
+    {
+        public MetadataChild2523? Child { get; set; }
+    }
+
+    public sealed class MetadataChild2523
+    {
+    }
+
+    public static class QueryExtensions2523
+    {
+        public static IChain2523<TEntity, TProperty, string, string> Include2523<TEntity, TProperty>(
+            this IQuery2523<TEntity> source,
+            Expression<Func<TEntity, TProperty>> selector)
+            => null!;
+
+        public static IChain2523<TEntity, TProperty, string, string> IncludePair2523<TEntity, TProperty>(
+            this IQuery2523<TEntity> source,
+            Expression<Func<TEntity, TProperty>> first,
+            Expression<Func<TEntity, TProperty>> second)
+            => null!;
+
+        public static IChain2523<TEntity, TNext, string, string> ThenInclude2523<TEntity, TPrevious, TNext>(
+            this IQuery2523<TEntity> source,
+            Expression<Func<TPrevious, TNext>> selector)
+            => null!;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2523NullableIncludeInferencePipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2523NullableIncludeInferencePipelineTests.cs
@@ -1,0 +1,223 @@
+// <copyright file="Issue2523NullableIncludeInferencePipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Default SDK-backed two-project EF coverage for issue #2523.
+/// </summary>
+public sealed class Issue2523NullableIncludeInferencePipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_TwoProjectNullableIncludeChainsCompile()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+        string dataDir = Path.Combine(sourceRoot, "Data");
+        string consumerDir = Path.Combine(sourceRoot, "Consumer");
+        Directory.CreateDirectory(dataDir);
+        Directory.CreateDirectory(consumerDir);
+
+        string dataProject = Path.Combine(dataDir, "Data.csproj");
+        File.WriteAllText(dataProject, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(dataDir, "Model.cs"), """
+            using System.Collections.Generic;
+            using Microsoft.EntityFrameworkCore;
+
+            namespace Data;
+
+            public sealed class Child { }
+            public sealed class Other { }
+            public sealed class Conversion { }
+
+            public sealed class Component
+            {
+                public Conversion? Conversion { get; set; }
+            }
+
+            public sealed class Entity
+            {
+                public Child? Child { get; set; }
+                public Other? Other { get; set; }
+            }
+
+            public sealed class Book
+            {
+                public Conversion? Conversion { get; set; }
+                public List<Component> Components { get; set; } = [];
+                public Other? Other { get; set; }
+            }
+
+            public sealed class Context : DbContext
+            {
+                public DbSet<Entity> Entities { get; set; } = null!;
+                public DbSet<Book> Books { get; set; } = null!;
+            }
+            """);
+
+        string consumerProject = Path.Combine(consumerDir, "Consumer.csproj");
+        File.WriteAllText(consumerProject, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+              <ItemGroup>
+                <ProjectReference Include="../Data/Data.csproj" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(consumerDir, "Query.cs"), """
+            using System.Linq;
+            using Data;
+            using Microsoft.EntityFrameworkCore;
+
+            namespace Consumer;
+
+            public static class Query
+            {
+                public static IQueryable<Entity> Minimal(Context context) =>
+                    context.Entities
+                        .Include((Entity entity) => entity.Child)
+                        .Include((Entity entity) => entity.Other);
+
+                public static IQueryable<Book> OahuShape(Context context) =>
+                    context.Books
+                        .Include((Book book) => book.Conversion)
+                        .Include((Book book) => book.Components)
+                        .ThenInclude((Component component) => component.Conversion)
+                        .Include((Book book) => book.Other);
+            }
+            """);
+        RunDotnetBuild(dataProject);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp(
+            "test/NullableIncludeInference",
+            consumerProject,
+            TargetKind.Library);
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("test/NullableIncludeData", dataProject, TargetKind.Library),
+            app,
+        });
+        Assert.All(
+            result.Apps,
+            current => Assert.True(
+                current.Succeeded,
+                current.AppId + " should compile through default --via-sdk/gsc. Stages: "
+                    + string.Join("; ", current.Stages.Select(stage => stage.Stage + "=" + stage.Status))));
+        AppResult appResult = result.Apps.Single(current => current.AppId == app.Id);
+
+        string appRunDir = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.Id));
+        string emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(appRunDir, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains(".Include(", emitted, StringComparison.Ordinal);
+        Assert.Contains(".ThenInclude(", emitted, StringComparison.Ordinal);
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2523",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static void RunDotnetBuild(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo(
+            "dotnet",
+            $"build \"{projectPath}\" --nologo --verbosity:quiet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start the issue #2523 data build.");
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(
+            process.ExitCode == 0,
+            "Failed to prebuild the issue #2523 data project:\n" + stdout + stderr);
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes #2523

## Summary
- classify imported constructed generic base/interface conversions from symbolic substitutions instead of erased CLR probe shapes
- recover generic method arguments from plain closed imported receivers and project reduced extension receivers through the declared hierarchy
- reify cross-context core type arguments and emit accepted imported reference upcasts as no-ops
- add binder, EF Include/ThenInclude chain, runtime, reflection, C# consumer, ILVerify, and default `--via-sdk` two-project regressions

## Validation
- Core targeted issue/control tests: 30 passed
- Compiler targeted runtime/emit/control tests: 13 passed
- Release SDK build: succeeded
- isolated-cache default `--via-sdk` issue #2523 + #2498 pipeline tests: 2 passed
