### PR TITLE
cs2gs: support implicit usings for bare type receivers

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue2546ImplicitUsings/Consumer.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue2546ImplicitUsings/Consumer.cs
@@ -1,0 +1,16 @@
+namespace Issue2546;
+
+internal sealed class Consumer
+{
+    public List<string> Items = new List<string>();
+
+    public HttpClient Client = new HttpClient();
+
+    public CancellationToken Token = default;
+
+    public object Complete(string path)
+    {
+        Console.WriteLine(path);
+        return Task.FromResult(Regex.Replace(Path.GetFileName(path), @"\s", string.Empty));
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue2546ImplicitUsings/GlobalUsings.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue2546ImplicitUsings/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using System.Globalization;
+global using System.Text.RegularExpressions;

--- a/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue2546ImplicitUsings/Issue2546ImplicitUsings.csproj
+++ b/tools/cs2gs/Cs2Gs.Tests/Fixtures/Issue2546ImplicitUsings/Issue2546ImplicitUsings.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2546ImplicitUsingsTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2546ImplicitUsingsTests.cs
@@ -1,0 +1,60 @@
+// <copyright file="Issue2546ImplicitUsingsTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public class Issue2546ImplicitUsingsTests
+{
+    [Fact]
+    public async Task EffectiveGlobalUsings_ImportOnlyNamespacesUsedByBareFrameworkTypes()
+    {
+        string projectPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "Fixtures",
+            "Issue2546ImplicitUsings",
+            "Issue2546ImplicitUsings.csproj");
+        LoadedCSharpProject project = await CSharpProjectLoader.LoadProjectAsync(projectPath);
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Fixture should bind through its SDK-generated global usings: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Contains(
+            project.Compilation.SyntaxTrees,
+            tree => tree.FilePath.EndsWith("GlobalUsings.g.cs", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            project.Documents,
+            document => document.FilePath.EndsWith("GlobalUsings.g.cs", StringComparison.Ordinal));
+
+        LoadedDocument document = Assert.Single(
+            project.Documents,
+            item => item.FilePath.EndsWith("Consumer.cs", StringComparison.Ordinal));
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Equal(
+            new[]
+            {
+                "System",
+                "System.Collections.Generic",
+                "System.IO",
+                "System.Net.Http",
+                "System.Text.RegularExpressions",
+                "System.Threading",
+                "System.Threading.Tasks",
+            },
+            unit.Imports.Select(importDirective => importDirective.Name));
+        Assert.DoesNotContain(unit.Imports, importDirective => importDirective.Name == "System.Globalization");
+        Assert.DoesNotContain(unit.Imports, importDirective => importDirective.Name == "System.Linq");
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -91,6 +91,16 @@ public sealed partial class CSharpToGSharpTranslator
                     SanitizeIdentifier(identifier.Identifier.Text));
             }
 
+            // A bare type used as an expression receiver (Path.Combine,
+            // Task.FromResult, Console.WriteLine, ...) does not pass through
+            // type-syntax translation. Map it here so SDK implicit/global
+            // usings still contribute the namespace import required by G#.
+            if (this.context.SemanticModel.GetAliasInfo(identifier) is null &&
+                this.context.GetSymbolInfo(identifier).Symbol is INamedTypeSymbol type)
+            {
+                return new TypeExpression(this.typeMapper.Map(type, this.context, identifier.GetLocation()));
+            }
+
             return new IdentifierExpression(SanitizeIdentifier(identifier.Identifier.Text));
         }
 


### PR DESCRIPTION
## Summary
- route bare type expression receivers through the semantic type mapper
- synthesize only imports actually required by effective SDK and hand-authored global usings
- add an SDK project-backed regression fixture covering `Path`, `Task`, and representative framework namespaces

## Validation
- `dotnet build GSharp.sln`
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-build --no-restore` (1,655 passed)

Fixes #2546