### PR TITLE
Fix cs2gs constant-context nullability

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2635ConstantContextNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2635ConstantContextNullabilityTranslationTests.cs
@@ -1,0 +1,61 @@
+// <copyright file="Issue2635ConstantContextNullabilityTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public class Issue2635ConstantContextNullabilityTranslationTests
+{
+    [Fact]
+    public void ConstantStringConcatenations_RemainConstantForFieldsAndLocals()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        private const string Extension = "".json"";
+        public const string Settings = ""appsettings"" + Extension;
+
+        public string UserAgent()
+        {
+            const string value = ""Mozilla/5.0 "" + ""AppleWebKit/537.36"";
+            return value;
+        }
+    }
+}");
+
+        Assert.Contains("const Settings string = \"appsettings\" + C.Extension", printed);
+        Assert.Contains("const value = \"Mozilla/5.0 \" + \"AppleWebKit/537.36\"", printed);
+        Assert.DoesNotContain("!!", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -785,6 +785,7 @@ public sealed partial class CSharpToGSharpTranslator
             if (translated is NonNullAssertionExpression
                 || value is PostfixUnaryExpressionSyntax
                     { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
+                || targetSymbol is IFieldSymbol { IsConst: true } or ILocalSymbol { IsConst: true }
                 || this.IsWithinExpressionTreeLambda(value)
                 || !this.TargetWillRemainNonNullableReference(targetType, targetSymbol)
                 || (!this.NullableReferenceValueMayBeNull(value)


### PR DESCRIPTION
Fixes #2635

Skip runtime null-forgiveness when the contextual target is a const field or local, preserving constant string concatenations. Adds field and local regression coverage.

Validation:
- 19 targeted concatenation/nullability tests passed
- Full Cs2Gs.Tests suite: 1,699 passed
- Oahu cycle-6: SettingsManager.gs:14, ExtensionsVarious.gs:192, and ProgrammaticLogin.gs:176 no longer emit `!!`; Oahu.Foundation translation and compilation pass