### PR TITLE
Preserve declaration pattern narrowed value type

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2646DeclarationPatternPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2646DeclarationPatternPipelineTests.cs
@@ -40,11 +40,18 @@ public sealed class Issue2646DeclarationPatternPipelineTests
 
             public static class Program
             {
-                public static int Run(int? rewriteCode)
+                public static int Run(int? rewriteResult)
                 {
-                    if (rewriteCode is int code)
+                    try
                     {
-                        return code;
+                        var rewriteCode = rewriteResult;
+                        if (rewriteCode is int code)
+                        {
+                            return code;
+                        }
+                    }
+                    catch
+                    {
                     }
 
                     return -1;
@@ -81,8 +88,9 @@ public sealed class Issue2646DeclarationPatternPipelineTests
             result.RunId,
             MigrationPipeline.SanitizeAppId(app.AppId),
             "Program.gs"));
-        Assert.Contains("let code = rewriteCode", translated, StringComparison.Ordinal);
-        Assert.Contains("if code is int32", translated, StringComparison.Ordinal);
+        Assert.Contains("var code int32", translated, StringComparison.Ordinal);
+        Assert.Contains("code = int32(__spill0)", translated, StringComparison.Ordinal);
+        Assert.DoesNotContain("let code = rewriteCode", translated, StringComparison.Ordinal);
         Assert.DoesNotContain("return rewriteCode", translated, StringComparison.Ordinal);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2646DeclarationPatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2646DeclarationPatternTranslationTests.cs
@@ -24,11 +24,18 @@ public sealed class Issue2646DeclarationPatternTranslationTests
             {
                 public sealed class Program
                 {
-                    public int Run(int? rewriteCode)
+                    public int Run(int? rewriteResult)
                     {
-                        if (rewriteCode is int code)
+                        try
                         {
-                            return code;
+                            var rewriteCode = rewriteResult;
+                            if (rewriteCode is int code)
+                            {
+                                return code;
+                            }
+                        }
+                        catch
+                        {
                         }
 
                         return -1;
@@ -37,9 +44,12 @@ public sealed class Issue2646DeclarationPatternTranslationTests
             }
             """);
 
-        Assert.Contains("let code = rewriteCode", printed, StringComparison.Ordinal);
-        Assert.Contains("if code is int32", printed, StringComparison.Ordinal);
+        Assert.Contains("let __spill0 = rewriteCode", printed, StringComparison.Ordinal);
+        Assert.Contains("var code int32", printed, StringComparison.Ordinal);
+        Assert.Contains("if __spill0 is int32", printed, StringComparison.Ordinal);
+        Assert.Contains("code = int32(__spill0)", printed, StringComparison.Ordinal);
         Assert.Contains("return code", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("let code = rewriteCode", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("if rewriteCode is int32", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("return rewriteCode", printed, StringComparison.Ordinal);
     }
@@ -62,17 +72,18 @@ public sealed class Issue2646DeclarationPatternTranslationTests
                             return -1;
                         }
 
+                        code = code + 1;
                         return code;
                     }
                 }
             }
             """);
 
-        Assert.Contains("let code = value", printed, StringComparison.Ordinal);
-        Assert.Contains("if code is int32", printed, StringComparison.Ordinal);
+        Assert.Contains("var code int32", printed, StringComparison.Ordinal);
+        Assert.Contains("code = int32(__spill0)", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("return value", printed, StringComparison.Ordinal);
         Assert.Equal(
-            "42\n-1",
+            "43\n-1",
             CompileAndRun(
                 printed,
                 "System.Console.WriteLine(C().Read(42))\nSystem.Console.WriteLine(C().Read(\"no\"))").Trim());

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.ControlFlow.cs
@@ -537,13 +537,13 @@ public sealed partial class CSharpToGSharpTranslator
         /// let t T? = receiver as T   // reference target
         /// if t != nil { … }
         ///
-        /// let t = receiver           // value target
-        /// if t is T { … }
+        /// let __spill0 = receiver    // value target
+        /// var t T
+        /// if __spill0 is T { t = T(__spill0); … }
         /// </code>
-        /// Testing the named local, rather than rewriting <c>t</c> back to the
-        /// scrutinee, lets gsc carry the same variable's narrowing through nested
-        /// and following scopes. Value targets keep the receiver's inferred type
-        /// because G# has no value-type <c>as</c> conversion.
+        /// Value-pattern binders use a separate typed local so their reads do not
+        /// rely on flow narrowing through an enclosing try/block. Reference targets
+        /// retain the nullable-local lowering used for G# nil narrowing.
         /// </summary>
         private bool TryBuildPositiveGuardHoist(
             IfStatementSyntax ifStatement, out IReadOnlyList<GStatement> result)
@@ -571,6 +571,12 @@ public sealed partial class CSharpToGSharpTranslator
             GTypeReference targetType = this.MapTypeSyntax(typeSyntax);
             string localName = SanitizeIdentifier(single.Identifier.Text);
             GExpression receiver = this.TranslateExpression(isPattern.Expression);
+
+            if (targetSymbol.IsValueType)
+            {
+                result = this.BuildPositiveValueGuardHoist(ifStatement, localName, targetType, receiver);
+                return true;
+            }
 
             // Record that this pattern variable is now a nullable G# local so an
             // assignment-LHS use inside the guard is null-forgiven (gsc narrows
@@ -625,6 +631,48 @@ public sealed partial class CSharpToGSharpTranslator
 
             result = new GStatement[] { hoist, new IfStatement(guard, then, elseBranch) };
             return true;
+        }
+
+        private IReadOnlyList<GStatement> BuildPositiveValueGuardHoist(
+            IfStatementSyntax ifStatement,
+            string localName,
+            GTypeReference targetType,
+            GExpression receiver)
+        {
+            string spillName = $"__spill{this.state.SpillCounter++}";
+            var spill = new IdentifierExpression(spillName);
+            var hoist = new LocalDeclarationStatement(
+                BindingKind.Let,
+                spillName,
+                type: null,
+                initializer: receiver);
+            var binder = new LocalDeclarationStatement(BindingKind.Var, localName, targetType);
+            var guard = new BinaryExpression(spill, "is", new TypeExpression(targetType));
+
+            GExpression narrowed = targetType is NamedTypeReference namedTarget
+                ? new InvocationExpression(
+                    new IdentifierExpression(namedTarget.Name),
+                    new[] { spill },
+                    namedTarget.TypeArguments)
+                : new NonNullAssertionExpression(spill);
+            var thenStatements = new List<GStatement>
+            {
+                new AssignmentStatement(new IdentifierExpression(localName), narrowed),
+            };
+            thenStatements.AddRange(this.TranslateStatementAsBlock(ifStatement.Statement).Statements);
+
+            GStatement elseBranch = ifStatement.Else == null
+                ? null
+                : ifStatement.Else.Statement is IfStatementSyntax elseIf
+                    ? this.TranslateIf(elseIf)
+                    : this.TranslateStatementAsBlock(ifStatement.Else.Statement);
+
+            return new GStatement[]
+            {
+                hoist,
+                binder,
+                new IfStatement(guard, new BlockStatement(thenStatements), elseBranch),
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- materialize positive value-pattern binders as typed locals instead of nullable/wider scrutinee aliases
- assign the binder only on the matching path, preserving mutation and following-scope semantics
- cover the exact Oahu try-block shape, runtime match/mismatch behavior, negative translation checks, and the SDK pipeline

## Exact Oahu proof
Before, `if (rewriteCode is int code) return code` became:

```gsharp
let code = rewriteCode
if code is int32 {
    return code
}
```

Inside the Oahu `try`, `code` remained `int32?` and produced `GS0156`. After:

```gsharp
let __spill0 = rewriteCode
var code int32
if __spill0 is int32 {
    code = int32(__spill0)
    return code
}
```

The scrutinee is evaluated once while the C# binder keeps its narrowed type and variable identity.

## Validation
- Issue2646 translation/runtime/pipeline tests: 3 passed
- related declaration-pattern regression tests: 20 passed
- Release solution build: 0 warnings, 0 errors

Fixes #2646
