### PR TITLE
Fix custom interface event accessor metadata

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -2192,6 +2192,18 @@ internal sealed partial class DeclarationBinder
     internal static bool TypeSignaturesEquivalent(TypeSymbol a, TypeSymbol b)
         => TypeSignaturesEquivalent(a, b, typeParamMap: null);
 
+    internal static bool InterfaceEventTypesEquivalent(
+        InterfaceSymbol iface,
+        EventSymbol interfaceEvent,
+        EventSymbol implementation)
+        => iface != null
+            && interfaceEvent != null
+            && implementation != null
+            && TypeSignaturesEquivalent(
+                interfaceEvent.Type,
+                implementation.Type,
+                BuildInterfaceTypeParameterMap(iface));
+
     private static bool TypeSignaturesEquivalent(
         TypeSymbol a,
         TypeSymbol b,

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -148,7 +148,7 @@ internal sealed partial class DeclarationBinder
                     structSymbol,
                     iface,
                     positionalInterfaceProps);
-                ResolveExplicitInterfaceEventImplementations(structSymbol, iface);
+                VerifyInterfaceEventImplementations(syntax, structSymbol, iface);
             }
 
             static void ResolveExplicitClrInterfaceImplementations(StructSymbol structSymbol)
@@ -614,27 +614,49 @@ internal sealed partial class DeclarationBinder
         }
     }
 
-    private void ResolveExplicitInterfaceEventImplementations(StructSymbol structSymbol, InterfaceSymbol iface)
+    private void VerifyInterfaceEventImplementations(
+        StructDeclarationSyntax syntax,
+        StructSymbol structSymbol,
+        InterfaceSymbol iface)
     {
-        // ADR-0149: resolve explicit-interface EVENT implementations
-        // (`event (IFoo) Changed T`) — generalizes the #2362 property
-        // pre-pass immediately above to events for the first time.
-        // Mirrors the property pre-pass exactly: resolved against the
-        // interface's OPEN DEFINITION event table (constructed
-        // generic interfaces do not substitute Events either — see
-        // InterfaceSymbol.TryResolveMembers), and is a pure resolve
-        // pass with no ordinary implicit-event-contract diagnostic
-        // (there is currently no implicit interface-event contract
-        // check in this binder at all — adding one is out of scope
-        // for this explicit-implementation feature and would risk an
-        // unrelated regression across every existing interface-event
-        // declaration in the test suite).
-        var explicitEventDefIface = iface.Definition ?? iface;
-        if (!explicitEventDefIface.Events.IsDefaultOrEmpty)
+        var eventDefIface = iface.Definition ?? iface;
+        if (eventDefIface.Events.IsDefaultOrEmpty)
         {
-            foreach (var openIevent in explicitEventDefIface.Events)
+            return;
+        }
+
+        foreach (var interfaceEvent in eventDefIface.Events)
+        {
+            if (TryResolveExplicitInterfaceEventImplementation(structSymbol, iface, interfaceEvent) != null)
             {
-                TryResolveExplicitInterfaceEventImplementation(structSymbol, iface, openIevent);
+                continue;
+            }
+
+            EventSymbol implementation = null;
+            for (var type = structSymbol; type != null && implementation == null; type = type.BaseClass)
+            {
+                foreach (var candidate in type.Events)
+                {
+                    if (candidate.HasExplicitInterfaceClause
+                        || candidate.Name != interfaceEvent.Name
+                        || (!ReferenceEquals(type, structSymbol) && candidate.Accessibility != Accessibility.Public)
+                        || !InterfaceEventTypesEquivalent(iface, interfaceEvent, candidate))
+                    {
+                        continue;
+                    }
+
+                    implementation = candidate;
+                    break;
+                }
+            }
+
+            if (implementation == null)
+            {
+                Diagnostics.ReportInterfaceMethodNotImplemented(
+                    syntax.Identifier.Location,
+                    structSymbol.Name,
+                    iface.Name,
+                    interfaceEvent.Name);
             }
         }
     }

--- a/src/Core/CodeAnalysis/Emit/InterfaceImplEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/InterfaceImplEmitter.cs
@@ -9,7 +9,10 @@
 #pragma warning disable SA1615 // return-value documentation missing — same as SA1611
 
 using System;
+using System.Collections.Generic;
+using System.Reflection;
 using System.Reflection.Metadata;
+using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Emit;
@@ -454,6 +457,141 @@ internal sealed class InterfaceImplEmitter
                 break;
             }
         }
+    }
+
+    /// <summary>
+    /// Issue #2718: custom event accessors are emitted through the general
+    /// function path, so their metadata shape must not rely on the field-like
+    /// event emitter's implicit-interface promotion. Bind every matching
+    /// ordinary custom event directly to its user or imported interface slots.
+    /// </summary>
+    internal void EmitImplicitCustomEventMethodImpls(StructSymbol structSymbol)
+    {
+        if (structSymbol == null
+            || structSymbol.Events.IsDefaultOrEmpty
+            || !this.cache.StructTypeDefs.TryGetValue(structSymbol, out var implTypeDef))
+        {
+            return;
+        }
+
+        foreach (var ev in structSymbol.Events)
+        {
+            if (ev.IsFieldLike
+                || ev.HasExplicitInterfaceClause
+                || !this.cache.EventAccessorHandles.TryGetValue(ev, out var implAccessors))
+            {
+                continue;
+            }
+
+            foreach (var iface in structSymbol.Interfaces)
+            {
+                var defIface = iface.Definition ?? iface;
+                foreach (var slotEvent in defIface.Events)
+                {
+                    if (slotEvent.Name != ev.Name
+                        || !DeclarationBinder.InterfaceEventTypesEquivalent(iface, slotEvent, ev)
+                        || IsExplicitlyImplemented(structSymbol, slotEvent))
+                    {
+                        continue;
+                    }
+
+                    var isGenericIface = ReflectionMetadataEmitter.IsUserGenericInterfaceReference(iface);
+                    if (slotEvent.AddMethodSymbol != null)
+                    {
+                        EntityHandle? declaration = isGenericIface
+                            ? this.outer.userTokens.ResolveUserInterfaceInstanceMethodToken(iface, slotEvent.AddMethodSymbol)
+                            : this.cache.MethodHandles.TryGetValue(slotEvent.AddMethodSymbol, out var handle)
+                                ? handle
+                                : (EntityHandle?)null;
+                        if (declaration.HasValue)
+                        {
+                            this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implAccessors.Add, declaration.Value);
+                        }
+                    }
+
+                    if (slotEvent.RemoveMethodSymbol != null)
+                    {
+                        EntityHandle? declaration = isGenericIface
+                            ? this.outer.userTokens.ResolveUserInterfaceInstanceMethodToken(iface, slotEvent.RemoveMethodSymbol)
+                            : this.cache.MethodHandles.TryGetValue(slotEvent.RemoveMethodSymbol, out var handle)
+                                ? handle
+                                : (EntityHandle?)null;
+                        if (declaration.HasValue)
+                        {
+                            this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implAccessors.Remove, declaration.Value);
+                        }
+                    }
+                }
+            }
+
+            var emittedClrSlots = new HashSet<MethodInfo>();
+            foreach (var ifaceSymbol in structSymbol.ImplementedClrInterfaces)
+            {
+                var declaredInterface = ifaceSymbol?.ClrType;
+                if (declaredInterface?.IsInterface != true)
+                {
+                    continue;
+                }
+
+                var interfaces = new List<Type> { declaredInterface };
+                interfaces.AddRange(declaredInterface.GetInterfaces());
+                foreach (var clrInterface in interfaces)
+                {
+                    var containingType = ReferenceEquals(clrInterface, declaredInterface)
+                        ? ifaceSymbol
+                        : TypeSymbol.FromClrType(clrInterface);
+                    foreach (var slotEvent in clrInterface.GetEvents(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                    {
+                        var slotType = MemberLookup.GetClrEventHandlerTypeSymbol(containingType, slotEvent);
+                        if (slotEvent.Name != ev.Name
+                            || !DeclarationBinder.TypeSignaturesEquivalent(slotType, ev.Type)
+                            || IsImportedSlotExplicitlyImplemented(structSymbol, slotEvent))
+                        {
+                            continue;
+                        }
+
+                        if (slotEvent.AddMethod != null && emittedClrSlots.Add(slotEvent.AddMethod))
+                        {
+                            var declaration = this.outer.memberRefs.GetMethodEntityHandle(slotEvent.AddMethod, containingType);
+                            this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implAccessors.Add, declaration);
+                        }
+
+                        if (slotEvent.RemoveMethod != null && emittedClrSlots.Add(slotEvent.RemoveMethod))
+                        {
+                            var declaration = this.outer.memberRefs.GetMethodEntityHandle(slotEvent.RemoveMethod, containingType);
+                            this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implAccessors.Remove, declaration);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static bool IsExplicitlyImplemented(StructSymbol type, EventSymbol slot)
+    {
+        foreach (var candidate in type.Events)
+        {
+            if (ReferenceEquals(candidate.ExplicitInterfaceMember, slot))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsImportedSlotExplicitlyImplemented(StructSymbol type, EventInfo slot)
+    {
+        foreach (var candidate in type.Events)
+        {
+            if (candidate.ExplicitInterfaceAddSlot == slot.AddMethod
+                || candidate.ExplicitInterfaceRemoveSlot == slot.RemoveMethod)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodInfoHelpers.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodInfoHelpers.cs
@@ -63,6 +63,29 @@ internal static class MethodInfoHelpers
         {
             foreach (var iface in structSym.Interfaces)
             {
+                var defIface = iface.Definition ?? iface;
+                foreach (var interfaceEvent in defIface.Events)
+                {
+                    EventSymbol implementationEvent = null;
+                    foreach (var candidate in structSym.Events)
+                    {
+                        if (ReferenceEquals(candidate.AddMethodSymbol, method)
+                            || ReferenceEquals(candidate.RemoveMethodSymbol, method)
+                            || ReferenceEquals(candidate.RaiseMethodSymbol, method))
+                        {
+                            implementationEvent = candidate;
+                            break;
+                        }
+                    }
+
+                    if (implementationEvent != null
+                        && interfaceEvent.Name == implementationEvent.Name
+                        && DeclarationBinder.InterfaceEventTypesEquivalent(iface, interfaceEvent, implementationEvent))
+                    {
+                        return true;
+                    }
+                }
+
                 if (iface.Methods.IsDefaultOrEmpty)
                 {
                     continue;
@@ -126,7 +149,8 @@ internal static class MethodInfoHelpers
 
                 foreach (var clrMethod in clrIface.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
                 {
-                    if (clrMethod.IsSpecialName || clrMethod.Name != method.Name)
+                    if (clrMethod.Name != method.Name
+                        || (clrMethod.IsSpecialName && !method.IsSpecialName))
                     {
                         continue;
                     }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -3384,6 +3384,10 @@ internal sealed class ReflectionMetadataEmitter
             // ADR-0149: emit MethodImpl rows for explicit-interface-clause
             // event implementations (add/remove/raise accessors).
             this.interfaceImpls.EmitExplicitInterfaceEventMethodImpls(c);
+
+            // Issue #2718: bind ordinary custom event accessors directly to
+            // matching user/imported interface event slots.
+            this.interfaceImpls.EmitImplicitCustomEventMethodImpls(c);
         }
 
         foreach (var c in topClasses)
@@ -3488,6 +3492,9 @@ internal sealed class ReflectionMetadataEmitter
             // ADR-0149: emit MethodImpl rows for explicit-interface-clause
             // event implementations (add/remove/raise accessors).
             this.interfaceImpls.EmitExplicitInterfaceEventMethodImpls(s);
+
+            // Issue #2718: see the class path above.
+            this.interfaceImpls.EmitImplicitCustomEventMethodImpls(s);
         }
 
         foreach (var s in topStructs)

--- a/test/Compiler.Tests/Emit/Issue2718CustomInterfaceEventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2718CustomInterfaceEventEmitTests.cs
@@ -1,0 +1,354 @@
+// <copyright file="Issue2718CustomInterfaceEventEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Runtime.Loader;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Issue #2718: custom event accessors implement interface accessor slots.</summary>
+public sealed class Issue2718CustomInterfaceEventEmitTests
+{
+    private const string DownloadSettingsContract = """
+        package Oahu.Core
+        import System
+
+        interface IDownloadSettings {
+            event ChangedSettings EventHandler
+        }
+
+        class DownloadSettings : IDownloadSettings {
+            event ChangedSettings EventHandler
+
+            func Raise() {
+                this.ChangedSettings?.Invoke(this, EventArgs.Empty)
+            }
+        }
+        """;
+
+    [Fact]
+    public void PerJobDownloadSettings_ImportedCustomEvent_HasExactMethodImplsAndDispatches()
+    {
+        const string source = """
+            package Cli.App
+            import System
+            import Oahu.Core
+
+            class PerJobDownloadSettings : IDownloadSettings {
+                private var inner IDownloadSettings
+
+                init(inner IDownloadSettings) {
+                    this.inner = inner
+                }
+
+                event ChangedSettings EventHandler {
+                    add { inner.ChangedSettings += value }
+                    remove { inner.ChangedSettings -= value }
+                }
+            }
+
+            func Main() {
+                var inner = DownloadSettings()
+                var concrete = PerJobDownloadSettings(inner)
+                var settings IDownloadSettings = concrete
+                var hits int32 = 0
+                var handler EventHandler = (sender object, args EventArgs) -> { hits += 1 }
+                settings.ChangedSettings += handler
+                inner.Raise()
+                settings.ChangedSettings -= handler
+                inner.Raise()
+                Console.WriteLine(hits)
+            }
+            """;
+
+        using var artifacts = Compile(source, "exe", DownloadSettingsContract);
+        Assert.Equal("1\n", Run(artifacts.OutputPath));
+        IlVerifier.Verify(artifacts.OutputPath, additionalReferences: new[] { artifacts.ContractsPath });
+
+        using var stream = File.OpenRead(artifacts.OutputPath);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var type = reader.TypeDefinitions
+            .Select(reader.GetTypeDefinition)
+            .Single(t => reader.GetString(t.Namespace) == "Cli.App"
+                && reader.GetString(t.Name) == "PerJobDownloadSettings");
+        var implementations = type.GetMethodImplementations()
+            .Select(reader.GetMethodImplementation)
+            .ToArray();
+
+        Assert.Equal(2, implementations.Length);
+        Assert.Equal(
+            new[] { "add_ChangedSettings", "remove_ChangedSettings" },
+            implementations
+                .Select(i => GetMethodName(reader, i.MethodBody))
+                .OrderBy(n => n)
+                .ToArray());
+
+        foreach (var implementation in implementations)
+        {
+            var method = reader.GetMethodDefinition((MethodDefinitionHandle)implementation.MethodBody);
+            Assert.True((method.Attributes & MethodAttributes.Public) != 0);
+            Assert.True((method.Attributes & MethodAttributes.Virtual) != 0);
+        }
+
+        var loadContext = new AssemblyLoadContext("Issue2718", isCollectible: true);
+        loadContext.Resolving += (_, name) => name.Name == "Oahu.Core"
+            ? loadContext.LoadFromAssemblyPath(artifacts.ContractsPath)
+            : null;
+        try
+        {
+            var assembly = loadContext.LoadFromAssemblyPath(artifacts.OutputPath);
+            var implementationType = assembly.GetType("Cli.App.PerJobDownloadSettings")!;
+            var interfaceType = implementationType.GetInterfaces()
+                .Single(i => i.FullName == "Oahu.Core.IDownloadSettings");
+            var interfaceMap = implementationType.GetInterfaceMap(interfaceType);
+            Assert.Equal(
+                new[] { "add_ChangedSettings", "remove_ChangedSettings" },
+                interfaceMap.TargetMethods.Select(m => m.Name).OrderBy(n => n).ToArray());
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    [Fact]
+    public void InheritedGenericInterface_PrivateCustomEvent_EmitsMethodImplsAndIlVerifies()
+    {
+        const string source = """
+            package Issue2718.Generic
+            import System
+
+            type ChangeHandler[T] = delegate func(value T) void
+
+            interface IChanges[T] {
+                event Changed ChangeHandler[T]
+            }
+
+            interface IIntChanges : IChanges[int32] {
+            }
+
+            class Sink : IIntChanges {
+                private var handler ChangeHandler[int32]?
+
+                private event Changed ChangeHandler[int32] {
+                    add { handler = value }
+                    remove { handler = nil }
+                }
+
+                func Fire(value int32) { handler?.Invoke(value) }
+            }
+
+            """;
+
+        using var artifacts = Compile(source, "library");
+        IlVerifier.Verify(artifacts.OutputPath);
+
+        using var stream = File.OpenRead(artifacts.OutputPath);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var type = reader.TypeDefinitions
+            .Select(reader.GetTypeDefinition)
+            .Single(t => reader.GetString(t.Name) == "Sink");
+        Assert.Equal(2, type.GetMethodImplementations().Count);
+
+        foreach (var name in new[] { "add_Changed", "remove_Changed" })
+        {
+            var method = type.GetMethods()
+                .Select(reader.GetMethodDefinition)
+                .Single(m => reader.GetString(m.Name) == name);
+            Assert.True((method.Attributes & MethodAttributes.Private) != 0);
+            Assert.True((method.Attributes & MethodAttributes.Virtual) != 0);
+        }
+    }
+
+    [Fact]
+    public void MismatchedCustomEventHandler_ReportsMissingInterfaceMember()
+    {
+        const string source = """
+            package Issue2718.Negative
+
+            type ChangeHandler[T] = delegate func(value T) void
+
+            interface IChanges {
+                event Changed ChangeHandler[int32]
+            }
+
+            class Bad : IChanges {
+                event Changed ChangeHandler[string] {
+                    add { }
+                    remove { }
+                }
+            }
+            """;
+
+        using var artifacts = Compile(source, "library", expectSuccess: false);
+        Assert.NotEqual(0, artifacts.ExitCode);
+        var output = artifacts.Stdout + artifacts.Stderr;
+        Assert.True(output.Contains("GS0187", StringComparison.Ordinal), output);
+    }
+
+    private static string GetMethodName(MetadataReader reader, EntityHandle handle)
+        => handle.Kind switch
+        {
+            HandleKind.MethodDefinition => reader.GetString(reader.GetMethodDefinition((MethodDefinitionHandle)handle).Name),
+            HandleKind.MemberReference => reader.GetString(reader.GetMemberReference((MemberReferenceHandle)handle).Name),
+            _ => throw new InvalidOperationException($"Unexpected method handle: {handle.Kind}"),
+        };
+
+    private static CompilationArtifacts Compile(
+        string source,
+        string target,
+        string contracts = null,
+        bool expectSuccess = true)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2718-artifacts",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        string contractsPath = null;
+        if (contracts != null)
+        {
+            var contractsSourcePath = Path.Combine(directory, "contracts.gs");
+            contractsPath = Path.Combine(directory, "Oahu.Core.dll");
+            File.WriteAllText(contractsSourcePath, contracts);
+            var contractsResult = RunCompiler(new[]
+            {
+                "/out:" + contractsPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                contractsSourcePath,
+            });
+            Assert.True(
+                contractsResult.ExitCode == 0,
+                $"contract compile failed\n{contractsResult.Stdout}\n{contractsResult.Stderr}");
+        }
+
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "Cli.App.dll");
+        File.WriteAllText(sourcePath, source);
+        var args = new System.Collections.Generic.List<string>
+        {
+            "/out:" + outputPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+        };
+        if (contractsPath != null)
+        {
+            args.Add("/reference:" + contractsPath);
+        }
+
+        args.Add(sourcePath);
+        var result = RunCompiler(args.ToArray());
+        if (expectSuccess)
+        {
+            Assert.True(
+                result.ExitCode == 0,
+                $"compile failed\n{result.Stdout}\n{result.Stderr}");
+        }
+
+        return new CompilationArtifacts(
+            directory,
+            outputPath,
+            contractsPath,
+            result.ExitCode,
+            result.Stdout,
+            result.Stderr);
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunCompiler(string[] args)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return (Program.Main(args), stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string Run(string assemblyPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath)!,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n");
+    }
+
+    private sealed class CompilationArtifacts : IDisposable
+    {
+        public CompilationArtifacts(
+            string directory,
+            string outputPath,
+            string contractsPath,
+            int exitCode,
+            string stdout,
+            string stderr)
+        {
+            Directory = directory;
+            OutputPath = outputPath;
+            ContractsPath = contractsPath;
+            ExitCode = exitCode;
+            Stdout = stdout;
+            Stderr = stderr;
+        }
+
+        public string Directory { get; }
+
+        public string OutputPath { get; }
+
+        public string ContractsPath { get; }
+
+        public int ExitCode { get; }
+
+        public string Stdout { get; }
+
+        public string Stderr { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                System.IO.Directory.Delete(Directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- emit MethodImpl rows for custom add/remove accessors implementing user or imported interface events
- handle inherited and constructed generic slots while preserving explicit implementation precedence and accessor visibility
- diagnose mismatched user-interface event handler shapes

## Verification
- exact Cli.App.PerJobDownloadSettings runtime dispatch, reflection interface map, metadata rows, and ILVerify
- inherited generic/private accessor and negative diagnostic coverage
- event/interface regression selection: 35 passed
- Core.Tests: 6,680 passed, 1 skipped
- Gsharp.Extensions build: succeeded with 0 warnings

Fixes #2718