### PR TITLE
Fix async iterator lambda capture slots

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -999,12 +999,14 @@ internal sealed partial class MethodBodyEmitter
         this.il.Token(delegateTypeHandle);
     }
 
-    // Phase 4 emit parity: load a captured variable. In a MoveNext body,
-    // the variable may be hoisted to a state-machine field; emit the field
-    // load instead of a local/parameter load in that case.
+    // Phase 4 emit parity: load a captured variable. In an async or async-
+    // iterator MoveNext body, the variable may be hoisted to a state-machine
+    // field; emit the field load instead of a local/parameter load.
     private void EmitCapturedVariableLoad(VariableSymbol captured)
     {
-        if (this.asyncFieldMap != null && this.asyncFieldMap.TryGetHoistedField(captured, out var hoistedField))
+        FieldSymbol hoistedField = null;
+        if ((this.asyncFieldMap != null && this.asyncFieldMap.TryGetHoistedField(captured, out hoistedField))
+            || (this.asyncIteratorEmitCtx != null && this.asyncIteratorEmitCtx.FieldMap.TryGetValue(captured, out hoistedField)))
         {
             // Load from the state machine: ldarg.0; ldfld <smStruct>::<hoistedField>
             if (!this.outer.cache.StructFieldDefs.TryGetValue(hoistedField, out var hoistedHandle))

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -373,16 +373,21 @@ internal sealed class StateMachineEmitter
 
     /// <summary>
     /// Lightweight emit-time context for async iterator MoveNext methods.
-    /// Carries the builder field, SM class, and builder info needed by
-    /// <see cref="EmitAwaitOnCompletedCall"/>.
+    /// Carries the builder field, SM class, builder info, and hoisted-variable
+    /// map needed by async-iterator body emission.
     /// </summary>
     public sealed class AsyncIteratorEmitContext
     {
-        public AsyncIteratorEmitContext(StructSymbol smClass, FieldSymbol builderField, AsyncMethodBuilderInfo builderInfo)
+        public AsyncIteratorEmitContext(
+            StructSymbol smClass,
+            FieldSymbol builderField,
+            AsyncMethodBuilderInfo builderInfo,
+            Dictionary<VariableSymbol, FieldSymbol> fieldMap)
         {
             this.SmClass = smClass;
             this.BuilderField = builderField;
             this.BuilderInfo = builderInfo;
+            this.FieldMap = fieldMap;
         }
 
         public StructSymbol SmClass { get; }
@@ -390,6 +395,8 @@ internal sealed class StateMachineEmitter
         public FieldSymbol BuilderField { get; }
 
         public AsyncMethodBuilderInfo BuilderInfo { get; }
+
+        public Dictionary<VariableSymbol, FieldSymbol> FieldMap { get; }
     }
 
     /// <summary>
@@ -992,7 +999,7 @@ internal sealed class StateMachineEmitter
             var returnClrType = plan.Function.Type?.ClrType
                 ?? typeof(System.Collections.Generic.IAsyncEnumerable<object>);
             var aiBuilderInfo = AsyncMethodBuilderInfo.Resolve(returnClrType, this.emitCtx.References);
-            this.AsyncIteratorEmitContexts[smClass] = new AsyncIteratorEmitContext(smClass, builderField, aiBuilderInfo);
+            this.AsyncIteratorEmitContexts[smClass] = new AsyncIteratorEmitContext(smClass, builderField, aiBuilderInfo, fieldMap);
         }
     }
 

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
@@ -60,6 +60,8 @@ public static class AsyncIteratorMoveNextBodyBuilder
         private readonly FieldSymbol builderField;
         private readonly Dictionary<VariableSymbol, FieldSymbol> fieldMap;
         private readonly Dictionary<Type, FieldSymbol> awaiterPoolFields;
+        private readonly TryDispatchPlan awaitTryDispatch;
+        private readonly IteratorTryDispatchPlan yieldTryDispatch;
 
         // Labels for yield resume points
         private readonly Dictionary<int, BoundLabel> yieldResumeLabels = new();
@@ -94,17 +96,26 @@ public static class AsyncIteratorMoveNextBodyBuilder
             this.fieldMap = fieldMap;
             this.awaiterPoolFields = awaiterPoolFields;
 
-            // Create resume labels for yields (negative states).
-            foreach (var kvp in plan.YieldStates.OrderBy(p => p.Value))
-            {
-                yieldResumeLabels[kvp.Value] = new BoundLabel($"<>ai_yieldResume_{kvp.Value}");
-            }
-
             // Create resume labels for awaits (non-negative states).
+            var awaitResumeMap = new Dictionary<BoundAwaitExpression, AwaitResumePoint>();
             foreach (var kvp in plan.AwaitStates.OrderBy(p => p.Value))
             {
                 awaitResumeLabels[kvp.Value] = new BoundLabel($"<>ai_awaitResume_{kvp.Value}");
                 awaitResumeAfterLabels[kvp.Value] = new BoundLabel($"<>ai_awaitAfter_{kvp.Value}");
+                awaitResumeMap[kvp.Key] = new AwaitResumePoint(
+                    kvp.Key,
+                    kvp.Value,
+                    awaitResumeLabels[kvp.Value],
+                    awaitResumeAfterLabels[kvp.Value]);
+            }
+
+            awaitTryDispatch = TryDispatchPlanner.Plan(plan.LoweredBody, awaitResumeMap);
+            yieldTryDispatch = IteratorTryDispatchPlanner.Plan(plan.LoweredBody, plan.YieldStates);
+
+            foreach (var kvp in plan.YieldStates.OrderBy(p => p.Value))
+            {
+                yieldResumeLabels[kvp.Value] = yieldTryDispatch.GetResumeLabel(kvp.Value)
+                    ?? new BoundLabel($"<>ai_yieldResume_{kvp.Value}");
             }
         }
 
@@ -174,7 +185,7 @@ public static class AsyncIteratorMoveNextBodyBuilder
                 var state = kvp.Value;
                 stmts.Add(new BoundConditionalGotoStatement(
                     null,
-                    yieldResumeLabels[state],
+                    yieldTryDispatch.GetOuterDispatchTarget(state) ?? yieldResumeLabels[state],
                     new BoundBinaryExpression(
                         null,
                         stateRead,
@@ -189,7 +200,7 @@ public static class AsyncIteratorMoveNextBodyBuilder
                 var state = kvp.Value;
                 stmts.Add(new BoundConditionalGotoStatement(
                     null,
-                    awaitResumeLabels[state],
+                    awaitTryDispatch.GetOuterDispatchTarget(state) ?? awaitResumeLabels[state],
                     new BoundBinaryExpression(
                         null,
                         ReadField(stateField),
@@ -370,6 +381,72 @@ public static class AsyncIteratorMoveNextBodyBuilder
                 return base.RewriteExpressionStatement(node);
             }
 
+            protected override BoundStatement RewriteTryStatement(BoundTryStatement node)
+            {
+                // Issue #2662: the newly exposed await-for awaits and yields
+                // can resume inside protected regions. Route them through the
+                // same outside-entry/inside-dispatch topology as ordinary
+                // async methods and synchronous iterators.
+                var result = (BoundTryStatement)base.RewriteTryStatement(node);
+                var awaitEntries = ctx.awaitTryDispatch.GetInternalDispatchEntries(node);
+                var yieldEntries = ctx.yieldTryDispatch.GetInternalDispatchEntries(node);
+                var awaitEntryLabel = ctx.awaitTryDispatch.GetEntryLabel(node);
+                var yieldEntryLabel = ctx.yieldTryDispatch.GetEntryLabel(node);
+
+                if (awaitEntries.IsDefaultOrEmpty
+                    && yieldEntries.IsDefaultOrEmpty
+                    && awaitEntryLabel == null
+                    && yieldEntryLabel == null)
+                {
+                    return result;
+                }
+
+                var tryStatements = ImmutableArray.CreateBuilder<BoundStatement>();
+                foreach (var entry in awaitEntries)
+                {
+                    tryStatements.Add(DispatchTo(entry.State, entry.Target));
+                }
+
+                foreach (var entry in yieldEntries)
+                {
+                    tryStatements.Add(DispatchTo(entry.State, entry.Target));
+                }
+
+                if (result.TryBlock is BoundBlockStatement block)
+                {
+                    tryStatements.AddRange(block.Statements);
+                }
+                else
+                {
+                    tryStatements.Add(result.TryBlock);
+                }
+
+                var rebuilt = new BoundTryStatement(
+                    null,
+                    new BoundBlockStatement(null, tryStatements.ToImmutable()),
+                    result.CatchClauses,
+                    result.FinallyBlock);
+
+                if (awaitEntryLabel == null && yieldEntryLabel == null)
+                {
+                    return rebuilt;
+                }
+
+                var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+                if (awaitEntryLabel != null)
+                {
+                    statements.Add(new BoundLabelStatement(null, awaitEntryLabel));
+                }
+
+                if (yieldEntryLabel != null && !ReferenceEquals(yieldEntryLabel, awaitEntryLabel))
+                {
+                    statements.Add(new BoundLabelStatement(null, yieldEntryLabel));
+                }
+
+                statements.Add(rebuilt);
+                return new BoundBlockStatement(null, statements.ToImmutable());
+            }
+
             protected override BoundExpression RewriteAwaitExpression(BoundAwaitExpression node)
             {
                 // If we reach here, await is nested. Should have been lifted by spiller.
@@ -380,6 +457,16 @@ public static class AsyncIteratorMoveNextBodyBuilder
             {
                 // In an async iterator, `return` means end iteration.
                 return new BoundGotoStatement(null, ctx.endOfBodyLabel);
+            }
+
+            private BoundConditionalGotoStatement DispatchTo(int state, BoundLabel target)
+            {
+                var condition = new BoundBinaryExpression(
+                    null,
+                    ctx.ReadField(ctx.stateField),
+                    BoundBinaryOperator.Bind(SyntaxKind.EqualsEqualsToken, TypeSymbol.Int32, TypeSymbol.Int32),
+                    Literal(state));
+                return new BoundConditionalGotoStatement(null, target, condition, jumpIfTrue: true);
             }
 
             private BoundBlockStatement EmitPerAwaitSequence(BoundAwaitExpression awaitExpr, VariableSymbol resultTarget)

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriter.cs
@@ -60,9 +60,13 @@ public static class AsyncIteratorRewriter
                 continue;
             }
 
+            // Issue #2662: lower loops first so synthesized await-for locals
+            // and awaits participate in state-machine slot/state allocation.
+            var loweredBody = Lowerer.Lower(body);
+
             // Run async lowering pipeline on the body: exception handler rewrite,
             // spill, ref-hoist. This lifts awaits to statement level.
-            var exhRewritten = AsyncExceptionHandlerRewriter.Rewrite(body);
+            var exhRewritten = AsyncExceptionHandlerRewriter.Rewrite(loweredBody);
             var spilledBody = SpillSequenceSpiller.Rewrite(exhRewritten);
             var refHoisted = RefInitializationHoister.Rewrite(spilledBody);
 
@@ -73,8 +77,13 @@ public static class AsyncIteratorRewriter
             var awaitCollector = new AwaitStateCollector();
             awaitCollector.Visit(refHoisted);
 
-            // Collect hoisted locals (all locals — they may live across yield or await).
-            var hoistedLocals = CollectHoistedLocals(refHoisted);
+            // Reuse the ordinary async capture analysis so assignment-only
+            // loop variables and nested-lambda captures are both hoisted.
+            var hoistedLocals = AsyncCaptureWalker
+                .Analyze(refHoisted, function.Parameters)
+                .Locals
+                .Cast<VariableSymbol>()
+                .ToImmutableArray();
 
             // Collect awaiter types for pooled awaiter fields.
             var awaiterTypes = CollectAwaiterTypes(refHoisted);
@@ -105,13 +114,6 @@ public static class AsyncIteratorRewriter
 
     private static TypeSymbol GetAsyncIteratorElementType(TypeSymbol type)
         => AsyncIteratorDetection.GetElementType(type);
-
-    private static ImmutableArray<VariableSymbol> CollectHoistedLocals(BoundStatement body)
-    {
-        var collector = new LocalCollector();
-        collector.Visit(body);
-        return collector.Locals.ToImmutableArray();
-    }
 
     private static ImmutableArray<(Type PoolKey, TypeSymbol FieldType)> CollectAwaiterTypes(BoundStatement body)
     {
@@ -187,36 +189,6 @@ public static class AsyncIteratorRewriter
         {
             states.Add(node, allocator.AllocateAwaitState());
             base.VisitAwaitExpression(node);
-        }
-    }
-
-    private sealed class LocalCollector : BoundTreeWalker
-    {
-        public List<VariableSymbol> Locals { get; } = [];
-
-        protected override void VisitVariableDeclaration(BoundVariableDeclaration node)
-        {
-            // Skip ref-struct (ByRef-like) locals — e.g. the synthesized
-            // DefaultInterpolatedStringHandler emitted for interpolated strings
-            // (ADR-0055 / issue #368). A ByRef-like type cannot be an instance
-            // field, so it must stay a MoveNext local rather than be hoisted.
-            // Issue #1919: use the metadata-load-safe TypeSymbol.IsByRefLike
-            // helper — a raw Type.IsByRefLike read throws NotSupportedException
-            // for a cross-context TypeBuilderInstantiation (e.g. a delegate
-            // local closed over a MetadataLoadContext type under gsc's
-            // `/reference:` mode).
-            if (TypeSymbol.IsByRefLike(node.Variable.Type))
-            {
-                base.VisitVariableDeclaration(node);
-                return;
-            }
-
-            if (!Locals.Contains(node.Variable))
-            {
-                Locals.Add(node.Variable);
-            }
-
-            base.VisitVariableDeclaration(node);
         }
     }
 

--- a/test/Compiler.Tests/Emit/CaptureMatrixEmitTests.cs
+++ b/test/Compiler.Tests/Emit/CaptureMatrixEmitTests.cs
@@ -259,6 +259,43 @@ public class CaptureMatrixEmitTests
                 Console.WriteLine(inner().Result)
             }
             """, "42\n");
+
+        yield return Row("Issue2662_ExactOahuCliApp", """
+            package Oahu.Cli.App
+            import System
+            import System.Collections.Generic
+
+            class JobUpdate {
+                var JobId string = ""
+                var Value int32 = 0
+            }
+
+            class JobScheduler {
+                init() {}
+
+                async func Drain(predicate Func[JobUpdate, bool]) IAsyncEnumerable[JobUpdate] {
+                    let update = JobUpdate()
+                    update.JobId = "job-42"
+                    update.Value = 42
+                    if predicate(update) {
+                        yield update
+                    }
+                }
+
+                async func ObserveAsync(jobId string) IAsyncEnumerable[JobUpdate] {
+                    await for u in this.Drain(u -> u.JobId == jobId) {
+                        yield u
+                    }
+                }
+            }
+
+            func Main() {
+                let e = JobScheduler().ObserveAsync("job-42").GetAsyncEnumerator()
+                if e.MoveNextAsync().AsTask().Result {
+                    Console.WriteLine(e.Current.Value)
+                }
+            }
+            """, "42\n");
     }
 
     [Theory]

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncCaptureWalkerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncCaptureWalkerTests.cs
@@ -52,6 +52,22 @@ ImmutableArray.Create<BoundStatement>(
     }
 
     [Fact]
+    public void Analyze_AssignmentOnlyLocal_IsHoisted()
+    {
+        var local = new LocalVariableSymbol("u", isReadOnly: false, TypeSymbol.Int32);
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(
+                null,
+                new BoundAssignmentExpression(null, local, new BoundLiteralExpression(null, 42)))));
+
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
+
+        Assert.Single(result.Locals);
+        Assert.Same(local, result.Locals[0]);
+    }
+
+    [Fact]
     public void Analyze_SameLocalReferencedTwice_AppearsOnce()
     {
         var local = new LocalVariableSymbol("x", isReadOnly: false, TypeSymbol.Int32);
@@ -263,6 +279,35 @@ ImmutableArray.Create<BoundStatement>(
             new BoundExpressionStatement(null, new BoundVariableExpression(null, ownLocal))));
         var literal = MakeLiteral(literalBody);
 
+        var body = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, literal)));
+
+        var result = AsyncCaptureWalker.Analyze(body, ImmutableArray<ParameterSymbol>.Empty);
+
+        Assert.Empty(result.Locals);
+    }
+
+    [Fact]
+    public void Analyze_LambdaOwnParameter_IsNotHoisted_WhenNotCaptured()
+    {
+        var parameter = new ParameterSymbol("u", TypeSymbol.Int32);
+        var literalBody = new BoundBlockStatement(null,
+ImmutableArray.Create<BoundStatement>(
+            new BoundExpressionStatement(null, new BoundVariableExpression(null, parameter))));
+        var function = new FunctionSymbol(
+            "<>lambda",
+            ImmutableArray.Create(parameter),
+            TypeSymbol.Void);
+        var functionType = FunctionTypeSymbol.Get(
+            ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32),
+            TypeSymbol.Void);
+        var literal = new BoundFunctionLiteralExpression(
+            null,
+            function,
+            functionType,
+            literalBody,
+            ImmutableArray<VariableSymbol>.Empty);
         var body = new BoundBlockStatement(null,
 ImmutableArray.Create<BoundStatement>(
             new BoundExpressionStatement(null, literal)));


### PR DESCRIPTION
## Summary
- lower `await for` before async-iterator state/slot planning and reuse the shared async capture analysis
- expose async-iterator hoisted fields when materializing nested lambdas
- route await/yield resumes through legal protected-region entry dispatches
- cover assignment-only locals and prove lambda-owned parameters are not hoisted

## Oahu proof
- reproduces the exact `Oahu.Cli.App.JobScheduler.ObserveAsync` shape: `await for u in this.Drain(u -> u.JobId == jobId)`
- baseline reaches `GS9998: Variable 'u' has no local slot or parameter index in the current method`
- fixed compiler emits ILVerify-clean code and prints `42` at runtime

## Validation
- Core.Tests: 6,671 passed, 1 skipped
- Compiler.Tests: 3,303 passed; 19 missing-`Gsharp.Extensions.dll` environment failures rerun green after building the dependency (128 relevant tests passed)
- post-rebase async capture/iterator suites: 95 passed
- exact Oahu runtime + ILVerify regression passed

Fixes #2662
