### PR TITLE
Fix dotted namespace-qualified static resolution

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -61,6 +61,21 @@ internal sealed partial class ExpressionBinder
             return qualifiedClrLiteral;
         }
 
+        // Resolve an exact CLR namespace/type path before the flat source-type
+        // fallback below can select an unrelated same-simple-name source type.
+        if (!syntax.IsNullConditional
+            && !QualifiedAccessStartsWithValue(syntax)
+            && syntax.LeftPart is NameExpressionSyntax qualifiedClrRoot
+            && syntax.RightPart is not NameExpressionSyntax)
+        {
+            ExpressionSyntax qualifiedClrMember = syntax.RightPart;
+            if (TryBindFullyQualifiedClrStaticAccess(
+                qualifiedClrRoot, ref qualifiedClrMember, out var qualifiedClrType))
+            {
+                return BindAccessorStep(null, qualifiedClrType, qualifiedClrMember);
+            }
+        }
+
         // A same-compilation SOURCE type constructed/referenced through a
         // package-qualified name — `Oahu.Decrypt.Mp4Operation(...)`,
         // `Oahu.Decrypt.Mp4Operation[TResult](...)`. Source types are visible by

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2585SemanticQualificationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2585SemanticQualificationTests.cs
@@ -79,6 +79,76 @@ public sealed class Issue2585SemanticQualificationTests
     }
 
     [Fact]
+    public void FullyQualifiedImportedStaticMember_SelectsTypeDespiteSourceHomonym()
+    {
+        Assert.Empty(Bind(
+            """
+            package Oahu.Core.Ex
+
+            class JsonExtensions {
+            }
+            """,
+            """
+            package Oahu.Audible.Json
+            import Oahu.Aux.Extensions
+
+            func Read() int32 {
+                return Oahu.Aux.Extensions.JsonExtensions.Options
+            }
+            """));
+    }
+
+    [Fact]
+    public void FullyQualifiedSourceStaticMember_SelectsMatchingPackage()
+    {
+        Assert.Empty(Bind(
+            """
+            package Target
+
+            class JsonExtensions {
+                shared {
+                    let Options int32 = 1
+                }
+            }
+            """,
+            """
+            package Other
+
+            class JsonExtensions {
+            }
+            """,
+            """
+            package Consumer
+
+            func Read() int32 {
+                return Target.JsonExtensions.Options
+            }
+            """));
+    }
+
+    [Fact]
+    public void FullyQualifiedImportedStaticMember_UnknownMemberRemainsDiagnosed()
+    {
+        Assert.Contains(
+            Bind(
+                """
+                package Oahu.Core.Ex
+
+                class JsonExtensions {
+                }
+                """,
+                """
+                package Consumer
+                import Oahu.Aux.Extensions
+
+                func Read() int32 {
+                    return Oahu.Aux.Extensions.JsonExtensions.Missing
+                }
+                """),
+            diagnostic => diagnostic.Id == "GS0158");
+    }
+
+    [Fact]
     public void ImportedGenericCompositeLiteral_ResolvesClosedType()
     {
         Assert.Empty(Bind("""
@@ -215,6 +285,14 @@ public sealed class Issue2585SemanticQualificationTests
                 public sealed class SelectList<T>
                 {
                     public T Value { get; set; }
+                }
+            }
+
+            namespace Oahu.Aux.Extensions
+            {
+                public static class JsonExtensions
+                {
+                    public static int Options => 1;
                 }
             }
             """;

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2585SemanticQualificationPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2585SemanticQualificationPipelineTests.cs
@@ -14,6 +14,48 @@ namespace Cs2Gs.Tests;
 public sealed class Issue2585SemanticQualificationPipelineTests
 {
     [Fact]
+    public async Task Pipeline_OahuCoreQualifiedJsonOptions_WithTypeHomonymCompiles()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("oahu-core-projects");
+        string coreProject = WriteOahuCoreFixture(sourceRoot);
+        string outputRoot = NewDirectory("oahu-core-pipeline");
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+
+        RunResult result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("corpus/Oahu.Core", coreProject, TargetKind.Library),
+        });
+
+        var app = Assert.Single(result.Apps);
+        Assert.True(
+            app.Succeeded,
+            app.AppId + " should compile. Stages: " +
+                string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+
+        string output = ReadOutput(outputRoot, result.RunId, "corpus/Oahu.Core");
+        Assert.Contains(
+            "Oahu.Aux.Extensions.JsonExtensions.Options",
+            output,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Pipeline_NestedNamespacesAndEventLambda_PreserveSemanticRootsAndCompile()
     {
         string compiler = FindSiblingTool("Compiler", "gsc.dll");
@@ -231,6 +273,49 @@ public sealed class Issue2585SemanticQualificationPipelineTests
             """);
 
         return (appProject, tuiProject);
+    }
+
+    private static string WriteOahuCoreFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+
+        string foundationDirectory = Path.Combine(sourceRoot, "Oahu.Foundation");
+        Directory.CreateDirectory(foundationDirectory);
+        string foundationProject = Path.Combine(foundationDirectory, "Oahu.Foundation.csproj");
+        File.WriteAllText(foundationProject, ProjectFile(null));
+        File.WriteAllText(Path.Combine(foundationDirectory, "JsonExtensions.cs"), """
+            namespace Oahu.Aux.Extensions;
+
+            public static class JsonExtensions
+            {
+                public static object Options => new();
+            }
+            """);
+
+        string coreDirectory = Path.Combine(sourceRoot, "Oahu.Core");
+        Directory.CreateDirectory(coreDirectory);
+        string coreProject = Path.Combine(coreDirectory, "Oahu.Core.csproj");
+        File.WriteAllText(coreProject, ProjectFile("../Oahu.Foundation/Oahu.Foundation.csproj"));
+        File.WriteAllText(Path.Combine(coreDirectory, "ExtensionsVarious.cs"), """
+            namespace Oahu.Core.Ex;
+
+            public static class JsonExtensions
+            {
+                public static bool ValidateJson(string json) => json is not null;
+            }
+            """);
+        File.WriteAllText(Path.Combine(coreDirectory, "Serialization.cs"), """
+            using Oahu.Aux.Extensions;
+
+            namespace Oahu.Audible.Json;
+
+            public abstract class Serialization<T>
+            {
+                private static object Options { get; } = JsonExtensions.Options;
+            }
+            """);
+
+        return coreProject;
     }
 
     private static string ProjectFile(string projectReference)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -1646,6 +1646,15 @@ public sealed partial class CSharpToGSharpTranslator
                 node.Initializer.Value,
                 this.TranslateNullSeamExpression(node.Initializer.Value, symbol?.ContainingType));
 
+            if (symbol != null)
+            {
+                initializer = this.ForgiveNullableReferenceValue(
+                    node.Initializer.Value,
+                    initializer,
+                    symbol.Type,
+                    symbol);
+            }
+
             // Issue #1072: a non-nullable reference static auto-property whose
             // initializer is nullable (e.g. `GetAttribute<...>()?.Member`) is
             // rendered `T?` so the initializer assignment type-checks.


### PR DESCRIPTION
## Summary
- resolve exact namespace-qualified CLR static receivers before flat source-type fallback can select a same-simple-name source type
- preserve non-null static auto-property initialization from oblivious referenced assemblies
- cover the Oahu.Core `Oahu.Aux.Extensions.JsonExtensions.Options` shape, source/import homonyms, and unknown-member/source-resolution negatives

## Oahu.Core proof
Before the fix, the exact cycle-5 migration reported `GS0158` at `Models/Serialization.gs` for `Oahu.Aux.Extensions.JsonExtensions.Options`.

After the fix, the same Oahu.Core source resolves that dotted receiver and the exact GS0158 is absent. The SDK-backed `corpus/Oahu.Core` regression reproduces the duplicate `JsonExtensions` names across the Core and Foundation assemblies and compiles green.

## Testing
- `dotnet build GSharp.sln -c Release --no-restore`
- issue #2585 + qualified-source negative controls: 19 passed
- Oahu.Core SDK-backed pipeline regressions: 2 passed
- Core.Tests: 6,618 passed, 1 skipped
- Cs2Gs.Tests: 1,694 passed
- LanguageServer.Tests: 450 passed
- Interpreter.Tests: 427 passed
- SDK/Extensions/analyzer/generator-host suites: 182 passed

Fixes #2585