### PR TITLE
Fix generic async result preservation

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -402,7 +402,7 @@ internal sealed class MemberLookup
         // recovers the member-bearing user `Shape` symbol.
         if (type is ImportedTypeSymbol importedSym
             && importedSym.OpenDefinition != null
-            && importedSym.HasSubstitutableTypeArgument)
+            && !importedSym.TypeArguments.IsDefaultOrEmpty)
         {
             if (importedSym.OpenDefinition.FullName == "System.Collections.Generic.IAsyncEnumerable`1"
                 && importedSym.TypeArguments.Length == 1)
@@ -423,6 +423,12 @@ internal sealed class MemberLookup
                     elementType = MapOpenClrTypeToSymbolic(iface.GetGenericArguments()[0], importedSym);
                     return true;
                 }
+            }
+
+            if (TryResolveClrPatternAsyncEnumerator(importedSym.OpenDefinition, out _, out _, out var openCurrentMember))
+            {
+                elementType = MapOpenClrTypeToSymbolic(GetClrMemberValueType(openCurrentMember), importedSym);
+                return true;
             }
         }
 
@@ -1160,15 +1166,39 @@ internal sealed class MemberLookup
             return null;
         }
 
+        if (openReturn.IsGenericType && !openReturn.IsGenericTypeDefinition)
+        {
+            var openReturnDefinition = openReturn.GetGenericTypeDefinition();
+            var fullName = openReturnDefinition.FullName;
+            if (fullName is "System.Threading.Tasks.Task`1"
+                or "System.Threading.Tasks.ValueTask`1"
+                or "System.Collections.Generic.IAsyncEnumerable`1")
+            {
+                var openArguments = openReturn.GetGenericArguments();
+                var projectedArguments = ImmutableArray.CreateBuilder<TypeSymbol>(openArguments.Length);
+                foreach (var argument in openArguments)
+                {
+                    projectedArguments.Add(MapOpenClrTypeToSymbolic(
+                        argument,
+                        receiverOpenDef,
+                        receiverTypeArgs,
+                        openMethod,
+                        symbolicMethodTypeArgs));
+                }
+
+                var symbolicArguments = projectedArguments.MoveToImmutable();
+                var erasedObject = ResolveErasedObjectInContext(openReturnDefinition);
+                var closedReturn = TryBuildErasedClosedGeneric(
+                    openReturnDefinition,
+                    openReturnDefinition.GetGenericArguments(),
+                    symbolicArguments,
+                    erasedObject) ?? openReturn;
+                return ImportedTypeSymbol.GetConstructed(closedReturn, openReturnDefinition, symbolicArguments);
+            }
+        }
+
         var mapped = MapOpenClrTypeToSymbolic(openReturn, receiverOpenDef, receiverTypeArgs, openMethod, symbolicMethodTypeArgs);
 
-        // Issue #833 surfaces the override when the projection still contains an
-        // in-scope type parameter. Issue #903 extends this to same-compilation
-        // user element types: when the receiver is e.g. `List[Check]` and
-        // `Check` is a struct/class still being compiled, the closed CLR method
-        // erased `TSource` to `object`, so a generic return like `Single() →
-        // TSource` would otherwise surface as `object` and lose the `Check`
-        // identity (breaking `net.Id`). The symbolic projection recovers it.
         return TypeSymbol.RequiresSymbolicProjection(mapped)
             ? mapped
             : null;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
@@ -45,6 +45,39 @@ internal sealed partial class OverloadResolver
         return false;
     }
 
+    private bool TryResolveImplicitInheritedTypeArguments(
+        TypeArgumentListSyntax typeArgumentList,
+        out Type[] clrTypeArguments,
+        out ImmutableArray<TypeSymbol> typeArgumentSymbols)
+    {
+        clrTypeArguments = null;
+        typeArgumentSymbols = default;
+        if (typeArgumentList == null)
+        {
+            return true;
+        }
+
+        clrTypeArguments = new Type[typeArgumentList.Arguments.Count];
+        var symbols = ImmutableArray.CreateBuilder<TypeSymbol>(typeArgumentList.Arguments.Count);
+        for (var i = 0; i < typeArgumentList.Arguments.Count; i++)
+        {
+            var symbol = bindTypeClause(typeArgumentList.Arguments[i]);
+            if (symbol == null)
+            {
+                return false;
+            }
+
+            symbols.Add(symbol);
+            var clrType = NullableLifting.GetEffectiveClrType(symbol);
+            clrTypeArguments[i] = clrType != null
+                ? binderCtx.References.MapClrTypeToReferences(clrType)
+                : binderCtx.References.GetCoreType("System.Object");
+        }
+
+        typeArgumentSymbols = symbols.MoveToImmutable();
+        return true;
+    }
+
     /// <summary>
     /// Issue #1159: returns the implicit-<c>this</c> parameter that an
     /// unqualified instance-member reference should bind against. For a direct
@@ -556,9 +589,17 @@ internal sealed partial class OverloadResolver
                 // inherited from a metadata base reached through one or more
                 // G#-defined base classes resolves — matching the qualified
                 // `this.Method(...)` path and G#-defined-base behavior.
+                if (!TryResolveImplicitInheritedTypeArguments(
+                    syntax.TypeArgumentList,
+                    out var inheritedClrTypeArgs,
+                    out var inheritedTypeArgSymbols))
+                {
+                    return new BoundErrorExpression(null);
+                }
+
                 var implicitBaseClr = ExpressionBinder.GetInheritedClrBaseType(implicitReceiverStruct) ?? typeof(object);
                 var implicitReceiverExpr = new BoundVariableExpression(null, effThis);
-                if (tryBindInheritedClrInstanceCall(implicitReceiverExpr, implicitBaseClr, syntax.Identifier.Text, boundArguments.ToImmutable(), syntax, out var implicitInheritedCall, null, default, argumentNames, allowProtectedInherited: true))
+                if (tryBindInheritedClrInstanceCall(implicitReceiverExpr, implicitBaseClr, syntax.Identifier.Text, boundArguments.ToImmutable(), syntax, out var implicitInheritedCall, inheritedClrTypeArgs, inheritedTypeArgSymbols, argumentNames, allowProtectedInherited: true))
                 {
                     return implicitInheritedCall;
                 }

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -697,9 +697,9 @@ public sealed class Lowerer : BoundTreeRewriter
         // `valueVariable` (Shape) — even though the runtime tolerates the
         // reference. Synthesize a symbolic `IAsyncEnumerator[Shape]` so
         // the BoundClrPropertyAccessExpression carries the user's `Shape`,
-        // mirroring the synchronous symbolic-open path. This symbolic
-        // recovery only applies to the interface fast path — the pattern
-        // fallback's `enumeratorClr` always carries a concrete CLR type.
+        // mirroring the synchronous symbolic-open path. Pattern-based
+        // wrappers can be erased too, so recover their open enumerator and
+        // Current shapes through the stream's symbolic arguments.
         TypeSymbol enumeratorType;
         TypeSymbol currentType;
         if (stream.Type is ImportedTypeSymbol streamImp
@@ -714,6 +714,26 @@ public sealed class Lowerer : BoundTreeRewriter
                 typeof(System.Collections.Generic.IAsyncEnumerator<>),
                 ImmutableArray.Create<TypeSymbol>(elementSym));
             currentType = elementSym;
+        }
+        else if (stream.Type is ImportedTypeSymbol patternImp
+            && patternImp.OpenDefinition != null
+            && !patternImp.TypeArguments.IsDefaultOrEmpty
+            && MemberLookup.TryResolveClrPatternAsyncEnumerator(
+                patternImp.OpenDefinition,
+                out var openGetAsyncEnumerator,
+                out _,
+                out var openCurrentMember))
+        {
+            enumeratorType = MemberLookup.MapOpenClrTypeToSymbolic(openGetAsyncEnumerator.ReturnType, patternImp);
+            var openCurrentType = openCurrentMember switch
+            {
+                System.Reflection.PropertyInfo property => property.PropertyType,
+                System.Reflection.FieldInfo field => field.FieldType,
+                _ => null,
+            };
+            currentType = openCurrentType == null
+                ? valueVariable.Type
+                : MemberLookup.MapOpenClrTypeToSymbolic(openCurrentType, patternImp);
         }
         else
         {

--- a/test/Compiler.Tests/Emit/Issue2601GenericAsyncResultsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2601GenericAsyncResultsEmitTests.cs
@@ -1,0 +1,255 @@
+// <copyright file="Issue2601GenericAsyncResultsEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2601: generic async-enumerable elements and imported
+/// <c>Task&lt;T&gt;</c> results must survive binding and emission.
+/// </summary>
+public class Issue2601GenericAsyncResultsEmitTests
+{
+    [Fact]
+    public void AwaitFor_ConfiguredAsyncEnumerable_UserElement_Runs()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class JobUpdate { var Value int32 = 0 }
+
+            async func Updates() IAsyncEnumerable[JobUpdate] {
+                var update = JobUpdate()
+                update.Value = 7
+                yield update
+            }
+
+            async func Run() {
+                await for update in Updates().ConfigureAwait(false) {
+                    Console.WriteLine(update.Value)
+                }
+            }
+
+            Run().Wait()
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Await_ImportedGenericInstanceTaskOfNullable_Runs()
+    {
+        const string HelperSource = """
+            using System.Threading.Tasks;
+
+            namespace ImportedAsync;
+
+            public class Dialog
+            {
+                public Task<T> ShowDialog<T>(object owner) =>
+                    Task.FromResult((T)(object)(bool?)true);
+            }
+            """;
+        var source = """
+            package P
+            import System
+            import ImportedAsync
+
+            class Wizard : Dialog {
+                init() {}
+
+                async func Run() {
+                    let result = await ShowDialog[bool?]("owner")
+                    Console.WriteLine(result == true)
+                }
+            }
+
+            Wizard().Run().Wait()
+            """;
+
+        Assert.Equal("True\n", CompileAndRun(source, HelperSource));
+    }
+
+    [Fact]
+    public void Await_NonGenericTask_StillCannotInitializeValue()
+    {
+        var diagnostics = CompileForDiagnostics("""
+            import System.Threading.Tasks
+
+            async func Run() {
+                let result = await Task.CompletedTask
+            }
+            """);
+
+        Assert.Contains("GS0124", diagnostics);
+    }
+
+    [Fact]
+    public void AwaitFor_GenericNonEnumerable_StillDiagnoses()
+    {
+        var diagnostics = CompileForDiagnostics("""
+            import System.Threading.Tasks
+
+            async func Run() {
+                await for value in Task.FromResult[int32](1) {
+                }
+            }
+            """);
+
+        Assert.Contains("GS0134", diagnostics);
+    }
+
+    private static string CompileAndRun(string source, string helperSource = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2601_").FullName;
+        try
+        {
+            var helperPath = helperSource == null
+                ? null
+                : BuildHelper(tempDir, helperSource);
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = CompilerArguments(srcPath, outPath, helperPath);
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousErr);
+            }
+
+            Assert.True(exitCode == 0, $"compile failed:\n{compileOut}\n{compileErr}");
+            IlVerifier.Verify(
+                outPath,
+                helperPath == null ? null : new[] { helperPath },
+                helperPath == null ? new[] { "StackUnexpected" } : null);
+
+            var process = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            process.ArgumentList.Add("exec");
+            process.ArgumentList.Add("--runtimeconfig");
+            process.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            process.ArgumentList.Add(outPath);
+
+            using var child = Process.Start(process);
+            var stdout = child.StandardOutput.ReadToEnd();
+            var stderr = child.StandardError.ReadToEnd();
+            Assert.True(child.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(child.ExitCode == 0, $"exited {child.ExitCode}\n{stderr}");
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private static string CompileForDiagnostics(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2601_negative_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousErr = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(CompilerArguments(srcPath, outPath, helperPath: null).ToArray());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousErr);
+            }
+
+            Assert.NotEqual(0, exitCode);
+            return stdout.ToString() + stderr;
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private static List<string> CompilerArguments(string sourcePath, string outputPath, string helperPath)
+    {
+        var args = new List<string>
+        {
+            "/out:" + outputPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+        };
+        if (helperPath != null)
+        {
+            args.Add("/r:" + helperPath);
+        }
+
+        args.Add(sourcePath);
+        return args;
+    }
+
+    private static string BuildHelper(string directory, string source)
+    {
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(File.Exists)
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "ImportedAsync",
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var path = Path.Combine(directory, "ImportedAsync.dll");
+        using var stream = File.Create(path);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return path;
+    }
+}


### PR DESCRIPTION
## Summary
- preserve explicit generic arguments on unqualified inherited CLR calls, retaining `Task<T>` await results
- project generic pattern-based async enumerators through binding and lowering so `await for` keeps its element type
- add compile/runtime regressions plus non-value and non-enumerable negatives

## Oahu cycle-4 evidence
Using the exact generated `Oahu.App.gsproj` and `Oahu.Cli.App.gsproj` with this compiler:
- `SetupWizardWindow.axaml.gs:23` no longer reports GS0124 for `await ShowDialog[bool?](owner)`
- `JobScheduler.gs:159,232,233` no longer report object-to-`JobUpdate` GS0155
- `JsonlHistoryStore.gs:83` no longer reports object-to-`JobRecord` GS0155
- the projects continue to report unrelated migration diagnostics

## Validation
- `dotnet build GSharp.sln -c Release --no-restore --nologo` (0 warnings, 0 errors)
- full `Core.Tests`: 6,606 passed, 1 skipped
- 26 related Compiler emit tests passed
- 25 related Core binding tests passed
- 4 new issue tests passed (2 runtime positives, 2 diagnostic negatives)

Fixes #2601