### PR TITLE
Fix imported generic constructor diagnostics

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -206,7 +206,15 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        return TryBindClrConstructorFromType(clrType, terminalCall, out result, openGenericDef, symbolicArgs);
+        var bound = TryBindClrConstructorFromType(
+            clrType,
+            terminalCall,
+            out result,
+            out var noApplicableOverload,
+            openGenericDef,
+            symbolicArgs);
+        return bound || FinishClrConstructorBindingFailure(
+            terminalCall, typeSimpleName, noApplicableOverload, ref result);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -779,14 +779,23 @@ internal sealed partial class ExpressionBinder
                 return true;
             }
 
-            return TryBindClrConstructorFromType(
+            var bound = TryBindClrConstructorFromType(
                 clrType,
                 syntax,
                 out result,
+                out var noApplicableOverload,
                 resultTypeOverride: dataClassAggregate);
+            return bound || FinishClrConstructorBindingFailure(
+                syntax, name, noApplicableOverload, ref result);
         }
 
-        if (TryBindClrConstructorFromType(clrType, syntax, out result, openGenericDefinition, symbolicTypeArgs))
+        if (TryBindClrConstructorFromType(
+                clrType,
+                syntax,
+                out result,
+                out var clrNoApplicableOverload,
+                openGenericDefinition,
+                symbolicTypeArgs))
         {
             return true;
         }
@@ -799,7 +808,35 @@ internal sealed partial class ExpressionBinder
             return true;
         }
 
-        return false;
+        return FinishClrConstructorBindingFailure(
+            syntax, name, clrNoApplicableOverload, ref result);
+    }
+
+    private bool FinishClrConstructorBindingFailure(
+        CallExpressionSyntax syntax,
+        string typeName,
+        bool noApplicableOverload,
+        ref BoundExpression result)
+    {
+        if (syntax.TypeArgumentList == null)
+        {
+            result = null;
+            return false;
+        }
+
+        if (result != null)
+        {
+            return true;
+        }
+
+        if (!noApplicableOverload)
+        {
+            return false;
+        }
+
+        Diagnostics.ReportNoApplicableOverload(syntax.Identifier.Location, typeName);
+        result = new BoundErrorExpression(syntax);
+        return true;
     }
 
     /// <summary>
@@ -894,6 +931,11 @@ internal sealed partial class ExpressionBinder
     /// <param name="clrType">The closed CLR type to construct.</param>
     /// <param name="syntax">The call syntax carrying the arguments and location.</param>
     /// <param name="result">The bound constructor call on success.</param>
+    /// <param name="noApplicableOverload">
+    /// Whether the type and its constructors resolved but none accepted the
+    /// supplied arguments. The caller reports this only after semantic-
+    /// aggregate constructor fallback has also failed.
+    /// </param>
     /// <param name="openGenericDefinition">
     /// Issue #671: when <paramref name="clrType"/> was closed with a
     /// <see cref="object"/> placeholder for one or more G# user-defined type
@@ -919,11 +961,13 @@ internal sealed partial class ExpressionBinder
         System.Type clrType,
         CallExpressionSyntax syntax,
         out BoundExpression result,
+        out bool noApplicableOverload,
         System.Type openGenericDefinition = null,
         ImmutableArray<TypeSymbol> symbolicTypeArgs = default,
         TypeSymbol resultTypeOverride = null)
     {
         result = null;
+        noApplicableOverload = false;
 
         if (clrType.IsAbstract || clrType.IsInterface)
         {
@@ -1077,6 +1121,12 @@ internal sealed partial class ExpressionBinder
 
         if (bestCtor == null)
         {
+            if (boundArguments.Any(static argument => argument.Type == TypeSymbol.Error))
+            {
+                result = new BoundErrorExpression(syntax);
+                return false;
+            }
+
             // Issue #524: CLR value types always have an implicit zero-init
             // default "constructor" — at the IL level that's `initobj T`, not
             // a `newobj` against any `.ctor`. Reflection's
@@ -1108,6 +1158,7 @@ internal sealed partial class ExpressionBinder
                 return true;
             }
 
+            noApplicableOverload = true;
             return false;
         }
 
@@ -1470,6 +1521,12 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        return TryBindClrConstructorFromType(nestedType, syntax, out result);
+        var bound = TryBindClrConstructorFromType(
+            nestedType,
+            syntax,
+            out result,
+            out var noApplicableOverload);
+        return bound || FinishClrConstructorBindingFailure(
+            syntax, nestedType.Name, noApplicableOverload, ref result);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue2621ImportedGenericConstructorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2621ImportedGenericConstructorEmitTests.cs
@@ -1,0 +1,170 @@
+// <copyright file="Issue2621ImportedGenericConstructorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue2621ImportedGenericConstructorEmitTests
+{
+    private const string FixtureSource = """
+        package Issue2621.Fixture
+
+        class Bucket[T] {
+            private var capacity int32
+
+            init() {
+                capacity = 0
+            }
+
+            init(capacity int32) {
+                this.capacity = capacity
+            }
+
+            prop Capacity int32 -> capacity
+        }
+        """;
+
+    [Fact]
+    public void ImportedGenericConstructor_Overloads_CompileAndRun()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2621-artifacts",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            var fixturePath = CompileFixture(directory);
+            const string source = """
+                package Oahu.Cli.Commands
+                import System
+                import System.Collections.Generic
+                import Issue2621.Fixture
+
+                let bucket = Bucket[string](7)
+                let empty = Bucket[string]()
+                let rows = List[IReadOnlyDictionary[string, object?]](3)
+                Console.WriteLine(bucket.Capacity)
+                Console.WriteLine(empty.Capacity)
+                Console.WriteLine(rows.Capacity)
+                """;
+            var outputPath = Path.Combine(directory, "Oahu.Cli.dll");
+            var result = Compile(directory, source, outputPath, fixturePath);
+            Assert.True(result.ExitCode == 0, $"compile failed\n{result.Stdout}\n{result.Stderr}");
+            IlVerifier.Verify(outputPath, additionalReferences: new[] { fixturePath });
+            Assert.Equal("7\n0\n3\n", Run(outputPath));
+
+            const string invalidSource = """
+                package Oahu.Cli.Commands
+                import Issue2621.Fixture
+
+                let bucket = Bucket[string]("bad")
+                """;
+            var invalid = Compile(
+                directory,
+                invalidSource,
+                Path.Combine(directory, "Invalid.dll"),
+                fixturePath,
+                target: "library");
+            var diagnostics = invalid.Stdout + invalid.Stderr;
+            Assert.NotEqual(0, invalid.ExitCode);
+            Assert.Contains("GS0267", diagnostics, StringComparison.Ordinal);
+            Assert.DoesNotContain("GS0130", diagnostics, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static string CompileFixture(string directory)
+    {
+        var sourcePath = Path.Combine(directory, "Fixture.gs");
+        var outputPath = Path.Combine(directory, "Issue2621.Fixture.dll");
+        File.WriteAllText(sourcePath, FixtureSource);
+        var result = RunCompiler(new[]
+        {
+            "/out:" + outputPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            sourcePath,
+        });
+        Assert.True(result.ExitCode == 0, $"fixture compile failed\n{result.Stdout}\n{result.Stderr}");
+        return outputPath;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) Compile(
+        string directory,
+        string source,
+        string outputPath,
+        string fixturePath,
+        string target = "exe")
+    {
+        var sourcePath = Path.Combine(directory, Path.GetFileNameWithoutExtension(outputPath) + ".gs");
+        File.WriteAllText(sourcePath, source);
+        return RunCompiler(new[]
+        {
+            "/out:" + outputPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/reference:" + fixturePath,
+            sourcePath,
+        });
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunCompiler(string[] args)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return (Program.Main(args), stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string Run(string assemblyPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath)!,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n");
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2621ImportedGenericConstructorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2621ImportedGenericConstructorTests.cs
@@ -1,0 +1,73 @@
+// <copyright file="Issue2621ImportedGenericConstructorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2621ImportedGenericConstructorTests
+{
+    [Fact]
+    public void OahuCli_ListOfNestedGeneric_WithCapacity_Binds()
+    {
+        const string source = """
+            package Oahu.Cli.Commands
+            import System.Collections.Generic
+
+            func BuildRows(capacity int32) List[IReadOnlyDictionary[string, object?]] {
+                return List[IReadOnlyDictionary[string, object?]](capacity)
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ImportedGenericConstructor_MismatchedOverload_IsNotMissingFunction()
+    {
+        const string source = """
+            package Oahu.Cli.Commands
+            import System.Collections.Generic
+
+            func BuildRows() {
+                let rows = List[IReadOnlyDictionary[string, object?]]("bad")
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0267");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == "GS0130");
+    }
+
+    [Fact]
+    public void ImportedGenericConstructor_ArgumentError_DoesNotCascadeToMissingFunction()
+    {
+        const string source = """
+            package Oahu.Cli.Commands
+            import System.Collections.Generic
+
+            func BuildRows() {
+                let rows = List[IReadOnlyDictionary[string, object?]](missing.Count)
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0157");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id is "GS0130" or "GS0267");
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
+    }
+}


### PR DESCRIPTION
## Summary
- keep explicit imported generic calls in constructor binding after argument/overload failures
- suppress secondary GS0130 cascades and report GS0267 for genuine overload mismatches
- cover the exact Oahu nested-generic capacity shape plus cross-assembly runtime and negative cases

## Validation
- exact Oahu repro: GS0130 before, only the upstream argument diagnostic after
- Core.Tests: 6,618 passed, 1 skipped
- targeted Compiler.Tests: 6 passed
- Release solution build: succeeded (0 warnings/errors) before latest-main rebase
- rebased Release issue tests: 4 passed

Fixes #2621