### PR TITLE
Fix imported nullable-oblivious boundaries

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2412CrossProjectObliviousNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2412CrossProjectObliviousNullabilityTranslationTests.cs
@@ -197,11 +197,10 @@ namespace LibA
     // ---- Negative controls --------------------------------------------------
 
     [Fact]
-    public void CrossProject_UnrelatedUntaintedSiblingMember_StaysNonNullable_NoSpuriousForgiveness()
+    public void CrossProject_UnrelatedUntaintedSiblingMember_IsForgivenAtImportedBoundary()
     {
-        // `Plain.Label` has NO direct or transitive taint evidence anywhere in
-        // LibB — the fix must not over-promote every cross-project symbol, only
-        // ones the sibling's own analysis actually proved tainted.
+        // `Plain.Label` has no taint evidence, but its imported oblivious
+        // reference contract is still T? to gsc and needs a target-aware bridge.
         const string libB = @"
 namespace LibB
 {
@@ -242,8 +241,7 @@ namespace LibA
 
         Assert.Contains("prop Label string -> \"fixed\"", printedB);
         Assert.DoesNotContain("prop Label string? ", printedB);
-        Assert.Contains("Target{Name: plain.Label}", Compact(printedA));
-        Assert.DoesNotContain("plain.Label!!", printedA);
+        Assert.Contains("Target{Name: plain.Label!!}", Compact(printedA));
     }
 
     [Fact]
@@ -296,14 +294,10 @@ namespace LibA
     }
 
     [Fact]
-    public void CrossProject_SameSimpleMemberNameInTwoSiblings_DoesNotCrossContaminate()
+    public void CrossProject_SameSimpleMemberNameInTwoSiblings_UsesImportedContracts()
     {
-        // Issue requirement: "multiple projects declaring same simple symbol
-        // names". LibC's `Impl.Name`/`IFoo.Name` shape mirrors LibB's exactly
-        // (same simple names, same shape) but carries NO tainting evidence, so
-        // it must stay non-nullable even though the CONSUMER references both
-        // siblings' same-named symbol side by side. Assembly/symbol identity
-        // (not name) must disambiguate the two.
+        // Both siblings emit non-null source contracts, while the consumer sees
+        // their independently imported oblivious reference contracts as T?.
         const string libC = @"
 namespace LibC
 {
@@ -358,8 +352,7 @@ namespace LibA
         Assert.DoesNotContain("prop Name string? {", printedC);
 
         Assert.Contains("TargetB{Name: foo.Name!!}", Compact(printedA));
-        Assert.Contains("TargetC{Name: foo.Name}", Compact(printedA));
-        Assert.DoesNotContain("TargetC{Name: foo.Name!!}", Compact(printedA));
+        Assert.Contains("TargetC{Name: foo.Name!!}", Compact(printedA));
     }
 
     // ---- Transitive (three-project) chain: the real Oahu shape -------------

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2429InitializerObliviousExternalForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2429InitializerObliviousExternalForgivenessTranslationTests.cs
@@ -542,13 +542,12 @@ namespace Demo
     }
 
     /// <summary>
-    /// Negative test: a nullable-ENABLED compilation constructing the same
-    /// object initializer from the same oblivious external member — the fix
-    /// is gated to oblivious compilations only (its own nullable flow analysis
-    /// is authoritative), so no <c>!!</c> is inserted.
+    /// A nullable-enabled consumer still needs the bridge because gsc maps the
+    /// imported producer's oblivious contract to <c>T?</c> independently of the
+    /// consumer's nullable context.
     /// </summary>
     [Fact]
-    public void ObjectInitializerLiteral_NullableEnabledCompilation_IsNotForgiven()
+    public void ObjectInitializerLiteral_NullableEnabledConsumer_IsForgiven()
     {
         string printed = TranslateEnabledWithObliviousLibrary(@"
 namespace Demo
@@ -564,17 +563,15 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("Target{Name: ext.Combine(\"hello\")}", Compact(printed));
-        Assert.DoesNotContain("ext.Combine(\"hello\")!!", printed);
+        Assert.Contains("Target{Name: ext.Combine(\"hello\")!!}", Compact(printed));
     }
 
     /// <summary>
-    /// Negative/scope control: same nullable-enabled gate, applied to a
-    /// collection-initializer element instead of an object-initializer
-    /// member.
+    /// The same producer-driven rule applies to a collection-initializer
+    /// element.
     /// </summary>
     [Fact]
-    public void CollectionInitializer_NullableEnabledCompilation_IsNotForgiven()
+    public void CollectionInitializer_NullableEnabledConsumer_IsForgiven()
     {
         string printed = TranslateEnabledWithObliviousLibrary(@"
 using System.Collections.Generic;
@@ -587,8 +584,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("List[string]{ ext.Combine(\"hello\") }", Compact(printed));
-        Assert.DoesNotContain("ext.Combine(\"hello\")!!", printed);
+        Assert.Contains("List[string]{ ext.Combine(\"hello\")!! }", Compact(printed));
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2514ImportedInterfaceConstraintPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2514ImportedInterfaceConstraintPipelineTests.cs
@@ -65,7 +65,7 @@ public sealed class Issue2514ImportedInterfaceConstraintPipelineTests
 
         Assert.Contains("func Read[T IPerson](value T) string -> value.Name", emitted, StringComparison.Ordinal);
         Assert.Contains("value.Name = name", emitted, StringComparison.Ordinal);
-        Assert.Contains("value.Books.Add(book)", emitted, StringComparison.Ordinal);
+        Assert.Contains("value.Books!!.Add(book)", emitted, StringComparison.Ordinal);
     }
 
     private static (string ContractsProject, string ConsumerProject) WriteFixture(string sourceRoot)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityPipelineTests.cs
@@ -15,6 +15,53 @@ namespace Cs2Gs.Tests;
 public sealed class Issue2579NullableReferenceFidelityPipelineTests
 {
     [Fact]
+    public async Task Pipeline_ViaSdk_ObliviousProjectReferenceMembers_AreForgivenAtStrictReferenceBoundaries()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("cycle4-projects");
+        (string producerProject, string consumerProject) = WriteCycle4Fixture(sourceRoot);
+        RunDotnetBuild(producerProject);
+        string outputRoot = NewDirectory("cycle4-pipeline-tests");
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+        RunResult result = await pipeline.RunAsync(
+            new[] { new CorpusApp("test/Issue2579Cycle4", consumerProject, TargetKind.Library) });
+        AppResult app = Assert.Single(result.Apps);
+        string emitted = ReadAppOutput(outputRoot, result.RunId, app.AppId);
+
+        Assert.Contains("model.Child!!.Name", emitted, StringComparison.Ordinal);
+        Assert.Contains("model.GetChild()!!.Name", emitted, StringComparison.Ordinal);
+        Assert.Contains("model.Name!!.Echo()", emitted, StringComparison.Ordinal);
+        Assert.Contains("let local = model.Name!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("Repro.Required = model.Name!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("Repro.Consume(model.Name!!)", emitted, StringComparison.Ordinal);
+        Assert.Contains("Holder(model.Name!!)", emitted, StringComparison.Ordinal);
+        Assert.Contains("model.Children!![0]", emitted, StringComparison.Ordinal);
+        Assert.Contains("for child in model.Children!!", emitted, StringComparison.Ordinal);
+        Assert.True(
+            app.Succeeded,
+            "Expected nullable-oblivious project-reference members to compile at strict G# " +
+                "reference boundaries. Stages: " +
+                string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+    }
+
+    [Fact]
     public async Task Pipeline_ViaSdk_ObliviousProducerReturns_AreForgivenAtConsumerUses()
     {
         string compiler = FindSiblingTool("Compiler", "gsc.dll");
@@ -238,6 +285,92 @@ public sealed class Issue2579NullableReferenceFidelityPipelineTests
                     foreach (var item in Factory.GetItems())
                         _ = item.Name;
                     return Required.Name.Length;
+                }
+            }
+            """);
+
+        return (producerProject, consumerProject);
+    }
+
+    private static (string ProducerProject, string ConsumerProject) WriteCycle4Fixture(
+        string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+        string producerDir = Path.Combine(sourceRoot, "Producer");
+        string consumerDir = Path.Combine(sourceRoot, "Consumer");
+        Directory.CreateDirectory(producerDir);
+        Directory.CreateDirectory(consumerDir);
+
+        string producerProject = Path.Combine(producerDir, "Producer.csproj");
+        File.WriteAllText(producerProject, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>disable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(producerDir, "Producer.cs"), """
+            using System.Collections.Generic;
+
+            namespace Cycle4Producer;
+
+            public sealed class Item
+            {
+                public string Name { get; set; } = "item";
+                public Item Child { get; set; }
+                public List<Item> Children { get; } = new();
+                public Item GetChild() => Child;
+            }
+
+            public static class ImportedExtensions
+            {
+                public static string Echo(this string value) => value;
+            }
+            """);
+
+        string consumerProject = Path.Combine(consumerDir, "Consumer.csproj");
+        File.WriteAllText(consumerProject, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>disable</Nullable>
+              </PropertyGroup>
+              <ItemGroup>
+                <ProjectReference Include="../Producer/Producer.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(consumerDir, "Consumer.cs"), """
+            using Cycle4Producer;
+
+            namespace Issue2579Cycle4;
+
+            public sealed class Holder
+            {
+                public Holder(string value) => Value = value;
+                public string Value { get; }
+            }
+
+            public static class Repro
+            {
+                private static string Required = "";
+                private static void Consume(string value) { }
+
+                public static int Run(Item model)
+                {
+                    _ = model.Child.Name;
+                    _ = model.GetChild().Name;
+                    _ = model.Name.Echo();
+                    string local = model.Name;
+                    Required = model.Name;
+                    Consume(model.Name);
+                    _ = new Holder(model.Name);
+                    model.Child.Name = local;
+                    _ = model.Children[0].Name;
+                    foreach (var child in model.Children)
+                        _ = child.Name;
+                    return local.Length;
                 }
             }
             """);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -599,20 +599,18 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
-            // Issue #2113 follow-up: a value produced by an EXTERNAL (metadata)
-            // member compiled WITHOUT a nullable context is oblivious — Roslyn
+            // A value produced by a member imported from a project or metadata
+            // assembly compiled WITHOUT a nullable context is oblivious — Roslyn
             // reports its reference-type return/type as `NullableAnnotation.None`
-            // — and gsc maps every such oblivious external reference type to `T?`.
+            // — and gsc maps every such imported reference type to `T?`.
             // A method-call/property/field receiver like `searcher.Get()` (from an
             // unannotated package, e.g. System.Management) is therefore rejected on
             // `recv.Member` / `recv[i]` / `for … in recv` (GS0158/GS0116) even
             // though C# accepts it (it would `NullReferenceException` on null just
             // the same). Assert `recv!!` to compile and preserve that throw-on-null
-            // behavior. Gated to oblivious so nullable-enabled projects — whose
-            // external refs carry real annotations — are untouched.
-            if (this.IsObliviousCompilation()
-                && (IsObliviousExternalNullableMember(symbol)
-                    || this.LocalInitializedFromObliviousExternalNullable(symbol)))
+            // behavior.
+            if (this.IsImportedObliviousNullableMember(symbol)
+                || this.LocalInitializedFromImportedObliviousNullable(symbol))
             {
                 return true;
             }
@@ -641,19 +639,14 @@ public sealed partial class CSharpToGSharpTranslator
         private bool IsObliviousCompilation() =>
             this.context.Compilation.Options.NullableContextOptions == NullableContextOptions.Disable;
 
-        // Issue #2113 follow-up: true when <paramref name="symbol"/> is an EXTERNAL
-        // (metadata) method/property/field whose reference-type return/type is
-        // oblivious (<c>NullableAnnotation.None</c>, i.e. the declaring assembly was
-        // compiled without a nullable context, e.g. System.Management). gsc maps
-        // every such oblivious external reference type to <c>T?</c>, so a value
-        // read from one is nullable from gsc's point of view. Restricted to
-        // external symbols because a SOURCE symbol in an oblivious compilation is
-        // also <c>None</c> but its nullability is decided by the whole-program
-        // taint analysis instead, not treated as unconditionally nullable.
-        private static bool IsObliviousExternalNullableMember(ISymbol symbol)
+        // True when <paramref name="symbol"/> is a method/property/field imported
+        // from another project or metadata assembly and its concrete reference
+        // return/type is oblivious. Same-compilation source symbols stay on the
+        // whole-program taint path; imported source and metadata contracts are
+        // already fixed and gsc maps their oblivious references to <c>T?</c>.
+        private bool IsImportedObliviousNullableMember(ISymbol symbol)
         {
-            if (symbol is not (IMethodSymbol or IPropertySymbol or IFieldSymbol)
-                || !symbol.DeclaringSyntaxReferences.IsDefaultOrEmpty)
+            if (symbol is not (IMethodSymbol or IPropertySymbol or IFieldSymbol))
             {
                 return false;
             }
@@ -676,19 +669,22 @@ public sealed partial class CSharpToGSharpTranslator
                 _ => null,
             };
 
-            return type is { IsReferenceType: true }
+            return !SymbolEqualityComparer.Default.Equals(
+                    original.ContainingAssembly,
+                    this.context.Compilation.Assembly)
+                && type is { IsReferenceType: true }
                 and not ITypeParameterSymbol
                 && type.NullableAnnotation == NullableAnnotation.None;
         }
 
         // Issue #2113 follow-up: true when <paramref name="symbol"/> is a `let`
-        // local whose type is inferred from an initializer that reads an oblivious
-        // external nullable member (e.g. `let coll = searcher.Get()`). gsc infers
+        // local whose type is inferred from an initializer that reads an imported
+        // oblivious member (e.g. `let coll = searcher.Get()`). gsc infers
         // such a local as `T?`, so a `coll.Member` / `for … in coll` use needs a
         // `!!` — but promoting the local's DECLARATION to `T?` cascades
         // nullable-conversion errors at its other (non-null) uses, so the
         // assertion is applied only here at the receiver/foreach-source use site.
-        private bool LocalInitializedFromObliviousExternalNullable(ISymbol symbol)
+        private bool LocalInitializedFromImportedObliviousNullable(ISymbol symbol)
         {
             if (symbol is not ILocalSymbol local)
             {
@@ -698,7 +694,7 @@ public sealed partial class CSharpToGSharpTranslator
             foreach (SyntaxReference reference in local.DeclaringSyntaxReferences)
             {
                 if (reference.GetSyntax() is VariableDeclaratorSyntax { Initializer.Value: { } initializer }
-                    && IsObliviousExternalNullableMember(
+                    && this.IsImportedObliviousNullableMember(
                         this.context.GetSymbolInfo(initializer).Symbol))
                 {
                     return true;
@@ -783,7 +779,8 @@ public sealed partial class CSharpToGSharpTranslator
         {
             if (value is PostfixUnaryExpressionSyntax
                     { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
-                || this.IsWithinExpressionTreeLambda(value))
+                || this.IsWithinExpressionTreeLambda(value)
+                || this.IsCallableValueExpression(value))
             {
                 return false;
             }
@@ -799,7 +796,8 @@ public sealed partial class CSharpToGSharpTranslator
             // gsc as T? regardless of the consumer's nullable context. Roslyn
             // reports that metadata as Annotation.None, so its flow state cannot
             // drive the target-aware receiver/value bridges below.
-            if (IsObliviousExternalNullableMember(this.context.GetSymbolInfo(value).Symbol))
+            ISymbol valueSymbol = this.context.GetSymbolInfo(value).Symbol;
+            if (this.IsImportedObliviousNullableMember(valueSymbol))
             {
                 return true;
             }
@@ -1090,7 +1088,7 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             // Issue #2202: a call (or property/field read) whose result comes from
-            // an EXTERNAL (metadata) member compiled without a nullable context is
+            // an imported member compiled without a nullable context is
             // oblivious — Roslyn reports its reference-type return/type as
             // `NullableAnnotation.None` — and gsc maps every such oblivious
             // external reference type to `T?` (see ClrNullability.cs). When such a
@@ -1099,10 +1097,9 @@ public sealed partial class CSharpToGSharpTranslator
             // nullability (oblivious); assert `!!` to bridge the gap. This mirrors
             // the RECEIVER-position handling in ReceiverIsNullableReferenceFieldOrProperty
             // (issue #2113) but for VALUE positions (return statements, expression
-            // bodies). Restricted to oblivious compilations so nullable-enabled
-            // projects — whose external refs carry real annotations — are untouched.
-            if (this.IsObliviousCompilation()
-                && IsObliviousExternalNullableMember(this.context.GetSymbolInfo(recv).Symbol))
+            // bodies). The declaring contract, not the consumer's nullable mode,
+            // determines how gsc imports the value.
+            if (this.IsImportedObliviousNullableMember(this.context.GetSymbolInfo(recv).Symbol))
             {
                 return true;
             }
@@ -1774,7 +1771,7 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return this.IsNullablePromotedValue(use)
-                || IsObliviousExternalNullableMember(this.context.GetSymbolInfo(use).Symbol);
+                || this.IsImportedObliviousNullableMember(this.context.GetSymbolInfo(use).Symbol);
         }
 
         private AnonymousFunctionExpressionSyntax FindResultLambda(ExpressionSyntax use)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1473,7 +1473,7 @@ public sealed partial class CSharpToGSharpTranslator
         //    elsewhere), and
         //  - a value READ from a GENUINELY EXTERNAL oblivious (metadata, no
         //    nullable context, no source ANYWHERE we can analyze) member the
-        //    fixpoint can't see at all (`IsObliviousExternalNullableMember`,
+        //    fixpoint can't see at all (`IsImportedObliviousNullableMember`,
         //    issue #2113 follow-up, e.g. `Asin: author.Asin` where `author` is
         //    an external oblivious type).
         // Both are forgiven identically here: the TARGET position (member/
@@ -1487,7 +1487,7 @@ public sealed partial class CSharpToGSharpTranslator
         //
         // Deliberately NOT narrowed to exclude PREBUILT SIBLING projects (an
         // earlier version of this bridge tried exactly that, gating
-        // `IsObliviousExternalNullableMember` on the value symbol's assembly
+        // `IsImportedObliviousNullableMember` on the value symbol's assembly
         // not matching one of `this.context.SiblingCompilations`): empirically,
         // against the real Oahu.Core corpus, that guard silently un-fixed the
         // exact two diagnostics this issue targets
@@ -1499,7 +1499,7 @@ public sealed partial class CSharpToGSharpTranslator
         // "oblivious external reference-returning member is `T?`" rule. This
         // mirrors the identical, already-documented precedent on the
         // RECEIVER-position rule (`ReceiverNeedsNullForgiveness`'s own
-        // `IsObliviousExternalNullableMember` check): a prior attempt to
+        // `IsImportedObliviousNullableMember` check): a prior attempt to
         // exclude sibling-project members from THAT blind rule was proven,
         // against the same real corpus, to regress 47 -> 90 compile errors.
         // Accepting the same harmless over-forgiveness here (a sibling member
@@ -1513,8 +1513,7 @@ public sealed partial class CSharpToGSharpTranslator
             ITypeSymbol targetType,
             ISymbol targetSymbolForPromotionCheck)
         {
-            if (!this.IsObliviousCompilation()
-                || translatedValue is NonNullAssertionExpression
+            if (translatedValue is NonNullAssertionExpression
                 || !this.TargetWillRemainNonNullableReference(
                     targetType,
                     targetSymbolForPromotionCheck))
@@ -1522,8 +1521,9 @@ public sealed partial class CSharpToGSharpTranslator
                 return translatedValue;
             }
 
-            bool needsForgiveness = this.IsNullablePromotedValue(valueExpression)
-                || IsObliviousExternalNullableMember(this.context.GetSymbolInfo(valueExpression).Symbol);
+            bool needsForgiveness =
+                (this.IsObliviousCompilation() && this.IsNullablePromotedValue(valueExpression))
+                || this.IsImportedObliviousNullableMember(this.context.GetSymbolInfo(valueExpression).Symbol);
 
             return needsForgiveness ? new NonNullAssertionExpression(translatedValue) : translatedValue;
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -589,7 +589,7 @@ public sealed partial class CSharpToGSharpTranslator
         // is consumed. Neither of those fixes reaches a subsequent bare assignment
         // STATEMENT: `TranslateExpressionStatement`'s assignment case translates
         // the RHS via plain `TranslateExpression` with no external-oblivious
-        // forgiveness of its own. This reuses the SAME `IsObliviousExternalNullableMember`
+        // forgiveness of its own. This reuses the SAME `IsImportedObliviousNullableMember`
         // detection those two fixes already use, applied at the assignment RHS use
         // site instead. Gated to a target whose OWN type is a non-annotated,
         // non-promoted reference type — i.e., one that genuinely expects
@@ -605,7 +605,7 @@ public sealed partial class CSharpToGSharpTranslator
             if (!this.IsObliviousCompilation()
                 || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
                 || translatedRhs is NonNullAssertionExpression
-                || !IsObliviousExternalNullableMember(this.context.GetSymbolInfo(assignment.Right).Symbol))
+                || !this.IsImportedObliviousNullableMember(this.context.GetSymbolInfo(assignment.Right).Symbol))
             {
                 return translatedRhs;
             }


### PR DESCRIPTION
## Summary
- recognize concrete nullable-oblivious reference results imported from source projects as well as metadata assemblies
- insert target-aware `!!` bridges at strict reference receivers, arguments, constructors, assignments, initializers, indexes, and foreach sources
- keep nullable value types, invalid conversions, callable values, and same-compilation taint semantics strict

## Exact Oahu.Core cycle-4 validation
The supplied cycle-4 response artifact (`gsc 0.3.215+5acd4068`) reproduced:

| Diagnostic | Before | After |
|---|---:|---:|
| GS0156 `string?` → `string` | 8 | 0 |
| GS0155 reference `T?` → `T` | 7 | 0 |
| GS0158 member access on `T?` | 23 | 0 |
| GS0154 nullable constructor arguments | 3 | 0 |

The baseline had 24 total GS0158 diagnostics; the sole remaining GS0158 is the unrelated static qualification `Oahu.Aux.Extensions.JsonExtensions.Options`, not nullable member access. The only other remaining Oahu.Core diagnostics are two `ThenInclude` extension-resolution GS0159 sites.

The fix is rebased onto and revalidated against latest `main` (`357de644`).

## Validation
- Oahu.Core cycle-4 SDK pipeline rerun: all targeted nullable diagnostics gone
- `Core.Tests`: 6606 passed, 1 skipped
- `Cs2Gs.Tests`: 1688 passed
- focused compiler emit/runtime: 1 passed
- focused strict nullable binding: 3 passed
- full solution build: 0 warnings, 0 errors

Fixes #2579