### PR TITLE
Fix imported inherited instance lookup

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1385,6 +1385,13 @@ internal sealed partial class ExpressionBinder
             return typeof(object);
         }
 
+        // Issue #2614: a by-ref source type with no CLR identity still rides
+        // through the same erased CLR type as its pointee.
+        if (typeSymbol is ByRefTypeSymbol byRef)
+        {
+            return GetEffectiveArgumentClrTypeForOverloadResolution(byRef.PointeeType)?.MakeByRefType();
+        }
+
         // Issue #2182: a G# slice `[]T` whose element type has no CLR backing
         // (a generic type parameter, or another same-compilation user type)
         // has a null `ClrType`, so `GetEffectiveArgumentClrType` returned null

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -148,8 +148,9 @@ internal sealed class MemberLookup
     }
 
     /// <summary>
-    /// Enumerates every public instance method on <paramref name="clrType"/>
-    /// and its transitive implemented interfaces with the given <paramref name="name"/>.
+    /// Enumerates every public instance method on <paramref name="clrType"/>,
+    /// its base chain, and its transitive implemented interfaces with the given
+    /// <paramref name="name"/>.
     /// The overload-resolution-facing variant, used by call sites that need to
     /// pass a candidate set into <see cref="OverloadResolution.Resolve"/>.
     /// Hides base-method-with-same-signature shadowing the same way C# does
@@ -160,6 +161,18 @@ internal sealed class MemberLookup
     /// <returns>The candidate list with self-slot methods first.</returns>
     public static IReadOnlyList<MethodInfo> SafeGetMethodsIncludingSelfAndInterfaces(Type clrType, string name)
     {
+        static Type GetBaseTypeSafe(Type type)
+        {
+            try
+            {
+                return type.BaseType;
+            }
+            catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+            {
+                return null;
+            }
+        }
+
         if (clrType == null)
         {
             return Array.Empty<MethodInfo>();
@@ -186,6 +199,27 @@ internal sealed class MemberLookup
                 if (string.Equals(m.Name, n, StringComparison.Ordinal))
                 {
                     result.Add(m);
+                }
+            }
+
+            // Issue #2614: MetadataLoadContext can reject an aggregate
+            // GetMethods call when one derived signature has a missing
+            // dependency. Probe each declaration level independently so that
+            // usable methods on an otherwise loadable base are not hidden.
+            if (selfMethods.Length == 0)
+            {
+                for (var current = clrType; current != null; current = GetBaseTypeSafe(current))
+                {
+                    foreach (var m in ClrTypeUtilities.SafeGetMethods(
+                        current,
+                        BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                    {
+                        if (string.Equals(m.Name, n, StringComparison.Ordinal)
+                            && !IsMethodHiddenByExisting(result, m))
+                        {
+                            result.Add(m);
+                        }
+                    }
                 }
             }
 

--- a/test/Compiler.Tests/Emit/Issue2614ImportedInheritedInstanceMethodEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2614ImportedInheritedInstanceMethodEmitTests.cs
@@ -1,0 +1,81 @@
+// <copyright file="Issue2614ImportedInheritedInstanceMethodEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue2614ImportedInheritedInstanceMethodEmitTests
+{
+    [Fact]
+    public void ConcurrentQueueOfSourceType_TryDequeue_Runs()
+    {
+        const string source = """
+            import System
+            import System.Collections.Concurrent
+
+            class ModalRequest {
+                var Value int32 = 0
+            }
+
+            var queued = ModalRequest()
+            queued.Value = 2614
+            var queue = ConcurrentQueue[ModalRequest]()
+            queue.Enqueue(queued)
+            var request ModalRequest? = nil
+            if queue.TryDequeue(&request) {
+                Console.WriteLine(request!!.Value)
+            }
+            """;
+
+        Assert.Equal("2614\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue2614_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            Assert.Equal(0, exitCode);
+            IlVerifier.Verify(outputPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo);
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}\n{stderr}");
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2614ImportedInheritedInstanceMethodTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2614ImportedInheritedInstanceMethodTests.cs
@@ -1,0 +1,140 @@
+// <copyright file="Issue2614ImportedInheritedInstanceMethodTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2614ImportedInheritedInstanceMethodTests
+{
+    [Fact]
+    public void OahuBclShapes_BindWithoutGS0159()
+    {
+        var result = BindWithFrameworkReferences("""
+            import System.Collections.Concurrent
+            import System.Security.AccessControl
+
+            class ModalRequest { }
+
+            func Probe(
+                queue ConcurrentQueue[ModalRequest],
+                security FileSecurity,
+                rule FileSystemAccessRule
+            ) {
+                var value ModalRequest? = nil
+                queue.TryDequeue(&value)
+                security.RemoveAccessRule(rule)
+            }
+            """);
+
+        Assert.DoesNotContain(result, diagnostic => diagnostic.Id == "GS0159");
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ImportedLookup_MissingDerivedSignature_WalksBasesAndDefaultInterfaces()
+    {
+        Assert.Single(MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(
+            new AggregateFailingType(typeof(RootCommand)),
+            nameof(Command.SetAction)));
+        Assert.Single(MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(
+            new AggregateFailingType(typeof(DerivedFileSecurity<int>)),
+            nameof(FileSecurity<int>.RemoveAccessRule)));
+        Assert.Single(MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(
+            new AggregateFailingType(typeof(QueueWithDefault)),
+            nameof(IQueueDefault.TryDequeue)));
+    }
+
+    [Fact]
+    public void UnknownImportedInstanceMethod_StillReportsGS0159()
+    {
+        var diagnostics = BindWithFrameworkReferences("""
+            import System.Collections.Concurrent
+
+            func Probe(queue ConcurrentQueue[string]) {
+                queue.NotAQueueMethod()
+            }
+            """);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("GS0159", diagnostic.Id);
+    }
+
+    private static ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> BindWithFrameworkReferences(string source)
+    {
+        using var references = ReferenceResolver.WithReferences(
+            Directory.EnumerateFiles(
+                RuntimeEnvironment.GetRuntimeDirectory(),
+                "*.dll",
+                SearchOption.TopDirectoryOnly));
+        var compilation = new Compilation(
+            references,
+            SyntaxTree.Parse(SourceText.From(source)));
+        return compilation.SyntaxTrees.SelectMany(tree => tree.Diagnostics)
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .ToImmutableArray();
+    }
+
+    private class Command
+    {
+        public void SetAction()
+        {
+        }
+    }
+
+    private sealed class RootCommand : Command
+    {
+    }
+
+    private class FileSecurity<T>
+    {
+        public void RemoveAccessRule(T rule)
+        {
+        }
+    }
+
+    private sealed class DerivedFileSecurity<T> : FileSecurity<T>
+    {
+    }
+
+    private interface IQueueDefault
+    {
+        bool TryDequeue() => true;
+    }
+
+    private sealed class QueueWithDefault : IQueueDefault
+    {
+    }
+
+    private sealed class AggregateFailingType : TypeDelegator
+    {
+        private readonly Type delegatedType;
+
+        public AggregateFailingType(Type delegatingType)
+            : base(delegatingType)
+        {
+            delegatedType = delegatingType;
+        }
+
+        public override Type GetGenericTypeDefinition() => delegatedType.GetGenericTypeDefinition();
+
+        public override MethodInfo[] GetMethods(BindingFlags bindingAttr)
+            => (bindingAttr & BindingFlags.DeclaredOnly) == 0
+                ? throw new FileNotFoundException("Simulated missing metadata dependency.")
+                : base.GetMethods(bindingAttr);
+    }
+}


### PR DESCRIPTION
## Summary
- fall back to declaration-by-declaration base walks when aggregate metadata method enumeration fails, retaining interface-default lookup and normal ordering
- erase symbolic by-ref pointees for imported overload resolution (`ConcurrentQueue[ModalRequest].TryDequeue`)
- cover the exact Oahu `RootCommand.SetAction`, `FileSecurity.RemoveAccessRule`, and `ConcurrentQueue.TryDequeue` names plus generic/non-generic bases, interface defaults, runtime, and unknown-member negatives

## Before / after proof
- before: `ImportedLookup_MissingDerivedSignature_WalksBasesAndDefaultInterfaces` failed with `Assert.Single(): collection was empty`
- before: the source-element `ConcurrentQueue.TryDequeue` repro emitted `GS0159: Cannot find function TryDequeue`
- after: all 3 issue binding tests pass; the runtime test prints `2614` and passes ILVerify

## Tests
- `Core.Tests`: 6,618 passed, 1 skipped
- `Compiler.Tests`: 3,288 passed
- issue filters: 3 Core passed; 1 Compiler runtime passed

Fixes #2614