### PR TITLE
Fix method-group conversion diagnostics before emit

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Constructors.cs
@@ -364,6 +364,13 @@ internal sealed partial class OverloadResolver
                     continue;
                 }
 
+                if (TryBindConstructorMethodGroup(argument, parameter.Type, parameterSyntaxV[i].Location, out var methodGroupArg))
+                {
+                    boundArguments[i] = methodGroupArg;
+                    hasErrorsV |= methodGroupArg is BoundErrorExpression;
+                    continue;
+                }
+
                 // Issue #2069/#2084: force the wrap for a func/arrow literal
                 // argument flowing into a NAMED delegate parameter — see the
                 // matching comment at the other constructor-argument path
@@ -610,6 +617,13 @@ internal sealed partial class OverloadResolver
                 && !ReferenceEquals(argument.Type, namedDelegateCtorTarget))
             {
                 boundArguments[i] = conversions.BindConversion(parameterSyntax[i].Location, argument, parameter.Type);
+                continue;
+            }
+
+            if (TryBindConstructorMethodGroup(argument, parameter.Type, parameterSyntax[i].Location, out var methodGroupArg))
+            {
+                boundArguments[i] = methodGroupArg;
+                hasErrors |= methodGroupArg is BoundErrorExpression;
                 continue;
             }
 
@@ -1029,6 +1043,13 @@ internal sealed partial class OverloadResolver
                 ? parameterSyntax[i].Location
                 : syntax.Identifier.Location;
 
+            if (TryBindConstructorMethodGroup(argument, paramType, argLocation, out var methodGroupArg))
+            {
+                convertedArguments.Add(methodGroupArg);
+                hasErrors |= methodGroupArg is BoundErrorExpression;
+                continue;
+            }
+
             // Issue #2069: force the wrap for a func/arrow literal argument
             // flowing into a NAMED delegate parameter — see the matching
             // comment above (constructor-argument path) for the full
@@ -1430,6 +1451,13 @@ internal sealed partial class OverloadResolver
                 i < parameterSyntax.Length ? parameterSyntax[i] : null,
                 parameter.Type);
 
+            if (TryBindConstructorMethodGroup(argument, parameter.Type, argLocation, out var methodGroupArg))
+            {
+                convertedArgs.Add(methodGroupArg);
+                hadErrors |= methodGroupArg is BoundErrorExpression;
+                continue;
+            }
+
             if (argument.Type == TypeSymbol.Error)
             {
                 hadErrors = true;
@@ -1520,6 +1548,22 @@ internal sealed partial class OverloadResolver
         }
 
         return new BoundConstructorChainingExpression(syntax, selectedCtor, convertedArgs.ToImmutable());
+    }
+
+    private bool TryBindConstructorMethodGroup(
+        BoundExpression argument,
+        TypeSymbol targetType,
+        TextLocation location,
+        out BoundExpression converted)
+    {
+        if (OverloadResolution.IsUnresolvedMethodGroupArgument(argument))
+        {
+            converted = conversions.BindConversion(location, argument, targetType);
+            return true;
+        }
+
+        converted = null;
+        return false;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue2700MethodGroupNullableDiagnosticsTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2700MethodGroupNullableDiagnosticsTests.cs
@@ -1,0 +1,116 @@
+// <copyright file="Issue2700MethodGroupNullableDiagnosticsTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Issue #2700: failed method-group conversions are diagnosed before emit.</summary>
+public sealed class Issue2700MethodGroupNullableDiagnosticsTests
+{
+    [Fact]
+    public void ClrMethodGroup_NullableObliviousDelegateParameter_BindsAndRuns()
+    {
+        const string source = """
+            package Issue2700
+            import System
+
+            class Runner {
+                private var callback (string?) -> void
+
+                init(callback (string?) -> void) {
+                    this.callback = callback
+                }
+
+                func Run() {
+                    callback("ok")
+                }
+            }
+
+            func Main() {
+                let runner = Runner(Console.WriteLine)
+                runner.Run()
+            }
+            """;
+
+        using var resolver = ReferenceResolver.WithReferences([]);
+        var compilation = new Compilation(resolver, SyntaxTree.Parse(SourceText.From(source)));
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream, null, null, "Issue2700Runtime");
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+
+        stream.Position = 0;
+        var context = new AssemblyLoadContext("Issue2700Runtime", isCollectible: true);
+        try
+        {
+            var assembly = context.LoadFromStream(stream);
+            var previous = Console.Out;
+            using var output = new StringWriter();
+            Console.SetOut(output);
+            try
+            {
+                assembly.EntryPoint!.Invoke(null, null);
+            }
+            finally
+            {
+                Console.SetOut(previous);
+            }
+
+            Assert.Equal("ok\n", output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    [Fact]
+    public void OahuAudibleClientMethodGroup_NullableParameterMismatch_ReportsSourceDiagnostic()
+    {
+        const string source = """
+            package Issue2700
+
+            interface IProfile { }
+
+            class Authorize {
+                async func RefreshTokenAsync(profile IProfile) { }
+                internal async func RefreshTokenAsync(profile IProfile?, automatic bool) { }
+            }
+
+            class AudibleApi {
+                init(refreshTokenAsyncFunc async (IProfile?) -> void) { }
+            }
+
+            class AudibleClient {
+                private var authorize Authorize?
+                private var audibleApi AudibleApi?
+
+                prop Api AudibleApi? {
+                    get {
+                        if audibleApi == nil {
+                            audibleApi = AudibleApi(authorize!!.RefreshTokenAsync)
+                        }
+                        return audibleApi!!
+                    }
+                }
+            }
+            """;
+
+        using var resolver = ReferenceResolver.WithReferences([]);
+        var compilation = new Compilation(resolver, SyntaxTree.Parse(SourceText.From(source)));
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream, null, null, "Issue2700Negative");
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0218");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS9998");
+    }
+}


### PR DESCRIPTION
## Summary
- route unresolved user and CLR method groups through target-typed conversion in every constructor path
- preserve valid nullable-oblivious CLR method-group conversions
- report GS0218 for the exact Oahu AudibleClient nullable mismatch instead of emit-time GS9998

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj` (6,678 passed, 1 skipped)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter FullyQualifiedName~Issue2700MethodGroupNullableDiagnosticsTests` (2 passed)

Fixes #2700