### PR TITLE
cs2gs: preserve friend assembly metadata

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -243,6 +243,12 @@ public sealed class TranslateStage : IMigrationStage
                 : null;
             var translator = new CSharpToGSharpTranslator(markMergedTypePartial: hasAnalyzerReferences, retainedFilePaths: retainedFilePaths);
 
+            EmitFriendAssemblyAnnotations(
+                context,
+                currentProject,
+                isReferencedProject,
+                usedOutputPaths);
+
             foreach (LoadedDocument document in currentProject.Documents)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -377,6 +383,51 @@ public sealed class TranslateStage : IMigrationStage
         EmitNerdbankGitVersioningBumps(context);
 
         return artifacts.Count == 0 ? StageOutcome.Passed() : StageOutcome.Failed(artifacts);
+    }
+
+    private static void EmitFriendAssemblyAnnotations(
+        StageExecutionContext context,
+        LoadedCSharpProject project,
+        bool isReferencedProject,
+        ISet<string> usedOutputPaths)
+    {
+        const string attributeName = "System.Runtime.CompilerServices.InternalsVisibleToAttribute";
+        List<string> friendAssemblies = project.Compilation.Assembly.GetAttributes()
+            .Where(attribute =>
+                attribute.AttributeClass?.ToDisplayString() == attributeName &&
+                attribute.ConstructorArguments.Length == 1 &&
+                attribute.ConstructorArguments[0].Value is string)
+            .Select(attribute => (string)attribute.ConstructorArguments[0].Value)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        if (friendAssemblies.Count == 0)
+        {
+            return;
+        }
+
+        string source = string.Join(
+            Environment.NewLine,
+            friendAssemblies.Select(name =>
+                "@assembly:InternalsVisibleTo(" +
+                Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(name, quote: true) +
+                ")")) + Environment.NewLine;
+        string relativePath = UniqueOutputPath(
+            PrefixReferencedProject("AssemblyInfo.gs", project, isReferencedProject),
+            usedOutputPaths);
+        string path = Path.Combine(context.AppRunDir, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path));
+        File.WriteAllText(path, source);
+
+        string emittedRelativePath = MigrationPipeline.SanitizeAppId(context.App.Id) + "/" +
+            relativePath.Replace(Path.DirectorySeparatorChar, '/');
+        context.EmittedFiles.Add(new EmittedGsFile(
+            path,
+            emittedRelativePath,
+            context.App.ProjectPath,
+            source)
+        {
+            IsFromReferencedProject = isReferencedProject,
+        });
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
@@ -201,6 +201,38 @@ public class MigrationPipelineTests
     }
 
     /// <summary>
+    /// MSBuild-generated friend-assembly metadata must become the equivalent
+    /// G# assembly annotation so migrated test projects can access internals.
+    /// </summary>
+    [Fact]
+    public async Task L2_Translate_PreservesInternalsVisibleTo()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        string corpus = ResolveCorpusDir();
+        string outRoot = NewOutputRoot("l2-friend-assembly");
+        var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
+        var pipeline = new MigrationPipeline(options, new IMigrationStage[] { new TranslateStage() });
+
+        CorpusApp l2 = CorpusDiscovery.FindById(corpus, "corpus/L2-Library");
+        RunResult result = await pipeline.RunAsync(new[] { l2 });
+        AppResult app = Assert.Single(result.Apps);
+
+        Assert.True(app.Succeeded);
+        string assemblyInfo = Directory.GetFiles(
+            Path.Combine(outRoot, result.RunId, MigrationPipeline.SanitizeAppId(l2.Id)),
+            "AssemblyInfo.gs",
+            SearchOption.AllDirectories).Single();
+        Assert.Equal(
+            "@assembly:InternalsVisibleTo(\"L2-Library.Tests\")" + Environment.NewLine,
+            File.ReadAllText(assemblyInfo));
+    }
+
+    /// <summary>
     /// Pointing the pipeline at <c>corpus/CompileGap-Library</c> translates
     /// cleanly but reaches the compile stage and captures a
     /// <c>compile-error</c> triage artifact. That fixture exists solely to

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -196,11 +196,11 @@ details.
 | App | translate | compile | ilverify | test-parity |
 | --- | --- | --- | --- | --- |
 | `corpus/L1-Console` | PASS | PASS | PASS | PASS |
-| `corpus/L2-Library` | PASS | PASS | PASS | FAIL ([#1929](https://github.com/DavidObando/gsharp/issues/1929), ledgered) |
-| `corpus/L3-Library` | PASS | PASS | PASS | skip (unverified, ledgered; [#1924](https://github.com/DavidObando/gsharp/issues/1924)/[#1929](https://github.com/DavidObando/gsharp/issues/1929)) |
+| `corpus/L2-Library` | PASS | PASS | PASS | PASS |
+| `corpus/L3-Library` | PASS | PASS | PASS | skip (unverified, ledgered; [#1924](https://github.com/DavidObando/gsharp/issues/1924)) |
 | `corpus/L4-Console` | PASS | PASS | PASS | PASS |
 | `corpus/L5-Console` | PASS | PASS | PASS | PASS |
-| `corpus/grid/G01…G14` (14 apps) | PASS | PASS | PASS | PASS |
+| `corpus/grid/G01…G14` (14 apps) | PASS except deliberate G07 unsupported operator | PASS | PASS | PASS |
 | `corpus/CompileGap-Library` | PASS | FAIL (deliberate, ledgered wontfix) | skip | skip |
 
 With `--baseline tools/cs2gs/triage/gaps.json` the run above gates green

--- a/tools/cs2gs/triage/gaps.json
+++ b/tools/cs2gs/triage/gaps.json
@@ -5,6 +5,20 @@
   ],
   "gaps": [
     {
+      "fingerprint": "sha256:6f8792050be1d47fac7ce41e95e0648de72bd0620f11414aff2e5dff56919e29",
+      "issue": 1908,
+      "status": "wontfix",
+      "title": "[cs2gs] Unsupported C# construct \u0027OperatorDeclaration\u0027 has no canonical G# form (corpus/G07-Members-Console)",
+      "stage": "translate",
+      "diagnosticId": "CS2GS-GAP",
+      "constructKind": "OperatorDeclaration",
+      "firstSeenRun": "2026-07-04T13-11-51Z_438d1f",
+      "apps": [
+        "corpus/G07-Members-Console"
+      ],
+      "notes": "C# 14 instance compound-assignment operator declarations (\u0060operator \u002B=\u0060 and siblings) have no canonical G# form: G# operator declarations are binary/unary only (ADR-0035) and there is no lossless mechanical rewrite to a binary operator, since the compound form mutates instance state in place. The translator reports this loudly (CS2GS-GAP) instead of emitting the invalid \u0060operator \u002B=\u0060 G# syntax that used to fail round-trip parse with GS0005 (issue #1908, fixed). Deliberately not translated pending a future G# language-level decision for compound-assignment operator declarations."
+    },
+    {
       "fingerprint": "sha256:7cec0cb40be8ae4fa272f36c7c8140e272ed9c99f0be5503b8179f3c14648b2e",
       "status": "wontfix",
       "title": "[cs2gs] GS0130 compiling translated corpus/CompileGap-Library (ReturnConstruct)",
@@ -20,7 +34,7 @@
     {
       "fingerprint": "sha256:9fb51a6cca02a85de69c74f6526cf2baf302376475da72f340e9038fd64710b9",
       "issue": 1929,
-      "status": "open",
+      "status": "resolved",
       "title": "[cs2gs] test-parity LIBRARY-BUILD-FAILED in migrated corpus/L2-Library (LibraryBuild)",
       "stage": "test-parity",
       "diagnosticId": "LIBRARY-BUILD-FAILED",
@@ -30,20 +44,6 @@
         "corpus/L2-Library"
       ],
       "notes": "G#-level semantics lost across assembly references blocks library test-parity (issue #1929); L3 parity is gated on the same family plus parser issue #1924."
-    },
-    {
-      "fingerprint": "sha256:6f8792050be1d47fac7ce41e95e0648de72bd0620f11414aff2e5dff56919e29",
-      "issue": 1908,
-      "status": "wontfix",
-      "title": "[cs2gs] Unsupported C# construct 'OperatorDeclaration' has no canonical G# form (corpus/G07-Members-Console)",
-      "stage": "translate",
-      "diagnosticId": "CS2GS-GAP",
-      "constructKind": "OperatorDeclaration",
-      "firstSeenRun": "2026-07-04T13-11-51Z_438d1f",
-      "apps": [
-        "corpus/G07-Members-Console"
-      ],
-      "notes": "C# 14 instance compound-assignment operator declarations (`operator +=` and siblings) have no canonical G# form: G# operator declarations are binary/unary only (ADR-0035) and there is no lossless mechanical rewrite to a binary operator, since the compound form mutates instance state in place. The translator reports this loudly (CS2GS-GAP) instead of emitting the invalid `operator +=` G# syntax that used to fail round-trip parse with GS0005 (issue #1908, fixed). Deliberately not translated pending a future G# language-level decision for compound-assignment operator declarations."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- emit evaluated InternalsVisibleTo metadata as G# assembly annotations
- restore L2 library test parity and resolve its stale gap ledger entry
- update the corpus migration matrix

## Validation
- targeted L2 pipeline tests pass
- strict corpus: 2 known intentional gaps, 0 new, 0 regressed, 0 stale

Fixes the remaining parity symptom from #1929.