### PR TITLE
Fix imported interpolated string handlers

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -509,18 +509,6 @@ internal static class OverloadResolution
             return ImplicitConversionKind.UserDefinedImplicit;
         }
 
-        // Issue #368: a `string`-typed argument (which is how an interpolated
-        // string statically types) is applicable to a parameter whose type is
-        // attributed `[InterpolatedStringHandler]`. The binder only ever
-        // rewrites an actual BoundInterpolatedStringExpression argument into the
-        // handler pattern, so this conversion is harmless for plain strings in
-        // practice and is ranked lowest (so a `string` overload always wins).
-        if (string.Equals(source.FullName, "System.String", StringComparison.Ordinal)
-            && InterpolatedStringHandlerInfo.IsHandlerType(target))
-        {
-            return ImplicitConversionKind.InterpolatedStringHandler;
-        }
-
         // Issue #889: a value-returning func/arrow literal (whose natural CLR
         // type is a Func<...>) is applicable to a void-returning delegate
         // parameter (System.Action / Action<...> / a named void delegate) by
@@ -2533,6 +2521,21 @@ internal static class OverloadResolution
                 var conv = ClassifyImplicit(paramTypes[i], argTypes[i], supplementaryInterfaceCheck);
                 if (conv == ImplicitConversionKind.None)
                 {
+                    // Issue #2640: handler conversion is contextual: only an
+                    // actual interpolated-string expression can target an
+                    // imported [InterpolatedStringHandler] parameter. Keeping
+                    // this beside the FormattableString fallback lets every CLR
+                    // Resolve caller share the rule, while a plain string no
+                    // longer reaches handler lowering and fails later as a
+                    // misleading by-ref argument error.
+                    if (interpolatedStringArgs != null
+                        && i < interpolatedStringArgs.Count
+                        && interpolatedStringArgs[i]
+                        && InterpolatedStringHandlerInfo.IsHandlerType(paramTypes[i]))
+                    {
+                        conv = ImplicitConversionKind.InterpolatedStringHandler;
+                    }
+
                     // ADR-0055 Tier 4 (#369): an interpolated-string argument
                     // (natural type `string`) additionally converts to an
                     // `IFormattable`/`FormattableString` parameter. This is the
@@ -2540,7 +2543,7 @@ internal static class OverloadResolution
                     // directly convert yet the candidate still applies; the
                     // binder re-lowers the interpolation against the chosen
                     // parameter once this candidate wins.
-                    if (interpolatedStringArgs != null
+                    else if (interpolatedStringArgs != null
                         && i < interpolatedStringArgs.Count
                         && interpolatedStringArgs[i]
                         && IsFormattableStringTarget(paramTypes[i]))

--- a/test/Compiler.Tests/Emit/Issue2640ImportedInterpolatedStringHandlerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2640ImportedInterpolatedStringHandlerEmitTests.cs
@@ -1,0 +1,143 @@
+// <copyright file="Issue2640ImportedInterpolatedStringHandlerEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Issue #2640: imported interpolated-string-handler overloads.</summary>
+public class Issue2640ImportedInterpolatedStringHandlerEmitTests
+{
+    [Fact]
+    public void OahuStringCreate_InvariantCulture_EmitsVerifiesAndRuns()
+    {
+        const string Source = """
+            package Oahu
+            import System
+            import System.Globalization
+
+            func getTerminalProgressSequence() string {
+                let state = 1
+                let pct = 42
+                return string.Create(CultureInfo.InvariantCulture, "\u001b]9;4;${state};${pct}\u001b\\")
+            }
+
+            Console.Write(getTerminalProgressSequence())
+            """;
+
+        var (exitCode, diagnostics, outputPath, directory) = Compile(Source);
+        try
+        {
+            Assert.True(exitCode == 0, diagnostics);
+            IlVerifier.Verify(outputPath);
+            Assert.Equal("\u001b]9;4;1;42\u001b\\", Run(outputPath, directory));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void StringCreate_PlainString_DoesNotBindHandlerOverload()
+    {
+        const string Source = """
+            package Negative
+            import System.Globalization
+
+            let value = string.Create(CultureInfo.InvariantCulture, "Oahu")
+            """;
+
+        var (exitCode, diagnostics, _, directory) = Compile(Source);
+        try
+        {
+            Assert.Equal(1, exitCode);
+            Assert.Contains("GS0159", diagnostics, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static (int ExitCode, string Diagnostics, string OutputPath, string Directory) Compile(string source)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2640",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + outputPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+        args.AddRange(BclReferences.Value.Select(path => "/r:" + path));
+        args.Add(sourcePath);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(args.ToArray());
+            return (exitCode, stdout.ToString() + stderr, outputPath, directory);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string Run(string outputPath, string directory)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = directory,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(outputPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec");
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}: {error}");
+        return output;
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var dotnetRoot = Directory.GetParent(runtimeDirectory)!.Parent!.Parent!.FullName;
+        var tfm = $"net{Environment.Version.Major}.0";
+        var packsRoot = Path.Combine(dotnetRoot, "packs", "Microsoft.NETCore.App.Ref");
+        var referenceDirectory = Directory.EnumerateDirectories(packsRoot, Environment.Version.Major + ".*")
+            .OrderByDescending(path => path, StringComparer.Ordinal)
+            .Select(path => Path.Combine(path, "ref", tfm))
+            .First(Directory.Exists);
+        return Directory.EnumerateFiles(referenceDirectory, "*.dll").ToList();
+    });
+}


### PR DESCRIPTION
## Summary
- make imported interpolated-string-handler applicability contextual to actual interpolation syntax
- preserve shared overload binding/lowering for ref handlers and generic formatted holes
- reject plain strings before by-ref validation

## Proof
- the exact Oahu `string.Create(CultureInfo.InvariantCulture, interpolated OSC sequence)` path emits, IL-verifies, and returns the expected state/progress sequence
- plain `"Oahu"` is rejected with GS0159

## Tests
- `Core.Tests`: 6,646 passed, 1 skipped
- focused `Compiler.Tests`: 2 passed

Fixes #2640