### PR TITLE
cs2gs: canonicalize convenience initializer delegation

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
@@ -333,20 +333,23 @@ public sealed class ConstructorDeclaration : GMember
     /// <param name="visibility">The accessibility.</param>
     /// <param name="attributes">The constructor attributes.</param>
     /// <param name="isConvenience">Whether this is a delegating <c>convenience init</c>.</param>
+    /// <param name="delegatingArguments">The same-type initializer arguments, or <see langword="null"/> for no delegation.</param>
     public ConstructorDeclaration(
         IReadOnlyList<Parameter> parameters,
         BlockStatement body,
         IReadOnlyList<GExpression> baseArguments = null,
         Visibility visibility = Visibility.Default,
         IReadOnlyList<AttributeUse> attributes = null,
-        bool isConvenience = false)
+        bool isConvenience = false,
+        IReadOnlyList<GExpression> delegatingArguments = null)
     {
         Parameters = parameters ?? new List<Parameter>();
         Body = body;
         BaseArguments = baseArguments;
         Visibility = visibility;
         Attributes = attributes ?? new List<AttributeUse>();
-        IsConvenience = isConvenience;
+        IsConvenience = isConvenience || delegatingArguments != null;
+        DelegatingArguments = delegatingArguments;
     }
 
     /// <summary>
@@ -355,6 +358,12 @@ public sealed class ConstructorDeclaration : GMember
     /// delegation call (<c>init(args)</c>) is the first statement of the body.
     /// </summary>
     public bool IsConvenience { get; }
+
+    /// <summary>
+    /// Gets the same-type initializer arguments. The printer lowers these to
+    /// the first effective body statement, preserving their evaluation order.
+    /// </summary>
+    public IReadOnlyList<GExpression> DelegatingArguments { get; }
 
     /// <summary>Gets the constructor parameters.</summary>
     public IReadOnlyList<Parameter> Parameters { get; }

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1679,8 +1679,21 @@ public static class GSharpPrinter
             sb.Append($" : base({baseArgs})");
         }
 
+        BlockStatement body = constructor.Body;
+        if (constructor.DelegatingArguments != null)
+        {
+            var statements = new List<GStatement>
+            {
+                new ExpressionStatement(new InvocationExpression(
+                    new IdentifierExpression("init"),
+                    constructor.DelegatingArguments)),
+            };
+            statements.AddRange(body.Statements);
+            body = new BlockStatement(statements, body.IsUnsafe, body.IsChecked, body.IsUnchecked);
+        }
+
         sb.Append(' ');
-        sb.Append(RenderBlock(constructor.Body, indent));
+        sb.Append(RenderBlock(body, indent));
         return sb.ToString();
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2538ConvenienceInitializerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2538ConvenienceInitializerTests.cs
@@ -1,0 +1,196 @@
+// <copyright file="Issue2538ConvenienceInitializerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>Issue #2538: C# this-constructor initializers lower canonically.</summary>
+public sealed class Issue2538ConvenienceInitializerTests
+{
+    private const string Source = """
+        using System;
+
+        namespace Issue2538;
+
+        public sealed class Routed
+        {
+            private int value;
+
+            public Routed(int left, int right)
+            {
+                value = (left * 10) + right;
+            }
+
+            public Routed(int seed)
+                : this(Trace(seed), Trace(seed + 1))
+            {
+                seed++;
+                value += seed;
+            }
+
+            public Routed()
+                : this(2)
+            {
+                value += 1000;
+            }
+
+            private static int Trace(int value)
+            {
+                Console.Write(value);
+                return value;
+            }
+
+            public int Value() => value;
+        }
+        """;
+
+    [Fact]
+    public void Translator_OverloadedThisInitializers_KeepDelegationCanonicalAndFirst()
+    {
+        (CompilationUnit unit, string printed) = Translate();
+        TypeDeclaration routed = Assert.Single(unit.Members.OfType<TypeDeclaration>());
+        ConstructorDeclaration singleArgument = routed.Members
+            .OfType<ConstructorDeclaration>()
+            .Single(c => c.Parameters.Count == 1);
+
+        Assert.NotNull(singleArgument.DelegatingArguments);
+        Assert.Equal(2, singleArgument.DelegatingArguments.Count);
+        Assert.DoesNotContain(
+            singleArgument.Body.Statements,
+            s => s is ExpressionStatement
+                {
+                    Expression: InvocationExpression
+                    {
+                        Target: IdentifierExpression { Name: "init" },
+                    },
+                });
+
+        int delegation = printed.IndexOf(
+            "init(Routed.Trace(seed), Routed.Trace(seed + 1))",
+            StringComparison.Ordinal);
+        int parameterShadow = printed.IndexOf("var seed = seed", StringComparison.Ordinal);
+        Assert.True(delegation >= 0 && parameterShadow > delegation, printed);
+
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            roundTrip.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", roundTrip.Errors) + "\n\nPrinted:\n" + printed);
+    }
+
+    [Fact]
+    public void Compiler_OverloadedThisInitializers_AcceptsCanonicalDelegation()
+    {
+        (_, string printed) = Translate();
+        (int exit, string output, _) = Compile(printed);
+
+        Assert.True(
+            exit == 0 && !output.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must accept translated overloaded constructors. Output:\n" +
+                output + "\n\nTranslated G#:\n" + printed);
+    }
+
+    [Fact]
+    public void Runtime_OverloadedThisInitializers_PreserveArgumentAndBodyOrder()
+    {
+        (_, string printed) = Translate();
+        (int compileExit, string compileOutput, string assembly) = Compile(printed);
+        Assert.True(compileExit == 0, compileOutput);
+
+        (int runExit, string stdout) = RunDotnet($"\"{assembly}\"");
+        Assert.True(runExit == 0, stdout);
+        Assert.Equal("231026" + Environment.NewLine, stdout);
+    }
+
+    private static (CompilationUnit Unit, string Printed) Translate()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Repro.cs", Source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        return (unit, GSharpPrinter.Print(unit));
+    }
+
+    private static (int Exit, string Output, string Assembly) Compile(string printed)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built before running this test.");
+
+        string workDir = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue-2538-e2e",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string source = Path.Combine(workDir, "Repro.gs");
+        string assembly = Path.Combine(workDir, "Repro.dll");
+        File.WriteAllText(
+            source,
+            printed + Environment.NewLine +
+                "Console.WriteLine(Routed().Value().ToString())" + Environment.NewLine);
+
+        (int exit, string output) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{assembly}\" \"{source}\"");
+        return (exit, output, assembly);
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(startInfo);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    "Compiler",
+                    "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -332,7 +332,7 @@ public sealed partial class CSharpToGSharpTranslator
             List<Parameter> parameters = this.MapParameters(symbol, node.ParameterList, skipFirst: false);
 
             List<GExpression> baseArguments = null;
-            bool isConvenience = false;
+            List<GExpression> delegatingArguments = null;
             if (node.Initializer != null)
             {
                 if (node.Initializer.ThisOrBaseKeyword.IsKind(SyntaxKind.BaseKeyword))
@@ -348,23 +348,16 @@ public sealed partial class CSharpToGSharpTranslator
                 {
                     // `: this(args)` (constructor delegation) maps to a G#
                     // `convenience init(params) { init(args); ... }`: the delegated
-                    // `init(args)` call is the first body statement (ADR-0065).
-                    isConvenience = true;
+                    // arguments are retained on the constructor model so its
+                    // canonical lowering always emits `init(args)` first.
+                    delegatingArguments = this.TranslateNullSeamArguments(
+                        node.Initializer.ArgumentList.Arguments, symbol);
                 }
             }
 
             BlockStatement body = this.TranslateBody(node, $"constructor on '{node.Identifier.Text}'");
 
-            if (isConvenience)
-            {
-                var delegated = new ExpressionStatement(new InvocationExpression(
-                    new IdentifierExpression("init"),
-                    this.TranslateNullSeamArguments(node.Initializer.ArgumentList.Arguments, symbol)));
-                var statements = new List<GStatement> { delegated };
-                statements.AddRange(body.Statements);
-                body = new BlockStatement(statements);
-            }
-            else if (propertyCtorInits != null && propertyCtorInits.Count > 0)
+            if (delegatingArguments == null && propertyCtorInits != null && propertyCtorInits.Count > 0)
             {
                 // OD-T1: move get-only auto-property inline initializers into the
                 // designated constructor body (G# has no property member
@@ -385,7 +378,7 @@ public sealed partial class CSharpToGSharpTranslator
                 baseArguments: baseArguments,
                 visibility: MapVisibility(symbol, this.context, node),
                 attributes: this.MapAttributes(node.AttributeLists),
-                isConvenience: isConvenience);
+                delegatingArguments: delegatingArguments);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- model C# `this(...)` delegation arguments separately from constructor body statements
- lower delegation at print time so `init(...)` is always the first effective convenience-init statement
- cover overloaded constructors through translation, gsc compilation, and runtime argument/body ordering

## Validation
- `dotnet build src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj -c Release --no-restore --nologo --verbosity:minimal`
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-build --no-restore --nologo --verbosity:minimal` (1662 passed)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter FullyQualifiedName~Adr0065ConvenienceInitEmitTests --nologo --verbosity:minimal` (9 passed)

Fixes #2538