### PR TITLE
Fix handler metadata-context lookups

### DIFF
--- a/src/Core/CodeAnalysis/Binding/InterpolatedStringHandlerInfo.cs
+++ b/src/Core/CodeAnalysis/Binding/InterpolatedStringHandlerInfo.cs
@@ -313,6 +313,9 @@ public sealed class InterpolatedStringHandlerInfo
         var wantAlign = part.Alignment.HasValue;
         var wantFormat = part.Format != null;
         var extra = (wantAlign ? 1 : 0) + (wantFormat ? 1 : 0);
+        var contextType = FindCoreContextType(handlerType);
+        var intType = ClrTypeUtilities.RemapHostCoreTypeToContext(typeof(int), contextType);
+        var stringType = ClrTypeUtilities.RemapHostCoreTypeToContext(typeof(string), contextType);
         var candidates = ImmutableArray.CreateBuilder<MethodInfo>();
 
         foreach (var candidate in handlerType.GetMethods(BindingFlags.Public | BindingFlags.Instance))
@@ -329,12 +332,12 @@ public sealed class InterpolatedStringHandlerInfo
             }
 
             var index = 1;
-            if (wantAlign && !parameters[index++].ParameterType.IsSameAs(typeof(int)))
+            if (wantAlign && !parameters[index++].ParameterType.IsSameAs(intType))
             {
                 continue;
             }
 
-            if (wantFormat && !parameters[index].ParameterType.IsSameAs(typeof(string)))
+            if (wantFormat && !parameters[index].ParameterType.IsSameAs(stringType))
             {
                 continue;
             }
@@ -347,7 +350,9 @@ public sealed class InterpolatedStringHandlerInfo
             return false;
         }
 
-        var valueClrType = NullableTypeSymbol.GetEffectiveClrType(holeType);
+        var valueClrType = ClrTypeUtilities.RemapHostCoreTypeToContext(
+            NullableTypeSymbol.GetEffectiveClrType(holeType),
+            contextType);
         if (valueClrType != null)
         {
             var argumentTypes = new System.Type[1 + extra];
@@ -355,12 +360,12 @@ public sealed class InterpolatedStringHandlerInfo
             var index = 1;
             if (wantAlign)
             {
-                argumentTypes[index++] = typeof(int);
+                argumentTypes[index++] = intType;
             }
 
             if (wantFormat)
             {
-                argumentTypes[index] = typeof(string);
+                argumentTypes[index] = stringType;
             }
 
             var resolution = OverloadResolution.Resolve<MethodInfo>(candidates, argumentTypes);
@@ -409,9 +414,45 @@ public sealed class InterpolatedStringHandlerInfo
             return true;
         }
 
-        method = method.MakeGenericMethod(typeof(object));
+        method = method.MakeGenericMethod(
+            ClrTypeUtilities.RemapHostCoreTypeToContext(typeof(object), contextType));
         typeArguments = ImmutableArray.Create(holeType);
         return true;
+    }
+
+    internal static bool TryResolveAppendLiteral(System.Type handlerType, out MethodInfo method)
+    {
+        method = handlerType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(candidate =>
+            {
+                if (candidate.Name != "AppendLiteral")
+                {
+                    return false;
+                }
+
+                var parameters = candidate.GetParameters();
+                return parameters.Length == 1 && parameters[0].ParameterType.IsSameAs(typeof(string));
+            });
+        return method != null;
+    }
+
+    private static System.Type FindCoreContextType(System.Type handlerType)
+    {
+        foreach (var constructor in handlerType.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+        {
+            foreach (var parameter in constructor.GetParameters())
+            {
+                var parameterType = parameter.ParameterType.IsByRef
+                    ? parameter.ParameterType.GetElementType()
+                    : parameter.ParameterType;
+                if (parameterType.IsSameAs(typeof(int)))
+                {
+                    return parameterType;
+                }
+            }
+        }
+
+        return handlerType;
     }
 
     private static bool ValidateAppendMethods(
@@ -421,7 +462,7 @@ public sealed class InterpolatedStringHandlerInfo
     {
         failure = null;
         if (parts.Any(part => part.IsLiteral && part.Literal.Length > 0)
-            && handlerType.GetMethod("AppendLiteral", new[] { typeof(string) }) == null)
+            && !TryResolveAppendLiteral(handlerType, out _))
         {
             failure = $"'{handlerType.Name}' has no AppendLiteral(string) method";
             return false;

--- a/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
@@ -603,8 +603,9 @@ internal sealed class InterpolatedStringHandlerLowerer : NestedFunctionBodyRewri
     }
 
     private static MethodInfo FindAppendLiteral(System.Type handlerType)
-        => handlerType.GetMethod("AppendLiteral", new[] { typeof(string) })
-            ?? throw new System.InvalidOperationException(
+        => InterpolatedStringHandlerInfo.TryResolveAppendLiteral(handlerType, out var method)
+            ? method
+            : throw new System.InvalidOperationException(
                 $"Interpolated-string handler '{handlerType.Name}' has no AppendLiteral(string) method.");
 
     private static bool AppendsReturnBool(System.Type handlerType, MethodInfo appendLiteral)

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
@@ -942,6 +943,56 @@ public static class ClrTypeUtilities
             Visit(t);
             return result.ToArray();
         });
+    }
+
+    internal static Type RemapHostCoreTypeToContext(Type type, Type contextObject)
+    {
+        if (type == null
+            || contextObject == null
+            || ReferenceEquals(contextObject.Assembly, typeof(object).Assembly))
+        {
+            return type;
+        }
+
+        if (type.IsByRef)
+        {
+            return RemapHostCoreTypeToContext(type.GetElementType(), contextObject).MakeByRefType();
+        }
+
+        if (type.IsPointer)
+        {
+            return RemapHostCoreTypeToContext(type.GetElementType(), contextObject).MakePointerType();
+        }
+
+        if (type.IsArray)
+        {
+            var element = RemapHostCoreTypeToContext(type.GetElementType(), contextObject);
+            return type.IsSZArray
+                ? element.MakeArrayType()
+                : element.MakeArrayType(type.GetArrayRank());
+        }
+
+        if (type.IsConstructedGenericType
+            && ReferenceEquals(type.GetGenericTypeDefinition().Assembly, typeof(object).Assembly))
+        {
+            var open = contextObject.Assembly.GetType(
+                type.GetGenericTypeDefinition().FullName,
+                throwOnError: false);
+            if (open != null)
+            {
+                return open.MakeGenericType(
+                    type.GetGenericArguments()
+                        .Select(argument => RemapHostCoreTypeToContext(argument, contextObject))
+                        .ToArray());
+            }
+        }
+
+        if (ReferenceEquals(type.Assembly, typeof(object).Assembly))
+        {
+            return contextObject.Assembly.GetType(type.FullName, throwOnError: false) ?? type;
+        }
+
+        return type;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
@@ -197,7 +197,7 @@ public sealed class ImportedTypeSymbol : TypeSymbol
                 return ClrType;
             }
 
-            args[i] = RemapHostCoreTypeToContext(argClr, contextObject);
+            args[i] = ClrTypeUtilities.RemapHostCoreTypeToContext(argClr, contextObject);
         }
 
         try
@@ -428,56 +428,6 @@ public sealed class ImportedTypeSymbol : TypeSymbol
         var baseName = StripGenericArity(type.Name);
         var args = type.GetGenericArguments().Select(BuildAggregateDisplayName);
         return $"{baseName}[{string.Join(", ", args)}]";
-    }
-
-    private static Type RemapHostCoreTypeToContext(Type type, Type contextObject)
-    {
-        if (type == null
-            || contextObject == null
-            || ReferenceEquals(contextObject.Assembly, typeof(object).Assembly))
-        {
-            return type;
-        }
-
-        if (type.IsByRef)
-        {
-            return RemapHostCoreTypeToContext(type.GetElementType(), contextObject).MakeByRefType();
-        }
-
-        if (type.IsPointer)
-        {
-            return RemapHostCoreTypeToContext(type.GetElementType(), contextObject).MakePointerType();
-        }
-
-        if (type.IsArray)
-        {
-            var element = RemapHostCoreTypeToContext(type.GetElementType(), contextObject);
-            return type.IsSZArray
-                ? element.MakeArrayType()
-                : element.MakeArrayType(type.GetArrayRank());
-        }
-
-        if (type.IsConstructedGenericType
-            && ReferenceEquals(type.GetGenericTypeDefinition().Assembly, typeof(object).Assembly))
-        {
-            var open = contextObject.Assembly.GetType(
-                type.GetGenericTypeDefinition().FullName,
-                throwOnError: false);
-            if (open != null)
-            {
-                return open.MakeGenericType(
-                    type.GetGenericArguments()
-                        .Select(argument => RemapHostCoreTypeToContext(argument, contextObject))
-                        .ToArray());
-            }
-        }
-
-        if (ReferenceEquals(type.Assembly, typeof(object).Assembly))
-        {
-            return contextObject.Assembly.GetType(type.FullName, throwOnError: false) ?? type;
-        }
-
-        return type;
     }
 
     private static string StripGenericArity(string name)

--- a/test/Compiler.Tests/Emit/Issue2640ImportedInterpolatedStringHandlerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2640ImportedInterpolatedStringHandlerEmitTests.cs
@@ -7,6 +7,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -15,18 +19,50 @@ namespace GSharp.Compiler.Tests.Emit;
 public class Issue2640ImportedInterpolatedStringHandlerEmitTests
 {
     [Fact]
-    public void OahuStringCreate_InvariantCulture_EmitsVerifiesAndRuns()
+    public void MetadataCompilation_AlignedStringCreate_DoesNotMixRuntimeTypes()
     {
         const string Source = """
-            package Oahu
+            package Oahu.Cli.Tui
             import System
             import System.Globalization
 
-            func formatPercent(value float64) string {
-                return string.Create(CultureInfo.InvariantCulture, "${int(Math.Round(value * 100.0)),3}%")
+            func FormatPercent(value float64) string {
+                return String.Create(CultureInfo.InvariantCulture, "${int(Math.Round(value * 100.0)),3}%")
+            }
+            """;
+
+        using var resolver = ReferenceResolver.WithReferences(BclReferences.Value);
+        Assert.True(
+            resolver.TryResolveType(
+                "System.Runtime.CompilerServices.DefaultInterpolatedStringHandler",
+                out var handlerType));
+        Assert.Throws<ArgumentException>(
+            () => handlerType.GetMethod("AppendLiteral", new[] { typeof(string) }));
+
+        var compilation = new Compilation(resolver, SyntaxTree.Parse(SourceText.From(Source)))
+        {
+            IsLibrary = true,
+        };
+        using var peStream = new MemoryStream();
+
+        var result = compilation.Emit(peStream);
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    [Fact]
+    public void OahuStringCreate_InvariantCulture_EmitsVerifiesAndRuns()
+    {
+        const string Source = """
+            package Oahu.Cli.Tui
+            import System
+            import System.Globalization
+
+            func FormatPercent(value float64) string {
+                return String.Create(CultureInfo.InvariantCulture, "${int(Math.Round(value * 100.0)),3}%")
             }
 
-            Console.Write(formatPercent(0.42))
+            Console.Write(FormatPercent(0.42))
             """;
 
         var (exitCode, diagnostics, outputPath, directory) = Compile(Source);
@@ -51,7 +87,7 @@ public class Issue2640ImportedInterpolatedStringHandlerEmitTests
             import System.Globalization
 
             let value = 42
-            Console.Write(string.Create(CultureInfo.InvariantCulture, "${value,6:0000}"))
+            Console.Write(String.Create(CultureInfo.InvariantCulture, "${value,6:0000}"))
             """;
 
         var (exitCode, diagnostics, outputPath, directory) = Compile(Source);
@@ -72,9 +108,10 @@ public class Issue2640ImportedInterpolatedStringHandlerEmitTests
     {
         const string Source = """
             package Negative
+            import System
             import System.Globalization
 
-            let value = string.Create(CultureInfo.InvariantCulture, "Oahu")
+            let value = String.Create(CultureInfo.InvariantCulture, "Oahu")
             """;
 
         var (exitCode, diagnostics, _, directory) = Compile(Source);


### PR DESCRIPTION
## Summary
- keep imported interpolated-string-handler literal and formatted lookup types in one reflection context
- share context-safe `AppendLiteral` resolution between binding validation and lowering
- cover the exact Oahu.Cli.Tui aligned `String.Create` path, the runtime/MetadataLoadContext `ArgumentException` boundary, IL verification, formatting, and negative overload resolution

## Tests
- `Core.Tests`: 6,678 passed, 1 skipped
- `Compiler.Tests`: 3,343 passed
- focused interpolated-handler `Core.Tests`: 16 passed
- focused issue #2640 `Compiler.Tests`: 4 passed

Fixes #2640