### PR TITLE
Fix ConcurrentDictionary deconstruction follow-up

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -3164,6 +3164,37 @@ internal sealed class MemberLookup
         return TypeSymbol.FromClrType(closedMethod.ReturnType);
     }
 
+    /// <summary>Resolves an imported method parameter through a symbolic receiver.</summary>
+    /// <param name="targetType">The symbolic imported receiver type.</param>
+    /// <param name="closedMethod">The reflected method selected from the erased receiver.</param>
+    /// <param name="parameterIndex">The zero-based parameter index.</param>
+    /// <returns>The parameter type after symbolic receiver substitution.</returns>
+    internal static TypeSymbol GetClrMethodParameterTypeSymbol(
+        TypeSymbol targetType,
+        MethodInfo closedMethod,
+        int parameterIndex)
+    {
+        if (GetImportedTypeSymbol(targetType) is ImportedTypeSymbol imported
+            && TryGetSymbolicDeclaringContext(
+                imported,
+                closedMethod?.DeclaringType,
+                out var openDefinition,
+                out var declaringTypeArguments))
+        {
+            var openMethod = TryGetOpenMethodOnDeclaringType(openDefinition, closedMethod);
+            var openParameters = openMethod?.GetParameters();
+            if (openParameters != null && (uint)parameterIndex < (uint)openParameters.Length)
+            {
+                return MapOpenClrTypeToSymbolic(
+                    openParameters[parameterIndex].ParameterType,
+                    openDefinition,
+                    declaringTypeArguments);
+            }
+        }
+
+        return TypeSymbol.FromClrType(closedMethod.GetParameters()[parameterIndex].ParameterType);
+    }
+
     /// <summary>Finds the symbolic generic context for a reflected declaring type.</summary>
     /// <param name="imported">The symbolic imported receiver.</param>
     /// <param name="declaringType">The reflected member's declaring type.</param>

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -1525,7 +1525,12 @@ internal sealed partial class StatementBinder
 
             for (var i = 0; i < identifiers.Count; i++)
             {
-                var elementType = TypeSymbol.FromClrType(parameters[i + receiverOffset].ParameterType.GetElementType());
+                var parameterType = receiverOffset == 0
+                    ? MemberLookup.GetClrMethodParameterTypeSymbol(receiver.Type, method, i)
+                    : TypeSymbol.FromClrType(parameters[i + receiverOffset].ParameterType);
+                var elementType = parameterType is ByRefTypeSymbol byRef
+                    ? byRef.PointeeType
+                    : TypeSymbol.FromClrType(parameters[i + receiverOffset].ParameterType.GetElementType());
                 var temp = new LocalVariableSymbol(
                     $"<deconstruct{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
                     isReadOnly: false,

--- a/test/Core.Tests/CodeAnalysis/Binding/ImportedExtensionMethodTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ImportedExtensionMethodTests.cs
@@ -48,12 +48,40 @@ for (key, value) in values {
 }
 total
 ";
-        AssertCompilesWithoutErrors(source);
+            AssertCompilesWithoutErrors(source);
         var result = new Compilation(SyntaxTree.Parse(SourceText.From(source)))
             .Evaluate(new Dictionary<VariableSymbol, object>());
 
         Assert.Empty(result.Diagnostics);
         Assert.Equal(3, result.Value);
+    }
+
+    [Fact]
+    public void ConcurrentDictionary_ForTupleIn_UsesImportedKeyValuePairDeconstructPattern()
+    {
+        var source = @"
+import System.Collections.Concurrent
+
+interface IValue {
+    prop Number int32 {
+        get;
+    }
+}
+
+class Value : IValue {
+    prop Number int32 -> 42
+}
+
+var values = ConcurrentDictionary[string, IValue]()
+values.TryAdd(""answer"", Value())
+
+var total = 0
+for (key, value) in values {
+    total = total + value.Number
+}
+total
+";
+    AssertCompilesWithoutErrors(source);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1922ForEachTupleDeconstructionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1922ForEachTupleDeconstructionTests.cs
@@ -99,6 +99,38 @@ namespace Demo
     }
 
     [Fact]
+    public void ConcurrentDictionaryDeconstruction_TranslatesToCompilerSupportedForTupleIn()
+    {
+        string printed = TranslateUnit(@"
+using System;
+using System.Collections.Concurrent;
+
+namespace Demo
+{
+    public interface IValue
+    {
+        int Number { get; }
+    }
+
+    public sealed class C
+    {
+        public void M(ConcurrentDictionary<string, IValue> values)
+        {
+            foreach (var (key, value) in values)
+            {
+                Console.WriteLine(value.Number);
+            }
+        }
+    }
+}");
+
+        Assert.Contains("import System.Collections.Concurrent", printed);
+        Assert.Contains("for (key, value) in values {", printed);
+        Assert.Contains("value.Number", printed);
+        Assert.DoesNotContain("import System.Collections.Generic", printed);
+    }
+
+    [Fact]
     public void AwaitForEachTupleDeconstruction_KeepsTempPlusLetLowering()
     {
         // G# has no first-class `await for (a, b) in` header, so the async

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2537ConcurrentDictionaryPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2537ConcurrentDictionaryPipelineTests.cs
@@ -1,0 +1,162 @@
+// <copyright file="Issue2537ConcurrentDictionaryPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2537ConcurrentDictionaryPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdk_ConcurrentDictionaryOfInterface_DeconstructsAndRuns()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectPath = WriteFixture(sourceRoot);
+        string outputRoot = NewDirectory("pipeline-tests");
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(
+            new[] { new CorpusApp("test/Issue2537", projectPath, TargetKind.Exe) });
+        AppResult app = Assert.Single(result.Apps);
+
+        Assert.True(
+            app.Succeeded,
+            "Expected ConcurrentDictionary deconstruction to compile via gsc. Stages: " +
+                string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+
+        string runDirectory = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.AppId));
+        string assembly = Directory.GetFiles(
+                Path.Combine(runDirectory, "bin"),
+                "Issue2537.dll",
+                SearchOption.AllDirectories)
+            .Single(path => !path.Contains(
+                Path.DirectorySeparatorChar + "ref" + Path.DirectorySeparatorChar,
+                StringComparison.Ordinal));
+        (int exitCode, string output) = RunDotnet($"\"{assembly}\"");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("42" + Environment.NewLine, output);
+    }
+
+    private static string WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+        string projectDir = Path.Combine(sourceRoot, "Issue2537");
+        Directory.CreateDirectory(projectDir);
+
+        string projectPath = Path.Combine(projectDir, "Issue2537.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "Program.cs"), """
+            using System;
+            using System.Collections.Concurrent;
+
+            var values = new ConcurrentDictionary<string, IValue>();
+            values.TryAdd("answer", new Value());
+            foreach (var (key, value) in values)
+            {
+                Console.WriteLine(value.Number);
+            }
+
+            public interface IValue
+            {
+                int Number { get; }
+            }
+
+            public sealed class Value : IValue
+            {
+                public int Number => 42;
+            }
+            """);
+        return projectPath;
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2537",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static (int ExitCode, string Output) RunDotnet(string arguments)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(startInfo);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- preserve symbolic generic receiver arguments when binding imported `Deconstruct` out parameters
- cover `ConcurrentDictionary<string, IValue>` through translator and compiler tests
- add SDK pipeline compile-and-run coverage for the exact interface-valued path

## Validation
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --verbosity minimal` (6594 passed, 1 skipped)
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-restore --verbosity minimal` (1673 passed)
- local GSharp SDK package build succeeded

Fixes #2537