### PR TITLE
Fix delegate-like callable conversions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -2082,7 +2082,10 @@ public sealed class Conversion
 
         for (var i = 0; i < from.Arity; i++)
         {
-            if (from.ParameterTypes[i] != to.ParameterTypes[i])
+            // Function parameters are contravariant: every value the target
+            // may supply must be accepted by the source callable.
+            var parameterConversion = ClassifyNonStructural(to.ParameterTypes[i], from.ParameterTypes[i]);
+            if (!parameterConversion.IsImplicit)
             {
                 return false;
             }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -552,9 +552,9 @@ internal sealed partial class MethodBodyEmitter
             $"Conversion from '{from.Name}' to '{to.Name}' is not yet supported by the emitter.");
     }
 
-    // Issues #1356/#2542: nullable return widening erases to the same CLR type,
-    // and Func's return slot is CLR-covariant for reference upcasts. Both are
-    // no-ops; parameters must remain exact.
+    // Issues #1356/#2542/#2618: reference nullability erases from parameter and
+    // return slots, and Func's return slot is CLR-covariant for reference
+    // upcasts. These conversions are representation-preserving no-ops.
     private static bool IsRepresentationPreservingFunctionConversion(
         FunctionTypeSymbol from,
         FunctionTypeSymbol to)
@@ -566,10 +566,15 @@ internal sealed partial class MethodBodyEmitter
 
         for (var i = 0; i < from.Arity; i++)
         {
-            if (from.ParameterTypes[i] != to.ParameterTypes[i])
+            if (!HaveSameReferenceRepresentation(from.ParameterTypes[i], to.ParameterTypes[i]))
             {
                 return false;
             }
+        }
+
+        if (from.ReturnType == to.ReturnType)
+        {
+            return true;
         }
 
         if (to.ReturnType is NullableTypeSymbol toNullableReturn
@@ -586,6 +591,44 @@ internal sealed partial class MethodBodyEmitter
 
         var returnConversion = Conversion.ClassifyNonStructural(from.ReturnType, to.ReturnType);
         return returnConversion.Exists && returnConversion.IsImplicit;
+    }
+
+    private static bool HaveSameReferenceRepresentation(TypeSymbol left, TypeSymbol right)
+    {
+        while (left is NullabilityAnnotatedTypeSymbol leftAnnotated)
+        {
+            left = leftAnnotated.BaseType;
+        }
+
+        while (right is NullabilityAnnotatedTypeSymbol rightAnnotated)
+        {
+            right = rightAnnotated.BaseType;
+        }
+
+        if (left is NullableTypeSymbol leftReferenceNullable
+            && Conversion.IsReferenceLikeTarget(leftReferenceNullable.UnderlyingType))
+        {
+            left = leftReferenceNullable.UnderlyingType;
+        }
+
+        if (right is NullableTypeSymbol rightReferenceNullable
+            && Conversion.IsReferenceLikeTarget(rightReferenceNullable.UnderlyingType))
+        {
+            right = rightReferenceNullable.UnderlyingType;
+        }
+
+        if (left == right)
+        {
+            return true;
+        }
+
+        if (!Conversion.IsReferenceLikeTarget(left) || !Conversion.IsReferenceLikeTarget(right))
+        {
+            return false;
+        }
+
+        return Conversion.ClassifyNonStructural(left, right).IsImplicit
+            && Conversion.ClassifyNonStructural(right, left).IsImplicit;
     }
 
     // Issue #1236: emit a lifted numeric widening between two distinct value-type

--- a/test/Compiler.Tests/Emit/Issue2618DelegateLikeConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2618DelegateLikeConversionEmitTests.cs
@@ -1,0 +1,175 @@
+// <copyright file="Issue2618DelegateLikeConversionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2618: user callable values retain delegate variance when passed to
+/// source constructors, while ordinary classes remain invalid lambda targets.
+/// </summary>
+public class Issue2618DelegateLikeConversionEmitTests
+{
+    [Fact]
+    public void LambdaAndMethodValue_UserFunctionConstructor_Run()
+    {
+        const string Source = """
+            package P
+            import System
+
+            class State {
+                var Value int32
+            }
+
+            class RelayLike {
+                let execute (State) -> void
+                init(action (State) -> void) {
+                    execute = action
+                }
+                func Execute() {
+                    execute(State{Value: 7})
+                }
+            }
+
+            class Handler {
+                func OnState(state State) {
+                    Console.WriteLine(state.Value)
+                }
+            }
+
+            func Main() {
+                let nullableAction = (state State?) -> {
+                    if state != nil {
+                        Console.WriteLine(state.Value)
+                    }
+                }
+                RelayLike(nullableAction).Execute()
+                let handler = Handler()
+                RelayLike(handler.OnState).Execute()
+            }
+            """;
+
+        Assert.Equal("7\n7\n", CompileAndRun(Source));
+    }
+
+    [Fact]
+    public void ArbitraryClass_RemainsInvalidLambdaTarget()
+    {
+        const string Source = """
+            class Ordinary {}
+
+            func Main() {
+                let invalid Ordinary = () -> {}
+            }
+            """;
+
+        Assert.Contains("GS0155", CompileForDiagnostics(Source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        string directory = NewDirectory();
+        string sourcePath = Path.Combine(directory, "test.gs");
+        string assemblyPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        try
+        {
+            using var stdout = new StringWriter();
+            var previous = Console.Out;
+            Console.SetOut(stdout);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + assemblyPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previous);
+            }
+
+            Assert.True(exitCode == 0, stdout.ToString());
+            IlVerifier.Verify(assemblyPath);
+
+            using var process = Process.Start(new ProcessStartInfo("dotnet")
+            {
+                ArgumentList =
+                {
+                    "exec",
+                    "--runtimeconfig",
+                    Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                    assemblyPath,
+                },
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            });
+            string output = process.StandardOutput.ReadToEnd();
+            string error = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, error);
+            return output.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string CompileForDiagnostics(string source)
+    {
+        string directory = NewDirectory();
+        string sourcePath = Path.Combine(directory, "test.gs");
+        string assemblyPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        try
+        {
+            using var stdout = new StringWriter();
+            var previous = Console.Out;
+            Console.SetOut(stdout);
+            try
+            {
+                Program.Main(new[]
+                {
+                    "/out:" + assemblyPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previous);
+            }
+
+            return stdout.ToString();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string NewDirectory()
+    {
+        string directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2618",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2618DelegateLikePipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2618DelegateLikePipelineTests.cs
@@ -1,0 +1,186 @@
+// <copyright file="Issue2618DelegateLikePipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+[Collection("Issue2599NuGetEnvironment")]
+public sealed class Issue2618DelegateLikePipelineTests : IDisposable
+{
+    private readonly string previousNuGetPackages;
+
+    public Issue2618DelegateLikePipelineTests()
+    {
+        this.previousNuGetPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        Environment.SetEnvironmentVariable("NUGET_PACKAGES", NewDirectory("sdk-packages"));
+    }
+
+    [Fact]
+    public async Task Pipeline_RelayCommandAndActionLikeConstructor_Compile()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("source");
+        string projectPath = WriteProject(sourceRoot);
+        AssertProcessSucceeds("dotnet", $"restore \"{projectPath}\" --nologo", sourceRoot);
+
+        string outputRoot = NewDirectory("output");
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+
+        RunResult result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("test/Issue2618", projectPath, TargetKind.Library),
+        });
+        AppResult app = Assert.Single(result.Apps);
+        Assert.True(
+            app.Succeeded,
+            string.Join(
+                Environment.NewLine,
+                app.Artifacts.Select(path => File.ReadAllText(Path.Combine(
+                    outputRoot,
+                    result.RunId,
+                    path)))));
+
+        string appDirectory = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.AppId));
+        string translated = File.ReadAllText(Path.Combine(appDirectory, "Repro.gs"));
+        Assert.Contains("let onState (State) -> void", translated, StringComparison.Ordinal);
+        Assert.Contains("Job(onState)", translated, StringComparison.Ordinal);
+
+        string generated = File.ReadAllText(Directory.GetFiles(
+            Path.Combine(appDirectory, "obj"),
+            "*Vm.Run.g.gs",
+            SearchOption.AllDirectories).Single());
+        Assert.Contains("AsyncRelayCommand(Run)", generated, StringComparison.Ordinal);
+        Assert.DoesNotContain("= RelayCommand(Run)", generated, StringComparison.Ordinal);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("NUGET_PACKAGES", this.previousNuGetPackages);
+    }
+
+    private static string WriteProject(string sourceRoot)
+    {
+        string projectPath = Path.Combine(sourceRoot, "Issue2618.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(sourceRoot, "Repro.cs"), """
+            using System;
+            using System.Threading.Tasks;
+            using CommunityToolkit.Mvvm.ComponentModel;
+            using CommunityToolkit.Mvvm.Input;
+
+            namespace Issue2618;
+
+            public sealed class State
+            {
+                public int Value { get; set; }
+            }
+
+            public sealed class Job
+            {
+                public Job(Action<State> callback) => callback(new State());
+            }
+
+            public partial class Vm : ObservableObject
+            {
+                [RelayCommand]
+                private async Task Run() => await Task.Yield();
+
+                public void Wire()
+                {
+                    Action<State> onState = state => _ = state.Value;
+                    _ = new Job(onState);
+                }
+            }
+            """);
+        return projectPath;
+    }
+
+    private static void AssertProcessSucceeds(string fileName, string arguments, string workingDirectory)
+    {
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, output);
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2618",
+            category,
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirectoryName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirectoryName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/gsgen/GSharp.GeneratorHost.Tests/GsStubProjectionTests.cs
+++ b/tools/gsgen/GSharp.GeneratorHost.Tests/GsStubProjectionTests.cs
@@ -128,6 +128,21 @@ class Seqs {
     }
 
     [Fact]
+    public void AsyncMethods_RenderObservableTaskReturnTypes()
+    {
+        var stub = Project(@"
+class Commands {
+    async func Run() {}
+    async func GetCount() int32 { return 1 }
+}
+");
+
+        Assert.Contains("global::System.Threading.Tasks.Task Run()", stub);
+        Assert.Contains("global::System.Threading.Tasks.Task<int> GetCount()", stub);
+        Assert.DoesNotContain("void Run()", stub);
+    }
+
+    [Fact]
     public void NonPartialClass_RendersWithoutPartial()
     {
         var stub = Project(@"

--- a/tools/gsgen/GSharp.GeneratorHost/GsStubRenderer.cs
+++ b/tools/gsgen/GSharp.GeneratorHost/GsStubRenderer.cs
@@ -460,12 +460,25 @@ public sealed class GsStubRenderer
             }
 
             var isVoid = method.Type == null || method.Type == TypeSymbol.Void;
-            sb.Append(isVoid ? "void" : speller.Spell(method.Type)).Append(' ').Append(method.Name);
+            sb.Append(RenderMethodReturnType(method, isVoid)).Append(' ').Append(method.Name);
             sb.Append(RenderTypeParameters(method.TypeParameters));
             sb.Append('(').Append(RenderParameters(method.Parameters)).Append(')');
             sb.Append(RenderConstraints(method.TypeParameters));
-            sb.AppendLine(isVoid ? " { }" : " => throw null!;");
+            sb.AppendLine(isVoid && !method.IsAsync ? " { }" : " => throw null!;");
         }
+    }
+
+    private string RenderMethodReturnType(FunctionSymbol method, bool isVoid)
+    {
+        if (!method.IsAsync)
+        {
+            return isVoid ? "void" : speller.Spell(method.Type);
+        }
+
+        var wrapper = method.AsyncReturnsValueTask
+            ? "global::System.Threading.Tasks.ValueTask"
+            : "global::System.Threading.Tasks.Task";
+        return isVoid ? wrapper : wrapper + "<" + speller.Spell(method.Type) + ">";
     }
 
     private string RenderParameters(ImmutableArray<ParameterSymbol> parameters)


### PR DESCRIPTION
## Summary
- preserve `Task`/`Task<T>` and `ValueTask`/`ValueTask<T>` signatures in gsgen C# stubs, so CommunityToolkit emits `AsyncRelayCommand` for G# async methods
- apply safe contravariance to user function/delegate-like parameters and emit reference-nullability-only reshapes as representation-preserving conversions
- keep arbitrary classes invalid lambda targets

## Exact Oahu proof
Before the fix, the current Oahu.UI migration reproduced seven generated `RelayCommand(asyncMethod)` GS0155 sites, including `Run`, both `Browse*Directory` methods, `SubmitDirectLogin`, and `SubmitResponseUrl`. After the fix, the same SDK-backed migration reports zero RelayCommand GS0155 diagnostics (seven target fingerprints removed; four unrelated diagnostics remain).

The project-backed regression also preserves and compiles the Oahu.App/Oahu.Cli.App `Action<State>`-like lambda/local plus source-constructor shape.

## Validation
- `dotnet build GSharp.sln -c Release --no-restore --nologo --verbosity:quiet` (0 warnings, 0 errors)
- full Core.Tests: 6,615 passed, 1 skipped
- full Compiler.Tests: 3,289 passed
- full GeneratorHost.Tests: 29 passed
- full Cs2Gs.Tests: 1,694 passed
- rebased focused runtime/negative/projection/SDK pipeline tests: 14 passed

Fixes #2618
