### PR TITLE
Ignore Avalonia Xaml closure verifier false positives

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
@@ -43,7 +43,11 @@ public class IlVerifyRunner
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex AvaloniaXamlClosureBuildPattern = new Regex(
-        @"(?:^|\+)XamlClosure_\d+::Build_\d+\(",
+        @"(?:^|\+)XamlClosure_\d+::Build_\d+\(\[System\.ComponentModel\]System\.IServiceProvider\)$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex AvaloniaObjectSlotStackMismatchPattern = new Regex(
+        @"\[found ref 'object'\]\[expected ref '[^'\r\n]+'\] Unexpected type on the stack\.$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly object ToolRestoreSync = new();
@@ -271,10 +275,12 @@ public class IlVerifyRunner
             return false;
         }
 
-        return error.Method.StartsWith(
+        bool generatedContextMethod = error.Method.StartsWith(
                 "CompiledAvaloniaXaml.XamlIlContext+Context`1::",
-                StringComparison.Ordinal)
-            || AvaloniaXamlClosureBuildPattern.IsMatch(error.Method);
+                StringComparison.Ordinal);
+        bool generatedClosureObjectSlot = AvaloniaXamlClosureBuildPattern.IsMatch(error.Method)
+            && AvaloniaObjectSlotStackMismatchPattern.IsMatch(error.RawLine ?? string.Empty);
+        return generatedContextMethod || generatedClosureObjectSlot;
     }
 
     private static IReadOnlyList<string> BuildReferenceSet(

--- a/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
@@ -42,6 +42,10 @@ public class IlVerifyRunner
         @"(?:\[(?<location>.*?)\]\s*\[offset[^\]]*\]\s*)?(?<message>.*)$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex AvaloniaXamlClosureBuildPattern = new Regex(
+        @"(?:^|\+)XamlClosure_\d+::Build_\d+\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private static readonly object ToolRestoreSync = new();
     private static readonly Dictionary<string, bool> ToolAvailabilityByRepoRoot = new(StringComparer.OrdinalIgnoreCase);
     private static readonly TimeSpan DotnetToolTimeout = TimeSpan.FromMinutes(5);
@@ -259,11 +263,19 @@ public class IlVerifyRunner
         return string.IsNullOrEmpty(candidate) ? null : candidate;
     }
 
-    private static bool IsAvaloniaXamlCompilerFalsePositive(IlVerifyError error) =>
-        string.Equals(error.Code, "StackUnexpected", StringComparison.Ordinal)
-        && error.Method?.StartsWith(
-            "CompiledAvaloniaXaml.XamlIlContext+Context`1::",
-            StringComparison.Ordinal) == true;
+    private static bool IsAvaloniaXamlCompilerFalsePositive(IlVerifyError error)
+    {
+        if (!string.Equals(error.Code, "StackUnexpected", StringComparison.Ordinal)
+            || string.IsNullOrEmpty(error.Method))
+        {
+            return false;
+        }
+
+        return error.Method.StartsWith(
+                "CompiledAvaloniaXaml.XamlIlContext+Context`1::",
+                StringComparison.Ordinal)
+            || AvaloniaXamlClosureBuildPattern.IsMatch(error.Method);
+    }
 
     private static IReadOnlyList<string> BuildReferenceSet(
         string assemblyPath,

--- a/tools/cs2gs/Cs2Gs.Tests/IlVerifyStageTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/IlVerifyStageTests.cs
@@ -4,8 +4,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.Loader;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Cs2Gs.Pipeline;
@@ -136,6 +140,101 @@ public class IlVerifyStageTests
 
         IlVerifyError surviving = Assert.Single(filtered);
         Assert.Equal("StackUnexpected", surviving.Code);
+    }
+
+    /// <summary>
+    /// #2671: Avalonia XamlIl deliberately carries concrete controls in
+    /// object-typed stack slots. Its generated XamlClosure Build methods run
+    /// correctly, but ILVerify reports StackUnexpected just as it does for the
+    /// existing generated XamlIlContext methods.
+    /// </summary>
+    [Fact]
+    public void AvaloniaXamlClosureBuilds_FilterExactUiFingerprints_AndGeneralize()
+    {
+        const string BookLibrary =
+            "Oahu.Core.UI.Avalonia.Views.BookLibraryView+XamlClosure_1::Build_1([System.ComponentModel]System.IServiceProvider)";
+        const string Conversion =
+            "Oahu.Core.UI.Avalonia.Views.ConversionView+XamlClosure_2::Build_1([System.ComponentModel]System.IServiceProvider)";
+        var builder = new TriageBuilder("run_1", "2026-07-21T00:00:00Z", "0.3.0", "corpus/Oahu.UI");
+
+        Assert.Equal(
+            "sha256:9d0322446fc5a1cc4b78e2a66d5d83354b6e527fcd49d9f907fe63ccbb034a53",
+            builder.IlVerifyFailure(new IlVerifyError("StackUnexpected", BookLibrary, BookLibrary)).Fingerprint);
+        Assert.Equal(
+            "sha256:94a053bb50ec2721c8600fe77dd02aa29a401f95bf174b39b459218f5dfea5a7",
+            builder.IlVerifyFailure(new IlVerifyError("StackUnexpected", Conversion, Conversion)).Fingerprint);
+
+        var errors = new[]
+        {
+            new IlVerifyError("StackUnexpected", BookLibrary, BookLibrary),
+            new IlVerifyError("StackUnexpected", Conversion, Conversion),
+            new IlVerifyError(
+                "StackUnexpected",
+                "Demo.View+XamlClosure_17::Build_42([System.ComponentModel]System.IServiceProvider)",
+                "generalized"),
+            new IlVerifyError("StackUnexpected", "Demo.View+XamlClosure_1::CreateContext()", "real create"),
+            new IlVerifyError("StackUnexpected", "Demo.View+Closure_1::Build_1()", "real closure"),
+            new IlVerifyError("ReturnVoid", "Demo.View+XamlClosure_1::Build_1()", "real code"),
+        };
+
+        IReadOnlyList<IlVerifyError> filtered = IlVerifyRunner.FilterIgnored(errors);
+
+        Assert.Equal(3, filtered.Count);
+        Assert.Contains(filtered, e => e.Method!.EndsWith("::CreateContext()", StringComparison.Ordinal));
+        Assert.Contains(filtered, e => e.Method!.Contains("+Closure_1::", StringComparison.Ordinal));
+        Assert.Contains(filtered, e => e.Code == "ReturnVoid");
+    }
+
+    /// <summary>
+    /// Emits the upstream XamlIl stack shape rather than merely feeding mocked
+    /// diagnostics to the filter: an object-typed local contains a concrete
+    /// ISupportInitialize implementation and is called without a cast. Real
+    /// ILVerify reports both exact Oahu Build fingerprints, while the CLR runs
+    /// both methods and observes BeginInit/EndInit.
+    /// </summary>
+    [Fact]
+    public void AvaloniaXamlClosureBuilds_RealIlVerifyAndRuntimeProof()
+    {
+        if (!IlVerifyRunner.IsEnabled || !IlVerifyToolAvailable())
+        {
+            return;
+        }
+
+        string directory = NewOutputRoot("issue2671-xaml-closure");
+        string assemblyPath = Path.Combine(directory, "Oahu.UI.dll");
+        EmitAvaloniaXamlClosureFixture(assemblyPath);
+
+        try
+        {
+            var result = new IlVerifyRunner().Verify(assemblyPath);
+            Assert.True(result.Succeeded, result.Output);
+            Assert.Empty(result.Errors);
+            Assert.Contains("[StackUnexpected]", result.Output, StringComparison.Ordinal);
+            Assert.Contains(
+                "BookLibraryView+XamlClosure_1::Build_1",
+                result.Output,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "ConversionView+XamlClosure_2::Build_1",
+                result.Output,
+                StringComparison.Ordinal);
+
+            var loadContext = new AssemblyLoadContext("issue2671-" + Guid.NewGuid().ToString("N"), isCollectible: true);
+            try
+            {
+                Assembly assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+                AssertClosureRan(assembly, "BookLibraryView+XamlClosure_1");
+                AssertClosureRan(assembly, "ConversionView+XamlClosure_2");
+            }
+            finally
+            {
+                loadContext.Unload();
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
     }
 
     /// <summary>
@@ -284,6 +383,82 @@ public class IlVerifyStageTests
         string root = Path.Combine(AppContext.BaseDirectory, "pipeline-tests", label, Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         return root;
+    }
+
+    private static void EmitAvaloniaXamlClosureFixture(string path)
+    {
+        var assembly = new PersistedAssemblyBuilder(
+            new AssemblyName("Oahu.UI." + Guid.NewGuid().ToString("N")),
+            typeof(object).Assembly);
+        ModuleBuilder module = assembly.DefineDynamicModule("Oahu.UI");
+
+        TypeBuilder control = module.DefineType("Oahu.Core.UI.Avalonia.Views.GeneratedControl", TypeAttributes.Public);
+        control.AddInterfaceImplementation(typeof(ISupportInitialize));
+        FieldBuilder beginCalled = control.DefineField("BeginCalled", typeof(bool), FieldAttributes.Public);
+        FieldBuilder endCalled = control.DefineField("EndCalled", typeof(bool), FieldAttributes.Public);
+        ConstructorBuilder constructor = control.DefineDefaultConstructor(MethodAttributes.Public);
+        DefineInitMethod(control, beginCalled, nameof(ISupportInitialize.BeginInit));
+        DefineInitMethod(control, endCalled, nameof(ISupportInitialize.EndInit));
+
+        DefineClosure(module, control, constructor, "BookLibraryView", "XamlClosure_1");
+        DefineClosure(module, control, constructor, "ConversionView", "XamlClosure_2");
+        control.CreateType();
+        assembly.Save(path);
+    }
+
+    private static void DefineInitMethod(TypeBuilder control, FieldBuilder field, string name)
+    {
+        MethodBuilder method = control.DefineMethod(
+            name,
+            MethodAttributes.Public | MethodAttributes.Virtual,
+            typeof(void),
+            Type.EmptyTypes);
+        ILGenerator il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, field);
+        il.Emit(OpCodes.Ret);
+        control.DefineMethodOverride(method, typeof(ISupportInitialize).GetMethod(name)!);
+    }
+
+    private static void DefineClosure(
+        ModuleBuilder module,
+        TypeBuilder control,
+        ConstructorBuilder constructor,
+        string viewName,
+        string closureName)
+    {
+        TypeBuilder view = module.DefineType(
+            "Oahu.Core.UI.Avalonia.Views." + viewName,
+            TypeAttributes.Public);
+        TypeBuilder closure = view.DefineNestedType(
+            closureName,
+            TypeAttributes.NestedPublic | TypeAttributes.Abstract | TypeAttributes.Sealed);
+        MethodBuilder build = closure.DefineMethod(
+            "Build_1",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(object),
+            new[] { typeof(IServiceProvider) });
+        ILGenerator il = build.GetILGenerator();
+        LocalBuilder root = il.DeclareLocal(typeof(object));
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, root);
+        il.Emit(OpCodes.Ldloc, root);
+        il.Emit(OpCodes.Callvirt, typeof(ISupportInitialize).GetMethod(nameof(ISupportInitialize.BeginInit))!);
+        il.Emit(OpCodes.Ldloc, root);
+        il.Emit(OpCodes.Callvirt, typeof(ISupportInitialize).GetMethod(nameof(ISupportInitialize.EndInit))!);
+        il.Emit(OpCodes.Ldloc, root);
+        il.Emit(OpCodes.Ret);
+        closure.CreateType();
+        view.CreateType();
+    }
+
+    private static void AssertClosureRan(Assembly assembly, string typeName)
+    {
+        Type closure = assembly.GetType("Oahu.Core.UI.Avalonia.Views." + typeName)!;
+        object result = closure.GetMethod("Build_1")!.Invoke(null, new object[] { null })!;
+        Assert.True((bool)result.GetType().GetField("BeginCalled")!.GetValue(result)!);
+        Assert.True((bool)result.GetType().GetField("EndCalled")!.GetValue(result)!);
     }
 
     private static string FindCompiler()

--- a/tools/cs2gs/Cs2Gs.Tests/IlVerifyStageTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/IlVerifyStageTests.cs
@@ -156,33 +156,39 @@ public class IlVerifyStageTests
         const string Conversion =
             "Oahu.Core.UI.Avalonia.Views.ConversionView+XamlClosure_2::Build_1([System.ComponentModel]System.IServiceProvider)";
         var builder = new TriageBuilder("run_1", "2026-07-21T00:00:00Z", "0.3.0", "corpus/Oahu.UI");
+        string bookLibraryError = AvaloniaObjectSlotError(BookLibrary, "[System.ComponentModel.Primitives]System.ComponentModel.ISupportInitialize");
+        string conversionError = AvaloniaObjectSlotError(Conversion, "[System.ComponentModel.Primitives]System.ComponentModel.ISupportInitialize");
 
         Assert.Equal(
             "sha256:9d0322446fc5a1cc4b78e2a66d5d83354b6e527fcd49d9f907fe63ccbb034a53",
-            builder.IlVerifyFailure(new IlVerifyError("StackUnexpected", BookLibrary, BookLibrary)).Fingerprint);
+            builder.IlVerifyFailure(new IlVerifyError("StackUnexpected", BookLibrary, bookLibraryError)).Fingerprint);
         Assert.Equal(
             "sha256:94a053bb50ec2721c8600fe77dd02aa29a401f95bf174b39b459218f5dfea5a7",
-            builder.IlVerifyFailure(new IlVerifyError("StackUnexpected", Conversion, Conversion)).Fingerprint);
+            builder.IlVerifyFailure(new IlVerifyError("StackUnexpected", Conversion, conversionError)).Fingerprint);
 
         var errors = new[]
         {
-            new IlVerifyError("StackUnexpected", BookLibrary, BookLibrary),
-            new IlVerifyError("StackUnexpected", Conversion, Conversion),
+            new IlVerifyError("StackUnexpected", BookLibrary, bookLibraryError),
+            new IlVerifyError("StackUnexpected", Conversion, conversionError),
             new IlVerifyError(
                 "StackUnexpected",
                 "Demo.View+XamlClosure_17::Build_42([System.ComponentModel]System.IServiceProvider)",
-                "generalized"),
+                AvaloniaObjectSlotError(
+                    "Demo.View+XamlClosure_17::Build_42([System.ComponentModel]System.IServiceProvider)",
+                    "Demo.Control")),
             new IlVerifyError("StackUnexpected", "Demo.View+XamlClosure_1::CreateContext()", "real create"),
             new IlVerifyError("StackUnexpected", "Demo.View+Closure_1::Build_1()", "real closure"),
             new IlVerifyError("ReturnVoid", "Demo.View+XamlClosure_1::Build_1()", "real code"),
+            new IlVerifyError("StackUnexpected", BookLibrary, "[found value 'int32'][expected ref 'object']"),
         };
 
         IReadOnlyList<IlVerifyError> filtered = IlVerifyRunner.FilterIgnored(errors);
 
-        Assert.Equal(3, filtered.Count);
+        Assert.Equal(4, filtered.Count);
         Assert.Contains(filtered, e => e.Method!.EndsWith("::CreateContext()", StringComparison.Ordinal));
         Assert.Contains(filtered, e => e.Method!.Contains("+Closure_1::", StringComparison.Ordinal));
         Assert.Contains(filtered, e => e.Code == "ReturnVoid");
+        Assert.Contains(filtered, e => e.RawLine!.Contains("found value 'int32'", StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -460,6 +466,10 @@ public class IlVerifyStageTests
         Assert.True((bool)result.GetType().GetField("BeginCalled")!.GetValue(result)!);
         Assert.True((bool)result.GetType().GetField("EndCalled")!.GetValue(result)!);
     }
+
+    private static string AvaloniaObjectSlotError(string method, string expected) =>
+        $"[IL]: Error [StackUnexpected]: [/proof/Oahu.UI.dll : {method}]" +
+        $"[offset 0x0000001B][found ref 'object'][expected ref '{expected}'] Unexpected type on the stack.";
 
     private static string FindCompiler()
     {

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -157,7 +157,12 @@ sha256sum obj/Release/net10.0/{,Avalonia/}Oahu.UI.dll \
   bin/Release/net10.0/Oahu.UI.dll
 ilspycmd -l c obj/Release/net10.0/Oahu.UI.dll | grep XamlClosure
 ilspycmd -l c obj/Release/net10.0/Avalonia/Oahu.UI.dll | grep XamlClosure
-ilverify bin/Release/net10.0/Oahu.UI.dll -s System.Private.CoreLib <reference flags>
+runtime=$(dotnet --list-runtimes | awk \
+  '$1=="Microsoft.NETCore.App" && $2~/^10[.]/{gsub(/[][]/,"",$3); p=$3"/"$2} END{print p}')
+ilverify bin/Release/net10.0/Oahu.UI.dll -s System.Private.CoreLib \
+  $(find "$runtime" -maxdepth 1 -name '*.dll' -exec printf -- '-r %s ' {} \;) \
+  $(find bin/Release/net10.0 -maxdepth 1 -name '*.dll' \
+    ! -name Oahu.UI.dll -exec printf -- '-r %s ' {} \;)
 ilspycmd -il bin/Release/net10.0/Oahu.UI.dll > proof.il
 ```
 

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -104,6 +104,70 @@ triage artifact; later stages are reported as `skip`.
    `Gsharp.NET.Sdk`) and compares the passing/failing test set against the C#
    xUnit oracle. Failures → `test-parity-failure`.
 
+### ILVerify exception policy
+
+Stage 3 does not treat green CI or an application that happens to run as proof
+that invalid non-unsafe IL is acceptable. An exception is method- and
+diagnostic-scoped and requires a matching C#-built baseline. Issue #2671 adds
+one such upstream exception for Avalonia 11.2.7 XamlIl-generated
+`XamlClosure_N::Build_N(IServiceProvider)` methods. The filter requires all of:
+
+- `StackUnexpected`;
+- the exact generated closure/method/signature convention; and
+- XamlIl's exact object-slot mismatch, `found ref 'object'` to an expected
+  reference type.
+
+Other errors in the same assembly and other errors in a matching method remain
+gating failures.
+
+The proof used Oahu commit
+`200e3b4c26c781368f74bbef098caea89bac8754` and its C# release artifact
+`8365085850`. Both the original C# build and migrated G# build contain these
+six identical diagnostics (paths normalized), hash
+`d467dfc517fa448a1cff59f934afc11bbcebf5901910629db36ad63e8264bf50`:
+
+| Method | Offsets | Triage fingerprint |
+| --- | --- | --- |
+| `BookLibraryView+XamlClosure_1::Build_1` | `0x1B`, `0x20`, `0xB1` | `sha256:9d0322446fc5a1cc4b78e2a66d5d83354b6e527fcd49d9f907fe63ccbb034a53` |
+| `ConversionView+XamlClosure_2::Build_1` | `0x1B`, `0x20`, `0xD7` | `sha256:94a053bb50ec2721c8600fe77dd02aa29a401f95bf174b39b459218f5dfea5a7` |
+
+Token-resolved ILSpy method disassemblies are identical after removing only
+the RVA comment: BookLibrary
+`d79a21c01d54baa12c9c7f689d1beba1b1dcd814160cfecf7048100f3f90cae4`;
+Conversion
+`66d3ea09ffba550e5d034135c085d9010c9ee85a6e003a2417132697e25ceeba`.
+The raw IL streams have the same sizes/maxstack (183/9 and 221/9) but different
+hashes because metadata row tokens differ between csc and gsc assemblies:
+
+| Method | Original raw IL SHA-256 | Migrated raw IL SHA-256 |
+| --- | --- | --- |
+| BookLibrary `Build_1` | `9af2771d7ae3e81889e17959afe409fc31bd8bbb33a827ddc156e6ffd43bbfdc` | `91db5378181a2bbcc720ad9d5018034cb960df3ef04cf827b73aba885d05b679` |
+| Conversion `Build_1` | `ef14249dfeb99e2455b14a06459735e5312fdfad05402724c69185234ffe6e1d` | `d81df7df85024b9ff4c5e5dd36fc3303d541687e75abcc57ba8917a0b723bfa7` |
+
+Ownership is also observable before verification. Neither compiler's
+`obj/Release/net10.0/Oahu.UI.dll` contains `XamlClosure` types. Avalonia's
+`CompileAvaloniaXamlTask` writes
+`obj/Release/net10.0/Avalonia/Oahu.UI.dll`; only that post-processed assembly
+contains them, and it is byte-identical to the copied `bin` assembly. The
+original pre/post hashes are `0f0d5e80…`/`f26eeb88…`; the migrated hashes are
+`86f7e159…`/`f534dc90…`. The relevant checks are:
+
+```sh
+sha256sum obj/Release/net10.0/{,Avalonia/}Oahu.UI.dll \
+  bin/Release/net10.0/Oahu.UI.dll
+ilspycmd -l c obj/Release/net10.0/Oahu.UI.dll | grep XamlClosure
+ilspycmd -l c obj/Release/net10.0/Avalonia/Oahu.UI.dll | grep XamlClosure
+ilverify bin/Release/net10.0/Oahu.UI.dll -s System.Private.CoreLib <reference flags>
+ilspycmd -il bin/Release/net10.0/Oahu.UI.dll > proof.il
+```
+
+Invoking both exact methods from each assembly returns `TextBlock` and
+`ProgressBar`, respectively. This establishes an upstream, runtime-valid
+verifier exception; it does not excuse unrelated Avalonia or gsc diagnostics.
+Applying the narrowed filter to either complete nine-error Oahu log leaves the
+same `AboutView.!XamlIlPopulate` `DelegateCtor` error gating. That separate
+diagnostic remains unsuppressed and is tracked by #2672.
+
 ## Construct coverage (ADR-0138)
 
 The authoritative statement of C# 14 coverage is


### PR DESCRIPTION
## Summary
- classify only Avalonia XamlIl generated `XamlClosure_N::Build_N(IServiceProvider)` object-slot `StackUnexpected` diagnostics proven identical in the C# baseline
- require the exact code, generated method/signature, and `found ref object` → expected-reference diagnostic; near misses remain gating
- add real persisted-assembly ILVerify/runtime coverage and exact Oahu fingerprint assertions
- document byte/method-level provenance and the exception policy

## Original-vs-migrated proof

**Provenance:** Oahu commit `200e3b4c26c781368f74bbef098caea89bac8754`; C# release artifact `8365085850` (`Oahu-linux-x64-tarball`, head SHA confirmed through the GitHub artifacts API); Avalonia 11.2.7.

Running ILVerify with full runtime/application references produced the same six path-normalized lines in both assemblies (combined SHA-256 `d467dfc517fa448a1cff59f934afc11bbcebf5901910629db36ad63e8264bf50`):

| Method | Identical offsets | Fingerprint |
| --- | --- | --- |
| `BookLibraryView+XamlClosure_1::Build_1` | `0x1B`, `0x20`, `0xB1` | `sha256:9d0322446fc5a1cc4b78e2a66d5d83354b6e527fcd49d9f907fe63ccbb034a53` |
| `ConversionView+XamlClosure_2::Build_1` | `0x1B`, `0x20`, `0xD7` | `sha256:94a053bb50ec2721c8600fe77dd02aa29a401f95bf174b39b459218f5dfea5a7` |

Method-level proof:
- IL sizes/maxstack match: Book `183/9`; Conversion `221/9`.
- Token-resolved disassemblies are identical after removing only RVA comments: Book hash `d79a21c…`; Conversion hash `66d3ea09…`.
- Raw IL hashes differ only because metadata-token row numbers differ; all raw and normalized hashes are recorded in `tools/cs2gs/README.md`.
- Reflection invocation of both exact methods in both actual assemblies returned `Avalonia.Controls.TextBlock` and `Avalonia.Controls.ProgressBar`.

## IL ownership proof

For both builds, `obj/Release/net10.0/Oahu.UI.dll` contains no `XamlClosure` type. Avalonia target `CompileAvaloniaXamlTask` writes `obj/Release/net10.0/Avalonia/Oahu.UI.dll`; only this post-processed assembly contains both closures, and its SHA-256 equals the copied `bin` assembly.

- C# pre/post: `0f0d5e80…` / `f26eeb88…`
- G# pre/post: `86f7e159…` / `f534dc90…`

Commands used (full reference flags omitted only for readability):
```sh
gh api repos/DavidObando/Oahu/actions/artifacts/8365085850
sha256sum obj/Release/net10.0/{,Avalonia/}Oahu.UI.dll bin/Release/net10.0/Oahu.UI.dll
ilspycmd -l c obj/Release/net10.0/Oahu.UI.dll | grep XamlClosure
ilspycmd -l c obj/Release/net10.0/Avalonia/Oahu.UI.dll | grep XamlClosure
ilverify bin/Release/net10.0/Oahu.UI.dll -s System.Private.CoreLib <reference flags>
ilspycmd -il bin/Release/net10.0/Oahu.UI.dll > proof.il
diff -u original-XamlClosure_N.il migrated-XamlClosure_N.il
```

This proves Avalonia, not csc/gsc, emitted the methods. A gsc emitter change cannot affect them.

## Narrowness / deferred work

Applying the final filter to either complete nine-error log yields `parsed=9 remaining=1`: only `AboutView.!XamlIlPopulate` `DelegateCtor` remains. It is **not suppressed** and remains tracked by #2672. Any different error code, method/signature, or stack mismatch remains gating.

## Validation
- `IlVerifyStageTests`: 11 passed
- `Cs2Gs.Tests`: 1,708 passed
- original and migrated exact Oahu ILVerify/runtime probes: passed as documented above

Fixes #2671