### PR TITLE
Fix nullable interface variance conversions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -903,7 +903,11 @@ public sealed class Conversion
                 {
                     foreach (var i in c.Interfaces)
                     {
-                        if (i == toInterface)
+                        // Issue #2535: lift declaration-site variance through a
+                        // class's implemented interface (e.g. C : IOut<object>
+                        // converts to IOut<object?>). Direct interface values
+                        // already use this same safe, reference-only check below.
+                        if (i == toInterface || IsVarianceCompatibleInterfaceConversion(i, toInterface))
                         {
                             return Conversion.Implicit;
                         }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2535NullableReferenceConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2535NullableReferenceConversionTests.cs
@@ -1,0 +1,69 @@
+// <copyright file="Issue2535NullableReferenceConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2535: class-to-interface conversion must honor the same safe
+/// declaration-site variance as an already interface-typed value.
+/// </summary>
+public sealed class Issue2535NullableReferenceConversionTests
+{
+    [Fact]
+    public void CovariantImplementedInterfaceLiftsThroughReferenceNullability()
+    {
+        var result = Evaluate("""
+            interface IService[out T] {}
+            class Service : IService[object] {}
+
+            func InterfaceControl(value IService[object]) IService[object?]? -> value
+            func Lift(value Service) IService[object?]? -> value
+            func NullableLift(value Service?) IService[object?]? -> value
+            func AssertedLift(value Service?) IService[object?] -> value!!
+            func FlowLift(value object?) IService[object?]? {
+                if value is Service {
+                    return value
+                }
+                return nil
+            }
+            """);
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void NullableReferenceCannotFlowToNonNullableOrUnrelatedTarget()
+    {
+        var result = Evaluate("""
+            interface IService {}
+            class Service : IService {}
+            class Other {}
+            interface IInvariant[T] {}
+            class InvariantService : IInvariant[object] {}
+
+            func DropsNull(value Service?) IService -> value
+            func Unrelated(value Other) IService? -> value
+            func InvariantWiden(value InvariantService) IInvariant[object?]? -> value
+            """);
+
+        Assert.Contains(result.Diagnostics, d => d.Id is "GS0155" or "GS0156");
+        Assert.Equal(3, result.Diagnostics.Count());
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = GsSyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GsCompilation(tree) { IsLibrary = true };
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary
- lift declaration-site variance through class implemented-interface conversions
- preserve nullable and null-forgiven flow conversions to covariant interfaces
- retain diagnostics for null-dropping, unrelated, and invariant conversions

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet build GSharp.sln --no-restore -graph`
- 28 related Core.Tests passed
- 5 nullable emit tests passed

Fixes #2535