### PR TITLE
Fix imported explicit interface implementations

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -2122,31 +2122,53 @@ internal sealed partial class DeclarationBinder
     /// downstream — <see cref="VerifyInterfaceImplementations"/>'s trailing
     /// unresolved-clause sweep does not re-report a second diagnostic for it).
     /// </summary>
-    private InterfaceSymbol ResolveExplicitInterfaceClauseTarget(StructSymbol structSymbol, TypeClauseSyntax clauseTypeSyntax, string memberName)
+    private TypeSymbol ResolveExplicitInterfaceClauseTarget(StructSymbol structSymbol, TypeClauseSyntax clauseTypeSyntax, string memberName)
     {
         var boundType = bindTypeClause(clauseTypeSyntax);
-        if (boundType is not InterfaceSymbol clauseIface)
+        if (boundType is InterfaceSymbol clauseIface)
         {
-            if (boundType != null && boundType != TypeSymbol.Error)
+            if (!structSymbol.Interfaces.IsDefaultOrEmpty)
             {
-                Diagnostics.ReportExplicitInterfaceClauseTypeNotInterface(clauseTypeSyntax.Location, boundType.Name, memberName);
+                foreach (var candidateIface in structSymbol.Interfaces)
+                {
+                    if (TypeSignaturesEquivalent(candidateIface, clauseIface))
+                    {
+                        return candidateIface;
+                    }
+                }
             }
 
+            Diagnostics.ReportExplicitInterfaceClauseNotImplemented(clauseTypeSyntax.Location, structSymbol.Name, clauseIface.Name, memberName);
             return null;
         }
 
-        if (!structSymbol.Interfaces.IsDefaultOrEmpty)
+        if (boundType?.ClrType?.IsInterface == true)
         {
-            foreach (var candidateIface in structSymbol.Interfaces)
+            foreach (var candidateIface in structSymbol.ImplementedClrInterfaces)
             {
-                if (TypeSignaturesEquivalent(candidateIface, clauseIface))
+                if (TypeSignaturesEquivalent(candidateIface, boundType))
                 {
                     return candidateIface;
                 }
+
+                var candidateClr = candidateIface.ClrType;
+                if (candidateClr != null
+                    && candidateClr.GetInterfaces().Any(inherited =>
+                        ClrTypeUtilities.AreSame(inherited, boundType.ClrType)))
+                {
+                    return boundType;
+                }
             }
+
+            Diagnostics.ReportExplicitInterfaceClauseNotImplemented(clauseTypeSyntax.Location, structSymbol.Name, boundType.Name, memberName);
+            return null;
         }
 
-        Diagnostics.ReportExplicitInterfaceClauseNotImplemented(clauseTypeSyntax.Location, structSymbol.Name, clauseIface.Name, memberName);
+        if (boundType != null && boundType != TypeSymbol.Error)
+        {
+            Diagnostics.ReportExplicitInterfaceClauseTypeNotInterface(clauseTypeSyntax.Location, boundType.Name, memberName);
+        }
+
         return null;
     }
 

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -129,6 +129,8 @@ internal sealed partial class DeclarationBinder
     {
         foreach (var (syntax, structSymbol) in pendingInterfaceImplementationChecks)
         {
+            ResolveExplicitClrInterfaceImplementations(structSymbol);
+
             var inheritedDefaultsBySignature = new Dictionary<string, (FunctionSymbol Method, InterfaceSymbol Iface)>(System.StringComparer.Ordinal);
             var conflictsReported = new HashSet<string>(System.StringComparer.Ordinal);
             var positionalInterfaceProps = new Dictionary<string, (ParameterSymbol Param, bool NeedsSetter)>(System.StringComparer.Ordinal);
@@ -147,6 +149,118 @@ internal sealed partial class DeclarationBinder
                     iface,
                     positionalInterfaceProps);
                 ResolveExplicitInterfaceEventImplementations(structSymbol, iface);
+            }
+
+            static void ResolveExplicitClrInterfaceImplementations(StructSymbol structSymbol)
+            {
+                foreach (var method in structSymbol.Methods)
+                {
+                    var target = method.ExplicitInterfaceClauseTarget;
+                    if (!method.HasExplicitInterfaceClause
+                        || target is InterfaceSymbol
+                        || target?.ClrType?.IsInterface != true)
+                    {
+                        continue;
+                    }
+
+                    foreach (var slot in target.ClrType.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+                    {
+                        if (!slot.IsSpecialName
+                            && slot.Name == method.Name
+                            && MemberLookup.MethodMatchesClrSignature(method, slot))
+                        {
+                            method.ExplicitInterfaceSlot = slot;
+                            method.ExplicitInterfaceSlotContainingType = target;
+                            break;
+                        }
+                    }
+                }
+
+                foreach (var property in structSymbol.Properties)
+                {
+                    var target = property.ExplicitInterfaceClauseTarget;
+                    if (!property.HasExplicitInterfaceClause
+                        || target is InterfaceSymbol
+                        || target?.ClrType?.IsInterface != true)
+                    {
+                        continue;
+                    }
+
+                    foreach (var slot in target.ClrType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                    {
+                        if (!ExplicitClrPropertyMatches(property, target, slot))
+                        {
+                            continue;
+                        }
+
+                        property.ExplicitInterfaceGetterSlot = slot.GetMethod;
+                        property.ExplicitInterfaceSetterSlot = slot.SetMethod;
+                        property.ExplicitInterfaceSlotContainingType = target;
+                        break;
+                    }
+                }
+
+                foreach (var eventSymbol in structSymbol.Events)
+                {
+                    var target = eventSymbol.ExplicitInterfaceClauseTarget;
+                    if (!eventSymbol.HasExplicitInterfaceClause
+                        || target is InterfaceSymbol
+                        || target?.ClrType?.IsInterface != true)
+                    {
+                        continue;
+                    }
+
+                    foreach (var slot in target.ClrType.GetEvents(BindingFlags.Public | BindingFlags.Instance))
+                    {
+                        if (slot.Name != eventSymbol.Name
+                            || !TypeSignaturesEquivalent(
+                                eventSymbol.Type,
+                                MemberLookup.GetClrEventHandlerTypeSymbol(target, slot)))
+                        {
+                            continue;
+                        }
+
+                        eventSymbol.ExplicitInterfaceAddSlot = slot.AddMethod;
+                        eventSymbol.ExplicitInterfaceRemoveSlot = slot.RemoveMethod;
+                        eventSymbol.ExplicitInterfaceRaiseSlot = slot.RaiseMethod;
+                        eventSymbol.ExplicitInterfaceSlotContainingType = target;
+                        break;
+                    }
+                }
+            }
+
+            static bool ExplicitClrPropertyMatches(
+                PropertySymbol property,
+                TypeSymbol target,
+                PropertyInfo slot)
+            {
+                if (slot.Name != property.Name
+                    || (slot.GetMethod != null) != property.HasGetter
+                    || (slot.SetMethod != null) != property.HasSetter
+                    || !TypeSignaturesEquivalent(
+                        property.Type,
+                        MemberLookup.GetClrPropertyTypeSymbol(target, slot)))
+                {
+                    return false;
+                }
+
+                var slotParameters = slot.GetIndexParameters();
+                if (slotParameters.Length != property.Parameters.Length)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < slotParameters.Length; i++)
+                {
+                    if (!ClrTypeUtilities.AreSame(
+                        NullableLifting.GetEffectiveClrType(property.Parameters[i].Type),
+                        slotParameters[i].ParameterType))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
             }
 
             SynthesizePositionalInterfaceProperties(structSymbol, positionalInterfaceProps);
@@ -606,7 +720,7 @@ internal sealed partial class DeclarationBinder
     /// </summary>
     private void VerifyExplicitInterfaceClauseResolution(StructDeclarationSyntax syntax, StructSymbol structSymbol)
     {
-        var seenSlots = new Dictionary<(InterfaceSymbol Iface, string Name), bool>();
+        var seenSlots = new Dictionary<(TypeSymbol Iface, string Name), bool>();
 
         if (!structSymbol.Methods.IsDefaultOrEmpty)
         {
@@ -629,7 +743,7 @@ internal sealed partial class DeclarationBinder
 
                 seenSlots[slot] = true;
 
-                if (method.ExplicitInterfaceMember == null)
+                if (method.ExplicitInterfaceMember == null && method.ExplicitInterfaceSlot == null)
                 {
                     Diagnostics.ReportExplicitInterfaceClauseMemberNotFound(
                         method.Declaration.Identifier.Location,
@@ -660,7 +774,9 @@ internal sealed partial class DeclarationBinder
 
                 seenSlots[slot] = true;
 
-                if (prop.ExplicitInterfaceMember == null)
+                if (prop.ExplicitInterfaceMember == null
+                    && prop.ExplicitInterfaceGetterSlot == null
+                    && prop.ExplicitInterfaceSetterSlot == null)
                 {
                     Diagnostics.ReportExplicitInterfaceClauseMemberNotFound(
                         prop.Declaration.Identifier.Location,
@@ -695,7 +811,9 @@ internal sealed partial class DeclarationBinder
 
                 seenSlots[slot] = true;
 
-                if (evt.ExplicitInterfaceMember == null)
+                if (evt.ExplicitInterfaceMember == null
+                    && evt.ExplicitInterfaceAddSlot == null
+                    && evt.ExplicitInterfaceRemoveSlot == null)
                 {
                     Diagnostics.ReportExplicitInterfaceClauseMemberNotFound(
                         evt.Declaration.Identifier.Location,
@@ -712,7 +830,7 @@ internal sealed partial class DeclarationBinder
         // interfaceimpl slot vs. a static-virtual method's own, unrelated
         // slot introduced by ADR-0089/#755), so they must never collide with
         // (or be conflated with) the instance sweep above.
-        var seenStaticSlots = new Dictionary<(InterfaceSymbol Iface, string Name), bool>();
+        var seenStaticSlots = new Dictionary<(TypeSymbol Iface, string Name), bool>();
 
         if (!structSymbol.StaticMethods.IsDefaultOrEmpty)
         {

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2050,6 +2050,23 @@ internal sealed class MemberLookup
     /// <returns><see langword="true"/> when a matching overload exists.</returns>
     public static bool HasMatchingMethodForClrSignature(StructSymbol structSymbol, MethodInfo clrMethod)
     {
+        foreach (var candidate in structSymbol.GetMethodsIncludingInherited(clrMethod.Name))
+        {
+            if (MethodMatchesClrSignature(candidate, clrMethod))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Determines whether one G# method matches an imported CLR method signature.</summary>
+    /// <param name="candidate">The candidate G# method.</param>
+    /// <param name="clrMethod">The imported CLR method.</param>
+    /// <returns><see langword="true"/> when the signatures match.</returns>
+    public static bool MethodMatchesClrSignature(FunctionSymbol candidate, MethodInfo clrMethod)
+    {
         var clrParams = clrMethod.GetParameters();
 
         // Issue #2230: an imported (metadata) interface method may itself be
@@ -2064,89 +2081,62 @@ internal sealed class MemberLookup
             ? clrMethod.GetGenericArguments()
             : System.Array.Empty<Type>();
 
-        foreach (var candidate in structSymbol.GetMethodsIncludingInherited(clrMethod.Name))
+        var callable = GetCallableParameters(candidate);
+        if (callable.Length != clrParams.Length)
         {
-            var callable = GetCallableParameters(candidate);
-            if (callable.Length != clrParams.Length)
-            {
-                continue;
-            }
+            return false;
+        }
 
-            var candidateTypeParams = candidate.TypeParameters.IsDefaultOrEmpty
-                ? ImmutableArray<TypeParameterSymbol>.Empty
-                : candidate.TypeParameters;
-            if (methodGenericParams.Length != candidateTypeParams.Length)
-            {
-                // Generic-arity mismatch: not a viable implementor of this
-                // interface method overload (mirrors issue #1007).
-                continue;
-            }
+        var candidateTypeParams = candidate.TypeParameters.IsDefaultOrEmpty
+            ? ImmutableArray<TypeParameterSymbol>.Empty
+            : candidate.TypeParameters;
+        if (methodGenericParams.Length != candidateTypeParams.Length)
+        {
+            return false;
+        }
 
-            // Issue #1071: an `async func` implementing a CLR interface method
-            // declared with an explicit `Task` / `Task[T]` return type has a
-            // declared (awaited) return of void / T. Compare the contract's
-            // unwrapped awaited result against the candidate's declared type.
-            if (candidate.IsAsync
-                && AsyncReturnTypeNormalizer.TryUnwrapTaskClrType(clrMethod.ReturnType, out var awaitedReturnClr))
+        if (candidate.IsAsync
+            && AsyncReturnTypeNormalizer.TryUnwrapTaskClrType(clrMethod.ReturnType, out var awaitedReturnClr))
+        {
+            if (!ClrParamTypeMatchesGenericMethodParam(candidate.Type, awaitedReturnClr, methodGenericParams, candidateTypeParams))
             {
-                if (!ClrParamTypeMatchesGenericMethodParam(candidate.Type, awaitedReturnClr, methodGenericParams, candidateTypeParams))
+                return false;
+            }
+        }
+        else if (!ClrParamTypeMatchesGenericMethodParam(candidate.Type, clrMethod.ReturnType, methodGenericParams, candidateTypeParams))
+        {
+            return false;
+        }
+
+        for (var i = 0; i < callable.Length; i++)
+        {
+            var clrParamType = clrParams[i].ParameterType;
+            var gsParam = callable[i];
+
+            if (clrParamType.IsByRef)
+            {
+                if (gsParam.RefKind == RefKind.None
+                    || !ClrParamTypeMatchesGenericMethodParam(
+                        gsParam.Type,
+                        clrParamType.GetElementType(),
+                        methodGenericParams,
+                        candidateTypeParams))
                 {
-                    continue;
+                    return false;
                 }
             }
-            else if (!ClrParamTypeMatchesGenericMethodParam(candidate.Type, clrMethod.ReturnType, methodGenericParams, candidateTypeParams))
+            else if (gsParam.RefKind != RefKind.None
+                || !ClrParamTypeMatchesGenericMethodParam(
+                    gsParam.Type,
+                    clrParamType,
+                    methodGenericParams,
+                    candidateTypeParams))
             {
-                continue;
-            }
-
-            var allMatch = true;
-            for (var i = 0; i < callable.Length; i++)
-            {
-                var clrParamType = clrParams[i].ParameterType;
-                var gsParam = callable[i];
-
-                if (clrParamType.IsByRef)
-                {
-                    // The CLR parameter is by-ref (out/ref/in) — compare the
-                    // element type and require the G# parameter's RefKind to be
-                    // non-None (Out, Ref, or In).
-                    if (gsParam.RefKind == RefKind.None)
-                    {
-                        allMatch = false;
-                        break;
-                    }
-
-                    var elementType = clrParamType.GetElementType();
-                    if (!ClrParamTypeMatchesGenericMethodParam(gsParam.Type, elementType, methodGenericParams, candidateTypeParams))
-                    {
-                        allMatch = false;
-                        break;
-                    }
-                }
-                else
-                {
-                    // Non-by-ref CLR parameter — the G# side must also be pass-by-value.
-                    if (gsParam.RefKind != RefKind.None)
-                    {
-                        allMatch = false;
-                        break;
-                    }
-
-                    if (!ClrParamTypeMatchesGenericMethodParam(gsParam.Type, clrParamType, methodGenericParams, candidateTypeParams))
-                    {
-                        allMatch = false;
-                        break;
-                    }
-                }
-            }
-
-            if (allMatch)
-            {
-                return true;
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/ExplicitInterfaceMetadataNaming.cs
+++ b/src/Core/CodeAnalysis/Emit/ExplicitInterfaceMetadataNaming.cs
@@ -40,15 +40,23 @@ internal static class ExplicitInterfaceMetadataNaming
     /// <param name="memberName">The declared (plain, source-visible) member name.</param>
     /// <param name="target">The resolved explicit-interface clause target, or <see langword="null"/>.</param>
     /// <returns>A collision-free metadata name, or <paramref name="memberName"/> unchanged.</returns>
-    internal static string GetMetadataName(string memberName, InterfaceSymbol target)
+    internal static string GetMetadataName(string memberName, TypeSymbol target)
     {
         if (target == null)
         {
             return memberName;
         }
 
-        return string.IsNullOrEmpty(target.PackageName)
-            ? $"{target.Name}.{memberName}"
-            : $"{target.PackageName}.{target.Name}.{memberName}";
+        if (target is InterfaceSymbol sourceInterface)
+        {
+            return string.IsNullOrEmpty(sourceInterface.PackageName)
+                ? $"{sourceInterface.Name}.{memberName}"
+                : $"{sourceInterface.PackageName}.{sourceInterface.Name}.{memberName}";
+        }
+
+        var interfaceName = target is ImportedTypeSymbol imported && imported.OpenDefinition != null
+            ? imported.OpenDefinition.FullName
+            : target.ClrType?.FullName;
+        return $"{interfaceName ?? target.Name}.{memberName}";
     }
 }

--- a/src/Core/CodeAnalysis/Emit/InterfaceImplEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/InterfaceImplEmitter.cs
@@ -174,7 +174,9 @@ internal sealed class InterfaceImplEmitter
             var slot = method.ExplicitInterfaceSlot;
             if (slot != null)
             {
-                var slotRef = this.outer.memberRefs.GetMethodReference(slot);
+                var slotRef = this.outer.memberRefs.GetMethodEntityHandle(
+                    slot,
+                    method.ExplicitInterfaceSlotContainingType);
                 this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implHandle, slotRef);
             }
 
@@ -236,7 +238,7 @@ internal sealed class InterfaceImplEmitter
     /// <param name="structSymbol">The implementing class or struct.</param>
     internal void EmitExplicitInterfacePropertyMethodImpls(StructSymbol structSymbol)
     {
-        if (structSymbol == null || structSymbol.Properties.IsDefaultOrEmpty || structSymbol.Interfaces.IsDefaultOrEmpty)
+        if (structSymbol == null || structSymbol.Properties.IsDefaultOrEmpty)
         {
             return;
         }
@@ -249,12 +251,34 @@ internal sealed class InterfaceImplEmitter
         foreach (var prop in structSymbol.Properties)
         {
             var ifaceMember = prop.ExplicitInterfaceMember;
-            if (ifaceMember == null)
+            if (!this.cache.PropertyAccessorHandles.TryGetValue(prop, out var implAccessors))
             {
                 continue;
             }
 
-            if (!this.cache.PropertyAccessorHandles.TryGetValue(prop, out var implAccessors))
+            if (prop.ExplicitInterfaceGetterSlot != null && implAccessors.Getter.HasValue)
+            {
+                var declaration = this.outer.memberRefs.GetMethodEntityHandle(
+                    prop.ExplicitInterfaceGetterSlot,
+                    prop.ExplicitInterfaceSlotContainingType);
+                this.emitCtx.Metadata.AddMethodImplementation(
+                    implTypeDef,
+                    implAccessors.Getter.Value,
+                    declaration);
+            }
+
+            if (prop.ExplicitInterfaceSetterSlot != null && implAccessors.Setter.HasValue)
+            {
+                var declaration = this.outer.memberRefs.GetMethodEntityHandle(
+                    prop.ExplicitInterfaceSetterSlot,
+                    prop.ExplicitInterfaceSlotContainingType);
+                this.emitCtx.Metadata.AddMethodImplementation(
+                    implTypeDef,
+                    implAccessors.Setter.Value,
+                    declaration);
+            }
+
+            if (ifaceMember == null || structSymbol.Interfaces.IsDefaultOrEmpty)
             {
                 continue;
             }
@@ -323,7 +347,7 @@ internal sealed class InterfaceImplEmitter
     /// <param name="structSymbol">The implementing class or struct.</param>
     internal void EmitExplicitInterfaceEventMethodImpls(StructSymbol structSymbol)
     {
-        if (structSymbol == null || structSymbol.Events.IsDefaultOrEmpty || structSymbol.Interfaces.IsDefaultOrEmpty)
+        if (structSymbol == null || structSymbol.Events.IsDefaultOrEmpty)
         {
             return;
         }
@@ -336,12 +360,39 @@ internal sealed class InterfaceImplEmitter
         foreach (var ev in structSymbol.Events)
         {
             var ifaceMember = ev.ExplicitInterfaceMember;
-            if (ifaceMember == null)
+            if (!this.cache.EventAccessorHandles.TryGetValue(ev, out var implAccessors))
             {
                 continue;
             }
 
-            if (!this.cache.EventAccessorHandles.TryGetValue(ev, out var implAccessors))
+            if (ev.ExplicitInterfaceAddSlot != null)
+            {
+                var declaration = this.outer.memberRefs.GetMethodEntityHandle(
+                    ev.ExplicitInterfaceAddSlot,
+                    ev.ExplicitInterfaceSlotContainingType);
+                this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implAccessors.Add, declaration);
+            }
+
+            if (ev.ExplicitInterfaceRemoveSlot != null)
+            {
+                var declaration = this.outer.memberRefs.GetMethodEntityHandle(
+                    ev.ExplicitInterfaceRemoveSlot,
+                    ev.ExplicitInterfaceSlotContainingType);
+                this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implAccessors.Remove, declaration);
+            }
+
+            if (ev.ExplicitInterfaceRaiseSlot != null && implAccessors.Raise.HasValue)
+            {
+                var declaration = this.outer.memberRefs.GetMethodEntityHandle(
+                    ev.ExplicitInterfaceRaiseSlot,
+                    ev.ExplicitInterfaceSlotContainingType);
+                this.emitCtx.Metadata.AddMethodImplementation(
+                    implTypeDef,
+                    implAccessors.Raise.Value,
+                    declaration);
+            }
+
+            if (ifaceMember == null || structSymbol.Interfaces.IsDefaultOrEmpty)
             {
                 continue;
             }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -2539,6 +2539,22 @@ internal sealed class ReflectionMetadataEmitter
                         continue;
                     }
 
+                    var alreadyDeclared = false;
+                    foreach (var implemented in c.ImplementedClrInterfaces)
+                    {
+                        if (implemented?.ClrType != null
+                            && ClrTypeUtilities.AreSame(implemented.ClrType, declaringIface))
+                        {
+                            alreadyDeclared = true;
+                            break;
+                        }
+                    }
+
+                    if (alreadyDeclared)
+                    {
+                        continue;
+                    }
+
                     bridgeInterfaces ??= new System.Collections.Generic.HashSet<System.Type>();
                     if (bridgeInterfaces.Add(declaringIface))
                     {

--- a/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/EventSymbol.cs
@@ -88,6 +88,18 @@ public sealed class EventSymbol : Symbol
     /// <summary>Gets or sets the imported CLR raise slot overridden by this event.</summary>
     public MethodInfo ExternalOverriddenRaiseMethod { get; set; }
 
+    /// <summary>Gets or sets the imported interface add slot explicitly implemented by this event.</summary>
+    public MethodInfo ExplicitInterfaceAddSlot { get; set; }
+
+    /// <summary>Gets or sets the imported interface remove slot explicitly implemented by this event.</summary>
+    public MethodInfo ExplicitInterfaceRemoveSlot { get; set; }
+
+    /// <summary>Gets or sets the imported interface raise slot explicitly implemented by this event.</summary>
+    public MethodInfo ExplicitInterfaceRaiseSlot { get; set; }
+
+    /// <summary>Gets or sets the imported interface type that owns the explicit accessor slots.</summary>
+    public TypeSymbol ExplicitInterfaceSlotContainingType { get; set; }
+
     /// <summary>Gets or sets the imported constructed base type that owns the overridden event accessors.</summary>
     public TypeSymbol ExternalOverrideContainingType { get; set; }
 
@@ -128,12 +140,12 @@ public sealed class EventSymbol : Symbol
     public bool HasExplicitInterfaceClause => Declaration?.HasExplicitInterfaceClause == true;
 
     /// <summary>
-    /// Gets or sets the <see cref="InterfaceSymbol"/> the explicit-interface
+    /// Gets or sets the interface type the explicit-interface
     /// qualifier clause (<see cref="HasExplicitInterfaceClause"/>) resolves
     /// to, bound by <see cref="Binding.DeclarationBinder.ResolveExplicitInterfaceClauses"/>.
     /// <c>null</c> until resolved.
     /// </summary>
-    public InterfaceSymbol ExplicitInterfaceClauseTarget { get; set; }
+    public TypeSymbol ExplicitInterfaceClauseTarget { get; set; }
 
     /// <summary>
     /// ADR-0105 Phase 2 — re-points this (reused) event at the declaration node

--- a/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -379,6 +379,9 @@ public sealed class FunctionSymbol : Symbol
     /// </summary>
     public System.Reflection.MethodInfo ExplicitInterfaceSlot { get; set; }
 
+    /// <summary>Gets or sets the imported interface type that owns <see cref="ExplicitInterfaceSlot"/>.</summary>
+    public TypeSymbol ExplicitInterfaceSlotContainingType { get; set; }
+
     /// <summary>
     /// Gets or sets the in-compilation (G#) interface member this method
     /// explicitly implements (issue #2010; property/indexer generalization:
@@ -420,7 +423,7 @@ public sealed class FunctionSymbol : Symbol
     public bool HasExplicitInterfaceClause => Declaration?.HasExplicitInterfaceClause == true;
 
     /// <summary>
-    /// Gets or sets the <see cref="InterfaceSymbol"/> the explicit-interface
+    /// Gets or sets the interface type the explicit-interface
     /// qualifier clause (<see cref="HasExplicitInterfaceClause"/>) resolves
     /// to, bound by <see cref="Binding.DeclarationBinder.ResolveExplicitInterfaceClauses"/>
     /// once the containing type's interface list is fully known. <c>null</c>
@@ -428,7 +431,7 @@ public sealed class FunctionSymbol : Symbol
     /// bind to an interface implemented by the containing type (a diagnostic
     /// is reported in that case).
     /// </summary>
-    public InterfaceSymbol ExplicitInterfaceClauseTarget { get; set; }
+    public TypeSymbol ExplicitInterfaceClauseTarget { get; set; }
 
     /// <summary>Gets a value indicating whether this function is a P/Invoke stub (ADR-0086).</summary>
     public bool IsPInvoke => PInvokeMetadata != null;

--- a/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
@@ -114,6 +114,15 @@ public sealed class PropertySymbol : Symbol
     /// <summary>Gets or sets the imported CLR setter slot overridden by this property.</summary>
     public MethodInfo ExternalOverriddenSetter { get; set; }
 
+    /// <summary>Gets or sets the imported interface getter slot explicitly implemented by this property.</summary>
+    public MethodInfo ExplicitInterfaceGetterSlot { get; set; }
+
+    /// <summary>Gets or sets the imported interface setter slot explicitly implemented by this property.</summary>
+    public MethodInfo ExplicitInterfaceSetterSlot { get; set; }
+
+    /// <summary>Gets or sets the imported interface type that owns the explicit accessor slots.</summary>
+    public TypeSymbol ExplicitInterfaceSlotContainingType { get; set; }
+
     /// <summary>Gets or sets the imported constructed base type that owns the overridden accessors.</summary>
     public TypeSymbol ExternalOverrideContainingType { get; set; }
 
@@ -171,12 +180,12 @@ public sealed class PropertySymbol : Symbol
     public bool HasExplicitInterfaceClause => Declaration?.HasExplicitInterfaceClause == true;
 
     /// <summary>
-    /// Gets or sets the <see cref="InterfaceSymbol"/> the explicit-interface
+    /// Gets or sets the interface type the explicit-interface
     /// qualifier clause (<see cref="HasExplicitInterfaceClause"/>) resolves
     /// to, bound by <see cref="Binding.DeclarationBinder.ResolveExplicitInterfaceClauses"/>.
     /// <c>null</c> until resolved.
     /// </summary>
-    public InterfaceSymbol ExplicitInterfaceClauseTarget { get; set; }
+    public TypeSymbol ExplicitInterfaceClauseTarget { get; set; }
 
     /// <summary>
     /// ADR-0105 Phase 2 — re-points this (reused) property at the declaration

--- a/test/Compiler.Tests/Emit/Issue2543ImportedExplicitInterfaceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2543ImportedExplicitInterfaceEmitTests.cs
@@ -1,0 +1,256 @@
+// <copyright file="Issue2543ImportedExplicitInterfaceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Issue #2543: explicit implementations bind to imported interface slots.</summary>
+public sealed class Issue2543ImportedExplicitInterfaceEmitTests
+{
+    private const string ContractsSource = """
+        package Issue2543.Contracts
+        import System
+
+        interface IContract {
+            func Echo(value string) string;
+            prop Name string { get; }
+            prop this[index int32] int32 { get; }
+            event Changed Action
+        }
+
+        interface IOther {
+            func Echo(value string) string;
+        }
+
+        interface IGeneric[T] {
+            func Convert(value T) T;
+            prop Value T { get; }
+        }
+
+        class Marker {}
+        """;
+
+    [Fact]
+    public void ImportedExplicitMembers_CompileEmitMethodImplsAndDispatch()
+    {
+        const string source = """
+            package Issue2543.App
+            import System
+            import Issue2543.Contracts
+
+            class Sink {
+                var Hits int32
+                init() { Hits = 0 }
+                func Bump() { Hits = Hits + 1 }
+            }
+
+            class Implementation : IContract, IGeneric[string] {
+                private var _handler Action?
+
+                private func (IContract) Echo(value string) string -> "explicit:" + value
+                private prop (IContract) Name string -> "imported"
+                private prop (IContract) this[index int32] int32 -> index * 3
+                private event (IContract) Changed Action {
+                    add { _handler = value }
+                    remove { _handler = nil }
+                }
+                private func (IGeneric[string]) Convert(value string) string -> value + ":generic"
+                private prop (IGeneric[string]) Value string -> "value"
+
+                func Fire() { _handler?.Invoke() }
+            }
+
+            func Main() {
+                var implementation = Implementation()
+                var contract IContract = implementation
+                var sink = Sink()
+                contract.Changed += func() { sink.Bump() }
+                implementation.Fire()
+                Console.WriteLine(contract.Echo("ok"))
+                Console.WriteLine(contract.Name)
+                Console.WriteLine(contract[4])
+                Console.WriteLine(sink.Hits)
+                var generic IGeneric[string] = implementation
+                Console.WriteLine(generic.Convert(generic.Value))
+            }
+            """;
+
+        using var artifacts = Compile(source, "exe");
+        Assert.Equal("explicit:ok\nimported\n12\n1\nvalue:generic\n", Run(artifacts.OutputPath));
+        IlVerifier.Verify(artifacts.OutputPath, additionalReferences: new[] { artifacts.ContractsPath });
+
+        using var stream = File.OpenRead(artifacts.OutputPath);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var implementation = reader.TypeDefinitions
+            .Select(reader.GetTypeDefinition)
+            .Single(type => reader.GetString(type.Name) == "Implementation");
+        Assert.Equal(7, implementation.GetMethodImplementations().Count);
+    }
+
+    [Theory]
+    [InlineData(
+        "class Bad { func (Marker) Echo(value string) string -> value }",
+        "GS0492")]
+    [InlineData(
+        "class Bad : IContract { func (IOther) Echo(value string) string -> value }",
+        "GS0493")]
+    [InlineData(
+        "class Bad : IContract { func (IContract) Missing() string -> \"missing\" }",
+        "GS0494")]
+    public void ImportedQualifierErrorsRetainSpecificDiagnostics(string declaration, string diagnosticId)
+    {
+        var source = $$"""
+            package Issue2543.Negative
+            import Issue2543.Contracts
+            {{declaration}}
+            """;
+
+        using var artifacts = Compile(source, "library", expectSuccess: false);
+        Assert.NotEqual(0, artifacts.ExitCode);
+        Assert.Contains(diagnosticId, artifacts.Stdout + artifacts.Stderr, StringComparison.Ordinal);
+    }
+
+    private static CompilationArtifacts Compile(string source, string target, bool expectSuccess = true)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2543-artifacts",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        var contractsSourcePath = Path.Combine(directory, "contracts.gs");
+        var contractsPath = Path.Combine(directory, "Issue2543.Contracts.dll");
+        File.WriteAllText(contractsSourcePath, ContractsSource);
+        var contractsResult = RunCompiler(new[]
+        {
+            "/out:" + contractsPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            contractsSourcePath,
+        });
+        Assert.True(
+            contractsResult.ExitCode == 0,
+            $"contract compile failed\n{contractsResult.Stdout}\n{contractsResult.Stderr}");
+
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "Issue2543.App.dll");
+        File.WriteAllText(sourcePath, source);
+        var result = RunCompiler(new[]
+        {
+            "/out:" + outputPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/reference:" + contractsPath,
+            sourcePath,
+        });
+        if (expectSuccess)
+        {
+            Assert.True(
+                result.ExitCode == 0,
+                $"compile failed\n{result.Stdout}\n{result.Stderr}");
+        }
+
+        return new CompilationArtifacts(
+            directory,
+            outputPath,
+            contractsPath,
+            result.ExitCode,
+            result.Stdout,
+            result.Stderr);
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunCompiler(string[] args)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return (Program.Main(args), stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string Run(string assemblyPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath)!,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n");
+    }
+
+    private sealed class CompilationArtifacts : IDisposable
+    {
+        public CompilationArtifacts(
+            string directory,
+            string outputPath,
+            string contractsPath,
+            int exitCode,
+            string stdout,
+            string stderr)
+        {
+            Directory = directory;
+            OutputPath = outputPath;
+            ContractsPath = contractsPath;
+            ExitCode = exitCode;
+            Stdout = stdout;
+            Stderr = stderr;
+        }
+
+        public string Directory { get; }
+
+        public string OutputPath { get; }
+
+        public string ContractsPath { get; }
+
+        public int ExitCode { get; }
+
+        public string Stdout { get; }
+
+        public string Stderr { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                System.IO.Directory.Delete(Directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- bind explicit-interface qualifiers to imported CLR interfaces, including constructed generic contracts
- resolve imported method/property/indexer/event slots and emit their MethodImpl mappings
- add cross-assembly runtime, metadata, ILVerify, and negative diagnostic coverage

## Tests
- 42 targeted Compiler.Tests passed
- 24 ADR-0149 Core.Tests passed

Fixes #2543