### PR TITLE
Fix partial cast receiver statement parsing

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
@@ -623,7 +623,9 @@ public partial class Parser
             // Issue #143: contextual `nameof(expr)` — argument is a name reference.
             current = ParseNameOfExpression();
         }
-        else if (Current.Kind == SyntaxKind.IdentifierToken && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
+        else if (Current.Kind == SyntaxKind.IdentifierToken
+            && Peek(1).Kind == SyntaxKind.OpenParenthesisToken
+            && !IsTokenOnNewLineAfter(Peek(1), Current))
         {
             current = ParseCallExpression();
             current = MaybeWrapWithObjectInitializer(current);

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -708,6 +708,9 @@ public partial class Parser
     /// <param name="node">The expression parsed so far on the current line.</param>
     /// <returns><c>true</c> when the current token is on a new line.</returns>
     private bool IsCurrentOnNewLineAfter(SyntaxNode node)
+        => IsTokenOnNewLineAfter(Current, node);
+
+    private bool IsTokenOnNewLineAfter(SyntaxToken token, SyntaxNode node)
     {
         if (node == null)
         {
@@ -716,7 +719,7 @@ public partial class Parser
 
         var text = syntaxTree.Text;
         var previousLine = text.GetLineIndex(System.Math.Max(0, node.Span.End - 1));
-        var currentLine = text.GetLineIndex(Current.Position);
+        var currentLine = text.GetLineIndex(token.Position);
         return currentLine > previousLine;
     }
 

--- a/test/Core.Tests/CodeAnalysis/Adr0144PartialTypesBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0144PartialTypesBinderTests.cs
@@ -132,6 +132,52 @@ Console.WriteLine(c.Abs())
     }
 
     [Fact]
+    public void CrossPackage_SecondaryPartialPropertyThroughAsCast_MergesAndRuns()
+    {
+        var generatedPart = SyntaxTree.Parse(SourceText.From(
+            """
+            package Models
+
+            partial class BookItemViewModel {
+                prop IsSelected bool
+            }
+            """,
+            "A.Generated.gs"));
+        var sourcePart = SyntaxTree.Parse(SourceText.From(
+            """
+            package Models
+
+            partial class BookItemViewModel(asin string) {
+                prop Asin string -> asin
+            }
+            """,
+            "B.Source.gs"));
+        var consumer = SyntaxTree.Parse(SourceText.From(
+            """
+            package Views
+            import Models
+            import System
+
+            class Selection {
+                prop Asin string
+                prop Item BookItemViewModel
+            }
+
+            let item object = BookItemViewModel("B001")
+            let selection object = Selection()
+            (selection as Selection)!!.Asin = (item as BookItemViewModel)!!.Asin
+            (selection as Selection)!!.Item = (item as BookItemViewModel)!!
+            Console.WriteLine((selection as Selection)!!.Asin)
+            """,
+            "C.View.gs"));
+
+        var output = CompileLoadInvokeCaptureStdout(
+            new[] { generatedPart, sourcePart, consumer },
+            "Issue2641-PartialCastReceiver");
+        Assert.Contains("B001", output);
+    }
+
+    [Fact]
     public void TwoPartialStructParts_Merge()
     {
         var source = @"package App

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2599AvaloniaCodebehindTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2599AvaloniaCodebehindTests.cs
@@ -91,6 +91,62 @@ public sealed class Issue2599AvaloniaCodebehindTests : IDisposable
         Assert.Contains("@System.CodeDom.Compiler.GeneratedCode", generated, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task Pipeline_SecondaryPartialPropertyThroughAsCast_Compiles()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("issue2641-source");
+        string projectPath = WriteIssue2641Project(sourceRoot);
+        AssertProcessSucceeds("dotnet", $"restore \"{projectPath}\" --nologo", sourceRoot);
+
+        string outputRoot = NewDirectory("issue2641-output");
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+
+        RunResult result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("test/Issue2641", projectPath, TargetKind.Library),
+        });
+
+        AppResult app = Assert.Single(result.Apps);
+        Assert.True(
+            app.Succeeded,
+            string.Join(
+                Environment.NewLine,
+                app.Artifacts.Select(path => File.ReadAllText(Path.Combine(
+                    outputRoot,
+                    result.RunId,
+                    path)))));
+
+        string appDirectory = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.AppId));
+        string view = File.ReadAllText(Path.Combine(appDirectory, "C.View.gs"));
+        Assert.Contains(
+            "(context as Selection)!!.Asin = (x as BookItemViewModel)!!.Asin",
+            view,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "(context as Selection)!!.Item = (x as BookItemViewModel)!!",
+            view,
+            StringComparison.Ordinal);
+    }
+
     public void Dispose()
     {
         Environment.SetEnvironmentVariable("NUGET_PACKAGES", this.previousNuGetPackages);
@@ -171,6 +227,67 @@ public sealed class Issue2599AvaloniaCodebehindTests : IDisposable
             public sealed class State
             {
                 public int Count { get; set; }
+            }
+            """);
+        return projectPath;
+    }
+
+    private static string WriteIssue2641Project(string sourceRoot)
+    {
+        string projectPath = Path.Combine(sourceRoot, "Issue2641.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(sourceRoot, "A.GeneratedPart.cs"), """
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace Issue2641.Models;
+
+            public partial class BookItemViewModel : ObservableObject
+            {
+                [ObservableProperty]
+                private bool isSelected;
+            }
+            """);
+        File.WriteAllText(Path.Combine(sourceRoot, "B.SourcePart.cs"), """
+            namespace Issue2641.Models;
+
+            public partial class BookItemViewModel
+            {
+                private readonly string asin;
+
+                public BookItemViewModel(string asin) => this.asin = asin;
+
+                public string Asin => asin;
+            }
+            """);
+        File.WriteAllText(Path.Combine(sourceRoot, "C.View.cs"), """
+            using Issue2641.Models;
+
+            namespace Issue2641.Views;
+
+            public sealed class Selection
+            {
+                public string Asin { get; set; } = string.Empty;
+
+                public BookItemViewModel Item { get; set; } = null!;
+            }
+
+            public sealed class View
+            {
+                public void Copy(object context, object x)
+                {
+                    (context as Selection)!.Asin = (x as BookItemViewModel)!.Asin;
+                    (context as Selection)!.Item = (x as BookItemViewModel)!;
+                }
             }
             """);
         return projectPath;


### PR DESCRIPTION
## Summary
- stop a next-line parenthesized statement from being parsed as arguments to the preceding member name
- cover cross-package, multi-document partial aggregation and cast receiver property lookup
- add a cs2gs project-backed source-generator regression matching the Oahu assignment sequence

## Exact Oahu proof
Re-ran `corpus/Oahu.UI` from `oahu-cycle6-wt` with isolated packages. The owned `BookLibraryView.axaml.gs:35` `Asin` diagnostic and fingerprint `c93cd2ddcaac...` disappeared. The sole remaining compile fingerprint is unrelated `GS0155` at `MainWindowViewModel.gs:81` (`51d25b3cb55f...`).

## Validation
- `dotnet build GSharp.sln -c Release --no-restore --nologo -m:1`
- Core.Tests: 6,647 passed, 1 skipped
- Cs2Gs.Tests: 1,699 passed
- exact Oahu.UI migration rerun; owned diagnostic absent

Fixes #2641