### PR TITLE
Fix named generic delegate arguments

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -767,8 +767,9 @@ internal sealed class ConversionClassifier
                     var substituted = TrySubstituteParameterTypeFromReceiver(
                         method, paramIndex, receiverType, symbolicMethodTypeArgs);
 
-                    // Issue #1512: a lambda argument bound to a generic method's
-                    // delegate parameter (e.g. `Func<Task,TResult>`) must convert
+                    // Issue #1512/#2643: a function-typed argument bound to a
+                    // generic method's delegate parameter (e.g.
+                    // `Func<Task,TResult>`) must convert
                     // to the SYMBOLIC delegate target recovered from the method's
                     // inferred type arguments (`Func<Task,T>`), not the closed CLR
                     // erasure (`Func<Task,object>`). Converting to the erased shape
@@ -785,7 +786,7 @@ internal sealed class ConversionClassifier
                     // delegate parameter closes over the method's own (still
                     // open) type argument must see the symbolic shape too.
                     if (substituted == null
-                        && (argument is BoundFunctionLiteralExpression
+                        && (argument.Type is FunctionTypeSymbol
                             || OverloadResolution.IsUnresolvedMethodGroupArgument(argument)))
                     {
                         substituted = TrySubstituteParameterTypeFromMethodTypeArgs(method, paramIndex, symbolicMethodTypeArgs);

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -3769,21 +3769,13 @@ internal sealed class MemberLookup
     /// arguments it was constructed with (<see cref="ImportedTypeSymbol.OpenDefinition"/>
     /// / <see cref="ImportedTypeSymbol.TypeArguments"/>), instead of
     /// reflecting over the (possibly type-erased) closed
-    /// <see cref="TypeSymbol.ClrType"/>. A delegate's <c>Invoke</c> method
-    /// parameters/return map 1:1 onto the delegate type's own open generic
-    /// parameters by position (verified: <c>typeof(Func&lt;,&gt;).GetMethod("Invoke")</c>'s
-    /// parameter/return <see cref="Type"/> instances are reference-equal to
-    /// <c>typeof(Func&lt;,&gt;).GetGenericArguments()</c>), so this only needs to
-    /// substitute each such open-parameter slot with the corresponding entry
-    /// in <paramref name="typeArguments"/>. Returns <see langword="false"/>
-    /// (letting the caller fall back to the reflection-based
-    /// <see cref="TryGetDelegateFunctionType(Type, out FunctionTypeSymbol)"/>)
-    /// for any Invoke slot that is NOT directly one of the delegate's own
-    /// generic parameters (e.g. a named delegate whose Invoke signature nests
-    /// a type parameter inside another generic, such as <c>List&lt;T&gt;</c>) —
-    /// an intentionally conservative scope covering the overwhelmingly common
-    /// <c>Func</c>/<c>Action</c>/simple-named-delegate shape without
-    /// attempting general type substitution.
+    /// <see cref="TypeSymbol.ClrType"/>. The delegate's complete <c>Invoke</c>
+    /// signature is projected through
+    /// <see cref="MapOpenClrTypeToSymbolic(Type, Type, ImmutableArray{TypeSymbol}, MethodInfo, ImmutableArray{TypeSymbol})"/>.
+    /// This preserves fixed parameters and recursively substitutes nested
+    /// generic shapes such as the <c>Action&lt;Conversion&gt;</c> callback in
+    /// <c>ConvertDelegate&lt;T&gt;</c>, instead of falling back to the
+    /// delegate's object-erased closed CLR type.
     /// </summary>
     /// <param name="openDefinition">The delegate's open CLR generic definition (e.g. <c>typeof(Func&lt;,&gt;)</c>).</param>
     /// <param name="typeArguments">The symbolic type arguments the delegate was constructed with.</param>
@@ -3824,28 +3816,19 @@ internal sealed class MemberLookup
             return false;
         }
 
-        static bool TryMapSlot(Type invokeSlotType, Type openDefinitionForSlot, ImmutableArray<TypeSymbol> args, out TypeSymbol mapped)
-        {
-            if (invokeSlotType.IsGenericParameter
-                && ClrTypeUtilities.IsSameAs(invokeSlotType.DeclaringType, openDefinitionForSlot)
-                && invokeSlotType.GenericParameterPosition >= 0
-                && invokeSlotType.GenericParameterPosition < args.Length)
-            {
-                mapped = args[invokeSlotType.GenericParameterPosition];
-                return mapped != null;
-            }
-
-            mapped = null;
-            return false;
-        }
-
         var parameters = invoke.GetParameters();
         var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(parameters.Length);
         var variadicBuilder = ImmutableArray.CreateBuilder<bool>(parameters.Length);
         var anyVariadic = false;
         foreach (var parameter in parameters)
         {
-            if (!TryMapSlot(parameter.ParameterType, openDefinition, typeArguments, out var mappedParam))
+            var mappedParam = MapOpenClrTypeToSymbolic(
+                parameter.ParameterType,
+                openDefinition,
+                typeArguments,
+                openMethodDefinition: null,
+                methodTypeArguments: default);
+            if (mappedParam == null || mappedParam == TypeSymbol.Error || TypeSymbol.ContainsTypeParameter(mappedParam))
             {
                 return false;
             }
@@ -3866,9 +3849,18 @@ internal sealed class MemberLookup
         {
             returnType = TypeSymbol.Void;
         }
-        else if (!TryMapSlot(invoke.ReturnType, openDefinition, typeArguments, out returnType))
+        else
         {
-            return false;
+            returnType = MapOpenClrTypeToSymbolic(
+                invoke.ReturnType,
+                openDefinition,
+                typeArguments,
+                openMethodDefinition: null,
+                methodTypeArguments: default);
+            if (returnType == null || returnType == TypeSymbol.Error || TypeSymbol.ContainsTypeParameter(returnType))
+            {
+                return false;
+            }
         }
 
         var variadicFlags = anyVariadic ? variadicBuilder.ToImmutable() : default;
@@ -4546,6 +4538,37 @@ internal sealed class MemberLookup
                 && string.Equals(openDef.FullName, "System.Linq.Expressions.Expression`1", StringComparison.Ordinal))
             {
                 UnifyForMethodTypeArgs(openArgs[0], actual, openMethod, result);
+                return;
+            }
+
+            // Issue #2643: infer through the Invoke signature rather than
+            // assuming a delegate's generic arguments are its parameters plus
+            // return. Named delegates such as ConvertDelegate<T> can mix fixed,
+            // nested-generic, and type-parameter slots in an unrelated order.
+            if (actual is FunctionTypeSymbol namedDelegateFunction
+                && ClrTypeUtilities.IsDelegateType(openClr))
+            {
+                var invoke = openClr.GetMethodSafe("Invoke");
+                var invokeParameters = invoke?.GetParameters();
+                if (invokeParameters != null
+                    && invokeParameters.Length == namedDelegateFunction.ParameterTypes.Length)
+                {
+                    for (var j = 0; j < invokeParameters.Length; j++)
+                    {
+                        UnifyForMethodTypeArgs(
+                            invokeParameters[j].ParameterType,
+                            namedDelegateFunction.ParameterTypes[j],
+                            openMethod,
+                            result);
+                    }
+
+                    if (!FunctionTypeSymbol.IsVoidReturn(namedDelegateFunction.ReturnType)
+                        && !invoke.ReturnType.IsSameAs(typeof(void)))
+                    {
+                        UnifyForMethodTypeArgs(invoke.ReturnType, namedDelegateFunction.ReturnType, openMethod, result);
+                    }
+                }
+
                 return;
             }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -47,7 +47,11 @@ internal sealed partial class MethodBodyEmitter
     //  * For any other function-typed value (a func-typed variable, call
     //    result, etc.) the runtime value is already a delegate; adapt it
     //    to the target delegate type via `dup / ldvirtftn Invoke / newobj`.
-    private void EmitFunctionToDelegateConversion(BoundExpression source, FunctionTypeSymbol sourceFn, Type targetDelegateHostType)
+    private void EmitFunctionToDelegateConversion(
+        BoundExpression source,
+        FunctionTypeSymbol sourceFn,
+        Type targetDelegateHostType,
+        EntityHandle? symbolicTargetCtorRef = null)
     {
         // Issue #1502: when the SOURCE function type carries a source-defined
         // user type (Struct/Class/Interface/Enum/Delegate) or a type parameter
@@ -73,6 +77,12 @@ internal sealed partial class MethodBodyEmitter
 
         if (source is BoundFunctionLiteralExpression literal)
         {
+            if (symbolicTargetCtorRef.HasValue)
+            {
+                this.EmitFunctionLiteral(literal, overrideDelegateType: null, symbolicDelegateCtorRef: symbolicTargetCtorRef.Value);
+                return;
+            }
+
             // Issue #1502: an async lambda whose Task-wrapped delegate shape
             // needs symbolic encoding (`Func<...,Task<TOutput>>`) is emitted
             // through the reified TypeSpec ctor ref.
@@ -107,6 +117,12 @@ internal sealed partial class MethodBodyEmitter
         // target delegate type.
         if (source is BoundMethodGroupExpression methodGroup)
         {
+            if (symbolicTargetCtorRef.HasValue)
+            {
+                this.EmitMethodGroupToNamedDelegate(methodGroup, symbolicTargetCtorRef.Value);
+                return;
+            }
+
             this.EmitMethodGroup(methodGroup, overrideDelegateType: sourceNeedsSymbolic ? null : targetDelegateType);
             return;
         }
@@ -130,9 +146,10 @@ internal sealed partial class MethodBodyEmitter
             invokeRef = this.outer.memberRefs.GetMethodReference(sourceInvoke);
         }
 
-        var ctorRef = sourceNeedsSymbolic
+        var ctorRef = symbolicTargetCtorRef
+            ?? (sourceNeedsSymbolic
             ? this.outer.memberRefs.GetFunctionDelegateCtorRef(sourceFn)
-            : (EntityHandle)this.outer.memberRefs.GetDelegateCtorReference(targetDelegateType);
+            : (EntityHandle)this.outer.memberRefs.GetDelegateCtorReference(targetDelegateType));
 
         this.EmitNullGuardedDelegateToDelegateAdaptation(source, invokeRef, ctorRef);
     }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -57,16 +57,17 @@ internal sealed partial class MethodBodyEmitter
         // Materialise the delegate with a `.ctor` MemberRef parented at the
         // constructed `Comparison<!TResult>` TypeSpec so the runtime instance
         // matches the callee's reified parameter.
-        if (conv.Expression is BoundFunctionLiteralExpression constructedDelegateLiteral
+        if (conv.Expression.Type is FunctionTypeSymbol constructedDelegateSource
             && conv.Type is ImportedTypeSymbol constructedDelegateTarget
             && constructedDelegateTarget.OpenDefinition != null
-            && constructedDelegateTarget.HasTypeParameterArgument
+            && constructedDelegateTarget.HasSubstitutableTypeArgument
             && ClrTypeUtilities.IsDelegateType(constructedDelegateTarget.ClrType))
         {
-            this.EmitFunctionLiteral(
-                constructedDelegateLiteral,
-                overrideDelegateType: null,
-                symbolicDelegateCtorRef: this.outer.memberRefs.GetConstructedDelegateCtorRef(constructedDelegateTarget));
+            this.EmitFunctionToDelegateConversion(
+                conv.Expression,
+                constructedDelegateSource,
+                constructedDelegateTarget.ClrType,
+                this.outer.memberRefs.GetConstructedDelegateCtorRef(constructedDelegateTarget));
             return;
         }
 

--- a/test/Compiler.Tests/Emit/Issue2643NamedGenericDelegateArgumentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2643NamedGenericDelegateArgumentEmitTests.cs
@@ -1,0 +1,269 @@
+// <copyright file="Issue2643NamedGenericDelegateArgumentEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public class Issue2643NamedGenericDelegateArgumentEmitTests
+{
+    [Fact]
+    public void OahuConvertDelegateExactSites_RunAndVerify()
+    {
+        var output = CompileAndRun(
+            """
+            package App
+            import System
+            import Lib2643
+            import Lib2643.Models
+
+            class SimpleCancellation : ICancellation {
+                let Name string
+                init(name string) { this.Name = name }
+            }
+
+            class CliCancellation : ICancellation {
+                let Name string
+                init(name string) { this.Name = name }
+            }
+
+            func Main() {
+                var mainWindowAction ((Book, SimpleCancellation, (Conversion) -> void) -> void)? = nil
+                mainWindowAction = (book Book, ctx SimpleCancellation, callback (Conversion) -> void) -> {
+                    callback(Conversion("${book.Name}:${ctx.Name}:window"))
+                }
+
+                var audibleAction ((Book, CliCancellation, (Conversion) -> void) -> void)? = nil
+                audibleAction = (book Book, ctx CliCancellation, callback (Conversion) -> void) -> {
+                    callback(Conversion("${book.Name}:${ctx.Name}:cli"))
+                }
+
+                let windowJob = DownloadDecryptJob[SimpleCancellation]()
+                Console.WriteLine(windowJob.Run(SimpleCancellation("simple"), mainWindowAction!!))
+                let cliJob = DownloadDecryptJob[CliCancellation]()
+                Console.WriteLine(cliJob.Run(CliCancellation("linked"), audibleAction!!))
+            }
+            """,
+            nameof(OahuConvertDelegateExactSites_RunAndVerify));
+
+        Assert.Equal("book:simple:window\nbook:linked:cli\n", output);
+    }
+
+    [Fact]
+    public void GenericMethod_InfersNamedDelegateTypeArgumentFromStructuralFunction_RunAndVerify()
+    {
+        var output = CompileAndRun(
+            """
+            package App
+            import System
+            import Lib2643
+            import Lib2643.Models
+
+            class SimpleCancellation : ICancellation {}
+
+            func Main() {
+                let convertAction (Book, SimpleCancellation, (Conversion) -> void) -> void =
+                    (book Book, ctx SimpleCancellation, callback (Conversion) -> void) -> {}
+                Console.WriteLine(GenericRunner.Infer(convertAction))
+            }
+            """,
+            nameof(GenericMethod_InfersNamedDelegateTypeArgumentFromStructuralFunction_RunAndVerify));
+
+        Assert.Equal("SimpleCancellation\n", output);
+    }
+
+    [Fact]
+    public void NamedDelegateValue_PreservesIdentityAcrossGenericCall_RunAndVerify()
+    {
+        var output = CompileAndRun(
+            """
+            package App
+            import System
+            import Lib2643
+
+            class SimpleCancellation : ICancellation {}
+
+            func Main() {
+                let action = GenericRunner.Create[SimpleCancellation]()
+                Console.WriteLine(GenericRunner.IsSame(action, action))
+            }
+            """,
+            nameof(NamedDelegateValue_PreservesIdentityAcrossGenericCall_RunAndVerify));
+
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void StructurallyIncompatibleFunction_StillRejected()
+    {
+        var libraries = EmitCSharpLibraries(nameof(StructurallyIncompatibleFunction_StillRejected));
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraries.ModelsPath, libraries.LibraryPath });
+        var compilation = new GsCompilation(
+            resolver,
+            GsSyntaxTree.Parse(SourceText.From(
+                """
+                package App
+                import Lib2643
+                import Lib2643.Models
+
+                class SimpleCancellation : ICancellation {}
+
+                func Main() {
+                    let bad (Book, SimpleCancellation, (int32) -> void) -> void =
+                        (book Book, ctx SimpleCancellation, callback (int32) -> void) -> {}
+                    let job = DownloadDecryptJob[SimpleCancellation]()
+                    job.Run(SimpleCancellation("simple"), bad)
+                }
+                """)));
+
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream, pdbStream: null, refStream: null, assemblyName: "Issue2643.Negative");
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0159");
+    }
+
+    private static string CompileAndRun(string source, string caseName)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2643Emit", caseName);
+        Directory.CreateDirectory(directory);
+        var libraries = EmitCSharpLibraries(caseName);
+        var consumerPath = Path.Combine(directory, "Consumer.dll");
+
+        using var resolver = ReferenceResolver.WithReferences(new[] { libraries.ModelsPath, libraries.LibraryPath });
+        var compilation = new GsCompilation(resolver, GsSyntaxTree.Parse(SourceText.From(source)));
+        using (var stream = File.Create(consumerPath))
+        {
+            var result = compilation.Emit(stream, pdbStream: null, refStream: null, assemblyName: "Issue2643." + caseName);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraries.ModelsPath, libraries.LibraryPath });
+
+        var context = new AssemblyLoadContext("Issue2643." + caseName, isCollectible: true);
+        try
+        {
+            context.Resolving += (_, name) => name.Name switch
+            {
+                "Lib2643" => context.LoadFromAssemblyPath(libraries.LibraryPath),
+                "Lib2643.Models" => context.LoadFromAssemblyPath(libraries.ModelsPath),
+                _ => null,
+            };
+            var assembly = context.LoadFromAssemblyPath(consumerPath);
+            var output = Console.Out;
+            using var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                assembly.EntryPoint!.Invoke(null, null);
+            }
+            finally
+            {
+                Console.SetOut(output);
+            }
+
+            return captured.ToString().Replace("\r\n", "\n");
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    private static (string LibraryPath, string ModelsPath) EmitCSharpLibraries(string caseName)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2643Emit", caseName);
+        Directory.CreateDirectory(directory);
+        var modelsPath = Path.Combine(directory, "Lib2643.Models.dll");
+        var libraryPath = Path.Combine(directory, "Lib2643.dll");
+        const string modelsSource = """
+            namespace Lib2643.Models
+            {
+                public sealed class Book
+                {
+                    public Book(string name) => Name = name;
+                    public string Name { get; }
+                }
+                public sealed class Conversion
+                {
+                    public Conversion(string value) => Value = value;
+                    public string Value { get; }
+                }
+            }
+            """;
+        const string source = """
+            using System;
+            using Lib2643.Models;
+
+            namespace Lib2643
+            {
+                public interface ICancellation { }
+                public delegate void ConvertDelegate<T>(
+                    Book book,
+                    T context,
+                    Action<Conversion> callback)
+                    where T : ICancellation;
+
+                public sealed class DownloadDecryptJob<T> where T : ICancellation
+                {
+                    public string Run(T context, ConvertDelegate<T> convertAction)
+                    {
+                        string result = null;
+                        convertAction(new Book("book"), context, conversion => result = conversion.Value);
+                        return result;
+                    }
+                }
+
+                public static class GenericRunner
+                {
+                    public static string Infer<T>(ConvertDelegate<T> action) where T : ICancellation => typeof(T).Name;
+
+                    public static ConvertDelegate<T> Create<T>() where T : ICancellation => (_, _, _) => { };
+
+                    public static bool IsSame<T>(ConvertDelegate<T> expected, ConvertDelegate<T> actual)
+                        where T : ICancellation
+                        => ReferenceEquals(expected, actual);
+                }
+            }
+            """;
+
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .ToArray();
+        var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+        var modelsCompilation = CSharpCompilation.Create(
+            "Lib2643.Models",
+            new[] { CSharpSyntaxTree.ParseText(modelsSource, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            options);
+        using (var stream = File.Create(modelsPath))
+        {
+            var result = modelsCompilation.Emit(stream);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        var compilation = CSharpCompilation.Create(
+            "Lib2643",
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references.Append(MetadataReference.CreateFromFile(modelsPath)),
+            options);
+
+        using var libraryStream = File.Create(libraryPath);
+        var libraryResult = compilation.Emit(libraryStream);
+        Assert.True(libraryResult.Success, string.Join(Environment.NewLine, libraryResult.Diagnostics));
+        return (libraryPath, modelsPath);
+    }
+}


### PR DESCRIPTION
## Summary
- preserve complete symbolic `Invoke` signatures for imported named generic delegates, including fixed and nested delegate parameters
- infer method type arguments through named delegate signatures and retain named delegate identity at generic call sites
- emit constructed target delegate adapters for function values closed over same-compilation types

## Exact before/after
Before, the translated Oahu call sites failed with GS0155:
- `MainWindow.axaml.gs:345`: structural `(Book, SimpleCancellation, (Conversion) -> void) -> void` rejected as `ConvertDelegate<SimpleCancellation>`
- `AudibleJobExecutor.gs:108`: structural `(Book, CliCancellation, (Conversion) -> void) -> void` rejected as `ConvertDelegate<CliCancellation>`

After, both exact shapes compile, IL-verify, and execute. Generic inference resolves `T` from the structural function; an existing named delegate remains reference-identical. A mismatched callback signature remains rejected.

## Tests
- `Issue2643NamedGenericDelegateArgumentEmitTests`: 4 passed
- `Core.Tests`: 6,646 passed, 1 skipped
- `Compiler.Tests`: 3,313 passed

Fixes #2643