### PR TITLE
Cover null-coalescing delegate common types

### DIFF
--- a/test/Compiler.Tests/Emit/Issue1239CoalesceCommonTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1239CoalesceCommonTypeEmitTests.cs
@@ -55,6 +55,38 @@ public class Issue1239CoalesceCommonTypeEmitTests
     }
 
     [Fact]
+    public void RightSubtypeAndDelegateFactory_ConvertToNullableLeftTypes()
+    {
+        var source = """
+            package P
+
+            import System
+
+            interface ILogger { func Name() string; }
+            class RealLogger : ILogger { func Name() string { return "real" } }
+            class NullLogger : ILogger { func Name() string { return "null" } }
+
+            func PickLogger(logger ILogger?) ILogger {
+                return logger ?? NullLogger()
+            }
+
+            func PickFactory(factory (() -> ILogger)?) () -> ILogger {
+                return factory ?? (() -> NullLogger())
+            }
+
+            var realFactory (() -> ILogger) = () -> RealLogger()
+            Console.WriteLine(PickLogger(RealLogger()).Name())
+            Console.WriteLine(PickLogger(nil).Name())
+            Console.WriteLine(PickFactory(realFactory)().Name())
+            Console.WriteLine(PickFactory(nil)().Name())
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("real\nnull\nreal\nnull\n", output);
+    }
+
+    [Fact]
     public void RightIsBaseClass_ResultIsBaseClass()
     {
         var source = """

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1239CoalesceCommonTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1239CoalesceCommonTypeTests.cs
@@ -48,6 +48,74 @@ class C {
     }
 
     [Fact]
+    public void RightSubtypeConvertsToNullableLeftInterface()
+    {
+        const string Source = @"package Issue2540.Iface
+
+interface ILogger { func Name() string; }
+class NullLogger : ILogger { func Name() string { return ""null"" } }
+class C {
+    func Pick(logger ILogger?) ILogger { return logger ?? NullLogger() }
+}
+";
+        var diagnostics = EmitDiagnostics(Source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0129");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void ImportedRightSubtypeConvertsToNullableLeftInterface()
+    {
+        const string Source = @"package Issue2540.ImportedIface
+
+import System
+import System.IO
+
+class C {
+    func Pick(resource IDisposable?) IDisposable { return resource ?? MemoryStream() }
+}
+";
+        var diagnostics = EmitDiagnostics(Source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0129");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void RightDelegateFactoryConvertsToNullableLeftDelegate()
+    {
+        const string Source = @"package Issue2540.Delegate
+
+interface ILogger { func Name() string; }
+class NullLogger : ILogger { func Name() string { return ""null"" } }
+class C {
+    func Pick(factory (() -> ILogger)?) () -> ILogger {
+        return factory ?? (() -> NullLogger())
+    }
+}
+";
+        var diagnostics = EmitDiagnostics(Source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0129");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void UnrelatedDelegateFactoryReturnStillReportsError()
+    {
+        const string Source = @"package Issue2540.InvalidDelegate
+
+interface ILogger { }
+class Other { }
+class C {
+    func Bad(factory (() -> ILogger)?) () -> ILogger {
+        return factory ?? (() -> Other())
+    }
+}
+";
+        var diagnostics = EmitDiagnostics(Source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0129");
+    }
+
+    [Fact]
     public void ExplicitTargetType_BindsToInterface()
     {
         const string Source = @"package Issue1239.Target


### PR DESCRIPTION
## Summary
- preserve latest main's generalized delegate return covariance implementation
- add issue-specific subtype-to-interface and nullable delegate-factory coalescing coverage
- guard unrelated delegate factory returns so GS0129 remains intact

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --filter FullyQualifiedName~Issue1239CoalesceCommonTypeTests --no-restore --verbosity minimal` (11 passed)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter "FullyQualifiedName~Issue1239CoalesceCommonTypeEmitTests|FullyQualifiedName~Issue2542DelegateFactoryCovarianceEmitTests" --no-restore --verbosity minimal` (9 passed)

Fixes #2540
