### PR TITLE
Fix translated record parameterless construction

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2281NonConstantRecordInitializerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2281NonConstantRecordInitializerTests.cs
@@ -3,10 +3,13 @@
 // </copyright>
 
 using System;
+using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Pipeline;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
 using Xunit;
@@ -127,6 +130,169 @@ namespace Demo
         Assert.DoesNotContain("let DownloadDirectory", printed);
     }
 
+    [Fact]
+    public void PropertyBodiedRecords_KeepTheirSynthesizedParameterlessConstruction()
+    {
+        string printed = TranslateUnit(@"
+namespace Oahu.Cli.App
+{
+    public sealed record LibraryFilter
+    {
+        public string? Search { get; init; }
+        public string? Author { get; init; }
+        public string? Series { get; init; }
+        public bool AvailableOnly { get; init; } = true;
+    }
+
+    public sealed record OahuConfig
+    {
+        public int Sequence { get; init; } = Next();
+        public int MaxParallelJobs { get; init; } = 1;
+        public bool KeepEncryptedFiles { get; init; }
+
+        private static int Next() => 42;
+        public static OahuConfig Default => new();
+    }
+
+    public static class Uses
+    {
+        public static LibraryFilter Filter() => new();
+    }
+}");
+
+        Assert.Contains(
+            "data class LibraryFilter(Search string? = default(string?), Author string? = default(string?), Series string? = default(string?), AvailableOnly bool = true)",
+            printed);
+        Assert.Contains("MaxParallelJobs int32 = 1, KeepEncryptedFiles bool = default(bool)", printed);
+        Assert.Contains("public let Sequence int32 =", printed);
+        Assert.Contains("prop Default OahuConfig -> OahuConfig()", printed);
+        Assert.Contains("func Filter() LibraryFilter -> LibraryFilter()", printed);
+    }
+
+    [Fact]
+    public async Task OahuCliAppShapes_ParameterlessConstruction_CompilesAndPreservesRuntimeDefaults()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null ||
+            repoRoot is null ||
+            GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectDirectory = Path.Combine(sourceRoot, "Oahu.Cli.App");
+        Directory.CreateDirectory(projectDirectory);
+        string projectPath = Path.Combine(projectDirectory, "Oahu.Cli.App.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDirectory, "Program.cs"), """
+            using System;
+            using System.Collections.Generic;
+            using System.Text.Json;
+
+            namespace Oahu.Cli.App.Paths
+            {
+                public static class CliPaths
+                {
+                    private static int calls;
+                    public static string DefaultDownloadDir => (++calls).ToString();
+                }
+            }
+
+            namespace Oahu.Cli.App.Models
+            {
+                using Oahu.Cli.App.Paths;
+
+                public enum DownloadQuality { Low, Medium, High }
+
+                public sealed record OahuConfig
+                {
+                    public string DownloadDirectory { get; init; } = CliPaths.DefaultDownloadDir;
+                    public DownloadQuality DefaultQuality { get; init; } = DownloadQuality.High;
+                    public int MaxParallelJobs { get; init; } = 1;
+                    public bool KeepEncryptedFiles { get; init; }
+                    public bool MultiPartDownload { get; init; }
+                    public bool ExportToAax { get; init; }
+                    public string ExportDirectory { get; init; } = "";
+                    public string? DefaultProfileAlias { get; init; }
+                    public string? Theme { get; init; }
+                    public bool AllowEncryptedFileCredentials { get; init; }
+                    public Dictionary<string, JsonElement>? ExtraProperties { get; init; }
+                    public static OahuConfig Default => new();
+                }
+            }
+
+            namespace Oahu.Cli.App.Library
+            {
+                public sealed record LibraryFilter
+                {
+                    public string? Search { get; init; }
+                    public string? Author { get; init; }
+                    public string? Series { get; init; }
+                    public bool AvailableOnly { get; init; } = true;
+                }
+            }
+
+            namespace Oahu.Cli.App
+            {
+                using Oahu.Cli.App.Library;
+                using Oahu.Cli.App.Models;
+
+                public static class Program
+                {
+                    public static void Main()
+                    {
+                        OahuConfig first = new();
+                        OahuConfig second = OahuConfig.Default;
+                        LibraryFilter filter = new();
+
+                        Console.WriteLine(first.DownloadDirectory);
+                        Console.WriteLine(second.DownloadDirectory);
+                        Console.WriteLine(first.DefaultQuality == DownloadQuality.High);
+                        Console.WriteLine(first.MaxParallelJobs);
+                        Console.WriteLine(first.KeepEncryptedFiles);
+                        Console.WriteLine(first.ExtraProperties is null);
+                        Console.WriteLine(filter.Search is null);
+                        Console.WriteLine(filter.AvailableOnly);
+                    }
+                }
+            }
+            """);
+
+        string stdoutGolden = Path.Combine(sourceRoot, "baseline.stdout.golden");
+        File.WriteAllText(stdoutGolden, "1\n2\nTrue\n1\nFalse\nTrue\nTrue\nTrue\n");
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp(
+            "Oahu.Cli.App",
+            projectPath,
+            TargetKind.Exe,
+            stdoutGolden: stdoutGolden);
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[] { new TranslateStage(), new CompileStage(), new TestParityStage() });
+
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+        Assert.True(
+            appResult.Succeeded,
+            "Exact Oahu.Cli.App record shapes should translate, compile, and preserve runtime defaults. Stages: " +
+                string.Join("; ", appResult.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+    }
+
     // Note: a `data struct` (record struct) counterpart of the non-constant-
     // initializer scenario above is not independently testable — C# itself
     // (CS8983) rejects a struct with ANY auto-property/field initializer that
@@ -157,5 +323,42 @@ namespace Demo
             "Translated G# must round-trip. Errors:\n" +
                 string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
         return printed;
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2281",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirectoryName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirectoryName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
     }
 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -1425,8 +1425,10 @@ public sealed partial class CSharpToGSharpTranslator
         /// no positional primary-constructor parameters and no explicit instance
         /// constructor to conflict with (checked by the caller) — every eligible
         /// auto-property becomes one primary-constructor parameter, in
-        /// declaration order, with the property's inline initializer (if any)
-        /// carried over as the parameter's default value. Bails (returns
+        /// declaration order, with the property's inline initializer carried
+        /// over as the parameter's default value. A property without an
+        /// initializer receives <c>default(T)</c>, matching the value assigned
+        /// by C#'s synthesized parameterless record constructor. Bails (returns
         /// <see cref="ConstructorLift.None"/>) if any auto-property participates
         /// in an interface/override contract (OD-T1): a G# primary-constructor
         /// parameter is not a property, so lifting it would break the contract
@@ -1510,7 +1512,7 @@ public sealed partial class CSharpToGSharpTranslator
 
                 GExpression defaultValue = prop.Initializer != null
                     ? this.TranslateExpression(prop.Initializer.Value)
-                    : null;
+                    : new DefaultValueExpression(type);
 
                 primaryParameters.Add(new Parameter(SanitizeIdentifier(prop.Identifier.Text), type, defaultValue: defaultValue));
                 propertiesAsParams.Add(propSymbol);


### PR DESCRIPTION
## Summary
- give lifted record properties without C# initializers typed `default(T)` constructor defaults
- preserve nonconstant property initializers as per-instance data-class body fields
- cover exact `LibraryFilter()` and `OahuConfig()` shapes through SDK compile and stdout runtime parity

## Exact reproduction before the fix
On current `main` (`5c3718b0`), the Oahu.Cli.App migration reported:
- `GS0144: Function 'LibraryFilter' requires 4 arguments but was given 0.` (CoreLibraryService.gs and FakeLibraryService.gs)
- `GS0144: Function 'OahuConfig' requires 10 arguments but was given 0.` (Models/OahuConfig.gs)

## Proof
- exact post-fix Oahu.Cli.App pipeline: translation passed; compile failures dropped from 16 to 14; neither named GS0144 remains
- issue regression + SDK compile/runtime parity: 6/6
- related record/default suites: 15/15
- full Cs2Gs.Tests: 1694/1695 in one run; the sole failure was a transient package-file sharing IOException and passed 3/3 on immediate focused retry
- commit contains the required `Copilot-Session` trailer and no co-author trailer

Fixes #2281
