### PR TITLE
Fix transitive generic interface closure

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -1055,17 +1055,20 @@ public sealed class Conversion
 
             if (to?.ClrType is { IsInterface: true } toClrInterface)
             {
-                foreach (var baseClrInterface in fromInterface.BaseClrInterfaces)
+                foreach (var iface in fromInterface.SelfAndAllBaseInterfaces())
                 {
-                    var clr = baseClrInterface?.ClrType;
-
-                    // Issue #2135: `toClrInterface` may be a
-                    // TypeBuilderInstantiation whose IsAssignableFrom throws
-                    // NotSupportedException at emit; use the guarded by-name
-                    // helper instead of calling IsAssignableFrom directly.
-                    if (clr != null && (clr.IsSameAs(toClrInterface) || ClrTypeUtilities.IsAssignableByName(toClrInterface, clr)))
+                    foreach (var baseClrInterface in iface.BaseClrInterfaces)
                     {
-                        return Conversion.Implicit;
+                        var clr = baseClrInterface?.ClrType;
+
+                        // Issue #2135: `toClrInterface` may be a
+                        // TypeBuilderInstantiation whose IsAssignableFrom throws
+                        // NotSupportedException at emit; use the guarded by-name
+                        // helper instead of calling IsAssignableFrom directly.
+                        if (clr != null && (clr.IsSameAs(toClrInterface) || ClrTypeUtilities.IsAssignableByName(toClrInterface, clr)))
+                        {
+                            return Conversion.Implicit;
+                        }
                     }
                 }
             }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -672,17 +672,20 @@ internal sealed partial class MethodBodyEmitter
 
             if (b?.ClrType is { IsInterface: true } targetClrInterface)
             {
-                foreach (var baseClrInterface in srcInterface.BaseClrInterfaces)
+                foreach (var iface in srcInterface.SelfAndAllBaseInterfaces())
                 {
-                    var clr = baseClrInterface?.ClrType;
-
-                    // Issue #2135: `targetClrInterface` may be a
-                    // TypeBuilderInstantiation whose IsAssignableFrom throws
-                    // NotSupportedException at emit; use the guarded by-name
-                    // helper instead of calling IsAssignableFrom directly.
-                    if (clr != null && (clr.IsSameAs(targetClrInterface) || ClrTypeUtilities.IsAssignableByName(targetClrInterface, clr)))
+                    foreach (var baseClrInterface in iface.BaseClrInterfaces)
                     {
-                        return true;
+                        var clr = baseClrInterface?.ClrType;
+
+                        // Issue #2135: `targetClrInterface` may be a
+                        // TypeBuilderInstantiation whose IsAssignableFrom throws
+                        // NotSupportedException at emit; use the guarded by-name
+                        // helper instead of calling IsAssignableFrom directly.
+                        if (clr != null && (clr.IsSameAs(targetClrInterface) || ClrTypeUtilities.IsAssignableByName(targetClrInterface, clr)))
+                        {
+                            return true;
+                        }
                     }
                 }
             }

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -32,6 +32,8 @@ public sealed class InterfaceSymbol : TypeSymbol
     private ImmutableArray<FunctionSymbol> staticMethods = ImmutableArray<FunctionSymbol>.Empty;
     private ImmutableArray<FunctionSymbol> privateMethods = ImmutableArray<FunctionSymbol>.Empty;
     private ImmutableArray<FunctionSymbol> staticPrivateMethods = ImmutableArray<FunctionSymbol>.Empty;
+    private ImmutableArray<InterfaceSymbol> baseInterfaces = ImmutableArray<InterfaceSymbol>.Empty;
+    private ImmutableArray<TypeSymbol> baseClrInterfaces = ImmutableArray<TypeSymbol>.Empty;
 
     // ADR-0087 R5 / issue #765: constructed instances of a generic interface
     // may be created (e.g. as a base type on a class declaration) BEFORE the
@@ -188,7 +190,10 @@ public sealed class InterfaceSymbol : TypeSymbol
     /// members to this interface's member-lookup surface and is emitted as an
     /// InterfaceImpl row on this interface's TypeDef.
     /// </summary>
-    public ImmutableArray<InterfaceSymbol> BaseInterfaces { get; private set; } = ImmutableArray<InterfaceSymbol>.Empty;
+    public ImmutableArray<InterfaceSymbol> BaseInterfaces
+        => Definition != null && !ReferenceEquals(Definition, this)
+            ? SubstituteBaseInterfaces(Definition.BaseInterfaces)
+            : baseInterfaces;
 
     /// <summary>
     /// Gets the directly-declared base interfaces imported from metadata
@@ -196,7 +201,10 @@ public sealed class InterfaceSymbol : TypeSymbol
     /// <c>interface B : System.IDisposable</c>. These are CLR interface types
     /// surfaced through their <see cref="TypeSymbol.ClrType"/>.
     /// </summary>
-    public ImmutableArray<TypeSymbol> BaseClrInterfaces { get; private set; } = ImmutableArray<TypeSymbol>.Empty;
+    public ImmutableArray<TypeSymbol> BaseClrInterfaces
+        => Definition != null && !ReferenceEquals(Definition, this)
+            ? SubstituteBaseClrInterfaces(Definition.BaseClrInterfaces)
+            : baseClrInterfaces;
 
     /// <summary>
     /// Gets the enclosing user-defined type when this interface is a nested
@@ -234,14 +242,14 @@ public sealed class InterfaceSymbol : TypeSymbol
     /// <param name="baseInterfaces">The directly-declared user base interfaces.</param>
     public void SetBaseInterfaces(ImmutableArray<InterfaceSymbol> baseInterfaces)
     {
-        BaseInterfaces = baseInterfaces;
+        this.baseInterfaces = baseInterfaces;
     }
 
     /// <summary>Sets <see cref="BaseClrInterfaces"/> (issue #1006). Intended to be called once by the binder.</summary>
     /// <param name="baseClrInterfaces">The directly-declared imported CLR base interfaces.</param>
     public void SetBaseClrInterfaces(ImmutableArray<TypeSymbol> baseClrInterfaces)
     {
-        BaseClrInterfaces = baseClrInterfaces;
+        this.baseClrInterfaces = baseClrInterfaces;
     }
 
     /// <summary>
@@ -627,6 +635,51 @@ public sealed class InterfaceSymbol : TypeSymbol
         return instance;
     }
 
+    private ImmutableArray<InterfaceSymbol> SubstituteBaseInterfaces(ImmutableArray<InterfaceSymbol> source)
+    {
+        if (source.IsDefaultOrEmpty)
+        {
+            return source;
+        }
+
+        var subst = GetTypeSubstitution();
+        var builder = ImmutableArray.CreateBuilder<InterfaceSymbol>(source.Length);
+        foreach (var baseInterface in source)
+        {
+            builder.Add((InterfaceSymbol)SubstituteType(baseInterface, subst, mapClrType));
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    private ImmutableArray<TypeSymbol> SubstituteBaseClrInterfaces(ImmutableArray<TypeSymbol> source)
+    {
+        if (source.IsDefaultOrEmpty)
+        {
+            return source;
+        }
+
+        var subst = GetTypeSubstitution();
+        var builder = ImmutableArray.CreateBuilder<TypeSymbol>(source.Length);
+        foreach (var baseInterface in source)
+        {
+            builder.Add(SubstituteType(baseInterface, subst, mapClrType));
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    private Dictionary<TypeParameterSymbol, TypeSymbol> GetTypeSubstitution()
+    {
+        var subst = new Dictionary<TypeParameterSymbol, TypeSymbol>(Definition.TypeParameters.Length);
+        for (var i = 0; i < Definition.TypeParameters.Length; i++)
+        {
+            subst[Definition.TypeParameters[i]] = TypeArguments[i];
+        }
+
+        return subst;
+    }
+
     private static FunctionSymbol SubstituteMethod(
         FunctionSymbol m,
         Dictionary<TypeParameterSymbol, TypeSymbol> subst,
@@ -708,11 +761,7 @@ public sealed class InterfaceSymbol : TypeSymbol
             return;
         }
 
-        var subst = new Dictionary<TypeParameterSymbol, TypeSymbol>(Definition.TypeParameters.Length);
-        for (var i = 0; i < Definition.TypeParameters.Length; i++)
-        {
-            subst[Definition.TypeParameters[i]] = TypeArguments[i];
-        }
+        var subst = GetTypeSubstitution();
 
         if (!defMethods.IsDefaultOrEmpty)
         {

--- a/test/Compiler.Tests/Emit/Issue2644TransitiveGenericInterfaceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2644TransitiveGenericInterfaceEmitTests.cs
@@ -1,0 +1,146 @@
+// <copyright file="Issue2644TransitiveGenericInterfaceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.Loader;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue2644TransitiveGenericInterfaceEmitTests
+{
+    [Fact]
+    public void OahuRegionPickerModal_CrossAssemblyConversionRunsAndHasInterfaceMetadata()
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue2644_").FullName;
+        try
+        {
+            var libraryPath = Path.Combine(directory, "Issue2644.Contracts.dll");
+            var librarySource = Path.Combine(directory, "contracts.gs");
+            File.WriteAllText(
+                librarySource,
+                """
+                package Issue2644.Contracts
+
+                public interface IModal {
+                    func Kind() string;
+                }
+
+                public interface IModal[T] : IModal {
+                    func Result() T;
+                }
+
+                public class RegionPickerModal : IModal[string] {
+                    public func Kind() string -> "region"
+                    public func Result() string -> "us"
+                }
+
+                public class Navigator {
+                    public func ShowModal(modal IModal) string -> modal.Kind()
+                }
+
+                public class HomeScreen {
+                    public func Open(navigator Navigator, pendingRegionModal RegionPickerModal) string {
+                        return navigator.ShowModal(pendingRegionModal)
+                    }
+                }
+                """);
+
+            Assert.Equal(
+                0,
+                Program.Main(
+                    new[]
+                    {
+                        "/out:" + libraryPath,
+                        "/target:library",
+                        "/targetframework:net10.0",
+                        librarySource,
+                    }));
+            IlVerifier.Verify(libraryPath);
+
+            VerifyInterfaceMetadata(libraryPath);
+
+            var executablePath = Path.Combine(directory, "Issue2644.Consumer.dll");
+            var consumerSource = Path.Combine(directory, "consumer.gs");
+            File.WriteAllText(
+                consumerSource,
+                """
+                package Issue2644.Consumer
+                import System
+                import Issue2644.Contracts
+
+                func Accept(modal IModal) string -> modal.Kind()
+
+                func Main() {
+                    var pendingRegionModal = RegionPickerModal()
+                    Console.WriteLine(Accept(pendingRegionModal))
+                    Console.WriteLine(HomeScreen().Open(Navigator(), pendingRegionModal))
+                }
+                """);
+
+            Assert.Equal(
+                0,
+                Program.Main(
+                    new[]
+                    {
+                        "/out:" + executablePath,
+                        "/target:exe",
+                        "/targetframework:net10.0",
+                        "/reference:" + libraryPath,
+                        consumerSource,
+                    }));
+            IlVerifier.Verify(executablePath, additionalReferences: new[] { libraryPath });
+            Assert.Equal("region\nregion\n", Run(executablePath, directory));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static void VerifyInterfaceMetadata(string assemblyPath)
+    {
+        var context = new AssemblyLoadContext("Issue2644", isCollectible: true);
+        try
+        {
+            var assembly = context.LoadFromAssemblyPath(assemblyPath);
+            var modal = assembly.GetType("Issue2644.Contracts.IModal", throwOnError: true)!;
+            var genericModal = assembly.GetType("Issue2644.Contracts.IModal`1", throwOnError: true)!;
+            var picker = assembly.GetType("Issue2644.Contracts.RegionPickerModal", throwOnError: true)!;
+
+            Assert.Contains(modal, picker.GetInterfaces());
+            Assert.Contains(
+                picker.GetInterfaces(),
+                iface => iface.IsGenericType && iface.GetGenericTypeDefinition() == genericModal);
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    private static string Run(string assemblyPath, string directory)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = directory,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+        Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}\n{stderr}");
+        return stdout.Replace("\r\n", "\n");
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2644TransitiveGenericInterfaceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2644TransitiveGenericInterfaceTests.cs
@@ -1,0 +1,120 @@
+// <copyright file="Issue2644TransitiveGenericInterfaceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2644TransitiveGenericInterfaceTests
+{
+    [Fact]
+    public void OahuRegionPickerModal_ConvertsToNonGenericModal()
+    {
+        var compilation = Compile(
+            """
+            package Oahu.Cli.Tui
+
+            interface IModal {
+                func Kind() string;
+            }
+
+            interface IModal[T] : IModal {
+                func Result() T;
+            }
+
+            class RegionPickerModal : IModal[string] {
+                func Kind() string -> "region"
+                func Result() string -> "us"
+            }
+
+            class Navigator {
+                func ShowModal(modal IModal) string -> modal.Kind()
+            }
+
+            func Open(navigator Navigator, pendingRegionModal RegionPickerModal) string {
+                return navigator.ShowModal(pendingRegionModal)
+            }
+            """);
+
+        Assert.Empty(GetDiagnostics(compilation));
+    }
+
+    [Fact]
+    public void ConstructedInterface_ClosesEveryTransitiveGenericBase()
+    {
+        var compilation = Compile(
+            """
+            package test
+
+            interface IRoot[T] {
+                func Get() T;
+            }
+
+            interface IMiddle[T] : IRoot[T] { }
+            interface ILeaf[T] : IMiddle[T] { }
+
+            class StringLeaf : ILeaf[string] {
+                func Get() string -> "ok"
+            }
+            """);
+
+        Assert.Empty(GetDiagnostics(compilation));
+        var leaf = compilation.GlobalScope.Structs.Single(type => type.Name == "StringLeaf");
+        var root = Assert.Single(
+            leaf.Interfaces.Where(
+                iface => iface.Definition.Name == "IRoot"
+                    && !iface.TypeArguments.IsDefaultOrEmpty));
+        Assert.Same(TypeSymbol.String, Assert.Single(root.TypeArguments));
+    }
+
+    [Fact]
+    public void GenericInterfaceChain_ConvertsTransitivelyToImportedBase()
+    {
+        var compilation = Compile(
+            """
+            package test
+            import System
+
+            interface IRoot[T] : IDisposable { }
+            interface ILeaf[T] : IRoot[T] { }
+
+            func Upcast(value ILeaf[string]) IDisposable {
+                return value
+            }
+            """);
+
+        Assert.Empty(GetDiagnostics(compilation));
+    }
+
+    [Fact]
+    public void GenericInterfaceClosure_DoesNotPermitMismatchedConstruction()
+    {
+        var compilation = Compile(
+            """
+            package test
+
+            interface IModal { }
+            interface IModal[T] : IModal { }
+
+            func Bad(modal IModal[int32]) IModal[string] {
+                return modal
+            }
+            """);
+
+        Assert.Contains(GetDiagnostics(compilation), diagnostic => diagnostic.Id == "GS0155");
+    }
+
+    private static Compilation Compile(string source)
+        => new(SyntaxTree.Parse(SourceText.From(source)));
+
+    private static IReadOnlyList<Diagnostic> GetDiagnostics(Compilation compilation)
+        => compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
+}


### PR DESCRIPTION
## Summary
- lazily substitute user and CLR base interfaces on constructed generic interface symbols, preserving bases bound after early construction
- walk the complete substituted user/CLR interface closure in conversion classification and no-op reference emission
- cover transitive substitution, imported-base conversion, invariant negatives, metadata, cross-assembly compilation, ILVerify, and runtime dispatch

## Exact Oahu proof
Before, the Oahu shape `RegionPickerModal : IModal[string]`, with `IModal[T] : IModal`, reported GS0155 at `navigator.ShowModal(pendingRegionModal)` because the constructed `IModal[string]` symbol lost `IModal`. After, that exact call binds cleanly. The emitted library also exposes both interface rows, and a separately compiled consumer prints `region` through both direct and HomeScreen paths.

## Validation
- Release solution build: 0 warnings, 0 errors
- full Core.Tests: 6,650 passed, 1 skipped
- related interface Compiler.Tests: 24 passed
- issue-specific Core/Compiler tests: 5 passed
- prior environment-only Issue750 failures rerun after the solution prerequisite build: 5 passed

Fixes #2644