### PR TITLE
Fix cycle-4 semantic qualification

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -962,6 +962,33 @@ internal sealed partial class ExpressionBinder
                         return BindImportedTypeLiteralExpression(syntax, importedClass.ClassType);
                     }
                 }
+                else if (!typeNameAmbiguous
+                    && syntax.TypeArgumentList != null
+                    && scope.TryLookupImportedGenericClass(
+                        typeName, syntax.TypeArgumentList.Arguments.Count, out var openImportedType)
+                    && TryResolveClrConstructionTypeArgs(
+                        syntax.TypeArgumentList, out var clrTypeArguments, out _, out var hasSymbolicArgument)
+                    && !hasSymbolicArgument)
+                {
+                    Type closedImportedType;
+                    try
+                    {
+                        closedImportedType = openImportedType.MakeGenericType(clrTypeArguments);
+                    }
+                    catch (ArgumentException)
+                    {
+                        Diagnostics.ReportUnableToFindType(syntax.TypeIdentifier.Location, typeName);
+                        return new BoundErrorExpression(null);
+                    }
+
+                    if (ImportedTypeSymbol.TryCreateSemanticAggregate(
+                        closedImportedType, scope.References, out var importedAggregate))
+                    {
+                        return BindStructLiteralExpression(syntax, importedAggregate);
+                    }
+
+                    return BindImportedTypeLiteralExpression(syntax, closedImportedType);
+                }
                 else if (!typeNameAmbiguous && syntax.TypeArgumentList == null && lookupType(typeName) is TypeParameterSymbol tpLiteral)
                 {
                     // Issue #988 / #1235 (object-initializer follow-up): `T{Field: value,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2585SemanticQualificationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2585SemanticQualificationTests.cs
@@ -79,6 +79,34 @@ public sealed class Issue2585SemanticQualificationTests
     }
 
     [Fact]
+    public void ImportedGenericCompositeLiteral_ResolvesClosedType()
+    {
+        Assert.Empty(Bind("""
+            package Consumer
+            import Oahu.Widgets
+
+            func Run() {
+                let list = SelectList[string]{ Value: "ok" }
+            }
+            """));
+    }
+
+    [Fact]
+    public void ImportedGenericCompositeLiteral_WrongArity_RemainsDiagnosed()
+    {
+        Assert.Contains(
+            Bind("""
+                package Consumer
+                import Oahu.Widgets
+
+                func Run() {
+                    SelectList[string, int32]{ Value: "bad" }
+                }
+                """),
+            diagnostic => diagnostic.Message.Contains("Cannot find type SelectList", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void SourceQualifiedTypeAndValueReceiver_RemainDistinct()
     {
         Assert.Empty(Bind(
@@ -179,6 +207,14 @@ public sealed class Issue2585SemanticQualificationTests
             {
                 public sealed class Make
                 {
+                }
+            }
+
+            namespace Oahu.Widgets
+            {
+                public sealed class SelectList<T>
+                {
+                    public T Value { get; set; }
                 }
             }
             """;

--- a/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
@@ -415,7 +415,8 @@ public class BodyTranslationTests
         string body = GetMethodBody(@"
             System.Console.WriteLine(n);
             var s = n.ToString();");
-        Assert.Contains("System.Console.WriteLine(n)", body);
+        Assert.Contains("import System", body);
+        Assert.Contains("Console.WriteLine(n)", body);
         Assert.Contains("n.ToString()", body);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2585SemanticQualificationPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2585SemanticQualificationPipelineTests.cs
@@ -59,6 +59,24 @@ public sealed class Issue2585SemanticQualificationPipelineTests
         Assert.Contains("package Oahu.Tui", tuiOutput, StringComparison.Ordinal);
         Assert.Contains("import AppTypes = Oahu.App", tuiOutput, StringComparison.Ordinal);
         Assert.Contains("vm.Changed += () ->", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("import Oahu.Cli.App.Core", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("import Oahu.Cli.Commands", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("import Oahu.Cli.Tui.Icons", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("import Oahu.Cli.Tui.Widgets", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("import Spectre.Console", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("import System", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("CoreEnvironment.Initialize()", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("TuiCommand.Reset()", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("Rule.Default", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("SelectList[string]", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("Icons.Success", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("DateTime.UtcNow", tuiOutput, StringComparison.Ordinal);
+        Assert.Contains("let vm ViewModel? = value as ViewModel", tuiOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("App.Core.CoreEnvironment", tuiOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("Commands.TuiCommand", tuiOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("Spectre.Console.Rule", tuiOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("Tui.Icons.Icons", tuiOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("System.DateTime", tuiOutput, StringComparison.Ordinal);
     }
 
     private static (string AppProject, string TuiProject) WriteFixture(string sourceRoot)
@@ -115,6 +133,47 @@ public sealed class Issue2585SemanticQualificationPipelineTests
                 }
             }
             """);
+        File.WriteAllText(Path.Combine(appDirectory, "Cycle4Types.cs"), """
+            namespace Oahu.Cli.App.Core
+            {
+                public static class CoreEnvironment
+                {
+                    public static void Initialize() { }
+                }
+            }
+
+            namespace Oahu.Cli.Commands
+            {
+                public static class TuiCommand
+                {
+                    public static void Reset() { }
+                }
+            }
+
+            namespace Oahu.Cli.Tui.Icons
+            {
+                public static class Icons
+                {
+                    public static string Success => "ok";
+                }
+            }
+
+            namespace Oahu.Cli.Tui.Widgets
+            {
+                public sealed class SelectList<T>
+                {
+                    public T Value { get; set; }
+                }
+            }
+
+            namespace Spectre.Console
+            {
+                public sealed class Rule
+                {
+                    public static string Default => "rule";
+                }
+            }
+            """);
 
         string tuiDirectory = Path.Combine(sourceRoot, "Tui");
         Directory.CreateDirectory(tuiDirectory);
@@ -122,6 +181,7 @@ public sealed class Issue2585SemanticQualificationPipelineTests
         File.WriteAllText(tuiProject, ProjectFile("../App/App.csproj"));
         File.WriteAllText(Path.Combine(tuiDirectory, "Wiring.cs"), """
             using AppTypes = Oahu.App;
+            using Oahu.Cli.Tui.Widgets;
             using Oahu.Tui;
 
             namespace Oahu
@@ -138,7 +198,34 @@ public sealed class Issue2585SemanticQualificationPipelineTests
                                 vm.Refresh();
                             };
                         }
+
                     }
+                }
+            }
+            """);
+        File.WriteAllText(Path.Combine(tuiDirectory, "Cycle4.cs"), """
+            using AppTypes = Oahu.App;
+            using Oahu.Cli.Tui.Widgets;
+
+            namespace Oahu.Cli;
+
+            public static class Cycle4
+            {
+                public static void Run(object value, bool blocked)
+                {
+                    App.Core.CoreEnvironment.Initialize();
+                    Commands.TuiCommand.Reset();
+                    var rule = Spectre.Console.Rule.Default;
+                    var list = new SelectList<string> { Value = "ok" };
+                    var icon = Tui.Icons.Icons.Success;
+                    var year = System.DateTime.UtcNow.Year;
+
+                    if (value is not AppTypes.ViewModel vm || blocked)
+                    {
+                        return;
+                    }
+
+                    vm.Refresh();
                 }
             }
             """);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -747,8 +747,25 @@ public sealed partial class CSharpToGSharpTranslator
         {
             result = null;
 
-            if (ifStatement.Condition is not IsPatternExpressionSyntax isPattern ||
-                isPattern.Pattern is not UnaryPatternSyntax notPattern ||
+            IsPatternExpressionSyntax isPattern;
+            ExpressionSyntax remainingCondition = null;
+            if (ifStatement.Condition is IsPatternExpressionSyntax directPattern)
+            {
+                isPattern = directPattern;
+            }
+            else if (ifStatement.Condition is BinaryExpressionSyntax logicalOr
+                && logicalOr.IsKind(SyntaxKind.LogicalOrExpression)
+                && logicalOr.Left is IsPatternExpressionSyntax leftPattern)
+            {
+                isPattern = leftPattern;
+                remainingCondition = logicalOr.Right;
+            }
+            else
+            {
+                return false;
+            }
+
+            if (isPattern.Pattern is not UnaryPatternSyntax notPattern ||
                 !notPattern.IsKind(SyntaxKind.NotPattern))
             {
                 return false;
@@ -836,6 +853,14 @@ public sealed partial class CSharpToGSharpTranslator
             // fails the local is nil, so the original then-block runs.
             GExpression guard = new BinaryExpression(
                 new IdentifierExpression(localName), "==", LiteralExpression.Null());
+            if (remainingCondition != null)
+            {
+                guard = new BinaryExpression(
+                    guard,
+                    "||",
+                    this.TranslateExpression(remainingCondition));
+            }
+
             BlockStatement then = this.TranslateStatementAsBlock(ifStatement.Statement);
 
             GStatement elseBranch = null;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -312,6 +312,18 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GExpression TranslateMemberAccess(MemberAccessExpressionSyntax member)
         {
+            // C# permits namespace-qualified type expressions without importing
+            // their namespace, including relative qualification from the current
+            // namespace. G# resolves expression receivers as values/types, not as
+            // C# namespace paths. Collapse the whole bound type expression through
+            // the type mapper so it emits the canonical type name and records the
+            // namespace import needed by the generated file.
+            if (this.context.GetSymbolInfo(member).Symbol is INamedTypeSymbol qualifiedType)
+            {
+                return new TypeExpression(
+                    this.typeMapper.Map(qualifiedType, this.context, member.GetLocation()));
+            }
+
             // Issue #2351: a bare (non-invoked) reference to an extension
             // method's method group (e.g. assigned to a delegate) never goes
             // through TranslateInvocation, so track its declaring namespace


### PR DESCRIPTION
## Summary
- collapse semantically bound namespace-qualified type receivers to canonical type references and synthesize required imports
- preserve negated pattern values across compound guards and resolve imported generic composite literals
- cover cycle-4 project translation and negative generic-arity behavior

## Oahu qualification
Before editing, exact `Oahu.Cli` and `Oahu.UI` migration reproduced GS0157 for `App.Core.*`, `Spectre.*`, `System.*`, `Commands.*`, `SelectList`, `Tui.*`, and `vm`.

After the fix, rerunning those same two projects with an isolated local SDK package produced zero GS0157 diagnostics (other pre-existing migration diagnostics remain).

## Testing
- `dotnet build GSharp.sln --no-restore`
- Core issue #2585 tests: 7 passed
- project-backed issue #2585 pipeline test: passed
- Core.Tests: 6,608 passed, 1 skipped
- Cs2Gs.Tests: 1,687 passed
- GeneratorHost.Tests: 27 passed
- related Compiler.Tests filters: 10 passed

Fixes #2585