### PR TITLE
Fix aligned interpolated string handlers

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -1829,6 +1829,7 @@ internal sealed partial class ExpressionBinder
                 parameters,
                 arguments,
                 receiver,
+                interp.Parts,
                 out var failure);
             if (handler == null)
             {

--- a/src/Core/CodeAnalysis/Binding/InterpolatedStringHandlerInfo.cs
+++ b/src/Core/CodeAnalysis/Binding/InterpolatedStringHandlerInfo.cs
@@ -202,6 +202,23 @@ public sealed class InterpolatedStringHandlerInfo
         ImmutableArray<BoundExpression> arguments,
         BoundExpression receiver,
         out string failure)
+        => TryCreate(
+            handlerClrType,
+            parameter,
+            parameters,
+            arguments,
+            receiver,
+            ImmutableArray<BoundInterpolatedStringPart>.Empty,
+            out failure);
+
+    internal static InterpolatedStringHandlerInfo TryCreate(
+        System.Type handlerClrType,
+        ParameterInfo parameter,
+        ParameterInfo[] parameters,
+        ImmutableArray<BoundExpression> arguments,
+        BoundExpression receiver,
+        ImmutableArray<BoundInterpolatedStringPart> parts,
+        out string failure)
     {
         failure = null;
 
@@ -250,6 +267,11 @@ public sealed class InterpolatedStringHandlerInfo
             return null;
         }
 
+        if (!ValidateAppendMethods(peeled, parts, out failure))
+        {
+            return null;
+        }
+
         // Issue #377 sub-item 1: capture the parameter's RefKind so the call
         // binder/lowerer can feed the constructed handler local by-ref.
         var handlerRefKind = RefKind.None;
@@ -277,6 +299,152 @@ public sealed class InterpolatedStringHandlerInfo
             hasOutBool,
             sources.ToImmutable(),
             handlerRefKind);
+    }
+
+    internal static bool TryResolveAppendFormatted(
+        System.Type handlerType,
+        BoundInterpolatedStringPart part,
+        TypeSymbol holeType,
+        out MethodInfo method,
+        out ImmutableArray<TypeSymbol> typeArguments)
+    {
+        method = null;
+        typeArguments = default;
+        var wantAlign = part.Alignment.HasValue;
+        var wantFormat = part.Format != null;
+        var extra = (wantAlign ? 1 : 0) + (wantFormat ? 1 : 0);
+        var candidates = ImmutableArray.CreateBuilder<MethodInfo>();
+
+        foreach (var candidate in handlerType.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (candidate.Name != "AppendFormatted")
+            {
+                continue;
+            }
+
+            var parameters = candidate.GetParameters();
+            if (parameters.Length != 1 + extra)
+            {
+                continue;
+            }
+
+            var index = 1;
+            if (wantAlign && !parameters[index++].ParameterType.IsSameAs(typeof(int)))
+            {
+                continue;
+            }
+
+            if (wantFormat && !parameters[index].ParameterType.IsSameAs(typeof(string)))
+            {
+                continue;
+            }
+
+            candidates.Add(candidate);
+        }
+
+        if (candidates.Count == 0)
+        {
+            return false;
+        }
+
+        var valueClrType = NullableTypeSymbol.GetEffectiveClrType(holeType);
+        if (valueClrType != null)
+        {
+            var argumentTypes = new System.Type[1 + extra];
+            argumentTypes[0] = valueClrType;
+            var index = 1;
+            if (wantAlign)
+            {
+                argumentTypes[index++] = typeof(int);
+            }
+
+            if (wantFormat)
+            {
+                argumentTypes[index] = typeof(string);
+            }
+
+            var resolution = OverloadResolution.Resolve<MethodInfo>(candidates, argumentTypes);
+            if (resolution.Outcome == OverloadResolution.ResolutionOutcome.Resolved)
+            {
+                method = resolution.Best;
+            }
+            else if (resolution.Outcome == OverloadResolution.ResolutionOutcome.Ambiguous)
+            {
+                foreach (var candidate in resolution.Ambiguous)
+                {
+                    if (candidate.IsGenericMethod)
+                    {
+                        continue;
+                    }
+
+                    if (method != null)
+                    {
+                        method = null;
+                        break;
+                    }
+
+                    method = candidate;
+                }
+            }
+
+            if (method == null)
+            {
+                return false;
+            }
+        }
+        else
+        {
+            method = candidates.FirstOrDefault(candidate => candidate.IsGenericMethodDefinition)
+                ?? candidates[0];
+        }
+
+        if (!method.IsGenericMethodDefinition)
+        {
+            return true;
+        }
+
+        if (valueClrType != null)
+        {
+            method = method.MakeGenericMethod(valueClrType);
+            return true;
+        }
+
+        method = method.MakeGenericMethod(typeof(object));
+        typeArguments = ImmutableArray.Create(holeType);
+        return true;
+    }
+
+    private static bool ValidateAppendMethods(
+        System.Type handlerType,
+        ImmutableArray<BoundInterpolatedStringPart> parts,
+        out string failure)
+    {
+        failure = null;
+        if (parts.Any(part => part.IsLiteral && part.Literal.Length > 0)
+            && handlerType.GetMethod("AppendLiteral", new[] { typeof(string) }) == null)
+        {
+            failure = $"'{handlerType.Name}' has no AppendLiteral(string) method";
+            return false;
+        }
+
+        foreach (var part in parts)
+        {
+            if (part.IsHole
+                && !TryResolveAppendFormatted(handlerType, part, part.Value.Type, out _, out _))
+            {
+                var shape = part.Alignment.HasValue && part.Format != null
+                    ? "(value, int, string)"
+                    : part.Alignment.HasValue
+                        ? "(value, int)"
+                        : part.Format != null
+                            ? "(value, string)"
+                            : "(value)";
+                failure = $"'{handlerType.Name}' has no applicable AppendFormatted{shape} method";
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static ConstructorInfo SelectConstructor(

--- a/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
@@ -484,7 +484,16 @@ internal sealed class InterpolatedStringHandlerLowerer : NestedFunctionBodyRewri
                     value = new BoundVariableExpression(null, holeTmp);
                 }
 
-                var (method, typeArguments) = this.ResolveUserAppendFormatted(handlerClrType, part, value.Type);
+                if (!InterpolatedStringHandlerInfo.TryResolveAppendFormatted(
+                    handlerClrType,
+                    part,
+                    value.Type,
+                    out var method,
+                    out var typeArguments))
+                {
+                    throw new System.InvalidOperationException(
+                        $"Interpolated-string handler '{handlerClrType.Name}' was lowered without a compatible AppendFormatted method.");
+                }
 
                 var arguments = ImmutableArray.CreateBuilder<BoundExpression>();
                 arguments.Add(value);
@@ -591,175 +600,6 @@ internal sealed class InterpolatedStringHandlerLowerer : NestedFunctionBodyRewri
         block.Add(inner);
         block.Add(endLabelStatement);
         return new BoundBlockStatement(syntax, block.ToImmutable());
-    }
-
-    private (MethodInfo Method, ImmutableArray<TypeSymbol> TypeArguments) ResolveUserAppendFormatted(
-        System.Type handlerType, BoundInterpolatedStringPart part, TypeSymbol holeType)
-    {
-        var wantAlign = part.Alignment.HasValue;
-        var wantFormat = part.Format != null;
-        var extra = (wantAlign ? 1 : 0) + (wantFormat ? 1 : 0);
-
-        // Collect every AppendFormatted overload whose arity and trailing
-        // alignment/format shape match the hole. Trailing-parameter shape is
-        // checked here (rather than via overload resolution on synthetic int /
-        // string arg types) because the supplied alignment/format pair is a
-        // literal pattern, not a value to coerce, and matches a handler
-        // overload only when its parameter types are *exactly* `int` /
-        // `string`. We intentionally do not pre-filter on the value parameter
-        // type: the right overload for the hole is selected by C#-style
-        // overload resolution below, so that e.g.
-        // `AppendFormatted(string)` wins over `AppendFormatted<T>(T)` for a
-        // `string` value (issue #418, P1-10).
-        var shapeCandidates = ImmutableArray.CreateBuilder<MethodInfo>();
-        MethodInfo anyAppendFormatted = null;
-        foreach (var method in handlerType.GetMethods(BindingFlags.Public | BindingFlags.Instance))
-        {
-            if (method.Name != "AppendFormatted")
-            {
-                continue;
-            }
-
-            anyAppendFormatted ??= method;
-
-            var ps = method.GetParameters();
-            if (ps.Length != 1 + extra)
-            {
-                continue;
-            }
-
-            var ok = true;
-            var idx = 1;
-            if (wantAlign)
-            {
-                ok = ps[idx].ParameterType.IsSameAs(typeof(int));
-                idx++;
-            }
-
-            if (ok && wantFormat)
-            {
-                ok = ps[idx].ParameterType.IsSameAs(typeof(string));
-            }
-
-            if (ok)
-            {
-                shapeCandidates.Add(method);
-            }
-        }
-
-        // Issue #418 (P1-10): when the value has a known CLR type, run the
-        // same C# "better function member" overload resolution used for
-        // BoundCallExpression so the value's static type drives the choice.
-        // Without this, a handler exposing both `AppendFormatted(int)` and
-        // `AppendFormatted(string)` would return the first reflected match
-        // regardless of the hole's type, producing invalid IL or an
-        // InvalidCastException at run time.
-        // Issue #1916 sibling: use the effective (Nullable<T>-aware) CLR
-        // type so overload resolution sees the real runtime stack shape for
-        // nullable value-type holes, not just the bare underlying type.
-        var valueClr = NullableTypeSymbol.GetEffectiveClrType(holeType);
-        if (shapeCandidates.Count > 0 && valueClr != null)
-        {
-            var argTypes = new System.Type[1 + extra];
-            argTypes[0] = valueClr;
-            var ai = 1;
-            if (wantAlign)
-            {
-                argTypes[ai++] = typeof(int);
-            }
-
-            if (wantFormat)
-            {
-                argTypes[ai] = typeof(string);
-            }
-
-            var resolution = OverloadResolution.Resolve<MethodInfo>(shapeCandidates, argTypes);
-            MethodInfo picked = null;
-            if (resolution.Outcome == OverloadResolution.ResolutionOutcome.Resolved)
-            {
-                picked = resolution.Best;
-            }
-            else if (resolution.Outcome == OverloadResolution.ResolutionOutcome.Ambiguous)
-            {
-                // C# §7.5.3.2 tie-break: a non-generic member is better than
-                // a generic one. The shared OverloadResolution.Resolve does
-                // not yet implement this, so apply it locally so e.g.
-                // `AppendFormatted(string)` beats `AppendFormatted<T>(T)` when
-                // both are applicable for a `string` hole.
-                MethodInfo nonGeneric = null;
-                foreach (var m in resolution.Ambiguous)
-                {
-                    if (!m.IsGenericMethod)
-                    {
-                        if (nonGeneric == null)
-                        {
-                            nonGeneric = m;
-                        }
-                        else
-                        {
-                            nonGeneric = null;
-                            break;
-                        }
-                    }
-                }
-
-                picked = nonGeneric;
-            }
-
-            if (picked != null)
-            {
-                return picked.IsGenericMethod && !picked.IsGenericMethodDefinition
-                    ? (picked, default)
-                    : CloseGenericAppend(picked, holeType);
-            }
-        }
-
-        // Fallback path (issue #418): used when the value has no live CLR type
-        // (a user-defined symbol type) or when no shape-matching overload was
-        // found. Mirror the prior "first match wins" behaviour but at least
-        // prefer a shape-matching candidate when available so the alignment /
-        // format slots are honoured.
-        MethodInfo fallback = null;
-        if (shapeCandidates.Count > 0)
-        {
-            fallback = shapeCandidates[0];
-        }
-        else
-        {
-            // No shape match — pick the first 1-arg AppendFormatted (the
-            // value-only overload), then any AppendFormatted, as a last
-            // resort.
-            foreach (var method in handlerType.GetMethods(BindingFlags.Public | BindingFlags.Instance))
-            {
-                if (method.Name == "AppendFormatted" && method.GetParameters().Length == 1)
-                {
-                    fallback = method;
-                    break;
-                }
-            }
-
-            fallback ??= anyAppendFormatted;
-        }
-
-        return CloseGenericAppend(fallback, holeType);
-    }
-
-    private static (MethodInfo Method, ImmutableArray<TypeSymbol> TypeArguments) CloseGenericAppend(MethodInfo open, TypeSymbol holeType)
-    {
-        if (!open.IsGenericMethodDefinition)
-        {
-            return (open, default);
-        }
-
-        // Issue #1916 sibling: close over the effective (Nullable<T>-aware)
-        // CLR type, matching the fix in the sibling `CloseAppendFormatted`.
-        var clrType = NullableTypeSymbol.GetEffectiveClrType(holeType);
-        if (clrType != null)
-        {
-            return (open.MakeGenericMethod(clrType), default);
-        }
-
-        return (open.MakeGenericMethod(typeof(object)), ImmutableArray.Create(holeType));
     }
 
     private static MethodInfo FindAppendLiteral(System.Type handlerType)

--- a/test/Compiler.Tests/Emit/Issue2640ImportedInterpolatedStringHandlerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2640ImportedInterpolatedStringHandlerEmitTests.cs
@@ -22,13 +22,11 @@ public class Issue2640ImportedInterpolatedStringHandlerEmitTests
             import System
             import System.Globalization
 
-            func getTerminalProgressSequence() string {
-                let state = 1
-                let pct = 42
-                return string.Create(CultureInfo.InvariantCulture, "\u001b]9;4;${state};${pct}\u001b\\")
+            func formatPercent(value float64) string {
+                return string.Create(CultureInfo.InvariantCulture, "${int(Math.Round(value * 100.0)),3}%")
             }
 
-            Console.Write(getTerminalProgressSequence())
+            Console.Write(formatPercent(0.42))
             """;
 
         var (exitCode, diagnostics, outputPath, directory) = Compile(Source);
@@ -36,7 +34,32 @@ public class Issue2640ImportedInterpolatedStringHandlerEmitTests
         {
             Assert.True(exitCode == 0, diagnostics);
             IlVerifier.Verify(outputPath);
-            Assert.Equal("\u001b]9;4;1;42\u001b\\", Run(outputPath, directory));
+            Assert.Equal(" 42%", Run(outputPath, directory));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void StringCreate_AlignmentAndFormat_EmitsVerifiesAndRuns()
+    {
+        const string Source = """
+            package Formatted
+            import System
+            import System.Globalization
+
+            let value = 42
+            Console.Write(string.Create(CultureInfo.InvariantCulture, "${value,6:0000}"))
+            """;
+
+        var (exitCode, diagnostics, outputPath, directory) = Compile(Source);
+        try
+        {
+            Assert.True(exitCode == 0, diagnostics);
+            IlVerifier.Verify(outputPath);
+            Assert.Equal("  0042", Run(outputPath, directory));
         }
         finally
         {

--- a/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringHandlerArgumentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringHandlerArgumentTests.cs
@@ -71,6 +71,41 @@ Console.WriteLine(msg)
         Assert.Contains("PFX:x=42", output);
     }
 
+    [Theory]
+    [InlineData("\"v=${42,6}\"", "P: v=    42")]
+    [InlineData("\"v=${42:0000}\"", "P: v=0042")]
+    [InlineData("\"v=${42,6:0000}\"", "P: v=  0042")]
+    public void Alignment_And_Format_Select_Matching_AppendFormatted(string interpolation, string expected)
+    {
+        var source = $@"package HandlerShape
+import System
+import GSharp.Core.Tests.Fixtures
+
+let msg = InterpolationHarness.Format(""P: "", {interpolation})
+Console.WriteLine(msg)
+";
+        Assert.Contains(expected, CompileAndRun(source, "HandlerShapeTest"));
+    }
+
+    [Theory]
+    [InlineData("\"v=${9,3}\"", "(value, int)")]
+    [InlineData("\"v=${9:000}\"", "(value, string)")]
+    public void Missing_AppendFormatted_Shape_Reports_Diagnostic(string interpolation, string expectedShape)
+    {
+        var source = $@"package HandlerShapeNegative
+import GSharp.Core.Tests.Fixtures
+
+let msg = InterpolationHarness.Gated(true, {interpolation})
+";
+        using var peStream = new MemoryStream();
+        var result = new Compilation(SyntaxTree.Parse(SourceText.From(source))).Emit(peStream);
+
+        Assert.False(result.Success);
+        var diagnostic = Assert.Single(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal("GS0221", diagnostic.Id);
+        Assert.Contains(expectedShape, diagnostic.Message, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void OutBool_Gated_Handler_Enabled_Emits_And_Runs()
     {

--- a/test/Core.Tests/Fixtures/InterpolatedStringHandlerFixtures.cs
+++ b/test/Core.Tests/Fixtures/InterpolatedStringHandlerFixtures.cs
@@ -38,6 +38,17 @@ public struct PrefixedInterpolatedStringHandler
         this.builder.Append(alignment < 0 ? text.PadRight(-alignment) : text.PadLeft(alignment));
     }
 
+    public void AppendFormatted<T>(T value, string format)
+        => this.AppendFormatted(value, alignment: 0, format);
+
+    public void AppendFormatted<T>(T value, int alignment, string format)
+    {
+        var text = value is System.IFormattable formattable
+            ? formattable.ToString(format, System.Globalization.CultureInfo.InvariantCulture)
+            : value?.ToString() ?? string.Empty;
+        this.builder.Append(alignment < 0 ? text.PadRight(-alignment) : text.PadLeft(alignment));
+    }
+
     public override string ToString() => this.builder.ToString();
 }
 


### PR DESCRIPTION
## Summary
- validate imported handler `AppendFormatted` overloads for value, alignment, format, and combined shapes during binding
- share that overload selection with lowering instead of falling back to an incompatible value-only method
- cover the exact Oahu `string.Create(CultureInfo.InvariantCulture, "${int(Math.Round(value * 100.0)),3}%")` path through emit, IL verification, and runtime
- diagnose unsupported alignment/format handler shapes without invalid IL or lowering crashes

## Tests
- `Core.Tests`: 6,674 passed, 1 skipped
- interpolated-handler focused `Core.Tests`: 16 passed
- issue #2640 focused `Compiler.Tests`: 3 passed

Fixes #2640