### PR TITLE
Fix Oahu nullable coalesce conversions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -111,6 +111,19 @@ public sealed class Conversion
     /// <returns>The classified conversion.</returns>
     internal static Conversion ClassifyCore(TypeSymbol from, TypeSymbol to, bool allowStructuralProjection)
     {
+        // Inner generic nullability metadata does not change the outer CLR type's
+        // conversion rules. Expose the symbolic generic/interface shape beneath
+        // it before applying identity, hierarchy, and variance classification.
+        while (from is NullabilityAnnotatedTypeSymbol fromAnnotated)
+        {
+            from = fromAnnotated.BaseType;
+        }
+
+        while (to is NullabilityAnnotatedTypeSymbol toAnnotated)
+        {
+            to = toAnnotated.BaseType;
+        }
+
         if (from == to)
         {
             return Conversion.Identity;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1239CoalesceCommonTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1239CoalesceCommonTypeTests.cs
@@ -6,7 +6,9 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
@@ -98,6 +100,66 @@ class C {
 ";
         var diagnostics = EmitDiagnostics(Source);
         Assert.Contains(diagnostics, d => d.Id == "GS0129");
+    }
+
+    [Fact]
+    public void NullabilityAnnotatedNullableInterface_UsesUnderlyingConversion()
+    {
+        var contract = new InterfaceSymbol(
+            "ILogger",
+            Accessibility.Public,
+            declaration: null,
+            packageName: "Issue2540");
+        var implementation = new StructSymbol(
+            "NullLogger",
+            ImmutableArray<FieldSymbol>.Empty,
+            Accessibility.Public,
+            declaration: null,
+            packageName: "Issue2540",
+            isData: false,
+            isInline: false,
+            isClass: true);
+        implementation.SetInterfaces(ImmutableArray.Create(contract));
+        var annotatedContract = new NullabilityAnnotatedTypeSymbol(
+            contract,
+            ImmutableArray.Create<byte>(1, 1));
+
+        var op = BoundBinaryOperator.Bind(
+            SyntaxKind.QuestionQuestionToken,
+            NullableTypeSymbol.Get(annotatedContract),
+            implementation);
+
+        Assert.NotNull(op);
+        Assert.Same(annotatedContract, op.Type);
+    }
+
+    [Fact]
+    public void NullabilityAnnotatedNullableInterface_PreservesUnrelatedNegative()
+    {
+        var contract = new InterfaceSymbol(
+            "ILogger",
+            Accessibility.Public,
+            declaration: null,
+            packageName: "Issue2540");
+        var other = new StructSymbol(
+            "Other",
+            ImmutableArray<FieldSymbol>.Empty,
+            Accessibility.Public,
+            declaration: null,
+            packageName: "Issue2540",
+            isData: false,
+            isInline: false,
+            isClass: true);
+        var annotatedContract = new NullabilityAnnotatedTypeSymbol(
+            contract,
+            ImmutableArray.Create<byte>(1, 1));
+
+        var op = BoundBinaryOperator.Bind(
+            SyntaxKind.QuestionQuestionToken,
+            NullableTypeSymbol.Get(annotatedContract),
+            other);
+
+        Assert.Null(op);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2540ImportedGenericCoalescePipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2540ImportedGenericCoalescePipelineTests.cs
@@ -43,6 +43,7 @@ public sealed class Issue2540ImportedGenericCoalescePipelineTests
             </Project>
             """);
         File.WriteAllText(Path.Combine(projectDir, "Service.cs"), """
+            using System.Collections.ObjectModel;
             using Microsoft.Extensions.Logging;
             using Microsoft.Extensions.Logging.Abstractions;
 
@@ -54,8 +55,16 @@ public sealed class Issue2540ImportedGenericCoalescePipelineTests
 
                 public Service(ILogger<Service>? logger = null)
                 {
-                    this.logger = logger ?? NullLogger<Service>.Instance;
+                    this.logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<Service>.Instance;
                 }
+            }
+
+            public sealed class Book { }
+
+            public static class Selection
+            {
+                public static Book Pick(Book? sel, ObservableCollection<Book> Books)
+                    => sel ?? Books[0];
             }
             """);
         RunDotnetBuild(projectPath);
@@ -75,6 +84,7 @@ public sealed class Issue2540ImportedGenericCoalescePipelineTests
         string emitted = ReadAppOutput(outputRoot, result.RunId, app.AppId);
 
         Assert.Contains("logger ?? NullLogger[Service].Instance", emitted, StringComparison.Ordinal);
+        Assert.Contains("sel ?? Books[0]", emitted, StringComparison.Ordinal);
         Assert.True(
             app.Succeeded,
             "Expected imported generic logger coalescing to compile via gsc. Stages: " +

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -439,9 +439,22 @@ public sealed partial class CSharpToGSharpTranslator
             bool receiverIsAnonymousType =
                 this.context.GetTypeInfo(member.Expression).Type is { IsAnonymousType: true };
 
-            GExpression target = this.MemberBindsToNullableThisExtension(member) || receiverIsAnonymousType
-                ? this.TranslateExpression(member.Expression)
-                : this.TranslateReceiverWithNullForgiveness(member.Expression);
+            GExpression target;
+            if (this.context.GetSymbolInfo(member.Expression).Symbol is INamedTypeSymbol
+                { IsGenericType: true } receiverNamedType)
+            {
+                // A qualified generic type is a MemberAccessExpressionSyntax;
+                // translate its bound type so its type arguments are retained.
+                target = new TypeExpression(
+                    this.typeMapper.Map(receiverNamedType, this.context, member.Expression.GetLocation()));
+            }
+            else
+            {
+                target = this.MemberBindsToNullableThisExtension(member) || receiverIsAnonymousType
+                    ? this.TranslateExpression(member.Expression)
+                    : this.TranslateReceiverWithNullForgiveness(member.Expression);
+            }
+
             string memberName = member.Name.Identifier.Text;
 
             // Issue #1905: C# pointer member access (`p->X`) and plain member


### PR DESCRIPTION
## Summary
- preserve generic type arguments on fully qualified static receivers, fixing Oahu's translated `logger ?? NullLogger.Instance` shape
- classify nullability-annotated generic reference types through their symbolic base for common-type conversion
- cover `sel ?? Books[0]` and preserve unrelated GS0129 negatives

## Verification
- exact Oahu.Cli.App/Oahu.UI migration rerun: target logger and collection-indexer GS0129 diagnostics absent
- Core coalescing tests: 55 passed
- Compiler coalescing tests: 79 passed
- Core suite: 6608 passed, 1 skipped
- cs2gs suite: 1687 passed

Fixes #2540