### PR TITLE
Preserve cs2gs property ABI

### DIFF
--- a/docs/adr/0051-property-declarations.md
+++ b/docs/adr/0051-property-declarations.md
@@ -149,7 +149,15 @@ class Foo {
 }
 ```
 
-Per-accessor accessibility modifiers (e.g., `private set`) are deferred to a follow-up phase. The initial implementation treats both accessors as having the same visibility as the property.
+An accessor may narrow the property's accessibility:
+
+```gs
+class Foo {
+    prop Name string { get; private set; }
+}
+```
+
+The getter remains public while `set_Name` is private in binding and CLR metadata.
 
 ### 5. Data struct interaction
 
@@ -243,7 +251,6 @@ Negative:
 
 - New contextual keyword to learn — mitigated by its visibility only inside type bodies.
 - Two ways to expose data on a type (field vs property) — style guidance will recommend `prop` for public API surface and fields for internal/private storage.
-- Per-accessor visibility (`private set`) is deferred, limiting some patterns initially.
 
 Neutral:
 
@@ -256,11 +263,10 @@ Neutral:
 - **Annotation-based (`@property` on methods, Option B)**: Rejected as too verbose, error-prone (naming conventions), and hostile to interface declarations.
 - **`var`/`val` prefix (Option C)**: Rejected because GSharp uses `var`/`let` at statement scope with different semantics; reusing inside type bodies would confuse.
 - **All fields auto-emit as properties (Option E)**: Rejected as a breaking change and contrary to Go's explicitness philosophy.
-- **Per-accessor visibility in v1**: Deferred — adds parser/binder complexity for a feature that can be added incrementally later.
+- **Uniform accessor visibility only**: Rejected because it cannot preserve common CLR property ABIs such as a public getter with a private setter.
 
 ## Follow-ups
 
-- Per-accessor accessibility modifiers (`prop Name string { get; private set }`).
 - `prop` on extension declarations (extension properties).
 - Interaction with `inline struct` (should inline structs allow computed properties?).
 - `init`-only setter semantics (write-once in constructor, read-only thereafter).

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -1401,6 +1401,8 @@ internal sealed partial class DeclarationBinder
                 bool isAutoProperty;
                 bool isInitOnly = false;
                 string setterParamName = "value";
+                var getterAccessibility = propAccessibility;
+                var setterAccessibility = propAccessibility;
 
                 if (propSyntax.OpenBraceToken == null)
                 {
@@ -1423,6 +1425,16 @@ internal sealed partial class DeclarationBinder
                     }
 
                     var writeAccessor = setAccessor ?? initAccessor;
+                    if (getAccessor?.AccessibilityModifier != null)
+                    {
+                        getterAccessibility = resolveAccessibility(getAccessor.AccessibilityModifier);
+                    }
+
+                    if (writeAccessor?.AccessibilityModifier != null)
+                    {
+                        setterAccessibility = resolveAccessibility(writeAccessor.AccessibilityModifier);
+                    }
+
                     hasGetter = getAccessor != null || propSyntax.Accessors.IsDefaultOrEmpty;
                     hasSetter = writeAccessor != null;
                     isInitOnly = setAccessor == null && initAccessor != null;
@@ -1514,7 +1526,9 @@ internal sealed partial class DeclarationBinder
                     isOverride,
                     setterParamName,
                     declaration: propSyntax,
-                    isInitOnly: isInitOnly)
+                    isInitOnly: isInitOnly,
+                    getterAccessibility: getterAccessibility,
+                    setterAccessibility: setterAccessibility)
                 {
                     IsIndexer = isIndexer,
                     Parameters = indexerParameters,
@@ -1554,7 +1568,7 @@ internal sealed partial class DeclarationBinder
                             propType,
                             declaration: null,
                             package,
-                            propAccessibility,
+                            getterAccessibility,
                             receiverType: structSymbol,
                             isOpen: isVirtual,
                             isOverride: isOverride);
@@ -1579,7 +1593,7 @@ internal sealed partial class DeclarationBinder
                             TypeSymbol.Void,
                             declaration: null,
                             package,
-                            propAccessibility,
+                            setterAccessibility,
                             receiverType: structSymbol,
                             isOpen: isVirtual,
                             isOverride: isOverride);
@@ -2252,6 +2266,8 @@ internal sealed partial class DeclarationBinder
                 bool hasSetter;
                 bool isAutoProperty;
                 string setterParamName = "value";
+                var getterAccessibility = propAccessibility;
+                var setterAccessibility = propAccessibility;
 
                 if (propSyntax.OpenBraceToken == null)
                 {
@@ -2263,6 +2279,16 @@ internal sealed partial class DeclarationBinder
                     var getAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsGetter);
                     var setAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsSetter);
                     var initAccessor = propSyntax.Accessors.FirstOrDefault(a => a.IsInit);
+                    var writeAccessor = setAccessor ?? initAccessor;
+                    if (getAccessor?.AccessibilityModifier != null)
+                    {
+                        getterAccessibility = resolveAccessibility(getAccessor.AccessibilityModifier);
+                    }
+
+                    if (writeAccessor?.AccessibilityModifier != null)
+                    {
+                        setterAccessibility = resolveAccessibility(writeAccessor.AccessibilityModifier);
+                    }
 
                     // Issue #946: `init` is instance-only; reject it on a static
                     // property declared inside a `shared` block (ADR-0053).
@@ -2295,7 +2321,9 @@ internal sealed partial class DeclarationBinder
                     isOverride: false,
                     setterParamName,
                     isStatic: true,
-                    declaration: propSyntax);
+                    declaration: propSyntax,
+                    getterAccessibility: getterAccessibility,
+                    setterAccessibility: setterAccessibility);
 
                 if (isAutoProperty)
                 {
@@ -2322,7 +2350,7 @@ internal sealed partial class DeclarationBinder
                             propType,
                             declaration: null,
                             package,
-                            propAccessibility,
+                            getterAccessibility,
                             receiverType: null);
                         getterSymbol.IsStatic = true;
                         getterSymbol.StaticOwnerType = structSymbol;
@@ -2339,7 +2367,7 @@ internal sealed partial class DeclarationBinder
                             TypeSymbol.Void,
                             declaration: null,
                             package,
-                            propAccessibility,
+                            setterAccessibility,
                             receiverType: null);
                         setterSymbol.IsStatic = true;
                         setterSymbol.StaticOwnerType = structSymbol;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -2764,9 +2764,9 @@ internal sealed partial class ExpressionBinder
 
         if (TypeMemberModel.TryGetStaticPropertyIncludingInherited(structSym, memberName, out var prop, out var propertyOwner))
         {
-            if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propertyOwner, function))
+            if (!AccessibilityChecker.IsAccessible(prop.GetterAccessibility, propertyOwner, function))
             {
-                Diagnostics.ReportMemberInaccessible(ne.Location, prop.Name, propertyOwner.Name, prop.Accessibility);
+                Diagnostics.ReportMemberInaccessible(ne.Location, prop.Name, propertyOwner.Name, prop.GetterAccessibility);
             }
 
             return new BoundPropertyAccessExpression(null, receiver: null, propertyOwner, prop);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -234,9 +234,9 @@ internal sealed partial class ExpressionBinder
 
                         // Issue #950 / #2044: enforce `protected`/`private`
                         // property access.
-                        if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
+                        if (!AccessibilityChecker.IsAccessible(prop.GetterAccessibility, propDeclaringType, this.function))
                         {
-                            Diagnostics.ReportMemberInaccessible(ne.IdentifierToken.Location, prop.Name, propDeclaringType.Name, prop.Accessibility);
+                            Diagnostics.ReportMemberInaccessible(ne.IdentifierToken.Location, prop.Name, propDeclaringType.Name, prop.GetterAccessibility);
                         }
 
                         return ApplyMemberNarrowing(new BoundPropertyAccessExpression(null, receiver, structSym, prop));
@@ -3200,9 +3200,9 @@ internal sealed partial class ExpressionBinder
                     return new BoundErrorExpression(null);
                 }
 
-                if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
+                if (!AccessibilityChecker.IsAccessible(prop.GetterAccessibility, propDeclaringType, this.function))
                 {
-                    Diagnostics.ReportMemberInaccessible(ne.IdentifierToken.Location, prop.Name, propDeclaringType.Name, prop.Accessibility);
+                    Diagnostics.ReportMemberInaccessible(ne.IdentifierToken.Location, prop.Name, propDeclaringType.Name, prop.GetterAccessibility);
                 }
 
                 return ApplyMemberNarrowing(new BoundPropertyAccessExpression(null, receiver, propDeclaringType, prop));

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -449,9 +449,9 @@ internal sealed partial class ExpressionBinder
 
                 // Issue #2059: object-initializer-suffix property write —
                 // mirrors the field check above.
-                if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
+                if (!AccessibilityChecker.IsAccessible(prop.SetterAccessibility, propDeclaringType, this.function))
                 {
-                    Diagnostics.ReportMemberInaccessible(initSyntax.PropertyIdentifier.Location, prop.Name, propDeclaringType.Name, prop.Accessibility);
+                    Diagnostics.ReportMemberInaccessible(initSyntax.PropertyIdentifier.Location, prop.Name, propDeclaringType.Name, prop.SetterAccessibility);
                 }
 
                 var value = BindExpression(initSyntax.Value);
@@ -548,9 +548,9 @@ internal sealed partial class ExpressionBinder
             // Issue #263: static property assignment.
             if (TypeMemberModel.TryGetStaticPropertyIncludingInherited(userStruct, fieldName, out var prop, out var propertyOwner))
             {
-                if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propertyOwner, function))
+                if (!AccessibilityChecker.IsAccessible(prop.SetterAccessibility, propertyOwner, function))
                 {
-                    Diagnostics.ReportMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propertyOwner.Name, prop.Accessibility);
+                    Diagnostics.ReportMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propertyOwner.Name, prop.SetterAccessibility);
                 }
 
                 if (!prop.HasSetter)
@@ -850,9 +850,9 @@ internal sealed partial class ExpressionBinder
 
                 // Issue #950 / #2044: enforce `protected`/`private` property
                 // assignment.
-                if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
+                if (!AccessibilityChecker.IsAccessible(prop.SetterAccessibility, propDeclaringType, this.function))
                 {
-                    Diagnostics.ReportMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propDeclaringType.Name, prop.Accessibility);
+                    Diagnostics.ReportMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propDeclaringType.Name, prop.SetterAccessibility);
                 }
 
                 // Issue #1132: writing a property of a read-only value-type
@@ -1220,9 +1220,9 @@ internal sealed partial class ExpressionBinder
 
         if (TypeMemberModel.TryGetStaticPropertyIncludingInherited(staticStruct, memberName, out var prop, out var propertyOwner))
         {
-            if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propertyOwner, function))
+            if (!AccessibilityChecker.IsAccessible(prop.SetterAccessibility, propertyOwner, function))
             {
-                Diagnostics.ReportMemberInaccessible(memberNameSyntax.Location, prop.Name, propertyOwner.Name, prop.Accessibility);
+                Diagnostics.ReportMemberInaccessible(memberNameSyntax.Location, prop.Name, propertyOwner.Name, prop.SetterAccessibility);
             }
 
             if (!prop.HasGetter || !prop.HasSetter)
@@ -1367,9 +1367,9 @@ internal sealed partial class ExpressionBinder
 
             // Issue #950 / #2044: enforce `protected`/`private` property
             // compound-assignment.
-            if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
+            if (!AccessibilityChecker.IsAccessible(prop.SetterAccessibility, propDeclaringType, this.function))
             {
-                Diagnostics.ReportMemberInaccessible(memberNameSyntax.IdentifierToken.Location, prop.Name, propDeclaringType.Name, prop.Accessibility);
+                Diagnostics.ReportMemberInaccessible(memberNameSyntax.IdentifierToken.Location, prop.Name, propDeclaringType.Name, prop.SetterAccessibility);
             }
 
             // Issue #1132: compound-mutating a property of a read-only value-type
@@ -1989,9 +1989,9 @@ internal sealed partial class ExpressionBinder
 
                 // Issue #950 / #2044: enforce `protected`/`private` property
                 // assignment through a chained/expression receiver.
-                if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
+                if (!AccessibilityChecker.IsAccessible(prop.SetterAccessibility, propDeclaringType, this.function))
                 {
-                    Diagnostics.ReportMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propDeclaringType.Name, prop.Accessibility);
+                    Diagnostics.ReportMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propDeclaringType.Name, prop.SetterAccessibility);
                 }
 
                 var propConverted = conversions.BindConversion(syntax.Value.Location, BindValue(prop.Type), prop.Type);
@@ -2164,9 +2164,9 @@ internal sealed partial class ExpressionBinder
 
             if (TypeMemberModel.TryGetStaticPropertyIncludingInherited(constructedStruct, fieldName, out var prop, out var propertyOwner))
             {
-                if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propertyOwner, function))
+                if (!AccessibilityChecker.IsAccessible(prop.SetterAccessibility, propertyOwner, function))
                 {
-                    Diagnostics.ReportMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propertyOwner.Name, prop.Accessibility);
+                    Diagnostics.ReportMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propertyOwner.Name, prop.SetterAccessibility);
                 }
 
                 if (!prop.HasSetter)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -2522,9 +2522,9 @@ internal sealed partial class ExpressionBinder
 
         // Issue #950 / #2044: enforce `protected`/`private` property access
         // against the declaring type.
-        if (!AccessibilityChecker.IsAccessible(prop.Accessibility, declaringType, this.function))
+        if (!AccessibilityChecker.IsAccessible(prop.GetterAccessibility, declaringType, this.function))
         {
-            Diagnostics.ReportMemberInaccessible(member.IdentifierToken.Location, prop.Name, declaringType.Name, prop.Accessibility);
+            Diagnostics.ReportMemberInaccessible(member.IdentifierToken.Location, prop.Name, declaringType.Name, prop.GetterAccessibility);
         }
 
         var receiver = new BoundVariableExpression(null, function.ThisParameter);
@@ -2610,9 +2610,9 @@ internal sealed partial class ExpressionBinder
 
         // Issue #950 / #2044: enforce `protected`/`private` property
         // assignment against the declaring type.
-        if (!AccessibilityChecker.IsAccessible(prop.Accessibility, declaringType, this.function))
+        if (!AccessibilityChecker.IsAccessible(prop.SetterAccessibility, declaringType, this.function))
         {
-            Diagnostics.ReportMemberInaccessible(memberLocation, prop.Name, declaringType.Name, prop.Accessibility);
+            Diagnostics.ReportMemberInaccessible(memberLocation, prop.Name, declaringType.Name, prop.SetterAccessibility);
         }
 
         var converted = conversions.BindConversion(valueLocation, value, prop.Type);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -109,9 +109,9 @@ internal sealed partial class ExpressionBinder
             // accessor instead of failing to find a field at all.
             if (TypeMemberModel.TryGetProperty(structType, memberName, out var property, out var propertyDeclaringType) && property.HasSetter)
             {
-                if (!AccessibilityChecker.IsAccessible(property.Accessibility, propertyDeclaringType, this.function))
+                if (!AccessibilityChecker.IsAccessible(property.SetterAccessibility, propertyDeclaringType, this.function))
                 {
-                    Diagnostics.ReportMemberInaccessible(initSyntax.FieldIdentifier.Location, property.Name, propertyDeclaringType.Name, property.Accessibility);
+                    Diagnostics.ReportMemberInaccessible(initSyntax.FieldIdentifier.Location, property.Name, propertyDeclaringType.Name, property.SetterAccessibility);
                 }
 
                 var propertyValueExpr = BindExpression(initSyntax.Value);

--- a/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
@@ -306,7 +306,9 @@ internal sealed class MemberDefEmitter
         // which always has a computed body and so never reaches this path)
         // is ALWAYS private in CLR metadata — see the matching remark on
         // ReflectionMetadataEmitter.EmitFunction's effectiveAccessibility.
-        var methodAttrs = (prop.HasExplicitInterfaceClause ? MethodAttributes.Private : MethodAttributes.Public)
+        var methodAttrs = (prop.HasExplicitInterfaceClause
+                ? MethodAttributes.Private
+                : AccessibilityMap.ToMethodVisibility(prop.GetterAccessibility))
             | MethodAttributes.SpecialName | MethodAttributes.HideBySig;
         if (prop.IsVirtual)
         {
@@ -395,7 +397,9 @@ internal sealed class MemberDefEmitter
         // ADR-0149: see the matching visibility comment in EmitPropertyGetter
         // — an explicit-interface qualifier clause property is always
         // private in CLR metadata.
-        var methodAttrs = (prop.HasExplicitInterfaceClause ? MethodAttributes.Private : MethodAttributes.Public)
+        var methodAttrs = (prop.HasExplicitInterfaceClause
+                ? MethodAttributes.Private
+                : AccessibilityMap.ToMethodVisibility(prop.SetterAccessibility))
             | MethodAttributes.SpecialName | MethodAttributes.HideBySig;
         if (prop.IsVirtual)
         {
@@ -543,7 +547,8 @@ internal sealed class MemberDefEmitter
         new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: false)
             .Parameters(0, r => this.encodeTypeSymbol(r.Type(), prop.Type), _ => { });
 
-        var methodAttrs = MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig | MethodAttributes.Static;
+        var methodAttrs = AccessibilityMap.ToMethodVisibility(prop.GetterAccessibility)
+            | MethodAttributes.SpecialName | MethodAttributes.HideBySig | MethodAttributes.Static;
 
         return this.emitCtx.Metadata.AddMethodDefinition(
             attributes: methodAttrs,
@@ -569,7 +574,8 @@ internal sealed class MemberDefEmitter
         new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: false)
             .Parameters(1, r => r.Void(), ps => this.encodeTypeSymbol(ps.AddParameter().Type(), prop.Type));
 
-        var methodAttrs = MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig | MethodAttributes.Static;
+        var methodAttrs = AccessibilityMap.ToMethodVisibility(prop.SetterAccessibility)
+            | MethodAttributes.SpecialName | MethodAttributes.HideBySig | MethodAttributes.Static;
 
         var firstParamHandle = this.nextParameterHandle();
         this.emitCtx.Metadata.AddParameter(

--- a/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
@@ -27,6 +27,8 @@ public sealed class PropertySymbol : Symbol
     /// <param name="isStatic">Whether this property is declared inside a <c>shared</c> block (ADR-0053).</param>
     /// <param name="declaration">The declaring syntax node, or <see langword="null"/> for synthesized properties.</param>
     /// <param name="isInitOnly">Whether the property's setter is an <c>init</c>-only accessor (issue #946).</param>
+    /// <param name="getterAccessibility">The getter accessibility, or the property accessibility when omitted.</param>
+    /// <param name="setterAccessibility">The setter accessibility, or the property accessibility when omitted.</param>
     public PropertySymbol(
         string name,
         TypeSymbol type,
@@ -39,7 +41,9 @@ public sealed class PropertySymbol : Symbol
         string setterParameterName = "value",
         bool isStatic = false,
         PropertyDeclarationSyntax declaration = null,
-        bool isInitOnly = false)
+        bool isInitOnly = false,
+        Accessibility? getterAccessibility = null,
+        Accessibility? setterAccessibility = null)
         : base(name)
     {
         Type = type;
@@ -53,6 +57,8 @@ public sealed class PropertySymbol : Symbol
         IsStatic = isStatic;
         Declaration = declaration;
         IsInitOnly = isInitOnly;
+        GetterAccessibility = getterAccessibility ?? accessibility;
+        SetterAccessibility = setterAccessibility ?? accessibility;
     }
 
     /// <inheritdoc/>
@@ -63,6 +69,12 @@ public sealed class PropertySymbol : Symbol
 
     /// <summary>Gets the property accessibility.</summary>
     public Accessibility Accessibility { get; }
+
+    /// <summary>Gets the getter accessor accessibility.</summary>
+    public Accessibility GetterAccessibility { get; }
+
+    /// <summary>Gets the setter accessor accessibility.</summary>
+    public Accessibility SetterAccessibility { get; }
 
     /// <summary>Gets a value indicating whether this property has a getter accessor.</summary>
     public bool HasGetter { get; }

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -2201,7 +2201,9 @@ public sealed class StructSymbol : TypeSymbol
                 p.SetterParameterName,
                 p.IsStatic,
                 p.Declaration,
-                p.IsInitOnly)
+                p.IsInitOnly,
+                p.GetterAccessibility,
+                p.SetterAccessibility)
             {
                 IsIndexer = p.IsIndexer,
                 Parameters = newParams,

--- a/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
@@ -855,6 +855,17 @@ public partial class Parser
         {
             var startToken = Current;
 
+            SyntaxToken accessibilityModifier = null;
+            if ((Current.Kind == SyntaxKind.PublicKeyword ||
+                 Current.Kind == SyntaxKind.InternalKeyword ||
+                 Current.Kind == SyntaxKind.PrivateKeyword ||
+                 Current.Kind == SyntaxKind.ProtectedKeyword) &&
+                Peek(1).Kind == SyntaxKind.IdentifierToken &&
+                (Peek(1).Text == "get" || Peek(1).Text == "set" || Peek(1).Text == "init"))
+            {
+                accessibilityModifier = NextToken();
+            }
+
             if (Current.Kind == SyntaxKind.IdentifierToken &&
                 (Current.Text == "get" || Current.Text == "set" || Current.Text == "init"))
             {
@@ -911,6 +922,7 @@ public partial class Parser
                 // else: bare accessor (no body, no semicolon) — valid in interfaces
                 accessors.Add(new PropertyAccessorSyntax(
                     syntaxTree,
+                    accessibilityModifier,
                     accessorKeyword,
                     openParen,
                     paramIdentifier,
@@ -1021,7 +1033,8 @@ public partial class Parser
         var getKeyword = new SyntaxToken(syntaxTree, SyntaxKind.IdentifierToken, arrowPosition, "get", null);
         var getAccessor = new PropertyAccessorSyntax(
             syntaxTree,
-            getKeyword,
+            accessibilityModifier: null,
+            accessorKeyword: getKeyword,
             openParenToken: null,
             parameterIdentifier: null,
             closeParenToken: null,

--- a/src/Core/CodeAnalysis/Syntax/PropertyAccessorSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/PropertyAccessorSyntax.cs
@@ -13,6 +13,7 @@ public sealed class PropertyAccessorSyntax : SyntaxNode
     /// Initializes a new instance of the <see cref="PropertyAccessorSyntax"/> class.
     /// </summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="accessibilityModifier">The optional accessor accessibility modifier.</param>
     /// <param name="accessorKeyword">The <c>get</c> or <c>set</c> identifier token.</param>
     /// <param name="openParenToken">The optional open parenthesis (for <c>set(value)</c>).</param>
     /// <param name="parameterIdentifier">The optional parameter identifier (for <c>set(value)</c>).</param>
@@ -21,6 +22,7 @@ public sealed class PropertyAccessorSyntax : SyntaxNode
     /// <param name="semicolonToken">The optional semicolon (for shorthand <c>get;</c> / <c>set;</c>).</param>
     public PropertyAccessorSyntax(
         SyntaxTree syntaxTree,
+        SyntaxToken accessibilityModifier,
         SyntaxToken accessorKeyword,
         SyntaxToken openParenToken,
         SyntaxToken parameterIdentifier,
@@ -29,6 +31,7 @@ public sealed class PropertyAccessorSyntax : SyntaxNode
         SyntaxToken semicolonToken)
         : base(syntaxTree)
     {
+        AccessibilityModifier = accessibilityModifier;
         AccessorKeyword = accessorKeyword;
         OpenParenToken = openParenToken;
         ParameterIdentifier = parameterIdentifier;
@@ -36,6 +39,9 @@ public sealed class PropertyAccessorSyntax : SyntaxNode
         Body = body;
         SemicolonToken = semicolonToken;
     }
+
+    /// <summary>Gets the optional accessor accessibility modifier.</summary>
+    public SyntaxToken AccessibilityModifier { get; }
 
     /// <inheritdoc/>
     public override SyntaxKind Kind => SyntaxKind.PropertyAccessor;

--- a/test/Compiler.Tests/Emit/PropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/PropertyEmitTests.cs
@@ -366,6 +366,44 @@ public class PropertyEmitTests
         Assert.Equal("Hello, World", result);
     }
 
+    [Fact]
+    public void AccessorAccessibility_EmitsMetadataAndRunsInsideDeclaringType()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            class ApplEnv {
+                shared {
+                    private var _name string? = nil
+                    prop ApplName string? {
+                        get { return _name }
+                        private set { _name = value }
+                    }
+                    func Override(name string?) {
+                        ApplName = name
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var type = assembly.GetTypes().Single(t => t.Name == "ApplEnv");
+        var property = type.GetProperty("ApplName");
+
+        Assert.NotNull(property);
+        Assert.True(property!.GetMethod!.IsPublic);
+        Assert.True(property.GetMethod.IsStatic);
+        Assert.True(property.GetSetMethod(nonPublic: true)!.IsPrivate);
+        Assert.True(property.GetSetMethod(nonPublic: true)!.IsStatic);
+        var nullability = new NullabilityInfoContext().Create(property);
+        Assert.Equal(NullabilityState.Nullable, nullability.ReadState);
+        Assert.Equal(NullabilityState.Nullable, nullability.WriteState);
+
+        type.GetMethod("Override")!.Invoke(null, new object[] { "Foundation" });
+        Assert.Equal("Foundation", property.GetValue(null));
+    }
+
     private static Assembly CompileToAssembly(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_property_emit_").FullName;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2044PrivateAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2044PrivateAccessibilityTests.cs
@@ -123,6 +123,41 @@ class Other {
     }
 
     [Fact]
+    public void ExternalCode_WritesPrivateSetter_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    prop Value int32 { get; private set; }
+}
+
+class Other {
+    func Poke(f Foo) {
+        f.Value = 3
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void DeclaringType_WritesPrivateSetter_NoAccessibilityDiagnostic()
+    {
+        var source = @"
+class Foo {
+    prop Value int32 { get; private set; }
+    func Poke() {
+        Value = 3
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
     public void InternalCode_ReadsAndWritesPrivateFieldFromSameType_NoDiagnostics()
     {
         var source = @"

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
@@ -78,12 +78,19 @@ public sealed class PropertyAccessor : GNode
     /// <param name="body">The optional accessor body.</param>
     /// <param name="setterParameterName">The setter value parameter name (e.g. <c>v</c>).</param>
     /// <param name="expressionBody">The optional single-statement arrow body (issue #1278 / ADR-0131); when set the accessor renders as <c>get -&gt; expr</c> / <c>set -&gt; expr</c>.</param>
-    public PropertyAccessor(AccessorKind kind, BlockStatement body = null, string setterParameterName = null, GStatement expressionBody = null)
+    /// <param name="visibility">The optional accessor-specific accessibility.</param>
+    public PropertyAccessor(
+        AccessorKind kind,
+        BlockStatement body = null,
+        string setterParameterName = null,
+        GStatement expressionBody = null,
+        Visibility visibility = Visibility.Default)
     {
         Kind = kind;
         Body = body;
         SetterParameterName = setterParameterName;
         ExpressionBody = expressionBody;
+        Visibility = visibility;
     }
 
     /// <summary>Gets the accessor kind.</summary>
@@ -101,6 +108,9 @@ public sealed class PropertyAccessor : GNode
     /// <c>get -&gt; expr</c> / <c>set -&gt; expr</c> rather than a block body.
     /// </summary>
     public GStatement ExpressionBody { get; }
+
+    /// <summary>Gets the optional accessor-specific accessibility.</summary>
+    public Visibility Visibility { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1537,6 +1537,7 @@ public static class GSharpPrinter
     private static string RenderAccessor(PropertyAccessor accessor, int indent)
     {
         var pad = Indent(indent);
+        var visibility = RenderVisibility(accessor.Visibility);
         string head;
         switch (accessor.Kind)
         {
@@ -1556,15 +1557,15 @@ public static class GSharpPrinter
         if (accessor.ExpressionBody != null)
         {
             // Issue #1278 / ADR-0131: expression-bodied accessor `get -> e` / `set -> e`.
-            return $"{pad}{head} -> {RenderArrowInline(accessor.ExpressionBody, indent)}";
+            return $"{pad}{visibility}{head} -> {RenderArrowInline(accessor.ExpressionBody, indent)}";
         }
 
         if (accessor.Body == null)
         {
-            return $"{pad}{head};";
+            return $"{pad}{visibility}{head};";
         }
 
-        return $"{pad}{head} {RenderBlock(accessor.Body, indent)}";
+        return $"{pad}{visibility}{head} {RenderBlock(accessor.Body, indent)}";
     }
 
     private static string RenderMethod(MethodDeclaration method, int indent)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1072FieldInitNullableTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1072FieldInitNullableTests.cs
@@ -37,7 +37,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("let Name string? =", printed);
+        Assert.Contains("let _name string? =", printed);
+        Assert.Contains("prop Name string?", printed);
     }
 
     [Fact]
@@ -52,8 +53,9 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("let Name string =", printed);
-        Assert.DoesNotContain("let Name string? =", printed);
+        Assert.Contains("let _name string =", printed);
+        Assert.Contains("prop Name string", printed);
+        Assert.DoesNotContain("let _name string? =", printed);
     }
 
     [Fact]
@@ -69,8 +71,9 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("let Name string =", printed);
-        Assert.DoesNotContain("let Name string? =", printed);
+        Assert.Contains("let _name string =", printed);
+        Assert.Contains("prop Name string", printed);
+        Assert.DoesNotContain("let _name string? =", printed);
     }
 
     [Fact]
@@ -87,7 +90,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("let Name string? =", printed);
+        Assert.Contains("let _name string? =", printed);
+        Assert.Contains("prop Name string?", printed);
     }
 
     [Fact]
@@ -121,7 +125,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("let Title string? =", printed);
+        Assert.Contains("let _title string? =", printed);
+        Assert.Contains("prop Title string?", printed);
     }
 
     private static string TranslateUnit(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1190StaticAutoPropertyTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1190StaticAutoPropertyTranslationTests.cs
@@ -13,15 +13,8 @@ using Xunit;
 namespace Cs2Gs.Tests;
 
 /// <summary>
-/// Issue #1190: a C# <c>static</c> get-only auto-property with an inline
-/// initializer (<c>public static Version OSVersion { get; } = GetOsVersion();</c>)
-/// must become a static read-only backing field inside the <c>shared { }</c> block
-/// (<c>shared { let OSVersion Version = GetOsVersion() }</c>), preserving the
-/// initializer. Previously it was mis-translated to an invalid static
-/// <c>prop … { get; init; }</c> (GS0374) and the initializer was dropped, causing
-/// downstream <c>GS0113</c> diagnostics. A mutable
-/// (<c>{ get; private set; }</c>) static auto-property maps to a
-/// <c>shared var NAME T = expr</c> field instead.
+/// Issues #1190/#2665: initialized static auto-properties preserve their
+/// initializer without collapsing the CLR property ABI to a field.
 /// </summary>
 public class Issue1190StaticAutoPropertyTranslationTests
 {
@@ -36,6 +29,8 @@ namespace Corpus.Issue1190
 
         public static string Mutable { get; set; } = ""m"";
 
+        public static string Maybe { get; } = GetMaybe();
+
         public static string Plain { get; }
 
         public static string Computed { get { return ""c""; } }
@@ -44,60 +39,81 @@ namespace Corpus.Issue1190
         {
             return ""1.0"";
         }
+
+        private static string? GetMaybe() => null;
     }
 }
 ";
 
     [Fact]
-    public void StaticGetOnlyWithInitializer_BecomesSharedLetField()
+    public void StaticGetOnlyWithInitializer_KeepsPropertyAndUsesPrivateLetBackingField()
     {
         SharedBlock shared = SharedBlockOf("ApplEnv");
 
         FieldDeclaration osVersion = shared.Members
             .OfType<FieldDeclaration>()
-            .Single(f => f.Name == "OSVersion");
+            .Single(f => f.Name == "_oSVersion");
 
         Assert.Equal(BindingKind.Let, osVersion.Binding);
+        Assert.Equal(Visibility.Private, osVersion.Visibility);
         Assert.NotNull(osVersion.Initializer);
+        Assert.Contains(shared.Members.OfType<PropertyDeclaration>(), p => p.Name == "OSVersion");
     }
 
     [Fact]
-    public void StaticPrivateSetWithInitializer_BecomesSharedVarField()
+    public void StaticPrivateSetWithInitializer_PreservesPropertyAndAccessorAccessibility()
     {
         SharedBlock shared = SharedBlockOf("ApplEnv");
 
         FieldDeclaration applName = shared.Members
             .OfType<FieldDeclaration>()
-            .Single(f => f.Name == "ApplName");
+            .Single(f => f.Name == "_applName");
 
         Assert.Equal(BindingKind.Var, applName.Binding);
         Assert.NotNull(applName.Initializer);
+        PropertyDeclaration property = shared.Members
+            .OfType<PropertyDeclaration>()
+            .Single(p => p.Name == "ApplName");
+        Assert.Equal(Visibility.Default, property.Accessors.Single(a => a.Kind == AccessorKind.Get).Visibility);
+        Assert.Equal(Visibility.Private, property.Accessors.Single(a => a.Kind == AccessorKind.Set).Visibility);
     }
 
     [Fact]
-    public void StaticGetSetWithInitializer_BecomesSharedVarField()
+    public void StaticGetSetWithInitializer_KeepsReadWriteProperty()
     {
         SharedBlock shared = SharedBlockOf("ApplEnv");
 
         FieldDeclaration mutable = shared.Members
             .OfType<FieldDeclaration>()
-            .Single(f => f.Name == "Mutable");
+            .Single(f => f.Name == "_mutable");
 
         Assert.Equal(BindingKind.Var, mutable.Binding);
         Assert.NotNull(mutable.Initializer);
+        Assert.Contains(shared.Members.OfType<PropertyDeclaration>(), p => p.Name == "Mutable");
     }
 
     [Fact]
-    public void ConvertedStaticAutoProperties_DoNotEmitInitAccessor()
+    public void ConvertedStaticAutoProperties_RenderBackingFieldsAndPropertyAccessors()
     {
         (CompilationUnit unit, _) = Translate();
         string rendered = GSharpPrinter.Print(unit);
 
-        // The shared fields preserve their initializers and never use `init`.
-        Assert.Contains("let OSVersion", rendered, StringComparison.Ordinal);
-        Assert.Contains("var ApplName", rendered, StringComparison.Ordinal);
-        Assert.DoesNotContain("OSVersion string { get; init; }", rendered, StringComparison.Ordinal);
-        Assert.DoesNotContain("ApplName string { get; init; }", rendered, StringComparison.Ordinal);
+        Assert.Contains("private let _oSVersion", rendered, StringComparison.Ordinal);
+        Assert.Contains("prop OSVersion string", rendered, StringComparison.Ordinal);
+        Assert.Contains("prop ApplName string", rendered, StringComparison.Ordinal);
+        Assert.Contains("private set", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("var ApplName", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NullableInitializer_PromotesBackingFieldAndPropertyTogether()
+    {
+        SharedBlock shared = SharedBlockOf("ApplEnv");
+        FieldDeclaration field = shared.Members.OfType<FieldDeclaration>().Single(f => f.Name == "_maybe");
+        PropertyDeclaration property = shared.Members.OfType<PropertyDeclaration>().Single(p => p.Name == "Maybe");
+
+        Assert.True(field.Type.IsNullable);
+        Assert.True(property.Type.IsNullable);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1741SilentDivergenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1741SilentDivergenceTests.cs
@@ -23,12 +23,10 @@ public class Issue1741SilentDivergenceTests
 {
     /// <summary>
     /// An accessor-level accessibility modifier (<c>{ get; private set; }</c>)
-    /// used to collapse to the plain auto form, silently widening a
-    /// private-set property to fully public. G# has no per-accessor
-    /// accessibility, so the loss is now diagnosed instead of silent.
+    /// must remain on the translated accessor.
     /// </summary>
     [Fact]
-    public void PrivateSetAccessor_ReportsAccessibilityLossDiagnostic()
+    public void PrivateSetAccessor_PreservesAccessibility()
     {
         (CompilationUnit unit, TranslationContext context) = Translate(@"
 namespace Demo
@@ -38,22 +36,19 @@ namespace Demo
         public int X { get; private set; }
     }
 }");
-        Assert.Contains(
+        Assert.DoesNotContain(
             context.Diagnostics,
-            d => d.Severity == TranslationSeverity.Warning
-                && d.Message.Contains("narrower accessibility", StringComparison.OrdinalIgnoreCase));
-        Assert.NotNull(unit);
+            d => d.Message.Contains("narrower accessibility", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("private set", GSharpPrinter.Print(unit), StringComparison.Ordinal);
     }
 
     /// <summary>
-    /// A protected get-accessor on a public property must also be diagnosed;
-    /// the fix generalizes to any accessor with a narrowing modifier, not just
-    /// <c>private set</c>.
+    /// A protected get-accessor on a public property is preserved too.
     /// </summary>
     [Fact]
-    public void ProtectedGetAccessor_ReportsAccessibilityLossDiagnostic()
+    public void ProtectedGetAccessor_PreservesAccessibility()
     {
-        (_, TranslationContext context) = Translate(@"
+        (CompilationUnit unit, TranslationContext context) = Translate(@"
 namespace Demo
 {
     public class C
@@ -61,10 +56,10 @@ namespace Demo
         public int X { protected get; set; }
     }
 }");
-        Assert.Contains(
+        Assert.DoesNotContain(
             context.Diagnostics,
-            d => d.Severity == TranslationSeverity.Warning
-                && d.Message.Contains("narrower accessibility", StringComparison.OrdinalIgnoreCase));
+            d => d.Message.Contains("narrower accessibility", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("protected get", GSharpPrinter.Print(unit), StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2490TupleScalarNullabilityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2490TupleScalarNullabilityTranslationTests.cs
@@ -147,7 +147,8 @@ public static class Repro
 
         Assert.Contains("prop Source (string?, string)", printed);
         Assert.Contains("var Field string?", printed);
-        Assert.Contains("var Property string?", printed);
+        Assert.Contains("var _property string?", printed);
+        Assert.Contains("prop Property string?", printed);
         Assert.DoesNotContain("prop Source (string?, string?)", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2579NullableReferenceFidelityPipelineTests.cs
@@ -101,7 +101,8 @@ public sealed class Issue2579NullableReferenceFidelityPipelineTests
         Assert.Contains("for item in Factory.GetItems()!!", emitted, StringComparison.Ordinal);
         Assert.Contains("yield line!!", emitted, StringComparison.Ordinal);
         Assert.Contains("return value!!", emitted, StringComparison.Ordinal);
-        Assert.Contains("let RequiredPath string = Factory.GetKey()!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("let _requiredPath string = Factory.GetKey()!!", emitted, StringComparison.Ordinal);
+        Assert.Contains("prop RequiredPath string", emitted, StringComparison.Ordinal);
         Assert.Contains("return (value ?? Factory.GetKey())!!", emitted, StringComparison.Ordinal);
         Assert.Contains("probe = Path.GetDirectoryName(probe!!)!!", emitted, StringComparison.Ordinal);
         Assert.Contains("Value: (value ?? Factory.GetKey())!!", emitted, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2613StaticDelegateMemberPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2613StaticDelegateMemberPipelineTests.cs
@@ -54,7 +54,8 @@ public sealed class Issue2613StaticDelegateMemberPipelineTests
             Environment.NewLine,
             Directory.GetFiles(runDirectory, "*.gs", SearchOption.AllDirectories)
                 .Select(File.ReadAllText));
-        Assert.Contains("var Property (int32) -> int32", emitted, StringComparison.Ordinal);
+        Assert.Contains("var _property (int32) -> int32", emitted, StringComparison.Ordinal);
+        Assert.Contains("prop Property (int32) -> int32", emitted, StringComparison.Ordinal);
         Assert.Contains("var Field (int32) -> int32", emitted, StringComparison.Ordinal);
         Assert.Contains("Factory.Property(2)", emitted, StringComparison.Ordinal);
         Assert.Contains("Factory.Field(2)", emitted, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
@@ -110,6 +110,26 @@ namespace Demo
     }
 
     [Fact]
+    public void ExpressionBodiedLocalFunction_ReturnsConditionalValue()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public string M(bool first)
+        {
+            string Pick() => first ? ""first"" : ""second"";
+            return Pick();
+        }
+    }
+}");
+
+        Assert.Contains("return if first", printed, StringComparison.Ordinal);
+        CompileAndRun(printed, "C().M(true)");
+    }
+
+    [Fact]
     public void MinimalRepro_LetActionBeforeLetHandler_Issue2231()
     {
         // Issue #2231's exact minimal repro: a delegate-typed local function

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -182,29 +182,6 @@ public sealed partial class CSharpToGSharpTranslator
 
             IReadOnlyList<AccessorDeclarationSyntax> declared = node.AccessorList.Accessors;
 
-            // Issue #1741: an accessor-level accessibility modifier (`{ get; private
-            // set; }`) narrows just that accessor; G# has no per-accessor
-            // accessibility, so it would silently widen back to the property's own
-            // accessibility. Diagnose the loss instead of translating it silently.
-            foreach (AccessorDeclarationSyntax accessor in declared)
-            {
-                SyntaxToken accessibilityModifier = accessor.Modifiers.FirstOrDefault(m =>
-                    m.IsKind(SyntaxKind.PrivateKeyword) ||
-                    m.IsKind(SyntaxKind.ProtectedKeyword) ||
-                    m.IsKind(SyntaxKind.InternalKeyword));
-                if (accessibilityModifier.IsKind(SyntaxKind.None))
-                {
-                    continue;
-                }
-
-                string accessorMods = string.Join(" ", accessor.Modifiers.Select(m => m.ValueText));
-                this.context.Report(new TranslationDiagnostic(
-                    accessor.Kind().ToString(),
-                    $"{displayName} accessor '{accessorMods} {accessor.Keyword.ValueText}' has narrower accessibility than the property; G# has no per-accessor accessibility, so it is widened to the property's own accessibility (ADR-0115 §B.11).",
-                    accessor.GetLocation(),
-                    TranslationSeverity.Warning));
-            }
-
             bool anyBodied = declared.Any(a => a.Body != null || a.ExpressionBody != null);
             bool hasSet = declared.Any(a => a.IsKind(SyntaxKind.SetAccessorDeclaration));
             bool hasGet = declared.Any(a => a.IsKind(SyntaxKind.GetAccessorDeclaration));
@@ -214,7 +191,7 @@ public sealed partial class CSharpToGSharpTranslator
             // maps to the canonical auto form `prop Name T` (ADR-0115 §B.11). An
             // init-only auto-property (get + init) keeps its explicit accessors so
             // the init-only semantics are preserved (issue #946).
-            if (!anyBodied && hasGet && hasSet)
+            if (!anyBodied && hasGet && hasSet && declared.All(a => a.Modifiers.Count == 0))
             {
                 return new List<PropertyAccessor>();
             }
@@ -258,6 +235,11 @@ public sealed partial class CSharpToGSharpTranslator
                     kind = AccessorKind.Set;
                 }
 
+                var accessorSymbol = this.context.GetDeclaredSymbol(accessor) as IMethodSymbol;
+                Visibility visibility = accessor.Modifiers.Count > 0
+                    ? MapVisibility(accessorSymbol, this.context, accessor, preserveStaticClassPrivate: true)
+                    : Visibility.Default;
+
                 bool bodied = accessor.Body != null || accessor.ExpressionBody != null;
                 BlockStatement body = bodied
                     ? this.TranslateBody(
@@ -296,7 +278,11 @@ public sealed partial class CSharpToGSharpTranslator
                     body = null;
                 }
 
-                accessors.Add(new PropertyAccessor(kind, body, expressionBody: arrowBody));
+                accessors.Add(new PropertyAccessor(
+                    kind,
+                    body,
+                    expressionBody: arrowBody,
+                    visibility: visibility));
             }
 
             return accessors;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -426,7 +426,11 @@ public sealed partial class CSharpToGSharpTranslator
         private bool IsStaticUsingTarget(INamedTypeSymbol owner)
             => owner != null && this.staticUsingTargets.Contains(owner.OriginalDefinition);
 
-        private static Visibility MapVisibility(ISymbol symbol, TranslationContext context, SyntaxNode node)
+        private static Visibility MapVisibility(
+            ISymbol symbol,
+            TranslationContext context,
+            SyntaxNode node,
+            bool preserveStaticClassPrivate = false)
         {
             if (symbol is null)
             {
@@ -449,7 +453,7 @@ public sealed partial class CSharpToGSharpTranslator
                     // to the position default so the qualified reference still binds
                     // (a private helper of a static utility class is an internal
                     // implementation detail with no external callers to over-expose).
-                    if (IsMemberOfExtensionBearingStaticClass(symbol))
+                    if (!preserveStaticClassPrivate && IsMemberOfExtensionBearingStaticClass(symbol))
                     {
                         return Visibility.Default;
                     }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -1318,8 +1318,15 @@ public sealed partial class CSharpToGSharpTranslator
                     // <see cref="WithSpillSeam"/> — evaluated per call, inside this
                     // very body, rather than being silently dropped by the
                     // enclosing null seam above.
-                    BlockStatement innerBody = new BlockStatement(this.WithSpillSeam(
-                        () => this.TranslateExpressionStatements(localFunction.ExpressionBody.Expression).ToList()).ToList());
+                    BlockStatement innerBody = localSymbol?.ReturnsVoid == false
+                        ? new BlockStatement(this.WithSpillSeam(
+                            () => new List<GStatement>
+                            {
+                                new ReturnStatement(
+                                    this.TranslateValueWithNullForgiveness(localFunction.ExpressionBody.Expression)),
+                            }).ToList())
+                        : new BlockStatement(this.WithSpillSeam(
+                            () => this.TranslateExpressionStatements(localFunction.ExpressionBody.Expression).ToList()).ToList());
                     lambda = isAsyncVoidHandler
                         ? new LambdaExpression(parameters, blockBody: this.BuildAsyncVoidHandlerWrapperBody(parameters, innerBody, localFunction.GetLocation()), isAsync: false, returnType: null, isFunctionLiteral: true)
                         : new LambdaExpression(parameters, blockBody: innerBody, isAsync: isAsync, returnType: returnType, isFunctionLiteral: true);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -32,7 +32,7 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression TranslateFieldExpression(FieldExpressionSyntax fieldExpression)
         {
             if (this.context.GetSymbolInfo(fieldExpression).Symbol is IFieldSymbol { AssociatedSymbol: IPropertySymbol owner } &&
-                this.state.FieldKeywordBackingFieldNames.TryGetValue(owner, out string backingName))
+                this.state.SynthesizedPropertyBackingFieldNames.TryGetValue(owner, out string backingName))
             {
                 return new IdentifierExpression(backingName);
             }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -127,13 +127,13 @@ public sealed partial class CSharpToGSharpTranslator
                         break;
                     }
 
-                    // Issue #1190: a static auto-property with an inline initializer
-                    // maps to a static backing field in the `shared { }` block, since
-                    // a static G# `prop` cannot carry an `init` accessor (GS0374) and
-                    // there is no instance constructor to receive the initializer.
-                    if (this.TryTranslateStaticAutoPropertyField(property, out FieldDeclaration staticField))
+                    if (this.TryTranslateStaticInitializedAutoProperty(
+                        property,
+                        out FieldDeclaration staticBackingField,
+                        out PropertyDeclaration staticProperty))
                     {
-                        yield return (staticField, true);
+                        yield return (staticBackingField, true);
+                        yield return (staticProperty, true);
                         break;
                     }
 
@@ -1599,24 +1599,17 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         /// <summary>
-        /// Issue #1190: a C# <c>static</c> auto-property with an inline initializer
-        /// (<c>public static Version OSVersion { get; } = GetOsVersion();</c>) has no
-        /// instance constructor to carry the initializer into (the OD-T1 path only
-        /// services instance properties), and a static G# <c>prop</c> cannot declare
-        /// an <c>init</c> accessor (GS0374). Such a property therefore maps to a
-        /// static read-only/mutable backing field inside the <c>shared { }</c> block,
-        /// preserving the initializer expression: a get-only property becomes a
-        /// <c>shared let NAME T = expr</c> field, and a mutable
-        /// (<c>{ get; private set; }</c> / <c>{ get; set; }</c>) property becomes a
-        /// <c>shared var NAME T = expr</c> field. It is accessed identically
-        /// (<c>Type.NAME</c>). A static auto-property without an initializer, or one
-        /// with a getter body, keeps its existing handling.
+        /// Issue #2665: preserves the CLR property ABI of an initialized static
+        /// auto-property by lowering only its storage to an initialized backing
+        /// field and keeping a computed property over that field.
         /// </summary>
-        private bool TryTranslateStaticAutoPropertyField(
+        private bool TryTranslateStaticInitializedAutoProperty(
             PropertyDeclarationSyntax node,
-            out FieldDeclaration field)
+            out FieldDeclaration field,
+            out PropertyDeclaration property)
         {
             field = null;
+            property = null;
 
             if (!node.Modifiers.Any(SyntaxKind.StaticKeyword) || node.Initializer == null)
             {
@@ -1644,9 +1637,12 @@ public sealed partial class CSharpToGSharpTranslator
             bool hasSet = accessors.Any(a => a.IsKind(SyntaxKind.SetAccessorDeclaration));
 
             var symbol = this.context.GetDeclaredSymbol(node) as IPropertySymbol;
-            GTypeReference type = symbol != null
-                ? this.typeMapper.Map(symbol.Type, this.context, node.GetLocation())
-                : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
+            if (symbol == null)
+            {
+                return false;
+            }
+
+            GTypeReference type = this.typeMapper.Map(symbol.Type, this.context, node.GetLocation());
 
             GExpression initializer = this.CoerceConstantToUnsigned(
                 node.Initializer.Value,
@@ -1654,39 +1650,69 @@ public sealed partial class CSharpToGSharpTranslator
             initializer = this.ForgiveNullableReferenceValue(
                 node.Initializer.Value,
                 initializer,
-                symbol?.Type,
+                symbol.Type,
                 symbol);
-
-            if (symbol != null)
-            {
-                initializer = this.ForgiveNullableReferenceValue(
-                    node.Initializer.Value,
-                    initializer,
-                    symbol.Type,
-                    symbol);
-            }
 
             // Issue #1072: a non-nullable reference static auto-property whose
             // initializer is nullable (e.g. `GetAttribute<...>()?.Member`) is
             // rendered `T?` so the initializer assignment type-checks.
-            if (symbol != null)
-            {
-                type = this.PromoteIfInitializerNullable(type, symbol, node.Initializer.Value);
-            }
+            type = this.PromoteIfInitializerNullable(type, symbol, node.Initializer.Value);
 
-            // A mutable static auto-property (`{ get; set; }` / `{ get; private set; }`)
-            // becomes a `var` field; an immutable get-only one becomes a `let` field.
             BindingKind binding = hasSet ? BindingKind.Var : BindingKind.Let;
+            string backingName = this.RegisterSynthesizedPropertyBackingField(symbol, primaryCtorParamNames: null);
 
             field = new FieldDeclaration(
                 binding,
-                SanitizeIdentifier(node.Identifier.Text),
+                backingName,
                 type,
                 initializer: initializer,
+                visibility: Visibility.Private);
+
+            var propertyAccessors = new List<PropertyAccessor>
+            {
+                new PropertyAccessor(
+                    AccessorKind.Get,
+                    new BlockStatement(new List<GStatement>
+                    {
+                        new ReturnStatement(new IdentifierExpression(backingName)),
+                    }),
+                    visibility: AccessorVisibility(accessors.First(a => a.IsKind(SyntaxKind.GetAccessorDeclaration)))),
+            };
+            if (hasSet)
+            {
+                propertyAccessors.Add(new PropertyAccessor(
+                    AccessorKind.Set,
+                    new BlockStatement(new List<GStatement>
+                    {
+                        new AssignmentStatement(
+                            new IdentifierExpression(backingName),
+                            new IdentifierExpression("value")),
+                    }),
+                    visibility: AccessorVisibility(accessors.First(a => a.IsKind(SyntaxKind.SetAccessorDeclaration)))));
+            }
+
+            property = new PropertyDeclaration(
+                SanitizeIdentifier(node.Identifier.Text),
+                type,
+                propertyAccessors,
                 visibility: MapVisibility(symbol, this.context, node),
                 attributes: this.MapAttributes(node.AttributeLists));
 
             return true;
+
+            Visibility AccessorVisibility(AccessorDeclarationSyntax accessor)
+            {
+                if (accessor.Modifiers.Count == 0)
+                {
+                    return Visibility.Default;
+                }
+
+                return MapVisibility(
+                    this.context.GetDeclaredSymbol(accessor),
+                    this.context,
+                    accessor,
+                    preserveStaticClassPrivate: true);
+            }
         }
 
         private (GMember Member, bool IsStatic, GMember BackingField) TranslateProperty(
@@ -1771,6 +1797,10 @@ public sealed partial class CSharpToGSharpTranslator
             if (symbol != null)
             {
                 type = this.PromoteIfUsedAsNullable(type, symbol);
+                if (node.Initializer != null)
+                {
+                    type = this.PromoteIfInitializerNullable(type, symbol, node.Initializer.Value);
+                }
             }
 
             // Issue #1907: register a synthesized backing field BEFORE mapping the
@@ -1880,23 +1910,31 @@ public sealed partial class CSharpToGSharpTranslator
                 return null;
             }
 
+            return this.RegisterSynthesizedPropertyBackingField(symbol, primaryCtorParamNames);
+        }
+
+        private string RegisterSynthesizedPropertyBackingField(
+            IPropertySymbol symbol,
+            IReadOnlyCollection<string> primaryCtorParamNames)
+        {
+            if (this.state.SynthesizedPropertyBackingFieldNames.TryGetValue(symbol, out string existing))
+            {
+                return existing;
+            }
+
             string propName = symbol.Name;
             string baseName = "_" + (propName.Length > 0
                 ? char.ToLowerInvariant(propName[0]) + propName.Substring(1)
                 : propName);
-
-            var taken = new HashSet<string>(StringComparer.Ordinal);
-            foreach (ISymbol member in symbol.ContainingType.GetMembers())
-            {
-                taken.Add(member.Name);
-            }
-
+            var taken = new HashSet<string>(
+                symbol.ContainingType.GetMembers().Select(member => member.Name),
+                StringComparer.Ordinal);
             if (primaryCtorParamNames != null)
             {
                 taken.UnionWith(primaryCtorParamNames);
             }
 
-            taken.UnionWith(this.state.FieldKeywordBackingFieldNames.Values);
+            taken.UnionWith(this.state.SynthesizedPropertyBackingFieldNames.Values);
 
             string candidate = baseName;
             for (int suffix = 2; taken.Contains(candidate); suffix++)
@@ -1904,7 +1942,7 @@ public sealed partial class CSharpToGSharpTranslator
                 candidate = baseName + suffix;
             }
 
-            this.state.FieldKeywordBackingFieldNames[symbol] = candidate;
+            this.state.SynthesizedPropertyBackingFieldNames[symbol] = candidate;
             return candidate;
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -104,7 +104,7 @@ internal sealed class DocumentTranslationState
     // every `field` reference/auto-accessor is rewritten to read/write it.
     // Keyed by property symbol so all accessors of the same property (get
     // AND set) resolve to the one synthesized name.
-    public Dictionary<IPropertySymbol, string> FieldKeywordBackingFieldNames { get; } =
+    public Dictionary<IPropertySymbol, string> SynthesizedPropertyBackingFieldNames { get; } =
         new Dictionary<IPropertySymbol, string>(SymbolEqualityComparer.Default);
 
     // Issue #1743: both <see cref="IsSymbolReassigned"/> and


### PR DESCRIPTION
## Summary
- keep initialized static C# auto-properties as G# properties over synthesized backing fields instead of ABI-breaking fields
- preserve accessor accessibility and nullable property/backing metadata through parsing, binding, emission, and cs2gs printing
- emit explicit returns for value-returning expression-bodied local functions, unblocking the exact Foundation runtime parity proof

## Verification
- exact Oahu `Oahu.Foundation.Tests`: C# baseline **2/2 passed**; migrated Foundation/tests **2/2 passed**
- Release solution build: **0 warnings, 0 errors**
- Core.Tests: **6671 passed, 1 skipped**
- Cs2Gs.Tests: **1708 passed**
- PropertyEmitTests: **60 passed**
- focused metadata/runtime/negative regressions: **36 passed** after rebase

Fixes #2665
