### PR TITLE
Fix await-for closure capture hoisting

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1992,6 +1992,17 @@ internal sealed class LambdaBinder
             return base.RewriteForRangeStatement(node);
         }
 
+        /// <inheritdoc/>
+        protected override BoundStatement RewriteAwaitForRangeStatement(BoundAwaitForRangeStatement node)
+        {
+            if (node.ValueVariable != null)
+            {
+                this.declared.Add(node.ValueVariable);
+            }
+
+            return base.RewriteAwaitForRangeStatement(node);
+        }
+
         protected override BoundStatement RewriteForEllipsisStatement(BoundForEllipsisStatement node)
         {
             if (node.Variable != null)

--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -868,6 +868,31 @@ internal static class CaptureBoxingRewriter
         }
 
         /// <inheritdoc/>
+        protected override BoundStatement RewriteAwaitForRangeStatement(BoundAwaitForRangeStatement node)
+        {
+            var stream = this.RewriteExpression(node.Stream);
+            var body = this.RewriteStatement(node.Body);
+            if (this.boxInfo.TryGetValue(node.ValueVariable, out var bi))
+            {
+                // Lambda bodies can reach boxing before await-for lowering.
+                body = PrependSeedStatements(body, this.BuildBoxSeedStatements(bi));
+            }
+
+            if (ReferenceEquals(stream, node.Stream) && ReferenceEquals(body, node.Body))
+            {
+                return node;
+            }
+
+            return new BoundAwaitForRangeStatement(
+                node.Syntax,
+                node.ValueVariable,
+                stream,
+                body,
+                node.BreakLabel,
+                node.ContinueLabel);
+        }
+
+        /// <inheritdoc/>
         protected override BoundStatement RewriteVariableDeclaration(BoundVariableDeclaration node)
         {
             if (this.boxInfo.TryGetValue(node.Variable, out var bi) && bi.Original == node.Variable)

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -769,9 +769,9 @@ public sealed class Lowerer : BoundTreeRewriter
         var moreDecl = new BoundVariableDeclaration(null, moreSymbol, moveNextAwait);
 
         var currentAccess = new BoundClrPropertyAccessExpression(null, enumeratorExpr, currentMember, currentType);
-        var assignValue = new BoundExpressionStatement(
-            null,
-            new BoundAssignmentExpression(null, valueVariable, currentAccess));
+
+        // The iteration binding is a fresh lexical local on every pass.
+        var assignValue = new BoundVariableDeclaration(null, valueVariable, currentAccess);
 
         var tryStatements = ImmutableArray.CreateBuilder<BoundStatement>();
         tryStatements.Add(new BoundLabelStatement(null, startLabel));

--- a/test/Compiler.Tests/Emit/Issue2691AwaitForNestedCaptureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2691AwaitForNestedCaptureEmitTests.cs
@@ -1,0 +1,174 @@
+// <copyright file="Issue2691AwaitForNestedCaptureEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2691: an await-for iteration variable captured by a nested lambda
+/// inside an async lambda had neither closure storage nor a MoveNext slot.
+/// </summary>
+public class Issue2691AwaitForNestedCaptureEmitTests
+{
+    [Fact]
+    public void OahuHistoryDelete_AsyncLambdaAwaitForNestedAny_RunsAndVerifies()
+    {
+        const string Source = """
+            package Oahu.Cli.Commands
+            import System
+            import System.Collections.Generic
+            import System.Linq
+            import System.Threading.Tasks
+
+            class JobRecord(asin string) {
+                prop Asin string -> asin
+            }
+
+            async func ReadAllAsync() IAsyncEnumerable[JobRecord] {
+                yield JobRecord("B")
+                await Task.Yield()
+                yield JobRecord("A")
+            }
+
+            let action = async () -> {
+                let asins = []string{ "A" }
+                var matches = 0
+                await for rec in ReadAllAsync() {
+                    let matchesAsin = asins.Any((a string) -> String.Equals(a, rec.Asin, StringComparison.OrdinalIgnoreCase))
+                    if matchesAsin {
+                        matches += 1
+                    }
+                }
+                return matches
+            }
+
+            Console.WriteLine(action().GetAwaiter().GetResult())
+            """;
+
+        Assert.Equal("1\n", CompileVerifyAndRun(Source, "Oahu"));
+    }
+
+    [Fact]
+    public void AwaitFor_EscapingClosures_GetFreshHoistedSlotPerIteration()
+    {
+        const string Source = """
+            package AwaitForCapture
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class JobRecord(asin string) {
+                prop Asin string -> asin
+            }
+
+            async func ReadAllAsync() IAsyncEnumerable[JobRecord] {
+                yield JobRecord("B")
+                await Task.Yield()
+                yield JobRecord("A")
+            }
+
+            async func Run() {
+                var readers = List[(() -> string)]()
+                await for rec in ReadAllAsync() {
+                    readers.Add(() -> rec.Asin)
+                }
+                Console.WriteLine(readers[0]() + readers[1]())
+            }
+
+            Run().GetAwaiter().GetResult()
+            """;
+
+        Assert.Equal("BA\n", CompileVerifyAndRun(Source, "Escaping"));
+    }
+
+    [Fact]
+    public void AwaitFor_VariableOutsideLoop_RemainsRejected()
+    {
+        var syntax = SyntaxTree.Parse(SourceText.From(
+            """
+            package AwaitForCaptureNegative
+            import System.Collections.Generic
+
+            class JobRecord {}
+
+            async func ReadAllAsync() IAsyncEnumerable[JobRecord] {
+                yield JobRecord()
+            }
+
+            async func Run() {
+                await for rec in ReadAllAsync() {}
+                let invalid = () -> rec
+            }
+            """));
+        var compilation = new Compilation(syntax);
+
+        using var output = new MemoryStream();
+        var result = compilation.Emit(output, pdbStream: null, refStream: null, assemblyName: "Issue2691.Negative");
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0125");
+    }
+
+    private static string CompileVerifyAndRun(string source, string caseName)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2691Emit", caseName);
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            Assert.True(exitCode == 0, $"compile failed ({exitCode}):\n{stdout}\n{stderr}");
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        IlVerifier.Verify(outputPath);
+
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                outputPath,
+            },
+            WorkingDirectory = directory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(process.ExitCode == 0, error);
+        return output.Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary
- classify `await for` iteration variables as lambda-local declarations
- allocate fresh per-iteration locals and closure boxes across async state-machine lowering
- cover the exact Oahu.Cli async lambda/`Any` capture, escaping closures, ILVerify/runtime, and negative scope behavior

## Testing
- `dotnet test GSharp.sln --nologo --verbosity:minimal`
- targeted await-for/closure suites (44 passed)

Fixes #2691