### PR TITLE
Fix imported generic nullable coalescing

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -238,14 +238,12 @@ public sealed record BoundBinaryOperator
             //     type, the result is the right type (reference upcast / interface
             //     implementation, e.g. `Foo? ?? IFoo` → `IFoo`, or numeric
             //     widening, e.g. `int32? ?? int64` → `int64`).
-            // Restricted to a non-nullable right operand so the result is a plain
-            // (non-nullable) type; ExpressionBinder.BindBinaryExpression inserts
-            // the operand conversions required for correct emit/evaluation. A
-            // mismatched nullable right operand still falls through to GS0129
-            // (unchanged behaviour) because lifted nullable numeric conversions
-            // are not part of the implicit-conversion lattice.
-            if (rightType is not NullableTypeSymbol
-                && leftUnderlying != null
+            // When the right operand is nullable, classify its underlying type
+            // by the same rules and lift the common result. This keeps imported
+            // generic implementations and ordinary subtype/interface pairs on
+            // the same conversion path instead of requiring exact nullable
+            // wrapper identity.
+            if (leftUnderlying != null
                 && rightUnderlying != null
                 && leftType != TypeSymbol.Error
                 && rightType != TypeSymbol.Error)
@@ -267,6 +265,11 @@ public sealed record BoundBinaryOperator
 
                 if (common != null)
                 {
+                    if (rightType is NullableTypeSymbol)
+                    {
+                        common = NullableTypeSymbol.Get(common);
+                    }
+
                     return new BoundBinaryOperator(syntaxKind, BoundBinaryOperatorKind.NullCoalesce, leftType, rightType, common);
                 }
             }

--- a/test/Compiler.Tests/Emit/Issue1239CoalesceCommonTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1239CoalesceCommonTypeEmitTests.cs
@@ -87,6 +87,31 @@ public class Issue1239CoalesceCommonTypeEmitTests
     }
 
     [Fact]
+    public void NullableRightSubtype_ConvertsToNullableLeftInterface()
+    {
+        var source = """
+            package P
+
+            import System
+
+            interface ILogger { func Name() string; }
+            class NullLogger : ILogger { func Name() string -> "null" }
+
+            func Pick(logger ILogger?, fallback NullLogger?) ILogger? {
+                var selected = logger ?? fallback
+                return selected
+            }
+
+            Console.WriteLine(Pick(nil, NullLogger())!!.Name())
+            Console.WriteLine(Pick(nil, nil) == nil)
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("null\nTrue\n", output);
+    }
+
+    [Fact]
     public void RightIsBaseClass_ResultIsBaseClass()
     {
         var source = """

--- a/test/Compiler.Tests/Emit/Issue2540ImportedGenericCoalesceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2540ImportedGenericCoalesceEmitTests.cs
@@ -1,0 +1,216 @@
+// <copyright file="Issue2540ImportedGenericCoalesceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue2540ImportedGenericCoalesceEmitTests
+{
+    private const string ContractsSource = """
+        package Issue2540.Contracts
+
+        interface ILogger[out T] {
+            func Name() string;
+        }
+
+        class Category {}
+        """;
+
+    private const string ImplementationsSource = """
+        package Issue2540.Implementations
+        import Issue2540.Contracts
+
+        class NullLogger : ILogger[Category] {
+            shared {
+                let Instance NullLogger = NullLogger()
+            }
+
+            func Name() string -> "null"
+        }
+        """;
+
+    [Fact]
+    public void ImportedGenericInterface_CoalescesWithConcreteSingleton()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2540-artifacts",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            var contractsPath = CompileContracts(directory);
+            var implementationsPath = CompileFixture(
+                directory,
+                "Issue2540.Implementations",
+                ImplementationsSource,
+                contractsPath);
+            const string source = """
+                package Issue2540.App
+                import System
+                import Issue2540.Contracts
+                import Issue2540.Implementations
+
+                class Service {
+                    private let logger ILogger[Category]
+
+                    init(logger ILogger[Category]?) {
+                        var selected = logger ?? NullLogger.Instance
+                        this.logger = selected
+                    }
+
+                    func Name() string -> logger!!.Name()!!
+                }
+
+                func Main() {
+                    Console.WriteLine(Service(nil).Name())
+                }
+                """;
+
+            var outputPath = Path.Combine(directory, "Issue2540.App.dll");
+            var result = Compile(
+                directory,
+                source,
+                outputPath,
+                contractsPath,
+                implementationsPath);
+            Assert.True(
+                result.ExitCode == 0,
+                $"compile failed\n{result.Stdout}\n{result.Stderr}");
+            IlVerifier.Verify(
+                outputPath,
+                additionalReferences: new[] { contractsPath, implementationsPath });
+            Assert.Equal("null\n", Run(outputPath));
+
+            const string invalidSource = """
+                package Issue2540.Invalid
+                import Issue2540.Contracts
+
+                class Other {}
+
+                func Bad(logger ILogger[Category]?) ILogger[Category] {
+                    return logger ?? Other()
+                }
+                """;
+            var invalid = Compile(
+                directory,
+                invalidSource,
+                Path.Combine(directory, "Issue2540.Invalid.dll"),
+                contractsPath,
+                implementationsPath,
+                target: "library");
+            Assert.NotEqual(0, invalid.ExitCode);
+            Assert.Contains("GS0129", invalid.Stdout + invalid.Stderr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static string CompileContracts(string directory)
+        => CompileFixture(directory, "Issue2540.Contracts", ContractsSource);
+
+    private static string CompileFixture(
+        string directory,
+        string assemblyName,
+        string source,
+        params string[] fixtureReferences)
+    {
+        var outputPath = Path.Combine(directory, assemblyName + ".dll");
+        var sourcePath = Path.Combine(directory, assemblyName + ".gs");
+        File.WriteAllText(sourcePath, source);
+        var args = new string[fixtureReferences.Length + 4];
+        args[0] = "/out:" + outputPath;
+        args[1] = "/target:library";
+        args[2] = "/targetframework:net10.0";
+        for (var i = 0; i < fixtureReferences.Length; i++)
+        {
+            args[i + 3] = "/reference:" + fixtureReferences[i];
+        }
+
+        args[^1] = sourcePath;
+        var result = RunCompiler(args);
+        Assert.True(
+            result.ExitCode == 0,
+            $"fixture compile failed\n{result.Stdout}\n{result.Stderr}");
+        return outputPath;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) Compile(
+        string directory,
+        string source,
+        string outputPath,
+        string contractsPath,
+        string implementationsPath,
+        string target = "exe")
+    {
+        var sourcePath = Path.Combine(directory, Path.GetFileNameWithoutExtension(outputPath) + ".gs");
+        File.WriteAllText(sourcePath, source);
+        return RunCompiler(new[]
+        {
+            "/out:" + outputPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/reference:" + contractsPath,
+            "/reference:" + implementationsPath,
+            sourcePath,
+        });
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunCompiler(string[] args)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return (Program.Main(args), stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string Run(string assemblyPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath)!,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n");
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1239CoalesceCommonTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1239CoalesceCommonTypeTests.cs
@@ -64,6 +64,43 @@ class C {
     }
 
     [Fact]
+    public void NullableRightSubtypeConvertsToNullableLeftInterface()
+    {
+        const string Source = @"package Issue2540.NullableIface
+
+interface ILogger { }
+class NullLogger : ILogger { }
+class C {
+    func Pick(logger ILogger?, fallback NullLogger?) ILogger? {
+        var selected = logger ?? fallback
+        return selected
+    }
+}
+";
+        var diagnostics = EmitDiagnostics(Source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0129");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void NullableUnrelatedTypesStillReportError()
+    {
+        const string Source = @"package Issue2540.InvalidNullable
+
+interface ILogger { }
+class Other { }
+class C {
+    func Bad(logger ILogger?, fallback Other?) ILogger? {
+        var selected = logger ?? fallback
+        return selected
+    }
+}
+";
+        var diagnostics = EmitDiagnostics(Source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0129");
+    }
+
+    [Fact]
     public void ImportedRightSubtypeConvertsToNullableLeftInterface()
     {
         const string Source = @"package Issue2540.ImportedIface

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2540ImportedGenericCoalescePipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2540ImportedGenericCoalescePipelineTests.cs
@@ -1,0 +1,149 @@
+// <copyright file="Issue2540ImportedGenericCoalescePipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2540ImportedGenericCoalescePipelineTests
+{
+    [Fact]
+    public async Task Pipeline_ImportedGenericLoggerCoalesce_Compiles()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+        string projectDir = Path.Combine(sourceRoot, "Issue2540");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "Issue2540.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "Service.cs"), """
+            using Microsoft.Extensions.Logging;
+            using Microsoft.Extensions.Logging.Abstractions;
+
+            namespace Issue2540;
+
+            public sealed class Service
+            {
+                private readonly ILogger<Service> logger;
+
+                public Service(ILogger<Service>? logger = null)
+                {
+                    this.logger = logger ?? NullLogger<Service>.Instance;
+                }
+            }
+            """);
+        RunDotnetBuild(projectPath);
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(
+            new[] { new CorpusApp("test/Issue2540", projectPath, TargetKind.Library) });
+        AppResult app = Assert.Single(result.Apps);
+        string emitted = ReadAppOutput(outputRoot, result.RunId, app.AppId);
+
+        Assert.Contains("logger ?? NullLogger[Service].Instance", emitted, StringComparison.Ordinal);
+        Assert.True(
+            app.Succeeded,
+            "Expected imported generic logger coalescing to compile via gsc. Stages: " +
+                string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+    }
+
+    private static string ReadAppOutput(string outputRoot, string runId, string appId)
+    {
+        string directory = Path.Combine(outputRoot, runId, MigrationPipeline.SanitizeAppId(appId));
+        return string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(directory, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2540",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private static void RunDotnetBuild(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo(
+            "dotnet",
+            $"build \"{projectPath}\" --nologo --verbosity:quiet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to build issue #2540 fixture.");
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, "Fixture build failed:\n" + stdout + stderr);
+    }
+}


### PR DESCRIPTION
## Summary
- generalize `??` common-type selection to nullable operands by classifying their underlying conversion and lifting the result
- preserve GS0129 for unrelated nullable and non-nullable operands
- add cross-assembly generic interface/concrete singleton compile, ILVerify, runtime, and cs2gs pipeline coverage

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --no-build --verbosity minimal` (6595 passed, 1 skipped)
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-restore --no-build --verbosity minimal` (1672 passed)
- `dotnet test test/Core.Tests/Core.Tests.csproj --filter FullyQualifiedName~Coalesc --no-restore --no-build --verbosity minimal` (53 passed)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter FullyQualifiedName~Coalesc --no-restore --no-build --verbosity minimal` (79 passed)
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --filter FullyQualifiedName~Issue2540ImportedGenericCoalescePipelineTests --no-restore --verbosity minimal` (1 passed)

Fixes #2540