### PR TITLE
Fix nullable collection initializer elements

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1050,7 +1050,7 @@ internal sealed class ConversionClassifier
 
     /// <summary>
     /// ADR-0087 §3 R5 / issue #765: when a method is invoked on a constructed
-    /// generic whose type arguments include user-defined symbolic types,
+    /// generic whose type arguments require symbolic projection,
     /// return the substituted symbolic parameter type for the call site so
     /// the binder does not insert a box conversion to the type-erased
     /// <see cref="object"/> shape. Returns <see langword="null"/> when no
@@ -1081,7 +1081,7 @@ internal sealed class ConversionClassifier
         TypeSymbol receiverType,
         ImmutableArray<TypeSymbol> symbolicMethodTypeArgs = default)
     {
-        // Issue #2385: the receiver type-argument gate below previously only
+        // Issues #2385/#2664: the receiver type-argument gate below previously only
         // matched a same-compilation user type when it was DIRECTLY a
         // StructSymbol/InterfaceSymbol/EnumSymbol/DelegateTypeSymbol (or
         // nested inside another ImportedTypeSymbol). A same-compilation
@@ -1093,7 +1093,7 @@ internal sealed class ConversionClassifier
         // misclassifying the argument as a boxing conversion and emitting an
         // invalid `box`/`ldnull` sequence against a value-type
         // `Nullable<T>` generic parameter slot (InvalidProgramException at
-        // runtime — see #2385). `TypeSymbol.ContainsSameCompilationUserType`
+        // runtime — see #2385). `TypeSymbol.RequiresSymbolicProjection`
         // is the general, already-established predicate for exactly this
         // shape (it recurses through NullableTypeSymbol/SliceTypeSymbol/
         // ArrayTypeSymbol/TupleTypeSymbol/nested ImportedTypeSymbol
@@ -1101,11 +1101,13 @@ internal sealed class ConversionClassifier
         // async-return-erasure bug), and is a structural superset of the old
         // ad hoc list, so replacing it here also generalizes to
         // same-compilation enums and array/tuple-wrapped shapes used as a
-        // generic type argument.
+        // generic type argument, and also retains nullable-reference
+        // annotations whose CLR type is otherwise identical to its underlying
+        // non-null reference.
         if (method == null
             || receiverType is not ImportedTypeSymbol imported
             || imported.TypeArguments.IsDefaultOrEmpty
-            || !imported.TypeArguments.Any(TypeSymbol.ContainsSameCompilationUserType))
+            || !imported.TypeArguments.Any(TypeSymbol.RequiresSymbolicProjection))
         {
             return null;
         }
@@ -1176,7 +1178,7 @@ internal sealed class ConversionClassifier
         var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openParamType, openDef, imported.TypeArguments, openMethod, symbolicMethodTypeArgs);
         return mapped != null
             && mapped != TypeSymbol.Error
-            && (TypeSymbol.ContainsTypeParameter(mapped) || TypeSymbol.ContainsSameCompilationUserType(mapped))
+            && TypeSymbol.RequiresSymbolicProjection(mapped)
             ? mapped
             : null;
     }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -855,7 +855,7 @@ internal sealed partial class ExpressionBinder
     /// <param name="typeArgumentList">The call's <c>[T1, T2]</c> list.</param>
     /// <param name="clrArgs">On success, the resolved (mapped) CLR type arguments ready for MakeGenericType.</param>
     /// <param name="symbolicArgs">On success, the symbolic type arguments in source order.</param>
-    /// <param name="hasSymbolicArg">On success, whether any argument is a G# user-defined type or in-scope type parameter.</param>
+    /// <param name="hasSymbolicArg">On success, whether any argument carries information its CLR type cannot represent.</param>
     /// <returns>Whether all type arguments resolved.</returns>
     private bool TryResolveClrConstructionTypeArgs(
         TypeArgumentListSyntax typeArgumentList,
@@ -888,21 +888,11 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            // Issue #671: a nested constructed generic that itself carries
-            // symbolic user-defined arguments (e.g. `List[MyGs]` used as an
-            // argument to `List[...]`) has a (type-erased) ClrType, but the
-            // outer construction must still preserve the symbolic shape so
-            // the emitter can recover the user-defined TypeDef tokens at the
-            // inner position. Flag the outer as symbolic so the symbolic args
-            // are retained, but keep the placeholder CLR type for
-            // MakeGenericType (the closed CLR shape erases to
-            // `Open<...,object,...>` at the outer level, and the emitter
-            // descends through the symbolic args to encode the real shape).
-            if (ta is ImportedTypeSymbol nested
-                && nested.OpenDefinition != null
-                && !nested.TypeArguments.IsDefaultOrEmpty
-                && nested.TypeArguments.Any(static a => a.ClrType == null
-                    || (a is ImportedTypeSymbol n && n.OpenDefinition != null && !n.TypeArguments.IsDefaultOrEmpty)))
+            // Issue #2664: preserve every symbolic argument shape that its CLR
+            // type cannot represent, including nullable references. Indexer and
+            // Add binding can then recover `T?` instead of target-typing `nil`
+            // against the erased non-null `T`.
+            if (TypeSymbol.RequiresSymbolicProjection(ta))
             {
                 hasSymbolicArg = true;
             }

--- a/test/Compiler.Tests/Emit/Issue479CollectionInitializerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue479CollectionInitializerEmitTests.cs
@@ -138,6 +138,40 @@ public class Issue479CollectionInitializerEmitTests
     }
 
     [Fact]
+    public void NullableReferenceElements_AreTargetTyped()
+    {
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+
+            let items = List[string?]{ nil, "value" }
+            let added = Dictionary[string, object?]{ "error": nil }
+            let indexed = Dictionary[string, object?]{ ["error"] = nil }
+            Console.WriteLine(items[0] == nil)
+            Console.WriteLine(added["error"] == nil)
+            Console.WriteLine(indexed["error"] == nil)
+            """;
+
+        Assert.Equal("True\nTrue\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NonNullableReferenceElements_RejectNil()
+    {
+        var source = """
+            package App
+            import System.Collections.Generic
+
+            let indexed = Dictionary[string, object]{ ["error"] = nil }
+            """;
+
+        var (exit, diagnostics) = CompileExpectingFailure(source);
+        Assert.NotEqual(0, exit);
+        Assert.Contains("GS0155", diagnostics);
+    }
+
+    [Fact]
     public void DictionaryInitializer_WithConstructorArgs_UsesComparer()
     {
         // The explicit-ctor-args form matching the C# new(StringComparer


### PR DESCRIPTION
## Summary
- preserve nullable reference type arguments through constructed collection calls
- target-type bare, keyed, and indexed `nil` elements against nullable collection slots
- retain GS0155 for the exact non-null `Dictionary[string, object]` sink

## Exact before / after
`Dictionary[string, object?]{["error"] = nil}`

Before: `GS0155: Cannot convert type 'nil' to 'object'.`

After: compiles, IL-verifies, and evaluates the stored value as `nil`.

## Tests
- collection initializer runtime + strict negative regressions: 15 passed
- nullable CLR parameter regressions: 9 passed
- Core.Tests: 6,669 passed, 1 skipped
- full Compiler.Tests rerun: no failures observed for 30 minutes; stopped after exceeding the shared runner window

Fixes #2664
