### PR TITLE
Fix semantic qualification roots

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -163,7 +163,7 @@ internal sealed partial class ExpressionBinder
     {
         result = null;
 
-        if (syntax.IsNullConditional)
+        if (syntax.IsNullConditional || QualifiedAccessStartsWithValue(syntax))
         {
             return false;
         }
@@ -234,7 +234,7 @@ internal sealed partial class ExpressionBinder
     {
         result = null;
 
-        if (syntax.IsNullConditional)
+        if (syntax.IsNullConditional || QualifiedAccessStartsWithValue(syntax))
         {
             return false;
         }
@@ -286,6 +286,10 @@ internal sealed partial class ExpressionBinder
         result = BindImportedTypeLiteralExpression(terminalLiteral, clrType);
         return true;
     }
+
+    private bool QualifiedAccessStartsWithValue(AccessorExpressionSyntax syntax) =>
+        syntax.LeftPart is NameExpressionSyntax name
+        && scope.TryLookupSymbol(name.IdentifierToken.Text) is VariableSymbol;
 
     /// <summary>
     /// Binds a same-compilation SOURCE type constructed or referenced through a

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -83,6 +83,7 @@ internal sealed partial class ExpressionBinder
         // own compilation's source type for a static event/field compound
         // assignment, mirroring the BindAccessorExpression read-path bug.
         if (accessor.LeftPart is NameExpressionSyntax staticLeftName
+            && EventReceiverNameCanBindAsType(staticLeftName, eventNameSyntax)
             && scope.TryLookupTypeAlias(staticLeftName.IdentifierToken.Text, out var staticTypeAlias)
             && staticTypeAlias is StructSymbol staticStruct)
         {
@@ -139,6 +140,7 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
         else if (accessor.LeftPart is NameExpressionSyntax leftName
+            && EventReceiverNameCanBindAsType(leftName, eventNameSyntax)
             && scope.TryLookupImportedClass(leftName.IdentifierToken.Text, leftName, out var importedClass))
         {
             receiverClrType = importedClass.ClassType;
@@ -387,6 +389,29 @@ internal sealed partial class ExpressionBinder
         }
 
         return new BoundClrEventSubscriptionExpression(null, boundReceiver, eventInfo, convertedHandler, isAdd);
+    }
+
+    private bool EventReceiverNameCanBindAsType(
+        NameExpressionSyntax receiver,
+        ExpressionSyntax rightPart)
+    {
+        string name = receiver.IdentifierToken.Text;
+        if (scope.TryLookupSymbol(name) is not VariableSymbol)
+        {
+            return true;
+        }
+
+        return TryResolveColorColorType(
+                name,
+                receiver,
+                out var importedType,
+                out var sourceType,
+                out var enumType)
+            && RightPartLooksLikeStaticMember(
+                importedType,
+                sourceType,
+                enumType,
+                rightPart);
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2585SemanticQualificationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2585SemanticQualificationTests.cs
@@ -1,0 +1,202 @@
+// <copyright file="Issue2585SemanticQualificationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2585SemanticQualificationTests
+{
+    private static readonly string LibraryPath = EmitLibrary();
+
+    [Fact]
+    public void ImportedNamespaceHomonym_DoesNotReclassifyEventLambdaParameterAsTypeRoot()
+    {
+        Assert.Empty(Bind("""
+            package Consumer
+            import Oahu.App
+            import Oahu.Tui
+
+            func Wire(hub Hub) {
+                hub.Changed += (vm ViewModel) -> {
+                    vm.Changed += () -> { }
+                }
+            }
+            """));
+    }
+
+    [Fact]
+    public void ImportedNamespaceHomonym_DoesNotReclassifyLocalValueAsTypeRoot()
+    {
+        Assert.Empty(Bind("""
+            package Consumer
+            import Oahu.App
+            import Oahu.Tui
+
+            func Run() {
+                let vm = ViewModel()
+                vm.Changed += () -> { }
+            }
+            """));
+    }
+
+    [Fact]
+    public void ImportedConstructorPath_DoesNotReclassifyLocalValueAsNamespaceRoot()
+    {
+        Assert.Empty(Bind("""
+            package Consumer
+            import Oahu.App
+            import Oahu.Trap
+
+            func Run() int32 {
+                let local = Factory()
+                return local.Make()
+            }
+            """));
+    }
+
+    [Fact]
+    public void ImportedNestedNamespaceAndAlias_RemainValidTypeQualifiers()
+    {
+        Assert.Empty(Bind("""
+            package Consumer
+            import Tui = Oahu.Tui
+
+            func Run() {
+                let direct = Oahu.Tui.Nested.Refresh()
+                let aliased = Tui.Nested.Refresh()
+            }
+            """));
+    }
+
+    [Fact]
+    public void SourceQualifiedTypeAndValueReceiver_RemainDistinct()
+    {
+        Assert.Empty(Bind(
+            """
+            package Oahu.App
+
+            class ViewModel {
+                event Changed () -> void
+
+                func Refresh() {
+                }
+            }
+            """,
+            """
+            package Oahu.Tui.Nested
+
+            class Refresh {
+                init(required int32) {
+                }
+            }
+
+            class vm {
+            }
+            """,
+            """
+            package Consumer
+            import AppAlias = Oahu.App
+
+            func Run() {
+                let vm = Oahu.App.ViewModel()
+                vm.Changed += () -> { }
+                vm.Refresh()
+                let aliased = AppAlias.ViewModel()
+                aliased.Refresh()
+                let qualified = Oahu.Tui.Nested.Refresh(1)
+            }
+            """));
+    }
+
+    private static System.Collections.Generic.IReadOnlyList<GSharp.Core.CodeAnalysis.Diagnostic> Bind(params string[] sources)
+    {
+        using var resolver = ReferenceResolver.WithReferences(new[] { LibraryPath });
+        var trees = sources
+            .Select(source => GSharp.Core.CodeAnalysis.Syntax.SyntaxTree.Parse(SourceText.From(source)))
+            .ToArray();
+        var compilation = new GsCompilation(resolver, trees) { IsLibrary = true };
+        return trees.SelectMany(tree => tree.Diagnostics)
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .Where(d => d.IsError)
+            .ToList();
+    }
+
+    private static string EmitLibrary()
+    {
+        string outputDirectory = Path.Combine(AppContext.BaseDirectory, "Issue2585Binding");
+        Directory.CreateDirectory(outputDirectory);
+        string libraryPath = Path.Combine(outputDirectory, "Issue2585.Library.dll");
+
+        const string source = """
+            using System;
+
+            namespace Oahu.App
+            {
+                public sealed class ViewModel
+                {
+                    public event Action Changed;
+                    public void Refresh() { }
+                }
+
+                public sealed class Hub
+                {
+                    public event Action<ViewModel> Changed;
+                }
+
+                public sealed class Factory
+                {
+                    public int Make() => 1;
+                }
+            }
+
+            namespace Oahu.Tui.Nested
+            {
+                public sealed class Refresh
+                {
+                    public Refresh() { }
+                }
+            }
+
+            namespace Oahu.Tui
+            {
+                public sealed class vm
+                {
+                }
+            }
+
+            namespace Oahu.Trap.local
+            {
+                public sealed class Make
+                {
+                }
+            }
+            """;
+
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))
+            .Split(Path.PathSeparator)
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "Issue2585.Library",
+            new[] { tree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = File.Create(libraryPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return libraryPath;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2585SemanticQualificationPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2585SemanticQualificationPipelineTests.cs
@@ -1,0 +1,217 @@
+// <copyright file="Issue2585SemanticQualificationPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2585SemanticQualificationPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_NestedNamespacesAndEventLambda_PreserveSemanticRootsAndCompile()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        (string appProject, string tuiProject) = WriteFixture(sourceRoot);
+        string outputRoot = NewDirectory("pipeline-tests");
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+
+        RunResult result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("test/App", appProject, TargetKind.Library),
+            new CorpusApp("test/Tui", tuiProject, TargetKind.Library),
+        });
+
+        Assert.All(
+            result.Apps,
+            app => Assert.True(
+                app.Succeeded,
+                app.AppId + " should compile. Stages: " +
+                    string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status))));
+
+        string appOutput = ReadOutput(outputRoot, result.RunId, "test/App");
+        Assert.Contains("package Oahu.App", appOutput, StringComparison.Ordinal);
+        Assert.Contains("package Oahu.Tui", appOutput, StringComparison.Ordinal);
+        Assert.Contains("package Oahu.Tui.Nested", appOutput, StringComparison.Ordinal);
+
+        string tuiOutput = ReadOutput(outputRoot, result.RunId, "test/Tui");
+        Assert.Contains("package Oahu.Tui", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("import AppTypes = Oahu.App", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("vm.Changed += () ->", tuiOutput, StringComparison.Ordinal);
+    }
+
+    private static (string AppProject, string TuiProject) WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+
+        string appDirectory = Path.Combine(sourceRoot, "App");
+        Directory.CreateDirectory(appDirectory);
+        string appProject = Path.Combine(appDirectory, "App.csproj");
+        File.WriteAllText(appProject, ProjectFile(null));
+        File.WriteAllText(Path.Combine(appDirectory, "ViewModel.cs"), """
+            using System;
+
+            namespace Oahu
+            {
+                namespace App
+                {
+                    public sealed class ViewModel
+                    {
+                        public event Action Changed;
+                        public void Refresh() { }
+                    }
+
+                    public sealed class Hub
+                    {
+                        public event Action<ViewModel> Changed;
+                    }
+                }
+            }
+            """);
+        File.WriteAllText(Path.Combine(appDirectory, "QualificationTrap.cs"), """
+            namespace Oahu
+            {
+                namespace Tui
+                {
+                    public sealed class vm
+                    {
+                    }
+                }
+            }
+            """);
+        File.WriteAllText(Path.Combine(appDirectory, "NestedTrap.cs"), """
+            namespace Oahu
+            {
+                namespace Tui
+                {
+                    namespace Nested
+                    {
+                        public sealed class Refresh
+                        {
+                            public Refresh() { }
+                        }
+                    }
+                }
+            }
+            """);
+
+        string tuiDirectory = Path.Combine(sourceRoot, "Tui");
+        Directory.CreateDirectory(tuiDirectory);
+        string tuiProject = Path.Combine(tuiDirectory, "Tui.csproj");
+        File.WriteAllText(tuiProject, ProjectFile("../App/App.csproj"));
+        File.WriteAllText(Path.Combine(tuiDirectory, "Wiring.cs"), """
+            using AppTypes = Oahu.App;
+            using Oahu.Tui;
+
+            namespace Oahu
+            {
+                namespace Tui
+                {
+                    public static class Wiring
+                    {
+                        public static void Connect(AppTypes.Hub hub)
+                        {
+                            hub.Changed += vm =>
+                            {
+                                vm.Changed += () => { };
+                                vm.Refresh();
+                            };
+                        }
+                    }
+                }
+            }
+            """);
+
+        return (appProject, tuiProject);
+    }
+
+    private static string ProjectFile(string projectReference)
+    {
+        string reference = projectReference is null
+            ? string.Empty
+            : $"""
+
+                <ItemGroup>
+                  <ProjectReference Include="{projectReference}" />
+                </ItemGroup>
+              """;
+        return $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>disable</Nullable>
+              </PropertyGroup>{reference}
+            </Project>
+            """;
+    }
+
+    private static string ReadOutput(string outputRoot, string runId, string appId)
+    {
+        string directory = Path.Combine(
+            outputRoot,
+            runId,
+            MigrationPipeline.SanitizeAppId(appId));
+        return string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(directory, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2585",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirectoryName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirectoryName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -530,8 +530,14 @@ public sealed partial class CSharpToGSharpTranslator
 
     private string ResolvePackage(CompilationUnitSyntax root, TranslationContext context)
     {
-        List<BaseNamespaceDeclarationSyntax> namespaces = root.DescendantNodes()
-            .OfType<BaseNamespaceDeclarationSyntax>()
+        List<(string Name, Location Location)> namespaces = EnumerateTopLevelDeclarations(root)
+            .Select(member => (
+                Symbol: context.GetDeclaredSymbol(member),
+                Location: member.GetLocation()))
+            .Where(item => item.Symbol?.ContainingNamespace is { IsGlobalNamespace: false })
+            .Select(item => (
+                item.Symbol.ContainingNamespace.ToDisplayString(),
+                item.Location))
             .ToList();
 
         if (namespaces.Count == 0)
@@ -539,14 +545,14 @@ public sealed partial class CSharpToGSharpTranslator
             return null;
         }
 
-        string dominant = namespaces[0].Name.ToString();
-        IEnumerable<string> distinct = namespaces.Select(n => n.Name.ToString()).Distinct();
+        string dominant = namespaces[0].Name;
+        IEnumerable<string> distinct = namespaces.Select(n => n.Name).Distinct();
         if (distinct.Count() > 1)
         {
             context.Report(new TranslationDiagnostic(
                 nameof(SyntaxKind.NamespaceDeclaration),
                 $"Multiple namespaces in one file; hoisting to the dominant namespace '{dominant}' (ADR-0115 §B.1).",
-                namespaces[0].Name.GetLocation(),
+                namespaces[0].Location,
                 TranslationSeverity.Warning));
         }
 


### PR DESCRIPTION
## Summary
- derive emitted package names from bound declaration namespaces, preserving nested roots
- keep local and lambda value receivers ahead of colliding source/imported type names while retaining static type qualification
- preserve namespace aliases and add project-backed nested-namespace/event-lambda coverage plus negative controls

## Testing
- `dotnet build GSharp.sln --no-restore`
- issue #2585 Core tests (5 passed)
- issue #2585 SDK-backed cs2gs pipeline test (passed)
- full solution run: Core, Cs2Gs, LanguageServer, Interpreter, SDK, Extensions, analyzers, and generator-host suites passed (9,306 tests; one baseline regeneration skipped)
- serial bounded Compiler.Tests filters with `MSBUILDDISABLENODEREUSE=1` passed: imported delegate/event lambdas (8), events (25), value/type collisions (3), package collisions (8), and nested qualification (3)
- PR CI passed build/Test, e2e, cs2gs, and extension jobs

## Deferred
- none

Fixes #2585