### PR TITLE
Fix imported reference construction binding

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -718,18 +718,31 @@ internal sealed partial class ExpressionBinder
         }
         else
         {
-            if (!scope.TryLookupImportedClass(name, declaration: null, out var importedClass))
+            if (scope.TryLookupTypeAlias(name, preferredArity: 0, out var typeAlias)
+                && typeAlias is ImportedTypeSymbol { ClrType: not null } importedAlias)
+            {
+                clrType = importedAlias.ClrType;
+            }
+            else if (scope.TryLookupImport(name, out var aliasImport)
+                && aliasImport.IsAlias
+                && scope.References.TryResolveType(aliasImport.Target, out var aliasedType))
+            {
+                clrType = aliasedType;
+            }
+            else if (scope.TryLookupImportedClass(name, declaration: null, out var importedClass))
+            {
+                clrType = importedClass.ClassType;
+            }
+            else
             {
                 return false;
             }
 
-            if (importedClass.ClassType.IsGenericTypeDefinition)
+            if (clrType.IsGenericTypeDefinition)
             {
                 // User wrote `List(...)` without `[T]`; can't construct an open generic.
                 return false;
             }
-
-            clrType = importedClass.ClassType;
         }
 
         // Issue #2263: for an imported `data class` the CLR type carries a real

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
@@ -149,11 +149,12 @@ internal sealed partial class OverloadResolver
 
     /// <summary>
     /// Issue #2403: whether <paramref name="syntax"/>'s unqualified callee name
-    /// could resolve to a genuine user-defined callable — a same-compilation
+    /// could resolve to a genuine non-constructor callable — a same-compilation
     /// free/extension <see cref="FunctionSymbol"/> reachable through
     /// <see cref="Scope"/>, or an implicit-<c>this</c> instance/static sibling
     /// method (including a private one) on the enclosing struct/class or
-    /// interface body — checked BEFORE the CLR constructor/conversion
+    /// interface body, or an inherited CLR method on the implicit receiver —
+    /// checked BEFORE the CLR constructor/conversion
     /// fallbacks a few lines below in <see cref="BindCallExpression"/> run. A
     /// same-named imported CLR type (e.g. <c>System.Net.Http.HttpClient</c>)
     /// must not shadow a colliding user method in call position, mirroring how
@@ -175,7 +176,7 @@ internal sealed partial class OverloadResolver
     /// the CLR paths run exactly as before, so genuine constructor/conversion
     /// calls (e.g. `StringBuilder(16)`) are unaffected.
     /// </remarks>
-    private bool HasUserCallableCandidate(CallExpressionSyntax syntax)
+    private bool HasNonConstructorCallableCandidate(CallExpressionSyntax syntax)
     {
         var name = syntax.Identifier.Text;
 
@@ -198,6 +199,14 @@ internal sealed partial class OverloadResolver
             // overload set of the enclosing type — mirror that union here.
             if (!TypeMemberModel.GetMethods(receiverStruct, name, MemberQuery.Instance(MemberKinds.Method)).IsDefaultOrEmpty
                 || !TypeMemberModel.GetMethods(receiverStruct, name, MemberQuery.Static(MemberKinds.Method)).IsDefaultOrEmpty)
+            {
+                return true;
+            }
+
+            // An imported type with the same simple name as an inherited CLR
+            // method must not turn an implicit-receiver call into construction.
+            var inheritedClr = ExpressionBinder.GetInheritedClrBaseType(receiverStruct) ?? typeof(object);
+            if (MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(inheritedClr, name).Count > 0)
             {
                 return true;
             }
@@ -273,16 +282,16 @@ internal sealed partial class OverloadResolver
             }
         }
 
-        // Issue #2403: a resolvable user-defined callable (same-compilation
+        // Issue #2403 / #2549: a resolvable non-constructor callable (same-compilation
         // free/extension function, or an implicit-`this` instance/static
-        // sibling method) with this name takes precedence over ALL THREE CLR
+        // sibling/inherited CLR method) with this name takes precedence over ALL THREE CLR
         // constructor/conversion fallback paths below, mirroring how a
         // same-named source method always shadows a colliding imported CLR
         // type (e.g. `System.Net.Http.HttpClient`) in call position. Computed
-        // once and reused by all three gates; see HasUserCallableCandidate's
+        // once and reused by all three gates; see HasNonConstructorCallableCandidate's
         // remarks for why only existence (not full overload applicability) is
         // checked here.
-        var hasUserCallable = HasUserCallableCandidate(syntax);
+        var hasNonConstructorCallable = HasNonConstructorCallableCandidate(syntax);
 
         // Issue #1263: when the construction carries an explicit type-argument
         // list (`Op[int32](5)`), resolve the constructed type by (name, arity)
@@ -301,7 +310,7 @@ internal sealed partial class OverloadResolver
         // takes precedence over CLR-imported-class construction a few lines
         // below, mirroring (a) how a same-named source function/method already
         // shadows a colliding imported CLR type in call position
-        // (HasUserCallableCandidate, issue #2403), and (b) how the
+        // (HasNonConstructorCallableCandidate, issue #2403), and (b) how the
         // struct/class-literal binder (BindStructLiteralExpression) already
         // checks TryLookupTypeAlias before ever falling back to
         // TryLookupImportedClass. Without this, `Type(...)` for a same-simple-
@@ -323,12 +332,12 @@ internal sealed partial class OverloadResolver
         // Also handles closed-generic imports (`List[int]()`,
         // `Dictionary[string, int]()`). Interpreter-only — resolves a
         // ConstructorInfo and emits BoundClrConstructorCallExpression.
-        if (!hasUserCallable && !hasSourceConstructibleType && tryBindClrConstructorCall(syntax, out var clrCtorCall))
+        if (!hasNonConstructorCallable && !hasSourceConstructibleType && tryBindClrConstructorCall(syntax, out var clrCtorCall))
         {
             return clrCtorCall;
         }
 
-        if (!hasUserCallable && syntax.Arguments.Count == 1 && lookupTypeWithArity(syntax.Identifier.Text, ctorPreferredArity) is TypeSymbol type)
+        if (!hasNonConstructorCallable && syntax.Arguments.Count == 1 && lookupTypeWithArity(syntax.Identifier.Text, ctorPreferredArity) is TypeSymbol type)
         {
             // Issue #663: when the call carries a `?` token (e.g. `string?(x)`),
             // wrap the resolved type in NullableTypeSymbol so the conversion
@@ -368,7 +377,7 @@ internal sealed partial class OverloadResolver
         // Issue #1069: a value struct (e.g. a `data struct`) declaring a
         // primary constructor is also positionally constructible —
         // `Entry(1, 2)` lowers to a struct literal initializing its fields.
-        if (!hasUserCallable
+        if (!hasNonConstructorCallable
             && lookupTypeWithArity(syntax.Identifier.Text, ctorPreferredArity) is StructSymbol classType
             && (classType.IsClass || classType.IsInline || classType.HasPrimaryConstructor))
         {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2549ImportedConstructionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2549ImportedConstructionTests.cs
@@ -1,0 +1,79 @@
+// <copyright file="Issue2549ImportedConstructionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2549ImportedConstructionTests
+{
+    [Fact]
+    public void ImportedReferenceTypes_ConstructAndImplicitObjectMethodBinds()
+    {
+        var outputDirectory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2549ImportedConstructionTests));
+        Directory.CreateDirectory(outputDirectory);
+        var libraryPath = Path.Combine(outputDirectory, "Issue2549.Library.dll");
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Issue2549.Library
+
+                class Empty { }
+
+                class GetType { }
+
+                class Named {
+                    prop Name string
+
+                    init(name string) {
+                        Name = name
+                    }
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var libraryStream = File.Create(libraryPath))
+        {
+            var result = library.Emit(libraryStream, pdbStream: null, refStream: null, assemblyName: "Issue2549.Library");
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Issue2549.Consumer
+                import System
+                import Issue2549.Library
+                import EmptyAlias = Issue2549.Library.Empty
+                import NamedAlias = Issue2549.Library.Named
+
+                type LocalNamed = NamedAlias
+
+                class Factory {
+                    func CreateEmpty() EmptyAlias -> EmptyAlias()
+                    func CreateNamed() LocalNamed -> LocalNamed("value")
+                    func RuntimeType() Type -> GetType()
+                }
+                """)));
+
+        using var consumerStream = new MemoryStream();
+        var consumerResult = consumer.Emit(
+            consumerStream,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: "Issue2549.Consumer");
+
+        Assert.True(consumerResult.Success, string.Join(Environment.NewLine, consumerResult.Diagnostics));
+    }
+}


### PR DESCRIPTION
## Summary
- route imported reference-type aliases through shared CLR constructor binding
- preserve implicit receiver methods when imported types share their names
- add cross-assembly regression coverage for default/argument constructors and `GetType()`

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore` (6,538 passed, 1 skipped)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter FullyQualifiedName~Issue1136ObjectMemberEmitTests --verbosity minimal` (6 passed)
- targeted post-rebase binding tests (23 passed)

Fixes #2549