### PR TITLE
cs2gs: resolve ILVerify sibling references

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
@@ -16,9 +16,10 @@ namespace Cs2Gs.Pipeline;
 /// <c>test/Compiler.Tests/IlVerifier.cs</c>: invoke <c>dotnet tool run
 /// ilverify</c> with the process working directory anchored at the repo root so
 /// the <c>.config/dotnet-tools.json</c> manifest is discovered, pass every
-/// path absolute, and add the host runtime BCL plus the app's references to the
-/// verifier's reference set. All process I/O is local — it only shells out to
-/// <c>dotnet</c>; there is no network egress and no keys.
+/// path absolute, and add the host runtime BCL plus the app's references and
+/// output-local dependency assemblies to the verifier's reference set. All
+/// process I/O is local — it only shells out to <c>dotnet</c>; there is no
+/// network egress and no keys.
 /// </summary>
 public class IlVerifyRunner
 {
@@ -134,8 +135,9 @@ public class IlVerifyRunner
     /// Verifies the IL of the assembly at <paramref name="assemblyPath"/> with
     /// the repo-pinned <c>dotnet-ilverify</c>, honoring the
     /// <see cref="SkipEnvVar"/> bypass. The host runtime BCL is always added to
-    /// the reference set; <paramref name="additionalReferences"/> (the corpus
-    /// app's <c>ReferencedAssemblies</c>) are appended. The
+    /// the reference set; sibling-project and package assemblies copied beside
+    /// the output are preferred, then <paramref name="additionalReferences"/>
+    /// (the corpus app's compile-time references) are appended. The
     /// <see cref="KnownIlVerifyFalsePositives"/> codes are passed as ignore
     /// flags and filtered from the parsed errors.
     /// </summary>
@@ -283,17 +285,30 @@ public class IlVerifyRunner
             Add(reference);
         }
 
+        string outputDirectory = Path.GetDirectoryName(fullAssembly);
+        if (!string.IsNullOrEmpty(outputDirectory) && Directory.Exists(outputDirectory))
+        {
+            foreach (string reference in Directory.EnumerateFiles(
+                outputDirectory,
+                "*.dll",
+                SearchOption.TopDirectoryOnly).OrderBy(path => path, StringComparer.Ordinal))
+            {
+                Add(reference);
+            }
+        }
+
         if (additionalReferences is not null)
         {
-            // Skip package copies of framework assemblies so ilverify does not
-            // load two identities for the same assembly (Refs #914).
-            var runtimeFileNames = new HashSet<string>(
-                BuildDefaultRuntimeReferences().Select(Path.GetFileName),
+            // The build output contains the exact sibling/package implementation
+            // assemblies the migrated app loads. Prefer them over source-project
+            // ref assemblies or package-cache copies with the same identity.
+            var preferredFileNames = new HashSet<string>(
+                ordered.Select(Path.GetFileName),
                 StringComparer.OrdinalIgnoreCase);
             foreach (string reference in additionalReferences)
             {
                 if (!string.IsNullOrEmpty(reference)
-                    && runtimeFileNames.Contains(Path.GetFileName(reference)))
+                    && preferredFileNames.Contains(Path.GetFileName(reference)))
                 {
                     continue;
                 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2541IlVerifyReferenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2541IlVerifyReferenceTests.cs
@@ -1,0 +1,160 @@
+// <copyright file="Issue2541IlVerifyReferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>Regression coverage for ILVerify reference resolution in multi-project migrations.</summary>
+public sealed class Issue2541IlVerifyReferenceTests
+{
+    [Fact]
+    public async Task Pipeline_SafeProjectReference_PassesIlVerify()
+    {
+        string compiler = FindCompiler();
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null
+            || !IlVerifyToolAvailable())
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        (string contractsProject, string consumerProject) = WriteFixture(sourceRoot);
+        string outputRoot = NewDirectory("pipeline-tests");
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[] { new TranslateStage(), new CompileStage(), new IlVerifyStage() });
+
+        RunResult result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("test/Contracts", contractsProject, TargetKind.Library),
+            new CorpusApp("test/Consumer", consumerProject, TargetKind.Library),
+        });
+
+        Assert.All(
+            result.Apps,
+            app => Assert.True(
+                app.Succeeded,
+                app.AppId + " should pass ILVerify. Stages: " +
+                    string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status))));
+        Assert.All(result.Apps, app => Assert.Equal("passed", app.Stages[2].Status));
+    }
+
+    private static (string ContractsProject, string ConsumerProject) WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+
+        string contractsDir = Path.Combine(sourceRoot, "Contracts");
+        Directory.CreateDirectory(contractsDir);
+        string contractsProject = Path.Combine(contractsDir, "Contracts.csproj");
+        File.WriteAllText(contractsProject, ProjectFile(null));
+        File.WriteAllText(Path.Combine(contractsDir, "Greeter.cs"), """
+            namespace Contracts;
+
+            public sealed class Greeter
+            {
+                public string Greet(string name) => "Hello, " + name;
+            }
+            """);
+
+        string consumerDir = Path.Combine(sourceRoot, "Consumer");
+        Directory.CreateDirectory(consumerDir);
+        string consumerProject = Path.Combine(consumerDir, "Consumer.csproj");
+        File.WriteAllText(consumerProject, ProjectFile("../Contracts/Contracts.csproj"));
+        File.WriteAllText(Path.Combine(consumerDir, "Welcome.cs"), """
+            using Contracts;
+
+            namespace Consumer;
+
+            public static class Welcome
+            {
+                public static string Message(string name) => new Greeter().Greet(name);
+            }
+            """);
+
+        return (contractsProject, consumerProject);
+    }
+
+    private static string ProjectFile(string projectReference)
+    {
+        string reference = projectReference is null
+            ? string.Empty
+            : $"""
+
+                <ItemGroup>
+                  <ProjectReference Include="{projectReference}" />
+                </ItemGroup>
+              """;
+        return $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>{reference}
+            </Project>
+            """;
+    }
+
+    private static bool IlVerifyToolAvailable()
+    {
+        try
+        {
+            return !IlVerifyRunner.IsEnabled || new IlVerifyRunner().EnsureToolAvailable();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2541",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindCompiler()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    "Compiler",
+                    "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- pass output-local sibling project and package assemblies to ILVerify
- prefer runtime output assemblies over duplicate compile-time refs
- add a safe two-project migration regression test

## Validation
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-restore` (1655 passed)

Fixes #2541