### PR TITLE
Fix for-range closure capture hoisting

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -45,10 +45,9 @@ namespace GSharp.Core.CodeAnalysis.Lowering;
 /// the lambda body to read the static field directly at every use.
 /// </para>
 /// <para>
-/// For-range key/value variables are intentionally not boxed: the
-/// existing snapshot emit happens to match C#'s
-/// per-iteration-fresh-variable semantics for <c>foreach</c>, so leaving
-/// them alone is both correct and cheaper.
+/// For-range key/value variables are boxed at the start of each iteration.
+/// This preserves foreach-style fresh-variable semantics when closures
+/// escape while still sharing one cell among closures from the same iteration.
 /// </para>
 /// </remarks>
 internal static class CaptureBoxingRewriter
@@ -865,6 +864,44 @@ internal static class CaptureBoxingRewriter
             }
 
             return new BoundSelectStatement(null, builder.MoveToImmutable());
+        }
+
+        /// <inheritdoc/>
+        protected override BoundStatement RewriteForRangeStatement(BoundForRangeStatement node)
+        {
+            var collection = this.RewriteExpression(node.Collection);
+            var body = this.RewriteStatement(node.Body);
+            var seed = ImmutableArray<BoundStatement>.Empty;
+
+            if (node.KeyVariable != null && this.boxInfo.TryGetValue(node.KeyVariable, out var keyBox))
+            {
+                seed = seed.AddRange(this.BuildBoxSeedStatements(keyBox));
+            }
+
+            if (node.ValueVariable != null && this.boxInfo.TryGetValue(node.ValueVariable, out var valueBox))
+            {
+                seed = seed.AddRange(this.BuildBoxSeedStatements(valueBox));
+            }
+
+            if (!seed.IsEmpty)
+            {
+                body = PrependSeedStatements(body, seed);
+            }
+
+            if (ReferenceEquals(collection, node.Collection) && ReferenceEquals(body, node.Body))
+            {
+                return node;
+            }
+
+            return new BoundForRangeStatement(
+                node.Syntax,
+                node.KeyVariable,
+                node.ValueVariable,
+                collection,
+                node.IterationKind,
+                body,
+                node.BreakLabel,
+                node.ContinueLabel);
         }
 
         /// <inheritdoc/>

--- a/test/Compiler.Tests/Emit/Issue2715ForRangeNestedCaptureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2715ForRangeNestedCaptureEmitTests.cs
@@ -1,0 +1,209 @@
+// <copyright file="Issue2715ForRangeNestedCaptureEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2715: a for-range variable captured by a nested lambda inside an
+/// outer lambda was boxed without allocating the box in the outer closure.
+/// </summary>
+public class Issue2715ForRangeNestedCaptureEmitTests
+{
+    [Fact]
+    public void OahuPlainOutputWriter_OuterSafeWriteForRowNestedSelect_RunsAndVerifies()
+    {
+        const string Source = """
+            package Oahu.Cli.Output
+            import System
+            import System.Collections.Generic
+            import System.IO
+            import System.Linq
+
+            class OutputColumn(key string, header string) {
+                prop Key string -> key
+                prop Header string -> header
+            }
+
+            class PlainOutputWriter {
+                private let writer TextWriter
+
+                init(writer TextWriter) {
+                    this.writer = writer
+                }
+
+                func WriteCollection(resourceName string, rows IReadOnlyList[IReadOnlyDictionary[string, object?]], columns IReadOnlyList[OutputColumn]) {
+                    PlainOutputWriter.SafeWrite(() -> {
+                        writer.WriteLine(String.Join('\t', columns.Select((c OutputColumn) -> c.Header)))
+                        for row in rows {
+                            writer.WriteLine(String.Join('\t', columns.Select((c OutputColumn) -> PlainOutputWriter.Format(if row!!.TryGetValue(c.Key, out var v) { v } else { default(object?) }))))
+                        }
+                    })
+                }
+
+                shared {
+                    private func SafeWrite(action () -> void) {
+                        try {
+                            action()
+                        } catch (ex IOException) {
+                        } catch (ex ObjectDisposedException) {
+                        }
+                    }
+
+                    private func Format(value object?) string {
+                        return value?.ToString() ?? String.Empty
+                    }
+                }
+            }
+
+            var first = Dictionary[string, object?]()
+            first.Add("left", "a")
+            first.Add("right", "b")
+            var second = Dictionary[string, object?]()
+            second.Add("left", "c")
+            second.Add("right", "d")
+            var rows = List[IReadOnlyDictionary[string, object?]]{ first, second }
+            var columns = List[OutputColumn]{ OutputColumn("right", "R"), OutputColumn("left", "L") }
+            let output = StringWriter()
+            PlainOutputWriter(output).WriteCollection("items", rows, columns)
+            Console.Write(output.ToString())
+            """;
+
+        Assert.Equal("R\tL\nb\ta\nd\tc\n", CompileVerifyAndRun(Source, "Oahu"));
+    }
+
+    [Fact]
+    public void ForRange_EscapingClosures_GetFreshBoxPerIteration()
+    {
+        const string Source = """
+            package ForRangeCapture
+            import System
+            import System.Collections.Generic
+
+            func SafeWrite(action () -> void) {
+                action()
+            }
+
+            var values = List[int32]{ 1, 2, 3 }
+            var readers = List[(() -> int32)]()
+            SafeWrite(() -> {
+                for value in values {
+                    readers.Add(() -> value)
+                }
+            })
+            Console.WriteLine(readers[0]())
+            Console.WriteLine(readers[1]())
+            Console.WriteLine(readers[2]())
+            """;
+
+        Assert.Equal("1\n2\n3\n", CompileVerifyAndRun(Source, "Escaping"));
+    }
+
+    [Fact]
+    public void ForRange_KeyAndValueCapturedByNestedClosure_RunsAndVerifies()
+    {
+        const string Source = """
+            package ForRangeKeyValueCapture
+            import System
+            import System.Collections.Generic
+
+            var values = List[string]{ "a", "b" }
+            var readers = List[(() -> string)]()
+            let outer = () -> {
+                for index, value in values {
+                    readers.Add(() -> index.ToString() + value)
+                }
+            }
+            outer()
+            Console.WriteLine(readers[0]())
+            Console.WriteLine(readers[1]())
+            """;
+
+        Assert.Equal("0a\n1b\n", CompileVerifyAndRun(Source, "KeyValue"));
+    }
+
+    [Fact]
+    public void ForRange_VariableOutsideLoop_RemainsRejected()
+    {
+        var syntax = SyntaxTree.Parse(SourceText.From(
+            """
+            package ForRangeCaptureNegative
+            import System.Collections.Generic
+
+            func Run() {
+                for value in List[int32]{ 1 } {}
+                let invalid = () -> value
+            }
+            """));
+        var compilation = new Compilation(syntax);
+
+        using var output = new MemoryStream();
+        var result = compilation.Emit(output, pdbStream: null, refStream: null, assemblyName: "Issue2715.Negative");
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0125");
+    }
+
+    private static string CompileVerifyAndRun(string source, string caseName)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2715Emit", caseName);
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            Assert.True(exitCode == 0, $"compile failed ({exitCode}):\n{stdout}\n{stderr}");
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        IlVerifier.Verify(outputPath);
+
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                outputPath,
+            },
+            WorkingDirectory = directory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(process.ExitCode == 0, error);
+        return output.Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary
- allocate and seed captured `for … in` key/value boxes inside each iteration before nested closure construction
- preserve fresh per-iteration cells for escaping closures while sharing cells within an iteration
- cover the exact Oahu `PlainOutputWriter` `SafeWrite`/row/`Select` shape, key/value captures, escaping closures, runtime, ILVerify, and negative scope behavior

## Testing
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter FullyQualifiedName~Issue2715ForRangeNestedCaptureEmitTests` (4 passed)
- closure capture regression group (64 passed)
- `dotnet test test/Core.Tests/Core.Tests.csproj` (6,680 passed, 1 skipped)

Fixes #2715