### PR TITLE
Fixes #1283: generalize implicit conversion application

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -532,7 +532,11 @@ public sealed class Conversion
                 return Conversion.None;
             }
 
-            if (from == toNullable.UnderlyingType)
+            // Issue #1283 cycle 5: imports in separate source files can mint
+            // distinct symbols for the same referenced CLR type. Compare the
+            // bare source with the nullable underlying through the ordinary
+            // identity classifier instead of reference equality.
+            if (ClassifyNonStructural(from, toNullable.UnderlyingType).IsIdentity)
             {
                 return Conversion.Implicit;
             }

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -516,29 +516,7 @@ internal sealed class ConversionClassifier
             // ClrType during binding, so resolve them symbolically first.
             if (TryResolveUserDefinedSymbolConversion(expression.Type, type, allowExplicit, out var userConvOp))
             {
-                var converted = userConvOp.Parameters.Length == 1
-                    ? BindConversion(diagnosticLocation, expression, userConvOp.Parameters[0].Type, allowExplicit)
-                    : expression;
-                return new BoundCallExpression(null, userConvOp, ImmutableArray.Create(converted));
-            }
-
-            // Issue #1283: lifted user-defined conversion to a nullable target.
-            // When the target is `U?` and the source `T` has a user-defined
-            // op_Implicit (or op_Explicit at an explicit position) producing the
-            // underlying `U`, apply the operator and then nullable-wrap the
-            // result (`U` -> `U?`). The recursive BindConversion call performs
-            // the standard nullable-wrap; it cannot recurse into a second
-            // user-defined operator because the produced value already has type
-            // `U`, the nullable's underlying type.
-            if (type is NullableTypeSymbol nullableTarget
-                && nullableTarget.UnderlyingType != expression.Type
-                && TryResolveUserDefinedSymbolConversion(expression.Type, nullableTarget.UnderlyingType, allowExplicit, out var liftedConvOp))
-            {
-                var liftedArg = liftedConvOp.Parameters.Length == 1
-                    ? BindConversion(diagnosticLocation, expression, liftedConvOp.Parameters[0].Type, allowExplicit)
-                    : expression;
-                var producedUnderlying = new BoundCallExpression(null, liftedConvOp, ImmutableArray.Create(liftedArg));
-                return BindConversion(diagnosticLocation, producedUnderlying, type, allowExplicit);
+                return BindUserDefinedSymbolConversion(diagnosticLocation, expression, type, userConvOp, allowExplicit);
             }
 
             // Stream E: fall back to a user-defined op_Implicit (and
@@ -590,10 +568,7 @@ internal sealed class ConversionClassifier
         {
             if (TryResolveUserDefinedSymbolConversion(expression.Type, type, allowExplicit, out var projectionUserConvOp))
             {
-                var converted = projectionUserConvOp.Parameters.Length == 1
-                    ? BindConversion(diagnosticLocation, expression, projectionUserConvOp.Parameters[0].Type, allowExplicit)
-                    : expression;
-                return new BoundCallExpression(null, projectionUserConvOp, ImmutableArray.Create(converted));
+                return BindUserDefinedSymbolConversion(diagnosticLocation, expression, type, projectionUserConvOp, allowExplicit);
             }
 
             if (expression.Type?.ClrType != null && type?.ClrType != null
@@ -1059,7 +1034,12 @@ internal sealed class ConversionClassifier
             && argument.Type != TypeSymbol.Error
             && TryResolveUserDefinedSymbolConversion(argument.Type, expectedType, allowExplicit: false, out var userConvOp))
         {
-            converted = new BoundCallExpression(null, userConvOp, ImmutableArray.Create(argument));
+            converted = BindUserDefinedSymbolConversion(
+                argument.Syntax?.Location ?? default,
+                argument,
+                expectedType,
+                userConvOp,
+                allowExplicit: false);
             return true;
         }
 
@@ -2008,8 +1988,12 @@ internal sealed class ConversionClassifier
     /// same-package struct/class as a static <c>op_Implicit</c> /
     /// <c>op_Explicit</c> method. Searches both the source and target type's
     /// static methods, preferring implicit conversions over explicit ones, just
-    /// like C#. These symbols have no reflectible CLR type during binding, so
-    /// the lookup is symbolic.
+    /// like C#. A candidate is applicable when standard implicit conversions
+    /// reach its operand and leave its result; this admits numeric/reference
+    /// adaptation and nullable result lifting without chaining user operators.
+    /// Ambiguous candidate sets are rejected rather than depending on member
+    /// declaration order. These symbols have no reflectible CLR type during
+    /// binding, so the lookup is symbolic.
     /// </summary>
     /// <param name="sourceType">The type of the value being converted.</param>
     /// <param name="targetType">The type being converted to.</param>
@@ -2025,11 +2009,15 @@ internal sealed class ConversionClassifier
             return false;
         }
 
-        // Pass 1: implicit conversions on the source then the target type.
-        if (TryFindUserConversion(sourceType, "op_Implicit", sourceType, targetType, out method)
-            || TryFindUserConversion(targetType, "op_Implicit", sourceType, targetType, out method))
+        var foundImplicit = TryFindUserConversion(
+            sourceType,
+            targetType,
+            "op_Implicit",
+            out method,
+            out var ambiguousImplicit);
+        if (foundImplicit || ambiguousImplicit)
         {
-            return true;
+            return foundImplicit;
         }
 
         if (!allowExplicit)
@@ -2037,37 +2025,124 @@ internal sealed class ConversionClassifier
             return false;
         }
 
-        // Pass 2: explicit conversions on the source then the target type.
-        return TryFindUserConversion(sourceType, "op_Explicit", sourceType, targetType, out method)
-            || TryFindUserConversion(targetType, "op_Explicit", sourceType, targetType, out method);
+        return TryFindUserConversion(sourceType, targetType, "op_Explicit", out method, out _);
     }
 
-    private static bool TryFindUserConversion(TypeSymbol declaring, string opName, TypeSymbol source, TypeSymbol target, out FunctionSymbol method)
+    private static bool TryFindUserConversion(
+        TypeSymbol source,
+        TypeSymbol target,
+        string opName,
+        out FunctionSymbol method,
+        out bool ambiguous)
     {
         method = null;
-        var owner = (declaring as StructSymbol)?.Definition ?? declaring as StructSymbol;
-        if (owner == null || owner.StaticMethods.IsDefaultOrEmpty)
+        ambiguous = false;
+        var candidates = new List<(FunctionSymbol Method, int SourceRank, int TargetRank)>();
+        CollectUserConversions(GetUserConversionOwner(source), opName, source, target, candidates);
+        CollectUserConversions(GetUserConversionOwner(target), opName, source, target, candidates);
+        if (candidates.Count == 0)
         {
             return false;
+        }
+
+        var best = new List<FunctionSymbol>();
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            var dominated = false;
+            for (var j = 0; j < candidates.Count; j++)
+            {
+                if (i == j)
+                {
+                    continue;
+                }
+
+                var other = candidates[j];
+                var candidate = candidates[i];
+                if (other.SourceRank <= candidate.SourceRank
+                    && other.TargetRank <= candidate.TargetRank
+                    && (other.SourceRank < candidate.SourceRank || other.TargetRank < candidate.TargetRank))
+                {
+                    dominated = true;
+                    break;
+                }
+            }
+
+            if (!dominated)
+            {
+                best.Add(candidates[i].Method);
+            }
+        }
+
+        if (best.Count != 1)
+        {
+            ambiguous = best.Count > 1;
+            return false;
+        }
+
+        method = best[0];
+        return true;
+    }
+
+    private static StructSymbol GetUserConversionOwner(TypeSymbol type)
+    {
+        while (type is NullableTypeSymbol nullable)
+        {
+            type = nullable.UnderlyingType;
+        }
+
+        return (type as StructSymbol)?.Definition ?? type as StructSymbol;
+    }
+
+    private static void CollectUserConversions(
+        StructSymbol owner,
+        string opName,
+        TypeSymbol source,
+        TypeSymbol target,
+        List<(FunctionSymbol Method, int SourceRank, int TargetRank)> candidates)
+    {
+        if (owner == null || owner.StaticMethods.IsDefaultOrEmpty)
+        {
+            return;
         }
 
         foreach (var candidate in owner.StaticMethods)
         {
             if (!string.Equals(candidate.Name, opName, StringComparison.Ordinal)
-                || candidate.Parameters.Length != 1)
+                || candidate.Parameters.Length != 1
+                || candidates.Any(c => ReferenceEquals(c.Method, candidate)))
             {
                 continue;
             }
 
-            if (Conversion.Classify(candidate.Parameters[0].Type, source).IsIdentity
-                && Conversion.Classify(candidate.Type, target).IsIdentity)
+            var sourceConversion = Conversion.ClassifyNonStructural(source, candidate.Parameters[0].Type);
+            var targetConversion = Conversion.ClassifyNonStructural(candidate.Type, target);
+            if (!sourceConversion.Exists || !sourceConversion.IsImplicit
+                || !targetConversion.Exists || !targetConversion.IsImplicit)
             {
-                method = candidate;
-                return true;
+                continue;
             }
-        }
 
-        return false;
+            candidates.Add((
+                candidate,
+                sourceConversion.IsIdentity ? 0 : 1,
+                targetConversion.IsIdentity ? 0 : 1));
+        }
+    }
+
+    private BoundExpression BindUserDefinedSymbolConversion(
+        TextLocation diagnosticLocation,
+        BoundExpression expression,
+        TypeSymbol targetType,
+        FunctionSymbol method,
+        bool allowExplicit)
+    {
+        var operand = BindConversion(
+            diagnosticLocation,
+            expression,
+            method.Parameters[0].Type,
+            allowExplicit: false);
+        var call = new BoundCallExpression(null, method, ImmutableArray.Create(operand));
+        return BindConversion(diagnosticLocation, call, targetType, allowExplicit);
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Compiler.Tests.csproj
+++ b/test/Compiler.Tests/Compiler.Tests.csproj
@@ -15,6 +15,7 @@
          ADR-0027 is unaffected. -->
     <ProjectReference Include="..\..\tools\gsgen\Gsgen.Cli\Gsgen.Cli.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageReference Include="Spectre.Console" Version="0.55.2" />
   </ItemGroup>
 
 </Project>

--- a/test/Compiler.Tests/Emit/Issue1283ImplicitConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1283ImplicitConversionEmitTests.cs
@@ -22,6 +22,68 @@ namespace GSharp.Compiler.Tests.Emit;
 public class Issue1283ImplicitConversionEmitTests
 {
     [Fact]
+    public void ExactOahuCliTui_StyleNullableAndSemanticColorSites_CompileWithoutGS0155()
+    {
+        var semanticColor = """
+            package Oahu.Cli.Tui.Tokens
+            import Spectre.Console
+
+            data struct SemanticColor(Value Color) {
+                func operator implicit(c SemanticColor) Color {
+                    return c.Value
+                }
+                func operator implicit(c SemanticColor) Style {
+                    return Style(c.Value)
+                }
+            }
+            """;
+        var sites = """
+            package Oahu.Cli.Tui.Widgets
+            import Spectre.Console
+            import Oahu.Cli.Tui.Tokens
+
+            class ConversionSites {
+                var fill Style?
+
+                func TakeNullable(fill Style?) {}
+                func TakeStyle(fill Style) {}
+
+                func ReturnNullable(fill Style) Style? {
+                    return fill
+                }
+
+                func PreserveNullable(fill Style?) Style? {
+                    let copy Style? = fill
+                    this.fill = fill
+                    this.TakeNullable(fill)
+                    return copy
+                }
+
+                func ReturnStyle(color SemanticColor) Style {
+                    return color
+                }
+
+                func Apply(fill Style, color SemanticColor) {
+                    let nullable Style? = fill
+                    this.fill = fill
+                    this.TakeNullable(fill)
+                    let style Style = color
+                    this.TakeStyle(color)
+                }
+            }
+            """;
+
+        var spectrePath = typeof(Spectre.Console.Style).Assembly.Location;
+        CompileAndVerify(
+            new[] { semanticColor, sites },
+            new[]
+            {
+                spectrePath,
+                Path.Combine(Path.GetDirectoryName(spectrePath)!, "Spectre.Console.Ansi.dll"),
+            });
+    }
+
+    [Fact]
     public void InBodyImplicit_AppliedAtEveryTargetTypedPosition_EmitsAndRuns()
     {
         var source = """
@@ -111,7 +173,7 @@ public class Issue1283ImplicitConversionEmitTests
 
     private static string CompileAndRun(string source)
     {
-        var tempDir = Directory.CreateTempSubdirectory("gs_issue1283_emit_").FullName;
+        var tempDir = CreateTestDirectory();
         try
         {
             var srcPath = Path.Combine(tempDir, "test.gs");
@@ -181,5 +243,68 @@ public class Issue1283ImplicitConversionEmitTests
         {
             try { Directory.Delete(tempDir, recursive: true); } catch { }
         }
+    }
+
+    private static void CompileAndVerify(string[] sources, string[] references)
+    {
+        var workDir = CreateTestDirectory();
+        try
+        {
+            var outPath = Path.Combine(workDir, "test.dll");
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var reference in references)
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            for (var i = 0; i < sources.Length; i++)
+            {
+                var sourcePath = Path.Combine(workDir, $"source{i}.gs");
+                File.WriteAllText(sourcePath, sources[i]);
+                args.Add(sourcePath);
+            }
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            var diagnostics = compileOut.ToString() + compileErr;
+            Assert.True(exitCode == 0, diagnostics);
+            Assert.DoesNotContain("GS0155", diagnostics, StringComparison.Ordinal);
+            IlVerifier.Verify(outPath, references);
+        }
+        finally
+        {
+            try { Directory.Delete(workDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CreateTestDirectory()
+    {
+        var root = Path.Combine(Environment.CurrentDirectory, "TestArtifacts");
+        Directory.CreateDirectory(root);
+        var path = Path.Combine(root, "gs_issue1283_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/ConversionOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ConversionOperatorTests.cs
@@ -236,6 +236,77 @@ var m Meters = 5
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
     }
 
+    [Fact]
+    public void ImplicitConversion_AppliesStandardConversionsBeforeAndAfterOperator()
+    {
+        var source = @"
+struct Meters {
+    var value int64
+    func operator implicit (n int64) Meters {
+        return Meters{value: n}
+    }
+}
+
+struct Count {
+    var value int32
+    func operator implicit (c Count) int32 {
+        return c.value
+    }
+}
+
+func make(n int32) Meters {
+    return n
+}
+
+func takeMeters(m Meters) int64 {
+    return m.value
+}
+
+func takeLong(n int64) int64 {
+    return n
+}
+
+func returnLong(c Count) int64 {
+    return c
+}
+
+let n int32 = 5
+let assigned Meters = n
+let passed = takeMeters(n)
+let returned = make(n).value
+let count = Count{value: 7}
+let widened int64 = count
+let widenedArgument = takeLong(count)
+let widenedReturn = returnLong(count)
+let lifted int64? = count
+var total = assigned.value + passed + returned + widened + widenedArgument + widenedReturn
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(36L, result.Value);
+    }
+
+    [Fact]
+    public void ImplicitConversion_AmbiguousStandardAdaptations_DoNotPickDeclarationOrder()
+    {
+        var source = @"
+struct Target {
+    var selected int32
+    func operator implicit (n int64) Target {
+        return Target{selected: 1}
+    }
+    func operator implicit (n float64) Target {
+        return Target{selected: 2}
+    }
+}
+
+let n int32 = 5
+let target Target = n
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
## Summary

- applies same-compilation user-defined implicit operators when standard implicit conversions adapt the operand and/or result
- folds nullable target lifting into the same one-operator path and preserves imported CLR identity for `T -> T?`
- rejects unresolved ties instead of selecting the first declared operator
- reproduces the exact Oahu.Cli.Tui `Style`/`Style?` and `SemanticColor`/`Style` assignment, argument, and return sites against Spectre.Console

## Post-fix proof

`ExactOahuCliTui_StyleNullableAndSemanticColorSites_CompileWithoutGS0155` compiles two Oahu packages against the real Spectre.Console 0.55.2 types, asserts no GS0155, and IL-verifies the result. Binding coverage additionally executes generalized pre/post conversions at assignment, argument, and return positions, verifies `Count -> int32 -> int64?` lifting, and confirms ambiguous operators remain rejected.

## Validation

- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --no-restore` — 6,617 passed, 1 skipped
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-restore --filter 'FullyQualifiedName~Issue1283|FullyQualifiedName~Conversion'` — 86 passed
- `dotnet build GSharp.sln -c Release` — 0 warnings, 0 errors

Fixes #1283
