### PR TITLE
Fix Visual Studio design-time compilation

### DIFF
--- a/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
+++ b/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
@@ -115,6 +115,16 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
     /// <summary>Gets or sets the managed resources to embed.</summary>
     public ITaskItem[] Resources { get; set; } = Array.Empty<ITaskItem>();
 
+    /// <summary>Gets or sets whether the task should return arguments without invoking gsc.</summary>
+    public string SkipCompilerExecution { get; set; }
+
+    /// <summary>Gets or sets whether the task should expose the generated compiler arguments.</summary>
+    public string ProvideCommandLineArgs { get; set; }
+
+    /// <summary>Gets the generated gsc command-line arguments for design-time builds.</summary>
+    [Output]
+    public ITaskItem[] CommandLineArgs { get; private set; } = Array.Empty<ITaskItem>();
+
     /// <inheritdoc/>
     public void Cancel() => this.cts.Cancel();
 
@@ -238,6 +248,22 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
         foreach (var s in this.Compile)
         {
             args.Add(QuoteIfNeeded(s.ItemSpec));
+        }
+
+        if (ParseBool(this.ProvideCommandLineArgs))
+        {
+            var commandLineArgs = new ITaskItem[args.Count];
+            for (var i = 0; i < args.Count; i++)
+            {
+                commandLineArgs[i] = new TaskItem(args[i]);
+            }
+
+            this.CommandLineArgs = commandLineArgs;
+        }
+
+        if (ParseBool(this.SkipCompilerExecution))
+        {
+            return true;
         }
 
         if (!string.IsNullOrEmpty(this.ResponseFilePath))

--- a/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
+++ b/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
@@ -290,6 +290,7 @@
                    $(DocumentationFile);
                    @(IntermediateRefAssembly);
                    @(_DebugSymbolsIntermediatePath)"
+          Returns="@(GsharpCommandLineArgs)"
           DependsOnTargets="$(CoreCompileDependsOn)">
 
     <!-- When the SDK asks for a reference assembly (ProduceReferenceAssembly=true),
@@ -338,7 +339,11 @@
         Compile="@(Compile)"
         References="@(ReferencePathWithRefAssemblies)"
         Resources="@(_GsharpCoreCompileResource)"
-        ResponseFilePath="$(IntermediateOutputPath)$(TargetName).rsp" />
+        SkipCompilerExecution="$(SkipCompilerExecution)"
+        ProvideCommandLineArgs="$(ProvideCommandLineArgs)"
+        ResponseFilePath="$(IntermediateOutputPath)$(TargetName).rsp">
+      <Output TaskParameter="CommandLineArgs" ItemName="GsharpCommandLineArgs" />
+    </BuildTask>
 
     <ItemGroup>
       <FileWrites Include="$(IntermediateOutputPath)$(TargetName)$(TargetExt)" />
@@ -356,6 +361,17 @@
                               '$(DebugType)' != ''                       and
                               '$(DebugType)' != 'none'                   and
                               '$(DebugType)' != 'embedded' " />
+    </ItemGroup>
+  </Target>
+
+  <!-- Visual Studio's managed CPS targets require each language SDK to expose
+       its design-time compiler arguments without running the compiler. -->
+  <Target Name="CompileDesignTime"
+          Returns="@(_CompilerCommandLineArgs)"
+          DependsOnTargets="_CheckCompileDesignTimePrerequisite;Compile"
+          Condition="'$(IsCrossTargetingBuild)' != 'true'">
+    <ItemGroup>
+      <_CompilerCommandLineArgs Include="@(GsharpCommandLineArgs)" />
     </ItemGroup>
   </Target>
 

--- a/src/vs-gsharp/src/VsGsharp/VsGsharp.csproj
+++ b/src/vs-gsharp/src/VsGsharp/VsGsharp.csproj
@@ -69,8 +69,8 @@
   </Target>
 
   <Target Name="GetVsixVersion"
-          DependsOnTargets="GetNuGetPackageVersion"
-          Returns="$(NuGetPackageVersion)" />
+          DependsOnTargets="GetBuildVersion"
+          Returns="$(FileVersion)" />
 
   <Target Name="IncludeGSharpLanguageServerInVsix"
           BeforeTargets="GetVsixSourceItems"

--- a/test/Sdk.Tests/BuildTaskDesignTimeTests.cs
+++ b/test/Sdk.Tests/BuildTaskDesignTimeTests.cs
@@ -1,0 +1,52 @@
+// <copyright file="BuildTaskDesignTimeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using Gsharp.NET.Sdk.Tools;
+using Microsoft.Build.Utilities;
+using Xunit;
+
+namespace GSharp.Sdk.Tests;
+
+/// <summary>
+/// Tests the compiler task's non-executing design-time mode.
+/// </summary>
+public class BuildTaskDesignTimeTests
+{
+    /// <summary>
+    /// Verifies that design-time builds expose arguments without filesystem or process side effects.
+    /// </summary>
+    [Fact]
+    public void SkipCompilerExecution_ReturnsArgumentsWithoutWritingResponseFile()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "gsharp-design-time-" + Guid.NewGuid().ToString("N"));
+        var responseFile = Path.Combine(tempDirectory, "project.rsp");
+        var task = new BuildTask
+        {
+            GsharpCompilerFullPath = Path.Combine(tempDirectory, "missing-gsc.dll"),
+            OutputPath = tempDirectory,
+            OutputName = "DesignTime",
+            TempOutputPath = tempDirectory,
+            TargetFramework = "net10.0",
+            BasePath = tempDirectory,
+            OutputType = "Library",
+            Compile = new[] { new TaskItem("Program.gs") },
+            References = new[] { new TaskItem("Reference.dll") },
+            ResponseFilePath = responseFile,
+            SkipCompilerExecution = "true",
+            ProvideCommandLineArgs = "true",
+        };
+
+        Assert.True(task.Execute());
+        Assert.False(File.Exists(responseFile));
+
+        var arguments = task.CommandLineArgs.Select(item => item.ItemSpec).ToArray();
+        Assert.Contains("/target:library", arguments);
+        Assert.Contains("/targetframework:net10.0", arguments);
+        Assert.Contains("/r:Reference.dll", arguments);
+        Assert.Contains("Program.gs", arguments);
+    }
+}

--- a/test/Sdk.Tests/SdkLayoutTests.cs
+++ b/test/Sdk.Tests/SdkLayoutTests.cs
@@ -89,6 +89,7 @@ public class SdkLayoutTests
         var coreCompile = doc.Descendants(MsbuildNs + "Target")
             .FirstOrDefault(t => (string)t.Attribute("Name") == "CoreCompile");
         Assert.NotNull(coreCompile);
+        Assert.Equal("@(GsharpCommandLineArgs)", (string)coreCompile.Attribute("Returns"));
 
         var buildTask = coreCompile.Element(MsbuildNs + "BuildTask");
         Assert.NotNull(buildTask);
@@ -105,6 +106,12 @@ public class SdkLayoutTests
         Assert.Equal("@(_GsharpCoreCompileResource)", attrs["Resources"]);
         Assert.Equal("$(OutputType)", attrs["OutputType"]);
         Assert.Equal("$(TargetFramework)", attrs["TargetFramework"]);
+        Assert.Equal("$(SkipCompilerExecution)", attrs["SkipCompilerExecution"]);
+        Assert.Equal("$(ProvideCommandLineArgs)", attrs["ProvideCommandLineArgs"]);
+        Assert.Contains(
+            buildTask.Elements(MsbuildNs + "Output"),
+            output => (string)output.Attribute("TaskParameter") == "CommandLineArgs"
+                && (string)output.Attribute("ItemName") == "GsharpCommandLineArgs");
 
         // Reference-assembly emit must be forwarded so MSBuild's
         // ProduceReferenceAssembly pipeline (which sets @(IntermediateRefAssembly)
@@ -125,6 +132,19 @@ public class SdkLayoutTests
         Assert.Contains(
             runSettingsTarget.Descendants(MsbuildNs + "_GsharpRunSettingsLine"),
             line => line.Attribute("Include")?.Value.Contains("$(TargetFramework)") == true);
+
+        var compileDesignTime = doc.Descendants(MsbuildNs + "Target")
+            .Single(t => (string)t.Attribute("Name") == "CompileDesignTime");
+        Assert.Equal("@(_CompilerCommandLineArgs)", (string)compileDesignTime.Attribute("Returns"));
+        Assert.Equal(
+            "_CheckCompileDesignTimePrerequisite;Compile",
+            (string)compileDesignTime.Attribute("DependsOnTargets"));
+        Assert.Equal(
+            "'$(IsCrossTargetingBuild)' != 'true'",
+            (string)compileDesignTime.Attribute("Condition"));
+        Assert.Contains(
+            compileDesignTime.Descendants(MsbuildNs + "_CompilerCommandLineArgs"),
+            item => (string)item.Attribute("Include") == "@(GsharpCommandLineArgs)");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- implement the managed CPS `CompileDesignTime` contract for G# projects
- return compiler arguments without writing a response file or launching `gsc`
- use a numeric VSIX file version so Visual Studio installs current development builds
- add focused SDK layout and design-time task coverage

## Validation
- `MSBUILDDISABLENODEREUSE=1 dotnet test test\Sdk.Tests\Sdk.Tests.csproj -c Debug` (43 passed)
- exercised `CompileDesignTime` against the generated Avalonia demo with Visual Studio design-time properties; no compiler response file or assembly was emitted
- built and installed the VSIX; the normal Visual Studio profile loaded `GSharp.Core 0.3.194+ff04b249de`