### PR TITLE
Canonicalize structural delegate identities

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1527,7 +1527,10 @@ internal sealed class ConversionClassifier
             for (var i = 0; i < targetParameterTypes.Length; i++)
             {
                 if (candidate.Parameters[i + parameterOffset].RefKind != targetParameterRefKinds[i]
-                    || !AreMethodGroupTypesEquivalent(candidateParameterTypes[i], targetParameterTypes[i]))
+                    || !TryCanonicalizeMethodGroupType(
+                        candidateParameterTypes[i],
+                        targetParameterTypes[i],
+                        out candidateParameterTypes[i]))
                 {
                     paramsMatch = false;
                     break;
@@ -1539,7 +1542,10 @@ internal sealed class ConversionClassifier
                 continue;
             }
 
-            if (!AreMethodGroupTypesEquivalent(candidateReturn, targetReturnType))
+            if (!TryCanonicalizeMethodGroupType(
+                candidateReturn,
+                targetReturnType,
+                out candidateReturn))
             {
                 continue;
             }
@@ -2299,8 +2305,22 @@ internal sealed class ConversionClassifier
         return ClrTypeUtilities.IsAssignableByName(invokeReturn, methodReturn);
     }
 
-    private static bool AreMethodGroupTypesEquivalent(TypeSymbol left, TypeSymbol right)
-        => TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(left, right);
+    private static bool TryCanonicalizeMethodGroupType(
+        TypeSymbol actual,
+        TypeSymbol expected,
+        out TypeSymbol canonical)
+    {
+        canonical = actual;
+        if (TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(actual, expected))
+        {
+            return true;
+        }
+
+        return MemberLookup.TryCanonicalizeStructuralFunctionType(actual, expected, out canonical)
+            && actual.ClrType != null
+            && expected.ClrType != null
+            && ClrTypeUtilities.AreSame(actual.ClrType, expected.ClrType);
+    }
 
     private static ImmutableArray<RefKind> GetMethodGroupTargetRefKinds(
         TypeSymbol targetType,

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -245,7 +245,7 @@ internal sealed partial class DeclarationBinder
 
         BindStructInstanceMethods(syntax, package, structSymbol, baseBinding, memberBinding);
         BindStructProperties(syntax, package, structSymbol, memberBinding);
-        BindStructEvents(syntax, package, structSymbol, memberBinding);
+        BindStructEvents(syntax, package, structSymbol, baseBinding, memberBinding);
         BindStructSharedBlock(syntax, package, structSymbol, fieldBinding, memberBinding);
         RegisterStructConversionOperators(package, memberBinding.PendingConversionOperators);
         RegisterStructDeferredInitializers(package, structSymbol, fieldBinding);
@@ -1621,6 +1621,7 @@ internal sealed partial class DeclarationBinder
         StructDeclarationSyntax syntax,
         PackageSymbol package,
         StructSymbol structSymbol,
+        StructBaseBindingResult baseBinding,
         StructMemberBindingContext memberBinding)
     {
         var existingNames = memberBinding.ExistingNames;
@@ -1664,6 +1665,11 @@ internal sealed partial class DeclarationBinder
                 {
                     continue;
                 }
+
+                handlerType = CanonicalizeInterfaceEventHandlerType(
+                    baseBinding,
+                    eventName,
+                    handlerType);
 
                 var eventAccessibility = resolveAccessibility(eventSyntax.AccessibilityModifier);
                 bool isFieldLike = eventSyntax.OpenBraceToken == null;
@@ -1847,6 +1853,98 @@ internal sealed partial class DeclarationBinder
 
             structSymbol.SetEvents(eventsBuilder.ToImmutable());
         }
+    }
+
+    private static TypeSymbol CanonicalizeInterfaceEventHandlerType(
+        StructBaseBindingResult baseBinding,
+        string eventName,
+        TypeSymbol handlerType)
+    {
+        if (handlerType is not FunctionTypeSymbol)
+        {
+            return handlerType;
+        }
+
+        TypeSymbol selected = null;
+        var ambiguous = false;
+
+        void Consider(TypeSymbol expected)
+        {
+            if (!MemberLookup.TryCanonicalizeStructuralFunctionType(
+                handlerType,
+                expected,
+                out var canonical))
+            {
+                return;
+            }
+
+            if (selected == null)
+            {
+                selected = canonical;
+            }
+            else if (!NamedDelegateIdentitiesMatch(selected, canonical))
+            {
+                ambiguous = true;
+            }
+        }
+
+        foreach (var iface in baseBinding.ImplementedInterfaces)
+        {
+            foreach (var interfaceEvent in (iface.Definition ?? iface).Events)
+            {
+                if (interfaceEvent.Name == eventName)
+                {
+                    Consider(interfaceEvent.Type);
+                }
+            }
+        }
+
+        foreach (var ifaceSymbol in baseBinding.ImplementedClrInterfaces)
+        {
+            var declaredInterface = ifaceSymbol?.ClrType;
+            if (declaredInterface?.IsInterface != true)
+            {
+                continue;
+            }
+
+            var interfaces = new List<Type> { declaredInterface };
+            interfaces.AddRange(declaredInterface.GetInterfaces());
+            foreach (var clrInterface in interfaces)
+            {
+                var containingType = ReferenceEquals(clrInterface, declaredInterface)
+                    ? ifaceSymbol
+                    : TypeSymbol.FromClrType(clrInterface);
+                foreach (var interfaceEvent in clrInterface.GetEvents(
+                    BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                {
+                    if (interfaceEvent.Name == eventName)
+                    {
+                        Consider(MemberLookup.GetClrEventHandlerTypeSymbol(
+                            containingType,
+                            interfaceEvent));
+                    }
+                }
+            }
+        }
+
+        return ambiguous ? handlerType : selected ?? handlerType;
+    }
+
+    private static bool NamedDelegateIdentitiesMatch(TypeSymbol left, TypeSymbol right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is DelegateTypeSymbol && right is DelegateTypeSymbol)
+        {
+            return TypeSignaturesEquivalent(left, right);
+        }
+
+        return left?.ClrType != null
+            && right?.ClrType != null
+            && ClrTypeUtilities.AreSame(left.ClrType, right.ClrType);
     }
 
     private void BindStructSharedBlock(

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1971,6 +1971,71 @@ internal sealed class MemberLookup
     }
 
     /// <summary>
+    /// Reifies a structural function type as an expected named delegate when
+    /// their complete signatures are identical. The direction is deliberate:
+    /// two named delegates never become equivalent merely because their
+    /// <c>Invoke</c> methods have the same shape.
+    /// </summary>
+    /// <param name="actual">The source structural function type.</param>
+    /// <param name="expected">The expected named delegate type.</param>
+    /// <param name="canonical">The expected delegate on success; otherwise the source type.</param>
+    /// <returns><see langword="true"/> when the structural signature exactly matches the delegate.</returns>
+    public static bool TryCanonicalizeStructuralFunctionType(
+        TypeSymbol actual,
+        TypeSymbol expected,
+        out TypeSymbol canonical)
+    {
+        canonical = actual;
+        if (actual is not FunctionTypeSymbol actualFunction
+            || expected is FunctionTypeSymbol
+            || !TryGetDelegateFunctionTypeFromSymbol(expected, out var expectedFunction)
+            || !FunctionShapesExactlyMatch(actualFunction, expectedFunction))
+        {
+            return false;
+        }
+
+        canonical = expected;
+        return true;
+
+        static bool FunctionShapesExactlyMatch(
+            FunctionTypeSymbol actual,
+            FunctionTypeSymbol expected)
+        {
+            if (actual.Arity != expected.Arity
+                || !actual.IsVariadic.SequenceEqual(expected.IsVariadic)
+                || !FunctionComponentExactlyMatches(actual.ReturnType, expected.ReturnType))
+            {
+                return false;
+            }
+
+            for (var i = 0; i < actual.Arity; i++)
+            {
+                if (!FunctionComponentExactlyMatches(
+                    actual.ParameterTypes[i],
+                    expected.ParameterTypes[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        static bool FunctionComponentExactlyMatches(TypeSymbol actual, TypeSymbol expected)
+        {
+            if (TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(actual, expected))
+            {
+                return true;
+            }
+
+            return actual is FunctionTypeSymbol actualFunction
+                && expected is not FunctionTypeSymbol
+                && TryGetDelegateFunctionTypeFromSymbol(expected, out var expectedFunction)
+                && FunctionShapesExactlyMatch(actualFunction, expectedFunction);
+        }
+    }
+
+    /// <summary>
     /// Issue #2130: resolves the effective lambda target shape for any target
     /// type that may consume a source lambda — a native function type, a
     /// delegate, or <c>System.Linq.Expressions.Expression&lt;TDelegate&gt;</c>.

--- a/test/Compiler.Tests/Emit/Issue2718CustomInterfaceEventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2718CustomInterfaceEventEmitTests.cs
@@ -49,7 +49,7 @@ public sealed class Issue2718CustomInterfaceEventEmitTests
                     this.inner = inner
                 }
 
-                event ChangedSettings EventHandler {
+                event ChangedSettings (object?, EventArgs) -> void {
                     add { inner.ChangedSettings += value }
                     remove { inner.ChangedSettings -= value }
                 }
@@ -113,11 +113,111 @@ public sealed class Issue2718CustomInterfaceEventEmitTests
             Assert.Equal(
                 new[] { "add_ChangedSettings", "remove_ChangedSettings" },
                 interfaceMap.TargetMethods.Select(m => m.Name).OrderBy(n => n).ToArray());
+            Assert.Equal(
+                typeof(EventHandler),
+                implementationType.GetEvent("ChangedSettings")!.EventHandlerType);
+            Assert.All(
+                interfaceMap.TargetMethods,
+                method => Assert.Equal(typeof(EventHandler), method.GetParameters().Single().ParameterType));
         }
         finally
         {
             loadContext.Unload();
         }
+    }
+
+    [Fact]
+    public void OahuCli_ActionOfAction_MethodGroup_BindsRunsAndIlVerifies()
+    {
+        const string contracts = """
+            package Oahu.Core
+            import System
+
+            class AppShellOptions { }
+
+            class TuiHost {
+                shared {
+                    func Run(options AppShellOptions?, registerRestore Action[Action]?) {
+                        registerRestore!!(() -> Console.WriteLine("restored"))
+                    }
+                }
+            }
+            """;
+        const string source = """
+            package Oahu.Cli
+            import System
+            import Oahu.Core
+
+            class CliEnvironment {
+                shared {
+                    func RegisterRestore(restore () -> void) {
+                        restore()
+                    }
+                }
+            }
+
+            func Main() {
+                TuiHost.Run(AppShellOptions{}, CliEnvironment.RegisterRestore)
+            }
+            """;
+
+        using var artifacts = Compile(source, "exe", contracts);
+        Assert.Equal("restored\n", Run(artifacts.OutputPath));
+        IlVerifier.Verify(artifacts.OutputPath, additionalReferences: new[] { artifacts.ContractsPath });
+
+        var loadContext = new AssemblyLoadContext("Issue2726", isCollectible: true);
+        loadContext.Resolving += (_, name) => name.Name == "Oahu.Core"
+            ? loadContext.LoadFromAssemblyPath(artifacts.ContractsPath)
+            : null;
+        try
+        {
+            var assembly = loadContext.LoadFromAssemblyPath(artifacts.OutputPath);
+            var method = assembly.GetTypes()
+                .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
+                .Single(candidate => candidate.Name == "RegisterRestore");
+            Assert.Equal(typeof(Action), method.GetParameters().Single().ParameterType);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    [Fact]
+    public void DistinctNamedDelegateOverloads_RemainAmbiguous()
+    {
+        const string contracts = """
+            package DelegateContracts
+
+            type FirstHandler = delegate func(value int32) void
+            type SecondHandler = delegate func(value int32) void
+
+            class Dispatcher {
+                shared {
+                    func Run(callback FirstHandler) { }
+                    func Run(callback SecondHandler) { }
+                }
+            }
+            """;
+        const string source = """
+            package DelegateConsumer
+            import DelegateContracts
+
+            class Handlers {
+                shared {
+                    func Handle(value int32) { }
+                }
+            }
+
+            func Main() {
+                Dispatcher.Run(Handlers.Handle)
+            }
+            """;
+
+        using var artifacts = Compile(source, "library", contracts, expectSuccess: false);
+        Assert.NotEqual(0, artifacts.ExitCode);
+        var output = artifacts.Stdout + artifacts.Stderr;
+        Assert.True(output.Contains("GS0160", StringComparison.Ordinal), output);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- canonicalize structural function shapes to the expected named CLR delegate during method-group matching
- bind structural custom interface events to the unique expected named delegate identity for valid accessor metadata
- retain distinct named-delegate overload ambiguity and cover the exact Oahu runtime, reflection, and ILVerify failures

## Testing
- `dotnet build GSharp.sln --no-restore --nologo --verbosity minimal`
- 338 related Compiler.Tests passed
- 647 related Core.Tests passed

Fixes #2726
Fixes #2718