### PR TITLE
Fix generic API method-group inference

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1459,6 +1459,11 @@ internal sealed class ConversionClassifier
             targetParameterTypes = pb.MoveToImmutable();
             targetReturnType = userDelegate.ReturnType;
         }
+        else if (MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(targetType, out var importedDelegate))
+        {
+            targetParameterTypes = importedDelegate.ParameterTypes;
+            targetReturnType = importedDelegate.ReturnType;
+        }
         else
         {
             if (targetType != null && targetType != TypeSymbol.Error)
@@ -1487,7 +1492,7 @@ internal sealed class ConversionClassifier
             {
                 var candidateParameterType = candidateOwner?.SubstituteMemberType(candidate.Parameters[i + parameterOffset].Type)
                     ?? candidate.Parameters[i + parameterOffset].Type;
-                if (!ReferenceEquals(candidateParameterType, targetParameterTypes[i]))
+                if (!AreMethodGroupTypesEquivalent(candidateParameterType, targetParameterTypes[i]))
                 {
                     paramsMatch = false;
                     break;
@@ -1500,7 +1505,7 @@ internal sealed class ConversionClassifier
             }
 
             var candidateReturn = candidateOwner?.SubstituteMemberType(candidate.Type) ?? candidate.Type ?? TypeSymbol.Void;
-            if (!ReferenceEquals(candidateReturn, targetReturnType))
+            if (!AreMethodGroupTypesEquivalent(candidateReturn, targetReturnType))
             {
                 continue;
             }
@@ -2163,6 +2168,12 @@ internal sealed class ConversionClassifier
 
         return ClrTypeUtilities.IsAssignableByName(invokeReturn, methodReturn);
     }
+
+    private static bool AreMethodGroupTypesEquivalent(TypeSymbol left, TypeSymbol right)
+        => ReferenceEquals(left, right)
+            || (left?.ClrType != null
+                && right?.ClrType != null
+                && ClrTypeUtilities.AreSame(left.ClrType, right.ClrType));
 
     // ADR-0062: an inner ref-kind modifier on a conditional ref-argument branch
     // must agree with the outer modifier text (`ref`, `out`, `in`, or `&`).

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -843,7 +843,8 @@ internal sealed partial class ExpressionBinder
             argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
             constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
-            structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments));
+            structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments),
+            methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution));
 
         switch (resolution.Outcome)
         {
@@ -1225,7 +1226,8 @@ internal sealed partial class ExpressionBinder
             argumentNames: extensionArgumentNames,
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
             constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments, argumentOffset: 1),
-            structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments, argumentOffset: 1));
+            structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments, argumentOffset: 1),
+            methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution, argumentOffset: 1));
 
         switch (resolution.Outcome)
         {
@@ -2699,7 +2701,8 @@ internal sealed partial class ExpressionBinder
             interpolatedStringArgs,
             argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
             constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
-            structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments));
+            structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments),
+            methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution));
         if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
         {
             return false;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2534,7 +2534,8 @@ internal sealed partial class ExpressionBinder
                     argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
                     supplementaryInterfaceCheck: supplementaryInterfaceCheck,
                     constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
-                    structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments));
+                    structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments),
+                    methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution));
                 switch (resolution.Outcome)
                 {
                     case OverloadResolution.ResolutionOutcome.Resolved:

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1486,6 +1486,147 @@ internal sealed partial class ExpressionBinder
         return null;
     }
 
+    internal static Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> MakeMethodGroupInference(
+        IReadOnlyList<BoundExpression> arguments,
+        Func<TypeSymbol, Type> projectType,
+        int argumentOffset = 0)
+    {
+        if (arguments == null || !arguments.Any(OverloadResolution.IsUnresolvedMethodGroupArgument))
+        {
+            return null;
+        }
+
+        return (argumentIndex, delegateParameterTypes) =>
+        {
+            var sourceIndex = argumentIndex - argumentOffset;
+            if (sourceIndex < 0 || sourceIndex >= arguments.Count)
+            {
+                return null;
+            }
+
+            return ResolveMethodGroupInferenceSignature(arguments[sourceIndex], delegateParameterTypes, projectType);
+        };
+    }
+
+    private static Tuple<Type[], Type> ResolveMethodGroupInferenceSignature(
+        BoundExpression argument,
+        IReadOnlyList<Type> delegateParameterTypes,
+        Func<TypeSymbol, Type> projectType)
+    {
+        if (argument is BoundClrMethodGroupExpression { ResolvedMethod: null } clrGroup)
+        {
+            var closesExtensionReceiver = clrGroup.Receiver != null
+                && clrGroup.Candidates.All(candidate => candidate.IsStatic);
+            var resolutionArguments = new Type[delegateParameterTypes.Count + (closesExtensionReceiver ? 1 : 0)];
+            if (closesExtensionReceiver)
+            {
+                var receiverClr = projectType(clrGroup.Receiver.Type);
+                if (receiverClr == null)
+                {
+                    return null;
+                }
+
+                resolutionArguments[0] = receiverClr;
+            }
+
+            for (var i = 0; i < delegateParameterTypes.Count; i++)
+            {
+                resolutionArguments[i + (closesExtensionReceiver ? 1 : 0)] = delegateParameterTypes[i];
+            }
+
+            var resolution = OverloadResolution.Resolve(clrGroup.Candidates, resolutionArguments);
+            if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
+            {
+                return null;
+            }
+
+            var method = resolution.Best;
+            var parameters = method.GetParameters();
+            var parameterOffset = closesExtensionReceiver ? 1 : 0;
+            var signatureParameters = new Type[parameters.Length - parameterOffset];
+            for (var i = parameterOffset; i < parameters.Length; i++)
+            {
+                signatureParameters[i - parameterOffset] = parameters[i].ParameterType;
+            }
+
+            return Tuple.Create(signatureParameters, method.ReturnType);
+        }
+
+        if (argument is not BoundMethodGroupExpression { FunctionType: null } userGroup)
+        {
+            return null;
+        }
+
+        var matches = new List<(Tuple<Type[], Type> Signature, OverloadResolution.ImplicitConversionKind[] Conversions)>();
+        foreach (var candidate in userGroup.Candidates)
+        {
+            var candidateOwner = userGroup.StaticOwnerType != null && candidate.StaticOwnerType is StructSymbol declaredOwner
+                ? TypeMemberModel.ResolveStaticMemberOwner(userGroup.StaticOwnerType, declaredOwner)
+                : null;
+            var parameterOffset = candidate.IsExtension && userGroup.Receiver != null ? 1 : 0;
+            if (candidate.Parameters.Length - parameterOffset != delegateParameterTypes.Count)
+            {
+                continue;
+            }
+
+            var parameterTypes = new Type[delegateParameterTypes.Count];
+            var conversions = new OverloadResolution.ImplicitConversionKind[delegateParameterTypes.Count];
+            var compatible = true;
+            for (var i = 0; i < parameterTypes.Length; i++)
+            {
+                var parameterSymbol = candidateOwner?.SubstituteMemberType(candidate.Parameters[i + parameterOffset].Type)
+                    ?? candidate.Parameters[i + parameterOffset].Type;
+                parameterTypes[i] = projectType(parameterSymbol);
+                conversions[i] = parameterTypes[i] == null
+                    ? OverloadResolution.ImplicitConversionKind.None
+                    : OverloadResolution.ClassifyImplicit(parameterTypes[i], delegateParameterTypes[i]);
+                if (conversions[i] == OverloadResolution.ImplicitConversionKind.None)
+                {
+                    compatible = false;
+                    break;
+                }
+            }
+
+            if (!compatible)
+            {
+                continue;
+            }
+
+            var returnSymbol = candidateOwner?.SubstituteMemberType(candidate.Type) ?? candidate.Type ?? TypeSymbol.Void;
+            var returnType = projectType(returnSymbol);
+            if (returnType == null)
+            {
+                continue;
+            }
+
+            matches.Add((Tuple.Create(parameterTypes, returnType), conversions));
+        }
+
+        var best = matches.Where(candidate =>
+            !matches.Any(other =>
+                !ReferenceEquals(candidate.Signature, other.Signature)
+                && IsBetterMethodGroupConversion(other.Conversions, candidate.Conversions))).ToList();
+        return best.Count == 1 ? best[0].Signature : null;
+    }
+
+    private static bool IsBetterMethodGroupConversion(
+        IReadOnlyList<OverloadResolution.ImplicitConversionKind> candidate,
+        IReadOnlyList<OverloadResolution.ImplicitConversionKind> other)
+    {
+        var strictlyBetter = false;
+        for (var i = 0; i < candidate.Count; i++)
+        {
+            if (candidate[i] > other[i])
+            {
+                return false;
+            }
+
+            strictlyBetter |= candidate[i] < other[i];
+        }
+
+        return strictlyBetter;
+    }
+
     /// <summary>
     /// Issue #1582: resolves the CLR/metadata base type that a user-defined G#
     /// class (transitively) derives from, so inherited CLR members can be

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -662,7 +662,11 @@ internal static class OverloadResolution
     /// Optional binder callback that recognizes an argument's symbolic object
     /// shape as projectable to a candidate CLR parameter type.
     /// </param>
-    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null)
+    /// <param name="methodGroupInference">
+    /// Optional callback that resolves a deferred method group from the input
+    /// types of the candidate's delegate parameter for generic inference.
+    /// </param>
+    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null)
         where T : MethodBase
     {
         var applicable = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)>();
@@ -686,7 +690,7 @@ internal static class OverloadResolution
             // rest.
             try
             {
-                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck, structuralProjectionArgumentCheck);
+                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck, structuralProjectionArgumentCheck, methodGroupInference);
             }
             catch (Exception ex) when (IsMetadataLoadFailure(ex))
             {
@@ -1066,16 +1070,23 @@ internal static class OverloadResolution
     /// definition from the supplied argument types. Implements a deliberately
     /// scoped subset of C# §7.5.2 "Type inference": only the input-type
     /// inference phase against argument CLR types, plus exact unification on
-    /// recursive generic / array shapes. Lambdas and unbound delegate-typed
-    /// arguments are not considered. Returns <see langword="true"/> with
+    /// recursive generic / array shapes. Deferred lambdas are not considered;
+    /// a deferred method group can contribute output inference through
+    /// <paramref name="methodGroupInference"/> after its delegate input types
+    /// are inferred from the other arguments. Returns <see langword="true"/> with
     /// <paramref name="typeArgs"/> populated when every method type parameter
     /// receives a single consistent bound; <see langword="false"/> otherwise.
     /// </summary>
     /// <param name="openMethod">An open generic method definition (i.e. <see cref="MethodBase.IsGenericMethodDefinition"/> is <see langword="true"/>).</param>
     /// <param name="argTypes">CLR types of the supplied arguments.</param>
     /// <param name="typeArgs">On success, the inferred type arguments in declaration order.</param>
+    /// <param name="methodGroupInference">Optional deferred method-group signature resolver.</param>
     /// <returns>Whether inference succeeded.</returns>
-    public static bool TryInferTypeArguments(MethodInfo openMethod, IReadOnlyList<Type> argTypes, out Type[] typeArgs)
+    public static bool TryInferTypeArguments(
+        MethodInfo openMethod,
+        IReadOnlyList<Type> argTypes,
+        out Type[] typeArgs,
+        Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null)
     {
         typeArgs = null;
         if (openMethod is null || !openMethod.IsGenericMethodDefinition)
@@ -1119,6 +1130,17 @@ internal static class OverloadResolution
             if (!UnifyForInference(parameters[i].ParameterType, arg, bounds))
             {
                 return false;
+            }
+        }
+
+        if (methodGroupInference != null)
+        {
+            for (var i = 0; i < argTypes.Count; i++)
+            {
+                if (argTypes[i] is null)
+                {
+                    TryInferMethodGroupArgument(parameters[i].ParameterType, i, bounds, methodGroupInference);
+                }
             }
         }
 
@@ -1388,6 +1410,57 @@ internal static class OverloadResolution
         }
 
         return false;
+    }
+
+    private static bool TryInferMethodGroupArgument(
+        Type delegateType,
+        int argumentIndex,
+        Dictionary<string, Type> bounds,
+        Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference)
+    {
+        if (!TryGetDelegateSignature(delegateType, out var delegateParameters, out var delegateReturn))
+        {
+            return false;
+        }
+
+        var closedInputs = new Type[delegateParameters.Length];
+        for (var i = 0; i < delegateParameters.Length; i++)
+        {
+            if (!TryCloseInferredType(delegateParameters[i], bounds, out closedInputs[i]))
+            {
+                return false;
+            }
+        }
+
+        var signature = methodGroupInference(argumentIndex, closedInputs);
+        if (signature?.Item1 is null
+            || signature.Item1.Length != delegateParameters.Length
+            || signature.Item2 is null)
+        {
+            return false;
+        }
+
+        var inferred = new Dictionary<string, Type>(bounds, StringComparer.Ordinal);
+        for (var i = 0; i < delegateParameters.Length; i++)
+        {
+            if (!UnifyForInference(delegateParameters[i], signature.Item1[i], inferred))
+            {
+                return false;
+            }
+        }
+
+        if (!UnifyForInference(delegateReturn, signature.Item2, inferred))
+        {
+            return false;
+        }
+
+        bounds.Clear();
+        foreach (var pair in inferred)
+        {
+            bounds.Add(pair.Key, pair.Value);
+        }
+
+        return true;
     }
 
     private static bool IsSafeArrayInterfaceVariance(Type target, Type source)
@@ -2186,7 +2259,7 @@ internal static class OverloadResolution
     /// so the per-candidate work can be guarded against reflection load
     /// failures (issue #321) without disturbing the surrounding control flow.
     /// </summary>
-    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null)
+    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null)
         where T : MethodBase
     {
         {
@@ -2266,6 +2339,7 @@ internal static class OverloadResolution
                 // unification, so the mapping must already be known before
                 // inference; we use this open candidate's parameters to compute it.
                 IReadOnlyList<Type> inferenceArgTypes = argTypes;
+                var inferenceMethodGroup = methodGroupInference;
                 if (argumentNames != null && HasAnyNamedArgument(argumentNames))
                 {
                     if (!TryBuildOrderedArgTypesForInference(mi, argTypes, argumentNames, out var orderedArgTypes))
@@ -2274,9 +2348,25 @@ internal static class OverloadResolution
                     }
 
                     inferenceArgTypes = orderedArgTypes;
+                    if (methodGroupInference != null
+                        && TryBuildNamedArgumentMapping(mi.GetParameters(), argTypes.Count, argumentNames, out var sourceToParameter))
+                    {
+                        var parameterToSource = Enumerable.Repeat(-1, mi.GetParameters().Length).ToArray();
+                        for (var sourceIndex = 0; sourceIndex < sourceToParameter.Length; sourceIndex++)
+                        {
+                            parameterToSource[sourceToParameter[sourceIndex]] = sourceIndex;
+                        }
+
+                        inferenceMethodGroup = (parameterIndex, delegateParameters) =>
+                            parameterIndex >= 0
+                                && parameterIndex < parameterToSource.Length
+                                && parameterToSource[parameterIndex] >= 0
+                                ? methodGroupInference(parameterToSource[parameterIndex], delegateParameters)
+                                : null;
+                    }
                 }
 
-                if (!TryInferTypeArguments(mi, inferenceArgTypes, out var typeArgs))
+                if (!TryInferTypeArguments(mi, inferenceArgTypes, out var typeArgs, inferenceMethodGroup))
                 {
                     return;
                 }

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -260,6 +260,12 @@ public sealed class ImportedClassSymbol : Symbol
             var t = NullableTypeSymbol.GetEffectiveClrType(arguments[i].Type);
             if (t == null && arguments[i].Type != TypeSymbol.Null)
             {
+                if (OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[i]))
+                {
+                    argTypes[i] = null;
+                    continue;
+                }
+
                 if (arguments[i].Type is StructSymbol { IsClass: true } ss)
                 {
                     t = ss.ImportedBaseType?.ClrType ?? typeof(object);
@@ -338,7 +344,8 @@ public sealed class ImportedClassSymbol : Symbol
             argumentNames,
             closed => MemberLookup.BuildSymbolicMethodTypeArgs(closed, typeArgSymbols, symbolicArgVector),
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
-            constantNarrowingArgumentCheck: ExpressionBinder.MakeConstantNarrowingArgumentCheck(arguments));
+            constantNarrowingArgumentCheck: ExpressionBinder.MakeConstantNarrowingArgumentCheck(arguments),
+            methodGroupInference: ExpressionBinder.MakeMethodGroupInference(arguments, ProjectMethodGroupType));
 
         switch (result.Outcome)
         {
@@ -407,6 +414,27 @@ public sealed class ImportedClassSymbol : Symbol
     /// <returns>Whether we found a matching function or not.</returns>
     public bool TryLookupFunction(string text, CallExpressionSyntax callExpression, ImmutableArray<BoundExpression> arguments, out ImportedFunctionSymbol function)
         => TryLookupFunction(text, callExpression, arguments, out function, out _);
+
+    private static Type ProjectMethodGroupType(TypeSymbol type)
+    {
+        var clrType = NullableTypeSymbol.GetEffectiveClrType(type);
+        if (clrType != null)
+        {
+            return clrType;
+        }
+
+        if (type is StructSymbol { IsClass: true } userClass)
+        {
+            return userClass.ImportedBaseType?.ClrType ?? typeof(object);
+        }
+
+        if (type is EnumSymbol)
+        {
+            return typeof(int);
+        }
+
+        return MemberLookup.TryProjectErasedClrType(type, out var erased) ? erased : null;
+    }
 
     /// <summary>
     /// ADR-0055 Tier 4 (#369): produces the per-argument flags marking which

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2546MethodGroupGenericInferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2546MethodGroupGenericInferenceTests.cs
@@ -1,0 +1,124 @@
+// <copyright file="Issue2546MethodGroupGenericInferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+public class Issue2546MethodGroupGenericInferenceTests
+{
+    [Fact]
+    public void ImportedMethodGroup_Select_InfersResultAndRuns()
+    {
+        const string Source = @"
+package ImportedMethodGroup
+import System
+import System.Collections.Generic
+import System.Linq
+
+func main() int32 {
+    var values = List[string]()
+    values.Add(""20"")
+    values.Add(""22"")
+    return values.Select(Int32.Parse).Sum()
+}
+";
+        Assert.Equal(42, CompileAndRun(Source, nameof(ImportedMethodGroup_Select_InfersResultAndRuns)));
+    }
+
+    [Fact]
+    public void OverloadedSourceMethodGroup_Select_InfersResultAndRuns()
+    {
+        const string Source = @"
+package SourceMethodGroup
+import System
+import System.Collections.Generic
+import System.Linq
+
+func ConvertValue(s string) int32 { return Int32.Parse(s) }
+func ConvertValue(n int32) string { return n.ToString() }
+
+func main() int32 {
+    var values = List[string]()
+    values.Add(""40"")
+    values.Add(""2"")
+    return values.Select(ConvertValue).Sum()
+}
+";
+        Assert.Equal(42, CompileAndRun(Source, nameof(OverloadedSourceMethodGroup_Select_InfersResultAndRuns)));
+    }
+
+    [Fact]
+    public void ImportedMethodGroup_StaticGenericApi_InfersResultAndRuns()
+    {
+        const string Source = @"
+package StaticGenericApi
+import System
+
+func main() int32 {
+    var values = []string{ ""40"", ""2"" }
+    var parsed = Array.ConvertAll(values, Int32.Parse)
+    return parsed[0] + parsed[1]
+}
+";
+        Assert.Equal(42, CompileAndRun(Source, nameof(ImportedMethodGroup_StaticGenericApi_InfersResultAndRuns)));
+    }
+
+    [Fact]
+    public void AmbiguousSourceMethodGroup_DoesNotInferArbitraryResult()
+    {
+        const string Source = @"
+package AmbiguousMethodGroup
+import System
+import System.Collections.Generic
+import System.Linq
+
+func Project(x IComparable) int32 { return 1 }
+func Project(x ICloneable) string { return ""x"" }
+
+func main() {
+    var values = List[string]()
+    values.Select(Project)
+}
+";
+        using var peStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(Source)));
+        var result = compilation.Emit(peStream);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    private static object CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var assembly = loadContext.LoadFromStream(peStream);
+            var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+            var main = program.GetMethod("main", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(main);
+            return main!.Invoke(null, null);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- infer generic delegate result types from source and imported method groups
- support extension, instance, constrained, and static imported generic APIs
- preserve method-group overload ranking and reject ambiguity

## Tests
- full Core.Tests: 6,541 passed, 1 skipped
- Compiler.Tests method-group filter: 27 passed
- post-rebase method-group suites: 21 passed

Fixes #2546