### PR TITLE
Publish Visual Studio extension during releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -346,3 +346,44 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: npx --yes @vscode/vsce publish --packagePath ./vsix/vscode-gsharp.vsix
+
+  publish-visual-studio-extension:
+    runs-on: windows-latest
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download Visual Studio VSIX
+        uses: actions/download-artifact@v5
+        with:
+          name: visual-studio-gsharp-vsix
+          path: ./vsix
+
+      - name: Publish to Visual Studio Marketplace
+        shell: pwsh
+        env:
+          VS_MARKETPLACE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $installPath = & $vswhere -latest -products * `
+            -requires Microsoft.VisualStudio.Component.VSSDK `
+            -property installationPath
+          if (-not $installPath) {
+            throw "Visual Studio SDK installation not found."
+          }
+
+          $publisher = Join-Path $installPath `
+            "VSSDK\VisualStudioIntegration\Tools\Bin\VsixPublisher.exe"
+          if (-not (Test-Path $publisher)) {
+            throw "VsixPublisher.exe not found at $publisher."
+          }
+
+          & $publisher publish `
+            -payload "$PWD\vsix\GSharp.VisualStudio.vsix" `
+            -publishManifest "$PWD\src\vs-gsharp\vs-publish.json" `
+            -personalAccessToken $env:VS_MARKETPLACE_PAT
+          if ($LASTEXITCODE -ne 0) {
+            throw "Visual Studio Marketplace publishing failed with exit code $LASTEXITCODE."
+          }

--- a/src/vs-gsharp/vs-publish.json
+++ b/src/vs-gsharp/vs-publish.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json.schemastore.org/vsix-publish",
+  "categories": [
+    "coding",
+    "programming languages"
+  ],
+  "identity": {
+    "internalName": "GSharp.VisualStudio"
+  },
+  "overview": "README.md",
+  "priceCategory": "free",
+  "publisher": "gsharplang",
+  "private": false,
+  "qna": true,
+  "repo": "https://github.com/DavidObando/gsharp"
+}


### PR DESCRIPTION
## Summary
- add the Visual Studio Marketplace publish manifest for gsharplang.GSharp.VisualStudio
- publish the release VSIX with Microsoft's official VsixPublisher.exe
- reuse the existing Marketplace PAT after the current GitHub/NuGet/VS Code release job succeeds

## Validation
- parsed the updated GitHub Actions workflow as YAML
- validated the publish manifest and linked overview
- verified VSSDK discovery locates VsixPublisher.exe