### PR TITLE
Fix imported project-reference member chains

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -478,10 +478,7 @@ internal sealed partial class ExpressionBinder
 
                     return BindExtensionMethodGroupOrError(receiver, ne);
                 }
-                else if (receiver != null
-                    && receiver.Type?.ClrType != null
-                    && (receiver.Type is not NullableTypeSymbol
-                        || receiver is BoundClrPropertyAccessExpression))
+                else if (CanBindClrInstanceMember(receiver))
                 {
                     // Phase 4 exit: read a public instance property or field on
                     // a CLR receiver (e.g. `lst.Count`, `sb.Length`,
@@ -589,6 +586,18 @@ internal sealed partial class ExpressionBinder
             default:
                 return new BoundErrorExpression(null);
         }
+    }
+
+    /// <summary>
+    /// Returns whether CLR instance lookup may continue through a receiver.
+    /// Imported fields and properties can carry oblivious reference metadata as
+    /// a nullable type, but remain valid intermediate receivers in a member chain.
+    /// </summary>
+    private static bool CanBindClrInstanceMember(BoundExpression receiver)
+    {
+        return receiver?.Type?.ClrType != null
+            && (receiver.Type is not NullableTypeSymbol
+                || receiver is BoundClrPropertyAccessExpression);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -2069,7 +2069,7 @@ internal sealed partial class ExpressionBinder
         }
 
         // CLR receiver → property/field write via reflection.
-        if (receiverType is not NullableTypeSymbol && receiverType?.ClrType != null)
+        if (CanBindClrInstanceMember(receiver))
         {
             var clrReceiverType = receiverType.ClrType;
             MemberInfo instanceMember = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, fieldName, BindingFlags.Public | BindingFlags.Instance);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2545CrossAssemblyMemberChainTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2545CrossAssemblyMemberChainTests.cs
@@ -1,0 +1,129 @@
+// <copyright file="Issue2545CrossAssemblyMemberChainTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2545CrossAssemblyMemberChainTests
+{
+    [Fact]
+    public void ImportedProjectTypes_MultiHopPropertiesAndFields_ReadAndWrite()
+    {
+        var libraryPath = EmitCSharpLibrary();
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        var consumer = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(
+                """
+                package Issue2545.Consumer
+                import Issue2545.Library
+
+                func Read(settings Settings) string ->
+                    settings.DownloadSettings.Profile.Name +
+                    settings.FieldDownload.FieldProfile.FieldName
+
+                func Write(settings Settings, profile Profile, value string) {
+                    settings.DownloadSettings.Profile = profile
+                    settings.DownloadSettings.Profile.Name = value
+                    settings.FieldDownload.FieldProfile = profile
+                    settings.FieldDownload.FieldProfile.FieldName = value
+                }
+                """)));
+
+        using var stream = new MemoryStream();
+        var result = consumer.Emit(stream, pdbStream: null, refStream: null, assemblyName: "Issue2545.Consumer");
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void ImportedProjectTypes_HidingStillSelectsDerivedMembers()
+    {
+        var libraryPath = EmitCSharpLibrary();
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        var consumer = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(
+                """
+                package Issue2545.Consumer
+                import Issue2545.Library
+
+                func Read(settings Settings) string? -> settings.Hidden.Value
+
+                func Write(settings Settings, value string) {
+                    settings.Hidden.Value = value
+                }
+                """)));
+
+        using var stream = new MemoryStream();
+        var result = consumer.Emit(stream, pdbStream: null, refStream: null, assemblyName: "Issue2545.Consumer");
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static string EmitCSharpLibrary()
+    {
+        const string source = """
+            namespace Issue2545.Library;
+
+            public sealed class Profile
+            {
+                public string Name { get; set; } = "";
+                public string FieldName = "";
+            }
+
+            public sealed class DownloadSettings
+            {
+                public Profile Profile { get; set; } = new();
+                public Profile FieldProfile = new();
+            }
+
+            public class BaseSettings
+            {
+                public object Value { get; set; } = new();
+            }
+
+            public sealed class DerivedSettings : BaseSettings
+            {
+                public new string Value { get; set; } = "";
+            }
+
+            public sealed class Settings
+            {
+                public DownloadSettings DownloadSettings { get; set; } = new();
+                public DownloadSettings FieldDownload = new();
+                public DerivedSettings Hidden { get; set; } = new();
+            }
+            """;
+
+        var outputDirectory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2545CrossAssemblyMemberChainTests));
+        Directory.CreateDirectory(outputDirectory);
+        var libraryPath = Path.Combine(outputDirectory, "Issue2545.Library.dll");
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "Issue2545.Library",
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = File.Create(libraryPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return libraryPath;
+    }
+}


### PR DESCRIPTION
## Summary
- share CLR receiver eligibility between imported member reads and writes
- allow multi-hop property and field assignments through oblivious imported metadata
- cover cross-assembly reads, writes, and derived-member hiding

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --nologo` (6,537 passed, 1 skipped)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter "FullyQualifiedName~ImportedMemberMatrixTests|FullyQualifiedName~Issue2525ImportedIndexerHidingEmitTests" --nologo` (15 passed)

Fixes #2545

> Note: the requested task named #2542, but the live #2542 is the unrelated delegate-covariance issue; the described imported-member-chain issue is live #2545.