### PR TITLE
Fix translated record semantics across project references

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -155,10 +155,11 @@ internal sealed partial class ExpressionBinder
 
                     var staticType = staticMember switch
                     {
-                        PropertyInfo sp => TypeSymbol.FromClrType(sp.PropertyType),
-                        FieldInfo sf => TypeSymbol.FromClrType(sf.FieldType),
+                        PropertyInfo sp => ClrNullability.GetPropertyTypeSymbol(sp),
+                        FieldInfo sf => ClrNullability.GetFieldTypeSymbol(sf),
                         _ => TypeSymbol.Error,
                     };
+                    staticType = NormalizeImportedSemanticAggregate(staticType, staticMember);
 
                     // Issue #1330: when the receiver is a generic type
                     // constructed over an in-scope generic type parameter
@@ -515,13 +516,15 @@ internal sealed partial class ExpressionBinder
                             ?? (prop.PropertyType.IsByRef
                                 ? MapClrMemberType(prop.PropertyType)
                                 : ClrNullability.GetPropertyTypeSymbol(prop));
+                        propType = NormalizeImportedSemanticAggregate(propType, prop);
                         return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrPropertyAccessExpression(null, receiver, prop, propType));
                     }
 
                     var fld = ClrTypeUtilities.SafeGetFieldIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
                     if (fld != null)
                     {
-                        return new BoundClrPropertyAccessExpression(null, receiver, fld, ClrNullability.GetFieldTypeSymbol(fld));
+                        var fieldType = NormalizeImportedSemanticAggregate(ClrNullability.GetFieldTypeSymbol(fld), fld);
+                        return new BoundClrPropertyAccessExpression(null, receiver, fld, fieldType);
                     }
 
                     // Issue #337: an instance member name that resolves to a
@@ -1933,7 +1936,7 @@ internal sealed partial class ExpressionBinder
     /// </summary>
     /// <param name="method">The imported method whose return type to map.</param>
     /// <returns>The nullability-aware return type symbol.</returns>
-    private static TypeSymbol MapClrMethodReturnType(System.Reflection.MethodInfo method)
+    private TypeSymbol MapClrMethodReturnType(System.Reflection.MethodInfo method)
     {
         if (method == null)
         {
@@ -1947,7 +1950,21 @@ internal sealed partial class ExpressionBinder
             return ByRefTypeSymbol.Get(TypeSymbol.FromClrType(returnClrType.GetElementType()!));
         }
 
-        return ClrNullability.GetReturnTypeSymbol(method);
+        return ImportedTypeSymbol.NormalizeSemanticAggregate(
+            ClrNullability.GetReturnTypeSymbol(method),
+            method.ReturnType,
+            scope.References);
+    }
+
+    private TypeSymbol NormalizeImportedSemanticAggregate(TypeSymbol type, MemberInfo member)
+    {
+        var clrType = member switch
+        {
+            PropertyInfo property => property.PropertyType,
+            FieldInfo field => field.FieldType,
+            _ => null,
+        };
+        return ImportedTypeSymbol.NormalizeSemanticAggregate(type, clrType, scope.References);
     }
 
     // ADR-0118 / issue #944: locate a user-declared indexer member on a (possibly

--- a/src/Core/CodeAnalysis/Symbols/ImportedFunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedFunctionSymbol.cs
@@ -74,11 +74,6 @@ public sealed class ImportedFunctionSymbol : Symbol
     private TypeSymbol GetMethodType(MethodInfo method)
     {
         var returnType = ClrNullability.GetReturnTypeSymbol(method);
-        if (returnType is ImportedTypeSymbol && ImportedTypeSymbol.TryCreateSemanticAggregate(method.ReturnType, ImportedClass?.References, out var aggregate))
-        {
-            return aggregate;
-        }
-
-        return returnType;
+        return ImportedTypeSymbol.NormalizeSemanticAggregate(returnType, method.ReturnType, ImportedClass?.References);
     }
 }

--- a/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
@@ -295,6 +295,24 @@ public sealed class ImportedTypeSymbol : TypeSymbol
         return aggregate != null;
     }
 
+    internal static TypeSymbol NormalizeSemanticAggregate(TypeSymbol type, Type clrType, ReferenceResolver references)
+    {
+        var nullable = type is NullableTypeSymbol;
+        var unwrapped = nullable ? ((NullableTypeSymbol)type).UnderlyingType : type;
+        var annotated = unwrapped as NullabilityAnnotatedTypeSymbol;
+        var baseType = annotated?.BaseType ?? unwrapped;
+        if (baseType is not ImportedTypeSymbol
+            || !TryCreateSemanticAggregate(clrType, references, out var aggregate))
+        {
+            return type;
+        }
+
+        TypeSymbol normalized = annotated == null
+            ? aggregate
+            : new NullabilityAnnotatedTypeSymbol(aggregate, annotated.NullableFlags);
+        return nullable ? NullableTypeSymbol.Get(normalized) : normalized;
+    }
+
     /// <summary>
     /// Legacy dispose hook. The cache is weakly keyed by assembly and each
     /// per-assembly dictionary uses metadata identity for CLR types, so disposed

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2291ImportedRecordWithCopyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2291ImportedRecordWithCopyTests.cs
@@ -121,6 +121,44 @@ public class Issue2291ImportedRecordWithCopyTests
     }
 
     [Fact]
+    public void Imported_CSharpRecordClass_FromStaticProperty_With_Compiles()
+    {
+        var libraryPath = EmitCSharpLibrary(
+            nameof(this.Imported_CSharpRecordClass_FromStaticProperty_With_Compiles),
+            """
+            #nullable enable
+            namespace Records
+            {
+                public record Person(string Name, int Age)
+                {
+                    public static Person Default => new("Ada", 30);
+                }
+            }
+            """);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraryPath });
+        resolver.CurrentAssemblyName = "Consumer";
+
+        var consumer = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+                import Records
+
+                func Run() int32 {
+                    let p = Person.Default
+                    let p2 = p with { Age = 5 }
+                    return p2.Age
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
     public void Imported_PlainCSharpClass_With_StillReportsGs0161()
     {
         var libraryPath = EmitCSharpLibrary(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2551TranslatedRecordProjectReferencePipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2551TranslatedRecordProjectReferencePipelineTests.cs
@@ -1,0 +1,202 @@
+// <copyright file="Issue2551TranslatedRecordProjectReferencePipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2551: a record translated in one project must retain data-class
+/// semantics when an independently translated consumer sees its reference
+/// assembly through a project reference.
+/// </summary>
+public sealed class Issue2551TranslatedRecordProjectReferencePipelineTests
+{
+    [Fact]
+    public async Task Pipeline_TranslatedRecordProjectReference_WithCopy_Runs()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        Fixture fixture = WriteFixture(sourceRoot);
+        RunDotnetBuild(fixture.ConsumerProject);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage(), new TestParityStage() });
+        var result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("test/Models", fixture.ModelsProject, TargetKind.Library),
+            new CorpusApp(
+                "test/Consumer",
+                fixture.ConsumerProject,
+                TargetKind.Exe,
+                stdoutGolden: fixture.StdoutGolden),
+        });
+
+        Assert.All(
+            result.Apps,
+            app => Assert.True(
+                app.Succeeded,
+                app.AppId + " should translate, compile, and run. Stages: "
+                    + string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status))));
+
+        string runDirectory = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId("test/Models"));
+        string producer = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(runDirectory, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+        Assert.Contains("data class Settings(", producer, StringComparison.Ordinal);
+    }
+
+    private static Fixture WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+
+        string modelsDirectory = Path.Combine(sourceRoot, "Models");
+        Directory.CreateDirectory(modelsDirectory);
+        string modelsProject = Path.Combine(modelsDirectory, "Models.csproj");
+        File.WriteAllText(modelsProject, ProjectFile());
+        File.WriteAllText(Path.Combine(modelsDirectory, "Settings.cs"), """
+            namespace Models;
+
+            public sealed record Settings
+            {
+                public string Label { get; init; } = "ready";
+
+                public int Retries { get; init; } = 3;
+
+                public static Settings Default => new();
+            }
+            """);
+
+        string consumerDirectory = Path.Combine(sourceRoot, "Consumer");
+        Directory.CreateDirectory(consumerDirectory);
+        string consumerProject = Path.Combine(consumerDirectory, "Consumer.csproj");
+        File.WriteAllText(consumerProject, ProjectFile("../Models/Models.csproj", outputType: "Exe"));
+        File.WriteAllText(Path.Combine(consumerDirectory, "Program.cs"), """
+            using System;
+            using Models;
+
+            var original = Settings.Default;
+            var changed = original with { Retries = 8 };
+            var copied = changed with { Label = "copied" };
+
+            Console.WriteLine(original.Label);
+            Console.WriteLine(original.Retries);
+            Console.WriteLine(changed.Label);
+            Console.WriteLine(changed.Retries);
+            Console.WriteLine(copied.Label);
+            Console.WriteLine(copied.Retries);
+            """);
+
+        string stdoutGolden = Path.Combine(sourceRoot, "baseline.stdout.golden");
+        File.WriteAllText(stdoutGolden, "ready\n3\nready\n8\ncopied\n8\n");
+        return new Fixture(modelsProject, consumerProject, stdoutGolden);
+    }
+
+    private static string ProjectFile(string projectReference = null, string outputType = null)
+    {
+        string output = outputType is null ? string.Empty : $"<OutputType>{outputType}</OutputType>";
+        string reference = projectReference is null
+            ? string.Empty
+            : $"""
+                <ItemGroup>
+                  <ProjectReference Include="{projectReference}" />
+                </ItemGroup>
+              """;
+        return $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                {output}
+              </PropertyGroup>
+              {reference}
+            </Project>
+            """;
+    }
+
+    private static void RunDotnetBuild(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("build");
+        startInfo.ArgumentList.Add(projectPath);
+        startInfo.ArgumentList.Add("--nologo");
+        startInfo.ArgumentList.Add("--verbosity:quiet");
+
+        using Process process = Process.Start(startInfo);
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, "Fixture build failed:\n" + stdout + stderr);
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2551",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirectoryName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirectoryName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private sealed record Fixture(string ModelsProject, string ConsumerProject, string StdoutGolden);
+}


### PR DESCRIPTION
## Summary
- canonicalize metadata-marked imported data-class and record types flowing from CLR fields, properties, and method returns
- preserve nullable/annotated wrappers while replacing the bare imported type with its semantic aggregate
- add focused static-property coverage plus a real cs2gs producer migration and cross-project consumer stdout-runtime fixture

## Tests
- `dotnet build GSharp.sln --configuration Release --no-restore -graph --verbosity quiet`
- `dotnet test test/Core.Tests/Core.Tests.csproj --configuration Release --no-build --no-restore --verbosity quiet` (6,594 passed, 1 skipped)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --configuration Release --no-build --no-restore --filter FullyQualifiedName~ImportedMemberMatrix --verbosity quiet` (8 passed)
- record translation/pipeline filter in `Cs2Gs.Tests` (8 passed)

## Deferred work
- None.

Fixes #2551
