### PR TITLE
Fix imported method type identity lookup

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -4620,6 +4620,7 @@ internal sealed class ReflectionMetadataEmitter
     // imported-method lookup, not user-token-cache state.
     internal static MethodInfo FindImportedMethod(Type declaringType, FunctionSymbol method, BindingFlags bindingFlags)
     {
+        MethodInfo match = null;
         foreach (var candidate in declaringType.GetMethods(bindingFlags))
         {
             if (!string.Equals(candidate.Name, method.Name, StringComparison.Ordinal))
@@ -4638,13 +4639,19 @@ internal sealed class ReflectionMetadataEmitter
             {
                 var candidateType = parameters[i].ParameterType;
                 var methodType = method.Parameters[i].Type.ClrType;
-                if (parameters[i].ParameterType.IsByRef != (method.Parameters[i].RefKind != RefKind.None))
+                var isByRef = candidateType.IsByRef;
+                if (isByRef != (method.Parameters[i].RefKind != RefKind.None))
                 {
                     matches = false;
                     break;
                 }
 
-                if (methodType != null && candidateType != methodType && candidateType != methodType.MakeByRefType())
+                if (isByRef)
+                {
+                    candidateType = candidateType.GetElementType();
+                }
+
+                if (methodType != null && !ClrTypeUtilities.AreSame(candidateType, methodType))
                 {
                     matches = false;
                     break;
@@ -4653,11 +4660,17 @@ internal sealed class ReflectionMetadataEmitter
 
             if (matches)
             {
-                return candidate;
+                if (match != null)
+                {
+                    // Normalization can collapse metadata-distinct overloads.
+                    return null;
+                }
+
+                match = candidate;
             }
         }
 
-        return null;
+        return match;
     }
 
     // Issue #1785: `async func f(...) T?` for a same-compilation user value

--- a/test/Compiler.Tests/Emit/Issue2701ImportedStructMethodEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2701ImportedStructMethodEmitTests.cs
@@ -1,0 +1,195 @@
+// <copyright file="Issue2701ImportedStructMethodEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue2701ImportedStructMethodEmitTests
+{
+    private const string FixtureSource = """
+        namespace Oahu.Cli;
+
+        public readonly struct Icon
+        {
+            public string Render(bool enabled) => enabled ? "icon:on" : "icon:off";
+        }
+        """;
+
+    private const string OahuSource = """
+        package Oahu.Cli.App
+
+        import System
+        import Oahu.Cli
+
+        func Main() {
+            var icon = Icon()
+            Console.WriteLine(icon.Render(true))
+        }
+        """;
+
+    [Fact]
+    public void ExactOahuIconRender_CrossAssembly_RunsVerifiesAndReferencesExactMethod()
+    {
+        using var artifacts = Compile(OahuSource);
+
+        Assert.DoesNotContain("GS9998", artifacts.Diagnostics, StringComparison.Ordinal);
+        Assert.Equal("icon:on\n", Run(artifacts.OutputPath));
+        IlVerifier.Verify(artifacts.OutputPath, additionalReferences: new[] { artifacts.FixturePath });
+
+        using var stream = File.OpenRead(artifacts.OutputPath);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var renderHandle = Assert.Single(
+            reader.MemberReferences,
+            handle => reader.GetString(reader.GetMemberReference(handle).Name) == "Render");
+        var render = reader.GetMemberReference(renderHandle);
+        var parent = reader.GetTypeReference((TypeReferenceHandle)render.Parent);
+
+        Assert.Equal("Oahu.Cli", reader.GetString(parent.Namespace));
+        Assert.Equal("Icon", reader.GetString(parent.Name));
+        Assert.Equal(new byte[] { 0x20, 0x01, 0x0E, 0x02 }, reader.GetBlobBytes(render.Signature));
+    }
+
+    [Fact]
+    public void IconRender_WithWrongArgument_RemainsACompileTimeError()
+    {
+        var source = OahuSource.Replace("Render(true)", "Render(1)", StringComparison.Ordinal);
+        using var artifacts = Compile(source, expectSuccess: false);
+
+        Assert.NotEqual(0, artifacts.ExitCode);
+        Assert.Contains("GS0159", artifacts.Diagnostics, StringComparison.Ordinal);
+        Assert.DoesNotContain("GS9998", artifacts.Diagnostics, StringComparison.Ordinal);
+    }
+
+    private static CompilationArtifacts Compile(string source, bool expectSuccess = true)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2701-artifacts",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        var fixturePath = Path.Combine(directory, "Oahu.Cli.dll");
+        EmitFixture(fixturePath);
+        var sourcePath = Path.Combine(directory, "Program.gs");
+        var outputPath = Path.Combine(directory, "Oahu.Cli.App.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(
+                new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    "/reference:" + fixturePath,
+                    sourcePath,
+                });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        var diagnostics = stdout.ToString() + stderr.ToString();
+        if (expectSuccess)
+        {
+            Assert.True(exitCode == 0, $"gsc failed:\n{diagnostics}");
+        }
+
+        return new CompilationArtifacts(directory, fixturePath, outputPath, exitCode, diagnostics);
+    }
+
+    private static void EmitFixture(string path)
+    {
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(reference => MetadataReference.CreateFromFile(reference));
+        var compilation = CSharpCompilation.Create(
+            "Oahu.Cli",
+            new[] { CSharpSyntaxTree.ParseText(FixtureSource) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var result = compilation.Emit(path);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static string Run(string assemblyPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath)!,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+        Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}\n{stderr}");
+        return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private sealed class CompilationArtifacts : IDisposable
+    {
+        public CompilationArtifacts(
+            string directory,
+            string fixturePath,
+            string outputPath,
+            int exitCode,
+            string diagnostics)
+        {
+            Directory = directory;
+            FixturePath = fixturePath;
+            OutputPath = outputPath;
+            ExitCode = exitCode;
+            Diagnostics = diagnostics;
+        }
+
+        public string Directory { get; }
+
+        public string FixturePath { get; }
+
+        public string OutputPath { get; }
+
+        public int ExitCode { get; }
+
+        public string Diagnostics { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                System.IO.Directory.Delete(Directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2701ImportedMethodLookupTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2701ImportedMethodLookupTests.cs
@@ -1,0 +1,101 @@
+// <copyright file="Issue2701ImportedMethodLookupTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Emit;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Emit;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+public sealed class Issue2701ImportedMethodLookupTests
+{
+    [Fact]
+    public void MetadataContextMethod_MatchesRuntimePrimitiveGenericArrayAndByRefTypes()
+    {
+        using var resolver = ReferenceResolver.WithReferences(new[] { typeof(Issue2701MethodFixture).Assembly.Location });
+        Assert.True(resolver.TryResolveType(typeof(Issue2701MethodFixture).FullName!, out var declaringType));
+
+        var runtimeTypes = new[]
+        {
+            TypeSymbol.Bool,
+            ImportedTypeSymbol.Get(typeof(List<bool[]>)),
+            ImportedTypeSymbol.Get(typeof(bool[,])),
+        };
+        var method = new FunctionSymbol(
+            nameof(Issue2701MethodFixture.Shapes),
+            ImmutableArray.Create(
+                new ParameterSymbol("visible", runtimeTypes[0]),
+                new ParameterSymbol("groups", runtimeTypes[1]),
+                new ParameterSymbol("grid", runtimeTypes[2]),
+                new ParameterSymbol("enabled", TypeSymbol.Bool, refKind: RefKind.Ref)),
+            TypeSymbol.Void);
+
+        var candidate = ReflectionMetadataEmitter.FindImportedMethod(
+            declaringType,
+            method,
+            BindingFlags.Public | BindingFlags.Instance);
+
+        Assert.NotNull(candidate);
+        var metadataBool = candidate!.GetParameters()[0].ParameterType;
+        Assert.Equal(typeof(bool).FullName, metadataBool.FullName);
+        Assert.False(ReferenceEquals(metadataBool, typeof(bool)));
+    }
+
+    [Fact]
+    public void StructurallyAmbiguousOverloads_ReturnNoMatch()
+    {
+        var first = DefineDuplicateType("Issue2701.First");
+        var second = DefineDuplicateType("Issue2701.Second");
+        var declaringType = DefineOverloads(first, second);
+        var method = new FunctionSymbol(
+            "Pick",
+            ImmutableArray.Create(new ParameterSymbol("value", ImportedTypeSymbol.Get(first))),
+            TypeSymbol.Void);
+
+        var candidate = ReflectionMetadataEmitter.FindImportedMethod(
+            declaringType,
+            method,
+            BindingFlags.Public | BindingFlags.Static);
+
+        Assert.Null(candidate);
+    }
+
+    private static Type DefineDuplicateType(string assemblyName)
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(assemblyName), AssemblyBuilderAccess.Run);
+        return assembly.DefineDynamicModule(assemblyName).DefineType("Oahu.Cli.Duplicate").CreateType()!;
+    }
+
+    private static Type DefineOverloads(Type first, Type second)
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Issue2701.Overloads"), AssemblyBuilderAccess.Run);
+        var type = assembly.DefineDynamicModule("Issue2701.Overloads").DefineType("Oahu.Cli.Overloads");
+        DefineOverload(type, first);
+        DefineOverload(type, second);
+        return type.CreateType()!;
+    }
+
+    private static void DefineOverload(TypeBuilder type, Type parameterType)
+    {
+        var method = type.DefineMethod(
+            "Pick",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(void),
+            new[] { parameterType });
+        method.GetILGenerator().Emit(OpCodes.Ret);
+    }
+}
+
+public sealed class Issue2701MethodFixture
+{
+    public void Shapes(bool visible, List<bool[]> groups, bool[,] grid, ref bool enabled)
+    {
+    }
+}


### PR DESCRIPTION
Fixes #2701

- compare imported parameter types structurally across runtime and MetadataLoadContext boundaries
- preserve by-ref shape and reject normalized ambiguities
- cover exact Oahu.Cli Icon.Render(bool) runtime, ILVerify, metadata signature, composite types, and negative cases