### PR TITLE
Fix Oahu aligned handler binding

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -786,8 +786,36 @@ internal sealed partial class ExpressionBinder
 
         var condition = BindExpression(syntax.Condition, TypeSymbol.Bool);
 
-        var whenTrue = BindBlockExpressionValue(syntax.ThenBlock, canBeVoid);
-        var whenFalse = BindIfExpressionElseBranch(syntax.ElseExpression, canBeVoid);
+        // Issue #2640: an if-expression branch observes the same nil-guard
+        // narrowing as an if-statement. Otherwise a nullable hole can poison
+        // the interpolation before handler overload resolution runs.
+        Dictionary<AccessPath, TypeSymbol> whenTrueNarrowing = null;
+        Dictionary<AccessPath, TypeSymbol> whenFalseNarrowing = null;
+        if (SmartCastStability.TryClassifyNilGuardLeaf(
+            condition,
+            restrictBareVariableToLocalsAndParams: false,
+            referenceNullableOnly: false,
+            out var target,
+            out var underlying,
+            out var nonNilWhenTrue))
+        {
+            var frame = new Dictionary<AccessPath, TypeSymbol> { [target] = underlying };
+            if (nonNilWhenTrue)
+            {
+                whenTrueNarrowing = frame;
+            }
+            else
+            {
+                whenFalseNarrowing = frame;
+            }
+        }
+
+        var whenTrue = BindWithNarrowing(
+            whenTrueNarrowing,
+            () => BindBlockExpressionValue(syntax.ThenBlock, canBeVoid));
+        var whenFalse = BindWithNarrowing(
+            whenFalseNarrowing,
+            () => BindIfExpressionElseBranch(syntax.ElseExpression, canBeVoid));
 
         if (condition is BoundErrorExpression || whenTrue is BoundErrorExpression || whenFalse is BoundErrorExpression)
         {
@@ -846,6 +874,26 @@ internal sealed partial class ExpressionBinder
 
         // Should not happen from well-formed parse trees.
         return new BoundErrorExpression(null);
+    }
+
+    private BoundExpression BindWithNarrowing(
+        Dictionary<AccessPath, TypeSymbol> narrowing,
+        Func<BoundExpression> bind)
+    {
+        if (narrowing == null)
+        {
+            return bind();
+        }
+
+        binderCtx.NarrowedVariables.Add(narrowing);
+        try
+        {
+            return bind();
+        }
+        finally
+        {
+            binderCtx.NarrowedVariables.RemoveAt(binderCtx.NarrowedVariables.Count - 1);
+        }
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue2640ImportedInterpolatedStringHandlerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2640ImportedInterpolatedStringHandlerEmitTests.cs
@@ -51,16 +51,14 @@ public class Issue2640ImportedInterpolatedStringHandlerEmitTests
     }
 
     [Fact]
-    public void OahuStringCreate_InvariantCulture_EmitsVerifiesAndRuns()
+    public void OahuJobsScreen_FormatPercent_EmitsVerifiesAndRuns()
     {
         const string Source = """
             package Oahu.Cli.Tui
             import System
             import System.Globalization
 
-            func FormatPercent(value float64) string {
-                return String.Create(CultureInfo.InvariantCulture, "${int(Math.Round(value * 100.0)),3}%")
-            }
+            func FormatPercent(p float64?) string -> if p != nil { String.Create(CultureInfo.InvariantCulture, "${int32(Math.Round(p * float64(100.0))),3}%") } else { "  …" }
 
             Console.Write(FormatPercent(0.42))
             """;
@@ -68,6 +66,8 @@ public class Issue2640ImportedInterpolatedStringHandlerEmitTests
         var (exitCode, diagnostics, outputPath, directory) = Compile(Source);
         try
         {
+            Assert.DoesNotContain("Cannot find function Create", diagnostics, StringComparison.Ordinal);
+            Assert.DoesNotContain("Cannot find function Round", diagnostics, StringComparison.Ordinal);
             Assert.True(exitCode == 0, diagnostics);
             IlVerifier.Verify(outputPath);
             Assert.Equal(" 42%", Run(outputPath, directory));


### PR DESCRIPTION
## Summary
- apply nil-guard narrowing inside if-expression branches before imported interpolated-string-handler overload resolution
- complete the exact nullable Oahu `JobsScreen.FormatPercent` aligned `String.Create` path after #2699
- prove the `Create`/`Round` GS0159 diagnostics are absent, then IL-verify and execute the emitted assembly

## Tests
- `Core.Tests`: 6,678 passed, 1 skipped
- focused interpolated-handler `Core.Tests`: 16 passed
- focused issue #2640 `Compiler.Tests`: 4 passed
- `Issue750ConstraintOverloadEmitTests`: 5 passed after building its SDK fixture

Fixes #2640