### PR TITLE
Refresh syntax highlighting for recent language features

### DIFF
--- a/src/vscode-gsharp/src/test/grammar.test.ts
+++ b/src/vscode-gsharp/src/test/grammar.test.ts
@@ -63,7 +63,7 @@ describe('gsharp.tmLanguage.json', () => {
     expect(uncovered).toEqual([]);
   });
 
-  it('covers the new 0.2 contextual keywords', () => {
+  it('covers compiler contextual keywords', () => {
     const contextual = repositoryMatchStrings('keywords').map(
       (m) => new RegExp(m),
     );
@@ -81,6 +81,8 @@ describe('gsharp.tmLanguage.json', () => {
       'not',
       'scoped',
       'ref',
+      'partial',
+      'sizeof',
     ];
     const missing = required.filter(
       (kw) => !contextual.some((r) => r.test(kw)),
@@ -94,6 +96,46 @@ describe('gsharp.tmLanguage.json', () => {
       ...repositoryMatchStrings('declarations'),
     ].map((m) => new RegExp(m));
     expect(matchers.some((r) => r.test('where'))).toBe(false);
+  });
+
+  it('does not treat the removed `null` alias as a literal', () => {
+    const constantMatchers = repositoryMatchStrings('constants').map(
+      (m) => new RegExp(m),
+    );
+    expect(constantMatchers.some((r) => r.test('null'))).toBe(false);
+  });
+
+  it('recognizes assembly-target annotations', () => {
+    const annotationMatchers = repositoryMatchStrings('annotations').map(
+      (m) => new RegExp(m),
+    );
+    expect(
+      annotationMatchers.some((r) =>
+        r.test('@assembly:InternalsVisibleTo'),
+      ),
+    ).toBe(true);
+  });
+
+  it('recognizes anonymous-object and explicit-interface declaration forms', () => {
+    const keywordMatchers = repositoryMatchStrings('keywords').map(
+      (m) => new RegExp(m),
+    );
+    expect(keywordMatchers.some((r) => r.test('object {'))).toBe(true);
+    expect(keywordMatchers.some((r) => r.test('object : IFoo {'))).toBe(true);
+
+    const declarationMatchers = repositoryMatchStrings('declarations').map(
+      (m) => new RegExp(m),
+    );
+    const declarations = [
+      'func (IFoo) M()',
+      'prop (IFoo) P int32',
+      'prop (IFoo) this[index int32] string',
+      'event (IFoo) Changed Handler',
+    ];
+    const missing = declarations.filter(
+      (declaration) => !declarationMatchers.some((r) => r.test(declaration)),
+    );
+    expect(missing).toEqual([]);
   });
 
   it('highlights all built-in primitive type names', () => {
@@ -157,7 +199,7 @@ describe('gsharp.tmLanguage.json', () => {
 
     const cases: [string, string][] = [
       ['..', 'keyword.operator.range.gsharp'],
-      ['...', 'keyword.operator.range.gsharp'],
+      ['...', 'keyword.operator.spread.gsharp'],
       ['->', 'keyword.operator.arrow.gsharp'],
       ['=>', 'keyword.operator.arrow.gsharp'],
       ['<-', 'keyword.operator.channel.gsharp'],
@@ -172,8 +214,10 @@ describe('gsharp.tmLanguage.json', () => {
       ['?[', 'keyword.operator.null-conditional.gsharp'],
       [':=', 'keyword.operator.assignment.gsharp'],
       ['<<=', 'keyword.operator.assignment.gsharp'],
+      ['>>>=', 'keyword.operator.assignment.gsharp'],
       ['>>=', 'keyword.operator.assignment.gsharp'],
       ['<<', 'keyword.operator.bitwise.gsharp'],
+      ['>>>', 'keyword.operator.bitwise.gsharp'],
       ['>>', 'keyword.operator.bitwise.gsharp'],
     ];
 

--- a/src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json
+++ b/src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json
@@ -159,6 +159,16 @@
     "annotations": {
       "patterns": [
         {
+          "name": "meta.annotation.assembly.gsharp",
+          "match": "(@)(assembly)(:)([A-Za-z_][A-Za-z0-9_]*)",
+          "captures": {
+            "1": { "name": "punctuation.definition.annotation.gsharp" },
+            "2": { "name": "storage.modifier.annotation-target.gsharp" },
+            "3": { "name": "punctuation.separator.annotation-target.gsharp" },
+            "4": { "name": "storage.type.annotation.gsharp" }
+          }
+        },
+        {
           "name": "meta.annotation.gsharp",
           "match": "(@)([A-Za-z_][A-Za-z0-9_]*)",
           "captures": {
@@ -170,6 +180,39 @@
     },
     "declarations": {
       "patterns": [
+        {
+          "comment": "Explicit-interface function: `func (IFoo) Name(...)`",
+          "match": "\\b(func)\\s+(\\()([A-Za-z_][A-Za-z0-9_.]*(?:\\[[^\\]\\r\\n]+\\])?)(\\))\\s+([A-Za-z_][A-Za-z0-9_]*)",
+          "captures": {
+            "1": { "name": "keyword.declaration.gsharp" },
+            "2": { "name": "punctuation.definition.interface.begin.gsharp" },
+            "3": { "name": "entity.name.type.interface.gsharp" },
+            "4": { "name": "punctuation.definition.interface.end.gsharp" },
+            "5": { "name": "entity.name.function.gsharp" }
+          }
+        },
+        {
+          "comment": "Explicit-interface property/indexer: `prop (IFoo) Name T`",
+          "match": "\\b(prop)\\s+(\\()([A-Za-z_][A-Za-z0-9_.]*(?:\\[[^\\]\\r\\n]+\\])?)(\\))\\s+(this|[A-Za-z_][A-Za-z0-9_]*)",
+          "captures": {
+            "1": { "name": "keyword.declaration.gsharp" },
+            "2": { "name": "punctuation.definition.interface.begin.gsharp" },
+            "3": { "name": "entity.name.type.interface.gsharp" },
+            "4": { "name": "punctuation.definition.interface.end.gsharp" },
+            "5": { "name": "entity.name.variable.property.gsharp" }
+          }
+        },
+        {
+          "comment": "Explicit-interface event: `event (IFoo) Changed Handler`",
+          "match": "\\b(event)\\s+(\\()([A-Za-z_][A-Za-z0-9_.]*(?:\\[[^\\]\\r\\n]+\\])?)(\\))\\s+([A-Za-z_][A-Za-z0-9_]*)",
+          "captures": {
+            "1": { "name": "keyword.declaration.gsharp" },
+            "2": { "name": "punctuation.definition.interface.begin.gsharp" },
+            "3": { "name": "entity.name.type.interface.gsharp" },
+            "4": { "name": "punctuation.definition.interface.end.gsharp" },
+            "5": { "name": "entity.name.variable.event.gsharp" }
+          }
+        },
         {
           "comment": "Aggregate declarations per ADR-0078: `class|struct|enum|interface Name`",
           "match": "\\b(class|struct|enum|interface)\\s+([A-Za-z_][A-Za-z0-9_]*)",
@@ -220,7 +263,7 @@
         },
         {
           "name": "keyword.modifier.contextual.gsharp",
-          "match": "\\b(and|checked|convenience|data|deinit|delegate|event|explicit|fixed|implicit|in|init|inline|make|nameof|not|or|out|params|prop|raise|record|ref|remove|scoped|shared|stackalloc|typeof|unchecked|unmanaged|unsafe|when|with|yield)\\b"
+          "match": "\\b(and|checked|convenience|data|deinit|delegate|event|explicit|fixed|implicit|in|init|inline|make|nameof|not|or|out|params|partial|prop|raise|record|ref|remove|scoped|shared|sizeof|stackalloc|typeof|unchecked|unmanaged|unsafe|when|with|yield)\\b"
         },
         {
           "name": "keyword.other.accessor.gsharp",
@@ -229,6 +272,10 @@
         {
           "name": "keyword.other.gsharp",
           "match": "\\b(import|package|using|var|let|is|as|scope|chan|map)\\b"
+        },
+        {
+          "name": "keyword.declaration.anonymous-object.gsharp",
+          "match": "\\bobject(?=\\s*(?:\\{|:))"
         }
       ]
     },
@@ -252,7 +299,7 @@
         },
         {
           "name": "constant.language.null.gsharp",
-          "match": "\\b(nil|null)\\b"
+          "match": "\\bnil\\b"
         },
         {
           "name": "variable.language.this.gsharp",
@@ -264,8 +311,12 @@
       "comment": "Patterns are ordered longest-match-first so multi-character operators win over their single-character prefixes.",
       "patterns": [
         {
+          "name": "keyword.operator.spread.gsharp",
+          "match": "\\.\\.\\."
+        },
+        {
           "name": "keyword.operator.range.gsharp",
-          "match": "\\.\\.\\.|\\.\\."
+          "match": "\\.\\."
         },
         {
           "name": "keyword.operator.assignment.gsharp",

--- a/website/src/theme/prism-include-languages.ts
+++ b/website/src/theme/prism-include-languages.ts
@@ -25,13 +25,14 @@ function registerGSharp(Prism: typeof PrismNamespace): void {
   // conversion operators (`explicit`/`implicit`), pattern combinators
   // (`and`/`or`/`not`), the `init()` constructor constraint (renamed from
   // `new()` by ADR-0097 / issue #997), the unsafe/low-level words
-  // (`unsafe`/`fixed`/`stackalloc`/`unmanaged`), and the overflow-context
+  // (`unsafe`/`fixed`/`stackalloc`/`unmanaged`/`sizeof`), partial declarations,
+  // and the overflow-context
   // markers `checked`/`unchecked` (issue #1881; `lock` is a reserved keyword,
   // not contextual — see `keywords` above).
   // `record` was removed in v0.2; the lexer still recognises it so the parser
   // can emit the GS0307 migration diagnostic, so we keep it here for fidelity.
   const contextualKeywords =
-    /\b(?:add|and|base|checked|convenience|data|deinit|delegate|event|explicit|fixed|get|implicit|in|init|inline|make|nameof|not|or|out|params|prop|raise|record|ref|remove|scoped|set|shared|stackalloc|this|typeof|unchecked|unmanaged|unsafe|when|with|yield)\b/;
+    /\b(?:add|and|base|checked|convenience|data|deinit|delegate|event|explicit|fixed|get|implicit|in|init|inline|make|nameof|not|or|out|params|partial|prop|raise|record|ref|remove|scoped|set|shared|sizeof|stackalloc|this|typeof|unchecked|unmanaged|unsafe|when|with|yield)\b/;
 
   // Built-in primitive type names (TypeSymbol). Width-bearing names are
   // canonical; friendly aliases (`int`, `long`, etc.) are accepted by the
@@ -81,6 +82,42 @@ function registerGSharp(Prism: typeof PrismNamespace): void {
       pattern: /'(?:\\(?:u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8}|x[0-9a-fA-F]{1,4}|.)|[^'\\\r\n])'/,
       greedy: true,
     },
+    'assembly-annotation': {
+      pattern: /(@assembly:\s*)[A-Za-z_]\w*/,
+      lookbehind: true,
+      alias: 'attr-name',
+    },
+    'annotation-target': {
+      pattern: /(@)assembly(?=:)/,
+      lookbehind: true,
+      alias: 'keyword',
+    },
+    annotation: {
+      pattern: /@[A-Za-z_]\w*/,
+      alias: 'attr-name',
+    },
+    'explicit-interface-declaration': {
+      pattern:
+        /\b(?:func|prop|event)\s+\([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*(?:\[[^\]\r\n]+\])?\)\s+(?:this|[A-Za-z_]\w*)/,
+      inside: {
+        function: {
+          pattern: /(^func\s+\([^)]+\)\s+)[A-Za-z_]\w*$/,
+          lookbehind: true,
+        },
+        property: {
+          pattern:
+            /(^(?:prop|event)\s+\([^)]+\)\s+)(?:this|[A-Za-z_]\w*)$/,
+          lookbehind: true,
+        },
+        'class-name': {
+          pattern:
+            /(\()[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*(?:\[[^\]\r\n]+\])?(?=\))/,
+          lookbehind: true,
+        },
+        keyword: /^(?:func|prop|event)\b/,
+        punctuation: /[()]/,
+      },
+    },
     'class-name': [
       {
         // Type after declaration keywords.
@@ -96,6 +133,10 @@ function registerGSharp(Prism: typeof PrismNamespace): void {
     keyword: keywords,
     'contextual-keyword': {
       pattern: contextualKeywords,
+      alias: 'keyword',
+    },
+    'anonymous-object': {
+      pattern: /\bobject(?=\s*(?:\{|:))/,
       alias: 'keyword',
     },
     'builtin-type': {


### PR DESCRIPTION
## Summary
- add `partial` and `sizeof` to TextMate and Prism contextual keyword highlighting
- recognize assembly-target annotations, anonymous objects, and explicit-interface members
- distinguish structural spread from range syntax and remove stale `null` literal highlighting
- expand TextMate grammar regression coverage for recent language features

## Validation
- `npm run test:unit -- --runTestsByPath src/test/grammar.test.ts --runInBand`
- `npm run lint -- --no-fix`
- `npm run typecheck` (website)
- direct Prism tokenization checks for each added construct