### PR TITLE
Fix ref bool PInvoke marshaling

### DIFF
--- a/src/Core/CodeAnalysis/Binding/PInvokeBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/PInvokeBinder.cs
@@ -394,9 +394,12 @@ internal static class PInvokeBinder
     /// <item>A user struct whose blittability is established by
     /// <see cref="BlittableDetector"/> (issued GS0349 otherwise).</item>
     /// </list>
-    /// Every other pointee — <c>bool</c>, <c>char</c>, <c>string</c>,
-    /// <c>object</c>, <c>decimal</c>, slices, sequences, nullable types —
-    /// is rejected with the new GS0352 diagnostic. <c>ref string</c> is the
+    /// A <c>bool</c> pointee is also accepted when an explicit
+    /// <c>@MarshalAs(UnmanagedType.Bool|I1|U1)</c> defines its native width.
+    /// Every other pointee — including an unannotated <c>bool</c>,
+    /// <c>char</c>, <c>string</c>, <c>object</c>, <c>decimal</c>, slices,
+    /// sequences, and nullable types — is rejected with the new GS0352
+    /// diagnostic. <c>ref string</c> is the
     /// canonical user mistake the diagnostic message coaches against
     /// (recommend an explicit <c>nint</c> + Marshal.PtrToStringUTF8 round
     /// trip instead).
@@ -415,6 +418,16 @@ internal static class PInvokeBinder
         }
 
         if (IsBlittablePrimitive(pointee))
+        {
+            return;
+        }
+
+        // Issue #2554: bool itself is deliberately still non-blittable. An
+        // explicit descriptor makes the runtime marshal through a temporary
+        // of the requested ABI width, so ref/out/in bool is safe only for the
+        // three scalar forms supported by the CLR marshaller.
+        if (pointee == TypeSymbol.Bool
+            && parameter.MarshalAsMetadata?.UnmanagedType is UnmanagedType.Bool or UnmanagedType.I1 or UnmanagedType.U1)
         {
             return;
         }

--- a/src/Core/CodeAnalysis/Emit/FunctionEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/FunctionEmitter.cs
@@ -1232,8 +1232,9 @@ internal sealed class FunctionEmitter
             // ADR-0096 / issue #762: stamp HasFieldMarshal on the outer
             // Param row when the parameter carries an `@MarshalAs(...)`
             // override. The outer stub uses the user-visible managed
-            // type (e.g. `int32`) so the override applies here; the
-            // inner blittable P/Invoke has no FieldMarshal row.
+            // type (e.g. `int32`) so reflection preserves the source
+            // contract. The inner P/Invoke also receives the descriptor
+            // below because that is the actual unmanaged transition.
             var outerParamAttrs = ParameterAttributes.None;
             if (p.MarshalAsMetadata != null)
             {
@@ -1323,10 +1324,17 @@ internal sealed class FunctionEmitter
         var innerSeq = 1;
         foreach (var p in function.Parameters)
         {
-            this.emitCtx.Metadata.AddParameter(
-                attributes: ParameterAttributes.None,
+            var innerParamAttrs = p.MarshalAsMetadata == null
+                ? ParameterAttributes.None
+                : ParameterAttributes.HasFieldMarshal;
+            var innerParamHandle = this.emitCtx.Metadata.AddParameter(
+                attributes: innerParamAttrs,
                 name: this.emitCtx.Metadata.GetOrAddString(p.Name ?? string.Empty),
                 sequenceNumber: innerSeq++);
+            if (p.MarshalAsMetadata != null)
+            {
+                EmitFieldMarshalRow(innerParamHandle, p.MarshalAsMetadata);
+            }
         }
 
         var innerName = "<" + function.Name + ">g__PInvoke|0_0";

--- a/test/Compiler.Tests/Emit/Issue760PInvokeRefOutInEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue760PInvokeRefOutInEmitTests.cs
@@ -178,6 +178,36 @@ public class Issue760PInvokeRefOutInEmitTests
         Assert.Equal("True\nTrue\n", output);
     }
 
+    [Theory]
+    [InlineData("DllImport")]
+    [InlineData("LibraryImport")]
+    public void ExplicitlyMarshaled_RefBool_RandR_WritesBack(string importAttribute)
+    {
+        if (!IsLibcCallable())
+        {
+            return;
+        }
+
+        // POSIX rand_r consumes and updates an unsigned int*. UnmanagedType.Bool
+        // gives the managed bool slot the same four-byte ABI representation.
+        var source = $$"""
+            package P
+            import System
+            import System.Runtime.InteropServices
+
+            @{{importAttribute}}("libc", EntryPoint: "rand_r")
+            func native_rand_r(@MarshalAs(UnmanagedType.Bool) ref seed bool) int32;
+
+            var seed = false
+            var rc = native_rand_r(ref seed)
+            Console.WriteLine(rc != 0)
+            Console.WriteLine(seed)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nTrue\n", output);
+    }
+
     [Fact]
     public void DllImport_RefParameter_EmitsByRefSignature_In_ImplMap()
     {

--- a/test/Compiler.Tests/Emit/Issue762MarshalAsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue762MarshalAsEmitTests.cs
@@ -84,6 +84,88 @@ func native_set_flag(@MarshalAs(UnmanagedType.I4) on bool) int32;
     }
 
     [Fact]
+    public void MarshalAs_Bool_OnRefBool_EmitsByRefSignatureAndFieldMarshal()
+    {
+        const string source = @"
+package P
+import System.Runtime.InteropServices
+
+@DllImport(""libfoo"", EntryPoint: ""set_flag"")
+func native_set_flag(@MarshalAs(UnmanagedType.Bool) ref flag bool) int32;
+";
+
+        var tempDir = Directory.CreateTempSubdirectory("gs_2554_ref_bool_").FullName;
+        try
+        {
+            var (_, outPath) = WriteAndCompile(tempDir, source);
+            IlVerifier.Verify(outPath);
+
+            using var pe = new PEReader(File.OpenRead(outPath));
+            var md = pe.GetMetadataReader();
+            var method = FindMethod(md, "native_set_flag");
+            Assert.Contains((byte)SignatureTypeCode.ByReference, md.GetBlobBytes(method.Signature));
+
+            var parameter = method.GetParameters()
+                .Select(md.GetParameter)
+                .Single(p => md.GetString(p.Name) == "flag");
+            Assert.True((parameter.Attributes & ParameterAttributes.HasFieldMarshal) != 0);
+            Assert.Equal(new byte[] { (byte)UnmanagedType.Bool }, md.GetBlobBytes(parameter.GetMarshallingDescriptor()));
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    [Fact]
+    public void MarshalAs_Bool_OnLibraryImportRefBool_ReachesInnerPInvoke()
+    {
+        const string source = @"
+package P
+import System.Runtime.InteropServices
+
+@LibraryImport(""libfoo"", EntryPoint: ""set_flag"")
+func native_set_flag(@MarshalAs(UnmanagedType.Bool) ref flag bool) int32;
+";
+
+        var tempDir = Directory.CreateTempSubdirectory("gs_2554_lib_ref_bool_").FullName;
+        try
+        {
+            var (_, outPath) = WriteAndCompile(tempDir, source);
+            IlVerifier.Verify(outPath);
+
+            using var pe = new PEReader(File.OpenRead(outPath));
+            var md = pe.GetMetadataReader();
+            var method = md.MethodDefinitions
+                .Select(md.GetMethodDefinition)
+                .Single(m => md.GetString(m.Name).Contains("native_set_flag")
+                    && (m.Attributes & MethodAttributes.PinvokeImpl) != 0);
+            var parameter = method.GetParameters()
+                .Select(md.GetParameter)
+                .Single(p => md.GetString(p.Name) == "flag");
+
+            Assert.True((parameter.Attributes & ParameterAttributes.HasFieldMarshal) != 0);
+            Assert.Equal(new byte[] { (byte)UnmanagedType.Bool }, md.GetBlobBytes(parameter.GetMarshallingDescriptor()));
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    [Fact]
     public void MarshalAs_LPArray_WithSizeParamIndex_EncodesAsLPArrayMaxParam()
     {
         const string source = @"

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue760PInvokeRefOutInBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue760PInvokeRefOutInBinderTests.cs
@@ -186,6 +186,61 @@ func native_bool(ref b bool) int32;
         Assert.Contains(scope.Diagnostics, d => d.Id == "GS0352");
     }
 
+    [Theory]
+    [InlineData("Bool")]
+    [InlineData("I1")]
+    [InlineData("U1")]
+    public void DllImport_With_ExplicitlyMarshaled_RefBool_Is_Accepted(string unmanagedType)
+    {
+        var source = $@"
+package P
+import System.Runtime.InteropServices
+
+@DllImport(""libc"", EntryPoint: ""native_bool"")
+func native_bool(@MarshalAs(UnmanagedType.{unmanagedType}) ref b bool) int32;
+";
+        var scope = BindSource(source);
+        var fn = scope.Functions.Single(f => f.Name == "native_bool");
+
+        Assert.Equal(RefKind.Ref, fn.Parameters[0].RefKind);
+        Assert.NotNull(fn.Parameters[0].MarshalAsMetadata);
+        Assert.DoesNotContain(scope.Diagnostics, d => d.Id is "GS0352" or "GS0357" or "GS0358");
+    }
+
+    [Theory]
+    [InlineData("I4")]
+    [InlineData("VariantBool")]
+    public void DllImport_With_Unsupported_RefBool_MarshalForm_Reports_GS0352(string unmanagedType)
+    {
+        var source = $@"
+package P
+import System.Runtime.InteropServices
+
+@DllImport(""libc"", EntryPoint: ""native_bool"")
+func native_bool(@MarshalAs(UnmanagedType.{unmanagedType}) ref b bool) int32;
+";
+        var scope = BindSource(source);
+        Assert.Contains(scope.Diagnostics, d => d.Id == "GS0352");
+    }
+
+    [Fact]
+    public void LibraryImport_With_ExplicitlyMarshaled_OutBool_Is_Accepted()
+    {
+        const string source = @"
+package P
+import System.Runtime.InteropServices
+
+@LibraryImport(""libc"", EntryPoint: ""native_bool"")
+func native_bool(@MarshalAs(UnmanagedType.Bool) out b bool) int32;
+";
+        var scope = BindSource(source);
+        var fn = scope.Functions.Single(f => f.Name == "native_bool");
+
+        Assert.True(fn.PInvokeMetadata.IsLibraryImport);
+        Assert.Equal(RefKind.Out, fn.Parameters[0].RefKind);
+        Assert.DoesNotContain(scope.Diagnostics, d => d.Id is "GS0352" or "GS0357" or "GS0358" or "GS0360");
+    }
+
     [Fact]
     public void DllImport_With_Ref_Char_Reports_GS0352()
     {


### PR DESCRIPTION
## Summary
- accept `ref`/`out`/`in bool` only when `MarshalAs(Bool|I1|U1)` defines the native ABI
- carry `MarshalAs` metadata to the actual LibraryImport inner PInvoke boundary
- cover binder safety, emitted FieldMarshal/byref metadata, and portable POSIX runtime writeback

## Tests
- `Core.Tests` (6,566 passed, 1 skipped)
- focused Issue760 binder tests (20 passed)
- focused Issue760/Issue762 compiler tests (36 passed)

Fixes #2554