### PR TITLE
Fix yield break target lowering

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -562,8 +562,9 @@ empirically (gsc **0.2.137+31ced6cfb7**) before adoption.
   fresh temporaries (`var __decon0 = x; var __decon1 = y; a = __decon0; b =
   __decon1`), preserving C#'s evaluate-all-then-assign order (and aliasing such as
   `(a, b) = (b, a)`).
-- **`yield break` → `break`.** Settled fact: G# has no `yield break`; it maps to
-  a plain loop-control `break` (supersedes the former §G #994 unsupported note).
+- **`yield break` → iterator-exit jump.** G# has no `yield break`; cs2gs jumps
+  to a synthesized label at the end of the nearest iterator body so termination
+  is independent of surrounding loop/switch topology.
 - **`foreach ((a, b) in xs)` tuple deconstruction → `for a, b in xs`.** A
   `ForEachVariableStatement` maps to the G# two-name iteration form; element
   names are collected from the tuple/declaration designation.
@@ -784,7 +785,7 @@ re-greening earlier stages and surfacing the next layer of gaps:
 | #991 | a `when` guard on a `switch` statement/expression arm won't parse | GS0005 | **resolved** (issue #991 — `case <pattern> when <bool>:` / `case <pattern> when <bool> { … }` parse a contextual `when` guard; an arm matches only when the pattern matches AND the guard is true; guarded arms never satisfy exhaustiveness; cs2gs now translates C# `when` guards to the new form) |
 | #992 | `and`/`or` binary patterns (`> 0 and < 10`) won't parse | GS0005 | **resolved** (issue #992 — `and`/`or`/`not` pattern combinators with C# precedence (`not` > `and` > `or`) and parentheses; compose with all pattern kinds; binding type patterns under `or`/`not` rejected with GS0390; smart-cast narrows under `and`, soundly under `or`, never under `not`; combined patterns never satisfy exhaustiveness; cs2gs now translates C# `and`/`or`/`not` patterns to the new form) |
 | #993 | an `is`/`case` type pattern **with** a binder (`x is T t`) leaves the binder unbound | GS0125 | open (L5 uses the no-binder form `x is T`) |
-| #994 | `yield break` has no canonical G# form | GS0005 | **resolved by design** (settled fact: G# has no `yield break`; the translator maps it to a plain `break` — §B.36, Oahu.Decrypt round) |
+| #994 | `yield break` has no canonical G# form | GS0005 | **resolved by design** (G# has no `yield break`; the translator jumps to the end of the nearest iterator body — §B.36) |
 | #1002 | a user reference-type async iterator (`IAsyncEnumerable[UserClass]`) → IL erases to `IAsyncEnumerable<object>` | ilverify `StackUnexpected` | **resolved** (user reference- and value-type element async iterators emit, ilverify, and run; `await for s in seq` recovers the user element type) |
 | #1006 | interface inheritance `interface B : A { … }` won't parse | GS0005 | **resolved** (parser/binder accept an interface base-interface clause; cs2gs now emits `interface B : A, C { … }` — Oahu.Foundation `Types/Interfaces.cs`) |
 | #1007 | a generic interface method signature `func F[T](…) R;` won't parse | GS0005 | **resolved** (parser/binder accept generic methods in interfaces; cs2gs now emits the `[T]` clause on interface methods — Oahu.Foundation `Diagnostics/Interfaces.cs`) |

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2552NestedBreakTargetTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2552NestedBreakTargetTests.cs
@@ -88,6 +88,52 @@ namespace Demo
     }
 }";
 
+    private const string IteratorSource = @"
+using System;
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public static IEnumerable<int> Values(int stop)
+        {
+            yield return 1;
+            while (true)
+            {
+                switch (stop)
+                {
+                    case 0:
+                        yield break;
+                    default:
+                        break;
+                }
+
+                yield return 2;
+                break;
+            }
+
+            if (stop == 2)
+            {
+                yield break;
+            }
+
+            yield return 3;
+        }
+
+        public static string Trace(int stop)
+        {
+            string trace = """";
+            foreach (int value in Values(stop))
+            {
+                trace += value.ToString();
+            }
+
+            return trace;
+        }
+    }
+}";
+
     [Fact]
     public void Translator_PreservesLoopBreaksAndLowersSwitchBreaks()
     {
@@ -115,6 +161,36 @@ namespace Demo
                 "Console.WriteLine(C.LoopInsideSwitch(0))");
 
         Assert.Equal("SLSxL" + Environment.NewLine + "LS", output.Trim());
+    }
+
+    [Fact]
+    public void Translator_LowersYieldBreakToNearestIteratorExit()
+    {
+        string printed = TranslateAndValidate(IteratorSource);
+
+        Assert.Equal(2, CountOccurrences(printed, "goto __iteratorExit"));
+        Assert.Equal(1, CountOccurrences(printed, "break"));
+    }
+
+    [Fact]
+    public void Compiler_AcceptsIteratorExitInsideAndOutsideNestedLoop()
+    {
+        string output = Compile(TranslateAndValidate(IteratorSource), out _);
+
+        Assert.DoesNotContain("GS0120", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Runtime_YieldBreakExitsIteratorAcrossNestedLoopAndSwitch()
+    {
+        string printed = TranslateAndValidate(IteratorSource);
+        string output = CompileAndRun(
+            printed,
+            "Console.WriteLine(C.Trace(0))" + Environment.NewLine +
+                "Console.WriteLine(C.Trace(1))" + Environment.NewLine +
+                "Console.WriteLine(C.Trace(2))");
+
+        Assert.Equal("1" + Environment.NewLine + "123" + Environment.NewLine + "12", output.Trim());
     }
 
     private static int CountOccurrences(string text, string value)

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -235,11 +235,11 @@ namespace Demo
     }
 
     /// <summary>
-    /// <c>yield break</c> maps to a plain G# <c>break</c> (settled fact: G# has
-    /// no <c>yield break</c>; ADR-0115 §B).
+    /// <c>yield break</c> maps to the nearest iterator exit label because G#
+    /// has no <c>yield break</c> (ADR-0115 §B).
     /// </summary>
     [Fact]
-    public void YieldBreak_MappedToBreak()
+    public void YieldBreak_MappedToIteratorExit()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -258,7 +258,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("break", printed);
+        Assert.Contains("goto __iteratorExit", printed);
+        Assert.Contains("__iteratorExit", printed);
         Assert.DoesNotContain("yield break", printed);
         Assert.DoesNotContain("unsupported", printed);
     }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -952,6 +952,11 @@ public sealed partial class CSharpToGSharpTranslator
                 .Any();
         }
 
+        private static bool HasYieldBreak(SyntaxNode bodyOwner)
+            => bodyOwner.DescendantNodes(n => n is not LocalFunctionStatementSyntax)
+                .OfType<YieldStatementSyntax>()
+                .Any(y => y.Expression == null);
+
         private List<AttributeUse> MapAttributes(IEnumerable<AttributeListSyntax> attributeLists)
         {
             var attributes = new List<AttributeUse>();
@@ -1106,7 +1111,17 @@ public sealed partial class CSharpToGSharpTranslator
             try
             {
                 BlockStatement body = this.TranslateBodyCore(bodyOwner, description);
-                return this.WithParameterShadows(bodyOwner, body);
+                body = this.WithParameterShadows(bodyOwner, body);
+                if (HasYieldBreak(bodyOwner))
+                {
+                    var statements = body.Statements.ToList();
+                    statements.Add(new LabeledStatement(
+                        IteratorExitLabelName(bodyOwner),
+                        new BlockStatement(new List<GStatement>())));
+                    body = new BlockStatement(statements, body.IsUnsafe);
+                }
+
+                return body;
             }
             finally
             {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -909,15 +909,22 @@ public sealed partial class CSharpToGSharpTranslator
         {
             // `yield return x` maps to the G# iterator `yield x` (sample
             // TupleSequenceIterators.gs); the enclosing func's return type is
-            // rewritten to `sequence[T]`. `yield break` maps to plain `break`
-            // (settled fact: G# has no `yield break`; ADR-0115 §B).
+            // rewritten to `sequence[T]`. G# has no `yield break`, so jump to
+            // the end of the nearest iterator body regardless of nested loops.
             if (node.Expression == null)
             {
-                return new[] { (GStatement)new BreakStatement() };
+                SyntaxNode target = GetBreakTarget(node);
+                return new[] { (GStatement)new GotoStatement(IteratorExitLabelName(target)) };
             }
 
             return new[] { (GStatement)new YieldStatement(this.TranslateExpression(node.Expression)) };
         }
+
+        private static SyntaxNode GetBreakTarget(YieldStatementSyntax node)
+            => node.Ancestors().First(n => n is MethodDeclarationSyntax or LocalFunctionStatementSyntax);
+
+        private static string IteratorExitLabelName(SyntaxNode node)
+            => $"__iteratorExit{node.SpanStart}";
 
         private GStatement TranslateForEachVariable(ForEachVariableStatementSyntax node)
         {


### PR DESCRIPTION
## Summary
- lower `yield break` to a synthesized exit for the nearest iterator body
- preserve termination across nested switch/loop topology
- add translation, compile, and runtime regression coverage from the cycle-3 shape

## Validation
- `dotnet build GSharp.sln -c Release -m:1`
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-restore --no-build -m:1` (1,674 passed)

Fixes #2552