### PR TITLE
Fix Avalonia generated partial codebehind

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -523,16 +523,6 @@ public sealed record BoundBinaryOperator
             return true;
         }
 
-        // Imported CLR classes are managed references too. Source-generator
-        // fields are often emitted under nullable-oblivious context, so their
-        // generated G# part can legitimately compare a bare imported class to
-        // nil even though it has no explicit nullable annotation.
-        if (nullableOrUnderlying is ImportedTypeSymbol importedType
-            && importedType.ClrType is { IsValueType: false })
-        {
-            return true;
-        }
-
         // Issue #2354 follow-up: a non-nullable G# `class` (as opposed to a
         // value-kind `struct`) is likewise always a CLR reference type at
         // the IL layer — the exact same rationale as the interface arm

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -523,6 +523,16 @@ public sealed record BoundBinaryOperator
             return true;
         }
 
+        // Imported CLR classes are managed references too. Source-generator
+        // fields are often emitted under nullable-oblivious context, so their
+        // generated G# part can legitimately compare a bare imported class to
+        // nil even though it has no explicit nullable annotation.
+        if (nullableOrUnderlying is ImportedTypeSymbol importedType
+            && importedType.ClrType is { IsValueType: false })
+        {
+            return true;
+        }
+
         // Issue #2354 follow-up: a non-nullable G# `class` (as opposed to a
         // value-kind `struct`) is likewise always a CLR reference type at
         // the IL layer — the exact same rationale as the interface arm

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -2409,7 +2409,7 @@ internal sealed partial class ExpressionBinder
     private bool IsNamespacePrefixSegment(string segment, bool isLeadingSegment = true) =>
         (!isLeadingSegment || scope.TryLookupSymbol(segment) is not VariableSymbol)
         && !scope.TryLookupTypeAlias(segment, out _)
-        && !scope.TryLookupImport(segment, out _)
+        && !(scope.TryLookupImport(segment, out var import) && import.IsAlias)
         && !scope.TryLookupImportedClass(segment, declaration: null, out _);
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2438AsyncVoidEventHandlerTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2438AsyncVoidEventHandlerTranslationTests.cs
@@ -104,6 +104,28 @@ namespace Demo
         Assert.Contains("SettingsChanged += SettingsChangedSettings", printed, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void GenericInstanceMethod_CopiesTypeParametersToAsyncBodyHelper()
+    {
+        string printed = TranslateAndValidate(@"
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public sealed class Handler
+    {
+        public async void Handle<T>(T value)
+        {
+            await Task.Yield();
+        }
+    }
+}");
+
+        Assert.Contains("func Handle[T](value T)", printed, StringComparison.Ordinal);
+        Assert.Contains("__asyncVoid_Handle[T](value)", printed, StringComparison.Ordinal);
+        Assert.Contains("private async func __asyncVoid_Handle[T](value T)", printed, StringComparison.Ordinal);
+    }
+
     /// <summary>
     /// The exact Oahu <c>AudibleApi.AaxFileConversionProgressUpdate</c> shape: a
     /// block-bodied <c>async void</c> LOCAL FUNCTION subscribed to a generic

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2599AvaloniaCodebehindTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2599AvaloniaCodebehindTests.cs
@@ -87,7 +87,7 @@ public sealed class Issue2599AvaloniaCodebehindTests : IDisposable
             Path.Combine(appDirectory, "obj"),
             "*LibraryView*.g.gs",
             SearchOption.AllDirectories).Single());
-        Assert.Contains("var booksGrid DataGrid", generated, StringComparison.Ordinal);
+        Assert.Contains("var booksGrid DataGrid?", generated, StringComparison.Ordinal);
         Assert.Contains("@System.CodeDom.Compiler.GeneratedCode", generated, StringComparison.Ordinal);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2599AvaloniaCodebehindTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2599AvaloniaCodebehindTests.cs
@@ -1,0 +1,231 @@
+// <copyright file="Issue2599AvaloniaCodebehindTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+[CollectionDefinition("Issue2599NuGetEnvironment", DisableParallelization = true)]
+public sealed class Issue2599NuGetEnvironmentCollection
+{
+}
+
+[Collection("Issue2599NuGetEnvironment")]
+public sealed class Issue2599AvaloniaCodebehindTests : IDisposable
+{
+    private readonly string previousNuGetPackages;
+
+    public Issue2599AvaloniaCodebehindTests()
+    {
+        this.previousNuGetPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        Environment.SetEnvironmentVariable(
+            "NUGET_PACKAGES",
+            NewDirectory("sdk-packages"));
+    }
+
+    [Fact]
+    public async Task Pipeline_AvaloniaGeneratedPartialAndCodebehind_CompileTogether()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("source");
+        string projectPath = WriteProject(sourceRoot);
+        AssertProcessSucceeds("dotnet", $"restore \"{projectPath}\" --nologo", sourceRoot);
+
+        string outputRoot = NewDirectory("output");
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+
+        RunResult result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("test/AvaloniaCodebehind", projectPath, TargetKind.Library),
+        });
+
+        AppResult app = Assert.Single(result.Apps);
+        Assert.True(
+            app.Succeeded,
+            string.Join(
+                Environment.NewLine,
+                app.Artifacts.Select(path => File.ReadAllText(Path.Combine(
+                    outputRoot,
+                    result.RunId,
+                    path)))));
+
+        string appDirectory = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.AppId));
+        string codebehind = File.ReadAllText(Path.Combine(appDirectory, "LibraryView.axaml.gs"));
+        Assert.Contains("open partial class LibraryView : UserControl", codebehind, StringComparison.Ordinal);
+        Assert.Contains("let vm State? = DataContext as State", codebehind, StringComparison.Ordinal);
+        Assert.Contains("if vm == nil || booksGrid == nil", codebehind, StringComparison.Ordinal);
+        Assert.Contains("__asyncVoid_OnLoaded(e)", codebehind, StringComparison.Ordinal);
+        Assert.Contains("private async func __asyncVoid_OnLoaded(e RoutedEventArgs)", codebehind, StringComparison.Ordinal);
+        Assert.Contains("base.OnLoaded(e)", codebehind, StringComparison.Ordinal);
+
+        string generated = File.ReadAllText(Directory.GetFiles(
+            Path.Combine(appDirectory, "obj"),
+            "*LibraryView*.g.gs",
+            SearchOption.AllDirectories).Single());
+        Assert.Contains("var booksGrid DataGrid", generated, StringComparison.Ordinal);
+        Assert.Contains("@System.CodeDom.Compiler.GeneratedCode", generated, StringComparison.Ordinal);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("NUGET_PACKAGES", this.previousNuGetPackages);
+    }
+
+    private static string WriteProject(string sourceRoot)
+    {
+        string packagesPath = Path.Combine(sourceRoot, "packages");
+        File.WriteAllText(
+            Path.Combine(sourceRoot, "Directory.Build.props"),
+            $"""
+             <Project>
+               <PropertyGroup>
+                 <RestorePackagesPath>{packagesPath}</RestorePackagesPath>
+               </PropertyGroup>
+             </Project>
+             """);
+        string projectPath = Path.Combine(sourceRoot, "AvaloniaCodebehind.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <RootNamespace>Issue2599.Fixture</RootNamespace>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Avalonia" Version="11.2.7" />
+                <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.7" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(sourceRoot, "LibraryView.axaml"), """
+            <UserControl
+                x:Class="Issue2599.Fixture.LibraryView"
+                xmlns="https://github.com/avaloniaui"
+                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+              <DataGrid x:Name="booksGrid" />
+            </UserControl>
+            """);
+        File.WriteAllText(Path.Combine(sourceRoot, "LibraryView.axaml.cs"), """
+            using System;
+            using System.Threading.Tasks;
+            using Avalonia.Controls;
+            using Avalonia.Interactivity;
+
+            namespace Issue2599.Fixture;
+
+            public partial class LibraryView : UserControl
+            {
+                public LibraryView()
+                {
+                    InitializeComponent();
+                }
+
+                protected override async void OnLoaded(RoutedEventArgs e)
+                {
+                    await Task.Yield();
+                    base.OnLoaded(e);
+                }
+
+                protected override void OnUnloaded(RoutedEventArgs e)
+                {
+                    if (DataContext is not State vm || booksGrid is null)
+                    {
+                        return;
+                    }
+
+                    vm.Count = booksGrid.Columns.Count;
+                    if (System.DateTime.UtcNow.Year > 0)
+                    {
+                        vm.Count++;
+                    }
+
+                    base.OnUnloaded(e);
+                }
+            }
+
+            public sealed class State
+            {
+                public int Count { get; set; }
+            }
+            """);
+        return projectPath;
+    }
+
+    private static void AssertProcessSucceeds(string fileName, string arguments, string workingDirectory)
+    {
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, output);
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2599",
+            category,
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirectoryName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirectoryName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.AsyncVoidHandlers.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.AsyncVoidHandlers.cs
@@ -36,10 +36,10 @@ public sealed partial class CSharpToGSharpTranslator
         // NON-async, void-returning wrapper with the ORIGINAL name/identity
         // (so method-group `+=`/`-=` subscription and unsubscription keep
         // referring to the SAME symbol/value) whose body:
-        //   1. binds the untouched original body to a nested `async func`
-        //      value (so its own awaits/exception flow are lowered exactly
-        //      like any other G# async function — no new async semantics are
-        //      invented),
+        //   1. binds the untouched original body to a private async instance
+        //      method (or a nested `async func` when no instance is available),
+        //      so its own awaits/exception flow are lowered exactly like any
+        //      other G# async function — no new async semantics are invented,
         //   2. invokes it immediately with the wrapper's own parameters
         //      (kicks off synchronously up to the first incomplete `await`,
         //      matching C#'s async-void semantics: the call returns void as
@@ -77,16 +77,21 @@ public sealed partial class CSharpToGSharpTranslator
         /// returned block is meant to become the ENTIRE (non-async, void)
         /// body of the translated handler — <paramref name="originalAsyncBody"/>
         /// (the handler's own, otherwise-unmodified translated body) becomes
-        /// the block body of a nested <c>async func</c> literal that the
-        /// wrapper invokes and observes.
+        /// the block body of a private async instance method (or a nested
+        /// <c>async func</c> literal when no containing instance is available)
+        /// that the wrapper invokes and observes.
         /// </summary>
         /// <param name="parameters">The handler's own parameter list (reused verbatim for the nested async literal and the forwarding call).</param>
         /// <param name="originalAsyncBody">The handler's untouched translated body.</param>
         /// <param name="location">A source location used to resolve/import the well-known BCL types the wrapper references.</param>
+        /// <param name="instanceBodyName">The synthesized private instance-method name, or <see langword="null"/> to use a nested function.</param>
+        /// <param name="methodTypeParameters">The original method type parameters copied to an instance helper.</param>
         private BlockStatement BuildAsyncVoidHandlerWrapperBody(
             IReadOnlyList<Parameter> parameters,
             BlockStatement originalAsyncBody,
-            Location location)
+            Location location,
+            string instanceBodyName = null,
+            IReadOnlyList<TypeParameter> methodTypeParameters = null)
         {
             const string bodyLocalName = "__gsAsyncVoidBody";
             const string taskParamName = "__gsAsyncVoidTask";
@@ -116,18 +121,38 @@ public sealed partial class CSharpToGSharpTranslator
                 type: new NamedTypeReference(syncContextTypeName) { IsNullable = true },
                 initializer: new MemberAccessExpression(new IdentifierExpression(syncContextTypeName), "Current"));
 
-            // let __gsAsyncVoidBody = async (params) -> { <original body> }
-            var bodyDeclaration = new LocalDeclarationStatement(
-                BindingKind.Let,
-                bodyLocalName,
-                initializer: new LambdaExpression(
+            LocalDeclarationStatement bodyDeclaration = null;
+            string bodyCallableName = bodyLocalName;
+            if (instanceBodyName != null)
+            {
+                bodyCallableName = instanceBodyName;
+                this.state.PendingInstanceSynthHelpers.Add(new MethodDeclaration(
+                    bodyCallableName,
                     parameters,
-                    blockBody: originalAsyncBody,
-                    isAsync: true,
-                    isFunctionLiteral: true));
+                    returnType: null,
+                    body: originalAsyncBody,
+                    typeParameters: methodTypeParameters,
+                    visibility: Visibility.Private,
+                    isAsync: true));
+            }
+            else
+            {
+                // let __gsAsyncVoidBody = async (params) -> { <original body> }
+                bodyDeclaration = new LocalDeclarationStatement(
+                    BindingKind.Let,
+                    bodyLocalName,
+                    initializer: new LambdaExpression(
+                        parameters,
+                        blockBody: originalAsyncBody,
+                        isAsync: true,
+                        isFunctionLiteral: true));
+            }
 
             List<GExpression> forwardedArguments = parameters
                 .Select(p => (GExpression)new IdentifierExpression(p.Name))
+                .ToList();
+            List<GTypeReference> forwardedTypeArguments = methodTypeParameters?
+                .Select(parameter => (GTypeReference)new NamedTypeReference(parameter.Name))
                 .ToList();
 
             // __gsAsyncVoidEx = __gsAsyncVoidTask.Exception!!.InnerException!!
@@ -199,11 +224,21 @@ public sealed partial class CSharpToGSharpTranslator
             // __gsAsyncVoidBody(args).ContinueWith((t) -> { ... }, OnlyOnFaulted | ExecuteSynchronously)
             var continueWithCall = new ExpressionStatement(new InvocationExpression(
                 new MemberAccessExpression(
-                    new InvocationExpression(new IdentifierExpression(bodyLocalName), forwardedArguments),
+                    new InvocationExpression(
+                        new IdentifierExpression(bodyCallableName),
+                        forwardedArguments,
+                        forwardedTypeArguments),
                     "ContinueWith"),
                 new List<GExpression> { continuationLambda, continuationOptions }));
 
-            return new BlockStatement(new GStatement[] { captureContextDeclaration, bodyDeclaration, continueWithCall });
+            var wrapperStatements = new List<GStatement> { captureContextDeclaration };
+            if (bodyDeclaration != null)
+            {
+                wrapperStatements.Add(bodyDeclaration);
+            }
+
+            wrapperStatements.Add(continueWithCall);
+            return new BlockStatement(wrapperStatements);
         }
 
         /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -747,7 +747,16 @@ public sealed partial class CSharpToGSharpTranslator
         {
             result = null;
 
-            if (ifStatement.Condition is not IsPatternExpressionSyntax isPattern ||
+            var extraGuards = new Stack<ExpressionSyntax>();
+            ExpressionSyntax condition = ifStatement.Condition;
+            while (condition is BinaryExpressionSyntax binary &&
+                   binary.IsKind(SyntaxKind.LogicalOrExpression))
+            {
+                condition = binary.Left;
+                extraGuards.Push(binary.Right);
+            }
+
+            if (condition is not IsPatternExpressionSyntax isPattern ||
                 isPattern.Pattern is not UnaryPatternSyntax notPattern ||
                 !notPattern.IsKind(SyntaxKind.NotPattern))
             {
@@ -836,6 +845,14 @@ public sealed partial class CSharpToGSharpTranslator
             // fails the local is nil, so the original then-block runs.
             GExpression guard = new BinaryExpression(
                 new IdentifierExpression(localName), "==", LiteralExpression.Null());
+            while (extraGuards.Count > 0)
+            {
+                guard = new BinaryExpression(
+                    guard,
+                    "||",
+                    this.TranslateExpression(extraGuards.Pop()));
+            }
+
             BlockStatement then = this.TranslateStatementAsBlock(ifStatement.Statement);
 
             GStatement elseBranch = null;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -997,8 +997,10 @@ public sealed partial class CSharpToGSharpTranslator
             // via `TranslateMember`) never leaks its helpers into this
             // (enclosing) type, and vice versa.
             List<MethodDeclaration> outerSynthHelpers = this.state.PendingSynthHelpers;
+            List<MethodDeclaration> outerInstanceSynthHelpers = this.state.PendingInstanceSynthHelpers;
             int outerSynthHelperCounter = this.state.SynthHelperCounter;
             this.state.PendingSynthHelpers = new List<MethodDeclaration>();
+            this.state.PendingInstanceSynthHelpers = new List<MethodDeclaration>();
             this.state.SynthHelperCounter = 0;
             try
             {
@@ -1007,6 +1009,7 @@ public sealed partial class CSharpToGSharpTranslator
             finally
             {
                 this.state.PendingSynthHelpers = outerSynthHelpers;
+                this.state.PendingInstanceSynthHelpers = outerInstanceSynthHelpers;
                 this.state.SynthHelperCounter = outerSynthHelperCounter;
             }
         }
@@ -1283,6 +1286,7 @@ public sealed partial class CSharpToGSharpTranslator
             // static, so they join the `shared { }` block alongside the type's
             // other static members.
             sharedMembers.AddRange(this.state.PendingSynthHelpers);
+            instanceMembers.AddRange(this.state.PendingInstanceSynthHelpers);
 
             // OD-T1: if get-only auto-property initializers needed to move into a
             // constructor but the type declares no designated instance constructor,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -1129,7 +1129,8 @@ public sealed partial class CSharpToGSharpTranslator
                 name = $"__init{this.state.SynthHelperCounter++}";
             }
             while (existingNames.Contains(name) ||
-                this.state.PendingSynthHelpers.Any(h => h.Name == name));
+                this.state.PendingSynthHelpers.Any(h => h.Name == name) ||
+                this.state.PendingInstanceSynthHelpers.Any(h => h.Name == name));
 
             return name;
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -991,7 +991,22 @@ public sealed partial class CSharpToGSharpTranslator
             bool isAsyncVoidHandler = body != null && IsCSharpAsyncVoidHandler(symbol);
             if (isAsyncVoidHandler)
             {
-                body = this.BuildAsyncVoidHandlerWrapperBody(parameters, body, node.GetLocation());
+                string instanceBodyName = null;
+                if (!symbol.IsStatic && symbol.ContainingType.TypeKind == TypeKind.Class)
+                {
+                    instanceBodyName = "__asyncVoid_" + SanitizeIdentifier(symbol.Name);
+                    while (symbol.ContainingType.GetMembers(instanceBodyName).Length > 0)
+                    {
+                        instanceBodyName += "_";
+                    }
+                }
+
+                body = this.BuildAsyncVoidHandlerWrapperBody(
+                    parameters,
+                    body,
+                    node.GetLocation(),
+                    instanceBodyName,
+                    typeParameters);
             }
 
             bool isOverride = symbol != null && symbol.IsOverride;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -670,6 +670,16 @@ public sealed partial class CSharpToGSharpTranslator
                     ? this.typeMapper.Map(symbol.Type, this.context, declarator.GetLocation())
                     : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
 
+                // Generator-produced fields declared under nullable-oblivious
+                // context (Avalonia x:Name fields are the common case) retain
+                // C#'s ability to hold/test null when translated as a standalone
+                // generated partial part.
+                if (this.preservePartialParts &&
+                    symbol?.Type is { IsReferenceType: true, NullableAnnotation: NullableAnnotation.None })
+                {
+                    type = MakeNullable(type);
+                }
+
                 // Issue #1072: a non-nullable reference/array field that is
                 // null-checked or null-assigned anywhere in the declaring type is
                 // really nullable; render it `T?` so the `== nil` guard type-checks.

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -224,6 +224,10 @@ internal sealed class DocumentTranslationState
     // helpers never leak into its enclosing type.
     public List<MethodDeclaration> PendingSynthHelpers { get; set; }
 
+    // Instance helpers synthesized while translating the current aggregate.
+    // Unlike PendingSynthHelpers, these remain ordinary class members.
+    public List<MethodDeclaration> PendingInstanceSynthHelpers { get; set; }
+
     // Monotonic counter for synthesizing null-seam helper method names
     // (issue #1849), reset per aggregate alongside `PendingSynthHelpers`.
     public int SynthHelperCounter { get; set; }

--- a/tools/gsgen/GSharp.GeneratorHost.Tests/GsgenCliTests.cs
+++ b/tools/gsgen/GSharp.GeneratorHost.Tests/GsgenCliTests.cs
@@ -188,6 +188,31 @@ public class GsgenCliTests : IDisposable
     }
 
     [Fact]
+    public void EndToEnd_SameGeneratorAssemblyFromTwoPackageRoots_RunsOnce()
+    {
+        string generatorDll = GeneratorDllFactory.Value;
+        string copiedGenerator = Path.Combine(this.workDir, "second-package-root", "generator.dll");
+        Directory.CreateDirectory(Path.GetDirectoryName(copiedGenerator));
+        File.Copy(generatorDll, copiedGenerator);
+
+        var outDir = Path.Combine(this.workDir, "gen");
+        var gs = this.WriteGs("Foo.gs", "package App\n\n@Obsolete\npartial class Foo {\n}\n");
+        var args = new List<string>
+        {
+            $"/gs:{gs}",
+            $"/analyzer:{generatorDll}",
+            $"/analyzer:{copiedGenerator}",
+            $"/out:{outDir}",
+        };
+        args.AddRange(RuntimeReferencePaths().Select(p => $"/r:{p}"));
+
+        int exit = GsgenProgram.Run(args.ToArray(), new StringWriter());
+
+        Assert.Equal(0, exit);
+        Assert.Single(Directory.EnumerateFiles(outDir, "*.g.gs"));
+    }
+
+    [Fact]
     public void OrphanCleanup_DeletesStalePartNotRegenerated()
     {
         string generatorDll = GeneratorDllFactory.Value;

--- a/tools/gsgen/GSharp.GeneratorHost/GeneratorRunner.cs
+++ b/tools/gsgen/GSharp.GeneratorHost/GeneratorRunner.cs
@@ -5,8 +5,10 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Cryptography;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -78,11 +80,19 @@ public static class GeneratorRunner
 
         var failures = new List<GeneratorFailure>();
         var generators = new List<ISourceGenerator>();
+        var analyzerHashes = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (string path in analyzerAssemblyPaths)
         {
             try
             {
+                using var stream = File.OpenRead(path);
+                string hash = Convert.ToHexString(SHA256.HashData(stream));
+                if (!analyzerHashes.Add(hash))
+                {
+                    continue;
+                }
+
                 var reference = new AnalyzerFileReference(path, AnalyzerAssemblyLoader.Instance);
                 generators.AddRange(reference.GetGenerators(LanguageNames.CSharp));
             }


### PR DESCRIPTION
## Summary
- preserve generated partial base/member context across Avalonia codebehind and deduplicate generator binaries across package roots
- keep async-void instance bodies in private async members so `base` stays valid, and preserve negated pattern binders across `||` guards
- resolve qualified namespace roots alongside ordinary imports and allow imported CLR references to compare with `nil`
- add a real Avalonia 11.2.7 project-backed translate+generate+compile regression

## Exact Oahu cycle-4 validation
Before editing, `Oahu.UI` reproduced 20 compile fingerprints and `Oahu.App` 17, including `vm`/`System` qualification, `DataGrid ==/!= nil`, generated `booksGrid`, and top-level `base.OnOpened` failures.

After the fix, the exact `Oahu.UI`/`Oahu.App` migration contains none of those owned diagnostics. Remaining diagnostics are unrelated next-wave gaps:
- `Oahu.UI`: GS0125 (39), GS0156 (2), GS0157 (21), GS0158 (8), GS0159 (13), primarily CommunityToolkit-generated member/call binding
- `Oahu.App`: GS0124 (1), GS0130 (1), GS0155 (2), GS0158 (4), GS0159 (8), existing construction/nullability/member-call gaps

## Validation
- `dotnet build GSharp.sln -c Release --no-restore --nologo -m:2`
- Core.Tests: 6,606 passed, 1 skipped
- Cs2Gs.Tests: 1,688 passed (subsequent resource-contended full retries aborted while other worktrees ran tests; all changed/added tests remained green)
- GSharp.GeneratorHost.Tests: 28 passed
- exact Oahu.UI/Oahu.App migration rerun and owned-diagnostic grep empty

Fixes #2599
