### PR TITLE
Fix iterator getter return-flow diagnostics

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1935,7 +1935,9 @@ public sealed class Binder
             binder.statements.FinalizeUserLabels();
             var lowered = Lowerer.Lower(body);
 
-            if (requireAllPathsReturn && !ControlFlowGraph.AllPathsReturn(lowered))
+            if (requireAllPathsReturn
+                && !IsIteratorReturnType(accessor.Type)
+                && !ControlFlowGraph.AllPathsReturn(lowered))
             {
                 binder.Diagnostics.ReportAllPathsMustReturn(bodySyntax.OpenBraceToken.Location);
             }
@@ -1984,7 +1986,9 @@ public sealed class Binder
             binder.statements.FinalizeUserLabels();
             var lowered = Lowerer.Lower(body, structSym);
 
-            if (allPathsReturnLocation != null && !ControlFlowGraph.AllPathsReturn(lowered))
+            if (allPathsReturnLocation != null
+                && !IsIteratorReturnType(member.Type)
+                && !ControlFlowGraph.AllPathsReturn(lowered))
             {
                 binder.Diagnostics.ReportAllPathsMustReturn(allPathsReturnLocation.Value);
             }

--- a/test/Compiler.Tests/Emit/Issue2619IteratorGetterReturnFlowTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2619IteratorGetterReturnFlowTests.cs
@@ -1,0 +1,148 @@
+// <copyright file="Issue2619IteratorGetterReturnFlowTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public class Issue2619IteratorGetterReturnFlowTests
+{
+    [Fact]
+    public void ExhaustiveIteratorGetters_EmitAndRun()
+    {
+        const string Source = """
+            package Oahu.Cli.Tui.Screens
+
+            import System.Collections.Generic
+
+            class LibraryScreen {
+                private var searchMode bool
+                private var queueServiceFactory object?
+
+                init(searchMode bool, queueServiceFactory object?) {
+                    this.searchMode = searchMode
+                    this.queueServiceFactory = queueServiceFactory
+                }
+
+                prop Hints IEnumerable[KeyValuePair[string, string?]] {
+                    get {
+                        if searchMode {
+                            yield KeyValuePair[string, string?]("Enter", "search")
+                            yield KeyValuePair[string, string?]("Esc", "cancel")
+                        } else {
+                            yield KeyValuePair[string, string?]("/", "search")
+                            yield KeyValuePair[string, string?]("↑↓", "navigate")
+                            yield KeyValuePair[string, string?]("PgUp/Dn", "page")
+                            yield KeyValuePair[string, string?]("Space", "select")
+                            yield KeyValuePair[string, string?]("a", "select all")
+                            if queueServiceFactory != nil {
+                                yield KeyValuePair[string, string?]("q", "enqueue")
+                            }
+                        }
+                    }
+                }
+            }
+
+            class SwitchValues {
+                private var value int32
+
+                init(value int32) {
+                    this.value = value
+                }
+
+                prop Values sequence[int32] {
+                    get {
+                        switch value {
+                            case 0 {
+                                yield 10
+                            }
+                            default {
+                                yield 20
+                            }
+                        }
+                    }
+                }
+            }
+
+            public var hintCount = 0
+            for hint in LibraryScreen(true, nil).Hints {
+                hintCount = hintCount + 1
+            }
+            for hint in LibraryScreen(false, "queue").Hints {
+                hintCount = hintCount + 1
+            }
+
+            public var switchSum = 0
+            for value in SwitchValues(0).Values {
+                switchSum = switchSum + value
+            }
+            for value in SwitchValues(1).Values {
+                switchSum = switchSum + value
+            }
+            """;
+
+        var assembly = CompileAndRun(Source);
+
+        Assert.Equal(8, GetField(assembly, "hintCount"));
+        Assert.Equal(30, GetField(assembly, "switchSum"));
+    }
+
+    [Fact]
+    public void IncompleteOrdinaryGetter_StillReportsGs0100()
+    {
+        const string Source = """
+            package Issue2619.Incomplete
+
+            class C {
+                private var condition bool
+
+                prop Value int32 {
+                    get {
+                        if condition {
+                            return 1
+                        }
+                    }
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(SourceText.From(Source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0100");
+    }
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            string.Join(Environment.NewLine, result.Diagnostics.Select(diagnostic => diagnostic.ToString())));
+
+        var assembly = Assembly.Load(peStream.ToArray());
+        var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+        return assembly;
+    }
+
+    private static int GetField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+        return (int)program.GetField(name, BindingFlags.Public | BindingFlags.Static)!.GetValue(null)!;
+    }
+}


### PR DESCRIPTION
## Summary
- exempt iterator property accessors from ordinary value-return fallthrough analysis, matching iterator functions and methods
- apply the rule to class/struct and default-interface accessor binding paths
- preserve GS0100 for genuinely incomplete non-iterator getters

## Exact Oahu.Cli.Tui proof
Before the fix, the translated `Oahu.Cli.Tui.Screens.LibraryScreen.Hints` getter — `IEnumerable[KeyValuePair[string, string?]]` with exhaustive search/non-search branches and nested queue availability — reported GS0100 at `get {`.

After the fix, that exact getter shape emits and runs. A second exhaustive switch-based iterator getter also emits and runs, while an ordinary getter with a real fallthrough still reports GS0100.

## Testing
- issue #2619 targeted flow/runtime tests: 2 passed
- Core.Tests: 6,615 passed, 1 skipped
- Cs2Gs.Tests: 1,693 passed
- LanguageServer.Tests: 450 passed
- Interpreter.Tests: 427 passed
- SDK/Extensions/analyzer/generator-host suites: 182 passed

Fixes #2619