### PR TITLE
Fix repeated deconstruction discards

### DIFF
--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Conditionals.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Conditionals.cs
@@ -1044,6 +1044,11 @@ internal sealed partial class StatementBinder
             {
                 var nameExpr = (NameExpressionSyntax)targets[i];
                 var initializer = bindExpression(values[i]);
+                if (IsDiscard(nameExpr.IdentifierToken))
+                {
+                    continue;
+                }
+
                 var variable = bindLocalVariable(nameExpr.IdentifierToken, isReadOnly: false, type: initializer.Type);
                 statements.Add(new BoundVariableDeclaration(syntax, variable, initializer));
             }
@@ -1070,6 +1075,11 @@ internal sealed partial class StatementBinder
         for (var i = 0; i < targets.Length; i++)
         {
             var nameExpr = (NameExpressionSyntax)targets[i];
+            if (IsDiscard(nameExpr.IdentifierToken))
+            {
+                continue;
+            }
+
             var name = nameExpr.IdentifierToken.Text;
             var variable = bindVariableReference(name, nameExpr.IdentifierToken.Location);
             if (variable == null)

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -1236,6 +1236,11 @@ internal sealed partial class StatementBinder
             for (var i = 0; i < syntax.Identifiers.Count; i++)
             {
                 var idTok = syntax.Identifiers[i];
+                if (IsDiscard(idTok))
+                {
+                    continue;
+                }
+
                 var elemType = tupleType.ElementTypes[i];
                 var elemVar = bindLocalVariable(idTok, isReadOnly: true, elemType);
                 var access = new BoundTupleElementAccessExpression(null, new BoundVariableExpression(null, tempVar), tupleType, i);
@@ -1263,6 +1268,11 @@ internal sealed partial class StatementBinder
             for (var i = 0; i < syntax.Identifiers.Count; i++)
             {
                 var idTok = syntax.Identifiers[i];
+                if (IsDiscard(idTok))
+                {
+                    continue;
+                }
+
                 var field = fields[i];
                 var elemVar = bindLocalVariable(idTok, isReadOnly: true, field.Type);
                 var access = new BoundFieldAccessExpression(null, new BoundVariableExpression(null, tempVar), structType, field);
@@ -1321,6 +1331,11 @@ internal sealed partial class StatementBinder
             var statements = ImmutableArray.CreateBuilder<BoundStatement>();
             for (var i = 0; i < identifiers.Count; i++)
             {
+                if (IsDiscard(identifiers[i]))
+                {
+                    continue;
+                }
+
                 var elemType = tupleType.ElementTypes[i];
                 var elemVar = bindLocalVariable(identifiers[i], isReadOnly: true, elemType);
                 var access = new BoundTupleElementAccessExpression(null, elementAccessBase, tupleType, i);
@@ -1343,6 +1358,11 @@ internal sealed partial class StatementBinder
             var statements = ImmutableArray.CreateBuilder<BoundStatement>();
             for (var i = 0; i < identifiers.Count; i++)
             {
+                if (IsDiscard(identifiers[i]))
+                {
+                    continue;
+                }
+
                 var field = fields[i];
                 var elemVar = bindLocalVariable(identifiers[i], isReadOnly: true, field.Type);
                 var access = new BoundFieldAccessExpression(null, elementAccessBase, structType, field);
@@ -1506,7 +1526,6 @@ internal sealed partial class StatementBinder
             for (var i = 0; i < identifiers.Count; i++)
             {
                 var elementType = TypeSymbol.FromClrType(parameters[i + receiverOffset].ParameterType.GetElementType());
-                var variable = bindLocalVariable(identifiers[i], isReadOnly: true, elementType);
                 var temp = new LocalVariableSymbol(
                     $"<deconstruct{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
                     isReadOnly: false,
@@ -1516,10 +1535,14 @@ internal sealed partial class StatementBinder
                     null,
                     new BoundVariableExpression(null, temp)));
                 refKinds.Add(RefKind.Out);
-                declarations.Add(new BoundVariableDeclaration(
-                    null,
-                    variable,
-                    new BoundVariableExpression(null, temp)));
+                if (!IsDiscard(identifiers[i]))
+                {
+                    var variable = bindLocalVariable(identifiers[i], isReadOnly: true, elementType);
+                    declarations.Add(new BoundVariableDeclaration(
+                        null,
+                        variable,
+                        new BoundVariableExpression(null, temp)));
+                }
             }
 
             BoundExpression call = receiverOffset == 1
@@ -1551,7 +1574,10 @@ internal sealed partial class StatementBinder
     {
         for (var i = 0; i < identifiers.Count; i++)
         {
-            bindLocalVariable(identifiers[i], isReadOnly: true, TypeSymbol.Error);
+            if (!IsDiscard(identifiers[i]))
+            {
+                bindLocalVariable(identifiers[i], isReadOnly: true, TypeSymbol.Error);
+            }
         }
     }
 
@@ -1588,6 +1614,11 @@ internal sealed partial class StatementBinder
             if (!TypeMemberModel.TryGetFieldIncludingInherited(structType, fieldName, MemberQuery.Instance(MemberKinds.Field), out var field, out var declaringType))
             {
                 Diagnostics.ReportUnableToFindMember(fieldSyntax.FieldIdentifier.Location, fieldName);
+                continue;
+            }
+
+            if (IsDiscard(fieldSyntax.LocalIdentifier))
+            {
                 continue;
             }
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -37,6 +37,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 internal sealed partial class StatementBinder
 {
+    private static bool IsDiscard(SyntaxToken token) => token.Text == "_";
+
     /// <summary>Signature for the root <see cref="ExpressionBinder.BindExpression(ExpressionSyntax, bool)"/> entry point.</summary>
     /// <param name="syntax">The expression syntax to bind.</param>
     /// <param name="canBeVoid">Whether the expression is permitted to have <c>void</c> type.</param>

--- a/test/Compiler.Tests/Emit/Issue2553RepeatedDiscardEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2553RepeatedDiscardEmitTests.cs
@@ -1,0 +1,81 @@
+// <copyright file="Issue2553RepeatedDiscardEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public class Issue2553RepeatedDiscardEmitTests
+{
+    [Fact]
+    public void RepeatedDiscards_CompileAndRunAcrossTupleLetAssignmentAndLoop()
+    {
+        const string source = """
+            package main
+            import System
+
+            func run() {
+                let (kept, _, _) = (10, 20, 30)
+                var assigned = 0
+                assigned, _, _ = 7, 8, 9
+                var loopTotal = 0
+                for (first, _, _) in [2](int32, int32, int32){(2, 20, 200), (3, 30, 300)} {
+                    loopTotal = loopTotal + first
+                }
+                Console.WriteLine(kept + assigned + loopTotal)
+            }
+
+            run()
+            """;
+
+        Assert.Equal("22\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue2553_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            Assert.Equal(0, exitCode);
+            IlVerifier.Verify(outputPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo);
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, $"dotnet exec failed:\n{stderr}");
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2553RepeatedDiscardBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2553RepeatedDiscardBinderTests.cs
@@ -1,0 +1,55 @@
+// <copyright file="Issue2553RepeatedDiscardBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public class Issue2553RepeatedDiscardBinderTests
+{
+    [Fact]
+    public void RepeatedDiscards_BindInTupleLetAssignmentAndLoop()
+    {
+        const string source = """
+            var value = 0
+            let (kept, _, _) = (1, 2, 3)
+            value, _, _ = 4, 5, 6
+            for (item, _, _) in [1](int32, int32, int32){(7, 8, 9)} {
+                value = value + item
+            }
+            """;
+
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Theory]
+    [InlineData("let (name, name, _) = (1, 2, 3)")]
+    [InlineData("for (name, name, _) in [1](int32, int32, int32){(1, 2, 3)} { }")]
+    public void RepeatedRealNames_StillReportGS0102(string statement)
+    {
+        var result = Evaluate(statement);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0102");
+    }
+
+    [Fact]
+    public void TupleDiscard_DoesNotEnterLookupScope()
+    {
+        var result = Evaluate("let (value, _, _) = (1, 2, 3)\n_");
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0125");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree).Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2553RepeatedDiscardRuntimeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2553RepeatedDiscardRuntimeTests.cs
@@ -1,0 +1,43 @@
+// <copyright file="Issue2553RepeatedDiscardRuntimeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public class Issue2553RepeatedDiscardRuntimeTests
+{
+    [Fact]
+    public void RepeatedDiscards_PreserveValuesAndEvaluateAssignmentRightHandSides()
+    {
+        const string source = """
+            var calls = 0
+            let (kept, _, _) = (10, 20, 30)
+            var assigned = 0
+            assigned, _, _ = ++calls, ++calls, ++calls
+            var loopTotal = 0
+            for (first, _, _) in [2](int32, int32, int32){(2, 20, 200), (3, 30, 300)} {
+                loopTotal = loopTotal + first
+            }
+            kept + assigned + calls + loopTotal
+            """;
+
+        var result = Evaluate(source);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(19, result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree).Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue2553RepeatedDiscardParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue2553RepeatedDiscardParserTests.cs
@@ -1,0 +1,38 @@
+// <copyright file="Issue2553RepeatedDiscardParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+public class Issue2553RepeatedDiscardParserTests
+{
+    [Fact]
+    public void RepeatedDiscards_ParseInTupleLetAssignmentAndLoop()
+    {
+        const string source = """
+            package p
+            func F() {
+                var value = 0
+                let (kept, _, _) = (1, 2, 3)
+                value, _, _ = 4, 5, 6
+                for (item, _, _) in [1](int32, int32, int32){(7, 8, 9)} {
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var body = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single().Body;
+        var tupleLet = Assert.IsType<TupleDeconstructionStatementSyntax>(body.Statements[1]);
+        Assert.Equal(new[] { "kept", "_", "_" }, tupleLet.Identifiers.Select(token => token.Text));
+        var assignment = Assert.IsType<MultiAssignmentStatementSyntax>(body.Statements[2]);
+        Assert.Equal(new[] { "value", "_", "_" }, assignment.Targets.Cast<NameExpressionSyntax>().Select(target => target.IdentifierToken.Text));
+        var loop = Assert.IsType<ForTupleRangeStatementSyntax>(body.Statements[3]);
+        Assert.Equal(new[] { "item", "_", "_" }, loop.Identifiers.Select(token => token.Text));
+    }
+}


### PR DESCRIPTION
## Summary
- treat `_` positions as independent discards in tuple lets, multi-assignments, named deconstruction, and tuple loops
- keep RHS evaluation and imported `Deconstruct` out slots without introducing discard variables
- preserve GS0102 diagnostics for repeated real names
- add parser, binder, evaluator runtime, and compiler emit coverage

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --filter "FullyQualifiedName~Issue2553RepeatedDiscard|FullyQualifiedName~Issue1922TupleForInStatementTests|FullyQualifiedName~MultiAssignmentTests|FullyQualifiedName~ImportedExtensionMethodTests"` (32 passed)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --no-restore --filter "FullyQualifiedName~Issue2553RepeatedDiscard|FullyQualifiedName~ForRangeEmitTests"` (10 passed)

Fixes #2553