### PR TITLE
Fix synchronous imported delegate stack balancing

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -955,8 +955,9 @@ internal sealed class ConversionClassifier
                     }
                     else if (substituted != null
                         && argument.Type != targetType
-                        && argument is not BoundFunctionLiteralExpression
-                        && !OverloadResolution.IsUnresolvedMethodGroupArgument(argument))
+                        && (!(argument is BoundFunctionLiteralExpression
+                                || OverloadResolution.IsUnresolvedMethodGroupArgument(argument))
+                            || !MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(targetType, out _)))
                     {
                         // Issue #2391: overload resolution necessarily sees the
                         // receiver's erased CLR signature, but conversion must

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -1301,7 +1301,7 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
-    /// Issue #903: symbol-based deferred arrow-lambda target inference. The
+    /// Issue #903 / #2673: symbol-based deferred arrow-lambda target inference. The
     /// CLR-driven <see cref="ResolveDeferredArrowLambdaArguments"/> paths infer
     /// the lambda's parameter type from the receiver's <em>CLR</em> type, which
     /// for a same-compilation generic element type (e.g. <c>List[Check]</c>
@@ -1315,12 +1315,10 @@ internal sealed partial class ExpressionBinder
     /// inferred symbolic arguments (reusing
     /// <see cref="MemberLookup.MapOpenClrTypeToSymbolic(Type, Type, ImmutableArray{TypeSymbol}, MethodInfo, ImmutableArray{TypeSymbol})"/>).
     /// A per-slot <see cref="FunctionTypeSymbol"/> carrying those parameter
-    /// types is produced (its return type is a placeholder — callers bind with
-    /// <c>inferReturnTypeFromBody</c>). Candidates must agree on the recovered
-    /// parameter types. The method succeeds <em>only</em> when at least one
-    /// recovered parameter type is a same-compilation user type, so the
-    /// referenced-element and primitive cases continue through the existing
-    /// CLR paths unchanged.
+    /// types is produced. Non-generic methods on constructed generic receivers
+    /// are recovered from the open declaring type too, including delegates
+    /// whose only symbolic slot is their return type. Candidates must agree on
+    /// the recovered shape.
     ///
     /// Issue #2345: also recovers the delegate's <em>return</em> shape when it
     /// is fully closed by the same unification (including the common case of a
@@ -1381,6 +1379,9 @@ internal sealed partial class ExpressionBinder
         }
 
         var symbolicArgVector = ImmutableArray.Create(symbolicArgs);
+        var receiverOpenDefinition = (receiverType as ImportedTypeSymbol)?.OpenDefinition;
+        var receiverTypeArguments = (receiverType as ImportedTypeSymbol)?.TypeArguments
+            ?? ImmutableArray<TypeSymbol>.Empty;
 
         // Record the expected delegate arity for each deferred lambda slot.
         var arityByIndex = new Dictionary<int, int>();
@@ -1401,7 +1402,7 @@ internal sealed partial class ExpressionBinder
 
         foreach (var method in methods)
         {
-            if (method == null || (!method.IsGenericMethodDefinition && !method.IsGenericMethod))
+            if (method == null)
             {
                 continue;
             }
@@ -1410,8 +1411,17 @@ internal sealed partial class ExpressionBinder
             ParameterInfo[] openParameters;
             try
             {
-                openMethod = method.IsGenericMethodDefinition ? method : method.GetGenericMethodDefinition();
-                if (!openMethod.IsGenericMethodDefinition)
+                if (method.IsGenericMethod)
+                {
+                    openMethod = method.IsGenericMethodDefinition ? method : method.GetGenericMethodDefinition();
+                }
+                else if (receiverOpenDefinition != null
+                    && !method.IsStatic
+                    && TryResolveOpenInstanceMethod(receiverOpenDefinition, method, out var resolvedOpenMethod))
+                {
+                    openMethod = resolvedOpenMethod;
+                }
+                else
                 {
                     continue;
                 }
@@ -1496,7 +1506,12 @@ internal sealed partial class ExpressionBinder
                 var slotUsable = true;
                 foreach (var invokeParameter in invokeParameters)
                 {
-                    var mapped = MemberLookup.MapOpenClrTypeToSymbolic(invokeParameter.ParameterType, openDefinition: null, typeArguments: default, openMethodDefinition: openMethod, methodTypeArguments: methodTypeArgs);
+                    var mapped = MemberLookup.MapOpenClrTypeToSymbolic(
+                        invokeParameter.ParameterType,
+                        receiverOpenDefinition,
+                        receiverTypeArguments,
+                        openMethod,
+                        methodTypeArgs);
                     if (mapped == null || mapped == TypeSymbol.Error || TypeSymbol.ContainsTypeParameter(mapped))
                     {
                         slotUsable = false;
@@ -1528,10 +1543,19 @@ internal sealed partial class ExpressionBinder
                 var returnClrType = invoke.ReturnType;
                 var mappedReturn = returnClrType != null && returnClrType.IsSameAs(typeof(void))
                     ? TypeSymbol.Void
-                    : MemberLookup.MapOpenClrTypeToSymbolic(returnClrType, openDefinition: null, typeArguments: default, openMethodDefinition: openMethod, methodTypeArguments: methodTypeArgs);
+                    : MemberLookup.MapOpenClrTypeToSymbolic(
+                        returnClrType,
+                        receiverOpenDefinition,
+                        receiverTypeArguments,
+                        openMethod,
+                        methodTypeArgs);
                 if (mappedReturn != null && mappedReturn != TypeSymbol.Error && !TypeSymbol.ContainsTypeParameter(mappedReturn))
                 {
                     slotReturnTypes[idx] = mappedReturn;
+                    if (TypeSymbol.ContainsSameCompilationUserType(mappedReturn))
+                    {
+                        candidateHasSameCompilationType = true;
+                    }
                 }
             }
 
@@ -1900,7 +1924,19 @@ internal sealed partial class ExpressionBinder
                 // (delegate-reshaping conversions still make it applicable to a
                 // concrete CLR delegate parameter when that path is chosen).
                 var argName = argumentNames.IsDefault ? null : argumentNames[argSlot];
-                if (UserExtensionHasFunctionTypedParameterAt(receiver, methodName, argSlot))
+                if (argumentNames.IsDefault
+                    && receiver?.Type is ImportedTypeSymbol symbolicReceiver
+                    && !symbolicReceiver.TypeArguments.IsDefaultOrEmpty
+                    && symbolicReceiver.TypeArguments.Any(TypeSymbol.RequiresSymbolicProjection))
+                {
+                    // Issue #2673: a constructed imported receiver can erase a
+                    // same-compilation type argument to object in reflection.
+                    // Defer the lambda so the existing symbolic-target pass
+                    // recovers the open method's reified delegate signature.
+                    deferredArrowLambdaIndices.Add(argSlot);
+                    boundArguments.Add(new BoundErrorExpression(inner));
+                }
+                else if (UserExtensionHasFunctionTypedParameterAt(receiver, methodName, argSlot))
                 {
                     boundArguments.Add(BindExpression(inner));
                 }

--- a/test/Compiler.Tests/Emit/Issue2673SymbolicReceiverDelegateReturnTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2673SymbolicReceiverDelegateReturnTests.cs
@@ -1,0 +1,199 @@
+// <copyright file="Issue2673SymbolicReceiverDelegateReturnTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Issue #2673: preserve symbolic delegate returns on imported generic receivers.</summary>
+public class Issue2673SymbolicReceiverDelegateReturnTests
+{
+    [Fact]
+    public void ExactTokenBucketRateLimiter_TryAcquire_VerifiesAndRuns()
+    {
+        const string source = """
+            package Oahu.Cli.Server.Hosting
+
+            import System
+            import System.Collections.Concurrent
+
+            class TokenBucketRateLimiter {
+                private let buckets ConcurrentDictionary[string, Bucket] = ConcurrentDictionary[string, Bucket](StringComparer.Ordinal)
+                private let ratePerSecond float64
+                private let burst int32
+
+                init(ratePerSecond float64, burst int32) {
+                    this.ratePerSecond = ratePerSecond
+                    this.burst = burst
+                }
+
+                func TryAcquire(key string) bool {
+                    if String.IsNullOrEmpty(key) {
+                        return true
+                    }
+                    let bucket = this.buckets.GetOrAdd(key, (_ string) -> Bucket(this.burst))
+                    lock bucket {
+                        let now = DateTimeOffset.UtcNow
+                        let elapsed = (now - bucket!!.LastRefill).TotalSeconds
+                        if elapsed > float64(0.0) {
+                            bucket!!.Tokens = Math.Min(this.burst, bucket!!.Tokens + (elapsed * this.ratePerSecond))
+                            bucket!!.LastRefill = now
+                        }
+                        if bucket!!.Tokens < 1.0 {
+                            return false
+                        }
+                        bucket!!.Tokens -= 1.0
+                        return true
+                    }
+                }
+
+                private class Bucket {
+                    init(initialTokens int32) {
+                        this.Tokens = initialTokens
+                        this.LastRefill = DateTimeOffset.UtcNow
+                    }
+
+                    prop Tokens float64
+                    prop LastRefill DateTimeOffset
+                }
+            }
+
+            let limiter = TokenBucketRateLimiter(0.000001, 2)
+            Console.WriteLine(limiter.TryAcquire(""))
+            Console.WriteLine(limiter.TryAcquire("key"))
+            Console.WriteLine(limiter.TryAcquire("key"))
+            Console.WriteLine(limiter.TryAcquire("key"))
+            """;
+
+        Assert.Equal("True\nTrue\nTrue\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NonGenericImportedMethod_SymbolicDelegateReturn_VerifiesAndRuns()
+    {
+        const string source = """
+            package Issue2673.Control
+            import System
+            import System.Collections.Concurrent
+
+            class Item {
+                var Value int32
+                init(value int32) { this.Value = value }
+            }
+
+            let items = ConcurrentDictionary[string, Item]()
+            let item = items.GetOrAdd("answer", (_ string) -> Item(42))
+            Console.WriteLine(item!!.Value)
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void IncompatibleSymbolicDelegateReturn_IsRejected()
+    {
+        const string source = """
+            package Issue2673.Negative
+            import System.Collections.Concurrent
+
+            class Item {}
+
+            func Probe() {
+                let items = ConcurrentDictionary[string, Item]()
+                let item = items.GetOrAdd("wrong", (_ string) -> "not an Item")
+            }
+            """;
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        var tempDir = Directory.CreateTempSubdirectory("gs_2673_negative_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(tempDir, "test.gs");
+            File.WriteAllText(sourcePath, source);
+            Assert.NotEqual(0, Program.Main(new[] { "/target:library", "/targetframework:net10.0", sourcePath }));
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+
+        Assert.Contains("GetOrAdd", stdout.ToString() + stderr);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2673_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(tempDir, "test.gs");
+            var outputPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(exitCode == 0, stdout.ToString() + stderr);
+            IlVerifier.Verify(outputPath);
+
+            File.WriteAllText(Path.ChangeExtension(outputPath, "runtimeconfig.json"), """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add(outputPath);
+            using var process = Process.Start(startInfo)!;
+            var result = process.StandardOutput.ReadToEnd();
+            var runtimeError = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            Assert.True(process.ExitCode == 0, runtimeError);
+            return result.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- defer explicitly typed lambdas on symbolically constructed imported receivers until the open method signature is available
- recover delegate parameter and return slots from non-generic methods on open generic declaring types
- reject function literals selected through an incompatible erased generic value overload

## Exact proof
The migrated `Oahu.Cli.Server.Hosting.TokenBucketRateLimiter.TryAcquire(string)` fingerprint previously emitted `Func<string,object>` where `Func<string,TokenBucketRateLimiter.Bucket>` was required (`StackUnexpected`, SHA-256 `5e6effd1e9e81eadaef33e4d462c0cf35c97d076dd8a0251fc5695f02472af52`). The committed compiler now passes translate, compile, ILVerify, and test parity for that exact C# source.

## Validation
- `dotnet build GSharp.sln -c Release --no-restore`
- exact RateLimiter migration pipeline: 1/1 green (translate/compile/ILVerify/parity)
- symbolic delegate regression suite: 39/39 passed
- Core.Tests: 6,669 passed, 1 skipped
- issue regression: runtime + ILVerify + incompatible-return negative coverage

Fixes #2673