### PR TITLE
Fix anonymous shape identity across translations

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2224AnonymousObjectCreationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2224AnonymousObjectCreationTests.cs
@@ -26,7 +26,7 @@ namespace Cs2Gs.Tests;
 /// anonymous type is inferred as a generic type argument in one lambda and
 /// then spelled as another lambda's parameter type. #2282 therefore
 /// supersedes the <c>object { }</c> lowering with a synthesized,
-/// shape-deduplicated <c>data class</c> (<c>AnonymousType0(1)</c>), which
+/// shape-deduplicated <c>data class</c> (<c>AnonymousType1_hash(1)</c>), which
 /// is nameable at both the construction site and any type-position use, and
 /// still preserves member names and legality inside expression trees (named
 /// class construction is permitted there, unlike a tuple literal).
@@ -48,8 +48,9 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("return AnonymousType0(1)", printed);
-        Assert.Contains("data class AnonymousType0(A int32)", printed);
+    string name = AnonymousTypeName(printed);
+    Assert.Contains($"return {name}(1)", printed);
+    Assert.Contains($"data class {name}(A int32)", printed);
     }
 
     [Fact]
@@ -69,8 +70,9 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("AnonymousType0(1, \"two\")", printed);
-        Assert.Contains("data class AnonymousType0(A int32, B string)", printed);
+        string name = AnonymousTypeName(printed);
+        Assert.Contains($"{name}(1, \"two\")", printed);
+        Assert.Contains($"data class {name}(A int32, B string)", printed);
         Assert.Contains("pair.A", printed);
         Assert.Contains("pair.B", printed);
         Assert.DoesNotContain("Item1", printed);
@@ -101,7 +103,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("AnonymousType0(1, \"two\")", printed);
+        Assert.Contains($"{AnonymousTypeName(printed)}(1, \"two\")", printed);
         Assert.Contains("pair.A", printed);
         Assert.Contains("pair.B", printed);
         Assert.DoesNotContain("pair!!", printed);
@@ -133,8 +135,9 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("AnonymousType0(id, row.Id)", printed);
-        Assert.Contains("data class AnonymousType0(id int32, Id int32)", printed);
+        string name = AnonymousTypeName(printed);
+        Assert.Contains($"{name}(id, row.Id)", printed);
+        Assert.Contains($"data class {name}(id int32, Id int32)", printed);
     }
 
     [Fact]
@@ -162,12 +165,13 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("AnonymousType0(1, \"x\")", printed);
-        Assert.Contains("AnonymousType0(2, \"y\")", printed);
+        string name = AnonymousTypeName(printed);
+        Assert.Contains($"{name}(1, \"x\")", printed);
+        Assert.Contains($"{name}(2, \"y\")", printed);
 
         int declarationCount = 0;
         int index = 0;
-        while ((index = printed.IndexOf("data class AnonymousType0(", index, System.StringComparison.Ordinal)) >= 0)
+        while ((index = printed.IndexOf($"data class {name}(", index, System.StringComparison.Ordinal)) >= 0)
         {
             declarationCount++;
             index++;
@@ -175,6 +179,11 @@ namespace Demo
 
         Assert.Equal(1, declarationCount);
     }
+
+    private static string AnonymousTypeName(string printed) =>
+        System.Text.RegularExpressions.Regex.Match(
+            printed,
+            @"data class (AnonymousType\d+_[0-9A-F]{16})\(").Groups[1].Value;
 
     private static string TranslateUnit(string source)
     {

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2282AnonymousTypeCrossBoundaryTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2282AnonymousTypeCrossBoundaryTests.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Text.RegularExpressions;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.CodeModel.RoundTrip;
@@ -86,10 +87,13 @@ namespace Demo
         // lambda's parameter type) all reference the SAME synthesized type —
         // proving the type is nameable across the boundary, not just usable
         // as a same-scope value.
-        Assert.Contains("AnonymousType0(table.Column", printed);
-        Assert.Contains("CreateTableBuilder[AnonymousType0]", printed);
-        Assert.Contains("(x AnonymousType0)", printed);
-        Assert.Contains("data class AnonymousType0(Id int32, Title string)", printed);
+        string name = Regex.Match(
+            printed,
+            @"data class (AnonymousType\d+_[0-9A-F]{16})\(").Groups[1].Value;
+        Assert.Contains($"{name}(table.Column", printed);
+        Assert.Contains($"CreateTableBuilder[{name}]", printed);
+        Assert.Contains($"(x {name})", printed);
+        Assert.Contains($"data class {name}(Id int32, Title string)", printed);
 
         // Named-member access resolves directly (no GS0159 "Cannot find
         // function Id" — the original bug's symptom of falling back to an

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2292AnonymousTypePackageScopeTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2292AnonymousTypePackageScopeTests.cs
@@ -5,7 +5,9 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.CodeModel.RoundTrip;
@@ -16,29 +18,14 @@ using Xunit;
 namespace Cs2Gs.Tests;
 
 /// <summary>
-/// Regression tests for issue #2292: cs2gs's per-anonymous-shape data-class
-/// synthesis (issue #2282) reused a shape->name dictionary that lived on a
-/// FRESH <see cref="CSharpTypeMapper"/> created for every single document
-/// (<c>CSharpToGSharpTranslator.TranslateDocument</c>), so two DIFFERENT
-/// files sharing the same G# package (e.g. every migration in an EF
-/// <c>Migrations</c> folder — one file per migration, all in the same
-/// namespace) each started counting from <c>AnonymousType0</c>. A distinct
-/// shape in file B could therefore mint the exact synthetic name already used
-/// by an unrelated shape in file A, and the two <c>data class AnonymousType0</c>
-/// declarations collided (GS0102 "already declared") once both files were
-/// compiled together as the same package.
+/// Regression tests for issue #2292: anonymous shape declarations are
+/// deduplicated across every document in one G# package. Issue #2598 further
+/// makes each synthetic name a stable function of the complete ordered shape,
+/// so the same rules remain consistent across packages and projects.
 /// <para>
-/// Note: WITHIN a single file/method boundary the shape dictionary and
-/// counter were already correctly scoped to the whole document (one
-/// <see cref="CSharpTypeMapper"/> per <c>TranslateDocument</c> call covers
-/// every method of every type in that file) — the collision only manifests
-/// ACROSS files of the same package, which is what the corpus evidence in
-/// #2292 (multiple Oahu.Data migration files) actually hit. The fix threads
-/// one <see cref="AnonymousTypeRegistry"/> per resolved package name through
-/// every mapper the translator creates, keyed on
-/// <c>CSharpToGSharpTranslator.anonymousTypeRegistriesByPackage</c>, so the
-/// synthetic-name counter and the shape-&gt;type dictionary are shared by
-/// every file in the package, not just every method in a file.
+/// One <see cref="AnonymousTypeRegistry"/> per resolved package is threaded
+/// through every mapper the translator creates, so an identical shape is
+/// emitted once and reused by later documents.
 /// </para>
 /// </summary>
 public class Issue2292AnonymousTypePackageScopeTests
@@ -69,14 +56,13 @@ namespace Demo
     }
 }";
         (string printedA, string printedB) = TranslateTwoFiles("MigrationA.cs", SourceA, "MigrationB.cs", SourceB);
+        string nameA = AnonymousTypeNames(printedA).Single();
+        string nameB = AnonymousTypeNames(printedB).Single();
 
-        // Each file mints a DISTINCT synthetic name for its DISTINCT shape —
-        // no two files in the same package emit the same 'AnonymousTypeN' for
-        // different shapes.
-        Assert.Contains("data class AnonymousType0(Id int32, Name string)", printedA);
-        Assert.Contains("data class AnonymousType1(Count int32, Flag bool, Extra float64)", printedB);
-        Assert.DoesNotContain("AnonymousType1", printedA);
-        Assert.DoesNotContain("data class AnonymousType0(Count", printedB);
+        // Distinct ordered shapes get distinct stable names.
+        Assert.NotEqual(nameA, nameB);
+        Assert.Contains($"data class {nameA}(Id int32, Name string)", printedA);
+        Assert.Contains($"data class {nameB}(Count int32, Flag bool, Extra float64)", printedB);
 
         // The proof that matters: gsc must compile BOTH files together (as one
         // package) with no GS0102 "already declared" collision.
@@ -109,14 +95,15 @@ namespace Demo
     }
 }";
         (string printedA, string printedB) = TranslateTwoFiles("MigrationA.cs", SourceA, "MigrationB.cs", SourceB);
+        string name = AnonymousTypeNames(printedA).Single();
 
         // The FIRST file to need the shape declares it...
-        Assert.Contains("data class AnonymousType0(Id int32, Name string)", printedA);
+        Assert.Contains($"data class {name}(Id int32, Name string)", printedA);
 
         // ...and the SECOND file reuses that same synthesized type by name
         // rather than re-declaring its own copy (a re-declaration would ALSO
         // be a GS0102 collision, even for an identical shape).
-        Assert.Contains("AnonymousType0(2, \"y\")", printedB);
+        Assert.Contains($"{name}(2, \"y\")", printedB);
         Assert.DoesNotContain("data class AnonymousType", printedB);
 
         CompileFilesTogether(("MigrationA.gs", printedA), ("MigrationB.gs", printedB));
@@ -142,8 +129,10 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("data class AnonymousType0(Id int32, Name string)", printed);
-        Assert.Contains("data class AnonymousType1(Count int32, Flag bool)", printed);
+        string[] names = AnonymousTypeNames(printed);
+        Assert.Equal(2, names.Length);
+        Assert.Contains($"data class {names[0]}(Id int32, Name string)", printed);
+        Assert.Contains($"data class {names[1]}(Count int32, Flag bool)", printed);
 
         CompileFilesTogether(("Migration.gs", printed));
     }
@@ -208,9 +197,10 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("data class AnonymousType0(Id int32, Title string)", printed);
-        Assert.Contains("CreateTableBuilder[AnonymousType0]", printed);
-        Assert.Contains("(x AnonymousType0) -> x.Id", printed);
+        string name = AnonymousTypeNames(printed).Single();
+        Assert.Contains($"data class {name}(Id int32, Title string)", printed);
+        Assert.Contains($"CreateTableBuilder[{name}]", printed);
+        Assert.Contains($"(x {name}) -> x.Id", printed);
 
         // The real proof (not just round-trip parse): gsc must actually BIND
         // the generic CreateTable/PrimaryKey calls and the x.Id member access
@@ -238,6 +228,11 @@ namespace Demo
                 string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
         return printed;
     }
+
+    private static string[] AnonymousTypeNames(string printed) =>
+        Regex.Matches(printed, @"data class (AnonymousType\d+_[0-9A-F]{16})\(")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
 
     /// <summary>
     /// Translates two files loaded into the SAME in-memory C# project with

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2342CrossPackageAnonymousTypeCollisionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2342CrossPackageAnonymousTypeCollisionTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.CodeModel.RoundTrip;
@@ -17,21 +18,10 @@ using Xunit;
 namespace Cs2Gs.Tests;
 
 /// <summary>
-/// Regression tests for issue #2342: <c>CSharpToGSharpTranslator</c> keys its
-/// per-package <see cref="Cs2Gs.Translator.AnonymousTypeRegistry"/> (issue
-/// #2292) by resolved G# package name, so two files in DIFFERENT packages —
-/// e.g. the real Oahu.Data shape, where <c>Oahu.BooksDatabase</c> and
-/// <c>Oahu.BooksDatabase.Migrations</c> each independently synthesize an
-/// anonymous-object shape from an EF-Core-style migration — each mint their
-/// OWN <c>AnonymousType0</c> starting from zero. cs2gs's translation output is
-/// therefore, by design, two same-simple-name top-level
-/// <c>data class AnonymousType0</c> declarations in two different <c>package</c>
-/// blocks. Before the #2342 fix, <c>gsc</c> rejected compiling both files
-/// together with <c>GS0102</c> ("'AnonymousType0' is already declared") because
-/// <c>BoundScope.TryDeclareTypeAlias</c> treated every top-level declaration in
-/// the WHOLE compilation as one flat, package-blind scope. After the fix, both
-/// packages' independently-synthesized shapes compile and emit as distinct
-/// types.
+/// Regression tests for issue #2342: independently synthesized anonymous
+/// shapes in different packages compile and emit as distinct package-qualified
+/// types. Issue #2598 now gives distinct shapes distinct stable simple names as
+/// well, preventing imported-package lookup from selecting the wrong arity.
 /// </summary>
 public class Issue2342CrossPackageAnonymousTypeCollisionTests
 {
@@ -41,12 +31,8 @@ public class Issue2342CrossPackageAnonymousTypeCollisionTests
         // Mirrors the real Oahu.Data shape: a "BooksDatabase" file with its own
         // top-level query shape, and a "BooksDatabase.Migrations" file (a child
         // package) whose migration independently projects an anonymous object.
-        // Both synthesize a shape named "AnonymousType0" (each package's
-        // registry starts counting at zero), and since one package is a strict
-        // dotted PREFIX of the other, the fix must also correctly treat them as
-        // distinct (mirroring the Foo/Foo.Bar prefix-package binder/compiler
-        // tests) rather than accidentally conflating a prefix relationship with
-        // sameness.
+        // One package is a strict dotted prefix of the other, so both package
+        // identity and shape identity must remain distinct.
         const string BooksDatabaseSource = @"
 namespace Oahu.BooksDatabase
 {
@@ -74,12 +60,15 @@ namespace Oahu.BooksDatabase.Migrations
             BooksDatabaseSource,
             "InitialCreate.cs",
             MigrationSource);
+        string booksType = AnonymousTypeName(printedBooksDatabase);
+        string migrationType = AnonymousTypeName(printedMigration);
 
         Assert.Contains("package Oahu.BooksDatabase", printedBooksDatabase);
-        Assert.Contains("data class AnonymousType0(SeriesId int32, BookId int32)", printedBooksDatabase);
+        Assert.Contains($"data class {booksType}(SeriesId int32, BookId int32)", printedBooksDatabase);
 
         Assert.Contains("package Oahu.BooksDatabase.Migrations", printedMigration);
-        Assert.Contains("data class AnonymousType0(Alias string, AudibleId string)", printedMigration);
+        Assert.Contains($"data class {migrationType}(Alias string, AudibleId string)", printedMigration);
+        Assert.NotEqual(booksType, migrationType);
 
         // The proof that matters: gsc must compile BOTH files together (as two
         // distinct packages) with no GS0102 "already declared" collision, and
@@ -88,9 +77,12 @@ namespace Oahu.BooksDatabase.Migrations
             ("BookRepository.gs", printedBooksDatabase),
             ("InitialCreate.gs", printedMigration));
 
-        AssertTypeIsEmitted(dllPath, "Oahu.BooksDatabase.AnonymousType0");
-        AssertTypeIsEmitted(dllPath, "Oahu.BooksDatabase.Migrations.AnonymousType0");
+        AssertTypeIsEmitted(dllPath, $"Oahu.BooksDatabase.{booksType}");
+        AssertTypeIsEmitted(dllPath, $"Oahu.BooksDatabase.Migrations.{migrationType}");
     }
+
+    private static string AnonymousTypeName(string printed) =>
+        Regex.Match(printed, @"data class (AnonymousType\d+_[0-9A-F]{16})\(").Groups[1].Value;
 
     private static (string PrintedA, string PrintedB) TranslateTwoFiles(
         string fileNameA,
@@ -130,9 +122,8 @@ namespace Oahu.BooksDatabase.Migrations
     }
 
     /// <summary>
-    /// Compiles every <c>(fileName, contents)</c> pair together, as ONE gsc
-    /// invocation spanning multiple packages, asserting zero compiler errors,
-    /// and returns the path to the emitted assembly for further inspection.
+    /// Compiles every <c>(fileName, contents)</c> pair together and returns the
+    /// emitted assembly for inspection.
     /// </summary>
     private static string CompileFilesTogether(params (string FileName, string Contents)[] files)
     {

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2496ExpressionTreeArgumentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2496ExpressionTreeArgumentForgivenessTranslationTests.cs
@@ -63,7 +63,9 @@ public sealed class Issue2496ExpressionTreeArgumentForgivenessTranslationTests
         Assert.Contains("HasKey((item Item) -> item.Id)", printed, StringComparison.Ordinal);
         Assert.Contains("HasIndex((item Item) -> item.Name)", printed, StringComparison.Ordinal);
         Assert.Contains("HasForeignKey((item Item) ->", printed, StringComparison.Ordinal);
-        Assert.Contains("AnonymousType0(item.ParentId, item.Name)", printed, StringComparison.Ordinal);
+        Assert.Matches(
+            @"AnonymousType2_[0-9A-F]{16}\(item\.ParentId, item\.Name\)",
+            printed);
         Assert.Contains("HasOptional((item Item) -> item.ParentId)", printed, StringComparison.Ordinal);
         Assert.Contains("Selector[Item]((item Item) -> item.Id)", printed, StringComparison.Ordinal);
         Assert.Contains("GenericSink.Accept", printed, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2538AnonymousConstructionPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2538AnonymousConstructionPipelineTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
@@ -62,14 +63,20 @@ public sealed class Issue2538AnonymousConstructionPipelineTests
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
         string printed = GSharpPrinter.Print(unit);
+        MatchCollection names = Regex.Matches(
+            printed,
+            @"data class (AnonymousType\d+_[0-9A-F]{16})\(");
+        Assert.Equal(2, names.Count);
+        string envelopeType = names[0].Groups[1].Value;
+        string apiType = names[1].Groups[1].Value;
 
         Assert.Contains(
-            "convenience init() {\n        init(AnonymousType0(2538, \"anonymous\"))",
+            $"convenience init() {{\n        init({envelopeType}(2538, \"anonymous\"))",
             printed,
             StringComparison.Ordinal);
-        Assert.Contains("Echo(AnonymousType1(true, 2))", printed, StringComparison.Ordinal);
-        Assert.DoesNotContain("AnonymousType0{", printed, StringComparison.Ordinal);
-        Assert.DoesNotContain("AnonymousType1{", printed, StringComparison.Ordinal);
+        Assert.Contains($"Echo({apiType}(true, 2))", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain(envelopeType + "{", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain(apiType + "{", printed, StringComparison.Ordinal);
 
         RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
         Assert.True(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2598AnonymousShapeConsistencyTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2598AnonymousShapeConsistencyTests.cs
@@ -1,0 +1,267 @@
+// <copyright file="Issue2598AnonymousShapeConsistencyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Pipeline;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2598AnonymousShapeConsistencyTests
+{
+    private const string ToolsSource = """
+        namespace Demo.Tools;
+
+        public static class ToolShapes
+        {
+            public static object Make() => new { active = "yes", sessions = 2 };
+        }
+        """;
+
+    private const string HostingSource = """
+        using Demo.Tools;
+
+        namespace Demo.Hosting;
+
+        public static class Endpoint
+        {
+            public static string Run()
+            {
+                _ = ToolShapes.Make();
+                var snapshot = new
+                {
+                    jobId = "42",
+                    asin = "A",
+                    title = "T",
+                    phase = "done",
+                    progress = 1.0,
+                    message = "ok",
+                };
+                return snapshot.jobId + ":" + snapshot.phase + ":" + snapshot.message;
+            }
+        }
+        """;
+
+    private const string ProgramSource = """
+        using System;
+        using Demo.Hosting;
+
+        Console.WriteLine(Endpoint.Run());
+        """;
+
+    [Fact]
+    public void Translator_UsesStableOrderedShapeNamesAcrossDocumentsAndProjects()
+    {
+        string[] translated = Translate(
+            ("A.Tools.cs", ToolsSource),
+            ("B.Hosting.cs", HostingSource));
+        string toolsType = AnonymousTypeName(translated[0]);
+        string hostingType = AnonymousTypeName(translated[1]);
+
+        Assert.NotEqual(toolsType, hostingType);
+        Assert.Contains($"{toolsType}(\"yes\", 2)", translated[0], StringComparison.Ordinal);
+        Assert.Contains(
+            $"{hostingType}(\"42\", \"A\", \"T\", \"done\", 1.0, \"ok\")",
+            translated[1],
+            StringComparison.Ordinal);
+
+        const string SameShapeA = """
+            namespace ProjectA;
+            public static class A
+            {
+                public static object Make() => new { JobId = "1", Phase = "ready" };
+            }
+            """;
+        const string SameShapeB = """
+            namespace ProjectB;
+            public static class B
+            {
+                public static object Make() => new { JobId = "2", Phase = "done" };
+            }
+            """;
+        Assert.Equal(
+            AnonymousTypeName(Translate(("A.cs", SameShapeA)).Single()),
+            AnonymousTypeName(Translate(("B.cs", SameShapeB)).Single()));
+    }
+
+    [Fact]
+    public async Task Pipeline_CrossPackageAnonymousShapes_CompileWithoutGS0144()
+    {
+        string compiler = FindCompiler();
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("projects");
+        string projectPath = WriteProject(sourceRoot);
+        string outputRoot = NewDirectory("pipeline");
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            OutputRoot = outputRoot,
+            SourceRoot = sourceRoot,
+        };
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+
+        RunResult result = await pipeline.RunAsync(
+            new[] { new CorpusApp("test/Issue2598", projectPath, TargetKind.Exe) });
+        AppResult app = Assert.Single(result.Apps);
+
+        Assert.True(
+            app.Succeeded,
+            "Cross-package anonymous shapes must compile without GS0144. Stages: " +
+                string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+    }
+
+    [Fact]
+    public void Runtime_CrossPackageAnonymousShapes_ConstructTheDeclaredShape()
+    {
+        string compiler = FindCompiler();
+        Assert.NotNull(compiler);
+
+        string[] translated = Translate(
+            ("A.Tools.cs", ToolsSource),
+            ("B.Hosting.cs", HostingSource));
+        translated = translated
+            .Append("package Demo.Hosting\n\nimport System\n\nConsole.WriteLine(Endpoint.Run())\n")
+            .ToArray();
+        string workDir = NewDirectory("runtime");
+        var paths = translated
+            .Select((source, index) =>
+            {
+                string path = Path.Combine(workDir, $"{index}.gs");
+                File.WriteAllText(path, source);
+                return path;
+            })
+            .ToArray();
+        string assembly = Path.Combine(workDir, "Issue2598.dll");
+        (int compileExit, string compileOutput) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{assembly}\" " +
+                string.Join(" ", paths.Select(path => $"\"{path}\"")));
+
+        Assert.True(
+            compileExit == 0,
+            "Translated fixture must compile without GS0144:\n" + compileOutput);
+        (int runExit, string output) = RunDotnet($"\"{assembly}\"");
+        Assert.Equal(0, runExit);
+        Assert.Equal("42:done:ok", output.Trim());
+    }
+
+    private static string[] Translate(params (string FileName, string Source)[] sources)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(sources);
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Fixture must bind as C#: " + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        var translator = new CSharpToGSharpTranslator();
+        return project.Documents
+            .Select(document =>
+            {
+                var context = new TranslationContext(
+                    project.Compilation,
+                    document.SemanticModel,
+                    document.FilePath);
+                return GSharpPrinter.Print(translator.TranslateDocument(document, context));
+            })
+            .ToArray();
+    }
+
+    private static string AnonymousTypeName(string source)
+    {
+        Match match = Regex.Match(
+            source,
+            @"data class (AnonymousType\d+_[0-9A-F]{16})\(");
+        Assert.True(match.Success, "Expected a synthesized anonymous type:\n" + source);
+        return match.Groups[1].Value;
+    }
+
+    private static string WriteProject(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+        string projectDir = Path.Combine(sourceRoot, "Issue2598");
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, "Issue2598.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDir, "A.Tools.cs"), ToolsSource);
+        File.WriteAllText(Path.Combine(projectDir, "B.Hosting.cs"), HostingSource);
+        File.WriteAllText(Path.Combine(projectDir, "Program.cs"), ProgramSource);
+        return projectPath;
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string directory = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2598",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        using var process = Process.Start(startInfo);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    "Compiler",
+                    "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -299,15 +299,27 @@ public sealed partial class CSharpToGSharpTranslator
                 anonymous.GetLocation(),
                 TranslationSeverity.Info));
 
-            GTypeReference syntheticType = this.context.GetTypeInfo(anonymous).Type is INamedTypeSymbol anonymousType
-                ? this.typeMapper.GetOrCreateAnonymousDataClass(anonymousType, this.context, anonymous.GetLocation())
-                : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
+            (GTypeReference Type, IReadOnlyList<IPropertySymbol> Properties) shape =
+                this.context.GetTypeInfo(anonymous).Type is INamedTypeSymbol anonymousType
+                    ? this.typeMapper.GetOrCreateAnonymousDataClassShape(
+                        anonymousType,
+                        this.context,
+                        anonymous.GetLocation())
+                    : (new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType), Array.Empty<IPropertySymbol>());
 
-            var arguments = anonymous.Initializers
-                .Select(i => this.TranslateExpression(i.Expression))
-                .ToList();
+            // Roslyn exposes anonymous properties in constructor order. Drive
+            // construction from that same registered order rather than an
+            // independent member enumeration so declaration and call arity/order
+            // cannot diverge across files or projects.
+            var arguments = shape.Properties.Count == anonymous.Initializers.Count
+                ? shape.Properties
+                    .Select((_, index) => this.TranslateExpression(anonymous.Initializers[index].Expression))
+                    .ToList()
+                : anonymous.Initializers
+                    .Select(initializer => this.TranslateExpression(initializer.Expression))
+                    .ToList();
 
-            return BuildConstruction(syntheticType, arguments);
+            return BuildConstruction(shape.Type, arguments);
         }
 
         private GExpression TranslateMemberAccess(MemberAccessExpressionSyntax member)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -93,16 +93,10 @@ public sealed partial class CSharpToGSharpTranslator
     // (GS0102). Null (default) preserves the exact prior no-filter behavior.
     private readonly HashSet<string> retainedFilePaths;
 
-    // Issue #2292: one AnonymousTypeRegistry per resolved G# package, shared
-    // across every document this translator instance translates (every
-    // pipeline caller creates ONE CSharpToGSharpTranslator per project and
-    // calls TranslateDocument once per file in that project — see
-    // TranslateStage/TestParityStage), so two unrelated files sharing the
-    // same package draw synthetic anonymous-type names from ONE counter and
-    // reuse an identical shape's data class instead of each starting a fresh
-    // dictionary/counter at zero (which allowed a distinct shape in file B to
-    // mint the same name as an unrelated shape already declared in file A —
-    // a GS0102 collision once both files' output is compiled together).
+    // One registry per resolved G# package deduplicates declarations across
+    // documents (#2292). Synthetic names themselves are derived from the full
+    // ordered shape (#2598), so distinct shapes cannot reuse a simple name
+    // across imported packages or independently translated projects.
     private readonly Dictionary<string, AnonymousTypeRegistry> anonymousTypeRegistriesByPackage =
         new(StringComparer.Ordinal);
 
@@ -211,7 +205,7 @@ public sealed partial class CSharpToGSharpTranslator
         IMethodSymbol entryPoint = context.Compilation.GetEntryPoint(default);
         INamedTypeSymbol entryType = entryPoint?.ContainingType;
 
-        // Issue #2292: share the anonymous-type registry with every other
+        // Share the anonymous-type registry with every other
         // document already translated (by this same translator instance)
         // into the same package, so distinct/identical shapes across FILES
         // never collide (see `anonymousTypeRegistriesByPackage`'s comment).

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -7,6 +7,8 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.Translator.Coverage;
 using Microsoft.CodeAnalysis;
@@ -63,21 +65,11 @@ public sealed class CSharpTypeMapper
     /// combinatorially explode across a large file). See
     /// <see cref="GetOrCreateAnonymousDataClass"/>.
     /// <para>
-    /// Issue #2292: this dictionary (and the synthetic-name counter) is now
-    /// owned by an <see cref="AnonymousTypeRegistry"/> that is shared across
-    /// EVERY <see cref="CSharpTypeMapper"/> instance translating documents
-    /// into the SAME G# package (<c>CSharpToGSharpTranslator</c> creates one
-    /// mapper per source file but keeps one registry per resolved package),
-    /// rather than living directly on this per-file mapper. Two unrelated
-    /// files in the same package used to each start their own private
-    /// dictionary/counter at zero, so a distinct shape in file B could still
-    /// mint the SAME synthetic name (<c>AnonymousType0</c>) as an unrelated
-    /// shape already declared in file A — both top-level declarations landing
-    /// in the same package caused GS0102 "already declared" even though
-    /// per-file the mapper looked file-scoped. Sharing the registry across the
-    /// whole package closes that gap while still deduplicating identical
-    /// shapes package-wide (a shape already declared by an earlier file is
-    /// reused, not re-declared, by a later one).
+    /// The <see cref="AnonymousTypeRegistry"/> is shared by every mapper for a
+    /// package so identical shapes are declared once (#2292). Names are derived
+    /// from the complete ordered shape rather than a translation-local counter,
+    /// keeping distinct declarations unambiguous across packages and projects
+    /// even when one package imports another (#2598).
     /// </para>
     /// </summary>
     private readonly AnonymousTypeRegistry anonymousTypeRegistry;
@@ -147,8 +139,7 @@ public sealed class CSharpTypeMapper
     /// mapper translating a document into the same G# package (issue #2292).
     /// </summary>
     /// <param name="anonymousTypeRegistry">
-    /// The package-scoped registry of already-synthesized anonymous-type
-    /// shapes and the next available synthetic-name index.
+    /// The package-scoped registry of already-synthesized anonymous-type shapes.
     /// </param>
     public CSharpTypeMapper(AnonymousTypeRegistry anonymousTypeRegistry)
     {
@@ -426,27 +417,28 @@ public sealed class CSharpTypeMapper
     /// <param name="context">The translation context that accumulates diagnostics.</param>
     /// <param name="location">The originating C# source location for diagnostics.</param>
     /// <returns>A reference to the synthesized (or already-cached) data class.</returns>
-    public NamedTypeReference GetOrCreateAnonymousDataClass(INamedTypeSymbol anonymousType, TranslationContext context, Location location)
+    public NamedTypeReference GetOrCreateAnonymousDataClass(INamedTypeSymbol anonymousType, TranslationContext context, Location location) =>
+        this.GetOrCreateAnonymousDataClassShape(anonymousType, context, location).Type;
+
+    internal (NamedTypeReference Type, IReadOnlyList<IPropertySymbol> Properties) GetOrCreateAnonymousDataClassShape(
+        INamedTypeSymbol anonymousType,
+        TranslationContext context,
+        Location location)
     {
         List<IPropertySymbol> properties = anonymousType.GetMembers().OfType<IPropertySymbol>().ToList();
         string shapeKey = string.Join(
             "|",
             properties.Select(p => p.Name + ":" + p.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
 
-        // Issue #2292: the shape->name dictionary and the synthetic-name
-        // counter both live on the shared package-scoped `anonymousTypeRegistry`
-        // (not on this per-file mapper), so a shape already synthesized by an
-        // EARLIER file in the same package is reused here (no re-declaration,
-        // avoiding a same-name GS0102 for an identical shape), and a shape
-        // that is new to this file still draws its synthetic index from the
-        // package-wide counter (so a distinct shape never collides with a
-        // name already minted by another file in the same package).
+        // A shape synthesized by an earlier file in the same package is reused
+        // without redeclaration. A new shape gets the same deterministic name
+        // in every document or project that translates it (#2598).
         if (this.anonymousTypeRegistry.TryGetExisting(shapeKey, out NamedTypeReference existing))
         {
-            return existing;
+            return (existing, properties);
         }
 
-        string syntheticName = this.anonymousTypeRegistry.NextSyntheticName();
+        string syntheticName = AnonymousTypeRegistry.SyntheticName(shapeKey, properties.Count);
         var parameters = properties
             .Select(p => new Cs2Gs.CodeModel.Ast.Parameter(CSharpToGSharpTranslator.SanitizeIdentifier(p.Name), this.Map(p.Type, context, location)))
             .ToList();
@@ -466,7 +458,7 @@ public sealed class CSharpTypeMapper
         var reference = new NamedTypeReference(syntheticName);
         this.anonymousTypeRegistry.Register(shapeKey, reference);
         this.pendingAnonymousDataClasses.Add(declaration);
-        return reference;
+        return (reference, properties);
     }
 
     /// <summary>
@@ -1185,26 +1177,14 @@ public sealed class CSharpTypeMapper
 }
 
 /// <summary>
-/// Issue #2292: the shape-&gt;synthesized-type dictionary and synthetic-name
-/// counter that <see cref="CSharpTypeMapper.GetOrCreateAnonymousDataClass"/>
-/// uses, factored out of <see cref="CSharpTypeMapper"/> so it can be shared
-/// across every mapper instance translating a document into the SAME G#
-/// package. <c>CSharpToGSharpTranslator</c> creates one <see cref="CSharpTypeMapper"/>
-/// per source file (so per-file state like <see cref="CSharpTypeMapper.ShortenedNamespaces"/>
-/// stays file-scoped) but keeps exactly one <see cref="AnonymousTypeRegistry"/>
-/// per resolved package name, keyed in a dictionary that outlives any single
-/// <c>TranslateDocument</c> call. Without this, two unrelated files in the
-/// same package each started counting from <c>AnonymousType0</c>, so a
-/// DISTINCT shape in file B could mint the exact name already used by an
-/// UNRELATED shape in file A — both top-level <c>data class</c> declarations
-/// landing in the same package/namespace, which is a GS0102 "already
-/// declared" collision at the gsc compile stage even though each file's own
-/// translation looked internally consistent.
+/// Stores the anonymous shapes already declared in one G# package. The
+/// registry is shared across that package's documents for declaration
+/// deduplication (#2292), while <see cref="SyntheticName"/> derives names from
+/// complete ordered shapes so independent packages and projects agree (#2598).
 /// </summary>
 public sealed class AnonymousTypeRegistry
 {
     private readonly Dictionary<string, NamedTypeReference> byShape = new(System.StringComparer.Ordinal);
-    private int nextIndex;
 
     /// <summary>
     /// Looks up an already-synthesized data-class reference for
@@ -1219,14 +1199,19 @@ public sealed class AnonymousTypeRegistry
         this.byShape.TryGetValue(shapeKey, out existing);
 
     /// <summary>
-    /// Mints the next package-wide-unique synthetic name (<c>AnonymousType0</c>,
-    /// <c>AnonymousType1</c>, ...). Drawing from a single counter shared by
-    /// every file in the package (rather than each file counting from zero)
-    /// is what prevents two distinct shapes in different files from
-    /// colliding on the same name.
+    /// Produces a deterministic synthetic name from the complete ordered shape.
+    /// The name is therefore identical wherever the same shape is translated
+    /// and different for unrelated shapes even when separate documents,
+    /// packages, projects, or translator instances are involved.
     /// </summary>
-    /// <returns>The next unused synthetic type name.</returns>
-    public string NextSyntheticName() => $"AnonymousType{this.nextIndex++}";
+    /// <param name="shapeKey">The ordered member-name/type shape.</param>
+    /// <param name="arity">The number of members in the shape.</param>
+    /// <returns>A stable shape-derived synthetic type name.</returns>
+    public static string SyntheticName(string shapeKey, int arity)
+    {
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(shapeKey));
+        return $"AnonymousType{arity}_{System.Convert.ToHexString(hash, 0, 8)}";
+    }
 
     /// <summary>
     /// Records that <paramref name="shapeKey"/> now resolves to


### PR DESCRIPTION
## Summary
- derive anonymous type names from the complete ordered member shape across documents, packages, and projects
- construct anonymous values from the same registered property order used by declarations
- add translator, SDK pipeline, runtime, and prior anonymous-shape regression coverage

## Verification
- reproduced cycle-4 Oahu.Cli.Server `AnonymousType0` 2-vs-6 and `AnonymousType1` 2-vs-5 GS0144 diagnostics before editing
- reran exact Oahu.Cli.Server and Oahu.Cli.App projects: anonymous-type GS0144 count 2 -> 0; Server compile diagnostics 10 -> 8
- `dotnet build GSharp.sln -c Release --no-restore`
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-build` (1690 passed)

Fixes #2598