### PR TITLE
Fix sealed record copy through references

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3024,7 +3024,7 @@ public sealed class Binder
                 // array — the exact shape the metadata importer produces for
                 // imported members (see ClrNullability) — so the emitter re-stamps
                 // a `[NullableAttribute]` and the inner nullability round-trips.
-                var concrete = ResolveClosedGenericTypeClauseSymbol(closed);
+                var concrete = ResolveClrTypeClauseSymbol(closed);
                 if (!closed.IsValueType)
                 {
                     var symArgs = symbolicArgs.ToImmutable();
@@ -3768,7 +3768,7 @@ public sealed class Binder
     {
         if (targetArity == 0)
         {
-            return TypeSymbol.FromClrType(clrType);
+            return ResolveClrTypeClauseSymbol(clrType);
         }
 
         if (!clrType.IsGenericTypeDefinition)
@@ -3828,7 +3828,7 @@ public sealed class Binder
                 return ImportedTypeSymbol.GetConstructed(closed, clrType, symbolicArgs.MoveToImmutable());
             }
 
-            return ResolveClosedGenericTypeClauseSymbol(closed);
+            return ResolveClrTypeClauseSymbol(closed);
         }
         catch (System.ArgumentException)
         {
@@ -4012,7 +4012,7 @@ public sealed class Binder
         {
             if (argSyntaxes.Count == 0)
             {
-                return TypeSymbol.FromClrType(nestedDef);
+                return ResolveClrTypeClauseSymbol(nestedDef);
             }
 
             Diagnostics.ReportTypeNotGeneric(syntax.Identifier.Location, syntax.DottedName);
@@ -4071,7 +4071,7 @@ public sealed class Binder
                 return ImportedTypeSymbol.GetConstructed(closed, nestedDef, symbolicArgs.MoveToImmutable());
             }
 
-            return ResolveClosedGenericTypeClauseSymbol(closed);
+            return ResolveClrTypeClauseSymbol(closed);
         }
         catch (System.ArgumentException)
         {
@@ -5822,23 +5822,17 @@ public sealed class Binder
         => NullableLifting.ResolveClrTypeForGenericArg(this.scope.References, typeSymbol);
 
     /// <summary>
-    /// Issue #2278: resolves a CLOSED generic CLR type (constructed from a
-    /// type-clause position — a parameter/return/local type-annotation, e.g.
-    /// <c>Box[int32]</c>, as opposed to a primary-constructor CALL) to its
-    /// semantic-aggregate <see cref="StructSymbol"/> when it is an imported
-    /// generic <c>data class</c>/<c>data struct</c>, so a type-clause use
-    /// resolves to the SAME aggregate identity that construction and member
-    /// access already do — matching the non-generic behavior wired up by
-    /// issue #2263. Falls back to the ordinary <see cref="TypeSymbol.FromClrType(Type)"/>
-    /// projection for every other closed generic type.
+    /// Resolves a CLR type used in a type clause to its semantic aggregate when
+    /// it is an imported data class/data struct. This keeps simple, qualified,
+    /// nested, and closed-generic spellings on the same symbol identity.
     /// </summary>
-    /// <param name="closed">The closed (fully constructed) generic CLR type.</param>
-    /// <returns>The semantic aggregate when <paramref name="closed"/> is a marked data type; otherwise the ordinary imported-type projection.</returns>
-    private TypeSymbol ResolveClosedGenericTypeClauseSymbol(Type closed)
+    /// <param name="type">The resolved CLR type.</param>
+    /// <returns>The semantic aggregate when <paramref name="type"/> is a marked data type; otherwise the ordinary imported-type projection.</returns>
+    private TypeSymbol ResolveClrTypeClauseSymbol(Type type)
     {
-        return ImportedTypeSymbol.TryCreateSemanticAggregate(closed, this.scope.References, out var aggregate)
+        return ImportedTypeSymbol.TryCreateSemanticAggregate(type, this.scope.References, out var aggregate)
             ? aggregate
-            : TypeSymbol.FromClrType(closed);
+            : TypeSymbol.FromClrType(type);
     }
 
     // Issue #337: build an (unresolved) CLR member method-group expression for a

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -48,10 +48,25 @@ internal sealed partial class ExpressionBinder
         // unchanged, aliasing/identity preserved for untouched members) fall out
         // for free once cs2gs actually emits a `data class` instead of downgrading
         // to a plain `class` (the cs2gs-side half of #2228).
-        if (!(receiver.Type is StructSymbol structType) || !structType.IsData)
+        var normalizedReceiverType = ImportedTypeSymbol.NormalizeSemanticAggregate(
+            receiver.Type,
+            receiver.Type.ClrType,
+            scope.References);
+        var structType = normalizedReceiverType switch
+        {
+            StructSymbol aggregate => aggregate,
+            NullabilityAnnotatedTypeSymbol { BaseType: StructSymbol aggregate } => aggregate,
+            _ => null,
+        };
+        if (structType == null || !structType.IsData)
         {
             Diagnostics.ReportCopyOrWithNotDataStruct(diagnosticLocation, receiver.Type);
             return new BoundErrorExpression(null);
+        }
+
+        if (!ReferenceEquals(receiver.Type, structType))
+        {
+            receiver = new BoundConversionExpression(null, structType, receiver);
         }
 
         var tempName = "$copy" + System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter).ToString(System.Globalization.CultureInfo.InvariantCulture);
@@ -124,39 +139,23 @@ internal sealed partial class ExpressionBinder
             }
         }
 
-        // Issue #2291: an imported C# record's positional members that are
-        // NOT backed by a visible field (property-only, e.g. auto-properties
-        // whose mangled backing field is intentionally hidden from the
-        // aggregate's field list) still need to participate in `with`/`copy`.
-        // `PrimaryConstructorParameters` names the record's full positional
-        // shape regardless of whether each member resolved to a field or a
-        // property (see ImportedTypeSymbol.BuildPrimaryConstructorParameters),
-        // so walking it here — skipping names already handled as a real
-        // field above — surfaces exactly the property-only positional
-        // members, for every kind of data class (gsc-native or imported).
-        if (!structType.PrimaryConstructorParameters.IsDefaultOrEmpty)
+        // Imported records may be positional or property-only. Copy every
+        // writable property that is not already represented by a visible field.
+        foreach (var property in structType.Properties)
         {
-            foreach (var parameter in structType.PrimaryConstructorParameters)
+            if (!property.HasSetter || !handledMembers.Add(property.Name))
             {
-                if (!handledMembers.Add(parameter.Name))
-                {
-                    continue;
-                }
+                continue;
+            }
 
-                if (!TypeMemberModel.TryGetProperty(structType, parameter.Name, out var property, out _) || !property.HasSetter)
-                {
-                    continue;
-                }
-
-                if (explicitValues.TryGetValue(parameter.Name, out var explicitValue))
-                {
-                    initializers.Add(new BoundFieldInitializer(property, explicitValue.Value));
-                }
-                else
-                {
-                    var access = new BoundPropertyAccessExpression(null, new BoundVariableExpression(null, tempVar), structType, property);
-                    initializers.Add(new BoundFieldInitializer(property, access));
-                }
+            if (explicitValues.TryGetValue(property.Name, out var explicitValue))
+            {
+                initializers.Add(new BoundFieldInitializer(property, explicitValue.Value));
+            }
+            else
+            {
+                var access = new BoundPropertyAccessExpression(null, new BoundVariableExpression(null, tempVar), structType, property);
+                initializers.Add(new BoundFieldInitializer(property, access));
             }
         }
 

--- a/src/Core/CodeAnalysis/Symbols/ImportedAssemblySemantics.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedAssemblySemantics.cs
@@ -95,7 +95,8 @@ internal static class ImportedAssemblySemantics
             && m.ReturnType.FullName == "System.Boolean"
             && m.GetParameters() is [{ ParameterType.FullName: "System.Text.StringBuilder" }]);
 
-        if (!hasPrintMembers)
+        var hasReferenceAssemblyShape = !hasPrintMembers && HasCSharpRecordReferenceShape(type);
+        if (!hasPrintMembers && !hasReferenceAssemblyShape)
         {
             return false;
         }
@@ -112,7 +113,7 @@ internal static class ImportedAssemblySemantics
         // fail detection, so `PrintMembers` alone — a marker unique to
         // compiler-synthesized records — is the correct, sufficient
         // signature for the value-type case.
-        if (!type.IsValueType)
+        if (!type.IsValueType && !hasReferenceAssemblyShape)
         {
             var hasCopyConstructor = ClrTypeUtilities.SafeGetConstructors(type, InstanceAny).Any(c =>
                 c.GetParameters() is [{ } onlyParameter] && ClrTypeUtilities.AreSame(onlyParameter.ParameterType, type));
@@ -173,6 +174,70 @@ internal static class ImportedAssemblySemantics
         {
             return false;
         }
+    }
+
+    // Reference assemblies omit the private/protected markers of a sealed
+    // record. Its compiler-generated public equality surface remains intact.
+    private static bool HasCSharpRecordReferenceShape(Type type)
+    {
+        const BindingFlags PublicInstance = BindingFlags.Public | BindingFlags.Instance;
+        const BindingFlags PublicStatic = BindingFlags.Public | BindingFlags.Static;
+
+        if (!type.IsSealed)
+        {
+            return false;
+        }
+
+        bool IsCompilerGenerated(MemberInfo member) => member.GetCustomAttributesData().Any(attribute =>
+            attribute.AttributeType.FullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
+
+        var implementsSelfEquatable = type.GetInterfaces().Any(iface =>
+            iface.IsGenericType
+            && iface.GetGenericTypeDefinition().FullName == "System.IEquatable`1"
+            && iface.GetGenericArguments() is [{ } argument]
+            && argument.FullName == type.FullName);
+        if (!implementsSelfEquatable)
+        {
+            return false;
+        }
+
+        var methods = ClrTypeUtilities.SafeGetMethods(type, PublicInstance | PublicStatic);
+        var hasTypedEquals = methods.Any(method =>
+            method.Name == "Equals"
+            && !method.IsStatic
+            && method.ReturnType.FullName == "System.Boolean"
+            && method.GetParameters() is [{ } parameter]
+            && parameter.ParameterType.FullName == type.FullName
+            && IsCompilerGenerated(method));
+        var hasEquality = methods.Any(method =>
+            method.Name == "op_Equality"
+            && method.IsStatic
+            && method.ReturnType.FullName == "System.Boolean"
+            && method.GetParameters() is [{ } left, { } right]
+            && left.ParameterType.FullName == type.FullName
+            && right.ParameterType.FullName == type.FullName
+            && IsCompilerGenerated(method));
+        var hasInequality = methods.Any(method =>
+            method.Name == "op_Inequality"
+            && method.IsStatic
+            && method.ReturnType.FullName == "System.Boolean"
+            && method.GetParameters() is [{ } left, { } right]
+            && left.ParameterType.FullName == type.FullName
+            && right.ParameterType.FullName == type.FullName
+            && IsCompilerGenerated(method));
+        var hasToString = methods.Any(method =>
+            method.Name == "ToString"
+            && !method.IsStatic
+            && method.ReturnType.FullName == "System.String"
+            && method.GetParameters().Length == 0
+            && IsCompilerGenerated(method));
+        var hasGetHashCode = methods.Any(method =>
+            method.Name == "GetHashCode"
+            && !method.IsStatic
+            && method.ReturnType.FullName == "System.Int32"
+            && method.GetParameters().Length == 0
+            && IsCompilerGenerated(method));
+        return hasTypedEquals && hasEquality && hasInequality && hasToString && hasGetHashCode;
     }
 
     // Issue #2291: the record's POSITIONAL primary constructor is the public

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2291ImportedRecordWithCopyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2291ImportedRecordWithCopyTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Loader;
 using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
@@ -159,6 +160,80 @@ public class Issue2291ImportedRecordWithCopyTests
     }
 
     [Fact]
+    public void Imported_SealedCSharpRecord_QualifiedTypeClause_With_Runs()
+    {
+        var referencePath = EmitCSharpReferenceLibrary(
+            nameof(this.Imported_SealedCSharpRecord_QualifiedTypeClause_With_Runs),
+            """
+            namespace Records
+            {
+                public sealed record Settings
+                {
+                    public string Label { get; init; } = "ready";
+                    public int Retries { get; init; } = 3;
+                }
+            }
+            """,
+            out var libraryPath);
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { referencePath });
+        resolver.CurrentAssemblyName = "Consumer";
+        Assert.True(resolver.TryResolveType("Records.Settings", out var reflected));
+        Assert.True(ImportedAssemblySemantics.TryDetectCSharpRecordSemantics(reflected, out _));
+
+        var consumer = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(
+                """
+                package Consumer
+
+                func Change(value Records.Settings) Records.Settings ->
+                    value with { Label = "copied", Retries = 8 }
+
+                func Main() {
+                    let original = Records.Settings()
+                    let changed = Change(original)
+                    Console.WriteLine(original.Label)
+                    Console.WriteLine(original.Retries)
+                    Console.WriteLine(changed.Label)
+                    Console.WriteLine(changed.Retries)
+                }
+                """)));
+
+        using var peStream = new MemoryStream();
+        var result = consumer.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "Consumer");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext("Issue2551-QualifiedRecord", isCollectible: true);
+        loadContext.Resolving += (context, name) =>
+            string.Equals(name.Name, "CSharpLib2291", StringComparison.Ordinal)
+                ? context.LoadFromAssemblyPath(libraryPath)
+                : null;
+        try
+        {
+            var assembly = loadContext.LoadFromStream(peStream);
+            var stdout = Console.Out;
+            using var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                assembly.EntryPoint!.Invoke(null, null);
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            Assert.Equal("ready\n3\ncopied\n8\n", captured.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    [Fact]
     public void Imported_PlainCSharpClass_With_StillReportsGs0161()
     {
         var libraryPath = EmitCSharpLibrary(
@@ -194,6 +269,31 @@ public class Issue2291ImportedRecordWithCopyTests
         Directory.CreateDirectory(outputDir);
         var libraryPath = Path.Combine(outputDir, "CSharpLib2291.dll");
 
+        var compilation = CreateCSharpCompilation(recordSource);
+        using (var peStream = File.Create(libraryPath))
+        {
+            var emitResult = compilation.Emit(peStream);
+            Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+        }
+
+        return libraryPath;
+    }
+
+    private static string EmitCSharpReferenceLibrary(string caseName, string recordSource, out string implementationPath)
+    {
+        implementationPath = EmitCSharpLibrary(caseName, recordSource);
+        var referencePath = Path.Combine(Path.GetDirectoryName(implementationPath)!, "CSharpLib2291.ref.dll");
+        var compilation = CreateCSharpCompilation(recordSource);
+        using var peStream = File.Create(referencePath);
+        var emitResult = compilation.Emit(
+            peStream,
+            options: new Microsoft.CodeAnalysis.Emit.EmitOptions(metadataOnly: true, includePrivateMembers: false));
+        Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+        return referencePath;
+    }
+
+    private static CSharpCompilation CreateCSharpCompilation(string recordSource)
+    {
         var syntaxTree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(
             recordSource,
             new CSharpParseOptions(LanguageVersion.Latest));
@@ -207,18 +307,10 @@ public class Issue2291ImportedRecordWithCopyTests
             .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
             .ToList();
 
-        var compilation = CSharpCompilation.Create(
+        return CSharpCompilation.Create(
             "CSharpLib2291",
             new[] { syntaxTree },
             references,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-
-        using (var peStream = File.Create(libraryPath))
-        {
-            var emitResult = compilation.Emit(peStream);
-            Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
-        }
-
-        return libraryPath;
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2551TranslatedRecordProjectReferencePipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2551TranslatedRecordProjectReferencePipelineTests.cs
@@ -91,6 +91,9 @@ public sealed class Issue2551TranslatedRecordProjectReferencePipelineTests
                 public int Retries { get; init; } = 3;
 
                 public static Settings Default => new();
+
+                public static Models.Settings Copy(Models.Settings value)
+                    => value with { Label = "producer" };
             }
             """);
 
@@ -100,22 +103,26 @@ public sealed class Issue2551TranslatedRecordProjectReferencePipelineTests
         File.WriteAllText(consumerProject, ProjectFile("../Models/Models.csproj", outputType: "Exe"));
         File.WriteAllText(Path.Combine(consumerDirectory, "Program.cs"), """
             using System;
-            using Models;
-
-            var original = Settings.Default;
-            var changed = original with { Retries = 8 };
+            var original = Models.Settings.Default;
+            var produced = Models.Settings.Copy(original);
+            var changed = Change(produced);
             var copied = changed with { Label = "copied" };
 
             Console.WriteLine(original.Label);
             Console.WriteLine(original.Retries);
+            Console.WriteLine(produced.Label);
+            Console.WriteLine(produced.Retries);
             Console.WriteLine(changed.Label);
             Console.WriteLine(changed.Retries);
             Console.WriteLine(copied.Label);
             Console.WriteLine(copied.Retries);
+
+            static Models.Settings Change(Models.Settings value)
+                => value with { Retries = 8 };
             """);
 
         string stdoutGolden = Path.Combine(sourceRoot, "baseline.stdout.golden");
-        File.WriteAllText(stdoutGolden, "ready\n3\nready\n8\ncopied\n8\n");
+        File.WriteAllText(stdoutGolden, "ready\n3\nproducer\n3\nproducer\n8\ncopied\n8\n");
         return new Fixture(modelsProject, consumerProject, stdoutGolden);
     }
 


### PR DESCRIPTION
## Summary
- recognize sealed C# records from the compiler-generated public surface retained in reference assemblies
- canonicalize qualified CLR type clauses and with/copy receivers to imported semantic aggregates
- preserve all writable properties when copying property-only records
- add reference-assembly runtime and translated project-reference pipeline coverage

## Validation
- exact Oahu `Oahu.Cli`, `Oahu.Cli.Server`, and `Oahu.Cli.Tui` migration: GS0161 reduced from 12 to 0
- Core.Tests: 6,607 passed, 1 skipped
- Cs2Gs.Tests: 1,687 passed
- Release solution build: 0 warnings, 0 errors

Fixes #2551