### PR TITLE
Fix inherited imported extension resolution

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -2120,6 +2120,12 @@ public sealed class Conversion
 
         for (var i = 0; i < invokeParamTypes.Length; i++)
         {
+            if (fn.ParameterTypes[i] is FunctionTypeSymbol nestedFunction
+                && IsFunctionToDelegateConvertible(nestedFunction, invokeParamTypes[i]))
+            {
+                continue;
+            }
+
             var fnParamClr = fn.ParameterTypes[i]?.ClrType;
             if (fnParamClr == null || !ClrTypeUtilities.IsAssignableByName(invokeParamTypes[i], fnParamClr))
             {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -419,7 +419,7 @@ internal sealed partial class ExpressionBinder
         return null;
     }
 
-    private bool TryBindUserStructDelegateFieldInvocation(
+    private bool TryBindUserStructDelegateMemberInvocation(
         BoundExpression receiver,
         StructSymbol receiverStruct,
         string methodName,
@@ -443,23 +443,37 @@ internal sealed partial class ExpressionBinder
             }
         }
 
-        if (matchedField == null)
+        PropertySymbol matchedProperty = null;
+        if (matchedField == null
+            && TypeMemberModel.TryGetProperty(
+                receiverStruct,
+                methodName,
+                out var property,
+                out var propertyDeclaringType)
+            && property.HasGetter)
+        {
+            matchedProperty = property;
+            declaringType = propertyDeclaringType;
+        }
+
+        var memberType = matchedField?.Type ?? matchedProperty?.Type;
+        if (memberType == null)
         {
             return false;
         }
 
         FunctionTypeSymbol functionType;
-        if (matchedField.Type is FunctionTypeSymbol fts)
+        if (memberType is FunctionTypeSymbol fts)
         {
             functionType = fts;
         }
-        else if (matchedField.Type is DelegateTypeSymbol nds)
+        else if (memberType is DelegateTypeSymbol nds)
         {
             functionType = nds.EquivalentFunctionType;
         }
-        else if (matchedField.Type?.ClrType is System.Type fieldClrType
-            && ClrTypeUtilities.IsDelegateType(fieldClrType)
-            && MemberLookup.TryGetDelegateFunctionType(fieldClrType, out var clrFn))
+        else if (memberType.ClrType is System.Type memberClrType
+            && ClrTypeUtilities.IsDelegateType(memberClrType)
+            && MemberLookup.TryGetDelegateFunctionType(memberClrType, out var clrFn))
         {
             functionType = clrFn;
         }
@@ -524,8 +538,10 @@ internal sealed partial class ExpressionBinder
             convertedArgs.Add(conversions.BindConversion(argLoc, permutedArgs[i], functionType.ParameterTypes[i]));
         }
 
-        var fieldLoad = new BoundFieldAccessExpression(null, receiver, declaringType, matchedField);
-        result = new BoundIndirectCallExpression(null, fieldLoad, functionType, convertedArgs.MoveToImmutable());
+        BoundExpression memberLoad = matchedField != null
+            ? new BoundFieldAccessExpression(null, receiver, declaringType, matchedField)
+            : new BoundPropertyAccessExpression(null, receiver, declaringType, matchedProperty);
+        result = new BoundIndirectCallExpression(null, memberLoad, functionType, convertedArgs.MoveToImmutable());
         return true;
     }
 
@@ -1108,6 +1124,7 @@ internal sealed partial class ExpressionBinder
         // arguments. Every argument must carry a concrete CLR type so overload
         // resolution (including generic inference) can run.
         var argTypes = new Type[arguments.Length + 1];
+        var deferredInferenceArgs = new bool[arguments.Length + 1];
         argTypes[0] = receiverClrType;
         var hasUserClassArg = false;
         for (var i = 0; i < arguments.Length; i++)
@@ -1144,6 +1161,17 @@ internal sealed partial class ExpressionBinder
                 hasUserClassArg = true;
             }
 
+            // A same-compilation lambda parameter may erase to its imported
+            // base while its inherited-interface receiver erases to object.
+            // Keep that CLR shape for applicability, but infer from the
+            // receiver's symbolic hierarchy instead of conflicting erasures.
+            if (receiver.Type is ImportedTypeSymbol
+                && arguments[i].Type is FunctionTypeSymbol functionType
+                && functionType.ParameterTypes.Any(TypeSymbol.RequiresSymbolicProjection))
+            {
+                deferredInferenceArgs[i + 1] = true;
+            }
+
             argTypes[i + 1] = t;
         }
 
@@ -1172,6 +1200,27 @@ internal sealed partial class ExpressionBinder
         if (candidates.Count == 0)
         {
             return false;
+        }
+
+        if (deferredInferenceArgs.Any(static deferred => deferred)
+            && receiverClrType.IsGenericType)
+        {
+            var receiverDefinition = receiverClrType.GetGenericTypeDefinition();
+            if (candidates.Any(candidate =>
+            {
+                var parameters = candidate.GetParameters();
+                if (parameters.Length == 0 || !parameters[0].ParameterType.IsGenericType)
+                {
+                    return false;
+                }
+
+                return ClrTypeUtilities.AreSame(
+                    receiverDefinition,
+                    parameters[0].ParameterType.GetGenericTypeDefinition());
+            }))
+            {
+                Array.Clear(deferredInferenceArgs);
+            }
         }
 
         // Issue #2523: when a symbolic imported receiver's own reconstructed
@@ -1224,6 +1273,12 @@ internal sealed partial class ExpressionBinder
         Func<Type, Type, bool> supplementaryInterfaceCheck = hasUserClassArg
             ? (source, target) => IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target)
             : null;
+        var argumentStructuralProjectionCheck = MakeStructuralProjectionArgumentCheck(arguments, argumentOffset: 1);
+        bool ExtensionStructuralProjectionCheck(int index, Type target) =>
+            index == 0
+                ? ClrTypeUtilities.IsAssignableByName(target, argTypes[0])
+                    || Conversion.ClassifyNonStructural(receiver.Type, TypeSymbol.FromClrType(target)).IsImplicit
+                : argumentStructuralProjectionCheck?.Invoke(index, target) == true;
 
         // Issue #1311: imported extension calls dispatch as
         // `Class.Method(this receiver, args…)`, so argTypes slot 0 is the
@@ -1248,9 +1303,10 @@ internal sealed partial class ExpressionBinder
                 isExpanded),
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
             constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments, argumentOffset: 1),
-            structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments, argumentOffset: 1),
+            structuralProjectionArgumentCheck: ExtensionStructuralProjectionCheck,
             methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution, argumentOffset: 1),
-            methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments, argumentOffset: 1));
+            methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments, argumentOffset: 1),
+            deferredInferenceArgs: deferredInferenceArgs);
 
         switch (resolution.Outcome)
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2296,12 +2296,12 @@ internal sealed partial class ExpressionBinder
                     return overloads.BindUserInstanceCall(receiver, defaultIfaceMethod, arguments, ce, argumentNames);
                 }
 
-                // Issue #527: fall back to a delegate/function-typed field on
+                // Issue #527: fall back to a delegate/function-typed member on
                 // the user struct/class. This is the same delegate-as-callable
                 // dispatch used for the imported-CLR path below; here the
                 // receiver's ClrType is null (the user type has not yet been
                 // emitted) so we have to handle the symbol-only shape too.
-                if (TryBindUserStructDelegateFieldInvocation(receiver, userClass, methodName, arguments, ce, out var userDelegateFieldCall))
+                if (TryBindUserStructDelegateMemberInvocation(receiver, userClass, methodName, arguments, ce, out var userDelegateFieldCall))
                 {
                     return userDelegateFieldCall;
                 }
@@ -2439,13 +2439,11 @@ internal sealed partial class ExpressionBinder
                 return overloads.BindUserInstanceCall(receiver, defaultIfaceMethodPriority, arguments, ce, argumentNames);
             }
 
-            // Issue #527: a G#-defined struct/class field whose type is a
+            // Issue #527: a G#-defined struct/class field or property whose type is a
             // function (or named delegate) is invokable through the same
             // call syntax as a bare function-typed variable. Lower to a load
-            // of the field value followed by an indirect call. Field lookup
-            // walks the inheritance chain (a class can inherit a delegate
-            // field from a base class).
-            if (TryBindUserStructDelegateFieldInvocation(receiver, userClassPriority, methodName, arguments, ce, out var userDelegateCall))
+            // of the member value followed by an indirect call.
+            if (TryBindUserStructDelegateMemberInvocation(receiver, userClassPriority, methodName, arguments, ce, out var userDelegateCall))
             {
                 return userDelegateCall;
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -2263,9 +2263,10 @@ internal sealed partial class ExpressionBinder
                 return false;
             }
 
-            return StructuralProjectionPlanner.CanProject(
-                boundArguments[argIndex].Type,
-                TypeSymbol.FromClrType(clrParameterType));
+            var sourceType = boundArguments[argIndex].Type;
+            var targetType = TypeSymbol.FromClrType(clrParameterType);
+            return Conversion.ClassifyNonStructural(sourceType, targetType).IsImplicit
+                || StructuralProjectionPlanner.CanProject(sourceType, targetType);
         };
     }
 }

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -3450,37 +3450,36 @@ internal sealed class MemberLookup
         if (source == null
             || targetOpenDefinition == null
             || !targetOpenDefinition.IsGenericTypeDefinition
-            || !TryMapThroughImplemented(source, targetOpenDefinition, out var mappedArguments)
-            || mappedArguments.Any(TypeSymbol.RequiresSymbolicProjection))
+            || !TryMapThroughImplemented(source, targetOpenDefinition, out var mappedArguments))
         {
             return false;
         }
 
+        var projectedArguments = new Type[mappedArguments.Length];
         var contextObject = ResolveErasedObjectInContext(targetOpenDefinition);
-        var erasedArguments = Enumerable.Repeat(
-            contextObject,
-            targetOpenDefinition.GetGenericArguments().Length).ToArray();
-        Type erased;
+        for (var i = 0; i < mappedArguments.Length; i++)
+        {
+            if (!TryProjectErasedClrType(mappedArguments[i], out projectedArguments[i]))
+            {
+                return false;
+            }
+
+            if (projectedArguments[i].IsSameAs(typeof(object)))
+            {
+                projectedArguments[i] = contextObject;
+            }
+        }
+
         try
         {
-            erased = targetOpenDefinition.MakeGenericType(erasedArguments);
+            projectedType = targetOpenDefinition.MakeGenericType(projectedArguments);
+            return !projectedType.ContainsGenericParameters;
         }
         catch
         {
+            projectedType = null;
             return false;
         }
-
-        var projected = ImportedTypeSymbol.GetConstructed(
-            erased,
-            targetOpenDefinition,
-            mappedArguments).ReifyClosedClrType();
-        if (projected == null || projected.ContainsGenericParameters)
-        {
-            return false;
-        }
-
-        projectedType = projected;
-        return true;
     }
 
     private static PropertyInfo[] CollectVisibleClrIndexers(TypeSymbol targetType, Type clrTarget)
@@ -4587,6 +4586,12 @@ internal sealed class MemberLookup
         if (incoming == null || ReferenceEquals(existing, incoming))
         {
             return existing;
+        }
+
+        if (existing.ClrType?.IsSameAs(typeof(object)) == true
+            && TypeSymbol.RequiresSymbolicProjection(incoming))
+        {
+            return incoming;
         }
 
         var existingNullable = existing is NullableTypeSymbol en

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -670,7 +670,12 @@ internal static class OverloadResolution
     /// Optional callback identifying which source arguments are deferred method
     /// groups, distinguishing them from other naturally untyped arguments.
     /// </param>
-    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null, Func<int, bool> methodGroupArgumentCheck = null)
+    /// <param name="deferredInferenceArgs">
+    /// Argument slots whose CLR delegate shape contains symbolic types and
+    /// therefore must not contribute erased evidence to generic inference.
+    /// Their original CLR types still participate in applicability and ranking.
+    /// </param>
+    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null, Func<int, bool> methodGroupArgumentCheck = null, IReadOnlyList<bool> deferredInferenceArgs = null)
         where T : MethodBase
     {
         var applicable = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)>();
@@ -694,7 +699,7 @@ internal static class OverloadResolution
             // rest.
             try
             {
-                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck, structuralProjectionArgumentCheck, methodGroupInference, methodGroupArgumentCheck);
+                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck, structuralProjectionArgumentCheck, methodGroupInference, methodGroupArgumentCheck, deferredInferenceArgs);
             }
             catch (Exception ex) when (IsMetadataLoadFailure(ex))
             {
@@ -2263,7 +2268,7 @@ internal static class OverloadResolution
     /// so the per-candidate work can be guarded against reflection load
     /// failures (issue #321) without disturbing the surrounding control flow.
     /// </summary>
-    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null, Func<int, bool> methodGroupArgumentCheck = null)
+    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null, Func<int, bool> methodGroupArgumentCheck = null, IReadOnlyList<bool> deferredInferenceArgs = null)
         where T : MethodBase
     {
         {
@@ -2347,10 +2352,24 @@ internal static class OverloadResolution
                 // unification, so the mapping must already be known before
                 // inference; we use this open candidate's parameters to compute it.
                 IReadOnlyList<Type> inferenceArgTypes = argTypes;
+                if (deferredInferenceArgs != null)
+                {
+                    var deferred = argTypes.ToArray();
+                    for (var i = 0; i < deferred.Length && i < deferredInferenceArgs.Count; i++)
+                    {
+                        if (deferredInferenceArgs[i])
+                        {
+                            deferred[i] = null;
+                        }
+                    }
+
+                    inferenceArgTypes = deferred;
+                }
+
                 var inferenceMethodGroup = methodGroupInference;
                 if (argumentNames != null && HasAnyNamedArgument(argumentNames))
                 {
-                    if (!TryBuildOrderedArgTypesForInference(mi, argTypes, argumentNames, out var orderedArgTypes))
+                    if (!TryBuildOrderedArgTypesForInference(mi, inferenceArgTypes, argumentNames, out var orderedArgTypes))
                     {
                         return;
                     }
@@ -2374,7 +2393,17 @@ internal static class OverloadResolution
                     }
                 }
 
-                if (!TryInferTypeArguments(mi, inferenceArgTypes, out var typeArgs, inferenceMethodGroup))
+                var symbolicTypeArgs = recoverTypeArgSymbols?.Invoke(mi, false) ?? default;
+                Type[] typeArgs = null;
+                var useRecoveredInference = deferredInferenceArgs?.Any(static deferred => deferred) == true
+                    && TryRecoverErasedTypeArguments(
+                        mi,
+                        symbolicTypeArgs,
+                        projectTypeArgument,
+                        out typeArgs);
+                if (!useRecoveredInference
+                    && !TryInferTypeArguments(mi, inferenceArgTypes, out typeArgs, inferenceMethodGroup)
+                    && !TryRecoverErasedTypeArguments(mi, symbolicTypeArgs, projectTypeArgument, out typeArgs))
                 {
                     return;
                 }
@@ -3890,6 +3919,37 @@ internal static class OverloadResolution
         return true;
     }
 
+    private static bool TryRecoverErasedTypeArguments(
+        MethodInfo openMethod,
+        ImmutableArray<TypeSymbol> recoveredSymbols,
+        Func<Type, Type> projectTypeArgument,
+        out Type[] typeArgs)
+    {
+        typeArgs = null;
+        if (openMethod is null
+            || recoveredSymbols.IsDefaultOrEmpty
+            || recoveredSymbols.Length != openMethod.GetGenericArguments().Length
+            || recoveredSymbols.Any(static symbol => symbol is null))
+        {
+            return false;
+        }
+
+        var result = new Type[recoveredSymbols.Length];
+        for (var i = 0; i < result.Length; i++)
+        {
+            var symbol = recoveredSymbols[i];
+            if (!MemberLookup.TryProjectErasedClrType(symbol, out var clrType))
+            {
+                return false;
+            }
+
+            result[i] = projectTypeArgument?.Invoke(clrType) ?? clrType;
+        }
+
+        typeArgs = result;
+        return true;
+    }
+
     /// <summary>
     /// Issue #750 / ADR-0088: validates that <paramref name="typeArgs"/>
     /// satisfies every CLR-level generic-parameter constraint declared on
@@ -4869,6 +4929,12 @@ internal static class OverloadResolution
             // throw on BaseType traversal; fall through to interface walk.
         }
 
+        var projected = FindClosedGenericFromDefinition(type, openDefinition, openDefName);
+        if (projected != null)
+        {
+            return projected;
+        }
+
         var ifaces = ClrTypeUtilities.SafeGetInterfaces(type);
 
         foreach (var iface in ifaces)
@@ -4880,6 +4946,64 @@ internal static class OverloadResolution
         }
 
         return null;
+    }
+
+    private static Type FindClosedGenericFromDefinition(Type type, Type openDefinition, string openDefinitionName)
+    {
+        if (type == null || !type.IsGenericType || type.IsGenericTypeDefinition)
+        {
+            return null;
+        }
+
+        try
+        {
+            var definition = type.GetGenericTypeDefinition();
+            var parameters = definition.GetGenericArguments();
+            var arguments = type.GetGenericArguments();
+            foreach (var candidate in definition.GetInterfaces())
+            {
+                var projected = Project(candidate);
+                if (projected != null)
+                {
+                    return projected;
+                }
+            }
+
+            for (var candidate = definition.BaseType; candidate != null; candidate = candidate.BaseType)
+            {
+                var projected = Project(candidate);
+                if (projected != null)
+                {
+                    return projected;
+                }
+            }
+
+            return null;
+
+            Type Project(Type candidate)
+            {
+                if (!candidate.IsGenericType
+                    || !MatchesOpenDefinition(
+                        candidate.GetGenericTypeDefinition(),
+                        openDefinition,
+                        openDefinitionName))
+                {
+                    return null;
+                }
+
+                var projected = candidate;
+                for (var i = 0; i < parameters.Length; i++)
+                {
+                    projected = SubstituteClrType(projected, parameters[i], arguments[i]);
+                }
+
+                return projected;
+            }
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex) || ex is ArgumentException)
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -259,6 +259,14 @@ public static class ClrTypeUtilities
             return true;
         }
 
+        if (target.IsGenericType
+            && source.IsGenericType
+            && AreSame(target.GetGenericTypeDefinition(), source.GetGenericTypeDefinition())
+            && GenericArgumentsAreAssignable(target, source))
+        {
+            return true;
+        }
+
         // Same-context fast path covers inheritance / interfaces.
         if (ReferenceEquals(target.Assembly, source.Assembly) || target.GetType() == source.GetType())
         {
@@ -953,6 +961,42 @@ public static class ClrTypeUtilities
         MemberCache<FieldInfo>.Cache.Clear();
         MemberCache<EventInfo>.Cache.Clear();
         MemberCache<ConstructorInfo>.Cache.Clear();
+    }
+
+    private static bool GenericArgumentsAreAssignable(Type target, Type source)
+    {
+        var parameters = target.GetGenericTypeDefinition().GetGenericArguments();
+        var targetArguments = target.GetGenericArguments();
+        var sourceArguments = source.GetGenericArguments();
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            if (AreSame(targetArguments[i], sourceArguments[i]))
+            {
+                continue;
+            }
+
+            if (targetArguments[i].IsValueType || sourceArguments[i].IsValueType)
+            {
+                return false;
+            }
+
+            var variance = parameters[i].GenericParameterAttributes & GenericParameterAttributes.VarianceMask;
+            if (variance == GenericParameterAttributes.Covariant
+                && IsAssignableByName(targetArguments[i], sourceArguments[i]))
+            {
+                continue;
+            }
+
+            if (variance == GenericParameterAttributes.Contravariant
+                && IsAssignableByName(sourceArguments[i], targetArguments[i]))
+            {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
     }
 
     private static bool IsConstructedGenericWithTypeBuilderArgument(Type type)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2523NullableIncludeInferencePipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2523NullableIncludeInferencePipelineTests.cs
@@ -72,7 +72,7 @@ public sealed class Issue2523NullableIncludeInferencePipelineTests
             public sealed class Book
             {
                 public Conversion? Conversion { get; set; }
-                public List<Component> Components { get; set; } = [];
+                public ICollection<Component> Components { get; set; } = [];
                 public Other? Other { get; set; }
             }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2536ObservableExtensionsPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2536ObservableExtensionsPipelineTests.cs
@@ -63,6 +63,7 @@ public sealed class Issue2536ObservableExtensionsPipelineTests
         File.WriteAllText(contractsProject, ProjectFile(null));
         File.WriteAllText(Path.Combine(contractsDirectory, "Contracts.cs"), """
             using System.Collections.Generic;
+            using System.IO;
 
             namespace Issue2536.Contracts;
 
@@ -74,6 +75,12 @@ public sealed class Issue2536ObservableExtensionsPipelineTests
             public interface IModels : IReadOnlyCollection<Model>
             {
             }
+
+            public static class StreamExtensions
+            {
+                public static long Remaining(this Stream stream) =>
+                    stream.Length - stream.Position;
+            }
             """);
 
         string consumerDirectory = Path.Combine(sourceRoot, "Consumer");
@@ -81,12 +88,28 @@ public sealed class Issue2536ObservableExtensionsPipelineTests
         string consumerProject = Path.Combine(consumerDirectory, "Consumer.csproj");
         File.WriteAllText(consumerProject, ProjectFile("../Contracts/Contracts.csproj"));
         File.WriteAllText(Path.Combine(consumerDirectory, "Repro.cs"), """
+            using System;
             using System.Collections.Generic;
             using System.Collections.ObjectModel;
+            using System.IO;
             using System.Linq;
             using Issue2536.Contracts;
+            using Microsoft.AspNetCore.Builder;
+            using Microsoft.AspNetCore.Http;
+            using Microsoft.Extensions.DependencyInjection;
 
             namespace Issue2536.Consumer;
+
+            public sealed class LocalModel
+            {
+                public int Value { get; set; }
+            }
+
+            public sealed class LocalStream : MemoryStream { }
+            public sealed class Factory
+            {
+                public Func<Model> Create { get; } = () => new Model();
+            }
 
             public static class Repro
             {
@@ -101,6 +124,27 @@ public sealed class Issue2536ObservableExtensionsPipelineTests
 
                 public static Model? FirstOrDefault(IModels items) =>
                     items.FirstOrDefault();
+
+                public static bool LocalAny(ObservableCollection<LocalModel> items) =>
+                    items.Any(item => item.Value > 0);
+
+                public static int LocalCount(ObservableCollection<LocalModel> items) =>
+                    items.Count(item => item.Value > 0);
+
+                public static IEnumerable<LocalModel> LocalWhere(ObservableCollection<LocalModel> items) =>
+                    items.Where(item => item.Value > 0);
+
+                public static LocalModel? LocalFirstOrDefault(ObservableCollection<LocalModel> items) =>
+                    items.FirstOrDefault();
+
+                public static IServiceCollection Register(IServiceCollection services, Factory factory) =>
+                    services.AddSingleton(_ => factory.Create());
+
+                public static IApplicationBuilder Use(IApplicationBuilder app) =>
+                    app.Use(async (context, next) => await next(context));
+
+                public static long StreamBase(LocalStream stream) =>
+                    stream.Remaining();
             }
             """);
 
@@ -122,7 +166,10 @@ public sealed class Issue2536ObservableExtensionsPipelineTests
               <PropertyGroup>
                 <TargetFramework>net10.0</TargetFramework>
                 <Nullable>enable</Nullable>
-              </PropertyGroup>{reference}
+              </PropertyGroup>
+              <ItemGroup>
+                <FrameworkReference Include="Microsoft.AspNetCore.App" />
+              </ItemGroup>{reference}
             </Project>
             """;
     }


### PR DESCRIPTION
## Summary
- preserve symbolic generic inference through inherited interfaces and base classes
- apply generic variance and nested delegate compatibility during imported extension overload resolution
- cover ObservableCollection LINQ, EF Include/ThenInclude, DI AddSingleton, ASP.NET Use, and imported Stream extensions through SDK-backed regressions

## Oahu validation
- reproduced cycle-4 diagnostics first on main@5acd4068
- rebased and reran the exact affected Oahu projects on latest main@944604a
- Oahu.UI ObservableCollection Where/Any/Count/FirstOrDefault: 0 target diagnostics
- Oahu.Core Include/ThenInclude: 0 target diagnostics
- Oahu.Cli.Server AddSingleton/Use: 0 target diagnostics
- Oahu.Decrypt Stream extensions: 0 target diagnostics

## Tests
- full Core.Tests passed locally
- full Cs2Gs.Tests: 1,687 passed locally
- focused SDK-backed extension/EF pipelines: 2 passed
- final CI: build, cs2gs, e2e, VS/VS Code extensions all green

Deferred work: none.

Fixes #2536