### PR TITLE
Support imported Deconstruct patterns

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -121,7 +121,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0161 | Error | `copy`/`with` receiver is not a `data struct`. | `.copy(…)` used on a plain `struct`. |
 | GS0162 | Error | Named arguments only supported for `data struct` `.copy(…)`. | Named arguments passed to a regular function. |
 | GS0163 | Error | Deconstruction field count mismatch. | `let (a, b) = p` where `p` is a `data struct` with three fields. |
-| GS0164 | Error | Deconstruction requires a tuple or `data struct` initializer. | Deconstruction attempted on a plain `struct`. |
+| GS0164 | Error | Deconstruction requires a tuple, `data struct`, or accessible `Deconstruct` method. | Deconstruction attempted on a type without a supported deconstruction shape. |
 | GS0165 | Error | Top-level statements may appear in at most one package per compilation. | Two or more `package` declarations in a single compilation each contain top-level statements (see [ADR-0066](adr/0066-top-level-statement-mechanics.md)). |
 | GS0166 | Warning | Top-level statements conflict with an explicit `Main` function. | Both top-level statements and a `func Main()` are present; TLS wins, the explicit `Main` is shadowed (see [ADR-0066](adr/0066-top-level-statement-mechanics.md) §4). |
 | GS0167 | Error | Multi-assignment target/value count mismatch. | `a, b = 1, 2, 3` — three values for two targets. |

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -1272,6 +1272,15 @@ internal sealed partial class StatementBinder
             return new BoundBlockStatement(syntax, statements.ToImmutable());
         }
 
+        if (TryBindImportedDeconstruct(
+            initializer,
+            syntax.Identifiers,
+            syntax.OpenParenToken.Location,
+            out var deconstructStatements))
+        {
+            return new BoundBlockStatement(syntax, deconstructStatements);
+        }
+
         Diagnostics.ReportDeconstructionRequiresTupleOrDataStruct(syntax.OpenParenToken.Location, initializer.Type);
         return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
     }
@@ -1343,6 +1352,15 @@ internal sealed partial class StatementBinder
             return statements.ToImmutable();
         }
 
+        if (TryBindImportedDeconstruct(
+            elementAccessBase,
+            identifiers,
+            openParenLocation,
+            out var deconstructStatements))
+        {
+            return deconstructStatements;
+        }
+
         if (elementType != TypeSymbol.Error)
         {
             Diagnostics.ReportDeconstructionRequiresTupleOrDataStruct(openParenLocation, elementType);
@@ -1350,6 +1368,182 @@ internal sealed partial class StatementBinder
 
         DeclareErrorTypedLocals(identifiers);
         return ImmutableArray<BoundStatement>.Empty;
+    }
+
+    private bool TryBindImportedDeconstruct(
+        BoundExpression receiver,
+        SeparatedSyntaxList<SyntaxToken> identifiers,
+        TextLocation location,
+        out ImmutableArray<BoundStatement> statements)
+    {
+        statements = default;
+        var receiverClrType = receiver.Type?.ClrType;
+        if (receiverClrType == null
+            && !MemberLookup.TryProjectErasedClrType(receiver.Type, out receiverClrType))
+        {
+            return false;
+        }
+
+        if (receiver.Type is ImportedTypeSymbol symbolicReceiver
+            && symbolicReceiver.OpenDefinition != null
+            && !symbolicReceiver.TypeArguments.IsDefaultOrEmpty)
+        {
+            receiverClrType = symbolicReceiver.ReifyClosedClrType() ?? receiverClrType;
+        }
+
+        var probes = new MemberLookup(binderCtx)
+            .CollectImportedMethodProbes(
+                staticClassType: null,
+                receiverClrType,
+                "Deconstruct",
+                includeExtensions: true);
+        foreach (var probe in probes)
+        {
+            var receiverOffset = probe.ReceiverParameterOffset;
+            var candidates = probe.Methods
+                .Where(method =>
+                {
+                    var parameters = method.GetParameters();
+                    return method.ReturnType.FullName == typeof(void).FullName
+                        && parameters.Length == identifiers.Count + receiverOffset
+                        && parameters.Skip(receiverOffset).All(parameter =>
+                            parameter.IsOut && parameter.ParameterType.IsByRef);
+                })
+                .ToList();
+            if (candidates.Count == 0)
+            {
+                continue;
+            }
+
+            var inferenceTypes = new Type[identifiers.Count + receiverOffset];
+            if (receiverOffset == 1)
+            {
+                inferenceTypes[0] = receiverClrType;
+            }
+
+            candidates = candidates
+                .Select(method =>
+                {
+                    if (!method.IsGenericMethodDefinition)
+                    {
+                        return method;
+                    }
+
+                    if (!OverloadResolution.TryInferTypeArguments(method, inferenceTypes, out var typeArguments))
+                    {
+                        return null;
+                    }
+
+                    try
+                    {
+                        for (var i = 0; i < typeArguments.Length; i++)
+                        {
+                            typeArguments[i] = scope.References.MapClrTypeToReferences(typeArguments[i])
+                                ?? typeArguments[i];
+                        }
+
+                        return method.MakeGenericMethod(typeArguments);
+                    }
+                    catch (ArgumentException)
+                    {
+                        return null;
+                    }
+                })
+                .Where(method => method != null)
+                .ToList();
+            if (candidates.Count == 0)
+            {
+                continue;
+            }
+
+            var argumentTypes = new Type[identifiers.Count + receiverOffset];
+            if (receiverOffset == 1)
+            {
+                argumentTypes[0] = receiverClrType;
+            }
+
+            Array.Fill(
+                argumentTypes,
+                OverloadResolution.InlineOutVarArgumentType,
+                startIndex: receiverOffset,
+                count: identifiers.Count);
+
+            var resolution = OverloadResolution.Resolve(
+                candidates,
+                argumentTypes,
+                projectTypeArgument: scope.References.MapClrTypeToReferences);
+            if (resolution.Outcome == OverloadResolution.ResolutionOutcome.Ambiguous)
+            {
+                Diagnostics.ReportAmbiguousOverload(
+                    location,
+                    "Deconstruct",
+                    resolution.Ambiguous.Length,
+                    resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
+                DeclareErrorTypedLocals(identifiers);
+                statements = ImmutableArray<BoundStatement>.Empty;
+                return true;
+            }
+
+            if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
+            {
+                continue;
+            }
+
+            var method = resolution.Best;
+            var parameters = method.GetParameters();
+            var arguments = ImmutableArray.CreateBuilder<BoundExpression>(parameters.Length);
+            var refKinds = ImmutableArray.CreateBuilder<RefKind>(parameters.Length);
+            var declarations = ImmutableArray.CreateBuilder<BoundStatement>(identifiers.Count);
+            if (receiverOffset == 1)
+            {
+                arguments.Add(conversions.BindConversion(
+                    location,
+                    receiver,
+                    TypeSymbol.FromClrType(parameters[0].ParameterType)));
+                refKinds.Add(RefKind.None);
+            }
+
+            for (var i = 0; i < identifiers.Count; i++)
+            {
+                var elementType = TypeSymbol.FromClrType(parameters[i + receiverOffset].ParameterType.GetElementType());
+                var variable = bindLocalVariable(identifiers[i], isReadOnly: true, elementType);
+                var temp = new LocalVariableSymbol(
+                    $"<deconstruct{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
+                    isReadOnly: false,
+                    elementType);
+                scope.TryDeclareVariable(temp);
+                arguments.Add(new BoundAddressOfExpression(
+                    null,
+                    new BoundVariableExpression(null, temp)));
+                refKinds.Add(RefKind.Out);
+                declarations.Add(new BoundVariableDeclaration(
+                    null,
+                    variable,
+                    new BoundVariableExpression(null, temp)));
+            }
+
+            BoundExpression call = receiverOffset == 1
+                ? new BoundClrStaticCallExpression(
+                    null,
+                    method,
+                    TypeSymbol.Void,
+                    arguments.MoveToImmutable(),
+                    refKinds.MoveToImmutable())
+                : new BoundImportedInstanceCallExpression(
+                    null,
+                    receiver,
+                    method,
+                    TypeSymbol.Void,
+                    arguments.MoveToImmutable(),
+                    refKinds.MoveToImmutable());
+            var result = ImmutableArray.CreateBuilder<BoundStatement>(identifiers.Count + 1);
+            result.Add(new BoundExpressionStatement(null, call));
+            result.AddRange(declarations);
+            statements = result.MoveToImmutable();
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>Declares each identifier as an error-typed local so a deconstruction failure doesn't cascade "variable doesn't exist" diagnostics through the loop body.</summary>

--- a/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
+++ b/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
@@ -79,7 +79,7 @@ internal static class DiagnosticDescriptors
     internal static readonly DiagnosticDescriptor CopyOrWithNotDataStruct = new("GS0161", DiagnosticSeverity.Error, "copy/with requires a data class or data struct receiver, but got '{0}'.");
     internal static readonly DiagnosticDescriptor NamedArgumentOnlyValidForCopy = new("GS0162", DiagnosticSeverity.Error, "Named arguments are only supported for data-struct .copy(...).");
     internal static readonly DiagnosticDescriptor DeconstructionFieldCountMismatch = new("GS0163", DiagnosticSeverity.Error, "Deconstruction requires {0} fields but was given {1}.");
-    internal static readonly DiagnosticDescriptor DeconstructionRequiresTupleOrDataStruct = new("GS0164", DiagnosticSeverity.Error, "Deconstruction requires a tuple or data struct initializer, but got '{0}'.");
+    internal static readonly DiagnosticDescriptor DeconstructionRequiresTupleOrDataStruct = new("GS0164", DiagnosticSeverity.Error, "Deconstruction requires a tuple, data struct, or accessible Deconstruct method, but got '{0}'.");
     internal static readonly DiagnosticDescriptor MultipleTopLevelFiles = new("GS0165", DiagnosticSeverity.Error, "Top-level statements may appear in at most one package per compilation.");
     internal static readonly DiagnosticDescriptor TopLevelStatementsConflictWithMain = new("GS0166", DiagnosticSeverity.Warning, "The entry point of the program is global statements; ignoring the explicit Main function entry point.");
     internal static readonly DiagnosticDescriptor MultiAssignmentMismatch = new("GS0167", DiagnosticSeverity.Error, "Multi-assignment has {0} target(s) but {1} value(s).");

--- a/test/Core.Tests/CodeAnalysis/Binding/ImportedExtensionMethodTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ImportedExtensionMethodTests.cs
@@ -33,6 +33,62 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 public class ImportedExtensionMethodTests
 {
     [Fact]
+    public void KeyValuePair_ForTupleIn_UsesImportedDeconstructPattern()
+    {
+        var source = @"
+import System.Collections.Generic
+
+var values = Dictionary[string, int32]()
+values.Add(""one"", 1)
+values.Add(""two"", 2)
+
+var total = 0
+for (key, value) in values {
+    total = total + value
+}
+total
+";
+        AssertCompilesWithoutErrors(source);
+        var result = new Compilation(SyntaxTree.Parse(SourceText.From(source)))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(3, result.Value);
+    }
+
+    [Fact]
+    public void GenericDeconstructExtension_FromReferencedAssembly_Binds()
+    {
+        var source = @"
+package Demo
+import GSharp.Core.Tests.Fixtures
+
+func Run() int32 {
+    var pair = ImportedPair2537[int32](4, 5)
+    let (left, right) = pair
+    return left + right
+}
+";
+        AssertBindsWithoutErrors(source);
+        AssertCompilesWithoutErrors(source, FixtureResolver());
+    }
+
+    [Fact]
+    public void GenericLambdaExtensionOverload_FromReferencedAssembly_Binds()
+    {
+        var source = @"
+package Demo
+import GSharp.Core.Tests.Fixtures
+
+func Run() string? {
+    var pair = ImportedPair2537[int32](4, 5)
+    return pair.Transform(func(value int32) string { return value.ToString() })
+}
+";
+        AssertBindsWithoutErrors(source);
+    }
+
+    [Fact]
     public void Where_OnList_InstanceSyntax_Compiles()
     {
         var source = @"
@@ -212,14 +268,16 @@ func Run() string {
         // are loaded through a MetadataLoadContext — the cross-reflection-context
         // configuration that reproduces issue #322. The Default resolver loads
         // host runtime assemblies and would not exercise that path.
-        var fixturePath = typeof(Fixtures.Handler322Extensions).Assembly.Location;
-        var resolver = ReferenceResolver.WithReferences(new[] { fixturePath });
+        var resolver = FixtureResolver();
         var tree = SyntaxTree.Parse(SourceText.From(source));
         var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), resolver);
         var program = Binder.BindProgram(globalScope, resolver);
         var diagnostics = globalScope.Diagnostics.AddRange(program.Diagnostics);
         Assert.DoesNotContain(diagnostics, d => d.IsError);
     }
+
+    private static ReferenceResolver FixtureResolver()
+        => ReferenceResolver.WithReferences(new[] { typeof(Fixtures.Handler322Extensions).Assembly.Location });
 
     private static void AssertCompilesWithoutErrors(string source)
     {
@@ -228,6 +286,16 @@ func Run() string {
             success,
             "Emit failed:\n" + string.Join("\n", diagnostics.Select(d => d.ToString())));
         Assert.DoesNotContain(diagnostics, d => d.IsError);
+    }
+
+    private static void AssertCompilesWithoutErrors(string source, ReferenceResolver resolver)
+    {
+        var compilation = new Compilation(resolver, SyntaxTree.Parse(SourceText.From(source)));
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "Emit failed:\n" + string.Join("\n", result.Diagnostics.Select(d => d.ToString())));
     }
 
     private static IReadOnlyList<Diagnostic> EmitDiagnostics(string source)

--- a/test/Core.Tests/Fixtures/Issue2537Extensions.cs
+++ b/test/Core.Tests/Fixtures/Issue2537Extensions.cs
@@ -1,0 +1,37 @@
+// <copyright file="Issue2537Extensions.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.Tests.Fixtures;
+
+public sealed class ImportedPair2537<T>
+{
+    public ImportedPair2537(T first, T second)
+    {
+        First = first;
+        Second = second;
+    }
+
+    public T First { get; }
+
+    public T Second { get; }
+}
+
+public static class Issue2537Extensions
+{
+    public static void Deconstruct<T>(this ImportedPair2537<T> pair, out T first, out T second)
+    {
+        first = pair.First;
+        second = pair.Second;
+    }
+
+    public static ImportedPair2537<T> Transform<T>(
+        this ImportedPair2537<T> pair,
+        System.Func<T, T> transform)
+        => new(transform(pair.First), transform(pair.Second));
+
+    public static TResult Transform<T, TResult>(
+        this ImportedPair2537<T> pair,
+        System.Func<T, TResult> transform)
+        => transform(pair.First);
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1922ForEachTupleDeconstructionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1922ForEachTupleDeconstructionTests.cs
@@ -76,6 +76,29 @@ namespace Demo
     }
 
     [Fact]
+    public void KeyValuePairDeconstruction_TranslatesToCompilerSupportedForTupleIn()
+    {
+        string printed = TranslateUnit(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public void M(Dictionary<string, int> values)
+        {
+            foreach (var (key, value) in values)
+            {
+            }
+        }
+    }
+}");
+
+        Assert.Contains("for (key, value) in values {", printed);
+        Assert.DoesNotContain("__decon", printed);
+    }
+
+    [Fact]
     public void AwaitForEachTupleDeconstruction_KeepsTempPlusLetLowering()
     {
         // G# has no first-class `await for (a, b) in` header, so the async


### PR DESCRIPTION
## Summary
- bind imported CLR instance and extension `Deconstruct` patterns for tuple declarations and `for` deconstruction
- infer generic extension receivers and preserve single evaluation through synthesized out locals
- cover KeyValuePair, cross-assembly generic/lambda extensions, and cs2gs dictionary foreach translation

## Validation
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --verbosity minimal` (6538 passed, 1 skipped)
- focused Core deconstruction/imported-extension suites (19 passed)
- focused cs2gs foreach deconstruction suite (4 passed)

Fixes #2537