### PR TITLE
Fix async state-machine stack lowering

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -915,8 +915,7 @@ internal sealed class ImportedMemberRefFactory
         handle = default;
         if (method == null
             || !TryNormalizeToSymbolicContainer(containingTypeSymbol, out var openDefinition, out var typeArguments)
-            || typeArguments.IsDefaultOrEmpty
-            || !typeArguments.Any(TypeSymbol.RequiresSymbolicProjection))
+            || typeArguments.IsDefaultOrEmpty)
         {
             return false;
         }
@@ -966,9 +965,8 @@ internal sealed class ImportedMemberRefFactory
         }
 
         // Synthesize an ImportedTypeSymbol view of the receiver so the
-        // parent TypeSpec encoder reaches the existing
-        // `ImportedTypeSymbol with HasTypeParameterArgument` branch in
-        // EncodeTypeSymbol uniformly — regardless of whether the actual
+        // parent TypeSpec encoder retains its constructed arguments uniformly
+        // — regardless of whether the actual
         // receiver was an ImportedTypeSymbol, a SequenceTypeSymbol with
         // null ClrType (issue #774), or an AsyncSequenceTypeSymbol with
         // null ClrType.

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -406,14 +406,14 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
-        // ADR-0087 §3 R6: a delegate whose parameter or return types
-        // reference open type parameters (e.g. `func(T) U`) is now
+        // ADR-0087 §3 R6: a delegate whose parameter or return types carry
+        // symbolic types (e.g. `func(T) U` or `async () -> T`) is
         // encoded as a reified `GENERICINST<Func`N><…>` shape. Dispatch
         // through a MemberRef parented at that TypeSpec — the runtime
         // delegate (e.g. `Func<int, int>`) resolves the MemberRef to
         // its concrete `Invoke` slot, so no `Delegate.DynamicInvoke`
         // marshalling is needed.
-        if (call.FunctionType.ClrType == null)
+        if (this.outer.userTokens.FunctionTypeNeedsSymbolicDelegate(call.FunctionType))
         {
             this.EmitExpression(call.Target);
             foreach (var arg in call.Arguments)

--- a/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
@@ -307,40 +307,20 @@ internal sealed class SignatureEncoder
                 encoder.GenericTypeParameter(tp.Ordinal);
             }
         }
-        else if (type is ImportedTypeSymbol symbolicImported
-            && !symbolicImported.TypeArguments.IsDefaultOrEmpty
-            && !symbolicImported.HasTypeParameterArgument
-            && symbolicImported.OpenDefinition != null
-            && symbolicImported.TypeArguments.Any(TypeSymbol.RequiresSymbolicProjection))
+        else if (type is ImportedTypeSymbol constructedImported
+            && !constructedImported.TypeArguments.IsDefaultOrEmpty
+            && constructedImported.OpenDefinition != null)
         {
+            // Issue #2666: the cached CLR projection may be object-erased even
+            // when every symbolic argument is concrete (for example the
+            // KeyValuePair[K,V] cell captured by an async foreach body).
             var genericInst = encoder.GenericInstantiation(
-                this.outer.memberRefs.GetTypeReference(symbolicImported.OpenDefinition),
-                symbolicImported.TypeArguments.Length,
-                isValueType: symbolicImported.OpenDefinition.IsValueType);
-            foreach (var arg in symbolicImported.TypeArguments)
+                this.outer.memberRefs.GetTypeReference(constructedImported.OpenDefinition),
+                constructedImported.TypeArguments.Length,
+                isValueType: constructedImported.OpenDefinition.IsValueType);
+            foreach (var arg in constructedImported.TypeArguments)
             {
                 this.EncodeTypeSymbol(genericInst.AddArgument(), arg);
-            }
-        }
-        else if (type is ImportedTypeSymbol erasedGeneric && erasedGeneric.HasTypeParameterArgument)
-        {
-            // ADR-0087 §3 R2: a generic CLR type constructed over an in-scope
-            // type parameter (e.g. `List[T]`) is no longer erased to
-            // `System.Object`. Emit a real `GENERICINST<def><args>` so the
-            // signature carries `Var`/`MVar` slots that match the actual
-            // runtime type. Boxing/unboxing at boundaries is now handled by
-            // explicit `box T`/`unbox.any T` in the body emitter when the
-            // value bridges across an `object` slot.
-            var openDef = erasedGeneric.OpenDefinition
-                ?? throw new InvalidOperationException(
-                    $"Imported generic '{erasedGeneric.Name}' has no OpenDefinition for GENERICINST encoding.");
-            var giOpen = encoder.GenericInstantiation(
-                this.outer.memberRefs.GetTypeReference(openDef),
-                erasedGeneric.TypeArguments.Length,
-                isValueType: openDef.IsValueType);
-            foreach (var arg in erasedGeneric.TypeArguments)
-            {
-                this.EncodeTypeSymbol(giOpen.AddArgument(), arg);
             }
         }
         else if (type is ArrayTypeSymbol arr)
@@ -557,19 +537,18 @@ internal sealed class SignatureEncoder
                 this.EncodeTypeSymbol(fnParamsEnc.AddParameter().Type(), fnPtr.ParameterTypes[i]);
             }
         }
+        else if (type is FunctionTypeSymbol fn)
+        {
+            // ADR-0087 §3 R6 / issue #2666: encode delegates from their symbolic shape.
+            // A nested open slot (for example `async () -> T`) can still have
+            // an object-erased ClrType (`Func<Task<object>>`); preferring that
+            // cached projection corrupts generic async state-machine fields.
+            // The reified signature retains the original nested Var/MVar slots.
+            this.EncodeFunctionTypeSymbol(encoder, fn);
+        }
         else if (type?.ClrType != null)
         {
             this.EncodeClrType(encoder, type.ClrType);
-        }
-        else if (type is FunctionTypeSymbol openFn)
-        {
-            // ADR-0087 §3 R6: encode an open-bearing delegate type as a
-            // reified `GENERICINST<Func`N or Action`N><args>` so the
-            // signature carries `Var`/`MVar` slots that match the
-            // runtime delegate. Previously the encoder fell back to
-            // `Func<object, object>`, and the call site bridged the
-            // value-type boundary through `Delegate.DynamicInvoke`.
-            this.EncodeFunctionTypeSymbol(encoder, openFn);
         }
         else if (type is MapTypeSymbol openMap)
         {

--- a/test/Compiler.Tests/Emit/Issue2666AsyncStateMachineStackEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2666AsyncStateMachineStackEmitTests.cs
@@ -1,0 +1,223 @@
+// <copyright file="Issue2666AsyncStateMachineStackEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2666: preserve constructed stack types in async state machines.
+/// Cycle 7 reported <c>Task&lt;object&gt;</c> versus <c>Task&lt;T0&gt;</c> in
+/// <c>ToolDispatcher.InvokeAsync.MoveNext</c>, and
+/// <c>KeyValuePair&lt;string, ConversionItemViewModel&gt;</c> versus
+/// <c>KeyValuePair&lt;object, object&gt;</c> in
+/// <c>MainWindow.OnRunDownloadPipeline.MoveNext</c>.
+/// </summary>
+public class Issue2666AsyncStateMachineStackEmitTests
+{
+    [Fact]
+    public void ExactToolDispatcherGenericAsyncDelegate_VerifiesAndRuns()
+    {
+        var source = """
+            package Oahu.Cli.Server.Hosting
+
+            import System
+            import System.Collections.Generic
+            import System.Diagnostics
+            import System.Threading.Tasks
+
+            enum CapabilityClass { Read }
+            enum ServerTransport { Stdio, Http }
+
+            class CapabilityPolicy {
+                prop Transport ServerTransport -> ServerTransport.Stdio
+                func Require(toolName string, capability CapabilityClass, confirmed bool) {}
+            }
+
+            class AuditLog {
+                func Write(transport string, principal string, toolName string, args IReadOnlyDictionary[string, object?]?, outcome string, latencyMs int64) {}
+            }
+
+            class ToolDispatcher(policy CapabilityPolicy, audit AuditLog) {
+                async func InvokeAsync[T](toolName string, capability CapabilityClass, args IReadOnlyDictionary[string, object?]?, body async () -> T, confirmed bool = false, principal string = "stdio") T {
+                    let transport = if policy.Transport == ServerTransport.Http { "http" } else { "stdio" }
+                    let sw = Stopwatch.StartNew()
+                    try {
+                        policy.Require(toolName, capability, confirmed)
+                    } catch (ex UnauthorizedAccessException) {
+                        SafeAudit(transport!!, principal, toolName, args, "denied", sw!!.ElapsedMilliseconds)
+                        throw ex
+                    }
+                    try {
+                        let result = await body().ConfigureAwait(false)
+                        SafeAudit(transport!!, principal, toolName, args, "ok", sw!!.ElapsedMilliseconds)
+                        return result
+                    } catch (ex Exception) {
+                        SafeAudit(transport!!, principal, toolName, args, "error", sw!!.ElapsedMilliseconds)
+                        throw ex
+                    }
+                }
+
+                private func SafeAudit(transport string, principal string, toolName string, args IReadOnlyDictionary[string, object?]?, outcome string, latencyMs int64) {
+                    audit.Write(transport, principal, toolName, args, outcome, latencyMs)
+                }
+            }
+
+            let dispatcher = ToolDispatcher(CapabilityPolicy(), AuditLog())
+            let result = dispatcher.InvokeAsync[int32]("probe", CapabilityClass.Read, nil, () -> Task.FromResult(42)).GetAwaiter().GetResult()
+            Console.WriteLine(result)
+            """;
+
+        Assert.Equal("42\n", CompileVerifyAndRun(source));
+    }
+
+    [Fact]
+    public void ExactOnRunDownloadPipelineCapturedDictionaryPair_VerifiesAndRuns()
+    {
+        const string HelperSource = """
+            namespace ImportedPipeline;
+
+            public sealed class ConversionItemViewModel
+            {
+                public ConversionItemViewModel(string asin) => Asin = asin;
+                public string Asin { get; }
+            }
+            """;
+        var source = """
+            package Oahu.App
+
+            import System
+            import System.Collections.Generic
+            import System.Linq
+            import System.Threading.Tasks
+            import ImportedPipeline
+
+            class MainWindow {
+                async func OnRunDownloadPipeline(items IReadOnlyList[ConversionItemViewModel]) int32 {
+                    await Task.Yield()
+                    let lookup = items.ToDictionary((i ConversionItemViewModel) -> i.Asin)
+                    var matched = 0
+                    for kvp in lookup {
+                        let item = items.FirstOrDefault((i ConversionItemViewModel) -> i.Asin == kvp.Key)
+                        if item != nil {
+                            matched += 1
+                        }
+                    }
+                    return matched
+                }
+            }
+
+            let items = List[ConversionItemViewModel]()
+            items.Add(ConversionItemViewModel("A"))
+            Console.WriteLine(MainWindow().OnRunDownloadPipeline(items).GetAwaiter().GetResult())
+            """;
+
+        Assert.Equal("1\n", CompileVerifyAndRun(source, HelperSource));
+    }
+
+    private static string CompileVerifyAndRun(string source, string helperSource = null)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue2666_").FullName;
+        try
+        {
+            var helperPath = helperSource == null ? null : BuildHelper(directory, helperSource);
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            var arguments = new List<string>
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+            if (helperPath != null)
+            {
+                arguments.Add("/reference:" + helperPath);
+            }
+
+            arguments.Add(sourcePath);
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(arguments.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(exitCode == 0, $"compile failed ({exitCode}):\n{stdout}\n{stderr}");
+            IlVerifier.Verify(outputPath, helperPath == null ? null : new[] { helperPath });
+
+            File.WriteAllText(Path.ChangeExtension(outputPath, ".runtimeconfig.json"), """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo);
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}:\n{error}");
+            return output.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private static string BuildHelper(string directory, string source)
+    {
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(File.Exists)
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "ImportedPipeline",
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var path = Path.Combine(directory, "ImportedPipeline.dll");
+        using var stream = File.Create(path);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return path;
+    }
+}


### PR DESCRIPTION
## Summary
- preserve all constructed imported type arguments in emitted signatures and member dispatch
- dispatch nested symbolic async delegates through reified `Func` TypeSpecs
- cover the exact App `OnRunDownloadPipeline.MoveNext` and Cli.Server `ToolDispatcher.InvokeAsync.MoveNext` StackUnexpected shapes with runtime + ILVerify tests

## Validation
- `Compiler.Tests`: 3,323 passed
- `Core.Tests`: 6,669 passed, 1 skipped
- exact issue tests: 2 passed

Fixes #2666