### PR TITLE
Fix deep imported base method lookup

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -202,23 +202,19 @@ internal sealed class MemberLookup
                 }
             }
 
-            // Issue #2614: MetadataLoadContext can reject an aggregate
-            // GetMethods call when one derived signature has a missing
-            // dependency. Probe each declaration level independently so that
-            // usable methods on an otherwise loadable base are not hidden.
-            if (selfMethods.Length == 0)
+            // Issues #2614 / #2638: an aggregate metadata walk may return a
+            // usable but incomplete set. Always probe each declaration level
+            // and union accessible methods without duplicating inherited slots.
+            for (var current = clrType; current != null; current = GetBaseTypeSafe(current))
             {
-                for (var current = clrType; current != null; current = GetBaseTypeSafe(current))
+                foreach (var m in ClrTypeUtilities.SafeGetMethods(
+                    current,
+                    BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
                 {
-                    foreach (var m in ClrTypeUtilities.SafeGetMethods(
-                        current,
-                        BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                    if (string.Equals(m.Name, n, StringComparison.Ordinal)
+                        && !IsMethodHiddenByExisting(result, m))
                     {
-                        if (string.Equals(m.Name, n, StringComparison.Ordinal)
-                            && !IsMethodHiddenByExisting(result, m))
-                        {
-                            result.Add(m);
-                        }
+                        result.Add(m);
                     }
                 }
             }
@@ -358,6 +354,11 @@ internal sealed class MemberLookup
         foreach (var m in existing)
         {
             if (!string.Equals(m.Name, candidate.Name, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (m.GetGenericArguments().Length != candidate.GetGenericArguments().Length)
             {
                 continue;
             }
@@ -4334,6 +4335,11 @@ internal sealed class MemberLookup
         foreach (var m in existing)
         {
             if (!string.Equals(m.Name, candidate.Name, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (m.GetGenericArguments().Length != candidate.GetGenericArguments().Length)
             {
                 continue;
             }

--- a/test/Compiler.Tests/Emit/Issue2638DeepImportedBaseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2638DeepImportedBaseEmitTests.cs
@@ -1,0 +1,191 @@
+// <copyright file="Issue2638DeepImportedBaseEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue2638DeepImportedBaseEmitTests
+{
+    private const string LibrarySource = """
+        namespace Issue2638.Library;
+
+        public sealed class Rule
+        {
+            public Rule(int value) => Value = value;
+            public int Value { get; }
+        }
+
+        public class Root
+        {
+            public string Apply(Rule rule) => "deep:" + rule.Value;
+            protected string ProtectedOnly() => "protected";
+            internal string InternalOnly() => "internal";
+            private string PrivateOnly() => "private";
+        }
+
+        public class Mid : Root
+        {
+            public string Distractor() => "distractor";
+        }
+
+        public sealed class Leaf : Mid
+        {
+            public string Own() => "own";
+        }
+        """;
+
+    [Fact]
+    public void CrossAssemblyDeepPublicMethod_Runs()
+    {
+        using var fixture = new Fixture();
+        var result = fixture.CompileGSharp("""
+            package Issue2638.Consumer
+            import System
+            import Issue2638.Library
+
+            Console.WriteLine(Leaf().Apply(Rule(2638)))
+            """, "exe");
+
+        Assert.Equal(0, result.ExitCode);
+        IlVerifier.Verify(result.OutputPath, additionalReferences: new[] { fixture.LibraryPath });
+        Assert.Equal("deep:2638\n", fixture.Run(result.OutputPath));
+    }
+
+    [Fact]
+    public void CrossAssemblyDeepNonPublicMethods_ReportGS0159()
+    {
+        using var fixture = new Fixture();
+        var result = fixture.CompileGSharp("""
+            package Issue2638.Consumer
+            import Issue2638.Library
+
+            func Probe(value Leaf) {
+                value.ProtectedOnly()
+                value.InternalOnly()
+                value.PrivateOnly()
+            }
+            """, "library");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Equal(3, Count(result.Output, "GS0159"));
+    }
+
+    private static int Count(string text, string value)
+    {
+        var count = 0;
+        for (var index = 0; (index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0; index += value.Length)
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        private readonly string directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue2638DeepImportedBaseEmitTests),
+            Guid.NewGuid().ToString("N"));
+
+        public Fixture()
+        {
+            Directory.CreateDirectory(directory);
+            LibraryPath = Path.Combine(directory, "Issue2638.Library.dll");
+            EmitCSharpLibrary(LibraryPath);
+        }
+
+        public string LibraryPath { get; }
+
+        public CompileResult CompileGSharp(string source, string target)
+        {
+            var sourcePath = Path.Combine(directory, "Consumer.gs");
+            var outputPath = Path.Combine(directory, "Consumer.dll");
+            File.WriteAllText(sourcePath, source);
+            var args = new List<string>
+            {
+                "/out:" + outputPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                "/r:" + LibraryPath,
+                sourcePath,
+            };
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            return new CompileResult(exitCode, outputPath, stdout.ToString() + stderr.ToString());
+        }
+
+        public string Run(string assemblyPath)
+        {
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add(assemblyPath);
+            using var process = Process.Start(startInfo);
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, $"exit {process.ExitCode}\n{stderr}");
+            return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+
+        private static void EmitCSharpLibrary(string path)
+        {
+            var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                    ?.Split(Path.PathSeparator)
+                    ?? Array.Empty<string>())
+                .Where(File.Exists)
+                .Select(file => MetadataReference.CreateFromFile(file));
+            var compilation = CSharpCompilation.Create(
+                "Issue2638.Library",
+                new[] { CSharpSyntaxTree.ParseText(LibrarySource, new CSharpParseOptions(LanguageVersion.Latest)) },
+                references,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            using var stream = File.Create(path);
+            var result = compilation.Emit(stream);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+    }
+
+    private sealed record CompileResult(int ExitCode, string OutputPath, string Output);
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2638DeepImportedBaseLookupTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2638DeepImportedBaseLookupTests.cs
@@ -1,0 +1,103 @@
+// <copyright file="Issue2638DeepImportedBaseLookupTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Binding;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2638DeepImportedBaseLookupTests
+{
+    [Fact]
+    public void PartialAggregateWalk_FindsDeepPublicMemberOnce()
+    {
+        var type = new PartialAggregateType(typeof(Leaf));
+
+        var methods = MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(type, nameof(Root.Apply));
+
+        Assert.Single(methods);
+        Assert.Equal(typeof(Root), methods[0].DeclaringType);
+    }
+
+    [Fact]
+    public void DeepOverloads_DifferingByGenericArity_AreNotDeduplicated()
+    {
+        Assert.Equal(
+            2,
+            MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(
+                new PartialAggregateType(typeof(Leaf)),
+                nameof(Root.Generic)).Count);
+    }
+
+    [Theory]
+    [InlineData("Protected")]
+    [InlineData(nameof(Root.Internal))]
+    [InlineData("Private")]
+    public void DeepNonPublicMembers_AreExcluded(string name)
+    {
+        Assert.Empty(MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(
+            new PartialAggregateType(typeof(Leaf)),
+            name));
+    }
+
+    private class Root
+    {
+        public string Apply(string value) => value;
+
+        public void Generic()
+        {
+        }
+
+        public void Generic<T>()
+        {
+        }
+
+        protected void Protected()
+        {
+        }
+
+        internal void Internal()
+        {
+        }
+
+        private void Private()
+        {
+        }
+    }
+
+    private class Mid : Root
+    {
+        public void Distractor()
+        {
+        }
+    }
+
+    private sealed class Leaf : Mid
+    {
+    }
+
+    private sealed class PartialAggregateType : TypeDelegator
+    {
+        private readonly Type delegatedType;
+
+        public PartialAggregateType(Type delegatedType)
+            : base(delegatedType)
+        {
+            this.delegatedType = delegatedType;
+        }
+
+        public override MethodInfo[] GetMethods(BindingFlags bindingAttr)
+        {
+            var methods = base.GetMethods(bindingAttr);
+            return (bindingAttr & BindingFlags.DeclaredOnly) == 0
+                ? methods.Where(method => method.Name == nameof(Mid.Distractor)).ToArray()
+                : methods;
+        }
+
+        public override Type BaseType => delegatedType.BaseType;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2638TypedForEachTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2638TypedForEachTranslationTests.cs
@@ -1,0 +1,86 @@
+// <copyright file="Issue2638TypedForEachTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2638TypedForEachTranslationTests
+{
+    [Fact]
+    public void OahuFileSecurityLoop_PreservesExplicitElementCast()
+    {
+        const string source = """
+            using System;
+            using System.Security.AccessControl;
+            using System.Security.Principal;
+
+            namespace Oahu.Cli.Server.Auth;
+
+            public static class TokenStore
+            {
+                public static void RemoveCurrent(FileSecurity sec)
+                {
+                    var current = sec.GetAccessRules(true, true, typeof(SecurityIdentifier));
+                    foreach (FileSystemAccessRule r in current)
+                    {
+                        sec.RemoveAccessRule(r);
+                    }
+                }
+            }
+            """;
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("TokenStore.cs", source) });
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+
+        Assert.Contains("for __foreach0 in current", printed, StringComparison.Ordinal);
+        Assert.Contains(
+            "let r FileSystemAccessRule = (__foreach0 as FileSystemAccessRule)!!",
+            printed,
+            StringComparison.Ordinal);
+        Assert.Contains("sec.RemoveAccessRule(r)", printed, StringComparison.Ordinal);
+        AssertTranslatedSourceCompiles(printed);
+    }
+
+    private static void AssertTranslatedSourceCompiles(string source)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2638TypedForEachTranslationTests));
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "TokenStore.gs");
+        var outputPath = Path.Combine(directory, "TokenStore.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var compiler = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "Compiler", "gsc.dll"));
+        Assert.True(File.Exists(compiler), "gsc.dll was not built.");
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(compiler);
+        startInfo.ArgumentList.Add("/target:library");
+        startInfo.ArgumentList.Add("/targetframework:net10.0");
+        startInfo.ArgumentList.Add("/out:" + outputPath);
+        startInfo.ArgumentList.Add(sourcePath);
+        using var process = Process.Start(startInfo);
+        var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(process.ExitCode == 0, output);
+        Assert.DoesNotContain("GS0159", output, StringComparison.Ordinal);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -1796,12 +1796,48 @@ public sealed partial class CSharpToGSharpTranslator
                     // lowers to G#'s async-iteration form `await for x in seq`
                     // (spec AwaitForRangeStmt). Without it, iterating an
                     // `IAsyncEnumerable<T>` with a plain `for` is rejected (GS0116).
+                    string loopIdentifier = SanitizeIdentifier(forEach.Identifier.Text);
+                    BlockStatement loopBody = this.TranslateStatementAsBlock(forEach.Statement);
+                    Conversion elementConversion = this.context.SemanticModel
+                        .GetForEachStatementInfo(forEach)
+                        .ElementConversion;
+                    if (!forEach.Type.IsVar && !elementConversion.IsImplicit)
+                    {
+                        string itemIdentifier = $"__foreach{this.state.DeconCounter++}";
+                        ITypeSymbol targetSymbol = this.context.GetTypeInfo(forEach.Type).Type;
+                        GTypeReference targetType = targetSymbol != null
+                            ? this.typeMapper.Map(targetSymbol, this.context, forEach.Type.GetLocation())
+                            : new NamedTypeReference(forEach.Type.ToString());
+                        GExpression converted = targetSymbol is { IsReferenceType: true }
+                            ? new BinaryExpression(
+                                new IdentifierExpression(itemIdentifier),
+                                "as",
+                                new TypeExpression(targetType))
+                            : new ConversionExpression(targetType, new IdentifierExpression(itemIdentifier));
+                        if (targetSymbol is { IsReferenceType: true, NullableAnnotation: not NullableAnnotation.Annotated })
+                        {
+                            converted = new NonNullAssertionExpression(converted);
+                        }
+
+                        var statements = new List<GStatement>(loopBody.Statements.Count + 1)
+                        {
+                            new LocalDeclarationStatement(
+                                BindingKind.Let,
+                                loopIdentifier,
+                                targetType,
+                                converted),
+                        };
+                        statements.AddRange(loopBody.Statements);
+                        loopBody = new BlockStatement(statements);
+                        loopIdentifier = itemIdentifier;
+                    }
+
                     return new[]
                     {
                         (GStatement)new ForInStatement(
-                            SanitizeIdentifier(forEach.Identifier.Text),
+                            loopIdentifier,
                             this.TranslateReceiverWithNullForgiveness(forEach.Expression),
-                            this.TranslateStatementAsBlock(forEach.Statement),
+                            loopBody,
                             isAwait: !forEach.AwaitKeyword.IsKind(SyntaxKind.None)),
                     };
 


### PR DESCRIPTION
## Summary
- always union public instance methods from every imported base declaration, even when aggregate reflection returns a partial non-empty set
- deduplicate inherited signatures without collapsing overloads that differ by generic arity
- preserve explicit C# `foreach` element conversions so Oahu's `FileSystemAccessRule` loop retains its runtime cast
- cover cross-assembly runtime dispatch and inaccessible-member negatives

## Oahu before / after
Exact generated `TokenStore.gs:116` before:
```gsharp
for r in current!! {
    sec!!.RemoveAccessRule(r)
}
```
`gsc`: `GS0159: Cannot find function RemoveAccessRule.`

After:
```gsharp
for __foreach0 in current!! {
    let r FileSystemAccessRule = (__foreach0 as FileSystemAccessRule)!!
    sec!!.RemoveAccessRule(r)
}
```
`gsc`: compiles without GS0159.

## Validation
- Core.Tests: 6,651 passed, 1 skipped
- Compiler.Tests: 3,311 passed
- Cs2Gs.Tests: 1,699 passed
- rebased targeted suites: 5 + 2 + 1 passed

Fixes #2638
