### PR TITLE
Fix runtime-built generic deconstruction

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using GSharp.Core.CodeAnalysis.Symbols;
 
@@ -40,6 +41,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </remarks>
 internal sealed class MemberLookup
 {
+    private static readonly ConditionalWeakTable<MethodInfo, MethodInfo> OpenMethodsByMappedMethod = new();
     private readonly BinderContext binderCtx;
 
     /// <summary>
@@ -184,6 +186,33 @@ internal sealed class MemberLookup
                 if (string.Equals(m.Name, n, StringComparison.Ordinal))
                 {
                     result.Add(m);
+                }
+            }
+
+            if (clrType.IsConstructedGenericType)
+            {
+                foreach (var openMethod in ClrTypeUtilities.SafeGetMethods(
+                    clrType.GetGenericTypeDefinition(),
+                    BindingFlags.Public | BindingFlags.Instance))
+                {
+                    if (!string.Equals(openMethod.Name, n, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        var mapped = TypeBuilder.GetMethod(clrType, openMethod);
+                        OpenMethodsByMappedMethod.GetValue(mapped, _ => openMethod);
+                        if (!IsMethodHiddenByExisting(result, mapped))
+                        {
+                            result.Add(mapped);
+                        }
+                    }
+                    catch (ArgumentException)
+                    {
+                        // Runtime constructed types already exposed their methods above.
+                    }
                 }
             }
 
@@ -3185,8 +3214,17 @@ internal sealed class MemberLookup
             var openParameters = openMethod?.GetParameters();
             if (openParameters != null && (uint)parameterIndex < (uint)openParameters.Length)
             {
+                var openParameterType = openParameters[parameterIndex].ParameterType;
+                if (openParameterType.IsByRef)
+                {
+                    return ByRefTypeSymbol.Get(MapOpenClrTypeToSymbolic(
+                        openParameterType.GetElementType(),
+                        openDefinition,
+                        declaringTypeArguments));
+                }
+
                 return MapOpenClrTypeToSymbolic(
-                    openParameters[parameterIndex].ParameterType,
+                    openParameterType,
                     openDefinition,
                     declaringTypeArguments);
             }
@@ -3194,6 +3232,9 @@ internal sealed class MemberLookup
 
         return TypeSymbol.FromClrType(closedMethod.GetParameters()[parameterIndex].ParameterType);
     }
+
+    internal static MethodInfo GetImportedMethodForEmission(MethodInfo method)
+        => OpenMethodsByMappedMethod.TryGetValue(method, out var openMethod) ? openMethod : method;
 
     /// <summary>Finds the symbolic generic context for a reflected declaring type.</summary>
     /// <param name="imported">The symbolic imported receiver.</param>
@@ -4234,6 +4275,12 @@ internal sealed class MemberLookup
         if (openDeclaringType == null || genericMethod == null)
         {
             return null;
+        }
+
+        if (OpenMethodsByMappedMethod.TryGetValue(genericMethod, out var mappedOpenMethod)
+            && ClrTypeUtilities.AreSame(mappedOpenMethod.DeclaringType, openDeclaringType))
+        {
+            return mappedOpenMethod;
         }
 
         if (ClrTypeUtilities.AreSame(genericMethod.DeclaringType, openDeclaringType))

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -1560,7 +1560,7 @@ internal sealed partial class StatementBinder
                 : new BoundImportedInstanceCallExpression(
                     null,
                     receiver,
-                    method,
+                    MemberLookup.GetImportedMethodForEmission(method),
                     TypeSymbol.Void,
                     arguments.MoveToImmutable(),
                     refKinds.MoveToImmutable());

--- a/test/Core.Tests/CodeAnalysis/Binding/ImportedExtensionMethodTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ImportedExtensionMethodTests.cs
@@ -2,10 +2,13 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Threading.Channels;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Compilation;
@@ -57,31 +60,38 @@ total
     }
 
     [Fact]
-    public void ConcurrentDictionary_ForTupleIn_UsesImportedKeyValuePairDeconstructPattern()
+    public void ConcurrentDictionaryOfNestedUserGeneric_ForTupleIn_UsesImportedKeyValuePairDeconstructPattern()
     {
         var source = @"
+import System
 import System.Collections.Concurrent
+import System.Threading.Channels
 
-interface IValue {
+class JobUpdate {
     prop Number int32 {
-        get;
+        get -> 42;
     }
 }
 
-class Value : IValue {
-    prop Number int32 -> 42
-}
-
-var values = ConcurrentDictionary[string, IValue]()
-values.TryAdd(""answer"", Value())
+var subscribers = ConcurrentDictionary[Guid, Channel[JobUpdate]]()
+subscribers.TryAdd(Guid.Empty, Channel.CreateUnbounded[JobUpdate]())
 
 var total = 0
-for (key, value) in values {
-    total = total + value.Number
+for (key, ch) in subscribers {
+    total = total + ch.Reader.Count
 }
 total
 ";
-    AssertCompilesWithoutErrors(source);
+        AssertCompilesWithoutErrors(
+            source,
+            ReferenceResolver.WithReferences(new[]
+            {
+                typeof(object).Assembly.Location,
+                typeof(Console).Assembly.Location,
+                typeof(ConcurrentDictionary<,>).Assembly.Location,
+                typeof(Channel).Assembly.Location,
+                typeof(List<>).Assembly.Location,
+            }.Distinct(StringComparer.OrdinalIgnoreCase)));
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1922ForEachTupleDeconstructionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1922ForEachTupleDeconstructionTests.cs
@@ -99,34 +99,36 @@ namespace Demo
     }
 
     [Fact]
-    public void ConcurrentDictionaryDeconstruction_TranslatesToCompilerSupportedForTupleIn()
+    public void ConcurrentDictionaryOfNestedUserGenericDeconstruction_TranslatesToCompilerSupportedForTupleIn()
     {
         string printed = TranslateUnit(@"
 using System;
 using System.Collections.Concurrent;
+using System.Threading.Channels;
 
 namespace Demo
 {
-    public interface IValue
+    public sealed class JobUpdate
     {
         int Number { get; }
     }
 
     public sealed class C
     {
-        public void M(ConcurrentDictionary<string, IValue> values)
+        public void M(ConcurrentDictionary<Guid, Channel<JobUpdate>> subscribers)
         {
-            foreach (var (key, value) in values)
+            foreach (var (key, ch) in subscribers)
             {
-                Console.WriteLine(value.Number);
+                Console.WriteLine(ch.Reader.Count);
             }
         }
     }
 }");
 
         Assert.Contains("import System.Collections.Concurrent", printed);
-        Assert.Contains("for (key, value) in values {", printed);
-        Assert.Contains("value.Number", printed);
+        Assert.Contains("import System.Threading.Channels", printed);
+        Assert.Contains("for (key, ch) in subscribers {", printed);
+        Assert.Contains("ch.Reader.Count", printed);
         Assert.DoesNotContain("import System.Collections.Generic", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2537ConcurrentDictionaryPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2537ConcurrentDictionaryPipelineTests.cs
@@ -16,7 +16,7 @@ namespace Cs2Gs.Tests;
 public sealed class Issue2537ConcurrentDictionaryPipelineTests
 {
     [Fact]
-    public async Task Pipeline_ViaSdk_ConcurrentDictionaryOfInterface_DeconstructsAndRuns()
+    public async Task Pipeline_ViaSdk_ConcurrentDictionaryOfNestedUserGeneric_DeconstructsAndRuns()
     {
         string compiler = FindSiblingTool("Compiler", "gsc.dll");
         string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
@@ -46,7 +46,7 @@ public sealed class Issue2537ConcurrentDictionaryPipelineTests
 
         Assert.True(
             app.Succeeded,
-            "Expected ConcurrentDictionary deconstruction to compile via gsc. Stages: " +
+            "Expected ConcurrentDictionary<Guid, Channel<JobUpdate>> deconstruction to compile via gsc. Stages: " +
                 string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
 
         string runDirectory = Path.Combine(
@@ -63,7 +63,7 @@ public sealed class Issue2537ConcurrentDictionaryPipelineTests
         (int exitCode, string output) = RunDotnet($"\"{assembly}\"");
 
         Assert.Equal(0, exitCode);
-        Assert.Equal("42" + Environment.NewLine, output);
+        Assert.Equal("0" + Environment.NewLine, output);
     }
 
     private static string WriteFixture(string sourceRoot)
@@ -82,26 +82,40 @@ public sealed class Issue2537ConcurrentDictionaryPipelineTests
               </PropertyGroup>
             </Project>
             """);
-        File.WriteAllText(Path.Combine(projectDir, "Program.cs"), """
+        File.WriteAllText(Path.Combine(projectDir, "JobUpdate.cs"), """
+            namespace Oahu.Cli.App.Models;
+
+            public sealed record JobUpdate
+            {
+                public required string JobId { get; init; }
+            }
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "JobScheduler.cs"), """
             using System;
             using System.Collections.Concurrent;
+            using System.Threading.Channels;
+            using Oahu.Cli.App.Models;
 
-            var values = new ConcurrentDictionary<string, IValue>();
-            values.TryAdd("answer", new Value());
-            foreach (var (key, value) in values)
-            {
-                Console.WriteLine(value.Number);
-            }
+            namespace Oahu.Cli.App.Jobs;
 
-            public interface IValue
+            public sealed class JobScheduler
             {
-                int Number { get; }
-            }
+                private readonly ConcurrentDictionary<Guid, Channel<JobUpdate>> subscribers = new();
 
-            public sealed class Value : IValue
-            {
-                public int Number => 42;
+                public void Run()
+                {
+                    subscribers.TryAdd(Guid.Empty, Channel.CreateUnbounded<JobUpdate>());
+                    foreach (var (key, ch) in subscribers)
+                    {
+                        Console.WriteLine(ch.Reader.Count);
+                    }
+                }
             }
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "Program.cs"), """
+            using Oahu.Cli.App.Jobs;
+
+            new JobScheduler().Run();
             """);
         return projectPath;
     }


### PR DESCRIPTION
## Summary
- map imported methods from runtime-built generic instantiations back to their open definitions for binding and emission
- preserve substituted by-ref output types instead of leaking open `!0`/`!1` locals into emitted IL
- cover the exact Oahu `ConcurrentDictionary<Guid, Channel<JobUpdate>>` translation, SDK compile, and runtime path

## Exact Oahu reproduction
- before: `Oahu.Cli.App` produced 36 compile diagnostics, including GS0164 at `for (key, ch) in subscribers`
- after: the same project produced 32 unrelated diagnostics and no GS0164

## Validation
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --verbosity minimal -p:GeneratePackageOnBuild=false -m:1` (6606 passed, 1 skipped)
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-restore --verbosity minimal -p:GeneratePackageOnBuild=false -m:1` (1687 passed)
- exact `cs2gs migrate --corpus ../Oahu --app Oahu.Cli.App`: GS0164 count 1 -> 0

Fixes #2537