### PR TITLE
Fix nullable tuple async task projection

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1085,41 +1085,11 @@ internal sealed class LambdaBinder
             return element;
         }
 
-        // Issue #1785 / #2026 / #2232 / #2381: a same-compilation user type
-        // anywhere in the element's structure — a bare struct/enum/interface/
-        // delegate, a nullable wrapping one, a tuple element, an array/slice
-        // element (`[]DiagnosticCheck`, `[N]DiagnosticCheck`), or an imported
-        // generic type argument (`List[DiagnosticCheck]`,
-        // `Dictionary[string,DiagnosticCheck]`, arbitrarily nested) — must
-        // route through the symbolic Task<T> construction below rather than
-        // the ordinary reflection-based `taskOpen.MakeGenericType(element.
-        // ClrType)` path further down. Two distinct CLR-type shapes trigger
-        // this, both signalling "not really closed yet":
-        //   - a genuinely null ClrType (bare struct/enum/interface/tuple/
-        //     array/slice — `SliceTypeSymbol`/`ArrayTypeSymbol`'s CLR shape is
-        //     computed ONCE, at construction, as `elementType.ClrType?.
-        //     MakeArrayType()`, so it stays null forever once captured before
-        //     the element's TypeBuilder closes);
-        //   - a NON-null but OBJECT-ERASED ClrType (an imported generic like
-        //     `List<>` closed over a still-building same-compilation argument
-        //     resolves via reflection to `List<object>`, since imported
-        //     generics do not report a null ClrType the way same-compilation
-        //     types do).
-        // `ContainsSameCompilationUserType` (recursing through nullable/
-        // array/slice/tuple/imported-generic wrappers via `GetWrappedTypes`)
-        // and the emitter's `ArgIsSymbolicUserDefined` (the same recursive
-        // shape, reused so the async function's OBSERVABLE return type used
-        // for lambda/delegate target typing — e.g. `Task.Run(() ->
-        // RunAsync())`'s `TResult` inference — matches the REAL closed
-        // generic the kickoff method's CLR signature carries after emission)
-        // together detect both shapes regardless of which one `element.
-        // ClrType` happens to report. A still-OPEN generic type parameter
-        // (e.g. the caller's own `U` substituted in for a generic async
-        // callee's declared return type, or a constructed generic like
-        // `Box[U]`) is handled by the sibling `ContainsTypeParameter` check.
-        if ((TypeSymbol.ContainsSameCompilationUserType(element)
-            || GSharp.Core.CodeAnalysis.Emit.ReflectionMetadataEmitter.ArgIsSymbolicUserDefined(element)
-            || TypeSymbol.ContainsTypeParameter(element))
+        // Issues #1785/#2026/#2232/#2381/#2713: use the same symbolic-shape
+        // predicate as TupleTypeSymbol. This includes type parameters,
+        // same-compilation user types, and nullable-reference annotations
+        // whose information cannot be recovered from a CLR Type.
+        if (TypeSymbol.RequiresSymbolicProjection(element)
             && Scope.References.TryResolveType(wrapperOpenName, out var symbolicTaskOpen))
         {
             // Issue #502 / #320: a user-defined async result type has no CLR

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -4680,16 +4680,10 @@ internal sealed class ReflectionMetadataEmitter
     // ClrType.IsValueType, which is null for in-flight user types — so the
     // kickoff method's real Task<T?> return type is closed over the emitted
     // Nullable<UserT> instead of falling back to the erased Task<object>.
-    // Issue #2381: generalized to reuse ArgIsSymbolicUserDefined so an
-    // imported generic collection closed over a same-compilation argument
-    // (`List[DiagnosticCheck]`, `Dictionary[string, DiagnosticCheck]`,
-    // `List[List[DiagnosticCheck]]`, arrays/slices of a user type, a
-    // nullable-wrapped user value type held as a type argument, …) routes
-    // through the same symbolic Task<T> construction as the bare
-    // struct/interface/enum/type-parameter case, instead of trusting the
-    // erased CLR type cached on the constructed ImportedTypeSymbol.
+    // Issues #2381/#2713: use the same symbolic projection predicate as
+    // WrapAsTask and async state-machine construction.
     private static bool IsAsyncUserDefinedResultType(TypeSymbol type)
-        => ArgIsSymbolicUserDefined(type);
+        => TypeSymbol.RequiresSymbolicProjection(type);
 
     private static bool TryCreateSymbolicAsyncTaskType(SynthesizedStateMachineType stateMachine, out TypeSymbol taskType)
     {

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
@@ -117,16 +117,9 @@ public static class AsyncStateMachineTypeBuilder
 
         var builderFieldType = TypeSymbol.FromClrType(builderInfo.BuilderType);
 
-        // Issue #2381: widened from a bare struct/interface/enum/type-
-        // parameter kickoff-type check to `ArgIsSymbolicUserDefined` (shared
-        // with the emitter's call-site/return-type symbolic-encoding gate)
-        // so an imported generic closed over a same-compilation argument
-        // (`List[DiagnosticCheck]`, `Dictionary[string, DiagnosticCheck]`,
-        // nested/array/nullable shapes, …) ALSO gets its builder field type
-        // rebuilt as a symbolic constructed generic instead of the
-        // reflection-resolved (and, for such an argument, object-erased)
-        // `builderInfo.BuilderType`.
-        if (ReflectionMetadataEmitter.ArgIsSymbolicUserDefined(kickoff.Type)
+        // Issues #2381/#2713: match WrapAsTask's symbolic projection guard so
+        // the builder field retains every result shape the CLR type erases.
+        if (TypeSymbol.RequiresSymbolicProjection(kickoff.Type)
             && builderInfo.BuilderType is { IsConstructedGenericType: true } builderClrType)
         {
             builderFieldType = ImportedTypeSymbol.GetConstructed(
@@ -280,13 +273,9 @@ public static class AsyncStateMachineTypeBuilder
                 // override in `Build` and `ResultTypeSymbol`), so the emitted
                 // IL still carries `!!0`/`!0`, not `object`.
                 //
-                // Issue #2381: widened to the shared `ArgIsSymbolicUserDefined`
-                // predicate so an array/slice of a same-compilation user type
-                // (`[N]DiagnosticCheck` / `[]DiagnosticCheck` — whose eagerly-
-                // cached `ClrType` is null when the element had no CLR type
-                // yet) reaches the same erase-then-re-widen treatment instead
-                // of aborting async state-machine synthesis outright.
-                if (ReflectionMetadataEmitter.ArgIsSymbolicUserDefined(kickoff.Type))
+                // Issues #2381/#2713: erase every symbolic projection only
+                // for reflection-based builder discovery; emission restores it.
+                if (TypeSymbol.RequiresSymbolicProjection(kickoff.Type))
                 {
                     inner = references.MapClrTypeToReferences(typeof(object));
                 }

--- a/test/Compiler.Tests/Emit/Issue2713NullableTupleAsyncEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2713NullableTupleAsyncEmitTests.cs
@@ -1,0 +1,156 @@
+// <copyright file="Issue2713NullableTupleAsyncEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2713: async functions returning a tuple with a nullable-reference
+/// element must remain Task-wrapped at call sites.
+/// </summary>
+public sealed class Issue2713NullableTupleAsyncEmitTests
+{
+    [Fact]
+    public void ExactOahuCoreNullableTupleAwait_DiagnosticsDropFromSevenToZero()
+    {
+        const string source = """
+            package Oahu.Core
+
+            import System
+            import System.Threading.Tasks
+
+            async func ReadAsync() (string?, int32) {
+                await Task.Yield()
+                return ("oahu", 7)
+            }
+
+            async func RunAsync() int32 {
+                let (text, value) = await ReadAsync()
+                let first = text
+                let second = value
+                let third = text
+                Console.WriteLine(text!!)
+                return value
+            }
+            """;
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source))) { IsLibrary = true };
+        var errors = compilation.BoundProgram.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
+
+        Assert.True(
+            errors.Length == 0,
+            $"The exact Oahu.Core regression must drop from 7 diagnostics to 0:{Environment.NewLine}"
+                + string.Join(Environment.NewLine, errors.Select(diagnostic => diagnostic.ToString())));
+    }
+
+    [Fact]
+    public void MinimalNullableTupleAsyncAwait_VerifiesAndRuns()
+    {
+        const string source = """
+            package Issue2713
+
+            import System
+            import System.Threading.Tasks
+
+            async func ReadAsync() (string?, int32) {
+                await Task.Yield()
+                return ("ok", 7)
+            }
+
+            async func RunAsync() int32 {
+                let (text, value) = await ReadAsync()
+                Console.WriteLine(text!!)
+                return value
+            }
+
+            Console.WriteLine(RunAsync().GetAwaiter().GetResult())
+            """;
+
+        Assert.Equal("ok\n7\n", CompileVerifyAndRun(source));
+    }
+
+    [Fact]
+    public void NonAsyncNullableTuple_RemainsNonAwaitable()
+    {
+        const string source = """
+            package Issue2713Negative
+
+            func Read() (string?, int32) {
+                return ("no task", 7)
+            }
+
+            async func Run() int32 {
+                let (text, value) = await Read()
+                return value
+            }
+            """;
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source))) { IsLibrary = true };
+        var diagnostics = compilation.BoundProgram.Diagnostics;
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0133");
+    }
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2713Emit");
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            Assert.True(exitCode == 0, $"compile failed ({exitCode}):{Environment.NewLine}{stdout}{stderr}");
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        IlVerifier.Verify(outputPath);
+
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                outputPath,
+            },
+            WorkingDirectory = directory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(process.ExitCode == 0, error);
+        return output.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- align async Task wrapping, state-machine builders, and emitted result metadata on `RequiresSymbolicProjection`
- preserve nullable-reference tuple results without weakening #2702 constructed-generic precision
- add exact Oahu.Core 7→0 diagnostics, runtime/ILVerify, and negative coverage

## Tests
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter 'FullyQualifiedName~Issue2713|FullyQualifiedName~Issue2702|FullyQualifiedName~Issue2381' --nologo --no-restore` (13 passed)
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter 'FullyQualifiedName~Issue2026|FullyQualifiedName~Issue2119' --nologo --no-restore` (13 passed)
- full Core.Tests (6,680 passed, 1 skipped)
- full Compiler.Tests (3,365 passed)

Fixes #2713