### PR TITLE
Fix void tail-if expression contexts

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -750,10 +750,15 @@ internal sealed partial class ExpressionBinder
     /// are lowered to <see cref="BoundBlockExpression"/> wrapping the final value.
     /// </summary>
     private BoundExpression BindIfExpression(IfExpressionSyntax syntax)
-        => BindIfExpression(syntax, targetType: null);
+        => BindIfExpression(syntax, targetType: null, canBeVoid: false);
 
-    private BoundExpression BindIfExpression(IfExpressionSyntax syntax, TypeSymbol targetType)
+    private BoundExpression BindIfExpression(
+        IfExpressionSyntax syntax,
+        TypeSymbol targetType,
+        bool canBeVoid = false)
     {
+        // A tail if/else in a discarded lambda/statement position may have
+        // void call or await arms; value-producing contexts keep the default.
         // Issue #1238: defer a no-common-type unification failure when this
         // if-expression is a bare argument awaiting its parameter target type
         // (see BindConditionalExpression for the full rationale). Consume the
@@ -771,8 +776,8 @@ internal sealed partial class ExpressionBinder
 
         var condition = BindExpression(syntax.Condition, TypeSymbol.Bool);
 
-        var whenTrue = BindBlockExpressionValue(syntax.ThenBlock);
-        var whenFalse = BindIfExpressionElseBranch(syntax.ElseExpression);
+        var whenTrue = BindBlockExpressionValue(syntax.ThenBlock, canBeVoid);
+        var whenFalse = BindIfExpressionElseBranch(syntax.ElseExpression, canBeVoid);
 
         if (condition is BoundErrorExpression || whenTrue is BoundErrorExpression || whenFalse is BoundErrorExpression)
         {
@@ -817,16 +822,16 @@ internal sealed partial class ExpressionBinder
     /// Binds the else branch of an if-expression: either a nested if-expression
     /// (<c>else if</c> chain) or a block expression.
     /// </summary>
-    private BoundExpression BindIfExpressionElseBranch(ExpressionSyntax elseSyntax)
+    private BoundExpression BindIfExpressionElseBranch(ExpressionSyntax elseSyntax, bool canBeVoid = false)
     {
         if (elseSyntax is IfExpressionSyntax nestedIf)
         {
-            return BindIfExpression(nestedIf);
+            return BindIfExpression(nestedIf, targetType: null, canBeVoid: canBeVoid);
         }
 
         if (elseSyntax is BlockExpressionSyntax block)
         {
-            return BindBlockExpressionValue(block);
+            return BindBlockExpressionValue(block, canBeVoid);
         }
 
         // Should not happen from well-formed parse trees.
@@ -840,7 +845,7 @@ internal sealed partial class ExpressionBinder
     /// a <see cref="BoundBlockExpression"/> wrapping the prefix statements and
     /// the trailing value.
     /// </summary>
-    private BoundExpression BindBlockExpressionValue(BlockExpressionSyntax syntax)
+    private BoundExpression BindBlockExpressionValue(BlockExpressionSyntax syntax, bool canBeVoid = false)
     {
         if (syntax.Expression == null)
         {
@@ -851,7 +856,7 @@ internal sealed partial class ExpressionBinder
         // If there are no prefix statements, just bind the expression directly.
         if (syntax.Statements.IsDefaultOrEmpty)
         {
-            return BindExpression(syntax.Expression);
+            return BindExpression(syntax.Expression, canBeVoid);
         }
 
         // Bind prefix statements.
@@ -862,7 +867,7 @@ internal sealed partial class ExpressionBinder
             boundStatements.Add(boundStmt);
         }
 
-        var boundExpression = BindExpression(syntax.Expression);
+        var boundExpression = BindExpression(syntax.Expression, canBeVoid);
         if (boundExpression is BoundErrorExpression)
         {
             return boundExpression;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -286,7 +286,9 @@ internal sealed partial class ExpressionBinder
 
     internal BoundExpression BindExpression(ExpressionSyntax syntax, bool canBeVoid = false)
     {
-        var result = BindExpressionpublic(syntax);
+        // Issue #2620: discard context must reach wrappers and tail-if arms,
+        // not merely suppress the final void-result check.
+        var result = BindExpressionpublic(syntax, canBeVoid);
         if (!canBeVoid && result.Type == TypeSymbol.Void)
         {
             Diagnostics.ReportExpressionMustHaveValue(syntax.Location);
@@ -296,15 +298,15 @@ internal sealed partial class ExpressionBinder
         return result;
     }
 
-    private BoundExpression BindExpressionpublic(ExpressionSyntax syntax)
+    private BoundExpression BindExpressionpublic(ExpressionSyntax syntax, bool canBeVoid = false)
     {
         switch (syntax.Kind)
         {
             case SyntaxKind.ParenthesizedExpression:
-                return BindParenthesizedExpression((ParenthesizedExpressionSyntax)syntax);
+                return BindParenthesizedExpression((ParenthesizedExpressionSyntax)syntax, canBeVoid);
             case SyntaxKind.CheckedExpression:
             case SyntaxKind.UncheckedExpression:
-                return BindCheckedExpression((CheckedExpressionSyntax)syntax);
+                return BindCheckedExpression((CheckedExpressionSyntax)syntax, canBeVoid);
             case SyntaxKind.LiteralExpression:
                 return BindLiteralExpression((LiteralExpressionSyntax)syntax);
             case SyntaxKind.InterpolatedStringExpression:
@@ -402,7 +404,7 @@ internal sealed partial class ExpressionBinder
                 // before reaching this dispatch.
                 return BindConditionalExpression((ConditionalExpressionSyntax)syntax);
             case SyntaxKind.IfExpression:
-                return BindIfExpression((IfExpressionSyntax)syntax);
+                return BindIfExpression((IfExpressionSyntax)syntax, targetType: null, canBeVoid: canBeVoid);
             case SyntaxKind.ThrowExpression:
                 return BindThrowExpression((ThrowExpressionSyntax)syntax);
             case SyntaxKind.IndirectAssignmentExpression:
@@ -439,9 +441,9 @@ internal sealed partial class ExpressionBinder
         }
     }
 
-    private BoundExpression BindParenthesizedExpression(ParenthesizedExpressionSyntax syntax)
+    private BoundExpression BindParenthesizedExpression(ParenthesizedExpressionSyntax syntax, bool canBeVoid)
     {
-        return BindExpression(syntax.Expression);
+        return BindExpression(syntax.Expression, canBeVoid);
     }
 
     // Issue #1881: `checked(expr)` / `unchecked(expr)` binds the inner
@@ -449,10 +451,10 @@ internal sealed partial class ExpressionBinder
     // is needed (mirrors Roslyn: the context only steers which opcodes the
     // arithmetic/conversions inside pick). Innermost nesting wins via the
     // save/restore scope.
-    private BoundExpression BindCheckedExpression(CheckedExpressionSyntax syntax)
+    private BoundExpression BindCheckedExpression(CheckedExpressionSyntax syntax, bool canBeVoid)
     {
         using var scope = binderCtx.PushCheckedContext(syntax.IsChecked);
-        return BindExpression(syntax.Expression);
+        return BindExpression(syntax.Expression, canBeVoid);
     }
 
     private BoundExpression BindNameExpression(NameExpressionSyntax syntax)

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -705,10 +705,7 @@ public static class SpillSequenceSpiller
                 innerExpr = innerSpill.Value;
             }
 
-            // Create a spill temp for the await result.
-            var spillLocal = MakeSpillTemp(awaitExpr.Type);
             var awaitNode = new BoundAwaitExpression(null, innerExpr, awaitExpr.Type, awaitExpr.AwaiterTypeSymbol);
-            var assignStmt = new BoundVariableDeclaration(null, spillLocal, awaitNode);
 
             var locals = ImmutableArray.CreateBuilder<LocalVariableSymbol>();
             var sideEffects = ImmutableArray.CreateBuilder<BoundStatement>();
@@ -719,8 +716,20 @@ public static class SpillSequenceSpiller
                 sideEffects.AddRange(innerSpill.SideEffects);
             }
 
+            if (awaitExpr.Type == TypeSymbol.Void)
+            {
+                sideEffects.Add(new BoundExpressionStatement(null, awaitNode));
+                return new BoundSpillSequenceExpression(
+                    null,
+                    locals.ToImmutable(),
+                    sideEffects.ToImmutable(),
+                    new BoundLiteralExpression(null, 0, TypeSymbol.Void));
+            }
+
+            // Create a spill temp for a value-producing await result.
+            var spillLocal = MakeSpillTemp(awaitExpr.Type);
             locals.Add(spillLocal);
-            sideEffects.Add(assignStmt);
+            sideEffects.Add(new BoundVariableDeclaration(null, spillLocal, awaitNode));
 
             return new BoundSpillSequenceExpression(
                 null,
@@ -1218,7 +1227,8 @@ public static class SpillSequenceSpiller
                 condition = spilledCondition.Value;
             }
 
-            var resultLocal = MakeSpillTemp(conditional.Type);
+            var isVoid = conditional.Type == TypeSymbol.Void;
+            var resultLocal = isVoid ? null : MakeSpillTemp(conditional.Type);
             var elseLabel = MakeLabel();
             var endLabel = MakeLabel();
 
@@ -1229,9 +1239,17 @@ public static class SpillSequenceSpiller
             var spilledTrue = SpillExpression(conditional.WhenTrue);
             locals.AddRange(spilledTrue.Locals);
             sideEffects.AddRange(spilledTrue.SideEffects);
-            sideEffects.Add(new BoundExpressionStatement(
-                null,
-                new BoundAssignmentExpression(null, resultLocal, spilledTrue.Value)));
+            if (!isVoid)
+            {
+                sideEffects.Add(new BoundExpressionStatement(
+                    null,
+                    new BoundAssignmentExpression(null, resultLocal, spilledTrue.Value)));
+            }
+            else if (spilledTrue.Value is not BoundLiteralExpression)
+            {
+                sideEffects.Add(new BoundExpressionStatement(null, spilledTrue.Value));
+            }
+
             sideEffects.Add(new BoundGotoStatement(null, endLabel));
 
             // else: result = whenFalse (spilled — only runs if condition was false)
@@ -1239,12 +1257,28 @@ public static class SpillSequenceSpiller
             var spilledFalse = SpillExpression(conditional.WhenFalse);
             locals.AddRange(spilledFalse.Locals);
             sideEffects.AddRange(spilledFalse.SideEffects);
-            sideEffects.Add(new BoundExpressionStatement(
-                null,
-                new BoundAssignmentExpression(null, resultLocal, spilledFalse.Value)));
+            if (!isVoid)
+            {
+                sideEffects.Add(new BoundExpressionStatement(
+                    null,
+                    new BoundAssignmentExpression(null, resultLocal, spilledFalse.Value)));
+            }
+            else if (spilledFalse.Value is not BoundLiteralExpression)
+            {
+                sideEffects.Add(new BoundExpressionStatement(null, spilledFalse.Value));
+            }
 
             // end:
             sideEffects.Add(new BoundLabelStatement(null, endLabel));
+
+            if (isVoid)
+            {
+                return new BoundSpillSequenceExpression(
+                    null,
+                    locals.ToImmutable(),
+                    sideEffects.ToImmutable(),
+                    new BoundLiteralExpression(null, 0, TypeSymbol.Void));
+            }
 
             locals.Add(resultLocal);
 

--- a/test/Compiler.Tests/Emit/Issue2620VoidExpressionContextEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2620VoidExpressionContextEmitTests.cs
@@ -1,0 +1,210 @@
+// <copyright file="Issue2620VoidExpressionContextEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Issue #2620: discarded tail-if branches may produce <c>void</c>.</summary>
+public class Issue2620VoidExpressionContextEmitTests
+{
+    [Fact]
+    public void ExactOahuTailIfLambda_VoidCalls_EmitsAndRuns()
+    {
+        var source = """
+            package Oahu.Cli
+            import System
+
+            class CliEnvironment {
+                shared {
+                    private func RunRestore() {
+                        Console.WriteLine("restore")
+                    }
+
+                    func InstallExitTrap() Action[bool] {
+                        return (first bool) -> {
+                            if first {
+                                CliEnvironment.RunRestore()
+                            } else {
+                                CliEnvironment.RunRestore()
+                            }
+                        }
+                    }
+                }
+            }
+
+            let trap = CliEnvironment.InstallExitTrap()
+            trap(true)
+            trap(false)
+            """;
+
+        Assert.Equal("restore\nrestore\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void TailIfAsyncLambda_VoidAwaitAndCall_EmitAndRun()
+    {
+        var source = """
+            package P
+            import System
+            import System.Threading.Tasks
+
+            async func Step(label string) {
+                await Task.Yield()
+                Console.WriteLine(label)
+            }
+
+            let handler = async (first bool) -> {
+                if first {
+                    await Step("first")
+                } else {
+                    Console.WriteLine("second")
+                }
+            }
+
+            handler(true).GetAwaiter().GetResult()
+            handler(false).GetAwaiter().GetResult()
+            """;
+
+        Assert.Equal("first\nsecond\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void TailIfVoidCalls_UsedAsValue_StillReportGS0124()
+    {
+        var diagnostics = CompileDiagnostics("""
+            package P
+
+            func Restore() {
+            }
+
+            let result = if true { Restore() } else { Restore() }
+            """);
+
+        Assert.Equal(2, Count(diagnostics, "GS0124"));
+    }
+
+    [Fact]
+    public void VoidAwait_UsedAsValue_StillReportsGS0124()
+    {
+        var diagnostics = CompileDiagnostics("""
+            package P
+            import System.Threading.Tasks
+
+            async func Invalid() {
+                let result = await Task.CompletedTask
+            }
+            """);
+
+        Assert.Equal(1, Count(diagnostics, "GS0124"));
+    }
+
+    private static int Count(string text, string value)
+    {
+        var count = 0;
+        var start = 0;
+        while ((start = text.IndexOf(value, start, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            start += value.Length;
+        }
+
+        return count;
+    }
+
+    private static string CompileDiagnostics(string source)
+    {
+        string diagnostics = null;
+        WithCompilation(source, (exitCode, output, _) =>
+        {
+            Assert.NotEqual(0, exitCode);
+            diagnostics = output;
+        });
+        return diagnostics;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        string output = null;
+        WithCompilation(source, (exitCode, diagnostics, outputPath) =>
+        {
+            Assert.True(exitCode == 0, $"compile failed ({exitCode}): {diagnostics}");
+            IlVerifier.Verify(outputPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outputPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outputPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var process = Process.Start(psi)!;
+            output = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}: {stderr}");
+        });
+        return output?.Replace("\r\n", "\n");
+    }
+
+    private static void WithCompilation(string source, Action<int, string, string> verify)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2620_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(tempDir, "test.gs");
+            var outputPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    "/nowarn:GS9100",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            verify(exitCode, stdout.ToString() + stderr, outputPath);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- propagate discarded-expression context through wrappers and tail-if branches, allowing statement-position void calls without weakening value contexts
- lower nested void awaits as effects instead of creating illegal void spill locals
- add exact Oahu `CliEnvironment.RunRestore()` runtime coverage, mixed await/call runtime coverage, and GS0124 negatives

## Oahu cycle-5 evidence
- before: generated `Oahu.Cli/CliEnvironment.gs:122` reported GS0124 on `CliEnvironment.RunRestore()` in the tail `if/else` of the `CancelKeyPress` lambda
- after: rebuilding the exact generated `Oahu.Cli.gsproj` with this compiler reports no GS0124 (unrelated migration diagnostics remain)

## Validation
- 4 new issue tests passed (2 ILVerify/runtime positives, 2 diagnostic negatives)
- 30 related issue #2349/#1376/#1619/#2620 compiler tests passed
- 18 related Core binding/async tests passed
- full Core.Tests: 6,615 passed, 1 skipped
- Gsharp.Extensions build: 0 warnings, 0 errors; its 5 dependent compiler tests passed

Fixes #2620