### PR TITLE
Fix nullable inherited imported property access

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -1801,6 +1801,11 @@ internal sealed partial class ExpressionBinder
                     return head;
                 }
 
+                if (nested.IsNullConditional)
+                {
+                    return BindNullConditionalAccessExpressionCore(head, nested.RightPart);
+                }
+
                 return BindAccessorStep(head, null, nested.RightPart);
 
             case CallExpressionSyntax ce:

--- a/test/Compiler.Tests/Emit/Issue2642NullableInheritedImportedPropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2642NullableInheritedImportedPropertyEmitTests.cs
@@ -1,0 +1,105 @@
+// <copyright file="Issue2642NullableInheritedImportedPropertyEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue2642NullableInheritedImportedPropertyEmitTests
+{
+    [Fact]
+    public void OahuSettings_NullConditionalImportedBaseProperty_Runs()
+    {
+        const string librarySource = """
+            package Issue2642.Ref
+
+            open class UserSettingsBase {
+                prop DownloadSettings string {
+                    get -> "2642"
+                }
+            }
+            """;
+        const string consumerSource = """
+            package Issue2642.App
+            import System
+            import Issue2642.Ref
+
+            class OahuUserSettings : UserSettingsBase { }
+
+            class CoreEnvironment {
+                shared {
+                    var settings OahuUserSettings?
+                    func Read() string? -> CoreEnvironment.settings?.DownloadSettings
+                    func Set() { CoreEnvironment.settings = OahuUserSettings{} }
+                }
+            }
+
+            Console.WriteLine(CoreEnvironment.Read())
+            CoreEnvironment.Set()
+            Console.WriteLine(CoreEnvironment.Read())
+            """;
+
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2642", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var libraryPath = Compile(directory, "Issue2642.Ref", librarySource, isLibrary: true);
+            var consumerPath = Compile(directory, "Issue2642.App", consumerSource, isLibrary: false, libraryPath);
+            IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(consumerPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(consumerPath);
+
+            using var process = Process.Start(startInfo);
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}\n{stderr}");
+            Assert.Equal("\n2642\n", stdout.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string Compile(
+        string directory,
+        string assemblyName,
+        string source,
+        bool isLibrary,
+        string reference = null)
+    {
+        var sourcePath = Path.Combine(directory, assemblyName + ".gs");
+        var outputPath = Path.Combine(directory, assemblyName + ".dll");
+        File.WriteAllText(sourcePath, source);
+
+        var args = new System.Collections.Generic.List<string>
+        {
+            "/out:" + outputPath,
+            isLibrary ? "/target:library" : "/target:exe",
+            "/targetframework:net10.0",
+        };
+        if (reference != null)
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        args.Add(sourcePath);
+        Assert.Equal(0, Program.Main(args.ToArray()));
+        return outputPath;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2642NullableInheritedImportedPropertyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2642NullableInheritedImportedPropertyTests.cs
@@ -1,0 +1,94 @@
+// <copyright file="Issue2642NullableInheritedImportedPropertyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2642NullableInheritedImportedPropertyTests
+{
+    private const string LibrarySource = """
+        package Issue2642.Ref
+
+        open class UserSettingsBase {
+            prop DownloadSettings string {
+                get -> "2642"
+            }
+        }
+        """;
+
+    [Fact]
+    public void OahuSettings_NullConditionalFindsImportedBaseProperty()
+    {
+        var result = CompileConsumer("""
+            package Issue2642.App
+            import Issue2642.Ref
+
+            class OahuUserSettings : UserSettingsBase { }
+
+            class CoreEnvironment {
+                shared {
+                    var settings OahuUserSettings?
+                    func Read() string? -> CoreEnvironment.settings?.DownloadSettings
+                }
+            }
+            """, nameof(this.OahuSettings_NullConditionalFindsImportedBaseProperty));
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void UnknownPropertyThroughNullConditional_StillReportsGS0158()
+    {
+        var result = CompileConsumer("""
+            package Issue2642.App
+            import Issue2642.Ref
+
+            class OahuUserSettings : UserSettingsBase { }
+
+            class CoreEnvironment {
+                shared {
+                    var settings OahuUserSettings?
+                    func Read() string? -> CoreEnvironment.settings?.NotDownloadSettings
+                }
+            }
+            """, nameof(this.UnknownPropertyThroughNullConditional_StillReportsGS0158));
+
+        Assert.Single(result.Diagnostics, diagnostic => diagnostic.Id == "GS0158");
+    }
+
+    private static EmitResult CompileConsumer(string source, string caseName)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2642", caseName);
+        Directory.CreateDirectory(directory);
+        var libraryPath = Path.Combine(directory, "Issue2642.Ref.dll");
+
+        var library = new Compilation(SyntaxTree.Parse(SourceText.From(LibrarySource)))
+        {
+            IsLibrary = true,
+        };
+        using (var stream = File.Create(libraryPath))
+        {
+            var result = library.Emit(stream, pdbStream: null, refStream: null, assemblyName: "Issue2642.Ref");
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        using var references = ReferenceResolver.WithReferences(new[] { libraryPath });
+        references.CurrentAssemblyName = "Issue2642.App";
+        var consumer = new Compilation(
+            references,
+            SyntaxTree.Parse(SourceText.From(source)))
+        {
+            IsLibrary = true,
+        };
+        using var output = new MemoryStream();
+        return consumer.Emit(output, pdbStream: null, refStream: null, assemblyName: "Issue2642.App");
+    }
+}


### PR DESCRIPTION
## Summary
- preserve nullable conditional access nested beneath user-type static qualification
- let `CoreEnvironment.settings?.DownloadSettings` unwrap the nullable receiver before resolving the property inherited from an imported base
- cover the exact Oahu names with cross-assembly binding, runtime/ILVerify, null-receiver, and unknown-property negative tests

## Before / after proof
- before: the Oahu-shaped cross-assembly repro reported `GS0158: Cannot find member DownloadSettings`
- after: the same `CoreEnvironment.settings?.DownloadSettings` source compiles and prints `2642`

## Tests
- issue filters: 2 Core passed; 1 Compiler runtime passed
- `Core.Tests`: 6,648 passed, 1 skipped
- `Compiler.Tests`: 3,310 passed

Fixes #2642