### PR TITLE
Fix nullable reference translation fidelity

### DIFF
--- a/test/Compiler.Tests/Emit/Issue2579NullableReferenceFidelityEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2579NullableReferenceFidelityEmitTests.cs
@@ -1,0 +1,149 @@
+// <copyright file="Issue2579NullableReferenceFidelityEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue2579NullableReferenceFidelityEmitTests
+{
+    [Fact]
+    public void GuardedNullableReferences_ExecuteAcrossMemberArgumentIndexAndForeachBoundaries()
+    {
+        string output = CompileAndRun("""
+            package Issue2579
+            import System
+            import System.Collections.Generic
+
+            func Length(value string) int32 -> value.Length
+
+            var value string? = "key"
+            var list = List[string]()
+            list.Add("a")
+            list.Add("b")
+            var values IEnumerable[string]? = list
+            var dict = Dictionary[string, int32]()
+            var total = 0
+
+            if value != nil {
+                var assigned string = value
+                total += Length(value)
+                dict[value] = assigned.Length
+            }
+
+            if !String.IsNullOrEmpty(value) {
+                total += Length(value)
+            }
+
+            if values != nil {
+                for item in values {
+                    total += item.Length
+                }
+            }
+
+            total += Length(value!!)
+            Console.WriteLine(total)
+            """);
+
+        Assert.Equal("11\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        string directory = Directory.CreateTempSubdirectory("gs_issue2579_").FullName;
+        try
+        {
+            string sourcePath = Path.Combine(directory, "test.gs");
+            string outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+            foreach (string reference in TrustedPlatformAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add("/nowarn:GS9100");
+            args.Add(sourcePath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            TextWriter previousOut = Console.Out;
+            TextWriter previousErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\n{compileOut}\n{compileErr}");
+            IlVerifier.Verify(outputPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using Process process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start emitted program.");
+            string stdout = process.StandardOutput.ReadToEnd();
+            string stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "Emitted program timed out.");
+            Assert.True(process.ExitCode == 0, stderr);
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        string assemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(assemblies))
+        {
+            yield break;
+        }
+
+        foreach (string path in assemblies.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2579NullableReferenceBoundaryTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2579NullableReferenceBoundaryTests.cs
@@ -1,0 +1,114 @@
+// <copyright file="Issue2579NullableReferenceBoundaryTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2579NullableReferenceBoundaryTests
+{
+    [Fact]
+    public void GuardsAndAssertions_EnableReferenceUsesAcrossAllBoundaries()
+    {
+        EvaluationResult result = Evaluate("""
+            import System
+            import System.Collections.Generic
+
+            func Length(value string) int32 -> value.Length
+
+            var value string? = "key"
+            var list = List[string]()
+            list.Add("a")
+            list.Add("b")
+            var values IEnumerable[string]? = list
+            var dict = Dictionary[string, int32]()
+            var total = 0
+
+            if value != nil {
+                var assigned string = value
+                total += Length(value)
+                dict[value] = assigned.Length
+            }
+
+            if !String.IsNullOrEmpty(value) {
+                total += Length(value)
+            }
+
+            if values != nil {
+                for item in values {
+                    total += item.Length
+                }
+            }
+
+            total += Length(value!!)
+            total
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(11, result.Value);
+    }
+
+    [Fact]
+    public void UnguardedNullableReferencesRemainHardErrors()
+    {
+        EvaluationResult result = Evaluate("""
+            import System.Collections.Generic
+
+            func Consume(value string) {}
+
+            var value string? = nil
+            var values IEnumerable[string]? = nil
+            var dict = Dictionary[string, int32]()
+            var assigned string = value
+            Consume(value)
+            var length = value.Length
+            var indexed = dict[value]
+            for item in values {}
+            """);
+
+        Assert.True(result.Diagnostics.Count() >= 5);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0158");
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.Id is "GS0154" or "GS0155" or "GS0156");
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0116");
+    }
+
+    [Fact]
+    public void NullableValuesAndInvalidReferenceConversionsRemainHardErrors()
+    {
+        EvaluationResult result = Evaluate("""
+            interface IService {}
+            class Service : IService {}
+            class Other {}
+
+            func NeedInt(value int32) {}
+            func NeedService(value IService) {}
+
+            var number int32? = 1
+            var service Service? = nil
+            var other = Other()
+            NeedInt(number)
+            NeedService(service)
+            NeedService(other)
+            """);
+
+        Assert.True(result.Diagnostics.Count() >= 3);
+        Assert.All(result.Diagnostics, diagnostic =>
+            Assert.Contains(diagnostic.Id, new[] { "GS0154", "GS0155", "GS0156" }));
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2259ObliviousNullConditionalIndexTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2259ObliviousNullConditionalIndexTranslationTests.cs
@@ -117,13 +117,11 @@ namespace Demo
     }
 
     [Fact]
-    public void Enabled_NullConditionalIndex_AssignedToArrayElement_StaysUnpromoted()
+    public void Enabled_NullConditionalIndex_AssignedToNonNullElement_IsForgiven()
     {
-        // The SAME shape under a nullable-ENABLED compilation (`Infix` is
-        // explicitly `string?[]`, so the assignment is a legal, if
-        // warning-worthy, `string? -> string` conversion): the fix is gated to
-        // oblivious compilations only, so no `!!` is inserted and the RHS is
-        // byte-identical to pre-#2259 behavior.
+        // Nullable-enabled C# also permits this warning-level conversion.
+        // Preserve that boundary with an assertion rather than widening the
+        // destination array's element contract.
         string printed = TranslateEnabled(@"
 namespace Demo
 {
@@ -141,8 +139,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("parts[i] = punct.Infix?[x]", printed);
-        Assert.DoesNotContain("!!", printed);
+        Assert.Contains("parts[i] = (punct.Infix?[x])!!", printed);
     }
 
     private static string TranslateOblivious(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2506PromotedCallReceiverForgivenessTranslationTests.cs
@@ -219,7 +219,7 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
     }
 
     [Fact]
-    public void ConditionalAccessNullableEnabledFlowAndExpressionTrees_AvoidObliviousOverAssertion()
+    public void ConditionalAccessExpressionTreesAndNullableEnabledReceivers_UseCorrectBoundary()
     {
         string oblivious = Translate("""
             using System;
@@ -274,8 +274,8 @@ public sealed class Issue2506PromotedCallReceiverForgivenessTranslationTests
             }
             """);
 
-        Assert.Contains("Repro.ExplicitMaybe().Name", enabled, StringComparison.Ordinal);
-        Assert.Contains("Repro.ExplicitMaybe()!!.Name", enabled, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(enabled, "Repro.ExplicitMaybe()!!.Name"));
+        Assert.DoesNotContain("Repro.ExplicitMaybe().Name", enabled, StringComparison.Ordinal);
         Assert.Contains("Repro.Always().Name", enabled, StringComparison.Ordinal);
         Assert.DoesNotContain("Repro.Always()!!.Name", enabled, StringComparison.Ordinal);
         Assert.Contains("item!!.Name", enabled, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessTranslationTests.cs
@@ -153,7 +153,7 @@ public sealed class Issue2511NullableIndexArgumentForgivenessTranslationTests
     }
 
     [Fact]
-    public void ExplicitNullableSourcePromotedAndNullableEnabledContracts_RemainAssertionFree()
+    public void ExplicitNullableIndexContractsRemainBareAndGuardedNonNullContractsCompile()
     {
         string oblivious = TranslateObliviousWithIndexerLibrary("""
             using System;
@@ -217,8 +217,7 @@ public sealed class Issue2511NullableIndexArgumentForgivenessTranslationTests
             """,
             NullableContextOptions.Enable);
 
-        Assert.Contains("return items[key]", enabled, StringComparison.Ordinal);
-        Assert.DoesNotContain("key!!", enabled, StringComparison.Ordinal);
+        Assert.Contains("return items[key!!]", enabled, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityPipelineTests.cs
@@ -1,0 +1,166 @@
+// <copyright file="Issue2579NullableReferenceFidelityPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2579NullableReferenceFidelityPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdk_NullableWarningBoundaries_TranslateAndCompile()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectPath = WriteFixture(sourceRoot);
+        string outputRoot = NewDirectory("pipeline-tests");
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(
+            new[] { new CorpusApp("test/Issue2579", projectPath, TargetKind.Library) });
+        AppResult app = Assert.Single(result.Apps);
+        string emitted = ReadAppOutput(outputRoot, result.RunId, app.AppId);
+
+        Assert.Contains("item!!.Next!!.Name", emitted, StringComparison.Ordinal);
+        Assert.Contains("item!!.Label()", emitted, StringComparison.Ordinal);
+        Assert.Contains("items!!.Count()", emitted, StringComparison.Ordinal);
+        Assert.Contains("for current in items!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("var required = key!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("required = key!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("Repro.Required = key!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("Repro.Consume(key!!)", emitted, StringComparison.Ordinal);
+        Assert.Contains("map_[key!!]", emitted, StringComparison.Ordinal);
+        Assert.True(
+            app.Succeeded,
+            "Expected nullable-enabled warning boundaries to compile via gsc. Stages: " +
+                string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+    }
+
+    private static string WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+        string projectDir = Path.Combine(sourceRoot, "Issue2579");
+        Directory.CreateDirectory(projectDir);
+
+        string projectPath = Path.Combine(projectDir, "Issue2579.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "Repro.cs"), """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            namespace Issue2579;
+
+            public sealed class Item
+            {
+                public string Name => "item";
+                public Item? Next => null;
+            }
+
+            public static class ItemExtensions
+            {
+                public static string Label(this Item item) => item.Name;
+            }
+
+            public static class Repro
+            {
+                private static string Required = "";
+                private static void Consume(string value) { }
+
+                public static int Run(
+                    Item? item,
+                    IEnumerable<Item>? items,
+                    Dictionary<string, string> map,
+                    string? key)
+                {
+                    _ = item.Next.Name;
+                    _ = item.Label();
+                    _ = items.Count();
+                    foreach (var current in items)
+                        _ = current.Name;
+                    string required = key;
+                    required = key;
+                    Required = key;
+                    Consume(key);
+                    _ = map[key];
+                    return required.Length;
+                }
+            }
+            """);
+        return projectPath;
+    }
+
+    private static string ReadAppOutput(string outputRoot, string runId, string appId)
+    {
+        string directory = Path.Combine(outputRoot, runId, MigrationPipeline.SanitizeAppId(appId));
+        return string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(directory, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2579",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityTranslationTests.cs
@@ -1,0 +1,138 @@
+// <copyright file="Issue2579NullableReferenceFidelityTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2579NullableReferenceFidelityTranslationTests
+{
+    [Fact]
+    public void NullableEnabledWarningBoundaries_EmitTargetAwareAssertions()
+    {
+        string printed = Translate("""
+            #nullable enable
+            using System.Collections.Generic;
+            using System.Linq;
+
+            namespace Demo;
+
+            public sealed class Item
+            {
+                public string Name => "item";
+                public Item? Next => null;
+            }
+
+            public static class ItemExtensions
+            {
+                public static string Label(this Item item) => item.Name;
+                public static string NullableLabel(this Item? item) => item?.Name ?? "";
+            }
+
+            public static class Repro
+            {
+                private static string Required = "";
+                private static void Consume(string value) { }
+
+                public static int Run(
+                    Item? item,
+                    IEnumerable<Item>? items,
+                    Dictionary<string, string> map,
+                    string? key)
+                {
+                    _ = item.Name;
+                    _ = item.Next.Name;
+                    _ = item.Label();
+                    _ = item.NullableLabel();
+                    _ = items.Count();
+                    foreach (var current in items)
+                        _ = current.Name;
+
+                    string required = key;
+                    required = key;
+                    Required = key;
+                    Consume(key);
+                    _ = map[key];
+                    Consume(key!);
+                    string? optional = key;
+                    return required.Length + optional?.Length ?? 0;
+                }
+            }
+            """);
+
+        Assert.Contains("item!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("item!!.Next!!.Name", printed, StringComparison.Ordinal);
+        Assert.Contains("item!!.Label()", printed, StringComparison.Ordinal);
+        Assert.Contains("item.NullableLabel()", printed, StringComparison.Ordinal);
+        Assert.Contains("items!!.Count()", printed, StringComparison.Ordinal);
+        Assert.Contains("for current in items!!", printed, StringComparison.Ordinal);
+        Assert.Contains("var required = key!!", printed, StringComparison.Ordinal);
+        Assert.Contains("required = key!!", printed, StringComparison.Ordinal);
+        Assert.Contains("Repro.Required = key!!", printed, StringComparison.Ordinal);
+        Assert.Contains("Repro.Consume(key!!)", printed, StringComparison.Ordinal);
+        Assert.Contains("map_[key!!]", printed, StringComparison.Ordinal);
+        Assert.Contains("let optional string? = key", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("optional string? = key!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("!!!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DirectAndAttributedGuards_KeepNullableValuesUsable()
+    {
+        string printed = Translate("""
+            #nullable enable
+            using System.Diagnostics.CodeAnalysis;
+
+            namespace Demo;
+
+            public static class Repro
+            {
+                private static bool Present([NotNullWhen(true)] string? value) =>
+                    value is not null;
+
+                private static int Length(string value) => value.Length;
+
+                public static int Direct(string? value)
+                {
+                    if (value is null)
+                        return 0;
+                    return Length(value);
+                }
+
+                public static int Attributed(string? value)
+                {
+                    if (!Present(value))
+                        return 0;
+                    return Length(value);
+                }
+            }
+            """);
+
+        Assert.Contains("Repro.Length(value!!)", printed, StringComparison.Ordinal);
+        Assert.Contains("@NotNullWhen(true)", printed, StringComparison.Ordinal);
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Errors) + "\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -510,7 +510,8 @@ public sealed partial class CSharpToGSharpTranslator
             GExpression translated = this.TranslateExpression(recv);
 
             if (this.ReceiverNeedsNullForgiveness(recv, isDereferenceReceiver: true)
-                || this.ReceiverIsNullableReferenceFieldOrProperty(recv))
+                || this.ReceiverIsNullableReferenceFieldOrProperty(recv)
+                || this.NullableReferenceValueMayBeNull(recv))
             {
                 translated = new NonNullAssertionExpression(translated);
             }
@@ -737,7 +738,75 @@ public sealed partial class CSharpToGSharpTranslator
                 return new NonNullAssertionExpression(translated);
             }
 
-            return translated;
+            (ITypeSymbol targetType, ISymbol targetSymbol) = this.FindContextualValueTarget(value);
+            return this.ForgiveNullableReferenceValue(value, translated, targetType, targetSymbol);
+        }
+
+        private GExpression ForgiveNullableReferenceValue(
+            ExpressionSyntax value,
+            GExpression translated,
+            ITypeSymbol targetType,
+            ISymbol targetSymbol)
+        {
+            if (translated is NonNullAssertionExpression
+                || value is PostfixUnaryExpressionSyntax
+                    { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
+                || this.IsWithinExpressionTreeLambda(value)
+                || !this.TargetWillRemainNonNullableReference(targetType, targetSymbol)
+                || !this.NullableReferenceValueMayBeNull(value))
+            {
+                return translated;
+            }
+
+            GExpression operand = value is ConditionalExpressionSyntax
+                or SwitchExpressionSyntax
+                or ConditionalAccessExpressionSyntax
+                    ? new ParenthesizedExpression(translated)
+                    : translated;
+            return new NonNullAssertionExpression(operand);
+        }
+
+        private bool NullableReferenceValueMayBeNull(ExpressionSyntax value)
+        {
+            if (value is PostfixUnaryExpressionSyntax
+                    { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
+                || this.IsWithinExpressionTreeLambda(value))
+            {
+                return false;
+            }
+
+            TypeInfo typeInfo = this.context.GetTypeInfo(value);
+            ITypeSymbol type = typeInfo.Type ?? typeInfo.ConvertedType;
+            return type is { IsReferenceType: true }
+                && typeInfo.Nullability.FlowState == NullableFlowState.MaybeNull
+                && (type.NullableAnnotation == NullableAnnotation.Annotated
+                    || typeInfo.Nullability.Annotation == NullableAnnotation.Annotated);
+        }
+
+        private (ITypeSymbol Type, ISymbol Symbol) FindContextualValueTarget(ExpressionSyntax value)
+        {
+            SyntaxNode current = value;
+            while (current.Parent is ParenthesizedExpressionSyntax
+                or ConditionalExpressionSyntax
+                or SwitchExpressionArmSyntax)
+            {
+                current = current.Parent;
+            }
+
+            ISymbol target = current.Parent switch
+            {
+                ReturnStatementSyntax => this.context.SemanticModel.GetEnclosingSymbol(value.SpanStart),
+                ArrowExpressionClauseSyntax arrow => this.context.GetDeclaredSymbol(arrow.Parent),
+                _ => null,
+            };
+
+            ITypeSymbol targetType = target switch
+            {
+                IMethodSymbol method => method.ReturnType,
+                IPropertySymbol property => property.Type,
+                _ => this.context.GetTypeInfo(value).ConvertedType,
+            };
+            return (targetType, target);
         }
 
         // Issue #2511: element-access arguments are call-like value sinks too.
@@ -751,8 +820,7 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression TranslateIndexArgumentWithNullForgiveness(ArgumentSyntax argument)
         {
             GExpression translated = this.TranslateExpression(argument.Expression);
-            if (!this.IsObliviousCompilation()
-                || !this.IndexArgumentTargetsNonNullableReference(argument)
+            if (!this.IndexArgumentTargetsNonNullableReference(argument)
                 || !this.IndexArgumentValueNeedsNullForgiveness(argument.Expression))
             {
                 return translated;
@@ -775,7 +843,18 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
+            ISymbol valueSymbol = this.context.GetSymbolInfo(value).Symbol;
+            if (valueSymbol != null && this.IsDominatedByNullCheckGuard(value, valueSymbol))
+            {
+                return false;
+            }
+
             if (this.ReceiverNeedsNullForgiveness(value))
+            {
+                return true;
+            }
+
+            if (this.NullableReferenceValueMayBeNull(value))
             {
                 return true;
             }
@@ -797,8 +876,9 @@ public sealed partial class CSharpToGSharpTranslator
                     return true;
             }
 
-            ISymbol symbol = this.context.GetSymbolInfo(value).Symbol;
-            return symbol is IFieldSymbol or IPropertySymbol or ILocalSymbol or IParameterSymbol or IMethodSymbol
+            ISymbol symbol = valueSymbol;
+            return this.IsObliviousCompilation()
+                && symbol is IFieldSymbol or IPropertySymbol or ILocalSymbol or IParameterSymbol or IMethodSymbol
                 && this.IsNullablePromotedValue(value)
                 && !this.IsDominatedByNullCheckGuard(value, symbol);
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -280,7 +280,13 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GExpression TranslateStaticExtensionReceiver(IArgumentOperation receiverArgument)
         {
-            var translated = this.TranslateExpression(((ArgumentSyntax)receiverArgument.Syntax).Expression);
+            ExpressionSyntax expression = ((ArgumentSyntax)receiverArgument.Syntax).Expression;
+            var translated = this.TranslateExpression(expression);
+            translated = this.ForgiveNullableReferenceValue(
+                expression,
+                translated,
+                receiverArgument.Parameter?.Type,
+                receiverArgument.Parameter);
             IOperation value = receiverArgument.Value;
 
             while (value is IConversionOperation { IsImplicit: true } implicitConversion)
@@ -1075,11 +1081,23 @@ public sealed partial class CSharpToGSharpTranslator
             // CoerceNumericArgumentToConverted (issue #1281) emits the bare operand
             // when gsc accepts the conversion on its own and keeps the explicit
             // `T(x)` wrap only where gsc still needs it.
-            return this.CoercePointerConversion(
+            GExpression translated = this.CoercePointerConversion(
                 argument.Expression,
                 this.CoerceNumericArgumentToConverted(
                     argument,
                     this.TranslateExpression(argument.Expression)));
+            if (!IsNameOfArgument(argument)
+                && this.context.SemanticModel.GetOperation(argument) is IArgumentOperation
+                    { Parameter: { } parameter })
+            {
+                translated = this.ForgiveNullableReferenceValue(
+                    argument.Expression,
+                    translated,
+                    parameter.Type,
+                    parameter);
+            }
+
+            return translated;
         }
 
         // Coerce an argument expression to the numeric type C# implicitly converted

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -617,14 +617,17 @@ public sealed partial class CSharpToGSharpTranslator
             // `null` for every existing single-compilation caller, so this
             // overload reduces to the exact prior single-compilation check —
             // a pure additive fix for the cross-project case.
-            if (ObliviousNullabilityAnalyzer.IsTainted(this.context.Compilation, symbol, this.context.SiblingCompilations))
+            if (declared.NullableAnnotation == NullableAnnotation.None
+                && ObliviousNullabilityAnalyzer.IsTainted(
+                    this.context.Compilation,
+                    symbol,
+                    this.context.SiblingCompilations))
             {
                 return true;
             }
 
-            return symbol is IMethodSymbol
-                ? false
-                : this.IsUsedAsNullable(symbol, this.GetNullabilityScope(symbol));
+            return symbol is not IMethodSymbol
+                && this.IsUsedAsNullable(symbol, this.GetNullabilityScope(symbol));
         }
 
         // Issue #2521: sink lowering must use the target contract that G# will

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -95,6 +95,17 @@ public sealed partial class CSharpToGSharpTranslator
                     }
                 }
 
+                if (initializer != null
+                    && declarator.Initializer?.Value is { } initializerSyntax
+                    && this.context.GetDeclaredSymbol(declarator) is ILocalSymbol localTarget)
+                {
+                    initializer = this.ForgiveNullableReferenceValue(
+                        initializerSyntax,
+                        initializer,
+                        localTarget.Type,
+                        localTarget);
+                }
+
                 // Issue #1954: `var g2 = grid;` — a simple `var` local initialized
                 // directly from another local/parameter/field that is ITSELF a
                 // tracked flat-lowered multi-dim array (see `multiDimArrays`)
@@ -1785,6 +1796,24 @@ public sealed partial class CSharpToGSharpTranslator
                     assignRhs = this.ForgiveEventSubscriptionRhs(assignment, assignRhs);
                     assignRhs = this.ForgiveElementAccessAssignmentRhs(assignment, assignRhs);
                     assignRhs = this.ForgiveObliviousExternalAssignmentRhs(assignment, assignRhs);
+                    if (assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
+                    {
+                        ISymbol assignmentTarget = this.context.GetSymbolInfo(assignment.Left).Symbol;
+                        ITypeSymbol assignmentTargetType = assignmentTarget switch
+                        {
+                            ILocalSymbol local => local.Type,
+                            IParameterSymbol parameter => parameter.Type,
+                            IFieldSymbol field => field.Type,
+                            IPropertySymbol property => property.Type,
+                            _ => this.context.GetTypeInfo(assignment.Left).Type,
+                        };
+                        assignRhs = this.ForgiveNullableReferenceValue(
+                            assignment.Right,
+                            assignRhs,
+                            assignmentTargetType,
+                            assignmentTarget);
+                    }
+
                     return new AssignmentStatement(
                         this.TranslateAssignmentTarget(assignment.Left),
                         assignRhs,


### PR DESCRIPTION
## Summary
- keep gsc nullable-reference checks strict while translating C# warning-level nullable boundaries with target-aware `!!` bridges
- cover receiver chains, source/imported extensions, assignments, arguments, indexes, foreach, explicit suppression, and flow guards
- preserve nullable value-type and invalid-conversion errors with compiler, runtime, translator, and via-SDK pipeline coverage

## Validation
- `Cs2Gs.Tests`: 1668 passed
- `Core.Tests`: 6593 passed, 1 skipped
- focused `Compiler.Tests` emit/runtime test passed
- focused issue #2579 via-SDK pipeline passed

Fixes #2579