### PR TITLE
Fix delegate construction ABI

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -1433,19 +1433,19 @@ internal sealed partial class ExpressionBinder
         // (it has no source syntax and, per the extension-call ADR, no
         // separate BoundExpression that needs updating outside `bound`).
         //
-        // Issue #1150: the delegate-rebind step deliberately narrows to
-        // ONLY numeric-return-widening (rather than the full erasing
-        // rebind used by ctor/static/instance/inherited dispatch): a full
-        // erasing rebind of a non-numeric-widening func/arrow literal
-        // would erase the produced delegate to the generic LINQ method's
-        // type-erased shape (e.g. `Func<object,object>`) while the call
-        // site re-closes the generic method over the real (symbolic) type
-        // argument — see Issue #1334 for the ilverify StackUnexpected
-        // mismatch this narrowing avoids.
+        // Issue #1150: generic extension methods keep ONLY numeric-return
+        // widening: full rebinding could erase a LINQ delegate to
+        // `Func<object,object>` while the call is re-closed over symbolic type
+        // arguments (#1334). Non-generic extensions have no such re-closing
+        // hazard and use full rebinding so nested named-delegate slots retain
+        // their exact CLR ABI (#2672).
         //
         // Issue #506 follow-up: still routes through BindClrParameterConversions
         // so value-type → object boxing fires for fixed-arity imported
         // extension calls too.
+        var extensionDelegateRebindMode = best.IsGenericMethod
+            ? ClrCallDelegateRebindMode.NumericWideningOnly
+            : ClrCallDelegateRebindMode.Full;
         bound = BuildResolvedClrCallArguments(
             bound,
             ce.Arguments,
@@ -1454,7 +1454,7 @@ internal sealed partial class ExpressionBinder
             receiver,
             ce.Location,
             ce,
-            ClrCallDelegateRebindMode.NumericWideningOnly,
+            extensionDelegateRebindMode,
             out var extensionHandlerPrelude,
             out var extensionUpdatedReceiver,
             receiverArgCount: 1);

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -871,10 +871,10 @@ internal sealed class LambdaBinder
 
         // Issue #2180: an async literal carries a DUAL return shape — the
         // FunctionSymbol's result type is the UNWRAPPED value (`T`), while its
-        // observable delegate return is the `Task[T]` wrapper. The erasure
-        // above collapses that to a single slot and, for a type-parameter
-        // result, erases it to `object` (the target delegate return `Task[T]`
-        // contains `T`). That erasure produces an async state machine whose
+        // observable delegate return is the `Task[T]` wrapper. Treating the
+        // target's observable Task as the FunctionSymbol result would wrap it
+        // again as Task<Task> during async lowering. For a type-parameter
+        // result, erasure also produces an async state machine whose
         // builder / SetResult are `AsyncTaskMethodBuilder[object]` and forces a
         // bogus `(Task[T])(object)` reference-cast at the call site — correct
         // for reference `T` but a silent miscompile for a value-type `T`
@@ -882,13 +882,12 @@ internal sealed class LambdaBinder
         // reifies per instantiation exactly like the SYNC generic-lambda path,
         // so keep the async result symbolic: the FunctionSymbol result stays
         // the unwrapped `T` (threaded into the SM as `Var(idx)`), while the
-        // delegate observable return keeps the `Task[T]` wrapper.
+        // delegate observable return keeps the target `Task`/`Task[T]` wrapper.
         var adapterResultType = adapterReturnType;
         var adapterDelegateReturnType = adapterReturnType;
         if (literal.Function.IsAsync
             && targetFunctionType.ReturnType != TypeSymbol.Void
-            && literal.Function.Type != null
-            && TypeSymbol.ContainsTypeParameter(targetFunctionType.ReturnType))
+            && literal.Function.Type != null)
         {
             adapterResultType = literal.Function.Type;
             adapterDelegateReturnType = targetFunctionType.ReturnType;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -85,6 +85,28 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #2672: an erased-lambda adapter can receive an imported named
+        // delegate while its original body expects the equivalent structural
+        // function. Rebuild the value over the named delegate's Invoke target
+        // so the adapter body and its outer delegate constructor both verify.
+        if (conv.Type is FunctionTypeSymbol delegateTargetFn
+            && conv.Expression.Type is ImportedTypeSymbol { ClrType: Type importedDelegateSource }
+            && ClrTypeUtilities.IsDelegateType(importedDelegateSource))
+        {
+            var invoke = importedDelegateSource.GetMethod("Invoke")
+                ?? throw new InvalidOperationException(
+                    $"Delegate type '{importedDelegateSource.FullName}' has no Invoke method.");
+            var ctor = this.outer.userTokens.FunctionTypeNeedsSymbolicDelegate(delegateTargetFn)
+                ? this.outer.memberRefs.GetFunctionDelegateCtorRef(delegateTargetFn)
+                : (EntityHandle)this.outer.memberRefs.GetDelegateCtorReference(
+                    this.outer.signatures.ResolveDelegateClrType(delegateTargetFn));
+            this.EmitNullGuardedDelegateToDelegateAdaptation(
+                conv.Expression,
+                this.outer.memberRefs.GetMethodReference(invoke),
+                ctor);
+            return;
+        }
+
         // Issue #295: GSharp function value → CLR delegate. This is the
         // general materialization that previously only happened in
         // argument position; routing it through EmitConversion makes

--- a/test/Compiler.Tests/Emit/Issue2672DelegateCtorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2672DelegateCtorEmitTests.cs
@@ -1,0 +1,128 @@
+// <copyright file="Issue2672DelegateCtorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Issue #2672: nested named-delegate parameters retain their exact delegate ABI.</summary>
+public sealed class Issue2672DelegateCtorEmitTests
+{
+    [Fact]
+    public void ImportedExtension_AsyncLambdaWithNamedDelegateParameter_VerifiesAndRuns()
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2672DelegateCtor");
+        Directory.CreateDirectory(directory);
+        var fixturePath = Path.Combine(directory, "Issue2672Fixture.dll");
+        var outputPath = Path.Combine(directory, "Issue2672Consumer.dll");
+        EmitFixture(fixturePath);
+
+        const string source = """
+            package Issue2672
+            import System
+            import System.Threading.Tasks
+            import Issue2672Fixture
+
+            func Main() {
+                let host = Host()
+                let result = host.Run(async (ctx Context, next async (Context) -> void) -> {
+                    await next(ctx)
+                    ctx.Hits = ctx.Hits + 1
+                }).GetAwaiter().GetResult()
+                Console.WriteLine(result)
+            }
+            """;
+
+        using (var resolver = ReferenceResolver.WithReferences(new[] { fixturePath }))
+        {
+            var compilation = new GsCompilation(resolver, GsSyntaxTree.Parse(SourceText.From(source)));
+            using var stream = File.Create(outputPath);
+            var result = compilation.Emit(stream, pdbStream: null, refStream: null, assemblyName: "Issue2672Consumer");
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        IlVerifier.Verify(outputPath, additionalReferences: new[] { fixturePath });
+        var context = new AssemblyLoadContext("Issue2672", isCollectible: true);
+        try
+        {
+            context.Resolving += (_, name) =>
+                name.Name == "Issue2672Fixture" ? context.LoadFromAssemblyPath(fixturePath) : null;
+            var assembly = context.LoadFromAssemblyPath(outputPath);
+            var previous = Console.Out;
+            using var output = new StringWriter();
+            Console.SetOut(output);
+            try
+            {
+                assembly.EntryPoint!.Invoke(null, null);
+            }
+            finally
+            {
+                Console.SetOut(previous);
+            }
+
+            Assert.Equal("2\n", output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    private static void EmitFixture(string path)
+    {
+        const string source = """
+            using System;
+            using System.Threading.Tasks;
+
+            namespace Issue2672Fixture;
+
+            public sealed class Context
+            {
+                public int Hits { get; set; }
+            }
+
+            public sealed class Host { }
+
+            public delegate Task Next(Context context);
+
+            public static class MiddlewareExtensions
+            {
+                public static async Task<int> Run(
+                    this Host host,
+                    Func<Context, Next, Task> middleware)
+                {
+                    var context = new Context();
+                    await middleware(context, c =>
+                    {
+                        c.Hits++;
+                        return Task.CompletedTask;
+                    });
+                    return context.Hits;
+                }
+            }
+            """;
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Where(File.Exists)
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "Issue2672Fixture",
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var stream = File.Create(path);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
@@ -206,7 +206,8 @@ public class IlVerifyRunner
         var ignored = new HashSet<string>(KnownIlVerifyFalsePositives, StringComparer.OrdinalIgnoreCase);
         return errors.Where(e =>
             (e.Code is null || !ignored.Contains(e.Code))
-            && !IsAvaloniaXamlCompilerFalsePositive(e)).ToList();
+            && !IsAvaloniaXamlCompilerFalsePositive(e)
+            && !IsAvaloniaXamlDelegateCtorFalsePositive(e)).ToList();
     }
 
     /// <summary>
@@ -264,6 +265,12 @@ public class IlVerifyRunner
         && error.Method?.StartsWith(
             "CompiledAvaloniaXaml.XamlIlContext+Context`1::",
             StringComparison.Ordinal) == true;
+
+    // Avalonia's XAML compiler binds static event handlers to RootObject. The
+    // byte-identical C# output fails ilverify's DelegateCtor check as well.
+    private static bool IsAvaloniaXamlDelegateCtorFalsePositive(IlVerifyError error) =>
+        string.Equals(error.Code, "DelegateCtor", StringComparison.Ordinal)
+        && error.Method?.Contains("::!XamlIlPopulate(", StringComparison.Ordinal) == true;
 
     private static IReadOnlyList<string> BuildReferenceSet(
         string assemblyPath,

--- a/tools/cs2gs/Cs2Gs.Tests/IlVerifyStageTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/IlVerifyStageTests.cs
@@ -129,6 +129,10 @@ public class IlVerifyStageTests
                 "StackUnexpected",
                 "CompiledAvaloniaXaml.XamlIlContext+Context`1::get_ParentProvider()",
                 "fp 4"),
+            new IlVerifyError(
+                "DelegateCtor",
+                "Oahu.Core.UI.Avalonia.Views.AboutView::!XamlIlPopulate(System.IServiceProvider, AboutView)",
+                "csc emits the same Avalonia-generated delegate construction"),
             new IlVerifyError("StackUnexpected", "P::Main(string[])", "real"),
         };
 


### PR DESCRIPTION
## Summary
- fully rebind non-generic extension delegate arguments so nested named-delegate slots keep their CLR ABI
- adapt imported named delegates back to structural function values inside generated lambda adapters without double-wrapping async results
- suppress Avalonia `!XamlIlPopulate` `DelegateCtor` output proven byte-identical under C#

## Exact proof
- `HttpEndpoints::Map` `DelegateCtor` fingerprint `sha256:f89a6848338b626984d15d89b43da0f45986670d5dd2bf342e9059ea7cf8e744`: removed; all four offsets `0x39/0x4C/0x5F/0x72` are absent
- `AboutView::!XamlIlPopulate` fingerprint `sha256:b44a2cfa56a5b9f9833a65881ed2d83782085cf8ac6c630a4480a901ee1feca7`: filtered as the identical Avalonia-generated C# false positive
- emitted middleware target is now exactly `Func<HttpContext, RequestDelegate, Task>`

## Validation
- Release solution build: 0 warnings, 0 errors
- Core.Tests: 6,669 passed, 1 skipped
- focused Compiler.Tests: 10 passed, including runtime + ILVerify regression
- focused Core delegate/async regressions: 31 passed
- focused cs2gs ILVerify filter: passed

Fixes #2672