### PR TITLE
Fix imported enum switch exhaustiveness

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExhaustivenessAnalyzer.cs
+++ b/src/Core/CodeAnalysis/Binding/ExhaustivenessAnalyzer.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reflection;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Text;
 
@@ -22,6 +23,7 @@ public static class ExhaustivenessAnalyzer
     /// <returns>True for enum types, sealed interfaces, and sealed-hierarchy classes; otherwise false.</returns>
     public static bool IsExhaustiveDiscriminant(TypeSymbol type)
         => type is EnumSymbol
+        || type?.ClrType.IsEnumSafe() == true
         || type is InterfaceSymbol { IsSealed: true }
         || type is StructSymbol { IsSealedHierarchy: true };
 
@@ -96,25 +98,23 @@ public static class ExhaustivenessAnalyzer
             return false;
         }
 
-        if (discriminantType is EnumSymbol enumSymbol)
+        if (TryGetEnumVariants(discriminantType, out var enumVariants))
         {
-            discriminantDescription = $"enum '{enumSymbol.Name}'";
-            var coveredValues = new HashSet<int>();
+            discriminantDescription = $"enum '{discriminantType.Name}'";
+            var coveredValues = new HashSet<object>();
             foreach (var pattern in patternArray)
             {
                 foreach (var leaf in FlattenDisjunction(pattern))
                 {
                     if (leaf is BoundConstantPattern constant
-                        && constant.Value is BoundLiteralExpression literal
-                        && literal.Type == enumSymbol
-                        && literal.Value is int value)
+                        && constant.Value is BoundLiteralExpression literal)
                     {
-                        coveredValues.Add(value);
+                        coveredValues.Add(literal.Value);
                     }
                 }
             }
 
-            missingNames = enumSymbol.Members
+            missingNames = enumVariants
                 .Where(member => !coveredValues.Contains(member.Value))
                 .Select(member => member.Name)
                 .ToImmutableArray();
@@ -184,6 +184,31 @@ public static class ExhaustivenessAnalyzer
         }
 
         return false;
+    }
+
+    private static bool TryGetEnumVariants(
+        TypeSymbol type,
+        out ImmutableArray<(string Name, object Value)> variants)
+    {
+        if (type is EnumSymbol enumSymbol)
+        {
+            variants = enumSymbol.Members
+                .Select(member => (member.Name, (object)member.Value))
+                .ToImmutableArray();
+            return true;
+        }
+
+        if (type?.ClrType.IsEnumSafe() != true)
+        {
+            variants = ImmutableArray<(string Name, object Value)>.Empty;
+            return false;
+        }
+
+        variants = ClrTypeUtilities.SafeGetFields(type.ClrType, BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.IsLiteral)
+            .Select(field => (field.Name, field.GetRawConstantValue()))
+            .ToImmutableArray();
+        return true;
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2548ImportedEnumExhaustivenessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2548ImportedEnumExhaustivenessTests.cs
@@ -1,0 +1,151 @@
+// <copyright file="Issue2548ImportedEnumExhaustivenessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2548: switch exhaustiveness includes enum members imported from
+/// assembly metadata, including aliases.
+/// </summary>
+public sealed class Issue2548ImportedEnumExhaustivenessTests
+{
+    [Fact]
+    public void ImportedEnum_CompleteExpressionAndStatement_CompileAndRun()
+    {
+        var libraryPath = EmitLibrary(nameof(this.ImportedEnum_CompleteExpressionAndStatement_CompileAndRun));
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+                import System
+                import Models
+
+                func Describe(state State) string {
+                    return switch state {
+                        case State.Unknown: "unknown"
+                        case State.Ready: "ready"
+                        case State.Done: "done"
+                    }
+                }
+
+                func Print(state State) {
+                    switch state {
+                        case State.Unknown { Console.WriteLine("unknown") }
+                        case State.Ready { Console.WriteLine("ready") }
+                        case State.Done { Console.WriteLine("done") }
+                    }
+                }
+
+                func Main() {
+                    Console.WriteLine(Describe(State.Active))
+                    Print(State.Done)
+                }
+                """)));
+
+        using var stream = new MemoryStream();
+        var result = consumer.Emit(stream, pdbStream: null, refStream: null, assemblyName: "Issue2548.Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        stream.Position = 0;
+        var context = new AssemblyLoadContext("Issue2548.Consumer", isCollectible: true);
+        context.Resolving += (loadContext, name) =>
+            string.Equals(name.Name, "Issue2548.Models", StringComparison.Ordinal)
+                ? loadContext.LoadFromAssemblyPath(libraryPath)
+                : null;
+        try
+        {
+            var assembly = context.LoadFromStream(stream);
+            var originalOut = Console.Out;
+            var output = new StringWriter();
+            Console.SetOut(output);
+            try
+            {
+                assembly.EntryPoint!.Invoke(null, null);
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+
+            Assert.Equal("ready\ndone\n", output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    [Fact]
+    public void ImportedEnum_IncompleteExpressionAndStatement_ReportMissingMember()
+    {
+        var libraryPath = EmitLibrary(nameof(this.ImportedEnum_IncompleteExpressionAndStatement_ReportMissingMember));
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+                import Models
+
+                func Describe(state State) string {
+                    return switch state {
+                        case State.Unknown: "unknown"
+                        case State.Ready: "ready"
+                    }
+                }
+
+                func Observe(state State) {
+                    switch state {
+                        case State.Unknown { let observed = 0 }
+                        case State.Active { let observed = 1 }
+                    }
+                }
+                """)));
+
+        Assert.Contains(
+            consumer.BoundProgram.Diagnostics,
+            diagnostic => diagnostic.Message == "Switch expression on enum 'Models.State' is not exhaustive: missing 'Done'.");
+        Assert.Contains(
+            consumer.BoundProgram.Diagnostics,
+            diagnostic => diagnostic.Message == "Switch statement on enum 'Models.State' is not exhaustive: missing 'Done'.");
+    }
+
+    private static string EmitLibrary(string caseName)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2548", caseName);
+        Directory.CreateDirectory(directory);
+        var libraryPath = Path.Combine(directory, "Issue2548.Models.dll");
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Models
+
+                enum State {
+                    Unknown = -1,
+                    Ready = 1,
+                    Active = Ready,
+                    Done = 2,
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using var stream = File.Create(libraryPath);
+        var result = library.Emit(stream, pdbStream: null, refStream: null, assemblyName: "Issue2548.Models");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return libraryPath;
+    }
+}


### PR DESCRIPTION
## Summary
- include CLR enum metadata in switch exhaustiveness analysis
- preserve value-based alias coverage and missing-member diagnostics
- add cross-assembly compile/runtime and negative regression coverage

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --filter "FullyQualifiedName~ExhaustivenessTests|FullyQualifiedName~Issue1912ExplicitEnumMemberValueTests" --nologo --verbosity minimal` (33 passed)
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --nologo --verbosity minimal` (6,556 passed, 1 skipped)

Fixes #2548