### PR TITLE
Fix delegate factory return covariance

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -2458,7 +2458,19 @@ public sealed class Conversion
             return true;
         }
 
-        return false;
+        // Issue #2542: same-compilation classes and interfaces have no CLR
+        // backing while binding, so the CLR-only delegate checks cannot see a
+        // safe concrete-to-interface (or derived-to-base) return covariance.
+        // Reuse the scalar conversion rules, but require both ends to be
+        // reference-like and exclude structural projection. Function
+        // parameters remain exact in IsFunctionShapeAssignable.
+        if (!IsReferenceLikeTarget(fromReturn) || !IsReferenceLikeTarget(toReturn))
+        {
+            return false;
+        }
+
+        var conversion = ClassifyNonStructural(fromReturn, toReturn);
+        return conversion.Exists && conversion.IsImplicit;
     }
 
     private static bool IsEnumLikeType(TypeSymbol type)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -110,7 +110,7 @@ internal sealed partial class MethodBodyEmitter
         // fire.
         if (conv.Expression.Type is FunctionTypeSymbol fnNoOpFrom
             && conv.Type is FunctionTypeSymbol fnNoOpTo
-            && IsReturnNullableWideningFunctionConversion(fnNoOpFrom, fnNoOpTo))
+            && IsRepresentationPreservingFunctionConversion(fnNoOpFrom, fnNoOpTo))
         {
             this.EmitExpression(conv.Expression);
             return;
@@ -552,14 +552,10 @@ internal sealed partial class MethodBodyEmitter
             $"Conversion from '{from.Name}' to '{to.Name}' is not yet supported by the emitter.");
     }
 
-    // Issue #1356: returns true when two function types differ only by a
-    // return-type nullable widening (`(P...) -> T` to `(P...) -> T?`, same
-    // underlying type), with identical parameter shapes. Such a conversion is a
-    // representation-preserving no-op because a nullable annotation erases to its
-    // underlying CLR type, so both function types materialise to the same
-    // delegate. The reverse direction (`T? -> T`) is not recognised — the binder
-    // already rejects it — so this never widens a narrowing.
-    private static bool IsReturnNullableWideningFunctionConversion(
+    // Issues #1356/#2542: nullable return widening erases to the same CLR type,
+    // and Func's return slot is CLR-covariant for reference upcasts. Both are
+    // no-ops; parameters must remain exact.
+    private static bool IsRepresentationPreservingFunctionConversion(
         FunctionTypeSymbol from,
         FunctionTypeSymbol to)
     {
@@ -576,8 +572,20 @@ internal sealed partial class MethodBodyEmitter
             }
         }
 
-        return to.ReturnType is NullableTypeSymbol toNullableReturn
-            && toNullableReturn.UnderlyingType == from.ReturnType;
+        if (to.ReturnType is NullableTypeSymbol toNullableReturn
+            && toNullableReturn.UnderlyingType == from.ReturnType)
+        {
+            return true;
+        }
+
+        if (!Conversion.IsReferenceLikeTarget(from.ReturnType)
+            || !Conversion.IsReferenceLikeTarget(to.ReturnType))
+        {
+            return false;
+        }
+
+        var returnConversion = Conversion.ClassifyNonStructural(from.ReturnType, to.ReturnType);
+        return returnConversion.Exists && returnConversion.IsImplicit;
     }
 
     // Issue #1236: emit a lifted numeric widening between two distinct value-type

--- a/test/Compiler.Tests/Emit/Issue2542DelegateFactoryCovarianceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2542DelegateFactoryCovarianceEmitTests.cs
@@ -1,0 +1,151 @@
+// <copyright file="Issue2542DelegateFactoryCovarianceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2542: factory function values may covary their return type, but their
+/// parameter types remain invariant.
+/// </summary>
+public class Issue2542DelegateFactoryCovarianceEmitTests
+{
+    [Fact]
+    public void FunctionValueAndLambda_ConcreteReturnToInterfaceFactory_Run()
+    {
+        var output = CompileAndRun("""
+            package P
+
+            interface IProduct {
+                func Name() string;
+            }
+
+            class Product : IProduct {
+                func Name() string { return "product" }
+            }
+
+            func Make() Product { return Product() }
+            func Use(factory () -> IProduct) string { return factory().Name() }
+
+            func Main() {
+                let factory () -> Product = Make
+                System.Console.WriteLine(Use(factory))
+                System.Console.WriteLine(Use(() -> Product()))
+            }
+            """);
+
+        Assert.Equal("product\nproduct\n", output);
+    }
+
+    [Fact]
+    public void NarrowerFactoryParameter_IsRejected()
+    {
+        var (exit, diagnostics) = TryCompile("""
+            package P
+
+            interface IAnimal { }
+            class Dog : IAnimal { }
+            class Cat : IAnimal { }
+
+            func DescribeDog(value Dog) string { return "dog" }
+            func Use(factory (IAnimal) -> string) string { return factory(Cat()) }
+
+            func Main() {
+                let factory (Dog) -> string = DescribeDog
+                System.Console.WriteLine(Use(factory))
+            }
+            """);
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("GS0154", diagnostics);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var dir = Directory.CreateTempSubdirectory("gs_2542_run_").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "test.gs");
+            var output = Path.Combine(dir, "test.dll");
+            File.WriteAllText(path, source);
+
+            var (exit, diagnostics) = RunCompiler(path, output, "exe");
+            Assert.True(exit == 0, diagnostics);
+            IlVerifier.Verify(output);
+
+            File.WriteAllText(Path.ChangeExtension(output, "runtimeconfig.json"), """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var start = new ProcessStartInfo("dotnet", "exec \"" + output + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var process = Process.Start(start)!;
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            Assert.True(process.ExitCode == 0, stderr);
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    private static (int Exit, string Diagnostics) TryCompile(string source)
+    {
+        var dir = Directory.CreateTempSubdirectory("gs_2542_compile_").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "test.gs");
+            var output = Path.Combine(dir, "test.dll");
+            File.WriteAllText(path, source);
+            return RunCompiler(path, output, "exe");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    private static (int Exit, string Diagnostics) RunCompiler(string source, string output, string target)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exit = Program.Main(new[]
+            {
+                "/out:" + output,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                source,
+            });
+            return (exit, stdout.ToString() + stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- generalize function return covariance to safe same-compilation reference upcasts
- emit CLR-covariant function conversions without adapters while keeping parameters invariant
- add runtime coverage for function values/lambdas and a negative parameter-variance regression

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --verbosity minimal` (6,542 passed, 1 skipped)
- focused Compiler.Tests covariance suite (11 passed)

Fixes #2542