### PR TITLE
Fix object alias static member binding

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -1452,10 +1452,10 @@ internal sealed partial class ExpressionBinder
 
     /// <summary>
     /// Issue #687 (Option A): when a name resolves to a value but also matches an
-    /// in-scope type with the same simple name (an imported CLR class, user-defined
-    /// struct/class, or enum), surface that type so the caller can apply the
-    /// C#-style "color color" preference when the right-hand side of the accessor
-    /// is a static member of the type.
+    /// in-scope type with the same simple name (an imported/aliased CLR type,
+    /// user-defined struct/class, or enum), surface that type so the caller can
+    /// apply the C#-style "color color" preference when the right-hand side of
+    /// the accessor is a static member of the type.
     /// </summary>
     private bool TryResolveColorColorType(
         string name,
@@ -1485,6 +1485,13 @@ internal sealed partial class ExpressionBinder
                 enumSymbol = foundEnum;
                 return true;
             }
+        }
+
+        var clrType = lookupType(name);
+        if (clrType?.ClrType != null && !ReferenceEquals(clrType, TypeSymbol.Void))
+        {
+            importedClassSymbol = new ImportedClassSymbol(clrType.ClrType, leftName, references: scope.References);
+            return true;
         }
 
         if (scope.TryLookupImportedClass(name, leftName, out var importedClass))

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -186,7 +186,7 @@ public sealed class ImportedClassSymbol : Symbol
         isAmbiguous = false;
         ambiguousMethods = ImmutableArray<MethodInfo>.Empty;
         isExpanded = false;
-        var methods = ClrTypeUtilities.SafeGetMethods(ClassType, GetImportedMemberBindingFlags(includeInstance: true))
+        var methods = ClrTypeUtilities.SafeGetMethods(ClassType, GetImportedMemberBindingFlags())
             .Where(IsVisibleToCurrentCompilation)
             .ToArray();
         var nameMatches = methods.Where(m => m.Name == text).ToList();

--- a/test/Compiler.Tests/Emit/Issue1136ObjectMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1136ObjectMemberEmitTests.cs
@@ -22,6 +22,24 @@ namespace GSharp.Compiler.Tests.Emit;
 public class Issue1136ObjectMemberEmitTests
 {
     [Fact]
+    public void ObjectAlias_ReferenceEquals_ExactOahuShape_EmitsAndRuns()
+    {
+        var source = """
+            package Oahu.Cli.Tui.Screens
+            import System
+
+            class Modal { }
+
+            let activeModal = Modal{}
+            let pendingModal = activeModal
+            Console.WriteLine(object.ReferenceEquals(activeModal, pendingModal))
+            Console.WriteLine(object.ReferenceEquals(activeModal, Modal{}))
+            """;
+
+        Assert.Equal("True\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
     public void ClassReceiver_ObjectMembers_EmitAndRun()
     {
         var source = """

--- a/test/Core.Tests/CodeAnalysis/Binding/ClrMemberAccessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClrMemberAccessTests.cs
@@ -172,6 +172,49 @@ var m = int.MaxValue
     }
 
     [Fact]
+    public void ObjectReferenceEquals_LowercaseAlias_Binds()
+    {
+        var result = Evaluate("""
+            class Item { }
+            let item = Item{}
+            object.ReferenceEquals(item, item)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.True((bool)result.Value);
+    }
+
+    [Fact]
+    public void ShadowedClrAlias_UsesStaticTypeOrInstanceValueByMemberKind()
+    {
+        var result = Evaluate("""
+            func Same(object string, left object, right object) bool -> object.ReferenceEquals(left, right)
+            func Length(object string) int32 -> object.Length
+            let value object = "same"
+            Same("shadow", value, value) && Length("shadow") == 6
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.True((bool)result.Value);
+    }
+
+    [Fact]
+    public void ClrTypeReceiver_RejectsInstanceMethod()
+    {
+        var result = Evaluate("func Bad() string? -> object.ToString()");
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0159");
+    }
+
+    [Fact]
+    public void ClrInstanceReceiver_RejectsStaticMethod()
+    {
+        var result = Evaluate("func Bad(value object) bool -> value.ReferenceEquals(value, value)");
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0159");
+    }
+
+    [Fact]
     public void StringEmpty_LowercaseAlias_UnknownMember_Diagnoses()
     {
         // The lowercase alias receiver still reports unknown members rather than


### PR DESCRIPTION
## Summary
- resolve CLR aliases as static type candidates even when a same-named value is in scope
- restrict type-qualified imported calls to static methods while preserving instance-value binding
- cover the exact Oahu `object.ReferenceEquals(activeModal, pendingModal)` shape at bind, emit, ILVerify, and runtime

## Before / after
- Before: Oahu `HomeScreen.gs` reported GS0158 for `object.ReferenceEquals(...)`; shadowed CLR aliases resolved only as values, and `object.ToString()` incorrectly bound as a type-qualified call.
- After: `object.ReferenceEquals(...)` emits and runs (`True` / `False` proof); type receivers reject instance methods and instance receivers reject static methods with GS0159.

## Validation
- `Core.Tests`: 6,650 passed, 1 skipped
- object/imported runtime suites: 15 passed
- focused issue tests: 5 passed

Fixes #2639