### PR TITLE
Fix cs2gs null literal forgiveness

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2525ImportedIndexerHidingPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2525ImportedIndexerHidingPipelineTests.cs
@@ -144,7 +144,10 @@ public sealed class Issue2525ImportedIndexerHidingPipelineTests
 
             public sealed class Holder
             {
-                public IDerived Values { get; } = null!;
+                public IDerived Values { get; } = CreateValues();
+
+                private static IDerived CreateValues() =>
+                    throw new System.InvalidOperationException();
             }
 
             public static class Repro

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -182,15 +182,72 @@ namespace Demo
     }
 
     /// <summary>
-    /// The C# null-forgiving <em>null literal</em> <c>null!</c> (passing null where
-    /// a non-nullable reference is expected) maps to <c>default(T)</c> for the
-    /// expected type — not <c>nil!!</c>, which G#'s Kotlin-style nullability
-    /// rejects (the assertion keeps the operand type <c>nil</c>, issue #1072).
-    /// <c>default(T)</c> is null at runtime — faithful to <c>null!</c> — and is a
-    /// native non-nullable G# value (#914).
+    /// A null literal remains <c>nil</c> at nullable sinks, including the exact
+    /// Oahu DownloadCommand dictionary assignment from issue #2647.
     /// </summary>
     [Fact]
-    public void SuppressNullableWarning_OnNullLiteralArgument_MapsToDefaultOfExpectedType()
+    public void NullLiteral_AtNullableSinks_NeverGetsNonNullAssertion()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class Box
+    {
+        public object? Value { get; set; }
+    }
+
+    public static class DownloadCommand
+    {
+        private static event System.Action Changed;
+
+        private static void Accept(object? value) { }
+
+        public static object? Record(
+            System.Collections.Generic.Dictionary<string, object?> response,
+            Box box)
+        {
+            var rows = new System.Collections.Generic.List<
+                System.Collections.Generic.IReadOnlyDictionary<string, object?>>();
+            rows.Add(new System.Collections.Generic.Dictionary<string, object?>
+            {
+                [""error""] = null,
+            });
+            var strict = new System.Collections.Generic.Dictionary<string, object>
+            {
+                [""bare""] = null,
+                [""suppressed""] = (null)!,
+            };
+            object? local = null;
+            local = null;
+            box.Value = null;
+            response[""error""] = null;
+            Accept((null)!);
+            Changed += null;
+            var strictKeys = new System.Collections.Generic.Dictionary<string, string>();
+            var missing = strictKeys[null];
+            var cast = (string)null;
+            System.Func<object> factory = () => null;
+            System.Console.WriteLine("""".StartsWith(null));
+            return null;
+        }
+    }
+}");
+
+        Assert.Contains("[\"error\"] = nil", printed);
+        Assert.Contains("response[\"error\"] = nil", printed);
+        Assert.Contains("strictKeys[nil]", printed);
+        Assert.Contains("StartsWith(nil)", printed);
+        Assert.DoesNotContain("default(object)", printed);
+        Assert.DoesNotContain("nil!!", printed);
+    }
+
+    /// <summary>
+    /// C#'s suppression on a null literal must not manufacture a non-null G#
+    /// value. Keeping <c>nil</c> lets the target type accept nullable sinks and
+    /// reject genuinely non-null sinks.
+    /// </summary>
+    [Fact]
+    public void SuppressNullableWarning_OnNullLiteral_PreservesTargetChecking()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -206,7 +263,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("base(default(Node))", printed);
+        Assert.Contains("base(nil)", printed);
+        Assert.DoesNotContain("default(Node)", printed);
         Assert.DoesNotContain("nil!!", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -783,6 +783,7 @@ public sealed partial class CSharpToGSharpTranslator
             bool includePromotedValue = false)
         {
             if (translated is NonNullAssertionExpression
+                || IsNullOrSuppressedNull(value)
                 || value is PostfixUnaryExpressionSyntax
                     { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
                 || this.IsWithinExpressionTreeLambda(value)
@@ -907,7 +908,8 @@ public sealed partial class CSharpToGSharpTranslator
 
         private bool IndexArgumentValueNeedsNullForgiveness(ExpressionSyntax value)
         {
-            if (value is PostfixUnaryExpressionSyntax
+            if (IsNullOrSuppressedNull(value)
+                || value is PostfixUnaryExpressionSyntax
                     { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
                 || this.IsWithinExpressionTreeLambda(value))
             {
@@ -1798,7 +1800,8 @@ public sealed partial class CSharpToGSharpTranslator
 
         private bool IsUnguardedForwardOfTaintedValueAsRuntimeLambdaResult(ExpressionSyntax use)
         {
-            if (!this.IsObliviousCompilation()
+            if (IsNullOrSuppressedNull(use)
+                || !this.IsObliviousCompilation()
                 || this.IsWithinExpressionTreeLambda(use)
                 || this.FindResultLambda(use) is not { } lambda
                 || this.GetLambdaTargetDelegateType(lambda) is not { DelegateInvokeMethod: { } invoke }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1514,6 +1514,7 @@ public sealed partial class CSharpToGSharpTranslator
             ISymbol targetSymbolForPromotionCheck)
         {
             if (translatedValue is NonNullAssertionExpression
+                || IsNullOrSuppressedNull(valueExpression)
                 || !this.TargetWillRemainNonNullableReference(
                     targetType,
                     targetSymbolForPromotionCheck))
@@ -2238,6 +2239,7 @@ public sealed partial class CSharpToGSharpTranslator
             if (this.IsObliviousCompilation()
                 && targetSymbol is { IsReferenceType: true }
                 && targetSymbol.NullableAnnotation != NullableAnnotation.Annotated
+                && !IsNullOrSuppressedNull(cast.Expression)
                 && cast.Expression is not PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
                 && this.IsNullablePromotedValue(cast.Expression))
             {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -695,16 +695,16 @@ public sealed partial class CSharpToGSharpTranslator
             expression is LiteralExpressionSyntax literal
                 && literal.IsKind(SyntaxKind.NullLiteralExpression);
 
-        // `null` or `null!` (a SuppressNullableWarning over a null literal).
-        private static bool IsNullOrSuppressedNull(ExpressionSyntax expression)
-        {
-            if (expression is PostfixUnaryExpressionSyntax suppress
-                && suppress.IsKind(SyntaxKind.SuppressNullableWarningExpression))
+        // `null`, parenthesized null, or either form under C# null suppression.
+        private static bool IsNullOrSuppressedNull(ExpressionSyntax expression) =>
+            expression switch
             {
-                expression = suppress.Operand;
-            }
-
-            return IsNullLiteral(expression);
-        }
+                ParenthesizedExpressionSyntax parenthesized =>
+                    IsNullOrSuppressedNull(parenthesized.Expression),
+                PostfixUnaryExpressionSyntax suppress
+                    when suppress.IsKind(SyntaxKind.SuppressNullableWarningExpression) =>
+                        IsNullOrSuppressedNull(suppress.Operand),
+                _ => IsNullLiteral(expression),
+            };
     }
 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -373,20 +373,11 @@ public sealed partial class CSharpToGSharpTranslator
                     // The C# null-forgiving operator `expr!` maps to G#'s postfix
                     // non-null assertion `expr!!` (spec: "Postfix `!!` asserts
                     // non-null"), preserving the assertion (ADR-0115 §B).
-                    //
-                    // Exception: the C# null-forgiving null literal `null!` (used to
-                    // pass null where a non-nullable reference is expected, e.g.
-                    // `: base(header, null!)`). G# follows Kotlin-style nullability
-                    // and rejects `nil!!` — the assertion keeps the operand's type
-                    // `nil`, so it cannot satisfy a non-nullable target (GS0154 /
-                    // GS0155 / a misleading GS0214 in base-initializer position,
-                    // issue #1072). Emit `default(T)` for the expected (converted)
-                    // type instead: this is null at runtime — behaviourally
-                    // identical to C#'s `null!` — and is a native, non-nullable G#
-                    // value (#914, #1072).
-                    if (suppressNullable.Operand.IsKind(SyntaxKind.NullLiteralExpression))
+                    // A null literal is never forgivable: preserve `nil` so its
+                    // target type accepts nullable sinks and rejects non-null ones.
+                    if (IsNullOrSuppressedNull(suppressNullable.Operand))
                     {
-                        return new DefaultValueExpression(this.ResolveExpressionType(suppressNullable));
+                        return this.TranslateExpression(suppressNullable.Operand);
                     }
 
                     return new NonNullAssertionExpression(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -520,6 +520,7 @@ public sealed partial class CSharpToGSharpTranslator
             if ((!assignment.IsKind(SyntaxKind.AddAssignmentExpression)
                     && !assignment.IsKind(SyntaxKind.SubtractAssignmentExpression))
                 || translatedRhs is NonNullAssertionExpression
+                || IsNullOrSuppressedNull(assignment.Right)
                 || this.context.GetSymbolInfo(assignment.Left).Symbol is not IEventSymbol eventSymbol
                 || eventSymbol.Type is not { IsReferenceType: true })
             {
@@ -554,6 +555,7 @@ public sealed partial class CSharpToGSharpTranslator
             if (!this.IsObliviousCompilation()
                 || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
                 || translatedRhs is NonNullAssertionExpression
+                || IsNullOrSuppressedNull(assignment.Right)
                 || assignment.Left is not ElementAccessExpressionSyntax
                 || !this.IsNullablePromotedValue(assignment.Right))
             {


### PR DESCRIPTION
## Summary
- preserve null literals as `nil` across target-aware forgiveness paths
- change the Oahu `DownloadCommand` site from `["error"] = nil!!` to `["error"] = nil`
- retain target typing so nullable sinks compile while genuinely non-null sinks reject `nil`

## Tests
- focused null-literal regression tests
- full `Cs2Gs.Tests` suite, including the strict-sink pipeline fixture
- CI `build`, `cs2gs`, `e2e`, VS/VS Code extension, and VSIX checks green

Fixes #2647