### PR TITLE
Fix async iterator protected-region branches

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
@@ -142,7 +142,8 @@ public static class AsyncIteratorMoveNextBodyBuilder
             // return; (after try/catch)
             stmts.Add(new BoundReturnStatement(null, null));
 
-            return new BoundBlockStatement(null, stmts.ToImmutable());
+            return AsyncIteratorProtectedRegionBranchRewriter.Rewrite(
+                new BoundBlockStatement(null, stmts.ToImmutable()));
         }
 
         private BoundBlockStatement BuildTryBody()

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorProtectedRegionBranchRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorProtectedRegionBranchRewriter.cs
@@ -1,0 +1,317 @@
+// <copyright file="AsyncIteratorProtectedRegionBranchRewriter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Iterators;
+
+/// <summary>
+/// Routes async-iterator branches that enter a protected try region through
+/// legal outside-entry and inside-dispatch points.
+/// </summary>
+internal static class AsyncIteratorProtectedRegionBranchRewriter
+{
+    public static BoundBlockStatement Rewrite(BoundBlockStatement body)
+    {
+        var plan = Planner.Create(body);
+        if (!plan.HasRoutes)
+        {
+            return body;
+        }
+
+        var selector = new LocalVariableSymbol("<>ai_seh_branch", isReadOnly: false, TypeSymbol.Int32);
+        var rewritten = (BoundBlockStatement)new Rewriter(plan, selector).RewriteStatement(body);
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>(rewritten.Statements.Length + 1);
+        statements.Add(new BoundVariableDeclaration(null, selector, new BoundLiteralExpression(null, 0)));
+        statements.AddRange(rewritten.Statements);
+        return new BoundBlockStatement(null, statements.ToImmutable());
+    }
+
+    private readonly struct Route
+    {
+        public Route(int selector, BoundLabel entryLabel)
+        {
+            Selector = selector;
+            EntryLabel = entryLabel;
+        }
+
+        public int Selector { get; }
+
+        public BoundLabel EntryLabel { get; }
+    }
+
+    private readonly struct DispatchEntry
+    {
+        public DispatchEntry(int selector, BoundLabel target)
+        {
+            Selector = selector;
+            Target = target;
+        }
+
+        public int Selector { get; }
+
+        public BoundLabel Target { get; }
+    }
+
+    private sealed class Plan
+    {
+        public Dictionary<BoundStatement, Route> Routes { get; } = new();
+
+        public Dictionary<BoundTryStatement, BoundLabel> EntryLabels { get; } = new();
+
+        public Dictionary<BoundTryStatement, List<DispatchEntry>> DispatchEntries { get; } = new();
+
+        public HashSet<BoundLabel> RoutedTargets { get; } = new();
+
+        public bool HasRoutes => Routes.Count != 0;
+    }
+
+    private sealed class Planner : BoundTreeWalker
+    {
+        private readonly List<BoundTryStatement> tryStack = new();
+        private readonly Dictionary<BoundLabel, ImmutableArray<BoundTryStatement>> labelRegions = new();
+        private readonly List<(BoundStatement Branch, BoundLabel Target, ImmutableArray<BoundTryStatement> Regions)> branches = new();
+
+        public static Plan Create(BoundStatement body)
+        {
+            var planner = new Planner();
+            planner.VisitStatement(body);
+            return planner.Build();
+        }
+
+        public override void VisitStatement(BoundStatement node)
+        {
+            switch (node)
+            {
+                case BoundLabelStatement label:
+                    labelRegions[label.Label] = tryStack.ToImmutableArray();
+                    return;
+                case BoundGotoStatement go:
+                    branches.Add((go, go.Label, tryStack.ToImmutableArray()));
+                    return;
+                case BoundConditionalGotoStatement conditional:
+                    branches.Add((conditional, conditional.Label, tryStack.ToImmutableArray()));
+                    break;
+            }
+
+            base.VisitStatement(node);
+        }
+
+        protected override void VisitTryStatement(BoundTryStatement node)
+        {
+            tryStack.Add(node);
+            VisitStatement(node.TryBlock);
+            tryStack.RemoveAt(tryStack.Count - 1);
+
+            foreach (var clause in node.CatchClauses)
+            {
+                VisitStatement(clause.Body);
+            }
+
+            if (node.FinallyBlock != null)
+            {
+                VisitStatement(node.FinallyBlock);
+            }
+        }
+
+        private Plan Build()
+        {
+            var plan = new Plan();
+            var selectors = new Dictionary<BoundLabel, int>();
+            var nextSelector = 1;
+            var nextEntry = 0;
+
+            foreach (var (branch, target, sourceRegions) in branches)
+            {
+                if (!labelRegions.TryGetValue(target, out var targetRegions))
+                {
+                    continue;
+                }
+
+                var commonDepth = 0;
+                while (commonDepth < sourceRegions.Length
+                    && commonDepth < targetRegions.Length
+                    && ReferenceEquals(sourceRegions[commonDepth], targetRegions[commonDepth]))
+                {
+                    commonDepth++;
+                }
+
+                if (commonDepth == targetRegions.Length)
+                {
+                    continue;
+                }
+
+                if (!selectors.TryGetValue(target, out var selector))
+                {
+                    selector = nextSelector++;
+                    selectors[target] = selector;
+                    plan.RoutedTargets.Add(target);
+                }
+
+                BoundLabel EntryLabel(BoundTryStatement tryStatement)
+                {
+                    if (!plan.EntryLabels.TryGetValue(tryStatement, out var label))
+                    {
+                        label = new BoundLabel("<>ai_seh_entry_" + nextEntry++);
+                        plan.EntryLabels[tryStatement] = label;
+                    }
+
+                    return label;
+                }
+
+                plan.Routes[branch] = new Route(selector, EntryLabel(targetRegions[commonDepth]));
+
+                for (var depth = commonDepth; depth < targetRegions.Length; depth++)
+                {
+                    var region = targetRegions[depth];
+                    var dispatchTarget = depth + 1 == targetRegions.Length
+                        ? target
+                        : EntryLabel(targetRegions[depth + 1]);
+
+                    if (!plan.DispatchEntries.TryGetValue(region, out var entries))
+                    {
+                        entries = new List<DispatchEntry>();
+                        plan.DispatchEntries[region] = entries;
+                    }
+
+                    var duplicate = false;
+                    foreach (var entry in entries)
+                    {
+                        if (entry.Selector == selector && ReferenceEquals(entry.Target, dispatchTarget))
+                        {
+                            duplicate = true;
+                            break;
+                        }
+                    }
+
+                    if (!duplicate)
+                    {
+                        entries.Add(new DispatchEntry(selector, dispatchTarget));
+                    }
+                }
+            }
+
+            return plan;
+        }
+    }
+
+    private sealed class Rewriter : BoundTreeRewriter
+    {
+        private readonly Plan plan;
+        private readonly LocalVariableSymbol selector;
+        private int skipOrdinal;
+
+        public Rewriter(Plan plan, LocalVariableSymbol selector)
+        {
+            this.plan = plan;
+            this.selector = selector;
+        }
+
+        protected override BoundStatement RewriteGotoStatement(BoundGotoStatement node)
+        {
+            if (!plan.Routes.TryGetValue(node, out var route))
+            {
+                return node;
+            }
+
+            return new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(
+                AssignSelector(route.Selector),
+                new BoundGotoStatement(null, route.EntryLabel)));
+        }
+
+        protected override BoundStatement RewriteConditionalGotoStatement(BoundConditionalGotoStatement node)
+        {
+            if (!plan.Routes.TryGetValue(node, out var route))
+            {
+                return base.RewriteConditionalGotoStatement(node);
+            }
+
+            var skip = new BoundLabel("<>ai_seh_skip_" + skipOrdinal++);
+            return new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(
+                new BoundConditionalGotoStatement(
+                    null,
+                    skip,
+                    RewriteExpression(node.Condition),
+                    jumpIfTrue: !node.JumpIfTrue),
+                AssignSelector(route.Selector),
+                new BoundGotoStatement(null, route.EntryLabel),
+                new BoundLabelStatement(null, skip)));
+        }
+
+        protected override BoundStatement RewriteLabelStatement(BoundLabelStatement node)
+        {
+            if (!plan.RoutedTargets.Contains(node.Label))
+            {
+                return node;
+            }
+
+            return new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(
+                node,
+                AssignSelector(0)));
+        }
+
+        protected override BoundStatement RewriteTryStatement(BoundTryStatement node)
+        {
+            var result = (BoundTryStatement)base.RewriteTryStatement(node);
+            if (plan.DispatchEntries.TryGetValue(node, out var entries))
+            {
+                var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+                foreach (var entry in entries)
+                {
+                    statements.Add(new BoundConditionalGotoStatement(
+                        null,
+                        entry.Target,
+                        new BoundBinaryExpression(
+                            null,
+                            new BoundVariableExpression(null, selector),
+                            BoundBinaryOperator.Bind(
+                                SyntaxKind.EqualsEqualsToken,
+                                TypeSymbol.Int32,
+                                TypeSymbol.Int32),
+                            new BoundLiteralExpression(null, entry.Selector)),
+                        jumpIfTrue: true));
+                }
+
+                if (result.TryBlock is BoundBlockStatement block)
+                {
+                    statements.AddRange(block.Statements);
+                }
+                else
+                {
+                    statements.Add(result.TryBlock);
+                }
+
+                result = new BoundTryStatement(
+                    null,
+                    new BoundBlockStatement(null, statements.ToImmutable()),
+                    result.CatchClauses,
+                    result.FinallyBlock);
+            }
+
+            if (!plan.EntryLabels.TryGetValue(node, out var entryLabel))
+            {
+                return result;
+            }
+
+            return new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(
+                new BoundLabelStatement(null, entryLabel),
+                new BoundExpressionStatement(null, new BoundVariableExpression(null, selector)),
+                result));
+        }
+
+        private BoundStatement AssignSelector(int value)
+        {
+            return new BoundExpressionStatement(
+                null,
+                new BoundAssignmentExpression(
+                    null,
+                    selector,
+                    new BoundLiteralExpression(null, value)));
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/CaptureMatrixEmitTests.cs
+++ b/test/Compiler.Tests/Emit/CaptureMatrixEmitTests.cs
@@ -297,30 +297,29 @@ public class CaptureMatrixEmitTests
             }
             """, "42\n");
 
-        yield return Row("Issue2662_ExactOahuCliAppAudibleJobExecutor", """
+        yield return Row("Issue2662_ExactOahuCliAppAudibleJobExecutor_2ff82b6ad30d", """
             package Oahu.Cli.App
             import System
             import System.Collections.Generic
+            import System.IO
             import System.Threading.Tasks
-            import System.Threading.Channels
 
             class JobUpdate {
                 var Value int32 = 0
             }
 
             class AudibleJobExecutor {
-                async func ExecuteAsync() IAsyncEnumerable[JobUpdate] {
-                    let channel = Channel.CreateUnbounded[JobUpdate]()
+                async func ExecuteAsync(skip bool) IAsyncEnumerable[JobUpdate] {
+                    if skip {
+                        goto iteratorExit
+                    }
+                    using let resource = MemoryStream()
                     let first = JobUpdate()
                     first.Value = 42
-                    channel.Writer.TryWrite(first)
-                    channel.Writer.TryComplete()
                     let runTask = Task.CompletedTask
                     try {
-                        while await channel.Reader.WaitToReadAsync() {
-                            while channel.Reader.TryRead(out var update) {
-                                yield update
-                            }
+                        if await Task.FromResult(true) {
+                            yield first
                         }
                     } finally {
                         try {
@@ -328,11 +327,14 @@ public class CaptureMatrixEmitTests
                         } catch (Exception) {
                         }
                     }
+                    iteratorExit:
+                    {
+                    }
                 }
             }
 
             func Main() {
-                let e = AudibleJobExecutor().ExecuteAsync().GetAsyncEnumerator()
+                let e = AudibleJobExecutor().ExecuteAsync(false).GetAsyncEnumerator()
                 var total = 0
                 if e.MoveNextAsync().AsTask().Result {
                     total = total + e.Current.Value
@@ -359,6 +361,51 @@ public class CaptureMatrixEmitTests
                 let e = AudibleJobExecutor().ExecuteAsync().GetAsyncEnumerator()
                 if e.MoveNextAsync().AsTask().Result {
                     Console.WriteLine(e.Current)
+                }
+            }
+            """, "42\n");
+
+        yield return Row("Issue2662_ExactOahuCliAppJsonlHistoryStore_8aff8d9048f7", """
+            package Oahu.Cli.App
+            import System
+            import System.Collections.Generic
+            import System.IO
+            import System.Threading.Tasks
+
+            class JobRecord {
+                var Value int32 = 0
+            }
+
+            class JsonlHistoryStore {
+                async func ReadAllAsync(skip bool) IAsyncEnumerable[JobRecord] {
+                    if skip {
+                        goto iteratorExit
+                    }
+                    using let reader = MemoryStream()
+                    var done = false
+                    while !done {
+                        let line = await Task.FromResult("42")
+                        var rec JobRecord? = nil
+                        try {
+                            rec = JobRecord()
+                            rec!!.Value = Int32.Parse(line)
+                        } catch (Exception) {
+                        }
+                        if rec != nil {
+                            yield rec!!
+                        }
+                        done = true
+                    }
+                    iteratorExit:
+                    {
+                    }
+                }
+            }
+
+            func Main() {
+                let e = JsonlHistoryStore().ReadAllAsync(false).GetAsyncEnumerator()
+                if e.MoveNextAsync().AsTask().Result {
+                    Console.WriteLine(e.Current.Value)
                 }
             }
             """, "42\n");


### PR DESCRIPTION
## Summary
- route arbitrary async-iterator MoveNext branches through outside-entry/inside-dispatch SEH topology
- preserve legal same-region and outward branches while handling nested protected regions
- cover the exact Oahu.Cli.App ExecuteAsync and ReadAllAsync shapes with runtime and strict ILVerify tests

## Verification
- exact cycle-9 Oahu.Cli.App rebuild: BranchIntoTry fingerprints 2 -> 0 (7 findings -> 0)
  - 2ff82b6ad30d ExecuteAsync
  - 8aff8d9048f7 ReadAllAsync
- capture matrix: 20/20 passed (runtime + ILVerify)
- negative lambda-own-parameter capture test passed
- Release solution build: 0 warnings, 0 errors
- solution suites green: Core 6678/6678, Cs2Gs 1713/1713, LanguageServer 450/450, Interpreter 429/429, Extensions 104/104, SDK 43/43, GeneratorHost 29/29, InternalAnalyzers 7/7

Fixes #2662