### PR TITLE
Fix imported data class construction with optional parameters

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -755,6 +755,18 @@ internal sealed partial class ExpressionBinder
             && dataClassAggregate.IsData
             && dataClassAggregate.HasPrimaryConstructor)
         {
+            // Issue #2550: gsc data classes also expose a parameterless CLR
+            // constructor as an implementation detail. Bind their source-level
+            // construction through the imported primary-constructor metadata
+            // so `Settings()` supplies declared defaults instead of selecting
+            // that zero-initializing constructor. C# records have no gsc marker
+            // and keep using CLR overload resolution (#2291/#2458).
+            if (ImportedAssemblySemantics.TryGetTypeSemantics(clrType, out _))
+            {
+                result = overloads.BindConstructorCallExpression(syntax, dataClassAggregate);
+                return true;
+            }
+
             return TryBindClrConstructorFromType(
                 clrType,
                 syntax,

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -1602,7 +1602,9 @@ internal sealed class TypeDefEmitter
     /// ADR-0101 follow-up / issue #819: emits one <c>Parameter</c> row per
     /// primary-constructor parameter, giving each a metadata name and
     /// stamping <c>[ParamArrayAttribute]</c> on the trailing variadic
-    /// parameter (when present). Returns the handle of the first emitted
+    /// parameter (when present). Optional parameters also carry the CLR
+    /// Optional/HasDefault flags and Constant row. Returns the handle of the
+    /// first emitted
     /// row — or the next available row when the parameter list is empty —
     /// suitable to feed into <c>AddMethodDefinition.parameterList</c>.
     /// Primary-ctor parameters never carry <c>ref</c> / <c>out</c> / <c>in</c>
@@ -1626,11 +1628,19 @@ internal sealed class TypeDefEmitter
         for (var i = 0; i < parameters.Length; i++)
         {
             var p = parameters[i];
+            var attributes = p.HasExplicitDefaultValue
+                ? ParameterAttributes.Optional | ParameterAttributes.HasDefault
+                : ParameterAttributes.None;
             var paramHandle = this.emitCtx.Metadata.AddParameter(
-                attributes: ParameterAttributes.None,
+                attributes: attributes,
                 name: this.emitCtx.Metadata.GetOrAddString(p.Name ?? string.Empty),
                 sequenceNumber: i + 1);
             handles.Add(paramHandle);
+
+            if (p.HasExplicitDefaultValue)
+            {
+                this.emitCtx.Metadata.AddConstant(paramHandle, p.ExplicitDefaultValue);
+            }
 
             if (p.IsVariadic)
             {

--- a/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
@@ -362,6 +362,13 @@ public sealed class ImportedTypeSymbol : TypeSymbol
                 isInitOnly: setter != null && IsInitOnlySetter(setter)));
         }
 
+        var primaryConstructorParameters = BuildPrimaryConstructorParameters(
+            fieldBuilder.ToImmutable(),
+            propertyBuilder.ToImmutable(),
+            fieldByToken,
+            semantics);
+        ApplyPrimaryConstructorDefaults(type, primaryConstructorParameters);
+
         var aggregate = new StructSymbol(
             name: BuildAggregateDisplayName(type),
             fields: fieldBuilder.ToImmutable(),
@@ -371,7 +378,7 @@ public sealed class ImportedTypeSymbol : TypeSymbol
             isData: semantics.IsData,
             isInline: false,
             isClass: !semantics.IsValueType,
-            primaryConstructorParameters: BuildPrimaryConstructorParameters(fieldBuilder.ToImmutable(), propertyBuilder.ToImmutable(), fieldByToken, semantics),
+            primaryConstructorParameters: primaryConstructorParameters,
             isOpen: false,
             baseClass: null,
             clrType: type);
@@ -479,6 +486,7 @@ public sealed class ImportedTypeSymbol : TypeSymbol
         for (var i = 0; i < semantics.PrimaryConstructorParameterNames.Length; i++)
         {
             var name = semantics.PrimaryConstructorParameterNames[i];
+            ParameterSymbol parameter = null;
 
             // Prefer the exact backing field recorded by metadata token
             // (issue #1953 follow-up) — this is immune to the parameter name
@@ -492,23 +500,74 @@ public sealed class ImportedTypeSymbol : TypeSymbol
                 && fieldByToken != null
                 && fieldByToken.TryGetValue(tokens[i], out var tokenField))
             {
-                builder.Add(new ParameterSymbol(name, tokenField.Type));
+                parameter = new ParameterSymbol(name, tokenField.Type);
+            }
+            else if (fieldMap.TryGetValue(name, out var field))
+            {
+                parameter = new ParameterSymbol(name, field.Type);
+            }
+            else if (propertyMap.TryGetValue(name, out var property))
+            {
+                parameter = new ParameterSymbol(name, property.Type);
+            }
+
+            if (parameter == null)
+            {
                 continue;
             }
 
-            if (fieldMap.TryGetValue(name, out var field))
-            {
-                builder.Add(new ParameterSymbol(name, field.Type));
-                continue;
-            }
-
-            if (propertyMap.TryGetValue(name, out var property))
-            {
-                builder.Add(new ParameterSymbol(name, property.Type));
-            }
+            builder.Add(parameter);
         }
 
         return builder.ToImmutable();
+    }
+
+    private static void ApplyPrimaryConstructorDefaults(Type type, ImmutableArray<ParameterSymbol> parameters)
+    {
+        var clrParameters = FindPrimaryConstructorParameters(
+            type,
+            parameters.Select(static parameter => parameter.Name).ToImmutableArray());
+        for (var i = 0; i < parameters.Length && i < clrParameters.Length; i++)
+        {
+            if (TryGetOptionalDefault(clrParameters[i], out var defaultValue))
+            {
+                parameters[i].SetExplicitDefaultValue(defaultValue);
+            }
+        }
+    }
+
+    private static ParameterInfo[] FindPrimaryConstructorParameters(Type type, ImmutableArray<string> names)
+    {
+        foreach (var constructor in ClrTypeUtilities.SafeGetConstructors(type, BindingFlags.Public | BindingFlags.Instance))
+        {
+            var parameters = constructor.GetParameters();
+            if (parameters.Length == names.Length
+                && parameters.Select(static p => p.Name).SequenceEqual(names, StringComparer.Ordinal))
+            {
+                return parameters;
+            }
+        }
+
+        return Array.Empty<ParameterInfo>();
+    }
+
+    private static bool TryGetOptionalDefault(ParameterInfo parameter, out object value)
+    {
+        value = null;
+        try
+        {
+            if (!parameter.IsOptional && !parameter.HasDefaultValue)
+            {
+                return false;
+            }
+
+            value = parameter.RawDefaultValue;
+            return value != DBNull.Value && value != Missing.Value;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static ImmutableArray<FunctionSymbol> BuildMethods(Type type, StructSymbol aggregate, bool includeInternal)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2550ImportedOptionalDataConstructionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2550ImportedOptionalDataConstructionTests.cs
@@ -1,0 +1,191 @@
+// <copyright file="Issue2550ImportedOptionalDataConstructionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2550: optional primary-constructor values must survive assembly
+/// boundaries so imported data classes and C# records can be constructed with
+/// omitted arguments before participating in <c>with</c>/<c>copy</c>.
+/// </summary>
+public class Issue2550ImportedOptionalDataConstructionTests
+{
+    [Fact]
+    public void Imported_GSharpDataClass_DefaultedConstruction_WithAndCopy_Run()
+    {
+        var libraryPath = EmitGSharpLibrary(
+            nameof(this.Imported_GSharpDataClass_DefaultedConstruction_WithAndCopy_Run));
+
+        var output = EmitAndRun(
+            libraryPath,
+            "Issue2550.GSharp",
+            """
+            package Runner
+            import Models
+
+            func Main() {
+                let original = Settings()
+                let partial = Settings(5)
+                let explicit = Settings(6, "explicit")
+                let changed = original with { Retries = 8 }
+                let copied = original.copy(Label: "copied")
+                Console.WriteLine(original.Retries)
+                Console.WriteLine(original.Label)
+                Console.WriteLine(partial.Retries)
+                Console.WriteLine(partial.Label)
+                Console.WriteLine(explicit.Retries)
+                Console.WriteLine(explicit.Label)
+                Console.WriteLine(changed.Retries)
+                Console.WriteLine(changed.Label)
+                Console.WriteLine(copied.Retries)
+                Console.WriteLine(copied.Label)
+            }
+            """);
+
+        Assert.Equal(
+            new[] { "3", "ready", "5", "ready", "6", "explicit", "8", "ready", "3", "copied" },
+            Lines(output));
+    }
+
+    [Fact]
+    public void Imported_CSharpRecord_DefaultedConstruction_WithAndCopy_Run()
+    {
+        var libraryPath = EmitCSharpLibrary(
+            nameof(this.Imported_CSharpRecord_DefaultedConstruction_WithAndCopy_Run));
+
+        var output = EmitAndRun(
+            libraryPath,
+            "Issue2550.CSharp",
+            """
+            package Runner
+            import Models
+
+            func Main() {
+                let original = Settings()
+                let partial = Settings(5)
+                let explicit = Settings(6, "explicit")
+                let changed = original with { Retries = 8 }
+                let copied = original.copy(Label: "copied")
+                Console.WriteLine(original.Retries)
+                Console.WriteLine(original.Label)
+                Console.WriteLine(partial.Retries)
+                Console.WriteLine(partial.Label)
+                Console.WriteLine(explicit.Retries)
+                Console.WriteLine(explicit.Label)
+                Console.WriteLine(changed.Retries)
+                Console.WriteLine(changed.Label)
+                Console.WriteLine(copied.Retries)
+                Console.WriteLine(copied.Label)
+            }
+            """);
+
+        Assert.Equal(
+            new[] { "3", "ready", "5", "ready", "6", "explicit", "8", "ready", "3", "copied" },
+            Lines(output));
+    }
+
+    private static string EmitGSharpLibrary(string caseName)
+    {
+        var libraryPath = LibraryPath(caseName, "Models.dll");
+        var library = new GsCompilation(
+            GsSyntaxTree.Parse(SourceText.From(
+                """
+                package Models
+
+                data class Settings(Retries int32 = 3, Label string = "ready")
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using var stream = File.Create(libraryPath);
+        var result = library.Emit(stream, pdbStream: null, refStream: null, assemblyName: "Models");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return libraryPath;
+    }
+
+    private static string EmitCSharpLibrary(string caseName)
+    {
+        var libraryPath = LibraryPath(caseName, "Models.dll");
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))
+            .Split(Path.PathSeparator)
+            .Where(File.Exists)
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "Models",
+            new[]
+            {
+                CSharpSyntaxTree.ParseText(
+                    """namespace Models; public record Settings(int Retries = 3, string Label = "ready");"""),
+            },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = File.Create(libraryPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return libraryPath;
+    }
+
+    private static string EmitAndRun(string libraryPath, string assemblyName, string source)
+    {
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = assemblyName;
+        var consumer = new GsCompilation(resolver, GsSyntaxTree.Parse(SourceText.From(source)));
+        using var stream = new MemoryStream();
+        var result = consumer.Emit(stream, pdbStream: null, refStream: null, assemblyName: assemblyName);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        stream.Position = 0;
+        var context = new AssemblyLoadContext(assemblyName, isCollectible: true);
+        context.Resolving += (loadContext, name) =>
+            string.Equals(name.Name, "Models", StringComparison.Ordinal)
+                ? loadContext.LoadFromAssemblyPath(libraryPath)
+                : null;
+        try
+        {
+            var assembly = context.LoadFromStream(stream);
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                assembly.EntryPoint!.Invoke(null, null);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    private static string LibraryPath(string caseName, string fileName)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2550", caseName);
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
+
+    private static string[] Lines(string output) =>
+        output.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+}


### PR DESCRIPTION
## Summary
- emit CLR optional/default metadata for primary-constructor parameters
- restore those defaults on imported semantic aggregates and prefer marked G# primary-constructor semantics over the synthetic parameterless constructor
- preserve C# record CLR overload resolution from #2291/#2458 while keeping #2263 with/copy identity behavior
- add cross-assembly runtime coverage for G# data classes and C# records using explicit, defaulted, `with`, and `copy` construction

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --verbosity quiet` (6537 passed, 1 skipped)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --no-restore --filter FullyQualifiedName~ImportedMemberMatrix --verbosity quiet` (8 passed)

Fixes #2550