### PR TITLE
Serialize Cs2Gs tests to prevent SDK build flakes

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/AssemblyInfo.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// <copyright file="AssemblyInfo.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Xunit;
+
+// SDK-backed tests launch nested builds that share process and package state.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Summary
- disable xUnit collection parallelization for Cs2Gs.Tests
- prevent SDK-backed tests from racing nested builds over shared process and package state
- follow the existing Compiler.Tests assembly-level convention

## Context
The v0.3.212 tag and matching main build failed in different SDK-backed tests, while v0.3.213 and later builds passed those same tests. Subsequent main runs failed in additional pipeline tests, confirming nondeterministic test infrastructure rather than a release-only regression.

## Validation
- not run locally due to the repository resource constraint; CI will exercise the full suite