### PR TITLE
Fix static delegate member invocation

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -3247,6 +3247,19 @@ internal sealed partial class ExpressionBinder
         }
 
         if (structSym != null
+            && TryBindUserStructDelegateMemberInvocation(
+                receiver: null,
+                structSym,
+                methodName,
+                arguments,
+                ce,
+                isStatic: true,
+                out var delegateMemberCall))
+        {
+            return delegateMemberCall;
+        }
+
+        if (structSym != null
             && TypeMemberModel.GetNearestImportedBase(structSym)?.ClrType is System.Type importedBase)
         {
             var imported = new ImportedClassSymbol(importedBase, ce, references: scope.References);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -425,41 +425,72 @@ internal sealed partial class ExpressionBinder
         string methodName,
         ImmutableArray<BoundExpression> arguments,
         CallExpressionSyntax ce,
+        bool isStatic,
         out BoundExpression result)
     {
         result = null;
 
-        // Walk the base chain so an inherited delegate field on a base class
-        // is invokable on a derived instance.
         FieldSymbol matchedField = null;
         StructSymbol declaringType = null;
-        for (var c = receiverStruct; c != null; c = c.BaseClass)
+        if (isStatic)
         {
-            if (c.TryGetField(methodName, out var f))
+            TypeMemberModel.TryGetStaticFieldIncludingInherited(
+                receiverStruct,
+                methodName,
+                out matchedField,
+                out declaringType);
+        }
+        else
+        {
+            // Walk the base chain so an inherited delegate field on a base class
+            // is invokable on a derived instance.
+            for (var c = receiverStruct; c != null; c = c.BaseClass)
             {
-                matchedField = f;
-                declaringType = c;
-                break;
+                if (c.TryGetField(methodName, out var f))
+                {
+                    matchedField = f;
+                    declaringType = c;
+                    break;
+                }
             }
         }
 
         PropertySymbol matchedProperty = null;
-        if (matchedField == null
-            && TypeMemberModel.TryGetProperty(
-                receiverStruct,
-                methodName,
-                out var property,
-                out var propertyDeclaringType)
-            && property.HasGetter)
+        if (matchedField == null)
         {
-            matchedProperty = property;
-            declaringType = propertyDeclaringType;
+            var foundProperty = isStatic
+                ? TypeMemberModel.TryGetStaticPropertyIncludingInherited(
+                    receiverStruct,
+                    methodName,
+                    out var property,
+                    out var propertyDeclaringType)
+                : TypeMemberModel.TryGetProperty(
+                    receiverStruct,
+                    methodName,
+                    out property,
+                    out propertyDeclaringType);
+            if (foundProperty && property.HasGetter)
+            {
+                matchedProperty = property;
+                declaringType = propertyDeclaringType;
+            }
         }
 
-        var memberType = matchedField?.Type ?? matchedProperty?.Type;
+        var memberType = matchedField != null && isStatic
+            ? declaringType.SubstituteMemberType(matchedField.Type)
+            : matchedField?.Type ?? matchedProperty?.Type;
         if (memberType == null)
         {
             return false;
+        }
+
+        if (isStatic)
+        {
+            var accessibility = matchedField?.Accessibility ?? matchedProperty.Accessibility;
+            if (!AccessibilityChecker.IsAccessible(accessibility, declaringType, function))
+            {
+                Diagnostics.ReportMemberInaccessible(ce.Identifier.Location, methodName, declaringType.Name, accessibility);
+            }
         }
 
         FunctionTypeSymbol functionType;
@@ -535,11 +566,20 @@ internal sealed partial class ExpressionBinder
         for (var i = 0; i < permutedArgs.Length; i++)
         {
             var argLoc = i < ce.Arguments.Count ? ce.Arguments[i].Location : ce.Location;
-            convertedArgs.Add(conversions.BindConversion(argLoc, permutedArgs[i], functionType.ParameterTypes[i]));
+            var argument = permutedArgs[i];
+            if (argument is BoundErrorExpression { Syntax: LambdaExpressionSyntax lambda }
+                && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(functionType.ParameterTypes[i], out var target))
+            {
+                argument = lambdas.BindLambdaExpression(lambda, target);
+            }
+
+            convertedArgs.Add(conversions.BindConversion(argLoc, argument, functionType.ParameterTypes[i]));
         }
 
         BoundExpression memberLoad = matchedField != null
-            ? new BoundFieldAccessExpression(null, receiver, declaringType, matchedField)
+            ? isStatic
+                ? new BoundFieldAccessExpression(null, receiver, declaringType, matchedField, memberType)
+                : new BoundFieldAccessExpression(null, receiver, declaringType, matchedField)
             : new BoundPropertyAccessExpression(null, receiver, declaringType, matchedProperty);
         result = new BoundIndirectCallExpression(null, memberLoad, functionType, convertedArgs.MoveToImmutable());
         return true;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2301,7 +2301,7 @@ internal sealed partial class ExpressionBinder
                 // dispatch used for the imported-CLR path below; here the
                 // receiver's ClrType is null (the user type has not yet been
                 // emitted) so we have to handle the symbol-only shape too.
-                if (TryBindUserStructDelegateMemberInvocation(receiver, userClass, methodName, arguments, ce, out var userDelegateFieldCall))
+                if (TryBindUserStructDelegateMemberInvocation(receiver, userClass, methodName, arguments, ce, isStatic: false, out var userDelegateFieldCall))
                 {
                     return userDelegateFieldCall;
                 }
@@ -2443,7 +2443,7 @@ internal sealed partial class ExpressionBinder
             // function (or named delegate) is invokable through the same
             // call syntax as a bare function-typed variable. Lower to a load
             // of the member value followed by an indirect call.
-            if (TryBindUserStructDelegateMemberInvocation(receiver, userClassPriority, methodName, arguments, ce, out var userDelegateCall))
+            if (TryBindUserStructDelegateMemberInvocation(receiver, userClassPriority, methodName, arguments, ce, isStatic: false, out var userDelegateCall))
             {
                 return userDelegateCall;
             }

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -109,6 +109,37 @@ internal sealed class SlotPlanner
             collector.Visit(kvp.Value);
         }
 
+        foreach (var type in this.emitCtx.Program.Structs
+            .OrderBy(s => s.Declaration?.Span.Start ?? int.MaxValue)
+            .ThenBy(s => s.Name, StringComparer.Ordinal))
+        {
+            foreach (var field in type.StaticFields)
+            {
+                if (type.StaticFieldInitializers.TryGetValue(field, out var initializer))
+                {
+                    collector.Visit(initializer);
+                }
+            }
+
+            foreach (var statement in type.StaticInitializerStatements)
+            {
+                collector.Visit(statement);
+            }
+        }
+
+        foreach (var type in this.emitCtx.Program.Interfaces
+            .OrderBy(i => i.Declaration?.Span.Start ?? int.MaxValue)
+            .ThenBy(i => i.Name, StringComparer.Ordinal))
+        {
+            foreach (var field in type.StaticFields)
+            {
+                if (type.StaticFieldInitializers.TryGetValue(field, out var initializer))
+                {
+                    collector.Visit(initializer);
+                }
+            }
+        }
+
         return sink;
     }
 

--- a/test/Compiler.Tests/Emit/Issue2613StaticDelegateMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2613StaticDelegateMemberEmitTests.cs
@@ -1,0 +1,134 @@
+// <copyright file="Issue2613StaticDelegateMemberEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue2613StaticDelegateMemberEmitTests
+{
+    private const string Source = """
+        package Issue2613
+        import System
+
+        type Transform = delegate func(value int32) int32
+
+        class Callbacks {
+            shared {
+                var Field (int32) -> int32 = (value int32) -> value + 1
+                private var propertyValue (int32) -> int32 = (value int32) -> value + 2
+                prop Property (int32) -> int32 {
+                    get -> propertyValue
+                    set { propertyValue = value }
+                }
+                var Named Transform = (value int32) -> value + 3
+            }
+        }
+
+        func Main() {
+            Callbacks.Field = (value int32) -> value + 10
+            Callbacks.Property = (value int32) -> value + 20
+            Callbacks.Named = (value int32) -> value + 30
+            let copy = Callbacks.Field
+            Console.WriteLine(copy(2))
+            Console.WriteLine(Callbacks.Field(2))
+            Console.WriteLine(Callbacks.Property(2))
+            Console.WriteLine(Callbacks.Named(2))
+        }
+        """;
+
+    [Fact]
+    public void StaticDelegateMembers_AssignReadAndInvoke_CompileWithoutLookupDiagnostics()
+    {
+        var (exitCode, diagnostics, _, directory) = Compile(
+            Source.Replace("Issue2613", "Issue2613Compile", StringComparison.Ordinal));
+        try
+        {
+            Assert.True(exitCode == 0, diagnostics);
+            Assert.DoesNotContain("GS0158", diagnostics, StringComparison.Ordinal);
+            Assert.DoesNotContain("GS0159", diagnostics, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void StaticDelegateMembers_AssignReadAndInvoke_Run()
+    {
+        var (exitCode, diagnostics, assembly, directory) = Compile(
+            Source.Replace("Issue2613", "Issue2613Runtime", StringComparison.Ordinal));
+        try
+        {
+            Assert.True(exitCode == 0, diagnostics);
+            IlVerifier.Verify(assembly);
+
+            File.WriteAllText(Path.ChangeExtension(assembly, "runtimeconfig.json"), """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var startInfo = new ProcessStartInfo("dotnet", "exec \"" + assembly + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var process = Process.Start(startInfo)!;
+            string output = process.StandardOutput.ReadToEnd();
+            string error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            Assert.True(process.ExitCode == 0, error);
+            Assert.Equal("12\n12\n22\n32\n", output.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static (int ExitCode, string Diagnostics, string Assembly, string Directory) Compile(string source)
+    {
+        string directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2613",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string sourcePath = Path.Combine(directory, "test.gs");
+        string assemblyPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        TextWriter previousOut = Console.Out;
+        TextWriter previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            int exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            return (exitCode, stdout.ToString() + stderr.ToString(), assemblyPath, directory);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2613StaticDelegateMemberPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2613StaticDelegateMemberPipelineTests.cs
@@ -1,0 +1,151 @@
+// <copyright file="Issue2613StaticDelegateMemberPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2613StaticDelegateMemberPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_StaticDelegatePropertyAndField_RemainAssignableAndInvocable()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectPath = WriteFixture(sourceRoot);
+        string outputRoot = NewDirectory("pipeline-tests");
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+
+        RunResult result = await pipeline.RunAsync(
+            new[] { new CorpusApp("test/Issue2613", projectPath, TargetKind.Exe) });
+        AppResult app = Assert.Single(result.Apps);
+        Assert.True(
+            app.Succeeded,
+            "Expected translated static delegates to compile. Stages: " +
+                string.Join("; ", app.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+
+        string runDirectory = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.AppId));
+        string emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(runDirectory, "*.gs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+        Assert.Contains("var Property (int32) -> int32", emitted, StringComparison.Ordinal);
+        Assert.Contains("var Field (int32) -> int32", emitted, StringComparison.Ordinal);
+        Assert.Contains("Factory.Property(2)", emitted, StringComparison.Ordinal);
+        Assert.Contains("Factory.Field(2)", emitted, StringComparison.Ordinal);
+
+        string assembly = Directory.GetFiles(
+                Path.Combine(runDirectory, "bin"),
+                "Issue2613.dll",
+                SearchOption.AllDirectories)
+            .Single(path => !path.Contains(
+                Path.DirectorySeparatorChar + "ref" + Path.DirectorySeparatorChar,
+                StringComparison.Ordinal));
+        var startInfo = new ProcessStartInfo("dotnet", "\"" + assembly + "\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        using var process = Process.Start(startInfo)!;
+        string output = process.StandardOutput.ReadToEnd();
+        string error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(process.ExitCode == 0, error);
+        Assert.Equal("12\n6\n", output.Replace("\r\n", "\n"));
+    }
+
+    private static string WriteFixture(string sourceRoot)
+    {
+        File.WriteAllText(Path.Combine(sourceRoot, "Directory.Build.props"), "<Project></Project>");
+        string projectDirectory = Path.Combine(sourceRoot, "Issue2613");
+        Directory.CreateDirectory(projectDirectory);
+        string projectPath = Path.Combine(projectDirectory, "Issue2613.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDirectory, "Program.cs"), """
+            using System;
+
+            public static class Factory
+            {
+                public static Func<int, int> Property { get; set; } = value => value + 1;
+                public static Func<int, int> Field = value => value + 2;
+            }
+
+            Factory.Property = value => value + 10;
+            Factory.Field = value => value * 3;
+            Console.WriteLine(Factory.Property(2));
+            Console.WriteLine(Factory.Field(2));
+            """);
+        return projectPath;
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2613",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirectoryName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirectoryName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- bind function- and named-delegate-typed shared fields/properties as callable values through their declaring type
- emit lambdas used by static field initializers and shared initializer blocks
- cover compiler diagnostics, runtime assignment/invocation, and cs2gs SDK pipeline parity

## Oahu cycle-5 proof
- before: 26 unique CliServiceFactory/RootCommandFactory GS0158/GS0159 diagnostics (66 total G# diagnostics)
- after: 0 exact factory diagnostics (7 unrelated G# diagnostics remain)

## Validation
- `dotnet build GSharp.sln --configuration Release --no-restore -graph`
- targeted Compiler.Tests: 2 passed
- targeted Cs2Gs.Tests pipeline: 1 passed
- full `dotnet test GSharp.sln --configuration Release --no-build`: 12,657 passed, 1 skipped
- `./build/run-e2e-tests.sh`: 12/12 passed
- full cs2gs corpus migration: 17/20 green; 2 known baseline gaps, 0 new/regressed/stale

Fixes #2613