### PR TITLE
Fix declaration pattern variable identity

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2646DeclarationPatternPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2646DeclarationPatternPipelineTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="Issue2646DeclarationPatternPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2646DeclarationPatternPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_OahuNullableIntDeclarationPattern_Compiles()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("source");
+        string projectPath = Path.Combine(sourceRoot, "Issue2646.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(sourceRoot, "Program.cs"), """
+            namespace Oahu.Cli;
+
+            public static class Program
+            {
+                public static int Run(int? rewriteCode)
+                {
+                    if (rewriteCode is int code)
+                    {
+                        return code;
+                    }
+
+                    return -1;
+                }
+            }
+            """);
+
+        string outputRoot = NewDirectory("output");
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
+
+        RunResult result = await pipeline.RunAsync(new[]
+        {
+            new CorpusApp("test/Issue2646", projectPath, TargetKind.Library),
+        });
+        AppResult app = Assert.Single(result.Apps);
+        Assert.True(
+            app.Succeeded,
+            string.Join(
+                Environment.NewLine,
+                app.Artifacts.Select(path => File.ReadAllText(Path.Combine(
+                    outputRoot,
+                    result.RunId,
+                    path)))));
+
+        string translated = File.ReadAllText(Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.AppId),
+            "Program.gs"));
+        Assert.Contains("let code = rewriteCode", translated, StringComparison.Ordinal);
+        Assert.Contains("if code is int32", translated, StringComparison.Ordinal);
+        Assert.DoesNotContain("return rewriteCode", translated, StringComparison.Ordinal);
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2646",
+            category,
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static string FindSiblingTool(string projectDirectoryName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirectoryName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2646DeclarationPatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2646DeclarationPatternTranslationTests.cs
@@ -1,0 +1,162 @@
+// <copyright file="Issue2646DeclarationPatternTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2646DeclarationPatternTranslationTests
+{
+    [Fact]
+    public void OahuNullableIntPattern_PreservesCodeIdentity()
+    {
+        string printed = Translate("""
+            namespace Oahu.Cli
+            {
+                public sealed class Program
+                {
+                    public int Run(int? rewriteCode)
+                    {
+                        if (rewriteCode is int code)
+                        {
+                            return code;
+                        }
+
+                        return -1;
+                    }
+                }
+            }
+            """);
+
+        Assert.Contains("let code = rewriteCode", printed, StringComparison.Ordinal);
+        Assert.Contains("if code is int32", printed, StringComparison.Ordinal);
+        Assert.Contains("return code", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("if rewriteCode is int32", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("return rewriteCode", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValuePattern_NarrowsNamedBinderAcrossFollowingScope()
+    {
+        string printed = Translate("""
+            namespace Demo
+            {
+                public sealed class C
+                {
+                    public int Read(object value)
+                    {
+                        if (value is int code)
+                        {
+                        }
+                        else
+                        {
+                            return -1;
+                        }
+
+                        return code;
+                    }
+                }
+            }
+            """);
+
+        Assert.Contains("let code = value", printed, StringComparison.Ordinal);
+        Assert.Contains("if code is int32", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("return value", printed, StringComparison.Ordinal);
+        Assert.Equal(
+            "42\n-1",
+            CompileAndRun(
+                printed,
+                "System.Console.WriteLine(C().Read(42))\nSystem.Console.WriteLine(C().Read(\"no\"))").Trim());
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+
+    private static string CompileAndRun(string printed, string entryPoint)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built before running this test.");
+
+        string directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue-2646",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string source = Path.Combine(directory, "Program.gs");
+        string output = Path.Combine(directory, "Program.dll");
+        File.WriteAllText(source, printed + Environment.NewLine + entryPoint + Environment.NewLine);
+
+        (int compileExit, string compileOutput) = Run(
+            $"\"{compiler}\" /target:exe /out:\"{output}\" \"{source}\"");
+        Assert.True(compileExit == 0, compileOutput + Environment.NewLine + printed);
+
+        (int runExit, string runOutput) = Run($"\"{output}\"");
+        Assert.True(runExit == 0, runOutput);
+        return runOutput;
+    }
+
+    private static (int ExitCode, string Output) Run(string arguments)
+    {
+        using var process = Process.Start(new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    "Compiler",
+                    "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914TranslatorFidelityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914TranslatorFidelityTests.cs
@@ -51,7 +51,7 @@ namespace Demo
     }
 
     [Fact]
-    public void PositivePattern_LocalScrutinee_UsedOnlyInsideThen_KeepsSmartCastNoHoist()
+    public void PositivePattern_LocalScrutinee_PreservesBinderIdentity()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -68,10 +68,8 @@ namespace Demo
     }
 }");
 
-        // A bare local scrutinee smart-casts in gsc, so no hoist: the existing
-        // smart-cast `is` test is kept and `esds` rewrites to the local.
-        Assert.Contains("local is E", printed);
-        Assert.DoesNotContain("as E", printed);
+        Assert.Contains("let esds E? = local as E", printed);
+        Assert.Contains("if esds != nil", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -149,8 +149,8 @@ namespace Demo
 
     /// <summary>
     /// ADR-0115 §B: `x is null` / `x is not null` map to G# `== nil` / `!= nil`,
-    /// and a type-test with a binder (`x is T t`) becomes a smart-cast `is T`
-    /// test that drops the binder (the receiver is narrowed inside the block).
+    /// and a type-test with a binder (`x is T t`) preserves the binder as a
+    /// nullable local narrowed by a nil test.
     /// </summary>
     [Fact]
     public void IsPattern_MapsToNilTestsAndSmartCast()
@@ -176,7 +176,7 @@ namespace Demo
 
         Assert.Contains("== nil", printed);
         Assert.Contains("!= nil", printed);
-        Assert.Contains("is string", printed);
+        Assert.Contains("let s string? = o as string", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -531,19 +531,19 @@ public sealed partial class CSharpToGSharpTranslator
 
         /// <summary>
         /// Lowers a C# positive type-pattern guard <c>if (receiver is T t) { … }</c>
-        /// to the smart-cast-friendly G# form below, but only when the pattern
-        /// variable <c>t</c> is referenced *outside* the then-block (C# leaks a
-        /// positive declaration-pattern variable into the enclosing scope under
-        /// definite-assignment rules, so later code reads or reassigns it).
+        /// to a smart-cast-friendly G# local that preserves the declaration
+        /// variable's identity.
         /// <code>
-        /// var t T? = receiver as T   // 'let' when t is never reassigned
-        /// if t != nil { … }          // t smart-casts to T inside the guard
-        /// … later statements using t …
+        /// let t T? = receiver as T   // reference target
+        /// if t != nil { … }
+        ///
+        /// let t = receiver           // value target
+        /// if t is T { … }
         /// </code>
-        /// When <c>t</c> is used only inside the then-block the existing
-        /// smart-cast binding (no hoist) is kept, so currently passing tests do not
-        /// regress. Only applies over a reference (non-value) target type, where the
-        /// <c>as T</c> + nil-guard form is valid.
+        /// Testing the named local, rather than rewriting <c>t</c> back to the
+        /// scrutinee, lets gsc carry the same variable's narrowing through nested
+        /// and following scopes. Value targets keep the receiver's inferred type
+        /// because G# has no value-type <c>as</c> conversion.
         /// </summary>
         private bool TryBuildPositiveGuardHoist(
             IfStatementSyntax ifStatement, out IReadOnlyList<GStatement> result)
@@ -557,46 +557,18 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            // The hoisted `as T` + `!= nil` guard is only valid when T is a
-            // reference type (or nullable value type); a non-nullable value-type
-            // target keeps the existing then-block smart-cast binding.
             ITypeSymbol targetSymbol = this.context.GetTypeInfo(typeSyntax).Type;
-            if (targetSymbol == null || targetSymbol.IsValueType)
+            if (targetSymbol == null)
             {
                 return false;
             }
 
-            // Hoist when EITHER the pattern variable escapes the then-block, OR the
-            // scrutinee is a non-trivial expression that gsc cannot smart-cast. gsc
-            // narrows only a bare local/parameter (ADR-0069); a method-call result,
-            // member-access chain or field reference re-emitted at each use of `t`
-            // would not smart-cast (→ GS0158) and, for a side-effecting scrutinee
-            // such as `M(out var x)`, would be re-evaluated (→ GS0102). When the
-            // scrutinee IS a smart-castable local and `t` is used solely inside the
-            // guarded block, the existing smart cast (rewriting `t` to the receiver)
-            // is correct and avoids an unnecessary local.
             if (this.context.GetDeclaredSymbol(single) is not ILocalSymbol patternSymbol)
             {
                 return false;
             }
 
             GTypeReference targetType = this.MapTypeSyntax(typeSyntax);
-            bool escapesThenBlock =
-                this.IsSymbolReferencedOutside(patternSymbol, ifStatement.Statement);
-
-            // The broadened "non-smart-castable scrutinee" hoist requires a
-            // well-formed nullable local annotation. NamedTypeReference (`T?`) and
-            // ArrayTypeReference (`[]?T`, incl. nullable jagged arrays `[]?[]T`,
-            // issue #1351) both nullable-annotate and round-trip-parse in gsc; a
-            // pointer/tuple target's nullable form does not yet, so for those keep
-            // the existing smart cast when the binder does not escape.
-            if (!escapesThenBlock &&
-                (this.IsSmartCastableScrutinee(isPattern.Expression) ||
-                 targetType is not (NamedTypeReference or ArrayTypeReference)))
-            {
-                return false;
-            }
-
             string localName = SanitizeIdentifier(single.Identifier.Text);
             GExpression receiver = this.TranslateExpression(isPattern.Expression);
 
@@ -611,17 +583,20 @@ public sealed partial class CSharpToGSharpTranslator
                 ? BindingKind.Var
                 : BindingKind.Let;
 
+            var local = new IdentifierExpression(localName);
+            GTypeReference localType = targetSymbol.IsValueType ? null : MakeNullable(targetType);
+            GExpression initializer = targetSymbol.IsValueType
+                ? receiver
+                : new BinaryExpression(receiver, "as", new TypeExpression(targetType));
             var hoist = new LocalDeclarationStatement(
                 binding,
                 localName,
-                MakeNullable(targetType),
-                new BinaryExpression(receiver, "as", new TypeExpression(targetType)));
+                localType,
+                initializer);
 
-            // `if t != nil { <then> }` — the positive guard; the then-block runs on a
-            // successful cast and `t` smart-casts to non-null T inside it. References
-            // to `t` print as the hoisted local (no patternBindings entry registered).
-            GExpression guard = new BinaryExpression(
-                new IdentifierExpression(localName), "!=", LiteralExpression.Null());
+            GExpression guard = targetSymbol.IsValueType
+                ? new BinaryExpression(local, "is", new TypeExpression(targetType))
+                : new BinaryExpression(local, "!=", LiteralExpression.Null());
             BlockStatement then = this.TranslateStatementAsBlock(ifStatement.Statement);
 
             GStatement elseBranch = null;
@@ -630,6 +605,22 @@ public sealed partial class CSharpToGSharpTranslator
                 elseBranch = ifStatement.Else.Statement is IfStatementSyntax elseIf
                     ? this.TranslateIf(elseIf)
                     : this.TranslateStatementAsBlock(ifStatement.Else.Statement);
+            }
+
+            // gsc narrows `local` throughout the guarded block, but does not carry
+            // that fact past the `if` when an exiting `else` makes C#'s pattern
+            // variable definitely assigned afterward. Keep later reads tied to
+            // the named local and materialize the already-proven target view.
+            if (targetSymbol.IsValueType && targetType is NamedTypeReference namedTarget)
+            {
+                this.state.PatternBindings[patternSymbol] = new InvocationExpression(
+                    new IdentifierExpression(namedTarget.Name),
+                    new[] { local },
+                    namedTarget.TypeArguments);
+            }
+            else
+            {
+                this.state.PatternBindings[patternSymbol] = new NonNullAssertionExpression(local);
             }
 
             result = new GStatement[] { hoist, new IfStatement(guard, then, elseBranch) };
@@ -687,40 +678,6 @@ public sealed partial class CSharpToGSharpTranslator
 
             single = designation as SingleVariableDesignationSyntax;
             return single != null;
-        }
-
-        // Returns true when <paramref name="symbol"/> is referenced anywhere in the
-        // current body scope outside <paramref name="excludedSubtree"/> (e.g. a
-        // pattern variable read or written after/around its `if`). Mirrors the
-        // body-walk in <see cref="IsLocalReassigned"/>.
-        private bool IsSymbolReferencedOutside(ISymbol symbol, SyntaxNode excludedSubtree)
-        {
-            SyntaxNode scope = this.state.CurrentBodyScope;
-            if (scope == null)
-            {
-                return false;
-            }
-
-            foreach (SyntaxNode node in scope.DescendantNodes())
-            {
-                if (node is not IdentifierNameSyntax identifier)
-                {
-                    continue;
-                }
-
-                if (excludedSubtree != null && excludedSubtree.Contains(identifier))
-                {
-                    continue;
-                }
-
-                ISymbol referenced = this.context.GetSymbolInfo(identifier).Symbol;
-                if (referenced != null && SymbolEqualityComparer.Default.Equals(referenced, symbol))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -49,6 +49,7 @@ public sealed partial class CSharpToGSharpTranslator
             // has no G# equivalent; references to the bound local are rewritten to a
             // member access on the arm's type-pattern designator (`circle.Radius`).
             if (this.state.PatternBindings.Count > 0 &&
+                !IsDirectWrite(identifier) &&
                 this.context.GetSymbolInfo(identifier).Symbol is { } boundSymbol &&
                 this.state.PatternBindings.TryGetValue(boundSymbol, out GExpression replacement))
             {
@@ -103,6 +104,22 @@ public sealed partial class CSharpToGSharpTranslator
 
             return new IdentifierExpression(SanitizeIdentifier(identifier.Identifier.Text));
         }
+
+        private static bool IsDirectWrite(IdentifierNameSyntax identifier) =>
+            identifier.Parent switch
+            {
+                AssignmentExpressionSyntax assignment when assignment.Left == identifier => true,
+                PrefixUnaryExpressionSyntax prefix
+                    when prefix.Operand == identifier &&
+                         prefix.Kind() is SyntaxKind.PreIncrementExpression or SyntaxKind.PreDecrementExpression => true,
+                PostfixUnaryExpressionSyntax postfix
+                    when postfix.Operand == identifier &&
+                         postfix.Kind() is SyntaxKind.PostIncrementExpression or SyntaxKind.PostDecrementExpression => true,
+                ArgumentSyntax argument
+                    when argument.Expression == identifier &&
+                         argument.RefKindKeyword.Kind() is SyntaxKind.RefKeyword or SyntaxKind.OutKeyword => true,
+                _ => false,
+            };
 
         // Builds the receiver expression used to qualify a bare sibling static
         // member reference through its owning type. For a non-generic owner this is


### PR DESCRIPTION
## Summary
- hoist positive declaration-pattern binders under their C# names instead of substituting the scrutinee
- preserve value/reference narrowing inside nested blocks and materialize narrowed reads after exiting branches
- keep direct assignments, increments, and ref/out writes targeting the real binder local

## Exact Oahu proof
Before, Oahu's `if (rewriteCode is int code) return code` became:

```gsharp
if rewriteCode is int32 {
    return rewriteCode
}
```

That reused the `int32?` scrutinee and produced `GS0156` at `Program.gs:64`. After:

```gsharp
let code = rewriteCode
if code is int32 {
    return code
}
```

The declaration identity and gsc narrowing now agree.

## Validation
- exact Oahu translation before/after assertions, including the old rewrite as a negative check
- runtime positive/mismatch paths and following-scope narrowing
- SDK-backed translate/compile pipeline regression
- full Cs2Gs.Tests: 1,701 passed
- Release solution build: 0 warnings, 0 errors

Fixes #2646
