### PR TITLE
Fix async iterator one-sided try dispatch

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/TryDispatchPlanner.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/TryDispatchPlanner.cs
@@ -216,6 +216,6 @@ internal sealed class TryDispatchPlan
     /// <returns>The dispatch entries; empty if this try has no awaits inside.</returns>
     public ImmutableArray<TryDispatchEntry> GetInternalDispatchEntries(BoundTryStatement tryStmt)
     {
-        return internalDispatch.TryGetValue(tryStmt, out var entries) ? entries : default;
+        return internalDispatch.TryGetValue(tryStmt, out var entries) ? entries : ImmutableArray<TryDispatchEntry>.Empty;
     }
 }

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorTryDispatchPlanner.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorTryDispatchPlanner.cs
@@ -283,7 +283,7 @@ internal sealed class IteratorTryDispatchPlan
     /// <returns>The dispatch entries; empty if this try has no yields inside.</returns>
     public ImmutableArray<IteratorTryDispatchEntry> GetInternalDispatchEntries(BoundTryStatement tryStmt)
     {
-        return internalDispatch.TryGetValue(tryStmt, out var entries) ? entries : default;
+        return internalDispatch.TryGetValue(tryStmt, out var entries) ? entries : ImmutableArray<IteratorTryDispatchEntry>.Empty;
     }
 
     /// <summary>Gets the yield states transitively inside the given user try.</summary>

--- a/test/Compiler.Tests/Emit/CaptureMatrixEmitTests.cs
+++ b/test/Compiler.Tests/Emit/CaptureMatrixEmitTests.cs
@@ -296,6 +296,72 @@ public class CaptureMatrixEmitTests
                 }
             }
             """, "42\n");
+
+        yield return Row("Issue2662_ExactOahuCliAppAudibleJobExecutor", """
+            package Oahu.Cli.App
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+            import System.Threading.Channels
+
+            class JobUpdate {
+                var Value int32 = 0
+            }
+
+            class AudibleJobExecutor {
+                async func ExecuteAsync() IAsyncEnumerable[JobUpdate] {
+                    let channel = Channel.CreateUnbounded[JobUpdate]()
+                    let first = JobUpdate()
+                    first.Value = 42
+                    channel.Writer.TryWrite(first)
+                    channel.Writer.TryComplete()
+                    let runTask = Task.CompletedTask
+                    try {
+                        while await channel.Reader.WaitToReadAsync() {
+                            while channel.Reader.TryRead(out var update) {
+                                yield update
+                            }
+                        }
+                    } finally {
+                        try {
+                            await runTask
+                        } catch (Exception) {
+                        }
+                    }
+                }
+            }
+
+            func Main() {
+                let e = AudibleJobExecutor().ExecuteAsync().GetAsyncEnumerator()
+                var total = 0
+                if e.MoveNextAsync().AsTask().Result {
+                    total = total + e.Current.Value
+                }
+                Console.WriteLine(total)
+            }
+            """, "42\n");
+
+        yield return Row("Issue2662_AudibleJobExecutor_YieldsOnlyTry", """
+            package Oahu.Cli.App
+            import System
+            import System.Collections.Generic
+
+            class AudibleJobExecutor {
+                async func ExecuteAsync() IAsyncEnumerable[int32] {
+                    try {
+                        yield 42
+                    } finally {
+                    }
+                }
+            }
+
+            func Main() {
+                let e = AudibleJobExecutor().ExecuteAsync().GetAsyncEnumerator()
+                if e.MoveNextAsync().AsTask().Result {
+                    Console.WriteLine(e.Current)
+                }
+            }
+            """, "42\n");
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- return initialized empty dispatch arrays from both await and yield planners
- handle awaits-only and yields-only async-iterator try regions symmetrically
- reproduce Oahu.Cli.App `AudibleJobExecutor.ExecuteAsync` and prove emitted IL plus runtime behavior

## Verification
- exact regression before fix: `GS9998: NullReferenceException` for both one-sided shapes
- capture matrix after fix: 19/19 passed (runtime + ILVerify)
- Release solution build: 0 warnings, 0 errors
- solution suites completed green: Core 6678/6678, Cs2Gs 1713/1713, LanguageServer 450/450, Interpreter 429/429, Extensions 104/104, SDK 43/43, GeneratorHost 29/29, InternalAnalyzers 7/7

Fixes #2662