### PR TITLE
Fix inherited imported extension receivers

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -4819,34 +4819,7 @@ internal static class OverloadResolution
             // throw on BaseType traversal; fall through to interface walk.
         }
 
-        Type[] ifaces;
-        try
-        {
-            ifaces = type.GetInterfaces();
-        }
-        catch (InvalidOperationException)
-        {
-            return null;
-        }
-        catch (NotSupportedException)
-        {
-            // Issue #666: TypeBuilderInstantiation (produced when
-            // FunctionTypeSymbol.BuildClrType constructs a host-runtime Func<>
-            // with MetadataLoadContext type arguments) throws
-            // NotSupportedException from GetInterfaces(). Treat as "no match"
-            // and let inference continue from other parameters.
-
-            // Fallback: if the type itself is a closed generic whose open
-            // definition matches by name, return it directly. This handles
-            // Func<T,bool> / Action<T> shapes from BuildClrType.
-            if (type.IsGenericType && !type.IsGenericTypeDefinition
-                && MatchesOpenDefinition(type.GetGenericTypeDefinition(), openDefinition, openDefName))
-            {
-                return type;
-            }
-
-            return null;
-        }
+        var ifaces = ClrTypeUtilities.SafeGetInterfaces(type);
 
         foreach (var iface in ifaces)
         {

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -2307,6 +2307,14 @@ internal sealed class ReflectionMetadataEmitter
             {
                 foreach (var clrBase in iface.BaseClrInterfaces)
                 {
+                    if (MemberLookup.TryGetSymbolicClrGenericInterface(clrBase, out _, out _))
+                    {
+                        this.emitCtx.Metadata.AddInterfaceImplementation(
+                            ifaceTypeDef,
+                            this.memberRefs.GetElementTypeToken(clrBase));
+                        continue;
+                    }
+
                     if (clrBase?.ClrType is System.Type clrType)
                     {
                         this.emitCtx.Metadata.AddInterfaceImplementation(

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -886,19 +886,53 @@ public static class ClrTypeUtilities
             return Array.Empty<Type>();
         }
 
-        // Issue #1678: Type.GetInterfaces() walks the full transitive interface
-        // graph on every call; memoize it per Type so a receiver used at N call
-        // sites (or matched against N interface methods) pays that walk once.
+        // Some MetadataLoadContext Type implementations return only direct
+        // interfaces. Complete the graph explicitly and include interfaces
+        // inherited through base classes, then cache that canonical result.
         return interfacesCache.GetValue(type, static t =>
         {
-            try
+            var result = new List<Type>();
+            var visited = new HashSet<Type>();
+
+            void Visit(Type current)
             {
-                return t.GetInterfaces();
+                if (current == null || !visited.Add(current))
+                {
+                    return;
+                }
+
+                Type[] direct;
+                try
+                {
+                    direct = current.GetInterfaces();
+                }
+                catch (Exception ex) when (IsMetadataLoadFailure(ex))
+                {
+                    direct = Array.Empty<Type>();
+                }
+
+                foreach (var iface in direct)
+                {
+                    if (!result.Contains(iface))
+                    {
+                        result.Add(iface);
+                    }
+
+                    Visit(iface);
+                }
+
+                try
+                {
+                    Visit(current.BaseType);
+                }
+                catch (Exception ex) when (IsMetadataLoadFailure(ex))
+                {
+                    // A partial graph is still useful to callers.
+                }
             }
-            catch (Exception ex) when (IsMetadataLoadFailure(ex))
-            {
-                return Array.Empty<Type>();
-            }
+
+            Visit(t);
+            return result.ToArray();
         });
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2536ImportedInheritedExtensionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2536ImportedInheritedExtensionTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="Issue2536ImportedInheritedExtensionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2536ImportedInheritedExtensionTests
+{
+    [Fact]
+    public void LinqExtensions_OnImportedInterfaceWithGenericBase_Bind()
+    {
+        string outputDirectory = Path.Combine(AppContext.BaseDirectory, "Issue2536");
+        Directory.CreateDirectory(outputDirectory);
+        string libraryPath = Path.Combine(outputDirectory, "Issue2536.Contracts.dll");
+
+        var library = new Compilation(
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Issue2536.Contracts
+                import System.Collections.Generic
+
+                class Item {
+                    prop Value int32
+                }
+
+                interface IItems : IReadOnlyCollection[Item] {
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using (var stream = File.Create(libraryPath))
+        {
+            var result = library.Emit(stream, pdbStream: null, refStream: null, assemblyName: "Issue2536.Contracts");
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        using var resolver = ReferenceResolver.WithReferences(RuntimeReferences().Append(libraryPath));
+        Assert.True(resolver.TryResolveType("Issue2536.Contracts.IItems", out var importedItems));
+        Assert.Contains(
+            importedItems.GetInterfaces(),
+            type => type.IsGenericType
+                && type.GetGenericTypeDefinition().FullName == typeof(IReadOnlyCollection<>).FullName
+                && type.GetGenericArguments()[0].FullName == "Issue2536.Contracts.Item");
+        var consumer = new Compilation(
+            resolver,
+            SyntaxTree.Parse(SourceText.From(
+                """
+                package Issue2536.Consumer
+                import Issue2536.Contracts
+                import System.Linq
+
+                func Exercise(items IItems) {
+                    var filtered = items.Where(func(item Item) bool { return item.Value > 0 })
+                    var any = items.Any(func(item Item) bool { return item.Value > 0 })
+                    var count = items.Count(func(item Item) bool { return item.Value > 0 })
+                    var first = items.FirstOrDefault()
+                }
+                """)))
+        {
+            IsLibrary = true,
+        };
+
+        using var output = new MemoryStream();
+        var consumerResult = consumer.Emit(
+            output,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: "Issue2536.Consumer");
+        Assert.True(consumerResult.Success, string.Join(Environment.NewLine, consumerResult.Diagnostics));
+    }
+
+    private static IEnumerable<string> RuntimeReferences()
+    {
+        var trustedAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        return string.IsNullOrEmpty(trustedAssemblies)
+            ? Array.Empty<string>()
+            : trustedAssemblies.Split(Path.PathSeparator)
+                .Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path));
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue666LinqExtensionOnClrRefTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue666LinqExtensionOnClrRefTypeTests.cs
@@ -136,6 +136,25 @@ var q = xs.AsEnumerable().Where(func(i Issue666ItemCls) bool { return true })
         AssertBindsWithoutErrors(source);
     }
 
+    [Fact]
+    public void Linq_OnObservableCollection_UserRefElement_InstanceSyntax_Binds()
+    {
+        var source = @"
+package Probe
+import System.Collections.ObjectModel
+import System.Linq
+
+class Item { }
+var xs = ObservableCollection[Item]()
+xs.Add(Item())
+var filtered = xs.Where(func(i Item) bool { return true })
+var any = xs.Any(func(i Item) bool { return true })
+var count = xs.Count(func(i Item) bool { return true })
+var first = xs.FirstOrDefault()
+";
+        AssertBindsWithoutErrors(source);
+    }
+
     // --- Regression guards: BCL types (should already pass) ---
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2536ObservableExtensionsPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2536ObservableExtensionsPipelineTests.cs
@@ -1,0 +1,166 @@
+// <copyright file="Issue2536ObservableExtensionsPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2536ObservableExtensionsPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ViaSdkDefault_ObservableAndInheritedInterfaceLinqExtensions_Compile()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        (string contractsProject, string consumerProject) = WriteFixture(sourceRoot);
+        string outputRoot = NewDirectory("pipeline-tests");
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        Assert.True(options.CompileViaSdk);
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("test/Contracts", contractsProject, TargetKind.Library),
+            new CorpusApp("test/Consumer", consumerProject, TargetKind.Library),
+        });
+
+        Assert.All(
+            result.Apps,
+            app => Assert.True(
+                app.Succeeded,
+                app.AppId + " should compile through default --via-sdk/gsc. Stages: "
+                    + string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status))));
+    }
+
+    private static (string ContractsProject, string ConsumerProject) WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+
+        string contractsDirectory = Path.Combine(sourceRoot, "Contracts");
+        Directory.CreateDirectory(contractsDirectory);
+        string contractsProject = Path.Combine(contractsDirectory, "Contracts.csproj");
+        File.WriteAllText(contractsProject, ProjectFile(null));
+        File.WriteAllText(Path.Combine(contractsDirectory, "Contracts.cs"), """
+            using System.Collections.Generic;
+
+            namespace Issue2536.Contracts;
+
+            public sealed class Model
+            {
+                public int Value { get; set; }
+            }
+
+            public interface IModels : IReadOnlyCollection<Model>
+            {
+            }
+            """);
+
+        string consumerDirectory = Path.Combine(sourceRoot, "Consumer");
+        Directory.CreateDirectory(consumerDirectory);
+        string consumerProject = Path.Combine(consumerDirectory, "Consumer.csproj");
+        File.WriteAllText(consumerProject, ProjectFile("../Contracts/Contracts.csproj"));
+        File.WriteAllText(Path.Combine(consumerDirectory, "Repro.cs"), """
+            using System.Collections.Generic;
+            using System.Collections.ObjectModel;
+            using System.Linq;
+            using Issue2536.Contracts;
+
+            namespace Issue2536.Consumer;
+
+            public static class Repro
+            {
+                public static IEnumerable<Model> Where(ObservableCollection<Model> items) =>
+                    items.Where(item => item.Value > 0);
+
+                public static bool Any(IModels items) =>
+                    items.Any(item => item.Value > 0);
+
+                public static int Count(ObservableCollection<Model> items) =>
+                    items.Count(item => item.Value > 0);
+
+                public static Model? FirstOrDefault(IModels items) =>
+                    items.FirstOrDefault();
+            }
+            """);
+
+        return (contractsProject, consumerProject);
+    }
+
+    private static string ProjectFile(string projectReference)
+    {
+        string reference = projectReference is null
+            ? string.Empty
+            : $"""
+
+                <ItemGroup>
+                  <ProjectReference Include="{projectReference}" />
+                </ItemGroup>
+              """;
+        return $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>{reference}
+            </Project>
+            """;
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2536",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirectoryName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirectoryName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- preserve symbolic generic arguments when emitting imported CLR base interfaces
- make generic inference walk transitive interfaces and base-class interfaces across metadata contexts
- cover LINQ on ObservableCollection and imported inherited IEnumerable receivers through compiler and cs2gs pipeline tests

## Validation
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --verbosity minimal` (6,595 passed, 1 skipped)
- focused Core extension suites (12 passed)
- focused SDK-backed cs2gs pipeline regression (1 passed)
- existing cs2gs suite reached 1,617 passed, 0 failed before the local test host aborted

Fixes #2536