### PR TITLE
Fix method-group delegate construction

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -204,6 +204,7 @@ public sealed class Binder
             isFormattableStringTargetType: ExpressionBinder.IsFormattableStringTargetType,
             bindInterpolatedStringAsFormattable: (syntax, targetType) => expressions.BindInterpolatedStringAsFormattable(syntax, targetType),
             createErasedFunctionLiteralAdapter: (literal, targetFunctionType) => lambdas.CreateErasedFunctionLiteralAdapter(literal, targetFunctionType),
+            createClrMethodGroupAdapter: (group, targetFunctionType) => lambdas.CreateClrMethodGroupAdapter(group, targetFunctionType),
             isLvalue: ExpressionBinder.IsLvalue,
             getRefKindFromModifier: GetRefKindFromModifier,
             refKindToString: RefKindToString);

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -65,6 +65,7 @@ internal sealed class ConversionClassifier
     private readonly Func<TypeSymbol, bool> isFormattableStringTargetType;
     private readonly Func<InterpolatedStringExpressionSyntax, TypeSymbol, BoundExpression> bindInterpolatedStringAsFormattable;
     private readonly Func<BoundFunctionLiteralExpression, FunctionTypeSymbol, BoundFunctionLiteralExpression> createErasedFunctionLiteralAdapter;
+    private readonly Func<BoundClrMethodGroupExpression, FunctionTypeSymbol, BoundExpression> createClrMethodGroupAdapter;
     private readonly Func<BoundExpression, bool> isLvalue;
     private readonly Func<SyntaxToken, RefKind> getRefKindFromModifier;
     private readonly Func<RefKind, string> refKindToString;
@@ -96,6 +97,9 @@ internal sealed class ConversionClassifier
     /// wraps a function-literal expression in an erased-signature adapter
     /// for the target generic function type. Owned by the lambda binder
     /// (which holds the nested rewriter), surfaced here as a callback.</param>
+    /// <param name="createClrMethodGroupAdapter">Callback that wraps a
+    /// resolved CLR method group when its exact signature differs from the
+    /// structural function target.</param>
     /// <param name="isLvalue">Callback that classifies a bound expression
     /// as an l-value (addressable). Used by the conditional-ref-argument
     /// validator.</param>
@@ -113,6 +117,7 @@ internal sealed class ConversionClassifier
         Func<TypeSymbol, bool> isFormattableStringTargetType,
         Func<InterpolatedStringExpressionSyntax, TypeSymbol, BoundExpression> bindInterpolatedStringAsFormattable,
         Func<BoundFunctionLiteralExpression, FunctionTypeSymbol, BoundFunctionLiteralExpression> createErasedFunctionLiteralAdapter,
+        Func<BoundClrMethodGroupExpression, FunctionTypeSymbol, BoundExpression> createClrMethodGroupAdapter,
         Func<BoundExpression, bool> isLvalue,
         Func<SyntaxToken, RefKind> getRefKindFromModifier,
         Func<RefKind, string> refKindToString)
@@ -124,6 +129,7 @@ internal sealed class ConversionClassifier
         this.isFormattableStringTargetType = isFormattableStringTargetType ?? throw new ArgumentNullException(nameof(isFormattableStringTargetType));
         this.bindInterpolatedStringAsFormattable = bindInterpolatedStringAsFormattable ?? throw new ArgumentNullException(nameof(bindInterpolatedStringAsFormattable));
         this.createErasedFunctionLiteralAdapter = createErasedFunctionLiteralAdapter ?? throw new ArgumentNullException(nameof(createErasedFunctionLiteralAdapter));
+        this.createClrMethodGroupAdapter = createClrMethodGroupAdapter ?? throw new ArgumentNullException(nameof(createClrMethodGroupAdapter));
         this.isLvalue = isLvalue ?? throw new ArgumentNullException(nameof(isLvalue));
         this.getRefKindFromModifier = getRefKindFromModifier ?? throw new ArgumentNullException(nameof(getRefKindFromModifier));
         this.refKindToString = refKindToString ?? throw new ArgumentNullException(nameof(refKindToString));
@@ -1401,7 +1407,10 @@ internal sealed class ConversionClassifier
             var resolution = OverloadResolution.Resolve(applicable, argTypes);
             if (resolution.Outcome == OverloadResolution.ResolutionOutcome.Resolved)
             {
-                return new BoundClrMethodGroupExpression(group.Syntax, group.Receiver, resolution.Best, targetType);
+                var resolved = new BoundClrMethodGroupExpression(group.Syntax, group.Receiver, resolution.Best, targetType);
+                return targetType is FunctionTypeSymbol functionTarget
+                    ? this.createClrMethodGroupAdapter(resolved, functionTarget)
+                    : resolved;
             }
         }
 

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -931,6 +931,120 @@ internal sealed class LambdaBinder
     }
 
     /// <summary>
+    /// Builds a thunk when a CLR method group's exact parameter types differ
+    /// from its structural function target. This commonly occurs when an
+    /// imported named delegate is nested in the method signature: direct
+    /// <c>ldftn/newobj</c> would pair incompatible signatures, while the thunk
+    /// lets ordinary conversion emission adapt each slot.
+    /// </summary>
+    /// <param name="group">The resolved CLR method group.</param>
+    /// <param name="targetFunctionType">The structural target function type.</param>
+    /// <returns>The original group for an exact signature; otherwise a synthesized adapter literal.</returns>
+    public BoundExpression CreateClrMethodGroupAdapter(
+        BoundClrMethodGroupExpression group,
+        FunctionTypeSymbol targetFunctionType)
+    {
+        var method = group.ResolvedMethod;
+        var methodParameters = method.GetParameters();
+        var closesStaticReceiver = method.IsStatic && group.Receiver != null;
+        var parameterOffset = closesStaticReceiver ? 1 : 0;
+        var invoke = targetFunctionType.ClrType?.GetMethodSafe("Invoke");
+        if (invoke == null
+            || methodParameters.Length != targetFunctionType.ParameterTypes.Length + parameterOffset
+            || methodParameters.Any(p => p.ParameterType.IsByRef))
+        {
+            return group;
+        }
+
+        var invokeParameters = invoke.GetParameters();
+        var exactSignature = invoke.ReturnType.IsSameAs(method.ReturnType);
+        for (var i = 0; exactSignature && i < invokeParameters.Length; i++)
+        {
+            exactSignature = invokeParameters[i].ParameterType.IsSameAs(methodParameters[i + parameterOffset].ParameterType);
+        }
+
+        if (exactSignature)
+        {
+            return group;
+        }
+
+        var adapterParameters = ImmutableArray.CreateBuilder<ParameterSymbol>(targetFunctionType.ParameterTypes.Length);
+        var arguments = ImmutableArray.CreateBuilder<BoundExpression>(methodParameters.Length);
+        LocalVariableSymbol receiverTemp = null;
+        BoundExpression adapterReceiver = group.Receiver;
+        if (group.Receiver != null)
+        {
+            receiverTemp = new LocalVariableSymbol(
+                $"<method_group_receiver{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
+                isReadOnly: true,
+                group.Receiver.Type);
+            adapterReceiver = new BoundVariableExpression(null, receiverTemp);
+        }
+
+        if (closesStaticReceiver)
+        {
+            arguments.Add(new BoundConversionExpression(
+                null,
+                ClrNullability.GetParameterTypeSymbol(methodParameters[0]),
+                adapterReceiver));
+        }
+
+        for (var i = 0; i < targetFunctionType.ParameterTypes.Length; i++)
+        {
+            var parameter = new ParameterSymbol(
+                $"arg{i}",
+                targetFunctionType.ParameterTypes[i],
+                declaringSyntax: group.Syntax);
+            adapterParameters.Add(parameter);
+            arguments.Add(new BoundConversionExpression(
+                null,
+                ClrNullability.GetParameterTypeSymbol(methodParameters[i + parameterOffset]),
+                new BoundVariableExpression(null, parameter)));
+        }
+
+        var methodReturnType = method.ReturnType.IsSameAs(typeof(void))
+            ? TypeSymbol.Void
+            : ClrNullability.GetReturnTypeSymbol(method);
+        BoundExpression call = method.IsStatic
+            ? new BoundClrStaticCallExpression(null, method, methodReturnType, arguments.MoveToImmutable())
+            : new BoundImportedInstanceCallExpression(
+                null,
+                adapterReceiver,
+                method,
+                methodReturnType,
+                arguments.MoveToImmutable());
+
+        BoundStatement statement = methodReturnType == TypeSymbol.Void
+            ? new BoundBlockStatement(
+                null,
+                ImmutableArray.Create<BoundStatement>(
+                    new BoundExpressionStatement(null, call),
+                    new BoundReturnStatement(null, null)))
+            : new BoundReturnStatement(
+                null,
+                new BoundConversionExpression(null, targetFunctionType.ReturnType, call));
+        var body = statement as BoundBlockStatement
+            ?? new BoundBlockStatement(null, ImmutableArray.Create(statement));
+        var function = new FunctionSymbol(
+            $"<method_group_adapter{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
+            adapterParameters.MoveToImmutable(),
+            targetFunctionType.ReturnType,
+            package: getCurrentFunction()?.Package)
+        {
+            LexicalEnclosingType = getCurrentFunction()?.LexicalEnclosingType,
+        };
+        var captured = CollectCapturedVariables(body, function.Parameters);
+        BoundExpression adapter = new BoundFunctionLiteralExpression(group.Syntax, function, targetFunctionType, body, captured);
+        return receiverTemp == null
+            ? adapter
+            : new BoundBlockExpression(
+                group.Syntax,
+                ImmutableArray.Create<BoundStatement>(
+                    new BoundVariableDeclaration(group.Syntax, receiverTemp, group.Receiver)),
+                adapter);
+    }
+
+    /// <summary>
     /// For an async lambda's declared return type, computes the
     /// observable return type the synthesized
     /// <see cref="FunctionTypeSymbol"/> must present to the delegate

--- a/test/Compiler.Tests/Emit/Issue2672DelegateCtorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2672DelegateCtorEmitTests.cs
@@ -20,6 +20,77 @@ namespace GSharp.Compiler.Tests.Emit;
 public sealed class Issue2672DelegateCtorEmitTests
 {
     [Fact]
+    public void ClrMethodGroup_NestedNamedDelegateSlot_VerifiesAndRunsBesideReturnIfLocal()
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2672MethodGroup");
+        Directory.CreateDirectory(directory);
+        var fixturePath = Path.Combine(directory, "Issue2672Fixture.dll");
+        var outputPath = Path.Combine(directory, "Issue2672MethodGroup.dll");
+        EmitFixture(fixturePath);
+
+        const string source = """
+            package Issue2672
+            import System
+            import System.Threading
+            import Issue2672Fixture
+
+            class Forwarder {
+                shared {
+                    func Forward(sendOrPost ((object?) -> void, object?) -> void, action () -> void) {
+                        Console.WriteLine(ContextFactory.Created)
+                        sendOrPost((state object?) -> action(), nil)
+                    }
+                }
+            }
+
+            func ForwardPost(sync SynchronizationContext, action () -> void) {
+                Forwarder.Forward(sync.Post, action)
+            }
+
+            func ForwardSend(sync SynchronizationContext, action () -> void) {
+                Forwarder.Forward(sync.Send, action)
+            }
+
+            func Sibling(type_ Type, fullName bool) string? {
+                let TypeName = func () string? {
+                    return if fullName { type_.FullName } else { type_.Name }
+                }
+                return TypeName()
+            }
+
+            func Main() {
+                let context = ImmediateSynchronizationContext()
+                Forwarder.Forward(ContextFactory.Current.Post, () -> Console.WriteLine("post"))
+                ForwardSend(context, () -> Console.WriteLine("send"))
+                Console.WriteLine(Sibling(typeof(string), false))
+            }
+            """;
+
+        Emit(source, outputPath, fixturePath);
+        IlVerifier.Verify(outputPath, additionalReferences: new[] { fixturePath });
+        Assert.Equal("1\npost\n1\nsend\nString\n", Run(outputPath, fixturePath));
+    }
+
+    [Fact]
+    public void ClrMethodGroup_IncompatibleArity_RemainsRejected()
+    {
+        const string source = """
+            package Issue2672
+            import System.Threading
+
+            func Bad(sync SynchronizationContext) {
+                let callback (string) -> void = sync.Post
+            }
+            """;
+        using var resolver = ReferenceResolver.WithReferences(Array.Empty<string>());
+        var compilation = new GsCompilation(resolver, GsSyntaxTree.Parse(SourceText.From(source)));
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream, pdbStream: null, refStream: null, assemblyName: "Issue2672Negative");
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0218");
+    }
+
+    [Fact]
     public void ImportedExtension_AsyncLambdaWithNamedDelegateParameter_VerifiesAndRuns()
     {
         var directory = Path.Combine(AppContext.BaseDirectory, "Issue2672DelegateCtor");
@@ -94,6 +165,29 @@ public sealed class Issue2672DelegateCtorEmitTests
 
             public sealed class Host { }
 
+            public sealed class ImmediateSynchronizationContext : System.Threading.SynchronizationContext
+            {
+                public override void Post(System.Threading.SendOrPostCallback callback, object? state)
+                    => callback(state);
+
+                public override void Send(System.Threading.SendOrPostCallback callback, object? state)
+                    => callback(state);
+            }
+
+            public static class ContextFactory
+            {
+                public static int Created { get; private set; }
+
+                public static System.Threading.SynchronizationContext Current
+                {
+                    get
+                    {
+                        Created++;
+                        return new ImmediateSynchronizationContext();
+                    }
+                }
+            }
+
             public delegate Task Next(Context context);
 
             public static class MiddlewareExtensions
@@ -124,5 +218,42 @@ public sealed class Issue2672DelegateCtorEmitTests
         using var stream = File.Create(path);
         var result = compilation.Emit(stream);
         Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static void Emit(string source, string outputPath, string fixturePath)
+    {
+        using var resolver = ReferenceResolver.WithReferences(new[] { fixturePath });
+        var compilation = new GsCompilation(resolver, GsSyntaxTree.Parse(SourceText.From(source)));
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream, pdbStream: null, refStream: null, assemblyName: Path.GetFileNameWithoutExtension(outputPath));
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static string Run(string outputPath, string fixturePath)
+    {
+        var context = new AssemblyLoadContext(Path.GetFileNameWithoutExtension(outputPath), isCollectible: true);
+        try
+        {
+            context.Resolving += (_, name) =>
+                name.Name == "Issue2672Fixture" ? context.LoadFromAssemblyPath(fixturePath) : null;
+            var assembly = context.LoadFromAssemblyPath(outputPath);
+            var previous = Console.Out;
+            using var output = new StringWriter();
+            Console.SetOut(output);
+            try
+            {
+                assembly.EntryPoint!.Invoke(null, null);
+            }
+            finally
+            {
+                Console.SetOut(previous);
+            }
+
+            return output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+        }
+        finally
+        {
+            context.Unload();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- synthesize isolated adapters when CLR method-group parameter identities differ from structural function targets
- evaluate and capture instance receivers once before delegate construction, preserving source order
- cover the Oahu `SynchronizationContext.Post`/`Send` named-delegate shape beside a sibling return-if local function

## Proof
- Oahu.Foundation exact `DelegateCtor` findings: **27 → 0**
- migrated Oahu.Foundation parity tests: **2/2 passed**
- issue runtime + ILVerify + negative tests: **3/3 passed**
- focused compiler method-group regressions: **17/17 passed**
- focused Core method-group regressions: **12/12 passed**
- Oahu Foundation translation tests: **24/24 passed**
- Core.Tests: **6,678 passed, 1 skipped**
- Release solution build: **0 warnings, 0 errors**

Fixes #2672