### PR TITLE
Fix discarded imported deconstruction finalization

### DIFF
--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -1562,7 +1562,7 @@ internal sealed partial class StatementBinder
             var result = ImmutableArray.CreateBuilder<BoundStatement>(identifiers.Count + 1);
             result.Add(new BoundExpressionStatement(null, call));
             result.AddRange(declarations);
-            statements = result.MoveToImmutable();
+            statements = result.ToImmutable();
             return true;
         }
 

--- a/test/Compiler.Tests/Issue2581GeneratedSourceCrashTests.cs
+++ b/test/Compiler.Tests/Issue2581GeneratedSourceCrashTests.cs
@@ -1,0 +1,77 @@
+// <copyright file="Issue2581GeneratedSourceCrashTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+public class Issue2581GeneratedSourceCrashTests
+{
+    [Fact]
+    public void Main_GeneratedSourceAndDiscardedDictionaryKey_EmitsStableAssembly()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gsc_2581_").FullName;
+        try
+        {
+            var generatedPath = Path.Combine(tempDir, "Repro.Version.gs");
+            var appPath = Path.Combine(tempDir, "App.gs");
+            File.WriteAllText(generatedPath, """
+                package Repro
+                @assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")
+                """);
+            File.WriteAllText(appPath, """
+                package Repro
+                import System.Collections.Generic
+
+                func Sum(values Dictionary[string, int32]) int32 {
+                    var total = 0
+                    for (_, value) in values {
+                        total += value
+                    }
+                    return total
+                }
+                """);
+
+            var first = Compile(tempDir, "first.dll", generatedPath, appPath);
+            var second = Compile(tempDir, "second.dll", generatedPath, appPath);
+
+            Assert.Equal(0, first.ExitCode);
+            Assert.Equal(0, second.ExitCode);
+            Assert.DoesNotContain("GS9998", first.Output);
+            Assert.DoesNotContain("GS9998", second.Output);
+            Assert.Equal(File.ReadAllBytes(first.OutputPath), File.ReadAllBytes(second.OutputPath));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static (int ExitCode, string Output, string OutputPath) Compile(
+        string directory,
+        string outputName,
+        params string[] sources)
+    {
+        var outputPath = Path.Combine(directory, outputName);
+        using var writer = new StringWriter();
+        var previous = Console.Out;
+        Console.SetOut(writer);
+        try
+        {
+            var args = new string[sources.Length + 4];
+            args[0] = "/out:" + outputPath;
+            args[1] = "/target:library";
+            args[2] = "/deterministic+";
+            args[3] = "/nowarn:GS9100";
+            sources.CopyTo(args, 4);
+            return (Program.Main(args), writer.ToString(), outputPath);
+        }
+        finally
+        {
+            Console.SetOut(previous);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- finalize imported deconstruction statement builders without assuming every tuple slot declares a local
- add a deterministic two-file `gsc` regression with generated version source first and a discarded dictionary key

## Root cause
`TryBindImportedDeconstruct` reserved `identifiers.Count + 1` statement slots, but discards intentionally omit declarations. Calling `MoveToImmutable()` therefore violated its exact Count/Capacity precondition for loops such as `for (_, value) in dictionary`.

## Oahu cycle-2 evidence
- latest `origin/main` (`ecce4842`) reproduced GS9998 from the supplied Oahu.Cli.App response file
- after this change, two full artifact runs both exited 1 with byte-identical diagnostic logs (`f8593179a50365f372d96721928edb6a2d00c800f2d7f51d642355d6a9245c10`) and zero GS9998 diagnostics
- the remaining first errors are GS0156 nullable-reference conversions in `Auth/CoreAuthService.gs` (for example line 170), covered by open #2579 rather than worked around here

## Validation
- `dotnet build GSharp.sln -c Release --nologo`
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --no-restore --nologo --filter 'FullyQualifiedName~ImportedExtensionMethodTests|FullyQualifiedName~Issue1922TupleForInStatementTests'` (19 passed)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-build --no-restore --nologo --filter 'FullyQualifiedName~Issue2581GeneratedSourceCrashTests|FullyQualifiedName~ProgramSilentFailureTests'` (4 passed)

Fixes #2581