### PR TITLE
Fix imported interface indexer hiding

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -977,6 +977,12 @@ internal sealed partial class ExpressionBinder
             var idxArgsAnnot = ImmutableArray.Create(BoundIndexArg());
             if (this.memberLookup.TryResolveClrIndexer(target.Type, clrAnnotIdx, idxArgsAnnot, out var idxPropAnnot, out var resolvedIdxArgsAnnot))
             {
+                if (idxPropAnnot.GetGetMethod(nonPublic: false) == null)
+                {
+                    Diagnostics.ReportTypeNotIndexable(targetLocation, target.Type);
+                    return new BoundErrorExpression(null);
+                }
+
                 var elemTypeAnnot = annotIdx.GetTypeArgumentSymbolForClrType(idxPropAnnot.PropertyType);
                 var convertedIdxArgsAnnot = BindClrIndexerArguments(
                     target.Type,
@@ -991,6 +997,12 @@ internal sealed partial class ExpressionBinder
             var idxArgs = ImmutableArray.Create(BoundIndexArg());
             if (this.memberLookup.TryResolveClrIndexer(target.Type, clrTarget, idxArgs, out var idxProp, out var resolvedIdxArgs))
             {
+                if (idxProp.GetGetMethod(nonPublic: false) == null)
+                {
+                    Diagnostics.ReportTypeNotIndexable(targetLocation, target.Type);
+                    return new BoundErrorExpression(null);
+                }
+
                 var elementType = target.Type is ImportedTypeSymbol imported
                     ? MapErasedIndexerElementType(imported, idxProp)
                     : ClrNullability.GetPropertyTypeSymbol(idxProp);
@@ -1633,7 +1645,7 @@ internal sealed partial class ExpressionBinder
             var idxArgsAnnotWr = ImmutableArray.Create(BindIndexValue());
             if (this.memberLookup.TryResolveClrIndexer(targetType, clrAnnotWr, idxArgsAnnotWr, out var idxPropAnnotWr, out var resolvedIdxArgsAnnotWr))
             {
-                if (!idxPropAnnotWr.CanWrite)
+                if (idxPropAnnotWr.GetSetMethod(nonPublic: false) == null)
                 {
                     Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
                     return new BoundErrorExpression(null);
@@ -1665,7 +1677,7 @@ internal sealed partial class ExpressionBinder
                 // managed pointer. Detect the ref-returning getter and store through
                 // it. A `ReadOnlySpan[T]` getter is `ref readonly T` — writing is a
                 // hard error (GS0226).
-                if (!idxProp.CanWrite)
+                if (idxProp.GetSetMethod(nonPublic: false) == null)
                 {
                     var refGetter = idxProp.GetGetMethod(nonPublic: false);
                     if (refGetter != null && refGetter.ReturnType.IsByRef)

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2605,36 +2605,28 @@ internal sealed class MemberLookup
         indexer = null;
         resolvedArguments = default;
 
-        var declaringTypes = clrTarget.IsInterface
-            ? EnumerateSelfAndInterfaces(clrTarget)
-            : new[] { clrTarget };
-        var properties = declaringTypes
-            .SelectMany(type => ClrTypeUtilities.SafeGetProperties(
-                type,
-                BindingFlags.Public | BindingFlags.Instance))
-            .Where(static property => property.GetMethod != null && property.GetIndexParameters().Length > 0)
-            .GroupBy(static property => (property.Module, property.MetadataToken))
-            .Select(static group => group.First())
-            .ToArray();
+        var properties = CollectVisibleClrIndexers(targetType, clrTarget);
         var hasSymbolicArgument = boundArguments.Any(static argument =>
             argument.Type?.ClrType == null
             || TypeSymbol.ContainsTypeParameter(argument.Type)
             || TypeSymbol.ContainsSameCompilationUserType(argument.Type)
             || argument.Type is ImportedTypeSymbol { HasSubstitutableTypeArgument: true });
-        if (hasSymbolicArgument)
+        var hasSetOnlyIndexer = properties.Any(static property => property.GetGetMethod(nonPublic: false) == null);
+        if (hasSymbolicArgument || hasSetOnlyIndexer)
         {
             var applicable = new List<(PropertyInfo Property, ImmutableArray<TypeSymbol> ParameterTypes)>();
             foreach (var property in properties)
             {
                 var parameters = property.GetIndexParameters();
-                if (parameters.Length != boundArguments.Length)
+                if (boundArguments.Length > parameters.Length
+                    || parameters.Skip(boundArguments.Length).Any(static parameter => !parameter.IsOptional))
                 {
                     continue;
                 }
 
-                var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(parameters.Length);
+                var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(boundArguments.Length);
                 var candidateApplicable = true;
-                for (var i = 0; i < parameters.Length; i++)
+                for (var i = 0; i < boundArguments.Length; i++)
                 {
                     var parameterType = GetIndexerParameterTypeSymbol(targetType, property, i);
                     parameterTypes.Add(parameterType);
@@ -2682,13 +2674,20 @@ internal sealed class MemberLookup
                 if (winner.HasValue)
                 {
                     indexer = winner.Value.Property;
-                    resolvedArguments = boundArguments;
+                    resolvedArguments = ConversionClassifier.AppendOmittedOptionalArguments(
+                        boundArguments,
+                        indexer.GetIndexParameters());
                     return true;
                 }
 
                 // Do not retry a genuine symbolic ambiguity against the
                 // object-erased CLR shape: doing so can incorrectly prefer an
                 // object overload over a more specific symbolic interface.
+                return false;
+            }
+
+            if (hasSetOnlyIndexer)
+            {
                 return false;
             }
         }
@@ -3345,6 +3344,92 @@ internal sealed class MemberLookup
         }
 
         projectedType = projected;
+        return true;
+    }
+
+    private static PropertyInfo[] CollectVisibleClrIndexers(TypeSymbol targetType, Type clrTarget)
+    {
+        var declaringTypes = clrTarget.IsInterface
+            ? EnumerateSelfAndInterfaces(clrTarget)
+            : new[] { clrTarget };
+        var collected = new List<PropertyInfo>();
+        foreach (var declaringType in declaringTypes)
+        {
+            foreach (var property in ClrTypeUtilities.SafeGetProperties(
+                declaringType,
+                BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (property.GetIndexParameters().Length == 0
+                    || (property.GetGetMethod(nonPublic: false) == null
+                        && property.GetSetMethod(nonPublic: false) == null)
+                    || collected.Any(existing =>
+                        ReferenceEquals(existing.Module, property.Module)
+                        && existing.MetadataToken == property.MetadataToken
+                        && ClrTypeUtilities.AreSame(existing.DeclaringType, property.DeclaringType)))
+                {
+                    continue;
+                }
+
+                collected.Add(property);
+            }
+        }
+
+        // Issue #2525: hide only along an actual declaration ancestry edge.
+        // Same-signature slots from unrelated bases must remain ambiguous.
+        return collected
+            .Where(candidate => !collected.Any(other =>
+                !ReferenceEquals(candidate, other)
+                && IsMoreDerivedClrType(other.DeclaringType, candidate.DeclaringType)
+                && HaveSameIndexerSignature(targetType, other, candidate)))
+            .ToArray();
+    }
+
+    private static bool IsMoreDerivedClrType(Type derived, Type baseType)
+    {
+        if (derived == null || baseType == null || ClrTypeUtilities.AreSame(derived, baseType))
+        {
+            return false;
+        }
+
+        if (baseType.IsInterface)
+        {
+            return ClrTypeUtilities.SafeGetInterfaces(derived)
+                .Any(candidate => ClrTypeUtilities.AreSame(candidate, baseType));
+        }
+
+        for (var current = derived.BaseType; current != null; current = current.BaseType)
+        {
+            if (ClrTypeUtilities.AreSame(current, baseType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HaveSameIndexerSignature(
+        TypeSymbol targetType,
+        PropertyInfo first,
+        PropertyInfo second)
+    {
+        var firstParameters = first.GetIndexParameters();
+        var secondParameters = second.GetIndexParameters();
+        if (firstParameters.Length != secondParameters.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < firstParameters.Length; i++)
+        {
+            if (!SameTypeSymbol(
+                GetIndexerParameterTypeSymbol(targetType, first, i),
+                GetIndexerParameterTypeSymbol(targetType, second, i)))
+            {
+                return false;
+            }
+        }
+
         return true;
     }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -1316,7 +1316,11 @@ internal sealed partial class MethodBodyEmitter
                 this.EmitExpression(arg);
             }
 
-            this.il.OpCode(ILOpCode.Call);
+            // Span-like value types require a direct call; ref-returning
+            // interface indexers still dispatch virtually (#2525).
+            this.il.OpCode(ReflectionMetadataEmitter.IsValueTypeSymbol(receiver.Type)
+                ? ILOpCode.Call
+                : ILOpCode.Callvirt);
             // Issue #671: receiver-aware MemberRef for symbolic constructed generics.
             this.il.Token(this.outer.memberRefs.GetMethodEntityHandle(refGetter, receiver.Type));
             this.EmitExpression(ixa.Value);

--- a/test/Compiler.Tests/Emit/Issue2525ImportedIndexerHidingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2525ImportedIndexerHidingEmitTests.cs
@@ -1,0 +1,961 @@
+// <copyright file="Issue2525ImportedIndexerHidingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2525: imported indexers declared on a derived interface hide
+/// same-signature indexers inherited from more distant interfaces.
+/// </summary>
+public sealed class Issue2525ImportedIndexerHidingEmitTests
+{
+    private const string ContractsSource = """
+        #nullable enable
+        using System;
+
+        namespace Issue2525.Contracts
+        {
+            public interface IBase
+            {
+                string this[string key] { get; set; }
+            }
+
+            public interface IDerived : IBase
+            {
+                new string this[string key] { get; set; }
+            }
+
+            public sealed class SlotStore : IDerived
+            {
+                private string baseValue = "";
+                private string derivedValue = "";
+
+                string IBase.this[string key]
+                {
+                    get => "base:" + baseValue;
+                    set => baseValue = value;
+                }
+
+                string IDerived.this[string key]
+                {
+                    get => "derived:" + derivedValue;
+                    set => derivedValue = value;
+                }
+            }
+
+            public interface IIntBase
+            {
+                int this[int index] { get; set; }
+            }
+
+            public interface IIntDerived : IIntBase
+            {
+                new int this[int index] { get; set; }
+            }
+
+            public sealed class IntStore : IIntDerived
+            {
+                private int baseValue;
+                private int derivedValue;
+
+                int IIntBase.this[int index]
+                {
+                    get => baseValue;
+                    set => baseValue = value;
+                }
+
+                int IIntDerived.this[int index]
+                {
+                    get => derivedValue;
+                    set => derivedValue = value;
+                }
+            }
+
+            public interface IGenericBase<T>
+            {
+                T this[T key] { get; set; }
+            }
+
+            public interface IGenericDerived<T> : IGenericBase<T>
+            {
+                new T this[T key] { get; set; }
+            }
+
+            public sealed class GenericStore<T> : IGenericDerived<T>
+            {
+                private T baseValue = default!;
+                private T derivedValue = default!;
+
+                T IGenericBase<T>.this[T key]
+                {
+                    get => baseValue;
+                    set => baseValue = value;
+                }
+
+                T IGenericDerived<T>.this[T key]
+                {
+                    get => derivedValue;
+                    set => derivedValue = value;
+                }
+            }
+
+            public interface IRoot
+            {
+                string this[string key] { get; set; }
+            }
+
+            public interface IMiddle : IRoot
+            {
+                new string this[string key] { get; set; }
+            }
+
+            public interface ILeaf : IMiddle
+            {
+                new string this[string key] { get; set; }
+            }
+
+            public sealed class MultiLevelStore : ILeaf
+            {
+                private string root = "";
+                private string middle = "";
+                private string leaf = "";
+
+                string IRoot.this[string key]
+                {
+                    get => "root:" + root;
+                    set => root = value;
+                }
+
+                string IMiddle.this[string key]
+                {
+                    get => "middle:" + middle;
+                    set => middle = value;
+                }
+
+                string ILeaf.this[string key]
+                {
+                    get => "leaf:" + leaf;
+                    set => leaf = value;
+                }
+            }
+
+            public interface IDiamondRoot
+            {
+                string this[string key] { get; set; }
+            }
+
+            public interface IDiamondLeft : IDiamondRoot
+            {
+                new string this[string key] { get; set; }
+            }
+
+            public interface IDiamondRight : IDiamondRoot
+            {
+            }
+
+            public interface IDiamondLeaf : IDiamondLeft, IDiamondRight
+            {
+                new string this[string key] { get; set; }
+            }
+
+            public sealed class DiamondStore : IDiamondLeaf
+            {
+                private string root = "";
+                private string left = "";
+                private string leaf = "";
+
+                string IDiamondRoot.this[string key]
+                {
+                    get => "root:" + root;
+                    set => root = value;
+                }
+
+                string IDiamondLeft.this[string key]
+                {
+                    get => "left:" + left;
+                    set => left = value;
+                }
+
+                string IDiamondLeaf.this[string key]
+                {
+                    get => "diamond:" + leaf;
+                    set => leaf = value;
+                }
+            }
+
+            public interface IOverloadBase
+            {
+                string this[object key] { get; }
+            }
+
+            public interface IOverloadDerived : IOverloadBase
+            {
+                string this[string key] { get; }
+            }
+
+            public sealed class OverloadStore : IOverloadDerived
+            {
+                string IOverloadBase.this[object key] => "object";
+                string IOverloadDerived.this[string key] => "string";
+            }
+
+            public interface IReturnBase
+            {
+                object this[string key] { get; }
+            }
+
+            public interface IReturnDerived : IReturnBase
+            {
+                new string this[string key] { get; }
+            }
+
+            public sealed class ReturnStore : IReturnDerived
+            {
+                object IReturnBase.this[string key] => new object();
+                string IReturnDerived.this[string key] => "derived-return";
+            }
+
+            public interface IGetBase
+            {
+                int this[int index] { get; set; }
+            }
+
+            public interface IGetDerived : IGetBase
+            {
+                new int this[int index] { get; }
+            }
+
+            public sealed class GetStore : IGetDerived
+            {
+                private int baseValue;
+
+                int IGetBase.this[int index]
+                {
+                    get => baseValue;
+                    set => baseValue = value;
+                }
+
+                int IGetDerived.this[int index] => 25;
+            }
+
+            public interface ISetBase
+            {
+                int this[int index] { get; set; }
+            }
+
+            public interface ISetDerived : ISetBase
+            {
+                new int this[int index] { set; }
+            }
+
+            public sealed class SetStore : ISetDerived
+            {
+                private int baseValue;
+                private int derivedValue;
+
+                int ISetBase.this[int index]
+                {
+                    get => baseValue;
+                    set => baseValue = value;
+                }
+
+                int ISetDerived.this[int index] { set => derivedValue = value; }
+
+                public int DerivedValue => derivedValue;
+            }
+
+            public interface IRefBase
+            {
+                int this[int index] { get; set; }
+            }
+
+            public interface IRefDerived : IRefBase
+            {
+                new ref int this[int index] { get; }
+            }
+
+            public sealed class RefStore : IRefDerived
+            {
+                private int baseValue;
+                private int derivedValue;
+
+                int IRefBase.this[int index]
+                {
+                    get => baseValue;
+                    set => baseValue = value;
+                }
+
+                ref int IRefDerived.this[int index] => ref derivedValue;
+            }
+
+            public interface IInitBase
+            {
+                string this[string key] { get; set; }
+            }
+
+            public interface IInitDerived : IInitBase
+            {
+                new string this[string key] { get; init; }
+            }
+
+            public sealed class InitStore : IInitDerived
+            {
+                private string baseValue = "";
+                private string derivedValue = "";
+
+                string IInitBase.this[string key]
+                {
+                    get => baseValue;
+                    set => baseValue = value;
+                }
+
+                string IInitDerived.this[string key]
+                {
+                    get => derivedValue;
+                    init => derivedValue = value;
+                }
+
+                public string DerivedValue => derivedValue;
+            }
+
+            public interface IOptionalBase
+            {
+                string this[string key, int suffix = 3] { get; }
+            }
+
+            public interface IOptionalDerived : IOptionalBase
+            {
+                new string this[string key, int suffix = 3] { get; }
+            }
+
+            public sealed class OptionalStore : IOptionalDerived
+            {
+                string IOptionalBase.this[string key, int suffix] => "base:" + suffix;
+                string IOptionalDerived.this[string key, int suffix] => "derived:" + suffix;
+            }
+
+            public interface IOptionalGenericBase<T>
+            {
+                string this[T key, int suffix = 4] { get; }
+            }
+
+            public interface IOptionalGenericDerived<T> : IOptionalGenericBase<T>
+            {
+                new string this[T key, int suffix = 4] { get; }
+            }
+
+            public sealed class OptionalGenericStore<T> : IOptionalGenericDerived<T>
+            {
+                string IOptionalGenericBase<T>.this[T key, int suffix] => "base-generic:" + suffix;
+                string IOptionalGenericDerived<T>.this[T key, int suffix] => "derived-generic:" + suffix;
+            }
+
+            public interface INullBase
+            {
+                string? this[string? key] { get; set; }
+            }
+
+            public interface INullDerived : INullBase
+            {
+                new string? this[string? key] { get; set; }
+            }
+
+            public sealed class NullStore : INullDerived
+            {
+                private string? baseValue;
+                private string? derivedValue;
+
+                string? INullBase.this[string? key]
+                {
+                    get => baseValue;
+                    set => baseValue = value;
+                }
+
+                string? INullDerived.this[string? key]
+                {
+                    get => derivedValue;
+                    set => derivedValue = value;
+                }
+            }
+
+            public interface IAmbiguousA
+            {
+                string this[string key] { get; }
+            }
+
+            public interface IAmbiguousB
+            {
+                string this[string key] { get; }
+            }
+
+            public interface IAmbiguous : IAmbiguousA, IAmbiguousB
+            {
+            }
+
+            public class ClassBase
+            {
+                public string this[string key] => "class-base";
+            }
+
+            public sealed class ClassDerived : ClassBase
+            {
+                public new string this[string key] => "class-derived";
+            }
+
+            public sealed class Holder
+            {
+                public IDerived Values { get; } = new SlotStore();
+            }
+        }
+        """;
+
+    [Fact]
+    public void HiddenSlots_ReadWriteExpressionsGenericsDiamondAndClasses_RunVerifyReflectAndWorkFromCSharp()
+    {
+        const string source = """
+            package Issue2525
+            import System
+            import Issue2525.Contracts
+
+            open data class Payload2525(Name string) {}
+
+            class Api {
+                shared {
+                    func Read(value IDerived) string -> value["key"]
+                    func Write(value IDerived, text string) { value["key"] = text }
+                    func ReadBase(value IBase) string -> value["key"]
+                    func WriteBase(value IBase, text string) { value["key"] = text }
+                    func Bump(value IIntDerived) int32 {
+                        value[0] += 1
+                        value[0]++
+                        return value[0]
+                    }
+                }
+            }
+
+            func Main() {
+                let slots = SlotStore()
+                let derived IDerived = slots
+                Api.Write(derived, "gsharp")
+                Console.WriteLine(Api.Read(derived))
+                let asBase IBase = derived
+                Api.WriteBase(asBase, "base")
+                Console.WriteLine(Api.ReadBase(asBase))
+
+                let ints = IntStore()
+                let intDerived IIntDerived = ints
+                intDerived[0] = 10
+                intDerived[0] += 4
+                intDerived[0]++
+                Console.WriteLine(intDerived[0])
+                let maybe IIntDerived? = intDerived
+                Console.WriteLine(maybe?[0])
+                let intBase IIntBase = intDerived
+                intBase[0] = 2
+                Console.WriteLine(intBase[0])
+
+                let generic = GenericStore[Payload2525]()
+                let genericDerived IGenericDerived[Payload2525] = generic
+                let derivedKey = Payload2525("derived-key")
+                genericDerived[derivedKey] = Payload2525("generic-derived")
+                Console.WriteLine(genericDerived[derivedKey].Name)
+                let genericBase IGenericBase[Payload2525] = genericDerived
+                let baseKey = Payload2525("base-key")
+                genericBase[baseKey] = Payload2525("generic-base")
+                Console.WriteLine(genericBase[baseKey].Name)
+
+                let multi = MultiLevelStore()
+                let leaf ILeaf = multi
+                leaf["key"] = "value"
+                Console.WriteLine(leaf["key"])
+                let root IRoot = leaf
+                root["key"] = "value"
+                Console.WriteLine(root["key"])
+
+                let diamond IDiamondLeaf = DiamondStore()
+                diamond["key"] = "value"
+                Console.WriteLine(diamond["key"])
+
+                let overloaded IOverloadDerived = OverloadStore()
+                Console.WriteLine(overloaded["key"])
+                let boxed object = "key"
+                Console.WriteLine(overloaded[boxed])
+
+                let changed IReturnDerived = ReturnStore()
+                Console.WriteLine(changed["key"].Length)
+
+                let getOnly IGetDerived = GetStore()
+                Console.WriteLine(getOnly[0])
+
+                let setStore = SetStore()
+                let setOnly ISetDerived = setStore
+                setOnly[0] = 2525
+                Console.WriteLine(setStore.DerivedValue)
+
+                let byRef IRefDerived = RefStore()
+                byRef[0] = 8
+                byRef[0]++
+                Console.WriteLine(byRef[0])
+
+                let initStore = InitStore()
+                let initLike IInitDerived = initStore
+                initLike["key"] = "init"
+                Console.WriteLine(initStore.DerivedValue)
+
+                let optional IOptionalDerived = OptionalStore()
+                Console.WriteLine(optional["key"])
+
+                let optionalGeneric IOptionalGenericDerived[Payload2525] = OptionalGenericStore[Payload2525]()
+                Console.WriteLine(optionalGeneric[Payload2525("key")])
+
+                let nullable INullDerived = NullStore()
+                nullable["nullable-key"] = "nullable-value"
+                let nullableResult string? = nullable["nullable-key"]
+                Console.WriteLine(nullableResult)
+
+                let classDerived = ClassDerived()
+                Console.WriteLine(classDerived["key"])
+                let classBase ClassBase = classDerived
+                Console.WriteLine(classBase["key"])
+
+                let holder = Holder{Values: {["nested"] = "write"}}
+                Console.WriteLine(holder.Values["nested"])
+            }
+            """;
+
+        using var result = Compile(source, "exe");
+        IlVerifier.Verify(result.OutputPath, additionalReferences: new[] { result.ContractsPath });
+        Assert.Equal(
+            """
+            derived:gsharp
+            base:base
+            15
+            15
+            2
+            generic-derived
+            generic-base
+            leaf:value
+            root:value
+            diamond:value
+            string
+            object
+            14
+            25
+            2525
+            9
+            init
+            derived:3
+            derived-generic:4
+            nullable-value
+            class-derived
+            class-base
+            derived:write
+            """.Replace("\r\n", "\n", StringComparison.Ordinal) + "\n",
+            Run(result.OutputPath));
+
+        var contracts = Assembly.LoadFrom(result.ContractsPath);
+        var derivedType = contracts.GetType("Issue2525.Contracts.IDerived", throwOnError: true)!;
+        var baseType = contracts.GetType("Issue2525.Contracts.IBase", throwOnError: true)!;
+        var derivedProperty = derivedType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Single();
+        var baseProperty = baseType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Single();
+        Assert.NotEqual(baseProperty.MetadataToken, derivedProperty.MetadataToken);
+
+        var emitted = Assembly.LoadFrom(result.OutputPath);
+        var api = emitted.GetType("Issue2525.Api", throwOnError: true)!;
+        Assert.Equal("Issue2525.Contracts.IDerived", api.GetMethod("Read")!.GetParameters()[0].ParameterType.FullName);
+        Assert.Equal("Issue2525.Contracts.IBase", api.GetMethod("ReadBase")!.GetParameters()[0].ParameterType.FullName);
+
+        var consumerPath = EmitCSharpConsumer(result.DirectoryPath, result.OutputPath, result.ContractsPath);
+        IlVerifier.Verify(consumerPath, additionalReferences: new[] { result.OutputPath, result.ContractsPath });
+        Assert.Equal(
+            "derived:consumer\nbase:consumer-base\n4\n",
+            Run(consumerPath));
+    }
+
+    [Theory]
+    [InlineData("func Bad(value IGetDerived) { value[0] = 1 }")]
+    [InlineData("func Bad(value ISetDerived) int32 -> value[0]")]
+    [InlineData("func Bad(value IAmbiguous) string -> value[\"key\"]")]
+    public void HiddenAccessorAvailabilityAndUnrelatedAmbiguity_ReportGS0116(string declaration)
+    {
+        var source = $$"""
+            package Issue2525.Errors
+            import Issue2525.Contracts
+
+            {{declaration}}
+            """;
+
+        using var result = Compile(source, "library", expectSuccess: false);
+        Assert.Contains("GS0116", result.Diagnostics, StringComparison.Ordinal);
+        Assert.Contains("not indexable", result.Diagnostics, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void UnrelatedBaseIndexers_AreAlsoAmbiguousInCSharp()
+    {
+        const string consumer = """
+            using Issue2525.Contracts;
+
+            public static class Consumer
+            {
+                public static string Read(IAmbiguous value) => value["key"];
+            }
+            """;
+
+        using var result = Compile("package Issue2525.Empty", "library");
+        var compilation = CreateCSharpCompilation(
+            "Issue2525.AmbiguousConsumer",
+            consumer,
+            OutputKind.DynamicallyLinkedLibrary,
+            result.ContractsPath);
+        Assert.Contains(
+            compilation.GetDiagnostics(),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error
+                && (diagnostic.Id == "CS0121" || diagnostic.Id == "CS0229"));
+    }
+
+    [Fact]
+    public void AspNetHeaderDictionary_StringValuesReadWriteShape_CompilesRunsAndIlVerifies()
+    {
+        var aspNetReferences = GetAspNetReferences();
+        if (aspNetReferences.Length == 0)
+        {
+            return;
+        }
+
+        const string source = """
+            package Issue2525.Headers
+            import Microsoft.AspNetCore.Http
+
+            class HeaderApi {
+                shared {
+                    func Read(headers IHeaderDictionary) string -> headers["Authorization"].ToString()
+                    func Write(headers IHeaderDictionary) { headers["Retry-After"] = "1" }
+                }
+            }
+            """;
+
+        using var result = Compile(
+            source,
+            "library",
+            additionalReferences: aspNetReferences,
+            emitContracts: false,
+            outputFileName: "Issue2525.Headers.dll");
+        IlVerifier.Verify(result.OutputPath, additionalReferences: aspNetReferences);
+
+        var consumerPath = EmitHeaderConsumer(
+            result.DirectoryPath,
+            result.OutputPath,
+            aspNetReferences);
+        IlVerifier.Verify(
+            consumerPath,
+            additionalReferences: aspNetReferences.Concat(new[] { result.OutputPath }).ToArray());
+        Assert.Equal("Bearer token\n1\n", Run(consumerPath, includeAspNetCore: true));
+    }
+
+    private static CompilationResult Compile(
+        string source,
+        string target,
+        bool expectSuccess = true,
+        IReadOnlyList<string> additionalReferences = null,
+        bool emitContracts = true,
+        string outputFileName = "Issue2525.dll")
+    {
+        var directory = NewDirectory();
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, outputFileName);
+        File.WriteAllText(sourcePath, source);
+
+        var contractsPath = emitContracts
+            ? EmitCSharpAssembly(directory, "Issue2525.Contracts", ContractsSource)
+            : null;
+        var references = new List<string>();
+        if (contractsPath != null)
+        {
+            references.Add(contractsPath);
+        }
+
+        if (additionalReferences != null)
+        {
+            references.AddRange(additionalReferences);
+        }
+
+        var args = new List<string>
+        {
+            "/out:" + outputPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+        args.AddRange(references.Select(reference => "/reference:" + reference));
+        args.Add(sourcePath);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        var diagnostics = stdout.ToString() + stderr;
+        if (expectSuccess)
+        {
+            Assert.True(exitCode == 0, diagnostics);
+        }
+        else
+        {
+            Assert.NotEqual(0, exitCode);
+        }
+
+        return new CompilationResult(directory, outputPath, contractsPath, diagnostics);
+    }
+
+    private static string EmitCSharpAssembly(string directory, string assemblyName, string source)
+    {
+        var outputPath = Path.Combine(directory, assemblyName + ".dll");
+        var compilation = CreateCSharpCompilation(
+            assemblyName,
+            source,
+            OutputKind.DynamicallyLinkedLibrary);
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return outputPath;
+    }
+
+    private static CSharpCompilation CreateCSharpCompilation(
+        string assemblyName,
+        string source,
+        OutputKind outputKind,
+        params string[] additionalReferences)
+    {
+        var references = TrustedPlatformAssemblies()
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .Concat(additionalReferences.Select(path => MetadataReference.CreateFromFile(path)));
+        return CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(outputKind, nullableContextOptions: NullableContextOptions.Enable));
+    }
+
+    private static string EmitCSharpConsumer(
+        string directory,
+        string gsharpAssembly,
+        string contractsAssembly)
+    {
+        const string source = """
+            using System;
+            using Issue2525;
+            using Issue2525.Contracts;
+
+            internal static class Program
+            {
+                private static void Main()
+                {
+                    var store = new SlotStore();
+                    IDerived derived = store;
+                    Api.Write(derived, "consumer");
+                    Console.WriteLine(Api.Read(derived));
+                    Api.WriteBase(derived, "consumer-base");
+                    Console.WriteLine(Api.ReadBase(derived));
+
+                    IIntDerived ints = new IntStore();
+                    ints[0] = 2;
+                    Console.WriteLine(Api.Bump(ints));
+                }
+            }
+            """;
+        var outputPath = Path.Combine(directory, "consumer.dll");
+        var compilation = CreateCSharpCompilation(
+            "Issue2525.Consumer",
+            source,
+            OutputKind.ConsoleApplication,
+            gsharpAssembly,
+            contractsAssembly);
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return outputPath;
+    }
+
+    private static string EmitHeaderConsumer(
+        string directory,
+        string gsharpAssembly,
+        IReadOnlyList<string> aspNetReferences)
+    {
+        const string source = """
+            using System;
+            using Issue2525.Headers;
+            using Microsoft.AspNetCore.Http;
+
+            internal static class Program
+            {
+                private static void Main()
+                {
+                    IHeaderDictionary headers = new HeaderDictionary();
+                    headers.Authorization = "Bearer token";
+                    HeaderApi.Write(headers);
+                    Console.WriteLine(HeaderApi.Read(headers));
+                    Console.WriteLine(headers["Retry-After"].ToString());
+                }
+            }
+            """;
+        var outputPath = Path.Combine(directory, "header-consumer.dll");
+        var references = aspNetReferences.Concat(new[] { gsharpAssembly }).ToArray();
+        var compilation = CreateCSharpCompilation(
+            "Issue2525.HeaderConsumer",
+            source,
+            OutputKind.ConsoleApplication,
+            references);
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return outputPath;
+    }
+
+    private static string Run(string assemblyPath, bool includeAspNetCore = false)
+    {
+        var runtimeConfigPath = Path.ChangeExtension(assemblyPath, ".runtimeconfig.json");
+        var frameworks = includeAspNetCore
+            ? """
+                "frameworks": [
+                  { "name": "Microsoft.NETCore.App", "version": "10.0.0" },
+                  { "name": "Microsoft.AspNetCore.App", "version": "10.0.0" }
+                ]
+              """
+            : """
+                "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+              """;
+        File.WriteAllText(
+            runtimeConfigPath,
+            $$"""
+            {
+              "runtimeOptions": {
+                "tfm": "net10.0",
+                {{frameworks}}
+              }
+            }
+            """);
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath)!,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(runtimeConfigPath);
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"dotnet exec failed ({process.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static string[] GetAspNetReferences()
+    {
+        var coreDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        var sharedDirectory = Directory.GetParent(coreDirectory!)?.Parent?.FullName;
+        var aspNetRoot = sharedDirectory == null
+            ? null
+            : Path.Combine(sharedDirectory, "Microsoft.AspNetCore.App");
+        if (aspNetRoot == null || !Directory.Exists(aspNetRoot))
+        {
+            return Array.Empty<string>();
+        }
+
+        var coreVersion = Path.GetFileName(coreDirectory);
+        var versionDirectory = Path.Combine(aspNetRoot, coreVersion);
+        if (!Directory.Exists(versionDirectory))
+        {
+            versionDirectory = Directory.GetDirectories(aspNetRoot)
+                .OrderByDescending(path => path, StringComparer.Ordinal)
+                .FirstOrDefault();
+        }
+
+        return versionDirectory == null
+            ? Array.Empty<string>()
+            : Directory.GetFiles(versionDirectory, "*.dll");
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var value = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        Assert.False(string.IsNullOrWhiteSpace(value));
+        return value!.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static string NewDirectory()
+    {
+        var path = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2525",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private sealed class CompilationResult : IDisposable
+    {
+        public CompilationResult(
+            string directoryPath,
+            string outputPath,
+            string contractsPath,
+            string diagnostics)
+        {
+            DirectoryPath = directoryPath;
+            OutputPath = outputPath;
+            ContractsPath = contractsPath;
+            Diagnostics = diagnostics;
+        }
+
+        public string DirectoryPath { get; }
+
+        public string OutputPath { get; }
+
+        public string ContractsPath { get; }
+
+        public string Diagnostics { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(DirectoryPath, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2525ImportedIndexerHidingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2525ImportedIndexerHidingEmitTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -110,6 +111,22 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
                 }
             }
 
+            public interface IGenericOverloadBase<TBase>
+            {
+                string this[TBase key] { get; }
+            }
+
+            public interface IGenericOverloadDerived<TBase, TDerived> : IGenericOverloadBase<TBase>
+            {
+                string this[TDerived key] { get; }
+            }
+
+            public sealed class GenericOverloadStore<TBase, TDerived> : IGenericOverloadDerived<TBase, TDerived>
+            {
+                string IGenericOverloadBase<TBase>.this[TBase key] => "generic-base";
+                string IGenericOverloadDerived<TBase, TDerived>.this[TDerived key] => "generic-derived";
+            }
+
             public interface IRoot
             {
                 string this[string key] { get; set; }
@@ -169,6 +186,19 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
                 new string this[string key] { get; set; }
             }
 
+            public interface IDiamondInheritedLeaf : IDiamondLeft, IDiamondRight
+            {
+            }
+
+            public interface IDiamondSibling : IDiamondRoot
+            {
+                new string this[string key] { get; set; }
+            }
+
+            public interface IDiamondAmbiguous : IDiamondLeft, IDiamondSibling
+            {
+            }
+
             public sealed class DiamondStore : IDiamondLeaf
             {
                 private string root = "";
@@ -194,6 +224,24 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
                 }
             }
 
+            public sealed class InheritedDiamondStore : IDiamondInheritedLeaf
+            {
+                private string root = "";
+                private string left = "";
+
+                string IDiamondRoot.this[string key]
+                {
+                    get => "root-inherited:" + root;
+                    set => root = value;
+                }
+
+                string IDiamondLeft.this[string key]
+                {
+                    get => "left-inherited:" + left;
+                    set => left = value;
+                }
+            }
+
             public interface IOverloadBase
             {
                 string this[object key] { get; }
@@ -208,6 +256,39 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
             {
                 string IOverloadBase.this[object key] => "object";
                 string IOverloadDerived.this[string key] => "string";
+            }
+
+            public interface IOverloadHidingBase
+            {
+                string this[string key] { get; }
+                string this[object key] { get; }
+            }
+
+            public interface IOverloadHidingDerived : IOverloadHidingBase
+            {
+                new string this[string key] { get; }
+            }
+
+            public sealed class OverloadHidingStore : IOverloadHidingDerived
+            {
+                string IOverloadHidingBase.this[string key] => "hidden-base-string";
+                string IOverloadHidingBase.this[object key] => "visible-base-object";
+                string IOverloadHidingDerived.this[string key] => "derived-string";
+            }
+
+            public interface IGenericSlot<T>
+            {
+                string this[T key] { get; }
+            }
+
+            public interface IDualGeneric : IGenericSlot<int>, IGenericSlot<string>
+            {
+            }
+
+            public sealed class DualGenericStore : IDualGeneric
+            {
+                string IGenericSlot<int>.this[int key] => "dual-int";
+                string IGenericSlot<string>.this[string key] => "dual-string";
             }
 
             public interface IReturnBase
@@ -426,9 +507,12 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
         const string source = """
             package Issue2525
             import System
+            import System.Linq.Expressions
             import Issue2525.Contracts
 
             open data class Payload2525(Name string) {}
+            open data class BaseKey2525(Name string) {}
+            open data class DerivedKey2525(Name string) {}
 
             class Api {
                 shared {
@@ -436,6 +520,16 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
                     func Write(value IDerived, text string) { value["key"] = text }
                     func ReadBase(value IBase) string -> value["key"]
                     func WriteBase(value IBase, text string) { value["key"] = text }
+                    func ReadExpression() Expression[Func[IDerived, string]] ->
+                        (value IDerived) -> value["key"]
+                    func ReadConstrained[T IDerived](value T) string -> value["key"]
+                    func WriteConstrained[T IDerived](value T, text string) { value["key"] = text }
+                    func ReadGenericBase(
+                        value IGenericOverloadDerived[BaseKey2525, DerivedKey2525],
+                        key BaseKey2525) string -> value[key]
+                    func ReadGenericDerived(
+                        value IGenericOverloadDerived[BaseKey2525, DerivedKey2525],
+                        key DerivedKey2525) string -> value[key]
                     func Bump(value IIntDerived) int32 {
                         value[0] += 1
                         value[0]++
@@ -452,6 +546,8 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
                 let asBase IBase = derived
                 Api.WriteBase(asBase, "base")
                 Console.WriteLine(Api.ReadBase(asBase))
+                Api.WriteConstrained[SlotStore](slots, "constrained")
+                Console.WriteLine(Api.ReadConstrained[SlotStore](slots))
 
                 let ints = IntStore()
                 let intDerived IIntDerived = ints
@@ -475,6 +571,11 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
                 genericBase[baseKey] = Payload2525("generic-base")
                 Console.WriteLine(genericBase[baseKey].Name)
 
+                let genericOverload IGenericOverloadDerived[BaseKey2525, DerivedKey2525] =
+                    GenericOverloadStore[BaseKey2525, DerivedKey2525]()
+                Console.WriteLine(Api.ReadGenericBase(genericOverload, BaseKey2525("base")))
+                Console.WriteLine(Api.ReadGenericDerived(genericOverload, DerivedKey2525("derived")))
+
                 let multi = MultiLevelStore()
                 let leaf ILeaf = multi
                 leaf["key"] = "value"
@@ -487,10 +588,22 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
                 diamond["key"] = "value"
                 Console.WriteLine(diamond["key"])
 
+                let inheritedDiamond IDiamondInheritedLeaf = InheritedDiamondStore()
+                inheritedDiamond["key"] = "value"
+                Console.WriteLine(inheritedDiamond["key"])
+
                 let overloaded IOverloadDerived = OverloadStore()
                 Console.WriteLine(overloaded["key"])
                 let boxed object = "key"
                 Console.WriteLine(overloaded[boxed])
+
+                let overloadHiding IOverloadHidingDerived = OverloadHidingStore()
+                Console.WriteLine(overloadHiding["key"])
+                Console.WriteLine(overloadHiding[boxed])
+
+                let dualGeneric IDualGeneric = DualGenericStore()
+                Console.WriteLine(dualGeneric[1])
+                Console.WriteLine(dualGeneric["key"])
 
                 let changed IReturnDerived = ReturnStore()
                 Console.WriteLine(changed["key"].Length)
@@ -540,16 +653,24 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
             """
             derived:gsharp
             base:base
+            derived:constrained
             15
             15
             2
             generic-derived
             generic-base
+            generic-base
+            generic-derived
             leaf:value
             root:value
             diamond:value
+            left-inherited:value
             string
             object
+            derived-string
+            visible-base-object
+            dual-int
+            dual-string
             14
             25
             2525
@@ -575,11 +696,16 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
         var api = emitted.GetType("Issue2525.Api", throwOnError: true)!;
         Assert.Equal("Issue2525.Contracts.IDerived", api.GetMethod("Read")!.GetParameters()[0].ParameterType.FullName);
         Assert.Equal("Issue2525.Contracts.IBase", api.GetMethod("ReadBase")!.GetParameters()[0].ParameterType.FullName);
+        var expression = Assert.IsAssignableFrom<LambdaExpression>(
+            api.GetMethod("ReadExpression")!.Invoke(null, null));
+        var slotStore = Activator.CreateInstance(
+            contracts.GetType("Issue2525.Contracts.SlotStore", throwOnError: true)!)!;
+        Assert.Equal("derived:", expression.Compile().DynamicInvoke(slotStore));
 
         var consumerPath = EmitCSharpConsumer(result.DirectoryPath, result.OutputPath, result.ContractsPath);
         IlVerifier.Verify(consumerPath, additionalReferences: new[] { result.OutputPath, result.ContractsPath });
         Assert.Equal(
-            "derived:consumer\nbase:consumer-base\n4\n",
+            "derived:consumer\nbase:consumer-base\nderived:consumer-constrained\n4\nleft-inherited:csharp\n",
             Run(consumerPath));
     }
 
@@ -587,6 +713,7 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
     [InlineData("func Bad(value IGetDerived) { value[0] = 1 }")]
     [InlineData("func Bad(value ISetDerived) int32 -> value[0]")]
     [InlineData("func Bad(value IAmbiguous) string -> value[\"key\"]")]
+    [InlineData("func Bad(value IDiamondAmbiguous) string -> value[\"key\"]")]
     public void HiddenAccessorAvailabilityAndUnrelatedAmbiguity_ReportGS0116(string declaration)
     {
         var source = $$"""
@@ -780,10 +907,16 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
                     Console.WriteLine(Api.Read(derived));
                     Api.WriteBase(derived, "consumer-base");
                     Console.WriteLine(Api.ReadBase(derived));
+                    Api.WriteConstrained<SlotStore>(store, "consumer-constrained");
+                    Console.WriteLine(Api.ReadConstrained<SlotStore>(store));
 
                     IIntDerived ints = new IntStore();
                     ints[0] = 2;
                     Console.WriteLine(Api.Bump(ints));
+
+                    IDiamondInheritedLeaf diamond = new InheritedDiamondStore();
+                    diamond["key"] = "csharp";
+                    Console.WriteLine(diamond["key"]);
                 }
             }
             """;

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2525ImportedIndexerHidingPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2525ImportedIndexerHidingPipelineTests.cs
@@ -1,0 +1,281 @@
+// <copyright file="Issue2525ImportedIndexerHidingPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Default <c>--via-sdk</c> coverage for imported interface indexer hiding,
+/// including the ASP.NET Core <c>IHeaderDictionary</c> shape from issue #2525.
+/// </summary>
+public sealed class Issue2525ImportedIndexerHidingPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_DerivedAndHeaderIndexers_Compile()
+    {
+        var compiler = FindSiblingTool("Compiler", "gsc.dll");
+        var repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        var sourceRoot = NewDirectory("scratch-projects");
+        var fixture = WriteFixture(sourceRoot);
+        RunDotnetBuild(fixture.ConsumerProject);
+
+        var outputRoot = NewDirectory("pipeline-tests");
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        var result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("test/Contracts", fixture.ContractsProject, TargetKind.Library),
+            new CorpusApp("test/Consumer", fixture.ConsumerProject, TargetKind.Library),
+        });
+
+        Assert.All(
+            result.Apps,
+            app => Assert.True(
+                app.Succeeded,
+                app.AppId + " should compile through default --via-sdk/gsc. Stages: "
+                    + string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status))));
+
+        var consumer = result.Apps.Single(app => app.AppId == "test/Consumer");
+        var runDirectory = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(consumer.AppId));
+        var emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(runDirectory, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.Contains("value[\"key\"]", emitted, StringComparison.Ordinal);
+        Assert.Contains("value[key] = replacement", emitted, StringComparison.Ordinal);
+        Assert.Contains("value[\"key\"] += \"!\"", emitted, StringComparison.Ordinal);
+        Assert.Contains("value?[\"key\"]", emitted, StringComparison.Ordinal);
+        Assert.Contains("Values: { [\"key\"] = \"nested\" }", Compact(emitted), StringComparison.Ordinal);
+        Assert.Contains("ctx.Request.Headers[\"Authorization\"]", emitted, StringComparison.Ordinal);
+        Assert.Contains("ctx.Response.Headers[\"Retry-After\"] = \"1\"", emitted, StringComparison.Ordinal);
+    }
+
+    private static Fixture WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+
+        var contractsDirectory = Path.Combine(sourceRoot, "Contracts");
+        Directory.CreateDirectory(contractsDirectory);
+        var contractsProject = Path.Combine(contractsDirectory, "Contracts.csproj");
+        File.WriteAllText(contractsProject, ProjectFile());
+        File.WriteAllText(Path.Combine(contractsDirectory, "Contracts.cs"), """
+            namespace Issue2525.Contracts;
+
+            public interface IBase
+            {
+                string this[string key] { get; set; }
+            }
+
+            public interface IDerived : IBase
+            {
+                new string this[string key] { get; set; }
+            }
+
+            public interface IGenericBase<T>
+            {
+                T this[T key] { get; set; }
+            }
+
+            public interface IGenericDerived<T> : IGenericBase<T>
+            {
+                new T this[T key] { get; set; }
+            }
+
+            public interface IDiamondRoot
+            {
+                string this[string key] { get; set; }
+            }
+
+            public interface IDiamondLeft : IDiamondRoot
+            {
+                new string this[string key] { get; set; }
+            }
+
+            public interface IDiamondRight : IDiamondRoot
+            {
+            }
+
+            public interface IDiamondLeaf : IDiamondLeft, IDiamondRight
+            {
+                new string this[string key] { get; set; }
+            }
+            """);
+
+        var consumerDirectory = Path.Combine(sourceRoot, "Consumer");
+        Directory.CreateDirectory(consumerDirectory);
+        var consumerProject = Path.Combine(consumerDirectory, "Consumer.csproj");
+        File.WriteAllText(
+            consumerProject,
+            ProjectFile("../Contracts/Contracts.csproj", includeAspNetCore: true));
+        File.WriteAllText(Path.Combine(consumerDirectory, "Repro.cs"), """
+            using Issue2525.Contracts;
+            using Microsoft.AspNetCore.Http;
+
+            namespace Issue2525.Consumer;
+
+            public sealed class Holder
+            {
+                public IDerived Values { get; } = null!;
+            }
+
+            public static class Repro
+            {
+                public static string Read(IDerived value) => value["key"];
+
+                public static void Write(IDerived value, string key, string replacement) =>
+                    value[key] = replacement;
+
+                public static string ReadBase(IDerived value) => ((IBase)value)["key"];
+
+                public static T ReadGeneric<T>(IGenericDerived<T> value, T key) => value[key];
+
+                public static string ReadDiamond(IDiamondLeaf value) => value["key"];
+
+                public static string Compound(IDerived value)
+                {
+                    value["key"] += "!";
+                    return value["key"];
+                }
+
+                public static string? Conditional(IDerived? value) => value?["key"];
+
+                public static Holder NestedInitializer() =>
+                    new Holder { Values = { ["key"] = "nested" } };
+
+                public static string HeaderRead(HttpContext ctx) =>
+                    ctx.Request.Headers["Authorization"].ToString();
+
+                public static void HeaderWrite(HttpContext ctx) =>
+                    ctx.Response.Headers["Retry-After"] = "1";
+            }
+            """);
+
+        return new Fixture(contractsProject, consumerProject);
+    }
+
+    private static string ProjectFile(
+        string projectReference = null,
+        bool includeAspNetCore = false)
+    {
+        var references = projectReference is null
+            ? string.Empty
+            : $"""
+
+                <ItemGroup>
+                  <ProjectReference Include="{projectReference}" />
+                </ItemGroup>
+              """;
+        var framework = includeAspNetCore
+            ? """
+
+                <ItemGroup>
+                  <FrameworkReference Include="Microsoft.AspNetCore.App" />
+                </ItemGroup>
+              """
+            : string.Empty;
+        return $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>{references}{framework}
+            </Project>
+            """;
+    }
+
+    private static void RunDotnetBuild(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(projectPath)!,
+        };
+        startInfo.ArgumentList.Add("build");
+        startInfo.ArgumentList.Add(projectPath);
+        startInfo.ArgumentList.Add("--nologo");
+        startInfo.ArgumentList.Add("--verbosity:quiet");
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet build.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(120_000), "dotnet build timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"dotnet build failed ({process.ExitCode})\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+
+    private static string Compact(string value) =>
+        string.Join(
+            " ",
+            value.Split((char[])null, StringSplitOptions.RemoveEmptyEntries));
+
+    private static string NewDirectory(string category)
+    {
+        var root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2525",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirectoryName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (var configuration in new[] { "Release", "Debug" })
+            {
+                var candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirectoryName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private sealed record Fixture(string ContractsProject, string ConsumerProject);
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2525ImportedIndexerHidingPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2525ImportedIndexerHidingPipelineTests.cs
@@ -71,6 +71,7 @@ public sealed class Issue2525ImportedIndexerHidingPipelineTests
 
         Assert.Contains("value[\"key\"]", emitted, StringComparison.Ordinal);
         Assert.Contains("value[key] = replacement", emitted, StringComparison.Ordinal);
+        Assert.Contains("func ReadConstrained[T IDerived]", emitted, StringComparison.Ordinal);
         Assert.Contains("value[\"key\"] += \"!\"", emitted, StringComparison.Ordinal);
         Assert.Contains("value?[\"key\"]", emitted, StringComparison.Ordinal);
         Assert.Contains("Values: { [\"key\"] = \"nested\" }", Compact(emitted), StringComparison.Ordinal);
@@ -156,6 +157,10 @@ public sealed class Issue2525ImportedIndexerHidingPipelineTests
                 public static string ReadBase(IDerived value) => ((IBase)value)["key"];
 
                 public static T ReadGeneric<T>(IGenericDerived<T> value, T key) => value[key];
+
+                public static string ReadConstrained<T>(T value)
+                    where T : IDerived =>
+                    value["key"];
 
                 public static string ReadDiamond(IDiamondLeaf value) => value["key"];
 


### PR DESCRIPTION
## Summary
- suppress same-signature CLR indexers only when declared by a genuinely more-derived interface or class
- resolve hidden properties before getter/setter availability, preserving unrelated-base ambiguity and distinct overloads
- emit virtual dispatch for ref-returning interface indexers
- cover minimal, generic, diamond, accessor, expression, ASP.NET `IHeaderDictionary`, runtime, reflection, C# interop, ILVerify, and default `--via-sdk` paths

## Rebase and review
- rebased onto `origin/main` at `77e65cee` (#2526) with `MemberLookup.cs` conflict resolved by retaining both constructed-hierarchy projection helpers and indexer-hiding logic
- audited every `TryResolveClrIndexer` read/write caller plus compound, increment, null-conditional, initializer, expression-tree, constrained-receiver, and emit paths
- expanded tests for symbolic erased overloads, repeated generic metadata tokens, mixed hidden overload sets, inherited/ambiguous diamonds, constrained receivers, expression trees, and C# consumer dispatch

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet build GSharp.sln -graph`
- issue #2525 Compiler.Tests: 7 passed
- indexer/rebase regressions: 68 passed
- full Compiler.Tests: 3,251 passed
- issue #2525 Cs2Gs.Tests: 1 passed
- full Cs2Gs.Tests with `RunConfiguration.DisableParallelization=true`: 1,650 passed
- rebuilt `Gsharp.NET.Sdk` nupkg and cleared matching NuGet cache before E2E
- GitHub CI: build, cs2gs, e2e, VS Code matrix, and VSIX passed

Fixes #2525
