### PR TITLE
Fix imported inherited event subscriptions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundClrEventSubscriptionExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrEventSubscriptionExpression.cs
@@ -26,7 +26,8 @@ public sealed class BoundClrEventSubscriptionExpression : BoundExpression
         BoundExpression handler,
         bool isAdd,
         TypeParameterSymbol constrainedReceiverTypeParameter = null,
-        TypeSymbol constrainedInterfaceType = null)
+        TypeSymbol constrainedInterfaceType = null,
+        TypeSymbol eventContainingType = null)
         : base(syntax)
     {
         Receiver = receiver;
@@ -35,6 +36,7 @@ public sealed class BoundClrEventSubscriptionExpression : BoundExpression
         IsAdd = isAdd;
         ConstrainedReceiverTypeParameter = constrainedReceiverTypeParameter;
         ConstrainedInterfaceType = constrainedInterfaceType;
+        EventContainingType = eventContainingType;
     }
 
     public BoundExpression Receiver { get; }
@@ -48,6 +50,8 @@ public sealed class BoundClrEventSubscriptionExpression : BoundExpression
     public TypeParameterSymbol ConstrainedReceiverTypeParameter { get; }
 
     public TypeSymbol ConstrainedInterfaceType { get; }
+
+    public TypeSymbol EventContainingType { get; }
 
     public bool IsConstrainedTypeParameterAccess => ConstrainedReceiverTypeParameter != null;
 

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1701,7 +1701,8 @@ public abstract class BoundTreeRewriter
             handler,
             node.IsAdd,
             node.ConstrainedReceiverTypeParameter,
-            node.ConstrainedInterfaceType);
+            node.ConstrainedInterfaceType,
+            node.EventContainingType);
     }
 
     /// <summary>Rewrites a user-defined event subscription expression (ADR-0052).</summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -73,6 +73,7 @@ internal sealed partial class ExpressionBinder
         // any value-producing expression with a CLR-backed type (instance event).
         BoundExpression boundReceiver = null;
         Type receiverClrType = null;
+        TypeSymbol importedEventTarget = null;
         BindingFlags flags;
 
         // Issue #2394: check the same-compilation SOURCE type (struct/
@@ -305,7 +306,16 @@ internal sealed partial class ExpressionBinder
                 }
             }
 
-            receiverClrType = boundReceiver.Type?.ClrType;
+            importedEventTarget = boundReceiver.Type;
+            receiverClrType = importedEventTarget?.ClrType;
+            if (receiverClrType == null
+                && boundReceiver.Type is StructSymbol sourceReceiver
+                && TypeMemberModel.GetNearestImportedBase(sourceReceiver) is TypeSymbol importedBase)
+            {
+                importedEventTarget = importedBase;
+                receiverClrType = importedBase.ClrType;
+            }
+
             if (receiverClrType == null)
             {
                 // Issue #648 (generalized by #2154): compound assignment fallback for
@@ -343,7 +353,11 @@ internal sealed partial class ExpressionBinder
             flags = BindingFlags.Public | BindingFlags.Instance;
         }
 
-        var eventInfo = isEventCapableOperator ? ClrTypeUtilities.SafeGetEvent(receiverClrType, eventName, flags) : null;
+        var eventInfo = isEventCapableOperator
+            ? boundReceiver != null
+                ? MemberLookup.SafeGetEventIncludingSelfAndInterfaces(receiverClrType, eventName)
+                : ClrTypeUtilities.SafeGetEvent(receiverClrType, eventName, flags)
+            : null;
         if (eventInfo == null)
         {
             // Issue #648 (generalized by #2154): compound assignment fallback for
@@ -364,7 +378,9 @@ internal sealed partial class ExpressionBinder
         }
 
         var handlerType = eventInfo.EventHandlerType;
-        var handlerTypeSymbol = TypeSymbol.FromClrType(handlerType);
+        var handlerTypeSymbol = importedEventTarget != null
+            ? MemberLookup.GetClrEventHandlerTypeSymbol(importedEventTarget, eventInfo)
+            : TypeSymbol.FromClrType(handlerType);
         var boundHandler = BindEventSubscriptionHandler(syntax.Value, handlerTypeSymbol);
 
         // The handler is most useful when expressed as a function literal of
@@ -388,7 +404,16 @@ internal sealed partial class ExpressionBinder
             convertedHandler = conversions.BindConversion(syntax.Value.Location, boundHandler, handlerTypeSymbol);
         }
 
-        return new BoundClrEventSubscriptionExpression(null, boundReceiver, eventInfo, convertedHandler, isAdd);
+        var eventContainingType = importedEventTarget == null
+            ? null
+            : MemberLookup.GetClrMemberDeclaringTypeSymbol(importedEventTarget, eventInfo);
+        return new BoundClrEventSubscriptionExpression(
+            null,
+            boundReceiver,
+            eventInfo,
+            convertedHandler,
+            isAdd,
+            eventContainingType: eventContainingType);
     }
 
     private bool EventReceiverNameCanBindAsType(

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -271,6 +271,32 @@ internal sealed class MemberLookup
         return null;
     }
 
+    /// <summary>Finds a public instance event on a CLR type or any implemented interface.</summary>
+    /// <param name="clrType">The CLR type to probe.</param>
+    /// <param name="name">The event name to match.</param>
+    /// <returns>The matching <see cref="EventInfo"/>, or <c>null</c>.</returns>
+    public static EventInfo SafeGetEventIncludingSelfAndInterfaces(Type clrType, string name)
+    {
+        if (clrType == null)
+        {
+            return null;
+        }
+
+        foreach (var type in EnumerateSelfAndInterfaces(clrType))
+        {
+            var eventInfo = ClrTypeUtilities.SafeGetEvent(
+                type,
+                name,
+                BindingFlags.Public | BindingFlags.Instance);
+            if (eventInfo != null)
+            {
+                return eventInfo;
+            }
+        }
+
+        return null;
+    }
+
     /// <summary>
     /// Issue #1181: collects the transitive closure of imported/BCL base
     /// interfaces declared on <paramref name="interfaceSymbol"/>. Delegates

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -545,7 +545,9 @@ internal sealed partial class MethodBodyEmitter
         else
         {
             this.il.OpCode(isStatic || receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
-            this.il.Token(this.outer.memberRefs.GetMethodReference(accessor));
+            this.il.Token(this.outer.memberRefs.GetMethodEntityHandle(
+                accessor,
+                subscription.EventContainingType));
         }
     }
 

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -527,7 +527,15 @@ public static class SpillSequenceSpiller
                         clrEventSub,
                         clrEventSub.Receiver,
                         clrEventSub.Handler,
-                        (recv, handler) => new BoundClrEventSubscriptionExpression(null, recv, clrEventSub.Event, handler, clrEventSub.IsAdd));
+                        (recv, handler) => new BoundClrEventSubscriptionExpression(
+                            null,
+                            recv,
+                            clrEventSub.Event,
+                            handler,
+                            clrEventSub.IsAdd,
+                            clrEventSub.ConstrainedReceiverTypeParameter,
+                            clrEventSub.ConstrainedInterfaceType,
+                            clrEventSub.EventContainingType));
                 case BoundEventSubscriptionExpression eventSub:
                     return SpillTwoOperand(
                         eventSub,

--- a/test/Compiler.Tests/Emit/Issue2615ImportedEventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2615ImportedEventEmitTests.cs
@@ -1,0 +1,207 @@
+// <copyright file="Issue2615ImportedEventEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Issue #2615: imported inherited events participate in access, binding, and emit.</summary>
+public sealed class Issue2615ImportedEventEmitTests
+{
+    private const string FixtureSource = """
+        using System.ComponentModel;
+
+        namespace OahuFixture;
+
+        public class ObservableObject : INotifyPropertyChanged
+        {
+            public event PropertyChangedEventHandler? PropertyChanged;
+
+            public void Raise(string name) =>
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+        """;
+
+    private const string OahuSource = """
+        package Oahu.Core.UI.Avalonia.ViewModels
+
+        import System
+        import System.ComponentModel
+        import OahuFixture
+
+        class BookItemViewModel : ObservableObject { }
+
+        class Probe {
+            var Hits int32
+
+            init() {
+                Hits = 0
+            }
+
+            func OnPropertyChanged(sender Object, e PropertyChangedEventArgs) {
+                Hits = Hits + 1
+            }
+
+            func Run() int32 {
+                let vm = BookItemViewModel()
+                vm.PropertyChanged += OnPropertyChanged
+                vm.Raise("IsSelected")
+                vm.PropertyChanged -= OnPropertyChanged
+                vm.Raise("Ignored")
+                return Hits
+            }
+        }
+        """;
+
+    [Fact]
+    public void ImportedInheritedPropertyChanged_AddRemove_Runs()
+    {
+        using var artifacts = Compile(OahuSource);
+        _ = Assembly.LoadFrom(artifacts.FixturePath);
+        var assembly = Assembly.LoadFrom(artifacts.OutputPath);
+        var probeType = assembly.GetType("Oahu.Core.UI.Avalonia.ViewModels.Probe");
+        var probe = Activator.CreateInstance(probeType!);
+
+        Assert.Equal(1, probeType!.GetMethod("Run")!.Invoke(probe, null));
+        IlVerifier.Verify(artifacts.OutputPath, additionalReferences: new[] { artifacts.FixturePath });
+    }
+
+    [Fact]
+    public void ImportedInheritedPropertyChanged_EmitsAddAndRemoveMemberReferences()
+    {
+        using var artifacts = Compile(OahuSource);
+        using var stream = File.OpenRead(artifacts.OutputPath);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var memberNames = reader.MemberReferences
+            .Select(handle => reader.GetString(reader.GetMemberReference(handle).Name))
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Contains("add_PropertyChanged", memberNames);
+        Assert.Contains("remove_PropertyChanged", memberNames);
+    }
+
+    [Fact]
+    public void MissingImportedInheritedEvent_RemainsGS0158()
+    {
+        var source = OahuSource.Replace("vm.PropertyChanged += OnPropertyChanged", "vm.Missing += OnPropertyChanged", StringComparison.Ordinal);
+        using var artifacts = Compile(source, expectSuccess: false);
+
+        Assert.NotEqual(0, artifacts.ExitCode);
+        Assert.Contains("GS0158", artifacts.Diagnostics, StringComparison.Ordinal);
+        Assert.Contains("Cannot find member Missing", artifacts.Diagnostics, StringComparison.Ordinal);
+    }
+
+    private static CompilationArtifacts Compile(string source, bool expectSuccess = true)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2615-artifacts",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        var fixturePath = Path.Combine(directory, "OahuFixture.dll");
+        EmitFixture(fixturePath);
+        var sourcePath = Path.Combine(directory, "BookLibraryViewModel.gs");
+        var outputPath = Path.Combine(directory, "Oahu.UI.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var (exitCode, stdout, stderr) = RunCompiler(new[]
+        {
+            "/out:" + outputPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            "/r:" + fixturePath,
+            "/nowarn:GS9100",
+            sourcePath,
+        });
+        if (expectSuccess)
+        {
+            Assert.True(exitCode == 0, $"gsc failed:\n{stdout}\n{stderr}");
+        }
+
+        return new CompilationArtifacts(directory, fixturePath, outputPath, exitCode, stdout + stderr);
+    }
+
+    private static void EmitFixture(string path)
+    {
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "OahuFixture",
+            new[] { CSharpSyntaxTree.ParseText(FixtureSource) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var result = compilation.Emit(path);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunCompiler(string[] args)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return (Program.Main(args), stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private sealed class CompilationArtifacts : IDisposable
+    {
+        public CompilationArtifacts(
+            string directory,
+            string fixturePath,
+            string outputPath,
+            int exitCode,
+            string diagnostics)
+        {
+            Directory = directory;
+            FixturePath = fixturePath;
+            OutputPath = outputPath;
+            ExitCode = exitCode;
+            Diagnostics = diagnostics;
+        }
+
+        public string Directory { get; }
+
+        public string FixturePath { get; }
+
+        public string OutputPath { get; }
+
+        public int ExitCode { get; }
+
+        public string Diagnostics { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                System.IO.Directory.Delete(Directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- resolve imported events through source-class metadata bases and CLR interfaces
- preserve symbolic event declaring types for add/remove member references
- cover exact Oahu.UI `INotifyPropertyChanged.PropertyChanged` access with runtime, metadata, and negative regressions

## Validation
- exact Oahu.UI-style repro: GS0158 before, clean emit after
- `Issue2615ImportedEventEmitTests`: 3 passed
- compiler event regressions: 96 passed
- Core.Tests: 6,615 passed, 1 skipped

Fixes #2615