### PR TITLE
Fix implicit object calls in interface defaults

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
@@ -593,6 +593,17 @@ internal sealed partial class OverloadResolver
                     var implicitReceiver = new BoundVariableExpression(null, effThis);
                     return BindUserInstanceCall(implicitReceiver, implicitIfaceMethod, boundArguments.ToImmutable(), syntax, argumentNames);
                 }
+
+                // Issue #2600: an interface default method's implicit `this`
+                // also exposes System.Object members. This is the bare-call
+                // counterpart of the qualified interface-receiver fallback
+                // from issue #2304 and applies in every expression context,
+                // including interpolation holes.
+                var implicitObjectReceiver = new BoundVariableExpression(null, effThis);
+                if (tryBindInheritedClrInstanceCall(implicitObjectReceiver, typeof(object), syntax.Identifier.Text, boundArguments.ToImmutable(), syntax, out var implicitObjectCall, null, default, argumentNames))
+                {
+                    return implicitObjectCall;
+                }
             }
 
             // ADR-0089 / ADR-0090: implicit static-self dispatch inside a

--- a/test/Compiler.Tests/Emit/DefaultInterfaceMethodsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/DefaultInterfaceMethodsEmitTests.cs
@@ -122,6 +122,70 @@ public class DefaultInterfaceMethodsEmitTests
     }
 
     [Fact]
+    public void ImplicitObjectMembers_InDefaultMethod_CompileInInterpolatedAndOrdinaryExpressions()
+    {
+        var source = """
+            package Probe
+            import System
+
+            interface IProbe {
+                func Describe() string { return "${GetType().Name}" }
+                func RuntimeType() Type { return GetType() }
+                func Hash() int32 { return GetHashCode() }
+                func Same() bool { return Equals(this) }
+                func Text() string? { return ToString() }
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    [Fact]
+    public void ImplicitObjectMembers_InDefaultMethod_Run()
+    {
+        var gsource = """
+            package Probe
+
+            public interface IProbe {
+                func Describe() string { return "${GetType().Name}" }
+                func HashStable() bool { return GetHashCode() == GetHashCode() }
+                func Same() bool { return Equals(this) }
+            }
+
+            public class ProbeImpl : IProbe {
+            }
+            """;
+
+        var consumerCs = """
+            using System;
+            using Probe;
+
+            IProbe probe = new ProbeImpl();
+            Console.WriteLine(probe.Describe());
+            Console.WriteLine(probe.HashStable());
+            Console.WriteLine(probe.Same());
+            """;
+
+        Assert.Equal("ProbeImpl\nTrue\nTrue\n", CompileGsharpLibAndRunCsharpConsumer(gsource, consumerCs));
+    }
+
+    [Fact]
+    public void ImplicitObjectLookup_UnknownMethod_StillReportsGS0130()
+    {
+        var source = """
+            package Probe
+
+            interface IProbe {
+                func Broken() string { return MissingObjectMember() }
+            }
+            """;
+
+        var diagnostics = CompileExpectingErrors(source);
+        Assert.Contains(diagnostics, d => d.Contains("GS0130") && d.Contains("MissingObjectMember"));
+    }
+
+    [Fact]
     public void DefaultInterfaceMethod_ConflictingDefaults_ReportsGS0318()
     {
         // Diamond-conflict diagnostic surfaces from gsc when two unrelated


### PR DESCRIPTION
## Summary
- resolve bare `System.Object` member calls through an interface default method’s effective `this` receiver
- cover ordinary and interpolated expression contexts without suppressing unknown-call diagnostics
- reproduce the exact cycle-4 `Oahu.Cli.App/Auth/IAuthService.gs` failure and remove its GS0130/GS0158 diagnostics

## Tests
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter FullyQualifiedName~DefaultInterfaceMethodsEmitTests` (6 passed)
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` (6,606 passed, 1 skipped)
- `dotnet build GSharp.sln -c Release -m:1`
- exact `cs2gs migrate --corpus <Oahu>/src --app corpus/Oahu.Cli.App --no-via-sdk`: before `IAuthService.gs` had GS0130 + GS0158; after, neither diagnostic remains (other cycle-4 project gaps remain)

Fixes #2600