### PR TITLE
Fix imported inherited static lookup

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -136,9 +136,15 @@ internal sealed partial class ExpressionBinder
                         // delegate-conversion context it materializes as a
                         // delegate over the selected overload; the conversion
                         // classifier decides which overload (if any) applies.
-                        if (TryBindClrMethodGroup(receiver: null, classSymbol.ClassType, wantStatic: true, ne.IdentifierToken.Text, out var staticGroup))
+                        var staticMethods = classSymbol.GetStaticMethodGroup(ne.IdentifierToken.Text);
+                        if (!staticMethods.IsEmpty)
                         {
-                            return staticGroup;
+                            return new BoundClrMethodGroupExpression(
+                                null,
+                                receiver: null,
+                                classSymbol.ClassType,
+                                ne.IdentifierToken.Text,
+                                staticMethods);
                         }
 
                         return BindExtensionMethodGroupOrError(receiver, ne);
@@ -680,7 +686,7 @@ internal sealed partial class ExpressionBinder
                 return false;
             }
 
-            if (TryBindClrMethodGroup(receiver: null, classSymbol.ClassType, wantStatic: true, name, out _))
+            if (!classSymbol.GetStaticMethodGroup(name).IsEmpty)
             {
                 return false;
             }

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -84,16 +84,19 @@ public sealed class ImportedClassSymbol : Symbol
     public bool TryLookupMember(string text, NameExpressionSyntax ne, out MemberInfo member)
     {
         _ = ne;
-        var bindingFlags = GetImportedMemberBindingFlags();
-        var property = ClrTypeUtilities.SafeGetProperty(ClassType, text, bindingFlags);
-        if (property != null && property.GetIndexParameters().Length == 0 && IsVisibleToCurrentCompilation(property))
+        var level = FindNearestNamedMemberLevel(text);
+        var property = level.Properties.FirstOrDefault(p =>
+            p.GetIndexParameters().Length == 0
+            && IsStatic(p)
+            && IsVisibleToCurrentCompilation(p));
+        if (property != null)
         {
             member = property;
             return true;
         }
 
-        var field = ClrTypeUtilities.SafeGetField(ClassType, text, bindingFlags);
-        if (field != null && IsVisibleToCurrentCompilation(field))
+        var field = level.Fields.FirstOrDefault(f => f.IsStatic && IsVisibleToCurrentCompilation(f));
+        if (field != null)
         {
             member = field;
             return true;
@@ -186,10 +189,9 @@ public sealed class ImportedClassSymbol : Symbol
         isAmbiguous = false;
         ambiguousMethods = ImmutableArray<MethodInfo>.Empty;
         isExpanded = false;
-        var methods = ClrTypeUtilities.SafeGetMethods(ClassType, GetImportedMemberBindingFlags())
-            .Where(IsVisibleToCurrentCompilation)
-            .ToArray();
-        var nameMatches = methods.Where(m => m.Name == text).ToList();
+        var nameMatches = FindNearestNamedMemberLevel(text).Methods
+            .Where(m => m.IsStatic && IsVisibleToCurrentCompilation(m))
+            .ToList();
         if (nameMatches.Count == 0)
         {
             return false;
@@ -423,6 +425,23 @@ public sealed class ImportedClassSymbol : Symbol
     public bool TryLookupFunction(string text, CallExpressionSyntax callExpression, ImmutableArray<BoundExpression> arguments, out ImportedFunctionSymbol function)
         => TryLookupFunction(text, callExpression, arguments, out function, out _);
 
+    /// <summary>
+    /// Gets the visible static methods from the nearest declaration level that
+    /// contains <paramref name="text"/>. A declaration on a derived type hides
+    /// every same-named base member when it is accessible, including when it is
+    /// not a static method.
+    /// </summary>
+    /// <param name="text">The method-group name.</param>
+    /// <returns>The visible, non-special static methods at the winning level.</returns>
+    internal ImmutableArray<MethodInfo> GetStaticMethodGroup(string text)
+        => FindNearestNamedMemberLevel(text).Methods
+            .Where(m =>
+                m.IsStatic
+                && !m.IsGenericMethodDefinition
+                && !m.IsSpecialName
+                && IsVisibleToCurrentCompilation(m))
+            .ToImmutableArray();
+
     private static Type ProjectMethodGroupType(TypeSymbol type)
     {
         var clrType = NullableTypeSymbol.GetEffectiveClrType(type);
@@ -478,21 +497,74 @@ public sealed class ImportedClassSymbol : Symbol
         return flags;
     }
 
-    private BindingFlags GetImportedMemberBindingFlags(bool includeInstance = false)
+    private NamedMemberLevel FindNearestNamedMemberLevel(string name)
     {
-        var flags = BindingFlags.Public | BindingFlags.Static;
-        if (includeInstance)
+        const BindingFlags Flags = BindingFlags.Public
+            | BindingFlags.NonPublic
+            | BindingFlags.Static
+            | BindingFlags.Instance
+            | BindingFlags.DeclaredOnly;
+
+        for (var current = ClassType; current != null; current = GetBaseTypeSafe(current))
         {
-            flags |= BindingFlags.Instance;
+            var methods = ClrTypeUtilities.SafeGetMethods(current, Flags)
+                .Where(m =>
+                    string.Equals(m.Name, name, StringComparison.Ordinal)
+                    && IsVisibleToCurrentCompilation(m))
+                .ToImmutableArray();
+            var properties = ClrTypeUtilities.SafeGetProperties(current, Flags)
+                .Where(p =>
+                    string.Equals(p.Name, name, StringComparison.Ordinal)
+                    && IsVisibleToCurrentCompilation(p))
+                .ToImmutableArray();
+            var fields = ClrTypeUtilities.SafeGetFields(current, Flags)
+                .Where(f =>
+                    string.Equals(f.Name, name, StringComparison.Ordinal)
+                    && IsVisibleToCurrentCompilation(f))
+                .ToImmutableArray();
+            var events = ClrTypeUtilities.SafeGetEvents(current, Flags)
+                .Any(e =>
+                    string.Equals(e.Name, name, StringComparison.Ordinal)
+                    && IsVisibleToCurrentCompilation(e));
+
+            if (!methods.IsEmpty || !properties.IsEmpty || !fields.IsEmpty || events || DeclaresVisibleNestedType(current, name))
+            {
+                return new NamedMemberLevel(methods, properties, fields);
+            }
         }
 
-        if (References?.CanAccessInternalMembers(ClassType.Assembly) == true)
-        {
-            flags |= BindingFlags.NonPublic;
-        }
-
-        return flags;
+        return NamedMemberLevel.Empty;
     }
+
+    private static Type GetBaseTypeSafe(Type type)
+    {
+        try
+        {
+            return type.BaseType;
+        }
+        catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+        {
+            return null;
+        }
+    }
+
+    private bool DeclaresVisibleNestedType(Type type, string name)
+    {
+        try
+        {
+            var nested = type.GetNestedType(name, BindingFlags.Public | BindingFlags.NonPublic);
+            return nested != null
+                && (nested.IsNestedPublic
+                    || (nested.IsNestedAssembly && References?.CanAccessInternalMembers(nested.Assembly) == true));
+        }
+        catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+        {
+            return false;
+        }
+    }
+
+    private static bool IsStatic(PropertyInfo property)
+        => property.GetMethod?.IsStatic == true || property.SetMethod?.IsStatic == true;
 
     private bool IsVisibleToCurrentCompilation(MethodBase method)
         => method.IsPublic || (method.IsAssembly && References?.CanAccessInternalMembers(method.DeclaringType?.Assembly) == true);
@@ -506,6 +578,14 @@ public sealed class ImportedClassSymbol : Symbol
         var setter = property.SetMethod;
         return (getter != null && IsVisibleToCurrentCompilation(getter))
             || (setter != null && IsVisibleToCurrentCompilation(setter));
+    }
+
+    private bool IsVisibleToCurrentCompilation(EventInfo eventInfo)
+    {
+        var add = eventInfo.AddMethod;
+        var remove = eventInfo.RemoveMethod;
+        return (add != null && IsVisibleToCurrentCompilation(add))
+            || (remove != null && IsVisibleToCurrentCompilation(remove));
     }
 
     /// <summary>
@@ -549,5 +629,16 @@ public sealed class ImportedClassSymbol : Symbol
         }
 
         return false;
+    }
+
+    private readonly record struct NamedMemberLevel(
+        ImmutableArray<MethodInfo> Methods,
+        ImmutableArray<PropertyInfo> Properties,
+        ImmutableArray<FieldInfo> Fields)
+    {
+        public static NamedMemberLevel Empty { get; } = new(
+            ImmutableArray<MethodInfo>.Empty,
+            ImmutableArray<PropertyInfo>.Empty,
+            ImmutableArray<FieldInfo>.Empty);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue2502InheritedStaticMembersEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2502InheritedStaticMembersEmitTests.cs
@@ -161,6 +161,68 @@ public sealed class Issue2502InheritedStaticMembersEmitTests
         }
     }
 
+    [Fact]
+    public void Issue2636_ImportedDerivedType_InheritedStaticMethodRunsAcrossAssemblies()
+    {
+        var directory = CreateTestDirectory();
+        try
+        {
+            var baseLibrary = Path.Combine(directory, "Issue2636.Base.dll");
+            EmitCSharpAssembly(
+                baseLibrary,
+                "Issue2636.Base",
+                """
+                using System.Threading.Tasks;
+
+                namespace Issue2636.Base;
+
+                public class BookDbContext
+                {
+                    public static Task<bool> StartupAsync() => Task.FromResult(true);
+                }
+                """,
+                OutputKind.DynamicallyLinkedLibrary);
+
+            var derivedLibrary = Path.Combine(directory, "Issue2636.Derived.dll");
+            EmitCSharpAssembly(
+                derivedLibrary,
+                "Issue2636.Derived",
+                """
+                using Issue2636.Base;
+
+                namespace Issue2636.Derived;
+
+                public sealed class BookDbContextLazyLoad : BookDbContext;
+                """,
+                OutputKind.DynamicallyLinkedLibrary,
+                baseLibrary);
+
+            const string Source = """
+                package Issue2636.Consumer
+                import System
+                import Issue2636.Derived
+
+                func Main() {
+                    Console.WriteLine(BookDbContextLazyLoad.StartupAsync()!!.GetAwaiter().GetResult())
+                }
+                """;
+
+            var executable = CompileGSharp(
+                directory,
+                "Issue2636.Consumer",
+                Source,
+                "exe",
+                baseLibrary,
+                derivedLibrary);
+            IlVerifier.Verify(executable, additionalReferences: new[] { baseLibrary, derivedLibrary });
+            Assert.Equal("True\n", Run(executable));
+        }
+        finally
+        {
+            TryDelete(directory);
+        }
+    }
+
     private static string CompileGSharp(
         string directory,
         string assemblyName,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2636ImportedInheritedStaticTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2636ImportedInheritedStaticTests.cs
@@ -1,0 +1,229 @@
+// <copyright file="Issue2636ImportedInheritedStaticTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2636ImportedInheritedStaticTests
+{
+    [Fact]
+    public void OahuBookDbContextLazyLoad_StartupAsyncAndStaticData_BindAcrossAssemblies()
+    {
+        var (basePath, derivedPath) = EmitLibraries();
+        var result = Compile(
+            basePath,
+            derivedPath,
+            """
+            package Issue2636.Consumer
+            import System.Threading.Tasks
+            import Issue2636.Derived
+
+            async func MainWindowStartupAsync() bool {
+                let canConnect bool = await BookDbContextLazyLoad.StartupAsync()!!
+                return canConnect
+            }
+
+            class CoreEnvironment {
+                shared {
+                    func InitializeDatabaseAsync() Task[bool] ->
+                        BookDbContextLazyLoad.StartupAsync()!!
+
+                    func InitializeDatabase() bool ->
+                        BookDbContextLazyLoad.StartupAsync()!!.GetAwaiter().GetResult()
+
+                    func InitializeFromMethodGroup() bool {
+                        let value () -> int32 = BookDbContextLazyLoad.Value
+                        return value() == 42
+                    }
+                }
+            }
+
+            func ReadStaticData() string ->
+                BookDbContextLazyLoad.Field!! + BookDbContextLazyLoad.Property!!
+            """);
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void DerivedDeclaration_HidesBaseOverloadSet()
+    {
+        var (basePath, derivedPath) = EmitLibraries();
+        var valid = Compile(
+            basePath,
+            derivedPath,
+            """
+            package Issue2636.Consumer
+            import Issue2636.Derived
+            func Pick() string -> HidingDerived.Pick("derived")!!
+            """);
+        Assert.True(valid.Success, string.Join(Environment.NewLine, valid.Diagnostics));
+
+        var invalid = Compile(
+            basePath,
+            derivedPath,
+            """
+            package Issue2636.Consumer
+            import Issue2636.Derived
+            func Pick() string -> HidingDerived.Pick(1)
+            """);
+        Assert.Contains(invalid.Diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void InaccessibleDeclarations_DoNotExposeInheritedStaticMembers()
+    {
+        var (basePath, derivedPath) = EmitLibraries();
+        var result = Compile(
+            basePath,
+            derivedPath,
+            """
+            package Issue2636.Consumer
+            import Issue2636.Derived
+
+            func PrivateCall() string -> BookDbContextLazyLoad.PrivateOnly()
+            func InternalCall() string -> BookDbContextLazyLoad.InternalOnly()
+            func ProtectedCall() string -> BookDbContextLazyLoad.ProtectedOnly()
+            """);
+
+        Assert.Equal(3, result.Diagnostics.Count(d => d.Id == "GS0159"));
+    }
+
+    [Fact]
+    public void InaccessibleDerivedDeclaration_DoesNotHideAccessibleBaseMember()
+    {
+        var (basePath, derivedPath) = EmitLibraries();
+        var result = Compile(
+            basePath,
+            derivedPath,
+            """
+            package Issue2636.Consumer
+            import Issue2636.Derived
+            func Pick() string -> InaccessibleHidingDerived.Pick(1)!!
+            """);
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void InheritedOverloadAmbiguity_RemainsAmbiguous()
+    {
+        var (basePath, derivedPath) = EmitLibraries();
+        var result = Compile(
+            basePath,
+            derivedPath,
+            """
+            package Issue2636.Consumer
+            import Issue2636.Base
+            import Issue2636.Derived
+            func Pick(value Both) string -> BookDbContextLazyLoad.Ambiguous(value)
+            """);
+
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0160");
+    }
+
+    private static (string BasePath, string DerivedPath) EmitLibraries()
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2636ImportedInheritedStaticTests));
+        Directory.CreateDirectory(directory);
+        var basePath = Path.Combine(directory, "Issue2636.Base.dll");
+        var derivedPath = Path.Combine(directory, "Issue2636.Derived.dll");
+
+        EmitCSharp(
+            basePath,
+            "Issue2636.Base",
+            """
+            using System.Threading.Tasks;
+
+            namespace Issue2636.Base;
+
+            public interface ILeft;
+            public interface IRight;
+            public sealed class Both : ILeft, IRight;
+
+            public class BookDbContext
+            {
+                public static string Field = "field";
+                public static string Property => "property";
+                public static int Value() => 42;
+                public static Task<bool> StartupAsync() => Task.FromResult(true);
+                public static string Ambiguous(ILeft value) => "left";
+                public static string Ambiguous(IRight value) => "right";
+                private static string PrivateOnly() => "private";
+                internal static string InternalOnly() => "internal";
+                protected static string ProtectedOnly() => "protected";
+            }
+
+            public class HidingBase
+            {
+                public static string Pick(int value) => "base";
+            }
+            """);
+
+        EmitCSharp(
+            derivedPath,
+            "Issue2636.Derived",
+            """
+            using Issue2636.Base;
+
+            namespace Issue2636.Derived;
+
+            public sealed class BookDbContextLazyLoad : BookDbContext;
+
+            public sealed class HidingDerived : HidingBase
+            {
+                public new static string Pick(string value) => "derived";
+            }
+
+            public sealed class InaccessibleHidingDerived : HidingBase
+            {
+                private new static string Pick(int value) => "hidden";
+            }
+            """,
+            basePath);
+
+        return (basePath, derivedPath);
+    }
+
+    private static (bool Success, System.Collections.Generic.IEnumerable<GSharp.Core.CodeAnalysis.Diagnostic> Diagnostics) Compile(
+        string basePath,
+        string derivedPath,
+        string source)
+    {
+        using var resolver = ReferenceResolver.WithReferences(new[] { basePath, derivedPath });
+        var compilation = new GsCompilation(resolver, GsSyntaxTree.Parse(SourceText.From(source))) { IsLibrary = true };
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream, pdbStream: null, refStream: null, assemblyName: "Issue2636.Consumer");
+        return (result.Success, result.Diagnostics);
+    }
+
+    private static void EmitCSharp(string path, string assemblyName, string source, params string[] additionalReferences)
+    {
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(reference => (MetadataReference)MetadataReference.CreateFromFile(reference))
+            .Concat(additionalReferences.Select(reference => MetadataReference.CreateFromFile(reference)));
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = File.Create(path);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+}


### PR DESCRIPTION
## Summary
- walk imported CLR base declarations for static methods, method groups, fields, and properties
- preserve C# nearest-accessible declaration hiding, member-kind hiding, overload ambiguity, and cross-assembly accessibility
- cover the exact Oahu `BookDbContextLazyLoad.StartupAsync()` GUI/CLI shapes plus runtime and negative cases

## Oahu proof
- baseline `gsc 0.3.226`: `CoreEnvironment.gs:37,47` each report `GS0159: Cannot find function StartupAsync`
- fixed `gsc`: `StartupAsync` GS0159 count `2 -> 0`; no diagnostics remain at lines 37 or 47

## Validation
- Core.Tests: 6,651 passed, 1 skipped
- Compiler.Tests: 3,310 passed
- post-rebase lookup suites: 19 Core + 5 Compiler passed
- ILVerify and cross-assembly runtime regression passed

Fixes #2636