### PR TITLE
Fix cycle-4 method group inference

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -612,6 +612,11 @@ internal sealed partial class ExpressionBinder
     /// </summary>
     private BoundExpression BindExtensionMethodGroupOrError(BoundExpression receiver, NameExpressionSyntax name)
     {
+        if (receiver is BoundErrorExpression)
+        {
+            return receiver;
+        }
+
         if (receiver != null)
         {
             var userCandidates = scope.TryLookupExtensionFunctions(receiver.Type, name.IdentifierToken.Text);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -852,7 +852,8 @@ internal sealed partial class ExpressionBinder
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
             constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
             structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments),
-            methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution));
+            methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution),
+            methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments));
 
         switch (resolution.Outcome)
         {
@@ -1248,7 +1249,8 @@ internal sealed partial class ExpressionBinder
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
             constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments, argumentOffset: 1),
             structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments, argumentOffset: 1),
-            methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution, argumentOffset: 1));
+            methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution, argumentOffset: 1),
+            methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments, argumentOffset: 1));
 
         switch (resolution.Outcome)
         {
@@ -2755,7 +2757,8 @@ internal sealed partial class ExpressionBinder
             argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
             constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
             structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments),
-            methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution));
+            methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution),
+            methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments));
         if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
         {
             return false;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2554,7 +2554,8 @@ internal sealed partial class ExpressionBinder
                     supplementaryInterfaceCheck: supplementaryInterfaceCheck,
                     constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
                     structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments),
-                    methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution));
+                    methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution),
+                    methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments));
                 switch (resolution.Outcome)
                 {
                     case OverloadResolution.ResolutionOutcome.Resolved:

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1271,7 +1271,9 @@ internal sealed partial class ExpressionBinder
 
         if (enclosing != null)
         {
-            var enclosingType = (enclosing.ReceiverType as StructSymbol) ?? (enclosing.StaticOwnerType as StructSymbol);
+            var enclosingType = (enclosing.ReceiverType as StructSymbol)
+                ?? (enclosing.StaticOwnerType as StructSymbol)
+                ?? (enclosing.LexicalEnclosingType as StructSymbol);
             if (enclosingType != null)
             {
                 var sharedMethods = TypeMemberModel.GetMethods(enclosingType, name, MemberQuery.Static(MemberKinds.Method));
@@ -1512,6 +1514,24 @@ internal sealed partial class ExpressionBinder
             }
 
             return ResolveMethodGroupInferenceSignature(arguments[sourceIndex], delegateParameterTypes, projectType);
+        };
+    }
+
+    internal static Func<int, bool> MakeMethodGroupArgumentCheck(
+        IReadOnlyList<BoundExpression> arguments,
+        int argumentOffset = 0)
+    {
+        if (arguments == null || !arguments.Any(OverloadResolution.IsUnresolvedMethodGroupArgument))
+        {
+            return null;
+        }
+
+        return argumentIndex =>
+        {
+            var sourceIndex = argumentIndex - argumentOffset;
+            return sourceIndex >= 0
+                && sourceIndex < arguments.Count
+                && OverloadResolution.IsUnresolvedMethodGroupArgument(arguments[sourceIndex]);
         };
     }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -666,7 +666,11 @@ internal static class OverloadResolution
     /// Optional callback that resolves a deferred method group from the input
     /// types of the candidate's delegate parameter for generic inference.
     /// </param>
-    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null)
+    /// <param name="methodGroupArgumentCheck">
+    /// Optional callback identifying which source arguments are deferred method
+    /// groups, distinguishing them from other naturally untyped arguments.
+    /// </param>
+    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null, Func<int, bool> methodGroupArgumentCheck = null)
         where T : MethodBase
     {
         var applicable = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)>();
@@ -690,7 +694,7 @@ internal static class OverloadResolution
             // rest.
             try
             {
-                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck, structuralProjectionArgumentCheck, methodGroupInference);
+                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck, structuralProjectionArgumentCheck, methodGroupInference, methodGroupArgumentCheck);
             }
             catch (Exception ex) when (IsMetadataLoadFailure(ex))
             {
@@ -2259,7 +2263,7 @@ internal static class OverloadResolution
     /// so the per-candidate work can be guarded against reflection load
     /// failures (issue #321) without disturbing the surrounding control flow.
     /// </summary>
-    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null)
+    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null, Func<int, bool> methodGroupArgumentCheck = null)
         where T : MethodBase
     {
         {
@@ -2478,6 +2482,25 @@ internal static class OverloadResolution
                 paramTypes[i] = paramTypeRewrite != null
                     ? paramTypeRewrite(parameters[paramIndex].ParameterType)
                     : parameters[paramIndex].ParameterType;
+
+                if (argTypes[i] is null
+                    && methodGroupInference != null
+                    && methodGroupArgumentCheck?.Invoke(i) == true)
+                {
+                    if (!TryGetDelegateSignature(paramTypes[i], out var delegateParameters, out var delegateReturn)
+                        || !IsMethodGroupSignatureCompatible(
+                            methodGroupInference(i, delegateParameters),
+                            delegateParameters,
+                            delegateReturn))
+                    {
+                        ok = false;
+                        break;
+                    }
+
+                    conversions[i] = ImplicitConversionKind.Identity;
+                    continue;
+                }
+
                 var conv = ClassifyImplicit(paramTypes[i], argTypes[i], supplementaryInterfaceCheck);
                 if (conv == ImplicitConversionKind.None)
                 {
@@ -2527,6 +2550,33 @@ internal static class OverloadResolution
                 applicable.Add((candidate, conversions, paramTypes, mapping, false));
             }
         }
+    }
+
+    private static bool IsMethodGroupSignatureCompatible(
+        Tuple<Type[], Type> signature,
+        IReadOnlyList<Type> delegateParameters,
+        Type delegateReturn)
+    {
+        if (signature?.Item1 is null
+            || signature.Item1.Length != delegateParameters.Count
+            || signature.Item2 is null)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < delegateParameters.Count; i++)
+        {
+            if (ClassifyImplicit(signature.Item1[i], delegateParameters[i]) == ImplicitConversionKind.None)
+            {
+                return false;
+            }
+        }
+
+        var methodVoid = string.Equals(signature.Item2.FullName, "System.Void", StringComparison.Ordinal);
+        var delegateVoid = string.Equals(delegateReturn?.FullName, "System.Void", StringComparison.Ordinal);
+        return methodVoid || delegateVoid
+            ? methodVoid && delegateVoid
+            : ClassifyImplicit(delegateReturn, signature.Item2) != ImplicitConversionKind.None;
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2546MethodGroupGenericInferenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2546MethodGroupGenericInferenceTests.cs
@@ -107,6 +107,104 @@ func main() int32 {
     }
 
     [Fact]
+    public void SourceMethodGroup_Select_InsideLambda_UsesLexicalOwnerAndRuns()
+    {
+        const string Source = @"
+package NestedDictionaryMethodGroup
+import System
+import System.Collections.Generic
+import System.Linq
+
+data class Record(Value string) {}
+
+class Repro {
+    shared {
+        func ToDictionary(record Record) Dictionary[string, string] {
+            var result = Dictionary[string, string]()
+            result.Add(""value"", record.Value)
+            return result
+        }
+
+        func Run(records IEnumerable[Record]) int32 {
+            var nested Func[int32] = () -> records.Select(ToDictionary).Single().Count
+            return nested()
+        }
+    }
+}
+
+func main() int32 {
+    var records = List[Record]()
+    records.Add(Record(""42""))
+    return Repro.Run(records)
+}
+";
+        Assert.Equal(1, CompileAndRun(Source, nameof(SourceMethodGroup_Select_InsideLambda_UsesLexicalOwnerAndRuns)));
+    }
+
+    [Fact]
+    public void InstanceMethodGroup_Where_RejectsIndexedOverloadAndRuns()
+    {
+        const string Source = @"
+package InstancePredicateMethodGroup
+import System.Collections.Generic
+import System.Linq
+
+func main() int32 {
+    var selected = List[string]()
+    selected.Add(""present"")
+    selected.Add(""missing"")
+    var byKey = Dictionary[string, int32]()
+    byKey.Add(""present"", 42)
+    return selected.Where(byKey.ContainsKey).Select((key string) -> byKey[key]).Single()
+}
+";
+        Assert.Equal(42, CompileAndRun(Source, nameof(InstanceMethodGroup_Where_RejectsIndexedOverloadAndRuns)));
+    }
+
+    [Fact]
+    public void ConstructedList_CapacityFromUserElementReadOnlyListCount_Runs()
+    {
+        const string Source = @"
+package UserElementCollectionCount
+import System.Collections.Generic
+
+data class Session(Name string) {}
+
+func Capacity(sessions IReadOnlyList[Session]) int32 {
+    var rows = List[string](sessions!!.Count)
+    return rows.Capacity
+}
+
+func main() int32 {
+    var sessions = List[Session]()
+    sessions.Add(Session(""one""))
+    return Capacity(sessions)
+}
+";
+        Assert.Equal(1, CompileAndRun(Source, nameof(ConstructedList_CapacityFromUserElementReadOnlyListCount_Runs)));
+    }
+
+    [Fact]
+    public void ErroneousReceiver_Count_DoesNotProduceMethodGroupDiagnostic()
+    {
+        const string Source = @"
+package ErrorRecovery
+import System.Collections.Generic
+
+func main() {
+    var rows = List[string](missing!!.Count)
+}
+";
+        using var peStream = new MemoryStream();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(Source)));
+        var result = compilation.Emit(peStream);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0125");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS0218");
+    }
+
+    [Fact]
     public void AmbiguousGenericSourceMethodGroup_DoesNotInferArbitraryResult()
     {
         const string Source = @"

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2546MethodGroupPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2546MethodGroupPipelineTests.cs
@@ -14,7 +14,7 @@ namespace Cs2Gs.Tests;
 public sealed class Issue2546MethodGroupPipelineTests
 {
     [Fact]
-    public async Task Pipeline_ViaSdk_LinqSourceMethodGroup_TranslatesAndCompiles()
+    public async Task Pipeline_ViaSdk_Cycle4MethodGroups_TranslateAndCompile()
     {
         string compiler = FindSiblingTool("Compiler", "gsc.dll");
         string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
@@ -43,9 +43,12 @@ public sealed class Issue2546MethodGroupPipelineTests
         string emitted = ReadAppOutput(outputRoot, result.RunId, app.AppId);
 
         Assert.Contains("records.Select(ToDictionary)", emitted, StringComparison.Ordinal);
+        Assert.Contains("selected.Where(byAsin", emitted, StringComparison.Ordinal);
+        Assert.Contains("sessions", emitted, StringComparison.Ordinal);
+        Assert.Contains(".Count)", emitted, StringComparison.Ordinal);
         Assert.True(
             app.Succeeded,
-            "Expected imported LINQ Select to accept the source method group. Stages: " +
+            "Expected the cycle-4 Oahu method-group call sites to compile. Stages: " +
                 string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
     }
 
@@ -73,11 +76,21 @@ public sealed class Issue2546MethodGroupPipelineTests
 
             public static class Repro
             {
-                public static Dictionary<string, string> ToDictionary<T>(T record) =>
-                    new() { ["value"] = "present" };
+                public static Dictionary<string, string> ToDictionary(Record record) =>
+                    new() { ["value"] = record.Value };
 
-                public static int Run(IEnumerable<Record> records) =>
-                    records.Select(ToDictionary).Single().Count;
+                public static int Run(IEnumerable<Record> records)
+                {
+                    var selected = new List<string> { "present", "missing" };
+                    var byAsin = new Dictionary<string, Record>
+                    {
+                        ["present"] = records.Single(),
+                    };
+                    var sessions = records.ToList();
+                    var rows = new List<IReadOnlyDictionary<string, object?>>(sessions.Count);
+                    System.Func<int> nested = () => records.Select(ToDictionary).Single().Count;
+                    return nested() + selected.Where(byAsin.ContainsKey).Count() + rows.Capacity;
+                }
             }
             """);
         return projectPath;


### PR DESCRIPTION
## Summary
- retain source method groups inside nested lambdas via their lexical owner
- validate deferred method groups against each candidate delegate signature before overload ranking
- stop errored receivers from cascading into false method-group conversions
- cover `Select(ToDictionary)`, `Where(byAsin.ContainsKey)`, and `List(sessions.Count)` in runtime and cs2gs pipeline tests

## Verification
- Oahu.Cli: target GS0125/GS0218 diagnostics absent
- Oahu.Cli.Tui: target GS0160 diagnostic absent
- Core.Tests: 6,610 passed, 1 skipped
- Compiler.Tests method-group filter: 27 passed
- Cs2Gs.Tests: 1,687 passed
- Release solution build: succeeded, 0 warnings

Fixes #2546