### PR TITLE
Fix never-returning lambda delegate conversions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -2140,6 +2140,11 @@ public sealed class Conversion
 
         var invokeReturnIsVoid = invokeReturnType == null
             || string.Equals(invokeReturnType.FullName, "System.Void", StringComparison.Ordinal);
+        if (fn.ReturnType == TypeSymbol.Never)
+        {
+            return true;
+        }
+
         if (fn.ReturnType == TypeSymbol.Void || fn.ReturnType == null)
         {
             return invokeReturnIsVoid;
@@ -2457,6 +2462,13 @@ public sealed class Conversion
     /// </summary>
     private static bool ReturnTypeWidens(TypeSymbol fromReturn, TypeSymbol toReturn)
     {
+        // Issue #2716: `never` is the bottom type. A callable that cannot
+        // return satisfies every result slot, including void.
+        if (fromReturn == TypeSymbol.Never && toReturn != null)
+        {
+            return true;
+        }
+
         if (fromReturn == null || toReturn == null
             || fromReturn == TypeSymbol.Void || toReturn == TypeSymbol.Void)
         {

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -441,6 +441,23 @@ internal sealed class ConversionClassifier
             return createErasedFunctionLiteralAdapter(literal, targetFunctionType);
         }
 
+        // Issue #2716: a throw-expression lambda naturally has a `never`
+        // result. Shape its synthesized method to the target result type; the
+        // body still throws and therefore needs no value conversion.
+        if (expression is BoundFunctionLiteralExpression neverCandidateLiteral
+            && neverCandidateLiteral.FunctionType is FunctionTypeSymbol neverCandidateFnType
+            && neverCandidateFnType.ReturnType == TypeSymbol.Never
+            && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(type, out var neverTargetFnType)
+            && !ReferenceEquals(neverTargetFnType.ReturnType, TypeSymbol.Never)
+            && Conversion.Classify(neverCandidateFnType, neverTargetFnType).IsImplicit)
+        {
+            var shaped = createErasedFunctionLiteralAdapter(neverCandidateLiteral, neverTargetFnType);
+            if (!ReferenceEquals(shaped, neverCandidateLiteral))
+            {
+                return BindConversion(diagnosticLocation, shaped, type, allowExplicit);
+            }
+        }
+
         // Issue #889: a `func`/arrow literal whose natural return type carries a
         // value (e.g. `() -> called = called + 1`, inferred as `() -> int32`)
         // converts to a void-returning delegate target (System.Action, a named

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -2013,7 +2013,9 @@ internal sealed class LambdaBinder
                         new BoundReturnStatement(rewritten.Syntax, expression: null)));
             }
 
-            if (rewritten.Expression.Type == this.adapterReturnType)
+            // A bottom-typed return never reaches the target slot.
+            if (rewritten.Expression.Type == this.adapterReturnType
+                || rewritten.Expression.Type == TypeSymbol.Never)
             {
                 return rewritten;
             }

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -113,6 +113,16 @@ internal sealed class SlotPlanner
             .OrderBy(s => s.Declaration?.Span.Start ?? int.MaxValue)
             .ThenBy(s => s.Name, StringComparer.Ordinal))
         {
+            // Issue #2716: instance initializers are injected into constructors
+            // after MethodDef planning, so discover their lambdas here.
+            foreach (var field in type.Fields)
+            {
+                if (type.InstanceFieldInitializers.TryGetValue(field, out var initializer))
+                {
+                    collector.Visit(initializer);
+                }
+            }
+
             foreach (var field in type.StaticFields)
             {
                 if (type.StaticFieldInitializers.TryGetValue(field, out var initializer))

--- a/test/Compiler.Tests/Emit/Issue1018ThrowExpressionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1018ThrowExpressionEmitTests.cs
@@ -180,6 +180,63 @@ public class Issue1018ThrowExpressionEmitTests
     }
 
     [Fact]
+    public void ThrowOnlyLambda_TypedFactoryShapes_ThrowThroughToCatch()
+    {
+        // Issue #2716: `() -> never` must lower to each target signature while
+        // retaining the throw as the only runtime control-flow edge.
+        var source = """
+            package P
+
+            import System
+
+            interface IAuthService {
+            }
+
+            class ServiceFactories {
+                private var _auth () -> IAuthService = () -> throw InvalidOperationException("auth")
+
+                func Auth() IAuthService -> this._auth()
+            }
+
+            type NumberFactory = delegate func() int32
+
+            let numberFactory Func[int32] = () -> throw InvalidOperationException("number")
+            let namedFactory NumberFactory = () -> throw InvalidOperationException("named")
+            let action Action = () -> throw InvalidOperationException("action")
+
+            let factories = ServiceFactories()
+            try {
+                factories.Auth()
+                Console.WriteLine("unreachable auth")
+            } catch (e InvalidOperationException) {
+                Console.WriteLine(e.Message)
+            }
+            try {
+                numberFactory()
+                Console.WriteLine("unreachable number")
+            } catch (e InvalidOperationException) {
+                Console.WriteLine(e.Message)
+            }
+            try {
+                namedFactory()
+                Console.WriteLine("unreachable named")
+            } catch (e InvalidOperationException) {
+                Console.WriteLine(e.Message)
+            }
+            try {
+                action()
+                Console.WriteLine("unreachable action")
+            } catch (e InvalidOperationException) {
+                Console.WriteLine(e.Message)
+            }
+            Console.WriteLine("done")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("auth\nnumber\nnamed\naction\ndone\n", output);
+    }
+
+    [Fact]
     public void ThrowExpression_InArgumentPosition()
     {
         var source = """

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1018ThrowExpressionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1018ThrowExpressionTests.cs
@@ -2,8 +2,12 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
+using System.Collections.Immutable;
 using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
@@ -146,6 +150,88 @@ func f(s string?) string {
 ";
         var diagnostics = EmitDiagnostics(Source);
         Assert.Contains(diagnostics, d => d.IsError && d.Message.Contains("System.Exception"));
+    }
+
+    [Theory]
+    [InlineData("int32")]
+    [InlineData("string")]
+    [InlineData("void")]
+    public void NeverReturningFunction_ConvertsToAnyFunctionResult(string resultName)
+    {
+        var resultType = resultName switch
+        {
+            "int32" => TypeSymbol.Int32,
+            "string" => TypeSymbol.String,
+            _ => TypeSymbol.Void,
+        };
+        var from = FunctionTypeSymbol.Get(ImmutableArray<TypeSymbol>.Empty, TypeSymbol.Never);
+        var to = FunctionTypeSymbol.Get(ImmutableArray<TypeSymbol>.Empty, resultType);
+
+        var conversion = Conversion.Classify(from, to);
+
+        Assert.True(conversion.Exists);
+        Assert.True(conversion.IsImplicit);
+    }
+
+    [Theory]
+    [InlineData(typeof(Func<int>))]
+    [InlineData(typeof(Func<string>))]
+    [InlineData(typeof(Action))]
+    public void NeverReturningFunction_ConvertsToAnyClrDelegateResult(Type delegateType)
+    {
+        var from = FunctionTypeSymbol.Get(ImmutableArray<TypeSymbol>.Empty, TypeSymbol.Never);
+
+        var conversion = Conversion.Classify(from, ImportedTypeSymbol.Get(delegateType));
+
+        Assert.True(conversion.Exists);
+        Assert.True(conversion.IsImplicit);
+    }
+
+    [Fact]
+    public void OahuServiceFactory_ThrowExpressionInitializer_BindsCleanly()
+    {
+        const string Source = """
+            package Oahu.Cli.Server.Hosting
+            import System
+
+            interface IAuthService {
+            }
+
+            class ServerHost {
+                class ServiceFactories {
+                    private var _auth () -> IAuthService = () -> throw InvalidOperationException("AuthFactory not configured")
+                }
+            }
+            """;
+
+        Assert.Empty(EmitDiagnostics(Source).Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void NonBottomReturnAndParameterMismatches_StayRejected()
+    {
+        var noParameters = ImmutableArray<TypeSymbol>.Empty;
+        var wrongReturn = Conversion.Classify(
+            FunctionTypeSymbol.Get(noParameters, TypeSymbol.String),
+            FunctionTypeSymbol.Get(noParameters, TypeSymbol.Int32));
+        var wrongParameter = Conversion.Classify(
+            FunctionTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(TypeSymbol.String), TypeSymbol.Never),
+            FunctionTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32), TypeSymbol.String));
+
+        Assert.False(wrongReturn.Exists);
+        Assert.False(wrongParameter.Exists);
+
+        const string Source = """
+            package Issue2716.Negative
+
+            interface IAuthService {
+            }
+
+            class ServiceFactories {
+                private var _auth () -> IAuthService = () -> "not an auth service"
+            }
+            """;
+        Assert.Contains(EmitDiagnostics(Source), d => d.IsError && d.Id == "GS0155");
     }
 
     private static System.Collections.Generic.IEnumerable<SyntaxNode> Descendants(SyntaxNode node)


### PR DESCRIPTION
## Summary
- treat `never` as compatible with every function/delegate result while preserving parameter and non-bottom return mismatches
- reshape throw-only lambdas to the target signature and discover instance-field initializer lambdas before MethodDef planning
- cover the exact Oahu `() -> IAuthService = () -> throw InvalidOperationException(...)` initializer, negative conversions, IL verification, and runtime control flow

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter FullyQualifiedName~Issue1018ThrowExpressionTests`
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter FullyQualifiedName~Issue1018ThrowExpressionEmitTests`
- full Core.Tests: 6,688 passed, 1 skipped

Fixes #2716