### PR TITLE
Fix lifted unary operators for nullable values

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundUnaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundUnaryOperator.cs
@@ -69,6 +69,23 @@ public sealed record BoundUnaryOperator
             return new BoundUnaryOperator(syntaxKind, BoundUnaryOperatorKind.NullAssertion, operandType, underlying);
         }
 
+        // Issue #2544: predefined unary operators lift from T to T? when T is
+        // a value type. Resolve the underlying operation first so invalid
+        // combinations (for example, +bool? or !int32?) still fail normally.
+        if (operandType is NullableTypeSymbol nullable
+            && nullable.UnderlyingType?.ClrType is { IsValueType: true })
+        {
+            var underlyingOperator = Bind(syntaxKind, nullable.UnderlyingType);
+            if (underlyingOperator != null)
+            {
+                return new BoundUnaryOperator(
+                    syntaxKind,
+                    underlyingOperator.Kind,
+                    operandType,
+                    NullableTypeSymbol.Get(underlyingOperator.Type));
+            }
+        }
+
         foreach (var op in supportedOperators)
         {
             if (op.SyntaxKind == syntaxKind && op.OperandType == operandType)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -190,6 +190,22 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #2544: predefined unary operators over Nullable<T> are lifted.
+        // Identity preserves the wrapper; other operators branch on HasValue.
+        if (u.Operand.Type is NullableTypeSymbol liftedOperand
+            && u.Type is NullableTypeSymbol liftedResult
+            && NullableLifting.IsValueTypeNullable(liftedOperand))
+        {
+            if (u.Op.Kind == BoundUnaryOperatorKind.Identity)
+            {
+                this.EmitExpression(u.Operand);
+                return;
+            }
+
+            this.EmitLiftedNullableUnary(u, liftedOperand, liftedResult);
+            return;
+        }
+
         // Issue #2023: checked integral negation (`-x` where x could be the
         // type's MinValue) must trap on overflow, matching #1881's checked
         // Sum/Difference/Product. Roslyn's own approach is followed: lower
@@ -239,6 +255,106 @@ internal sealed partial class MethodBodyEmitter
         {
             EmitSubI4Truncation(u.Op.Type);
         }
+    }
+
+    private void EmitLiftedNullableUnary(
+        BoundUnaryExpression u,
+        NullableTypeSymbol operandNullable,
+        NullableTypeSymbol resultNullable)
+    {
+        if (operandNullable != resultNullable)
+        {
+            throw new NotSupportedException(
+                $"Lifted unary operator '{u.Op.Kind}' with differing operand and result types is not supported.");
+        }
+
+        if (!this.receiverSpillSlots.TryGetValue(u.Operand, out var slot))
+        {
+            throw new InvalidOperationException(
+                $"No scratch slot pre-allocated for lifted unary operator '{u.Op.Kind}'.");
+        }
+
+        var nullResult = this.il.DefineLabel();
+        var end = this.il.DefineLabel();
+
+        this.EmitExpression(u.Operand);
+        this.il.StoreLocal(slot);
+        this.il.LoadLocalAddress(slot);
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(this.GetNullableHasValueRef(operandNullable));
+        this.il.Branch(ILOpCode.Brfalse, nullResult);
+
+        var underlying = operandNullable.UnderlyingType;
+        if (u.Op.Kind == BoundUnaryOperatorKind.Negation
+            && u.IsChecked
+            && IsIntegralNegationOperand(underlying))
+        {
+            if (underlying == TypeSymbol.Int64)
+            {
+                this.il.LoadConstantI8(0);
+            }
+            else
+            {
+                this.il.LoadConstantI4(0);
+            }
+
+            this.EmitUnwrappedNullableValue(slot, operandNullable);
+            this.il.OpCode(ILOpCode.Sub_ovf);
+            if (underlying == TypeSymbol.Int8)
+            {
+                this.il.OpCode(ILOpCode.Conv_ovf_i1);
+            }
+            else if (underlying == TypeSymbol.Int16)
+            {
+                this.il.OpCode(ILOpCode.Conv_ovf_i2);
+            }
+        }
+        else
+        {
+            this.EmitUnwrappedNullableValue(slot, operandNullable);
+            switch (u.Op.Kind)
+            {
+                case BoundUnaryOperatorKind.Negation:
+                    if (underlying == TypeSymbol.Decimal)
+                    {
+                        var neg = typeof(decimal).GetMethod("op_UnaryNegation", new[] { typeof(decimal) });
+                        this.il.Call(this.outer.memberRefs.GetMethodEntityHandle(neg));
+                    }
+                    else
+                    {
+                        this.il.OpCode(ILOpCode.Neg);
+                    }
+
+                    break;
+                case BoundUnaryOperatorKind.LogicalNegation:
+                    this.il.LoadConstantI4(0);
+                    this.il.OpCode(ILOpCode.Ceq);
+                    break;
+                case BoundUnaryOperatorKind.OnesComplement:
+                    this.il.OpCode(ILOpCode.Not);
+                    break;
+                default:
+                    throw new NotSupportedException($"Lifted unary operator '{u.Op.Kind}' is not supported.");
+            }
+
+            if (u.Op.Kind == BoundUnaryOperatorKind.OnesComplement
+                || u.Op.Kind == BoundUnaryOperatorKind.Negation)
+            {
+                this.EmitSubI4Truncation(underlying);
+            }
+        }
+
+        this.il.OpCode(ILOpCode.Newobj);
+        this.il.Token(this.GetNullableResultConstructor(resultNullable));
+        this.il.Branch(ILOpCode.Br, end);
+
+        this.il.MarkLabel(nullResult);
+        this.il.LoadLocalAddress(slot);
+        this.il.OpCode(ILOpCode.Initobj);
+        this.il.Token(this.outer.memberRefs.GetElementTypeToken(resultNullable));
+        this.il.LoadLocal(slot);
+
+        this.il.MarkLabel(end);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -583,12 +583,11 @@ internal sealed class MethodBodyPlanner
             receiverSpillSlots[assn] = slot;
         }
 
-        // Issue #504: `!!` on a value-type `Nullable<T>` lowers to a
-        // `stloc tmp; ldloca tmp; call Nullable<T>::get_Value` sequence; the
-        // temp must be typed as `Nullable<T>` (not the unwrapped T). Reuse
-        // receiverSpillSlots — the dictionary already aggregates several
-        // distinct-by-node-identity scratch-slot kinds (receiver spills and
-        // assignment-value spills).
+        // Issue #504 / #2544: `!!` and lifted unary operators on a value-type
+        // `Nullable<T>` need a `Nullable<T>` spill so emit can call
+        // HasValue/get_Value from its address. Reuse receiverSpillSlots — the
+        // dictionary already aggregates several distinct-by-node-identity
+        // scratch-slot kinds (receiver spills and assignment-value spills).
         //
         // Issue #1591: the slot is keyed by the unwrap's OPERAND node, NOT by
         // the BoundUnaryExpression node itself. When the smart-cast-narrowed

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -1358,6 +1358,18 @@ internal sealed class SlotPlanner
 
         protected override void VisitUnaryExpression(BoundUnaryExpression node)
         {
+            // Issue #2544: non-identity lifted unary operators need the same
+            // Nullable<T>-typed spill slot as `!!` so emit can branch on
+            // HasValue and unwrap the present value exactly once.
+            if (node.Op.Kind != BoundUnaryOperatorKind.NullAssertion
+                && node.Op.Kind != BoundUnaryOperatorKind.Identity
+                && node.Operand.Type is NullableTypeSymbol liftedOperand
+                && node.Type is NullableTypeSymbol
+                && NullableLifting.IsValueTypeNullable(liftedOperand))
+            {
+                this.sink.Add(node);
+            }
+
             if (node.Op.Kind == BoundUnaryOperatorKind.NullAssertion)
             {
                 bool needsSlot = false;

--- a/src/Core/CodeAnalysis/Evaluator.Operators.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Operators.cs
@@ -31,6 +31,16 @@ public sealed partial class Evaluator
     {
         var operand = EvaluateExpression(u.Operand);
 
+        // Issue #2544: lifted unary operators propagate an empty Nullable<T>.
+        // Present nullable values are boxed as T and continue through the
+        // existing underlying operation below.
+        if (operand == null
+            && u.Operand.Type is NullableTypeSymbol
+            && u.Type is NullableTypeSymbol)
+        {
+            return null;
+        }
+
         // Issue #615: unwrap enum operands to underlying before arithmetic/bitwise.
         var rawOperand = UnwrapEnumToUnderlying(operand);
 

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2544LiftedUnaryOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2544LiftedUnaryOperatorTests.cs
@@ -1,0 +1,115 @@
+// <copyright file="Issue2544LiftedUnaryOperatorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+public class Issue2544LiftedUnaryOperatorTests
+{
+    [Fact]
+    public void Interpreter_LiftedUnaryOperatorsMatchNullableSemantics()
+    {
+        Assert.Equal(true, Evaluate("var value bool? = nil\n(!value) ?? true"));
+        Assert.Equal(false, Evaluate("var value bool? = true\n(!value) ?? true"));
+        Assert.Equal(-5, Evaluate("var value int32? = 5\n(-value) ?? 0"));
+    }
+
+    [Fact]
+    public void LiftedUnaryOperators_PropagateNilAndOperateOnPresentValues()
+    {
+        const string Source = """
+            package Issue2544
+            import System
+
+            var yes bool? = true
+            var noBool bool? = nil
+            Console.WriteLine((!yes) ?? true)
+            Console.WriteLine((!noBool) ?? false)
+
+            var five int32? = 5
+            var noInt int32? = nil
+            Console.WriteLine((-five) ?? 42)
+            Console.WriteLine((-noInt) ?? 42)
+            Console.WriteLine((^five) ?? 0)
+            Console.WriteLine((+five) ?? 0)
+            """;
+
+        Assert.Equal("False\nFalse\n-5\n42\n-6\n5\n", CompileAndRun(Source));
+    }
+
+    [Theory]
+    [InlineData("+", "bool?")]
+    [InlineData("!", "int32?")]
+    [InlineData("-", "uint32?")]
+    public void InvalidUnderlyingUnaryOperation_StillReportsGS0128(string op, string type)
+    {
+        var source = $"package Invalid\nvar value {type} = nil\nvar bad = {op}value\n";
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        using var peStream = new MemoryStream();
+
+        var result = compilation.Emit(peStream);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0128");
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        using var peStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext("Issue2544", isCollectible: true);
+        try
+        {
+            var assembly = loadContext.LoadFromStream(peStream);
+            var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+            var entry = program.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var previous = Console.Out;
+            using var output = new StringWriter();
+            Console.SetOut(output);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(previous);
+            }
+
+            return output.ToString().Replace("\r\n", "\n");
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static object Evaluate(string source)
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(result.Diagnostics);
+        return result.Value;
+    }
+}


### PR DESCRIPTION
## Summary
- bind predefined unary operators through their nullable value-type underlying operation
- emit and interpret lifted null propagation, including `bool?` logical negation
- retain GS0128 for invalid underlying unary operations

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore` (6,545 passed)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter "FullyQualifiedName~NullableLiftedBinaryOperatorEmitTests|FullyQualifiedName~Issue2398ExpressionTreeLiftedUserOperatorEmitTests"` (23 passed)

Fixes #2544