### PR TITLE
Fix nullable reference sink forgiveness

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityPipelineTests.cs
@@ -54,6 +54,7 @@ public sealed class Issue2579NullableReferenceFidelityPipelineTests
         Assert.Contains("Holder(model.Name!!)", emitted, StringComparison.Ordinal);
         Assert.Contains("model.Children!![0]", emitted, StringComparison.Ordinal);
         Assert.Contains("for child in model.Children!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("ImageSink.Image = image!!", emitted, StringComparison.Ordinal);
         Assert.True(
             app.Succeeded,
             "Expected nullable-oblivious project-reference members to compile at strict G# " +
@@ -98,6 +99,14 @@ public sealed class Issue2579NullableReferenceFidelityPipelineTests
         Assert.Contains("Repro.Required = Factory.GetItem()!!", emitted, StringComparison.Ordinal);
         Assert.Contains("Factory.GetMap()!![Factory.GetKey()!!]", emitted, StringComparison.Ordinal);
         Assert.Contains("for item in Factory.GetItems()!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("yield line!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("return value!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("let RequiredPath string = Factory.GetKey()!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("return (value ?? Factory.GetKey())!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("probe = Path.GetDirectoryName(probe!!)!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("Value: (value ?? Factory.GetKey())!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("return number", emitted, StringComparison.Ordinal);
+        Assert.DoesNotContain("number!!", emitted, StringComparison.Ordinal);
         Assert.True(
             app.Succeeded,
             "Expected nullable-enabled consumers of nullable-disabled producers to compile via gsc. Stages: " +
@@ -261,6 +270,7 @@ public sealed class Issue2579NullableReferenceFidelityPipelineTests
             </Project>
             """);
         File.WriteAllText(Path.Combine(consumerDir, "Consumer.cs"), """
+            using System.IO;
             using ObliviousProducer;
 
             namespace Issue2579Oblivious;
@@ -274,6 +284,7 @@ public sealed class Issue2579NullableReferenceFidelityPipelineTests
             {
                 private static Item Required = new();
                 private static void Consume(Item item) { }
+                public static string RequiredPath { get; } = Factory.GetKey();
 
                 public static int Run()
                 {
@@ -286,6 +297,46 @@ public sealed class Issue2579NullableReferenceFidelityPipelineTests
                         _ = item.Name;
                     return Required.Name.Length;
                 }
+
+                public static IEnumerable<string> ReadLines(string? line)
+                {
+                    yield return line;
+                }
+
+                public static string Require(string? value)
+                {
+                    return value;
+                }
+
+                public static string RequireFallback(string? value)
+                {
+                    return value ?? Factory.GetKey();
+                }
+
+                public static string RewritePath(string path)
+                {
+                    var probe = path;
+                    while (!string.IsNullOrEmpty(probe) && !Directory.Exists(probe))
+                    {
+                        probe = Path.GetDirectoryName(probe);
+                    }
+                    return probe;
+                }
+
+                public static Holder Build(string? value)
+                {
+                    return new Holder { Value = value ?? Factory.GetKey() };
+                }
+
+                public static object Box(int? number)
+                {
+                    return number;
+                }
+            }
+
+            public sealed class Holder
+            {
+                public string Value { get; set; } = "";
             }
             """);
 
@@ -327,6 +378,17 @@ public sealed class Issue2579NullableReferenceFidelityPipelineTests
             {
                 public static string Echo(this string value) => value;
             }
+
+            public sealed class Bitmap
+            {
+            }
+
+            #nullable enable
+            public static class ImageSink
+            {
+                public static Bitmap Image { get; set; } = new();
+            }
+            #nullable restore
             """);
 
         string consumerProject = Path.Combine(consumerDir, "Consumer.csproj");
@@ -371,6 +433,11 @@ public sealed class Issue2579NullableReferenceFidelityPipelineTests
                     foreach (var child in model.Children)
                         _ = child.Name;
                     return local.Length;
+                }
+
+                public static void SetImage(Bitmap image = null)
+                {
+                    ImageSink.Image = image;
                 }
             }
             """);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -281,7 +281,7 @@ public sealed partial class CSharpToGSharpTranslator
             // captured or its mutation of `b` is silently dropped (issue #1723). The
             // walk is parenthesis-transparent (`a = (b = c)`) since a link's RHS may
             // be a parenthesized nested assignment.
-            var lefts = new List<(GExpression Target, string Op)>();
+            var lefts = new List<(GExpression Target, string Op, ExpressionSyntax Syntax)>();
             ExpressionSyntax current = assignment;
             TupleExpressionSyntax tupleLink = null;
             ExpressionSyntax tupleLinkRight = null;
@@ -310,7 +310,7 @@ public sealed partial class CSharpToGSharpTranslator
                     break;
                 }
 
-                lefts.Add((this.TranslateExpression(link.Left), link.OperatorToken.Text));
+                lefts.Add((this.TranslateExpression(link.Left), link.OperatorToken.Text, link.Left));
                 current = link.Right;
             }
 
@@ -370,6 +370,36 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 bool hasOuterLink = i > 0;
                 GExpression assignedValue = value;
+                if (lefts[i].Op == "=")
+                {
+                    ISymbol target = this.context.GetSymbolInfo(lefts[i].Syntax).Symbol;
+                    ITypeSymbol targetType = target switch
+                    {
+                        ILocalSymbol local => local.Type,
+                        IParameterSymbol parameter => parameter.Type,
+                        IFieldSymbol field => field.Type,
+                        IPropertySymbol property => property.Type,
+                        _ => this.context.GetTypeInfo(lefts[i].Syntax).Type,
+                    };
+                    ISymbol promotionTarget = target;
+                    if (target is ILocalSymbol inferredLocal
+                        && inferredLocal.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
+                            is VariableDeclaratorSyntax { Initializer.Value: { } initializer } declarator
+                        && declarator.Ancestors().OfType<VariableDeclarationSyntax>()
+                            .FirstOrDefault()?.Type.IsVar == true)
+                    {
+                        targetType = this.context.GetTypeInfo(initializer).Type;
+                        promotionTarget = null;
+                    }
+
+                    assignedValue = this.ForgiveNullableReferenceValue(
+                        current,
+                        assignedValue,
+                        targetType,
+                        promotionTarget,
+                        includePromotedValue: true);
+                }
+
                 if (hasOuterLink && lefts[i].Op == "=" && !valueIsShared)
                 {
                     // About to be assigned to more than one target — spill once

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -779,14 +779,18 @@ public sealed partial class CSharpToGSharpTranslator
             ExpressionSyntax value,
             GExpression translated,
             ITypeSymbol targetType,
-            ISymbol targetSymbol)
+            ISymbol targetSymbol,
+            bool includePromotedValue = false)
         {
             if (translated is NonNullAssertionExpression
                 || value is PostfixUnaryExpressionSyntax
                     { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
                 || this.IsWithinExpressionTreeLambda(value)
                 || !this.TargetWillRemainNonNullableReference(targetType, targetSymbol)
-                || !this.NullableReferenceValueMayBeNull(value))
+                || (!this.NullableReferenceValueMayBeNull(value)
+                    && !(includePromotedValue
+                        && this.IsObliviousCompilation()
+                        && this.IsNullablePromotedValue(value))))
             {
                 return translated;
             }
@@ -826,9 +830,27 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
-            return typeInfo.Nullability.FlowState == NullableFlowState.MaybeNull
+            bool nullableByShape = value switch
+            {
+                ParenthesizedExpressionSyntax parenthesized =>
+                    this.NullableReferenceValueMayBeNull(parenthesized.Expression),
+                CastExpressionSyntax cast =>
+                    this.NullableReferenceValueMayBeNull(cast.Expression),
+                ConditionalExpressionSyntax conditional =>
+                    this.NullableReferenceValueMayBeNull(conditional.WhenTrue)
+                        || this.NullableReferenceValueMayBeNull(conditional.WhenFalse),
+                SwitchExpressionSyntax switchExpression => switchExpression.Arms.Any(arm =>
+                    this.NullableReferenceValueMayBeNull(arm.Expression)),
+                BinaryExpressionSyntax coalesce
+                    when coalesce.IsKind(SyntaxKind.CoalesceExpression) =>
+                        this.NullableReferenceValueMayBeNull(coalesce.Right),
+                _ => false,
+            };
+
+            return nullableByShape
+                || (typeInfo.Nullability.FlowState == NullableFlowState.MaybeNull
                 && (type.NullableAnnotation == NullableAnnotation.Annotated
-                    || typeInfo.Nullability.Annotation == NullableAnnotation.Annotated);
+                    || typeInfo.Nullability.Annotation == NullableAnnotation.Annotated));
         }
 
         private (ITypeSymbol Type, ISymbol Symbol) FindContextualValueTarget(ExpressionSyntax value)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1521,11 +1521,11 @@ public sealed partial class CSharpToGSharpTranslator
                 return translatedValue;
             }
 
-            bool needsForgiveness =
-                (this.IsObliviousCompilation() && this.IsNullablePromotedValue(valueExpression))
-                || this.IsImportedObliviousNullableMember(this.context.GetSymbolInfo(valueExpression).Symbol);
-
-            return needsForgiveness ? new NonNullAssertionExpression(translatedValue) : translatedValue;
+            return (this.NullableReferenceValueMayBeNull(valueExpression)
+                    || (this.IsObliviousCompilation()
+                        && this.IsNullablePromotedValue(valueExpression)))
+                ? new NonNullAssertionExpression(translatedValue)
+                : translatedValue;
         }
 
         // Object-initializer member assignment (`Field = value` inside `T{ ... }`

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -729,6 +729,11 @@ public sealed partial class CSharpToGSharpTranslator
                     initializer = this.CoerceConstantToUnsigned(
                         declarator.Initializer.Value,
                         this.TranslateNullSeamExpression(declarator.Initializer.Value, symbol?.ContainingType));
+                    initializer = this.ForgiveNullableReferenceValue(
+                        declarator.Initializer.Value,
+                        initializer,
+                        symbol?.Type,
+                        symbol);
 
                     // Issue #1072: a non-nullable reference field whose initializer
                     // is nullable (e.g. `?.`-access) is rendered `T?`.
@@ -1645,6 +1650,11 @@ public sealed partial class CSharpToGSharpTranslator
             GExpression initializer = this.CoerceConstantToUnsigned(
                 node.Initializer.Value,
                 this.TranslateNullSeamExpression(node.Initializer.Value, symbol?.ContainingType));
+            initializer = this.ForgiveNullableReferenceValue(
+                node.Initializer.Value,
+                initializer,
+                symbol?.Type,
+                symbol);
 
             // Issue #1072: a non-nullable reference static auto-property whose
             // initializer is nullable (e.g. `GetAttribute<...>()?.Member`) is

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -1781,11 +1781,23 @@ public sealed partial class CSharpToGSharpTranslator
                             IPropertySymbol property => property.Type,
                             _ => this.context.GetTypeInfo(assignment.Left).Type,
                         };
+                        ISymbol promotionTarget = assignmentTarget;
+                        if (assignmentTarget is ILocalSymbol inferredAssignmentLocal
+                            && inferredAssignmentLocal.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
+                                is VariableDeclaratorSyntax { Initializer.Value: { } initializer } declarator
+                            && declarator.Ancestors().OfType<VariableDeclarationSyntax>()
+                                .FirstOrDefault()?.Type.IsVar == true)
+                        {
+                            assignmentTargetType = this.context.GetTypeInfo(initializer).Type;
+                            promotionTarget = null;
+                        }
+
                         assignRhs = this.ForgiveNullableReferenceValue(
                             assignment.Right,
                             assignRhs,
                             assignmentTargetType,
-                            assignmentTarget);
+                            promotionTarget,
+                            includePromotedValue: true);
                     }
 
                     return new AssignmentStatement(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -917,7 +917,7 @@ public sealed partial class CSharpToGSharpTranslator
                 return new[] { (GStatement)new GotoStatement(IteratorExitLabelName(target)) };
             }
 
-            return new[] { (GStatement)new YieldStatement(this.TranslateExpression(node.Expression)) };
+            return new[] { (GStatement)new YieldStatement(this.TranslateValueWithNullForgiveness(node.Expression)) };
         }
 
         private static SyntaxNode GetBreakTarget(YieldStatementSyntax node)


### PR DESCRIPTION
## Summary
- generalize target-aware nullable-reference forgiveness through assignments, field/property initializers, returns, object initializers, and yields
- recurse through conditional/coalesce sink values without broad receiver or argument over-forgiveness
- keep nullable value types strict (`int?` never receives reference `!!`)

## Exact Oahu cycle-5 validation

| Project / shape | Before | After |
|---|---|---|
| Oahu.Cli.App `GS0156 string? -> string` | 4 | 0 |
| Oahu.Cli `yield line` | `yield line` (2 sites) | `yield line!!` (2 sites) |
| Oahu.UI `Bitmap? -> Bitmap` | `ProfileImage = profileImage` | `ProfileImage = profileImage!!` |

The Oahu.Cli.App SDK compile fell from 16 diagnostics to 12; all four removed diagnostics were the targeted `GS0156` sinks. The 12 residual diagnostics are unrelated extension/member/delegate/default-argument gaps.

## Validation
- focused cycle-5 pipeline tests: 3 passed
- affected nullable regression set: 50 passed
- full `Cs2Gs.Tests`: 1693 passed
- full Release solution build: 0 warnings, 0 errors

Fixes #2579