### PR TITLE
Fix nullable-oblivious producer consumption

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2425ExplicitLocalObliviousExternalForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2425ExplicitLocalObliviousExternalForgivenessTranslationTests.cs
@@ -267,15 +267,11 @@ namespace Demo
     }
 
     /// <summary>
-    /// Negative/scope control: a `var` local reads the SAME oblivious external
-    /// member and is later returned, but the fix is intentionally scoped to
-    /// EXPLICIT-typed locals (issue #2425's title) — a `var` local never had an
-    /// explicit type to retain/drop in the first place, and gets no
-    /// initializer-forgiveness from this change. (Tracked as a related, but
-    /// distinct, gap — not fixed here.)
+    /// A `var` local also needs forgiveness at its oblivious external initializer
+    /// so G# infers the same non-null type that C# does.
     /// </summary>
     [Fact]
-    public void VarLocal_IsNotForgiven_ScopeControl()
+    public void VarLocal_IsForgivenAtInitializer()
     {
         string printed = TranslateObliviousWithObliviousLibrary(@"
 namespace Demo
@@ -290,8 +286,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("let result = ext.Combine(\"hello\")", printed);
-        Assert.DoesNotContain("ext.Combine(\"hello\")!!", printed);
+        Assert.Contains("let result = ext.Combine(\"hello\")!!", printed);
     }
 
     /// <summary>
@@ -354,12 +349,11 @@ namespace Demo
     }
 
     /// <summary>
-    /// Negative test: a nullable-ENABLED compilation calling the same oblivious
-    /// external method — the fix is gated to oblivious compilations only (its
-    /// own nullable flow analysis is authoritative), so no `!!` is inserted.
+    /// A nullable-enabled consumer still sees a nullable-oblivious producer's
+    /// unannotated reference return as T? in G#, so it needs the same bridge.
     /// </summary>
     [Fact]
-    public void NullableEnabledCompilation_IsNotForgiven()
+    public void NullableEnabledCompilation_IsForgiven()
     {
         string printed = TranslateEnabledWithObliviousLibrary(@"
 namespace Demo
@@ -374,8 +368,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("let result = ext.Combine(\"hello\")", printed);
-        Assert.DoesNotContain("ext.Combine(\"hello\")!!", printed);
+        Assert.Contains("let result = ext.Combine(\"hello\")!!", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2427ObliviousExternalAssignmentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2427ObliviousExternalAssignmentForgivenessTranslationTests.cs
@@ -392,12 +392,11 @@ namespace Demo
     }
 
     /// <summary>
-    /// Negative test: a nullable-ENABLED compilation calling the same oblivious
-    /// external method — the fix is gated to oblivious compilations only (its
-    /// own nullable flow analysis is authoritative), so no `!!` is inserted.
+    /// A nullable-enabled consumer still sees a nullable-oblivious producer's
+    /// unannotated reference return as T? in G#, so assignment needs the bridge.
     /// </summary>
     [Fact]
-    public void NullableEnabledCompilation_IsNotForgiven()
+    public void NullableEnabledCompilation_IsForgiven()
     {
         string printed = TranslateEnabledWithObliviousLibrary(@"
 namespace Demo
@@ -413,8 +412,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("result = ext.Combine(\"hello\")", printed);
-        Assert.DoesNotContain("ext.Combine(\"hello\")!!", printed);
+        Assert.Contains("result = ext.Combine(\"hello\")!!", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityPipelineTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -13,6 +14,49 @@ namespace Cs2Gs.Tests;
 
 public sealed class Issue2579NullableReferenceFidelityPipelineTests
 {
+    [Fact]
+    public async Task Pipeline_ViaSdk_ObliviousProducerReturns_AreForgivenAtConsumerUses()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("oblivious-projects");
+        (string producerProject, string consumerProject) = WriteObliviousFixture(sourceRoot);
+        RunDotnetBuild(producerProject);
+        string outputRoot = NewDirectory("oblivious-pipeline-tests");
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(
+            new[] { new CorpusApp("test/Issue2579Oblivious", consumerProject, TargetKind.Library) });
+        AppResult app = Assert.Single(result.Apps);
+        string emitted = ReadAppOutput(outputRoot, result.RunId, app.AppId);
+
+        Assert.Contains("Factory.GetItem()!!.Next!!.Name", emitted, StringComparison.Ordinal);
+        Assert.Contains("Factory.GetItem()!!.Label()", emitted, StringComparison.Ordinal);
+        Assert.Contains("Repro.Consume(Factory.GetItem()!!)", emitted, StringComparison.Ordinal);
+        Assert.Contains("Repro.Required = Factory.GetItem()!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("Factory.GetMap()!![Factory.GetKey()!!]", emitted, StringComparison.Ordinal);
+        Assert.Contains("for item in Factory.GetItems()!!", emitted, StringComparison.Ordinal);
+        Assert.True(
+            app.Succeeded,
+            "Expected nullable-enabled consumers of nullable-disabled producers to compile via gsc. Stages: " +
+                string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+    }
+
     [Fact]
     public async Task Pipeline_ViaSdk_NullableWarningBoundaries_TranslateAndCompile()
     {
@@ -116,6 +160,108 @@ public sealed class Issue2579NullableReferenceFidelityPipelineTests
             }
             """);
         return projectPath;
+    }
+
+    private static (string ProducerProject, string ConsumerProject) WriteObliviousFixture(
+        string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+        string producerDir = Path.Combine(sourceRoot, "Producer");
+        string consumerDir = Path.Combine(sourceRoot, "Consumer");
+        Directory.CreateDirectory(producerDir);
+        Directory.CreateDirectory(consumerDir);
+
+        string producerProject = Path.Combine(producerDir, "Producer.csproj");
+        File.WriteAllText(producerProject, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>disable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(producerDir, "Producer.cs"), """
+            using System.Collections.Generic;
+
+            namespace ObliviousProducer;
+
+            public sealed class Item
+            {
+                public string Name => "item";
+                public Item Next => this;
+            }
+
+            public static class Factory
+            {
+                public static Item GetItem() => new();
+                public static IEnumerable<Item> GetItems() => new[] { new Item() };
+                public static Dictionary<string, Item> GetMap() =>
+                    new() { ["key"] = new Item() };
+                public static string GetKey() => "key";
+            }
+            """);
+
+        string consumerProject = Path.Combine(consumerDir, "Consumer.csproj");
+        File.WriteAllText(consumerProject, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+              <ItemGroup>
+                <ProjectReference Include="../Producer/Producer.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(consumerDir, "Consumer.cs"), """
+            using ObliviousProducer;
+
+            namespace Issue2579Oblivious;
+
+            public static class ItemExtensions
+            {
+                public static string Label(this Item item) => item.Name;
+            }
+
+            public static class Repro
+            {
+                private static Item Required = new();
+                private static void Consume(Item item) { }
+
+                public static int Run()
+                {
+                    _ = Factory.GetItem().Next.Name;
+                    _ = Factory.GetItem().Label();
+                    Consume(Factory.GetItem());
+                    Required = Factory.GetItem();
+                    _ = Factory.GetMap()[Factory.GetKey()].Name;
+                    foreach (var item in Factory.GetItems())
+                        _ = item.Name;
+                    return Required.Name.Length;
+                }
+            }
+            """);
+
+        return (producerProject, consumerProject);
+    }
+
+    private static void RunDotnetBuild(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo(
+            "dotnet",
+            $"build \"{projectPath}\" --nologo --verbosity:quiet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+
+        using var process = Process.Start(startInfo);
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, "Failed to prebuild producer project:\n" + stdout + stderr);
     }
 
     private static string ReadAppOutput(string outputRoot, string runId, string appId)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -777,8 +777,21 @@ public sealed partial class CSharpToGSharpTranslator
 
             TypeInfo typeInfo = this.context.GetTypeInfo(value);
             ITypeSymbol type = typeInfo.Type ?? typeInfo.ConvertedType;
-            return type is { IsReferenceType: true }
-                && typeInfo.Nullability.FlowState == NullableFlowState.MaybeNull
+            if (type is not { IsReferenceType: true })
+            {
+                return false;
+            }
+
+            // An oblivious producer's unannotated reference return is imported by
+            // gsc as T? regardless of the consumer's nullable context. Roslyn
+            // reports that metadata as Annotation.None, so its flow state cannot
+            // drive the target-aware receiver/value bridges below.
+            if (IsObliviousExternalNullableMember(this.context.GetSymbolInfo(value).Symbol))
+            {
+                return true;
+            }
+
+            return typeInfo.Nullability.FlowState == NullableFlowState.MaybeNull
                 && (type.NullableAnnotation == NullableAnnotation.Annotated
                     || typeInfo.Nullability.Annotation == NullableAnnotation.Annotated);
         }
@@ -814,7 +827,8 @@ public sealed partial class CSharpToGSharpTranslator
         // argument to a non-null reference parameter that cs2gs will keep
         // non-null. Arrays and numeric/string/span indices therefore stay on
         // their existing paths, explicitly nullable indexer contracts remain
-        // untouched, and nullable-enabled projects receive no new assertions.
+        // untouched, and nullable-enabled projects receive new assertions only
+        // for values imported from nullable-oblivious assemblies.
         // A genuinely null oblivious key follows the existing `!!` bridge
         // policy and fails at runtime before the index operation.
         private GExpression TranslateIndexArgumentWithNullForgiveness(ArgumentSyntax argument)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -223,32 +223,6 @@ public sealed partial class CSharpToGSharpTranslator
                             // natural type) promote identically.
                             emitType = true;
                         }
-                        else if (this.IsObliviousCompilation()
-                            && IsObliviousExternalNullableMember(
-                                this.context.GetSymbolInfo(declarator.Initializer.Value).Symbol))
-                        {
-                            // Issue #2425: the explicit-type-equals-initializer-type
-                            // shape above elides the type clause and relies on
-                            // inference (issue #1737 above doesn't fire — the
-                            // whole-program taint fixpoint only tracks
-                            // same/sibling-SOURCE symbols, and an EXTERNAL member
-                            // never seeds one of its edges). But the initializer
-                            // itself is a value-position read of an oblivious
-                            // (metadata, no nullable context) external member —
-                            // exactly the shape #2202's TranslateValueWithNullForgiveness
-                            // already forgives for a `return ext.Combine(...)` direct
-                            // return. gsc maps that read to `T?`, so with no type
-                            // clause emitted here gsc would infer the LOCAL itself as
-                            // `T?` (e.g. `let codeVerifier = tokenBytes.ToUrlBase64String()`
-                            // → `codeVerifier : string?`), and a later `return
-                            // codeVerifier;` has no external symbol left at the read
-                            // site to trigger forgiveness (GS0156). Assert `!!` at the
-                            // INITIALIZER instead — mirroring the direct-return fix —
-                            // so the local infers the declared non-null type from the
-                            // start and every later use (return/argument/assignment)
-                            // needs no further special-casing.
-                            initializer = new NonNullAssertionExpression(initializer);
-                        }
                     }
 
                     if (emitType)


### PR DESCRIPTION
## Summary
- recognize unannotated reference values from nullable-disabled producer assemblies independently of the consumer nullable context
- route them through existing target-aware receiver/value forgiveness without changing gsc or nullable value-type rules
- add a project-backed producer/consumer pipeline regression covering member chains, extension calls, arguments, assignment, indexing, and foreach

## Validation
- `Core.Tests`: 6593 passed, 1 skipped
- `Cs2Gs.Tests`: 1672 passed

Fixes #2579