### PR TITLE
Fix qualified imported object construction

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -143,8 +143,9 @@ internal sealed partial class ExpressionBinder
     /// <summary>
     /// Binds a fully-qualified imported-type constructor written in expression
     /// position, e.g. <c>System.Text.StringBuilder()</c> or
-    /// <c>System.Collections.Generic.List[int]()</c>. Such an expression parses
-    /// as an accessor chain whose terminal segment is the constructor call, so
+    /// <c>System.Collections.Generic.List[int]()</c>, including an object
+    /// initializer suffix. Such an expression parses as an accessor chain whose
+    /// terminal segment is the constructor call (or its initializer wrapper), so
     /// it never reaches <see cref="TryBindClrConstructorCall"/> (which only sees
     /// simple-name calls). This walks the dotted name, resolves the closed CLR
     /// type via the active references/imports, and reuses the shared
@@ -164,10 +165,12 @@ internal sealed partial class ExpressionBinder
 
         // Flatten the accessor chain into the leading namespace/type segments
         // and the terminal constructor call. Anything that isn't a pure
-        // dotted-name chain ending in a call is not a qualified constructor.
+        // dotted-name chain ending in a call (optionally wrapped by an object
+        // initializer) is not a qualified constructor.
         var segments = new List<string>();
         ExpressionSyntax current = syntax;
         CallExpressionSyntax terminalCall = null;
+        ObjectCreationExpressionSyntax terminalObjectCreation = null;
         while (true)
         {
             if (current is AccessorExpressionSyntax accessor)
@@ -185,6 +188,13 @@ internal sealed partial class ExpressionBinder
             if (current is CallExpressionSyntax call)
             {
                 terminalCall = call;
+                break;
+            }
+
+            if (current is ObjectCreationExpressionSyntax { Target: CallExpressionSyntax objectCall } objectCreation)
+            {
+                terminalCall = objectCall;
+                terminalObjectCreation = objectCreation;
                 break;
             }
 
@@ -206,15 +216,21 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var bound = TryBindClrConstructorFromType(
+        var handled = TryBindClrConstructorFromType(
             clrType,
             terminalCall,
             out result,
             out var noApplicableOverload,
             openGenericDef,
-            symbolicArgs);
-        return bound || FinishClrConstructorBindingFailure(
-            terminalCall, typeSimpleName, noApplicableOverload, ref result);
+            symbolicArgs)
+            || FinishClrConstructorBindingFailure(
+                terminalCall, typeSimpleName, noApplicableOverload, ref result);
+        if (handled && terminalObjectCreation != null)
+        {
+            result = BindObjectInitializerSuffix(terminalObjectCreation, result);
+        }
+
+        return handled;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/ImportedTypeIdentityTests.cs
+++ b/test/Compiler.Tests/ImportedTypeIdentityTests.cs
@@ -15,6 +15,40 @@ namespace GSharp.Compiler.Tests;
 public class ImportedTypeIdentityTests
 {
     [Fact]
+    public void QualifiedImportedConstructor_WithObjectInitializer_BindsExactOahuSiteDespiteLocalTypeCollision()
+    {
+        var source = """
+            package Oahu.Cli.Commands
+            import System
+            import Spectre.Console
+            import Spectre.Console.Rendering
+
+            class Rule {}
+
+            class UiPreviewCommand {
+                shared {
+                    func RenderPreview(console IAnsiConsole, args string) {
+                        let rule = Spectre.Console.Rule(args){Justification = Justify.Left}
+                        console.Write(rule!!)
+                    }
+                }
+            }
+
+            UiPreviewCommand.RenderPreview(AnsiConsole.Console, "Theme")
+            """;
+        var spectrePath = typeof(Spectre.Console.Rule).Assembly.Location;
+
+        var (exitCode, output) = Compile(
+            source,
+            spectrePath,
+            Path.Combine(Path.GetDirectoryName(spectrePath)!, "Spectre.Console.Ansi.dll"));
+
+        Assert.True(exitCode == 0, output);
+        Assert.DoesNotContain("GS0157", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("GS0159", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FullyQualifiedAndImportedExternalType_Unify()
     {
         var source = """
@@ -63,7 +97,7 @@ public class ImportedTypeIdentityTests
         Assert.Equal("hit", value);
     }
 
-    private static (int ExitCode, string Output) Compile(string source)
+    private static (int ExitCode, string Output) Compile(string source, params string[] references)
     {
         var workDir = CreateTestDirectory("gs_identity_test_");
         try
@@ -81,6 +115,11 @@ public class ImportedTypeIdentityTests
             };
 
             foreach (var reference in TrustedPlatformAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            foreach (var reference in references)
             {
                 args.Add("/reference:" + reference);
             }


### PR DESCRIPTION
## Summary
- bind dotted imported CLR constructors when an object initializer wraps the terminal call
- preserve exact namespace qualification over colliding local type names
- cover the exact `Spectre.Console.Rule(args)` / `console.Write(rule)` Oahu site

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --nologo` (6,669 passed, 1 skipped)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter FullyQualifiedName~ImportedTypeIdentityTests --no-restore --nologo` (3 passed)
- `dotnet build src/Sdk/Gsharp.Extensions/Gsharp.Extensions.csproj --nologo`

Fixes #2663