### PR TITLE
Fix generic LINQ source method groups

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundMethodGroupExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundMethodGroupExpression.cs
@@ -13,12 +13,10 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
 /// Issue #324 / ADR-0063 §9: a bare reference to a named function used in a
-/// value context (C#/F# "method group"). When the name resolves to a single
-/// candidate, <see cref="Function"/> is bound eagerly and <see cref="FunctionType"/>
-/// is its signature. When the name resolves to multiple overloads,
-/// <see cref="Candidates"/> contains every overload and final overload
-/// selection is deferred to <c>BindConversion</c>, where the target delegate
-/// signature drives the pick.
+/// value context (C#/F# "method group"). A single non-generic candidate is
+/// bound eagerly. Overloaded and generic candidates defer selection and generic
+/// inference to <c>BindConversion</c>, where the target delegate signature is
+/// available.
 /// </summary>
 public sealed class BoundMethodGroupExpression : BoundExpression
 {
@@ -42,7 +40,8 @@ public sealed class BoundMethodGroupExpression : BoundExpression
         BoundExpression receiver,
         FunctionSymbol function,
         FunctionTypeSymbol type,
-        StructSymbol staticOwnerType)
+        StructSymbol staticOwnerType,
+        ImmutableArray<TypeSymbol> methodTypeArguments = default)
         : base(syntax)
     {
         Receiver = receiver;
@@ -50,6 +49,7 @@ public sealed class BoundMethodGroupExpression : BoundExpression
         FunctionType = type;
         Candidates = ImmutableArray.Create(function);
         StaticOwnerType = staticOwnerType;
+        MethodTypeArguments = methodTypeArguments;
     }
 
     public BoundMethodGroupExpression(SyntaxNode syntax, BoundExpression receiver, ImmutableArray<FunctionSymbol> candidates)
@@ -91,6 +91,9 @@ public sealed class BoundMethodGroupExpression : BoundExpression
 
     /// <summary>Gets the type used to qualify a static method group.</summary>
     public StructSymbol StaticOwnerType { get; }
+
+    /// <summary>Gets the inferred type arguments for a generic source method.</summary>
+    public ImmutableArray<TypeSymbol> MethodTypeArguments { get; }
 
     public override TypeSymbol Type => FunctionType ?? (TypeSymbol)TypeSymbol.Error;
 

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -2138,7 +2138,13 @@ public abstract class BoundTreeRewriter
         }
 
         return node.FunctionType != null
-            ? new BoundMethodGroupExpression(node.Syntax, receiver, node.Function, node.FunctionType, node.StaticOwnerType)
+            ? new BoundMethodGroupExpression(
+                node.Syntax,
+                receiver,
+                node.Function,
+                node.FunctionType,
+                node.StaticOwnerType,
+                node.MethodTypeArguments)
             : new BoundMethodGroupExpression(node.Syntax, receiver, node.Candidates, node.StaticOwnerType);
     }
 

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1476,13 +1476,22 @@ internal sealed class ConversionClassifier
 
         FunctionSymbol pick = null;
         StructSymbol pickOwner = null;
+        ImmutableArray<TypeSymbol> pickMethodTypeArguments = default;
+        TypeSymbol[] pickParameterTypes = null;
+        TypeSymbol pickReturnType = null;
         foreach (var candidate in group.Candidates)
         {
             var candidateOwner = group.StaticOwnerType != null && candidate.StaticOwnerType is StructSymbol declaredOwner
                 ? TypeMemberModel.ResolveStaticMemberOwner(group.StaticOwnerType, declaredOwner)
                 : null;
-            var parameterOffset = candidate.IsExtension && group.Receiver != null ? 1 : 0;
-            if (candidate.Parameters.Length - parameterOffset != targetParameterTypes.Length)
+            if (!ExpressionBinder.TryCloseMethodGroupCandidate(
+                candidate,
+                group.Receiver,
+                candidateOwner,
+                targetParameterTypes,
+                out var candidateParameterTypes,
+                out var candidateReturn,
+                out var candidateMethodTypeArguments))
             {
                 continue;
             }
@@ -1490,9 +1499,7 @@ internal sealed class ConversionClassifier
             var paramsMatch = true;
             for (var i = 0; i < targetParameterTypes.Length; i++)
             {
-                var candidateParameterType = candidateOwner?.SubstituteMemberType(candidate.Parameters[i + parameterOffset].Type)
-                    ?? candidate.Parameters[i + parameterOffset].Type;
-                if (!AreMethodGroupTypesEquivalent(candidateParameterType, targetParameterTypes[i]))
+                if (!AreMethodGroupTypesEquivalent(candidateParameterTypes[i], targetParameterTypes[i]))
                 {
                     paramsMatch = false;
                     break;
@@ -1504,7 +1511,6 @@ internal sealed class ConversionClassifier
                 continue;
             }
 
-            var candidateReturn = candidateOwner?.SubstituteMemberType(candidate.Type) ?? candidate.Type ?? TypeSymbol.Void;
             if (!AreMethodGroupTypesEquivalent(candidateReturn, targetReturnType))
             {
                 continue;
@@ -1531,6 +1537,9 @@ internal sealed class ConversionClassifier
 
             pick = candidate;
             pickOwner = candidateOwner;
+            pickMethodTypeArguments = candidateMethodTypeArguments;
+            pickParameterTypes = candidateParameterTypes;
+            pickReturnType = candidateReturn;
         }
 
         if (pick == null)
@@ -1539,16 +1548,14 @@ internal sealed class ConversionClassifier
             return new BoundErrorExpression(null);
         }
 
-        var pickParameterOffset = pick.IsExtension && group.Receiver != null ? 1 : 0;
-        var pickParams = ImmutableArray.CreateBuilder<TypeSymbol>(pick.Parameters.Length - pickParameterOffset);
-        for (var i = pickParameterOffset; i < pick.Parameters.Length; i++)
-        {
-            pickParams.Add(pickOwner?.SubstituteMemberType(pick.Parameters[i].Type) ?? pick.Parameters[i].Type);
-        }
-
-        var pickReturn = pickOwner?.SubstituteMemberType(pick.Type) ?? pick.Type ?? TypeSymbol.Void;
-        var pickFnType = FunctionTypeSymbol.Get(pickParams.MoveToImmutable(), pickReturn);
-        var resolvedGroup = new BoundMethodGroupExpression(group.Syntax, group.Receiver, pick, pickFnType, pickOwner);
+        var pickFnType = FunctionTypeSymbol.Get(ImmutableArray.Create(pickParameterTypes), pickReturnType);
+        var resolvedGroup = new BoundMethodGroupExpression(
+            group.Syntax,
+            group.Receiver,
+            pick,
+            pickFnType,
+            pickOwner,
+            pickMethodTypeArguments);
 
         // If the target is the native function type matching the pick exactly,
         // identity-convert; otherwise let the regular conversion machinery turn

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -54,7 +54,7 @@ internal sealed partial class ExpressionBinder
 
     private BoundMethodGroupExpression BuildInstanceMethodGroup(BoundExpression receiver, ImmutableArray<FunctionSymbol> methods)
     {
-        if (methods.Length == 1)
+        if (methods.Length == 1 && !methods[0].IsGeneric)
         {
             var only = methods[0];
             var paramTypes = ImmutableArray.CreateBuilder<TypeSymbol>(only.Parameters.Length);
@@ -90,9 +90,8 @@ internal sealed partial class ExpressionBinder
     /// ADR-0112 §"method-group semantics": builds a <see cref="BoundMethodGroupExpression"/>
     /// for a user-defined type's method(s). A <paramref name="receiver"/> of
     /// <see langword="null"/> yields a static (null-target) group; a non-null
-    /// receiver yields an instance group captured against it. Candidates that
-    /// cannot participate in a method-group→delegate conversion (generic or
-    /// variadic) are filtered out; the group is only produced when at least one
+    /// receiver yields an instance group captured against it. Variadic
+    /// candidates are filtered out; the group is only produced when at least one
     /// usable candidate remains.
     /// </summary>
     private bool TryBuildUserMethodGroup(
@@ -111,11 +110,6 @@ internal sealed partial class ExpressionBinder
         var usable = ImmutableArray.CreateBuilder<FunctionSymbol>(methods.Length);
         foreach (var m in methods)
         {
-            if (m.IsGeneric)
-            {
-                continue;
-            }
-
             var hasVariadic = false;
             foreach (var parameter in m.Parameters)
             {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1293,7 +1293,6 @@ internal sealed partial class ExpressionBinder
     private static bool IsMethodGroupCandidateUsable(FunctionSymbol function)
     {
         if (function.IsInstanceMethod
-            || function.IsGeneric
             || function.IsExtension
             || function.IsStatic
             || function.StaticOwnerType != null
@@ -1320,6 +1319,12 @@ internal sealed partial class ExpressionBinder
         if (!IsMethodGroupCandidateUsable(function))
         {
             return false;
+        }
+
+        if (function.IsGeneric)
+        {
+            methodGroup = new BoundMethodGroupExpression(null, ImmutableArray.Create(function));
+            return true;
         }
 
         var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(function.Parameters.Length);
@@ -1565,8 +1570,15 @@ internal sealed partial class ExpressionBinder
             var candidateOwner = userGroup.StaticOwnerType != null && candidate.StaticOwnerType is StructSymbol declaredOwner
                 ? TypeMemberModel.ResolveStaticMemberOwner(userGroup.StaticOwnerType, declaredOwner)
                 : null;
-            var parameterOffset = candidate.IsExtension && userGroup.Receiver != null ? 1 : 0;
-            if (candidate.Parameters.Length - parameterOffset != delegateParameterTypes.Count)
+            var targetParameterTypes = delegateParameterTypes.Select(TypeSymbol.FromClrType).ToArray();
+            if (!TryCloseMethodGroupCandidate(
+                candidate,
+                userGroup.Receiver,
+                candidateOwner,
+                targetParameterTypes,
+                out var closedParameters,
+                out var closedReturn,
+                out _))
             {
                 continue;
             }
@@ -1576,9 +1588,7 @@ internal sealed partial class ExpressionBinder
             var compatible = true;
             for (var i = 0; i < parameterTypes.Length; i++)
             {
-                var parameterSymbol = candidateOwner?.SubstituteMemberType(candidate.Parameters[i + parameterOffset].Type)
-                    ?? candidate.Parameters[i + parameterOffset].Type;
-                parameterTypes[i] = projectType(parameterSymbol);
+                parameterTypes[i] = projectType(closedParameters[i]);
                 conversions[i] = parameterTypes[i] == null
                     ? OverloadResolution.ImplicitConversionKind.None
                     : OverloadResolution.ClassifyImplicit(parameterTypes[i], delegateParameterTypes[i]);
@@ -1594,8 +1604,7 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            var returnSymbol = candidateOwner?.SubstituteMemberType(candidate.Type) ?? candidate.Type ?? TypeSymbol.Void;
-            var returnType = projectType(returnSymbol);
+            var returnType = projectType(closedReturn);
             if (returnType == null)
             {
                 continue;
@@ -1609,6 +1618,71 @@ internal sealed partial class ExpressionBinder
                 !ReferenceEquals(candidate.Signature, other.Signature)
                 && IsBetterMethodGroupConversion(other.Conversions, candidate.Conversions))).ToList();
         return best.Count == 1 ? best[0].Signature : null;
+    }
+
+    internal static bool TryCloseMethodGroupCandidate(
+        FunctionSymbol candidate,
+        BoundExpression receiver,
+        StructSymbol candidateOwner,
+        IReadOnlyList<TypeSymbol> targetParameterTypes,
+        out TypeSymbol[] closedParameters,
+        out TypeSymbol closedReturn,
+        out ImmutableArray<TypeSymbol> methodTypeArguments)
+    {
+        closedParameters = null;
+        closedReturn = null;
+        methodTypeArguments = default;
+
+        var parameterOffset = candidate.IsExtension && receiver != null ? 1 : 0;
+        if (candidate.Parameters.Length - parameterOffset != targetParameterTypes.Count)
+        {
+            return false;
+        }
+
+        Dictionary<TypeParameterSymbol, TypeSymbol> substitution = null;
+        if (candidate.IsGeneric)
+        {
+            substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>();
+            if (parameterOffset == 1)
+            {
+                var receiverParameter = candidateOwner?.SubstituteMemberType(candidate.Parameters[0].Type)
+                    ?? candidate.Parameters[0].Type;
+                Binder.InferTypeArguments(receiverParameter, receiver.Type, substitution);
+            }
+
+            for (var i = 0; i < targetParameterTypes.Count; i++)
+            {
+                var parameter = candidateOwner?.SubstituteMemberType(candidate.Parameters[i + parameterOffset].Type)
+                    ?? candidate.Parameters[i + parameterOffset].Type;
+                Binder.InferTypeArguments(parameter, targetParameterTypes[i], substitution);
+            }
+
+            var typeArguments = ImmutableArray.CreateBuilder<TypeSymbol>(candidate.TypeParameters.Length);
+            foreach (var typeParameter in candidate.TypeParameters)
+            {
+                if (!substitution.TryGetValue(typeParameter, out var typeArgument)
+                    || !Binder.SatisfiesConstraint(typeArgument, typeParameter))
+                {
+                    return false;
+                }
+
+                typeArguments.Add(typeArgument);
+            }
+
+            methodTypeArguments = typeArguments.MoveToImmutable();
+        }
+
+        closedParameters = new TypeSymbol[targetParameterTypes.Count];
+        for (var i = 0; i < closedParameters.Length; i++)
+        {
+            var parameter = candidateOwner?.SubstituteMemberType(candidate.Parameters[i + parameterOffset].Type)
+                ?? candidate.Parameters[i + parameterOffset].Type;
+            closedParameters[i] = substitution == null ? parameter : Binder.SubstituteType(parameter, substitution);
+        }
+
+        var returnType = candidateOwner?.SubstituteMemberType(candidate.Type) ?? candidate.Type ?? TypeSymbol.Void;
+        closedReturn = substitution == null ? returnType : Binder.SubstituteType(returnType, substitution);
+        return true;
     }
 
     private static bool IsBetterMethodGroupConversion(

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -446,6 +446,17 @@ internal sealed partial class MethodBodyEmitter
             ftnToken = this.outer.userTokens.ResolveUserInstanceMethodToken(receiverStruct, methodGroup.Function);
         }
 
+        if (methodGroup.Function.IsGeneric)
+        {
+            if (methodGroup.MethodTypeArguments.Length != methodGroup.Function.TypeParameters.Length)
+            {
+                throw new InvalidOperationException(
+                    $"Generic method group '{methodGroup.Function.Name}' has no inferred type arguments.");
+            }
+
+            ftnToken = this.outer.userTokens.BuildMethodSpecForGenericMethodGroup(ftnToken, methodGroup);
+        }
+
         if (methodGroup.Receiver == null)
         {
             this.il.OpCode(ILOpCode.Ldnull);

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -226,6 +226,9 @@ internal sealed class UserTokenResolver
         return this.BuildMethodSpec(openMethod, args);
     }
 
+    internal EntityHandle BuildMethodSpecForGenericMethodGroup(EntityHandle openMethod, BoundMethodGroupExpression methodGroup)
+        => this.BuildMethodSpec(openMethod, methodGroup.MethodTypeArguments.ToArray());
+
     /// <summary>
     /// ADR-0087 §3 R3+R4: builds a MethodSpec for a generic G# user
     /// instance method call (`h.Box[int32](42)`). Same inference rules

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2546MethodGroupGenericInferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2546MethodGroupGenericInferenceTests.cs
@@ -73,6 +73,64 @@ func main() int32 {
     }
 
     [Fact]
+    public void GenericSourceMethodGroup_Select_UserElementToDictionary_InfersResultAndRuns()
+    {
+        const string Source = @"
+package DictionaryMethodGroup
+import System
+import System.Collections.Generic
+import System.Linq
+
+data class Record(Value string) {}
+
+class Repro {
+    shared {
+        func ToDictionary[T any](record T) Dictionary[string, string] {
+            var result = Dictionary[string, string]()
+            result.Add(""value"", ""present"")
+            return result
+        }
+
+        func Run(records IEnumerable[Record]) int32 {
+            return records.Select(ToDictionary).Single().Count
+        }
+    }
+}
+
+func main() int32 {
+    var records = List[Record]()
+    records.Add(Record(""42""))
+    return Repro.Run(records)
+}
+";
+        Assert.Equal(1, CompileAndRun(Source, nameof(GenericSourceMethodGroup_Select_UserElementToDictionary_InfersResultAndRuns)));
+    }
+
+    [Fact]
+    public void AmbiguousGenericSourceMethodGroup_DoesNotInferArbitraryResult()
+    {
+        const string Source = @"
+package AmbiguousGenericMethodGroup
+import System.Collections.Generic
+import System.Linq
+
+func Project[T any](value T) int32 { return 1 }
+func Project[T any](value List[T]) string { return ""x"" }
+
+func main() {
+    var values = List[List[string]]()
+    values.Select(Project)
+}
+";
+        using var peStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(Source)));
+        var result = compilation.Emit(peStream);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
     public void AmbiguousSourceMethodGroup_DoesNotInferArbitraryResult()
     {
         const string Source = @"

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2546MethodGroupPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2546MethodGroupPipelineTests.cs
@@ -1,0 +1,131 @@
+// <copyright file="Issue2546MethodGroupPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2546MethodGroupPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdk_LinqSourceMethodGroup_TranslatesAndCompiles()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectPath = WriteFixture(sourceRoot);
+        string outputRoot = NewDirectory("pipeline-tests");
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+
+        RunResult result = await pipeline.RunAsync(
+            new[] { new CorpusApp("test/Issue2546", projectPath, TargetKind.Library) });
+        AppResult app = Assert.Single(result.Apps);
+        string emitted = ReadAppOutput(outputRoot, result.RunId, app.AppId);
+
+        Assert.Contains("records.Select(ToDictionary)", emitted, StringComparison.Ordinal);
+        Assert.True(
+            app.Succeeded,
+            "Expected imported LINQ Select to accept the source method group. Stages: " +
+                string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+    }
+
+    private static string WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+        string projectDir = Path.Combine(sourceRoot, "Issue2546");
+        Directory.CreateDirectory(projectDir);
+
+        string projectPath = Path.Combine(projectDir, "Issue2546.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "Repro.cs"), """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            namespace Issue2546;
+
+            public sealed record Record(string Value);
+
+            public static class Repro
+            {
+                public static Dictionary<string, string> ToDictionary<T>(T record) =>
+                    new() { ["value"] = "present" };
+
+                public static int Run(IEnumerable<Record> records) =>
+                    records.Select(ToDictionary).Single().Count;
+            }
+            """);
+        return projectPath;
+    }
+
+    private static string ReadAppOutput(string outputRoot, string runId, string appId)
+    {
+        string directory = Path.Combine(outputRoot, runId, MigrationPipeline.SanitizeAppId(appId));
+        return string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(directory, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2546",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- infer source generic method arguments from target delegate inputs
- preserve inferred arguments through conversion, rewriting, and MethodSpec emission
- retain ambiguous method-group rejection and cover translated `records.Select(ToDictionary)`

## Tests
- Core.Tests: 6,595 passed, 1 skipped
- Compiler.Tests method-group filter: 27 passed
- Cs2Gs.Tests: 1,672 passed

Fixes #2546