### PR TITLE
cs2gs: preserve Nullable.Value in expression trees

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2661ExpressionTreeNullablePipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2661ExpressionTreeNullablePipelineTests.cs
@@ -53,6 +53,7 @@ public sealed class Issue2661ExpressionTreeNullablePipelineTests
 
         Assert.DoesNotContain("b.Conversion!!", emitted, StringComparison.Ordinal);
         Assert.DoesNotContain("b.PurchaseDate!!", emitted, StringComparison.Ordinal);
+        Assert.Contains(".Select((b Book) -> b.PurchaseDate.Value)", emitted, StringComparison.Ordinal);
         Assert.Contains("book.Conversion!!.AccountId", emitted, StringComparison.Ordinal);
         Assert.Contains("book.PurchaseDate!!", emitted, StringComparison.Ordinal);
         Assert.True(
@@ -79,7 +80,7 @@ public sealed class Issue2661ExpressionTreeNullablePipelineTests
         process.WaitForExit();
 
         Assert.True(process.ExitCode == 0, error);
-        Assert.Equal("account\n2026\n", output.Replace("\r\n", "\n"));
+        Assert.Equal("2026\naccount\n2026\n2026\nnullable\n", output.Replace("\r\n", "\n"));
     }
 
     private static (string ApiProject, string AppProject) WriteFixture(string sourceRoot)
@@ -143,19 +144,23 @@ public sealed class Issue2661ExpressionTreeNullablePipelineTests
         File.WriteAllText(Path.Combine(projectDirectory, "BookLibrary.cs"), """
             using System;
             using System.Linq;
+            using System.Linq.Expressions;
             using BookApi;
 
             public static class BookLibrary
             {
-                public static void SinceLatestPurchaseDate(
+                public static DateTime SinceLatestPurchaseDate(
                     IQueryable<Book> books,
                     Conversion profileId)
                 {
-                    var query = books
+                    var latest = books
                         .Where(b => b.PurchaseDate.HasValue &&
                             b.Conversion.AccountId == profileId.AccountId &&
                             b.Conversion.Region == profileId.Region)
-                        .Select(b => b.PurchaseDate.Value);
+                        .Select(b => b.PurchaseDate.Value)
+                        .OrderBy(b => b)
+                        .LastOrDefault();
+                    return latest + TimeSpan.FromMilliseconds(1);
                 }
 
                 public static void Main()
@@ -163,10 +168,27 @@ public sealed class Issue2661ExpressionTreeNullablePipelineTests
                     var book = new Book(
                         new Conversion("account", "region"),
                         new DateTime(2026, 7, 21));
+                    Console.WriteLine(
+                        SinceLatestPurchaseDate(
+                            new[] { book }.AsQueryable(),
+                            new Conversion("account", "region")).Year);
                     Func<Book, string> account = book => book.Conversion.AccountId;
                     Func<Book, DateTime> purchased = book => book.PurchaseDate.Value;
                     Console.WriteLine(account(book));
                     Console.WriteLine(purchased(book).Year);
+
+                    Expression<Func<Book, DateTime>> selected =
+                        value => value.PurchaseDate.Value;
+                    var compiled = selected.Compile();
+                    Console.WriteLine(compiled(book).Year);
+                    try
+                    {
+                        compiled(new Book(new Conversion("account", "region"), null));
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        Console.WriteLine("nullable");
+                    }
                 }
             }
             """);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2661ExpressionTreeNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2661ExpressionTreeNullableTranslationTests.cs
@@ -50,6 +50,7 @@ public sealed class Issue2661ExpressionTreeNullableTranslationTests
             """);
 
         Assert.Contains("b.PurchaseDate != nil", printed, StringComparison.Ordinal);
+        Assert.Contains(".Select((b Book) -> b.PurchaseDate.Value)", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("b.PurchaseDate!!", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("b.Conversion!!", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("GS0473", printed, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -439,14 +439,10 @@ public sealed partial class CSharpToGSharpTranslator
             // does not match against the `Ac4DsiV1?` `this` slot (GS0159). Keep the
             // declared-nullable receiver so the extension resolves.
             // A C# nullable *value* type (`T?` lowering to `System.Nullable<T>`)
-            // exposes `.Value` and `.HasValue`, but G# models a value-type `T?`
-            // directly (no `Nullable<T>` member surface) and relies on Kotlin-style
-            // smart-casts, so those members do not exist on the G# side. Rewrite
-            // them to the idiomatic G# equivalents (#914):
-            //   * `x.Value`    -> `x!!`      (assert non-null, matching C#'s throw-
-            //                                 if-null semantics; harmless once the
-            //                                 local is already smart-cast-narrowed).
-            //   * `x.HasValue` -> `x != nil` (a plain null test on the raw receiver).
+            // exposes `.Value` and `.HasValue`. Runtime lambdas use G#'s idiomatic
+            // `x!!` unwrap, but `!!` is forbidden in expression trees: retain
+            // `.Value` there so lowering produces the CLR Nullable<T>.Value
+            // property node. `HasValue` remains the plain `x != nil` null test.
             // Guard on the receiver's *declared* type being `System.Nullable<T>` so
             // a user type with a member literally named `Value`/`HasValue` is
             // unaffected. Nullable *reference* types (`string?`) have a non-
@@ -459,7 +455,7 @@ public sealed partial class CSharpToGSharpTranslator
                     case "Value":
                         GExpression nullableValue = this.TranslateExpression(member.Expression);
                         return this.IsWithinExpressionTreeLambda(member.Expression)
-                            ? nullableValue
+                            ? new MemberAccessExpression(nullableValue, "Value")
                             : new NonNullAssertionExpression(nullableValue);
                     case "HasValue":
                         // Parenthesize the null test so it composes correctly


### PR DESCRIPTION
Fixes #2661

## Summary
- retain `Nullable<T>.Value` as a CLR property access inside expression-tree lambdas
- continue suppressing translator-injected null-forgiveness there
- keep `!!` for ordinary runtime delegates
- exercise the translated expression tree through compilation and runtime execution, including the null/throw path

## Exact Oahu.Core proof
Source (`BookLibrary.cs:1374`):
```csharp
.Select(b => b.PurchaseDate.Value)
```

Before (`BookLibrary.gs:528`):
```gsharp
.Select((b Book) -> b.PurchaseDate)
```
Direct gsc: `BookLibrary.gs(530,18): error GS0155: Cannot convert type 'System.DateTime?' to 'System.DateTime'.`

After:
```gsharp
.Select((b Book) -> b.PurchaseDate.Value)
```
Direct gsc: `GS0155` x0. Oahu.Core now advances past binding to the next latent, unrelated emit-phase `GS9998`.

## Validation
- `dotnet build GSharp.sln -c Release`: green, 0 warnings/errors
- `Cs2Gs.Tests`: 1713/1713 green
- expression-tree suite: 80/80 green
- issue pipeline/translation/runtime/negative tests: 3/3 green
