### PR TITLE
Fix char numeric promotion

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -281,10 +281,8 @@ public sealed record BoundBinaryOperator
         // (Mixed `T? op T` is handled in BindBinaryExpression by lifting
         // the non-nullable side to T? via an implicit conversion before
         // re-binding.) Arithmetic / bitwise lift to T?; equality and
-        // ordering lift to bool. Shifts are intentionally excluded —
-        // they take a non-matching int rhs and are rarely used on
-        // nullables; falling through here leaves them as a non-fatal
-        // "operator undefined" diagnostic at user-source level.
+        // ordering lift to bool. Shift operands are normalized to nullable
+        // int32 counts by the binder before reaching this generic lift.
         //
         // Issue #614 audit: intentionally a single arm — this is a generic
         // lifting meta-algorithm that already handles ALL liftable operator
@@ -419,11 +417,9 @@ public sealed record BoundBinaryOperator
     /// <summary>
     /// PR N-4: returns true for operator kinds that have a lifted
     /// counterpart per C# §7.3.7 — arithmetic, bitwise, equality, and
-    /// ordering. Logical short-circuit (&amp;&amp;, ||), null-coalesce, and
-    /// shift operators are excluded; the former two require the user-
-    /// defined `true`/`false` operator surface, null-coalesce is itself
-    /// the way to consume a nullable, and shifts are bound on a non-
-    /// matching int rhs which the simple matching arm cannot lift.
+    /// ordering and shifts. Logical short-circuit (&amp;&amp;, ||) requires the
+    /// user-defined `true`/`false` operator surface, and null-coalesce is itself
+    /// the way to consume a nullable.
     /// </summary>
     private static bool IsLiftableKind(BoundBinaryOperatorKind kind)
     {
@@ -438,6 +434,9 @@ public sealed record BoundBinaryOperator
             case BoundBinaryOperatorKind.BitwiseOr:
             case BoundBinaryOperatorKind.BitwiseXor:
             case BoundBinaryOperatorKind.BitClear:
+            case BoundBinaryOperatorKind.ShiftLeft:
+            case BoundBinaryOperatorKind.ShiftRight:
+            case BoundBinaryOperatorKind.UnsignedShiftRight:
             case BoundBinaryOperatorKind.Equals:
             case BoundBinaryOperatorKind.NotEquals:
             case BoundBinaryOperatorKind.Less:

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -455,24 +455,19 @@ public sealed class Conversion
                     return Conversion.Identity;
                 }
 
-                // Issue #1236: lifted numeric widening — `T1? → T2?` is an
-                // implicit conversion whenever the underlying `T1 → T2` is an
-                // implicit (lossless) numeric widening (e.g. `uint8? → int32?`,
-                // `int32? → int64?`). This mirrors C# §10.2.6 lifted conversions
-                // and lets nullable numeric operands participate in the same
-                // widening lattice as their non-nullable forms, so a lifted
-                // binary operator can bind at a common underlying type. The
-                // emitter / evaluator unwrap the source, convert the underlying
-                // value, and re-wrap, propagating null. Restricted to value-type
-                // numeric underlyings so reference-typed nullable wrappers (which
-                // share a CLR representation) keep their identity-only rule.
-                if (fromNullable.UnderlyingType?.ClrType is { IsValueType: true }
-                    && toNullable.UnderlyingType?.ClrType is { IsValueType: true })
+                // Issues #1236/#2616: lift both implicit and explicit numeric
+                // conversions through Nullable<T>. Compound char assignment
+                // uses the explicit int32? -> char? direction; ordinary
+                // widening remains implicit.
+                if (fromNullable.UnderlyingType?.ClrType is { IsValueType: true } fromNullableClr
+                    && toNullable.UnderlyingType?.ClrType is { IsValueType: true } toNullableClr
+                    && NumericWideningLattice.IsNumericPrimitive(fromNullableClr.FullName)
+                    && NumericWideningLattice.IsNumericPrimitive(toNullableClr.FullName))
                 {
                     var liftedUnderlying = Classify(fromNullable.UnderlyingType, toNullable.UnderlyingType);
-                    if (liftedUnderlying.Exists && liftedUnderlying.IsImplicit && !liftedUnderlying.IsIdentity)
+                    if (liftedUnderlying.Exists && !liftedUnderlying.IsIdentity)
                     {
-                        return Conversion.Implicit;
+                        return liftedUnderlying.IsImplicit ? Conversion.Implicit : Conversion.Explicit;
                     }
                 }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -998,7 +998,19 @@ internal sealed partial class ExpressionBinder
         var op = BindBinaryOperatorWithNumericAdaptation(baseOperatorKind, ref left, ref right, rhsLocation, rhsLocation);
         if (op != null)
         {
-            return new BoundBinaryExpression(null, left, op, right);
+            var binary = new BoundBinaryExpression(null, left, op, right, binderCtx.IsCheckedContext);
+            var targetType = leftRead.Type;
+            var targetUnderlying = targetType is NullableTypeSymbol nullableTarget
+                ? nullableTarget.UnderlyingType
+                : targetType;
+
+            // Issue #2616 / ECMA-334 §14.14.2: compound assignment includes
+            // the explicit numeric conversion back to the LHS type. Keep this
+            // narrowly on char so ADR-0044's existing small-integer compound
+            // semantics are unchanged.
+            return targetUnderlying == TypeSymbol.Char && binary.Type != targetType
+                ? conversions.BindConversion(rhsLocation, binary, targetType, allowExplicit: true)
+                : binary;
         }
 
         // Issue #1554: fall back to user-defined / CLR operator resolution,
@@ -1010,6 +1022,7 @@ internal sealed partial class ExpressionBinder
     {
         var name = bareName.IdentifierToken.Text;
         var isAdd = syntax.OperatorToken.Kind == SyntaxKind.PlusEqualsToken;
+        var isEventOperator = isAdd || syntax.OperatorToken.Kind == SyntaxKind.MinusEqualsToken;
 
         // Try implicit `this` event: walk the receiver type's events (including inherited).
         // ADR-0112 A5: intentionally NOT routed through TypeMemberModel.TryGetEvent —
@@ -1017,7 +1030,7 @@ internal sealed partial class ExpressionBinder
         // this bound node must carry the *declaring* type `t` as its owner. Collapsing
         // into TryGetEvent(receiverStruct, …) would change the owner from the declaring
         // base to the derived type, breaking bound-node parity. Left as a manual walk.
-        if (function?.ThisParameter != null && function.ReceiverType is StructSymbol receiverStruct)
+        if (isEventOperator && function?.ThisParameter != null && function.ReceiverType is StructSymbol receiverStruct)
         {
             for (var t = receiverStruct; t != null; t = t.BaseClass)
             {
@@ -1050,8 +1063,9 @@ internal sealed partial class ExpressionBinder
                 && GetInheritedClrBaseType(thisStruct) is System.Type inheritedBaseClr)
             {
                 var inheritedReceiver = new BoundVariableExpression(null, effThis);
+                SyntaxFacts.TryGetCompoundAssignmentBaseOperator(syntax.OperatorToken.Kind, out var inheritedBaseOperator);
                 var inheritedCompound = TryBindChainedClrCompoundAssignment(
-                    inheritedReceiver, inheritedBaseClr, name, bareName, syntax, isAdd ? SyntaxKind.PlusToken : SyntaxKind.MinusToken, includeInherited: true);
+                    inheritedReceiver, inheritedBaseClr, name, bareName, syntax, inheritedBaseOperator, includeInherited: true);
                 if (inheritedCompound != null)
                 {
                     return inheritedCompound;
@@ -1073,7 +1087,7 @@ internal sealed partial class ExpressionBinder
 
         // Synthesize the binary expression: variable op rhs.
         var leftExpr = BindNameExpressionCore(bareName);
-        var baseOpSyntaxKind = isAdd ? SyntaxKind.PlusToken : SyntaxKind.MinusToken;
+        SyntaxFacts.TryGetCompoundAssignmentBaseOperator(syntax.OperatorToken.Kind, out var baseOpSyntaxKind);
         var leftType = leftExpr.Type;
         var binaryResult = TryBindCompoundBinaryOperation(baseOpSyntaxKind, leftExpr, boundRhs, syntax.Value.Location);
         if (binaryResult == null)
@@ -1145,7 +1159,11 @@ internal sealed partial class ExpressionBinder
                 convertedResult);
         }
 
-        if (variable.IsReadOnly)
+        if (variable is ParameterSymbol inParameter && inParameter.RefKind == RefKind.In)
+        {
+            Diagnostics.ReportCannotAssignToInParameter(syntax.OperatorToken.Location, inParameter.Name);
+        }
+        else if (variable.IsReadOnly)
         {
             Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, name);
         }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -54,6 +54,16 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
+        // Issue #2616 / ECMA-334 §14.2.6.1: char participates in unary numeric
+        // promotion as int32. Promote before operator lookup so the bound
+        // operand, operator signature, evaluator value, and emitted stack type
+        // all agree; recording a char operand with an int32 result would leave
+        // the interpreter operating on a boxed Char.
+        if (TryGetPromotedCharUnaryType(syntax.OperatorToken.Kind, boundOperand.Type, out var promotedUnaryType))
+        {
+            boundOperand = conversions.BindConversion(syntax.Operand.Location, boundOperand, promotedUnaryType);
+        }
+
         var boundOperator = BoundUnaryOperator.Bind(syntax.OperatorToken.Kind, boundOperand.Type);
 
         if (boundOperator == null)
@@ -1748,6 +1758,45 @@ internal sealed partial class ExpressionBinder
     {
         var boundOperator = BoundBinaryOperator.Bind(operatorKind, boundLeft.Type, boundRight.Type);
 
+        if (operatorKind is SyntaxKind.ShiftLeftToken or SyntaxKind.ShiftRightToken or SyntaxKind.UnsignedShiftRightToken
+            && (GetNullableUnderlying(boundLeft.Type) == TypeSymbol.Char
+                || GetNullableUnderlying(boundRight.Type) == TypeSymbol.Char))
+        {
+            if (GetNullableUnderlying(boundLeft.Type) == TypeSymbol.Char)
+            {
+                var promotedLeftType = boundLeft.Type is NullableTypeSymbol
+                    ? NullableTypeSymbol.Get(TypeSymbol.Int32)
+                    : TypeSymbol.Int32;
+                boundLeft = conversions.BindConversion(leftLocation, boundLeft, promotedLeftType);
+            }
+
+            if (GetNullableUnderlying(boundRight.Type) == TypeSymbol.Char)
+            {
+                var promotedRightType = boundRight.Type is NullableTypeSymbol
+                    ? NullableTypeSymbol.Get(TypeSymbol.Int32)
+                    : TypeSymbol.Int32;
+                boundRight = conversions.BindConversion(rightLocation, boundRight, promotedRightType);
+            }
+
+            boundOperator = BoundBinaryOperator.Bind(operatorKind, boundLeft.Type, boundRight.Type);
+        }
+
+        // Issue #2616 / ECMA-334 §14.2.6.2: char is promoted by the standard
+        // binary numeric-promotion rules, not closed under char arithmetic.
+        // Insert real numeric conversions before binding so all downstream
+        // consumers observe the promoted operand types.
+        if ((boundOperator == null || IsPromotedCharOperator(operatorKind))
+            && TryGetPromotedCharBinaryType(operatorKind, boundLeft.Type, boundRight.Type, out var promotedBinaryType))
+        {
+            var promotedOperator = BoundBinaryOperator.Bind(operatorKind, promotedBinaryType, promotedBinaryType);
+            if (promotedOperator != null)
+            {
+                boundLeft = conversions.BindConversion(leftLocation, boundLeft, promotedBinaryType);
+                boundRight = conversions.BindConversion(rightLocation, boundRight, promotedBinaryType);
+                boundOperator = promotedOperator;
+            }
+        }
+
         // Issue #1923: boxed-constant equality (`answer == 42` where `answer`
         // is typed `object`). The operator table only registers the
         // homogeneous `object == object -> bool` arm, so a non-`object`
@@ -2003,6 +2052,102 @@ internal sealed partial class ExpressionBinder
 
         return boundOperator;
     }
+
+    private static bool TryGetPromotedCharUnaryType(SyntaxKind operatorKind, TypeSymbol operandType, out TypeSymbol promotedType)
+    {
+        var nullable = operandType as NullableTypeSymbol;
+        if ((nullable?.UnderlyingType ?? operandType) == TypeSymbol.Char
+            && operatorKind is SyntaxKind.PlusToken or SyntaxKind.MinusToken or SyntaxKind.HatToken)
+        {
+            promotedType = nullable == null ? TypeSymbol.Int32 : NullableTypeSymbol.Get(TypeSymbol.Int32);
+            return true;
+        }
+
+        promotedType = null;
+        return false;
+    }
+
+    private static bool TryGetPromotedCharBinaryType(
+        SyntaxKind operatorKind,
+        TypeSymbol leftType,
+        TypeSymbol rightType,
+        out TypeSymbol promotedType)
+    {
+        promotedType = null;
+        if (!IsPromotedCharOperator(operatorKind))
+        {
+            return false;
+        }
+
+        var leftNullable = leftType as NullableTypeSymbol;
+        var rightNullable = rightType as NullableTypeSymbol;
+        var left = leftNullable?.UnderlyingType ?? leftType;
+        var right = rightNullable?.UnderlyingType ?? rightType;
+        if (left != TypeSymbol.Char && right != TypeSymbol.Char)
+        {
+            return false;
+        }
+
+        var other = left == TypeSymbol.Char ? right : left;
+        TypeSymbol target;
+        if (other == TypeSymbol.Decimal)
+        {
+            target = TypeSymbol.Decimal;
+        }
+        else if (other == TypeSymbol.Float64)
+        {
+            target = TypeSymbol.Float64;
+        }
+        else if (other == TypeSymbol.Float32)
+        {
+            target = TypeSymbol.Float32;
+        }
+        else if (other == TypeSymbol.UInt64)
+        {
+            target = TypeSymbol.UInt64;
+        }
+        else if (other == TypeSymbol.Int64)
+        {
+            target = TypeSymbol.Int64;
+        }
+        else if (other == TypeSymbol.UInt32)
+        {
+            target = TypeSymbol.UInt32;
+        }
+        else if (other == TypeSymbol.NInt)
+        {
+            target = TypeSymbol.NInt;
+        }
+        else if (other == TypeSymbol.NUInt)
+        {
+            target = TypeSymbol.NUInt;
+        }
+        else if (other == TypeSymbol.Char || IsIntegerType(other))
+        {
+            target = TypeSymbol.Int32;
+        }
+        else
+        {
+            return false;
+        }
+
+        promotedType = leftNullable != null || rightNullable != null
+            ? NullableTypeSymbol.Get(target)
+            : target;
+        return true;
+    }
+
+    private static bool IsPromotedCharOperator(SyntaxKind operatorKind) =>
+        operatorKind is SyntaxKind.PlusToken or SyntaxKind.MinusToken
+            or SyntaxKind.StarToken or SyntaxKind.SlashToken or SyntaxKind.PercentToken
+            or SyntaxKind.AmpersandToken or SyntaxKind.PipeToken or SyntaxKind.HatToken
+            or SyntaxKind.AmpersandHatToken
+            or SyntaxKind.EqualsEqualsToken or SyntaxKind.BangEqualsToken
+            or SyntaxKind.LessToken or SyntaxKind.LessOrEqualsToken
+            or SyntaxKind.GreaterToken or SyntaxKind.GreaterOrEqualsToken;
+
+    private static TypeSymbol GetNullableUnderlying(TypeSymbol type) =>
+        type is NullableTypeSymbol nullable ? nullable.UnderlyingType : type;
 
     // issue #1144: the ten G# integer primitive types (signed + unsigned,
     // including the native-int pair). Membership mirrors the integral sets in

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -644,7 +644,7 @@ internal sealed partial class MethodBodyEmitter
         this.il.LoadLocalAddress(srcSlot);
         this.il.OpCode(ILOpCode.Call);
         this.il.Token(getValueOrDefault);
-        this.TryEmitNumericConversion(fromUnderlying, toUnderlying);
+        this.TryEmitNumericConversion(fromUnderlying, toUnderlying, conv.IsChecked);
         this.il.OpCode(ILOpCode.Newobj);
         this.il.Token(this.outer.memberRefs.GetCtorReference(toCtor));
         this.il.Branch(ILOpCode.Br, end);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -1753,6 +1753,15 @@ internal sealed partial class MethodBodyEmitter
                 this.il.OpCode(ILOpCode.Not);
                 this.il.OpCode(ILOpCode.And);
                 break;
+            case BoundBinaryOperatorKind.ShiftLeft:
+                this.il.OpCode(ILOpCode.Shl);
+                break;
+            case BoundBinaryOperatorKind.ShiftRight:
+                this.il.OpCode(isUnsigned ? ILOpCode.Shr_un : ILOpCode.Shr);
+                break;
+            case BoundBinaryOperatorKind.UnsignedShiftRight:
+                this.il.OpCode(ILOpCode.Shr_un);
+                break;
             default:
                 throw new NotSupportedException($"EmitUnderlyingArithmetic: unexpected kind '{kind}'.");
         }

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -1643,6 +1643,9 @@ internal sealed class SlotPlanner
                 case BoundBinaryOperatorKind.BitwiseOr:
                 case BoundBinaryOperatorKind.BitwiseXor:
                 case BoundBinaryOperatorKind.BitClear:
+                case BoundBinaryOperatorKind.ShiftLeft:
+                case BoundBinaryOperatorKind.ShiftRight:
+                case BoundBinaryOperatorKind.UnsignedShiftRight:
                 case BoundBinaryOperatorKind.Equals:
                 case BoundBinaryOperatorKind.NotEquals:
                 case BoundBinaryOperatorKind.Less:

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -588,7 +588,9 @@ public sealed partial class Evaluator
                 && IsSupportedNumericClrType(targetUnderlyingClr)
                 && value.GetType() != targetUnderlyingClr)
             {
-                return UncheckedNumericConvert(value, targetUnderlyingClr);
+                return node.IsChecked
+                    ? CheckedNumericConvert(value, targetUnderlyingClr)
+                    : UncheckedNumericConvert(value, targetUnderlyingClr);
             }
 
             return value;
@@ -644,24 +646,20 @@ public sealed partial class Evaluator
         // Convert.ChangeType is checked and throws OverflowException instead.
         if (value is decimal dv)
         {
-            // decimal → primitive is checked at the BCL level even for
-            // unchecked casts; route through (long) first when applicable.
-            if (to.IsSameAs(typeof(float)))
-            {
-                return (float)dv;
-            }
-
-            if (to.IsSameAs(typeof(double)))
-            {
-                return (double)dv;
-            }
-
-            return UncheckedNumericConvert((long)dv, to);
+            // Decimal explicit operators always range-check, even in an
+            // unchecked context. Match the emitter's Decimal op_Explicit call.
+            return ConvertDecimal(dv, to);
         }
 
         if (to.IsSameAs(typeof(decimal)))
         {
-            return Convert.ToDecimal(value, System.Globalization.CultureInfo.InvariantCulture);
+            return value switch
+            {
+                char c => (decimal)c,
+                nint i => (decimal)i,
+                nuint i => (decimal)i,
+                _ => Convert.ToDecimal(value, System.Globalization.CultureInfo.InvariantCulture),
+            };
         }
 
         // For everything else, go through long / double, then unchecked cast.
@@ -731,12 +729,16 @@ public sealed partial class Evaluator
     // unlike a `long` intermediate which would misread the top bit of an
     // unsigned 64-bit value — then a single checked narrowing switch below
     // range-checks against the true value regardless of the source's
-    // signedness. decimal is unaffected by checked/unchecked in C# (decimal
-    // arithmetic/conversions always overflow-check), so it reuses the
-    // unchecked path's decimal handling.
+    // signedness. Decimal conversions always overflow-check and use their
+    // target-specific explicit operators in both contexts.
     private static object CheckedNumericConvert(object value, Type to)
     {
-        if (value is decimal || to.IsSameAs(typeof(decimal)))
+        if (value is decimal decimalValue)
+        {
+            return ConvertDecimal(decimalValue, to);
+        }
+
+        if (to.IsSameAs(typeof(decimal)))
         {
             return UncheckedNumericConvert(value, to);
         }
@@ -770,6 +772,25 @@ public sealed partial class Evaluator
 
         return CheckedNarrowFromInt128(asInt128, to);
     }
+
+    private static object ConvertDecimal(decimal value, Type to) => to switch
+    {
+        Type t when t.IsSameAs(typeof(sbyte)) => (sbyte)value,
+        Type t when t.IsSameAs(typeof(byte)) => (byte)value,
+        Type t when t.IsSameAs(typeof(short)) => (short)value,
+        Type t when t.IsSameAs(typeof(ushort)) => (ushort)value,
+        Type t when t.IsSameAs(typeof(int)) => (int)value,
+        Type t when t.IsSameAs(typeof(uint)) => (uint)value,
+        Type t when t.IsSameAs(typeof(long)) => (long)value,
+        Type t when t.IsSameAs(typeof(ulong)) => (ulong)value,
+        Type t when t.IsSameAs(typeof(nint)) => (nint)value,
+        Type t when t.IsSameAs(typeof(nuint)) => (nuint)value,
+        Type t when t.IsSameAs(typeof(char)) => (char)value,
+        Type t when t.IsSameAs(typeof(float)) => (float)value,
+        Type t when t.IsSameAs(typeof(double)) => (double)value,
+        Type t when t.IsSameAs(typeof(decimal)) => value,
+        _ => throw new InvalidOperationException($"Unsupported decimal conversion target {to}"),
+    };
 
     private static object CheckedNarrowFromInt128(Int128 v, Type to) => checked(to switch
     {

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.cs
@@ -88,31 +88,13 @@ public partial class Parser
         }
 
         if (Peek(0).Kind == SyntaxKind.IdentifierToken &&
-            SyntaxFacts.TryGetCompoundAssignmentBaseOperator(Peek(1).Kind, out var baseOpKind))
+            SyntaxFacts.TryGetCompoundAssignmentBaseOperator(Peek(1).Kind, out _))
         {
-            // For `+=` and `-=` on a bare identifier, emit an
-            // EventSubscriptionExpressionSyntax so the binder can distinguish
-            // event subscription (`EventName += handler`) from compound
-            // arithmetic assignment (`x += 1`). The binder falls back to
-            // compound assignment if the name is not an event.
-            if (Peek(1).Kind == SyntaxKind.PlusEqualsToken || Peek(1).Kind == SyntaxKind.MinusEqualsToken)
-            {
-                var identifierToken = NextToken();
-                var opToken = NextToken();
-                var rhs = ParseAssignmentExpression();
-                var leftName = new NameExpressionSyntax(syntaxTree, identifierToken);
-                return new EventSubscriptionExpressionSyntax(syntaxTree, leftName, opToken, rhs);
-            }
-
-            var identifierToken2 = NextToken();
-            var compoundToken = NextToken();
-            var right = ParseAssignmentExpression();
-
-            var leftName2 = new NameExpressionSyntax(syntaxTree, identifierToken2);
-            var baseOpToken = new SyntaxToken(syntaxTree, baseOpKind, compoundToken.Position, SyntaxFacts.GetText(baseOpKind), null);
-            var binary = new BinaryExpressionSyntax(syntaxTree, leftName2, baseOpToken, right);
-            var equalsToken = new SyntaxToken(syntaxTree, SyntaxKind.EqualsToken, compoundToken.Position, SyntaxFacts.GetText(SyntaxKind.EqualsToken), null);
-            return new AssignmentExpressionSyntax(syntaxTree, identifierToken2, equalsToken, binary);
+            var identifierToken = NextToken();
+            var opToken = NextToken();
+            var rhs = ParseAssignmentExpression();
+            var leftName = new NameExpressionSyntax(syntaxTree, identifierToken);
+            return new EventSubscriptionExpressionSyntax(syntaxTree, leftName, opToken, rhs);
         }
 
         var expression = ParseRangeExpression();

--- a/test/Compiler.Tests/Emit/Issue2616CharNumericPromotionRuntimeTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2616CharNumericPromotionRuntimeTests.cs
@@ -1,0 +1,106 @@
+// <copyright file="Issue2616CharNumericPromotionRuntimeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Issue #2616 end-to-end runtime and IL verification.</summary>
+public class Issue2616CharNumericPromotionRuntimeTests
+{
+    [Fact]
+    public void PromotedCharOperations_RunWithEcmaResults()
+    {
+        const string Source = """
+            package P
+            import System
+
+            var a char = '5'
+            var b char = '1'
+            Console.WriteLine(a - b)
+            Console.WriteLine(-a)
+            Console.WriteLine(^b)
+            Console.WriteLine(a + uint32(1))
+
+            var c char = 'A'
+            c += 2
+            c ^= char(1)
+            Console.WriteLine(c)
+
+            var lifted char? = 'D'
+            lifted -= 'A'
+            Console.WriteLine(int32(lifted.Value))
+
+            var shifted char? = char(2)
+            shifted <<= char(2)
+            Console.WriteLine(int32(shifted.Value))
+            """;
+
+        Assert.Equal("4\n-53\n-50\n54\nB\n3\n8\n", CompileAndRun(Source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue2616_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(exitCode == 0, $"gsc failed:\n{stdout}\n{stderr}");
+            IlVerifier.Verify(outputPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo);
+            var runtimeOutput = process!.StandardOutput.ReadToEnd();
+            var runtimeError = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, $"runtime failed:\n{runtimeOutput}\n{runtimeError}");
+            return runtimeOutput.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2616CharNumericPromotionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2616CharNumericPromotionTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="Issue2616CharNumericPromotionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>Issue #2616: ECMA numeric promotion for char expressions.</summary>
+public class Issue2616CharNumericPromotionTests
+{
+    [Fact]
+    public void ExactOahuKeyCharSubtraction_BindsAsInt32()
+    {
+        const string Source = """
+            package Oahu.Cli.Tui
+            import System
+
+            func tabIndex(key ConsoleKeyInfo) int32 {
+                let idx = key.KeyChar - '1'
+                return idx
+            }
+            """;
+
+        Assert.Empty(Errors(Source));
+    }
+
+    [Fact]
+    public void UnaryBinaryNullableAndCompoundCharForms_Bind()
+    {
+        const string Source = """
+            package P
+
+            func promoted(a char, b char, u uint32, d float64) float64 {
+                let unary int32 = +a - -b + ^a
+                let chars int32 = a + b * a - b / a + b % a
+                let mixed uint32 = a + u
+                return d + a
+            }
+
+            func lifted(a char?, b char?) int32? {
+                return a - b
+            }
+
+            func liftedShift(a char?, count char?) int32? {
+                return a << count
+            }
+
+            func compound(input char, other char) char {
+                var ch = input
+                ch += other
+                ch -= '1'
+                ch *= other
+                ch /= other
+                ch %= other
+                ch &= other
+                ch |= other
+                ch ^= other
+                ch <<= 1
+                ch >>= 1
+                return ch
+            }
+
+            func liftedCompound(left char?, right char?) char? {
+                var value = left
+                value += right
+                value -= right
+                return value
+            }
+            """;
+
+        Assert.Empty(Errors(Source));
+    }
+
+    [Fact]
+    public void NonAdditiveCompoundOnInParameter_PreservesGs0237()
+    {
+        var errors = Errors("func bad(in ch char) { ch *= 2 }");
+        Assert.Contains(errors, d => d.Id == "GS0237");
+        Assert.DoesNotContain(errors, d => d.Id == "GS0127");
+    }
+
+    [Theory]
+    [InlineData("int8", "int32")]
+    [InlineData("uint8", "int32")]
+    [InlineData("int16", "int32")]
+    [InlineData("uint16", "int32")]
+    [InlineData("int32", "int32")]
+    [InlineData("uint32", "uint32")]
+    [InlineData("int64", "int64")]
+    [InlineData("uint64", "uint64")]
+    [InlineData("nint", "nint")]
+    [InlineData("nuint", "nuint")]
+    [InlineData("float32", "float32")]
+    [InlineData("float64", "float64")]
+    [InlineData("decimal", "decimal")]
+    public void CharWithNumericPrimitive_UsesEcmaPromotionTarget(string operandType, string resultType)
+    {
+        Assert.Empty(Errors($"let result {resultType} = 'A' + {operandType}(1)"));
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("\"x\"")]
+    public void NonNumericCharOperand_StillReportsGs0129(string operand)
+    {
+        Assert.Contains(Errors($"let bad = 'a' - {operand}"), d => d.Id == "GS0129");
+    }
+
+    private static IReadOnlyList<Diagnostic> Errors(string source)
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        using var pe = new MemoryStream();
+        return compilation.Emit(pe).Diagnostics
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2616CharNumericPromotionEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2616CharNumericPromotionEmitTests.cs
@@ -1,0 +1,108 @@
+// <copyright file="Issue2616CharNumericPromotionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>Issue #2616 emitter proof for the exact Oahu subtraction.</summary>
+public class Issue2616CharNumericPromotionEmitTests
+{
+    [Fact]
+    public void ExactOahuKeyCharSubtraction_EmitsAndExecutesAsInt32()
+    {
+        const string Source = """
+            package Oahu.Cli.Tui
+            import System
+
+            func tabIndex(key ConsoleKeyInfo) int32 {
+                let idx = key.KeyChar - '1'
+                return idx
+            }
+            """;
+
+        using var pe = new MemoryStream();
+        var result = new Compilation(SyntaxTree.Parse(SourceText.From(Source))).Emit(pe);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        pe.Position = 0;
+        var context = new AssemblyLoadContext(nameof(ExactOahuKeyCharSubtraction_EmitsAndExecutesAsInt32), isCollectible: true);
+        try
+        {
+            var assembly = context.LoadFromStream(pe);
+            var method = assembly.GetTypes().SelectMany(t => t.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+                .Single(m => m.Name == "tabIndex");
+            Assert.Equal(4, method.Invoke(null, new object[] { new ConsoleKeyInfo('5', ConsoleKey.D5, false, false, false) }));
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    [Fact]
+    public void CheckedLiftedCharCompound_EmitsOverflowCheck()
+    {
+        const string Source = """
+            package P
+
+            func add(charValue char?) char? {
+                var result = charValue
+                checked {
+                    result += 65536
+                }
+                return result
+            }
+
+            func addOperator(charValue char?, amount uint32?) char? {
+                var result = charValue
+                checked {
+                    result += amount
+                }
+                return result
+            }
+
+            func addDecimal(charValue char?, amount decimal?) char? {
+                var result = charValue
+                checked {
+                    result += amount
+                }
+                return result
+            }
+            """;
+
+        using var pe = new MemoryStream();
+        var result = new Compilation(SyntaxTree.Parse(SourceText.From(Source))).Emit(pe);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        pe.Position = 0;
+        var context = new AssemblyLoadContext(nameof(CheckedLiftedCharCompound_EmitsOverflowCheck), isCollectible: true);
+        try
+        {
+            var assembly = context.LoadFromStream(pe);
+            var methods = assembly.GetTypes().SelectMany(t => t.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic));
+            AssertOverflow(methods.Single(m => m.Name == "add"), (char?)'A');
+            AssertOverflow(methods.Single(m => m.Name == "addOperator"), (char?)'A', (uint?)uint.MaxValue);
+            AssertOverflow(methods.Single(m => m.Name == "addDecimal"), (char?)'A', (decimal?)65536m);
+        }
+        finally
+        {
+            context.Unload();
+        }
+
+        static void AssertOverflow(MethodInfo method, params object[] arguments)
+        {
+            var exception = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, arguments));
+            Assert.IsType<OverflowException>(exception.InnerException);
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue2616CharNumericPromotionInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2616CharNumericPromotionInterpreterTests.cs
@@ -1,0 +1,82 @@
+// <copyright file="Issue2616CharNumericPromotionInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>Issue #2616 interpreter parity for promoted char values.</summary>
+public class Issue2616CharNumericPromotionInterpreterTests
+{
+    [Fact]
+    public void UnaryBinaryAndCompoundCharArithmetic_EvaluatesPromotedValues()
+    {
+        const string Source = """
+            var a char = '5'
+            var b char = '1'
+            var difference = a - b
+            var unary = -a + ^b + +a
+            var value char = 'A'
+            value += 2
+            var lifted char? = 'C'
+            lifted -= 'A'
+            """;
+
+        var variables = new Dictionary<VariableSymbol, object>();
+        var result = new Compilation(SyntaxTree.Parse(SourceText.From(Source))).Evaluate(variables);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(4, Value("difference"));
+        Assert.Equal(-(int)'5' + ~(int)'1' + (int)'5', Value("unary"));
+        Assert.Equal('C', Value("value"));
+        Assert.Equal((char)2, Value("lifted"));
+
+        object Value(string name) => variables.Single(pair => pair.Key.Name == name).Value;
+    }
+
+    [Fact]
+    public void CheckedLiftedCharCompound_ThrowsOnNarrowingOverflow()
+    {
+        const string Source = """
+            var value char? = 'A'
+            var narrowingCaught = "no"
+            var operatorCaught = "no"
+            var decimalCaught = "no"
+            checked {
+                try {
+                    value += 65536
+                } catch (e OverflowException) {
+                    narrowingCaught = "yes"
+                }
+                try {
+                    value += uint32(4294967295)
+                } catch (e OverflowException) {
+                    operatorCaught = "yes"
+                }
+                try {
+                    value += decimal(65536)
+                } catch (e OverflowException) {
+                    decimalCaught = "yes"
+                }
+            }
+            """;
+
+        var variables = new Dictionary<VariableSymbol, object>();
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(Source)));
+        var result = compilation.Evaluate(variables);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("yes", Value("narrowingCaught"));
+        Assert.Equal("yes", Value("operatorCaught"));
+        Assert.Equal("yes", Value("decimalCaught"));
+
+        object Value(string name) => variables.Single(pair => pair.Key.Name == name).Value;
+    }
+}


### PR DESCRIPTION
## Summary
- apply ECMA unary and binary numeric promotion to `char`, including mixed numeric and nullable operands
- preserve compound-assignment narrowing, checked overflow, lifted shifts, and interpreter/emitter parity
- route every bare compound operator through the shared compound binder without weakening `in` diagnostics

## Exact Oahu proof
Before, `let idx = key.KeyChar - '1'` from `Oahu.Cli.Tui/Shell/AppShell.cs` produced:

```
GS0129: Binary operator '-' is not defined for types 'char' and 'char'.
```

Related char compound forms produced GS0129/GS0156. After rebuilding `gsc`, the exact `ConsoleKeyInfo.KeyChar - '1'` repro plus plain/lifted compound forms compile to a verified library with zero diagnostics (`Wrote .../oahu.dll`).

## Tests
- binder matrix across all numeric primitives, nullable shifts, negative operands, and diagnostics
- emitter execution and checked-overflow tests
- interpreter arithmetic/compound/checked parity tests
- runtime compile, ILVerify, and execution tests
- related numeric/compound suites and Release solution build

Fixes #2616