### PR TITLE
Fix constrained generic receiver spill planning

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -4203,12 +4203,15 @@ internal sealed class ReflectionMetadataEmitter
         FunctionSymbol function,
         IReadOnlyDictionary<VariableSymbol, int> locals)
     {
-        if (!IsValueTypeSymbol(receiver.Type))
+        // A constrained type parameter needs an address even though its
+        // value/reference shape is unknown until the generic is closed.
+        if (!IsValueTypeSymbol(receiver.Type) && receiver.Type is not TypeParameterSymbol)
         {
             return false;
         }
 
         if (receiver is BoundVariableExpression bve
+            && bve.NarrowedType == null
             && this.CanLoadVariableAddressForReceiverSpill(bve.Variable, function, locals))
         {
             return false;

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -986,60 +986,13 @@ internal sealed class SlotPlanner
 
         protected override void VisitImportedInstanceCallExpression(BoundImportedInstanceCallExpression node)
         {
-            // Issue #943: a constrained type-parameter call needs the receiver's
-            // address for the `constrained.` prefix. Variable receivers
-            // (parameters/locals/globals) are addressable directly; any other
-            // shape (an rvalue such as `getX().CompareTo(y)`) must be spilled to
-            // a local so its address can be taken.
-            //
-            // Issue #2335 (audit follow-up): a NARROWED variable receiver
-            // (ADR-0069 smart-cast — `bve.NarrowedType != null`, e.g. `if x is
-            // T { x.ToString() }` narrowing an `object`-typed parameter/local
-            // to a type-parameter view `T`) is NOT addressable directly either:
-            // the narrowed view still physically lives in the wider DECLARED
-            // storage slot, so taking that slot's own address yields
-            // `<declared>&` (e.g. `object&`), not the `!!T&` the `constrained.`
-            // prefix requires — ilverify rejects the mismatch
-            // (`StackUnexpected`) and, pre-verification, the wrong pointer
-            // shape corrupts the receiver read. Route a narrowed variable
-            // receiver through the same rvalue-spill path as any other
-            // non-addressable receiver shape so the emitter re-materializes
-            // the correctly narrowed `!!T` value (via
-            // `EmitNarrowingCastIfNeeded`) into a fresh scratch local of type
-            // `T` before taking ITS address.
-            if (node.IsConstrainedTypeParameterCall
-                && (node.Receiver is not BoundVariableExpression importedRecvVar || importedRecvVar.NarrowedType != null))
-            {
-                this.sink.Add(node.Receiver);
-            }
-            else
-            {
-                this.AddIfNeeded(node.Receiver);
-            }
-
+            this.AddReceiver(node.Receiver, node.IsConstrainedTypeParameterCall);
             base.VisitImportedInstanceCallExpression(node);
         }
 
         protected override void VisitUserInstanceCallExpression(BoundUserInstanceCallExpression node)
         {
-            // Issue #1052: a constrained type-parameter call needs the receiver's
-            // address for the `constrained.` prefix. Variable receivers
-            // (parameters/locals/globals) are addressable directly; any other shape
-            // (an rvalue) must be spilled to a local so its address can be taken.
-            //
-            // Issue #2335 (audit follow-up): see the matching narrowed-variable
-            // rationale in VisitImportedInstanceCallExpression above — a
-            // narrowed variable receiver must also be spilled here.
-            if (node.IsConstrainedTypeParameterCall
-                && (node.Receiver is not BoundVariableExpression userRecvVar || userRecvVar.NarrowedType != null))
-            {
-                this.sink.Add(node.Receiver);
-            }
-            else
-            {
-                this.AddIfNeeded(node.Receiver);
-            }
-
+            this.AddReceiver(node.Receiver, node.IsConstrainedTypeParameterCall);
             base.VisitUserInstanceCallExpression(node);
         }
 
@@ -1047,7 +1000,7 @@ internal sealed class SlotPlanner
         {
             if (node.Receiver != null)
             {
-                this.AddIfNeeded(node.Receiver);
+                this.AddReceiver(node.Receiver, node.IsConstrainedTypeParameterAccess);
             }
 
             base.VisitClrPropertyAccessExpression(node);
@@ -1057,7 +1010,7 @@ internal sealed class SlotPlanner
         {
             if (node.Receiver != null)
             {
-                this.AddIfNeeded(node.Receiver);
+                this.AddReceiver(node.Receiver, node.IsConstrainedTypeParameterAccess);
                 this.AddIfCompoundReused(node.Receiver, node.Value);
             }
 
@@ -1109,7 +1062,7 @@ internal sealed class SlotPlanner
         {
             if (node.Receiver != null)
             {
-                this.AddIfNeeded(node.Receiver);
+                this.AddReceiver(node.Receiver, node.IsConstrainedTypeParameterAccess);
             }
 
             base.VisitClrEventSubscriptionExpression(node);
@@ -1127,8 +1080,18 @@ internal sealed class SlotPlanner
 
         protected override void VisitClrIndexExpression(BoundClrIndexExpression node)
         {
-            this.AddIfNeeded(node.Target);
+            this.AddReceiver(node.Target, node.IsConstrainedTypeParameterAccess);
             base.VisitClrIndexExpression(node);
+        }
+
+        protected override void VisitClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
+        {
+            if (node.TargetExpression != null)
+            {
+                this.AddReceiver(node.TargetExpression, node.IsConstrainedTypeParameterAccess);
+            }
+
+            base.VisitClrIndexAssignmentExpression(node);
         }
 
         protected override void VisitTupleElementAccessExpression(BoundTupleElementAccessExpression node)
@@ -1166,6 +1129,18 @@ internal sealed class SlotPlanner
             {
                 this.sink.Add(receiver);
             }
+        }
+
+        private void AddReceiver(BoundExpression receiver, bool isConstrained)
+        {
+            if (isConstrained
+                && (receiver is not BoundVariableExpression bve || bve.NarrowedType != null))
+            {
+                this.sink.Add(receiver);
+                return;
+            }
+
+            this.AddIfNeeded(receiver);
         }
 
         // Issue #1688: a compound member assignment (`getObj().F += x` /

--- a/test/Compiler.Tests/Emit/Issue2725ConstrainedNullAssertedReceiverEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2725ConstrainedNullAssertedReceiverEmitTests.cs
@@ -1,0 +1,129 @@
+// <copyright file="Issue2725ConstrainedNullAssertedReceiverEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2725: constrained member access over a null-asserted generic receiver
+/// must reserve the addressable receiver spill consumed by the emitter.
+/// </summary>
+public sealed class Issue2725ConstrainedNullAssertedReceiverEmitTests
+{
+    private const string ExactOahuCoreFingerprint = "2f128c1866ee";
+
+    [Fact]
+    public void ExactOahuCoreFingerprint_NullAssertedConstrainedCount_RunsAndVerifies()
+    {
+        const string Source = """
+            package Oahu.Core
+            import System
+            import System.Collections.Generic
+
+            func CountText[T ICollection[object]](p T?) string {
+                return p!!.Count.ToString()
+            }
+
+            func MutateText[T IList[object]](p T?) string {
+                p!!.Add("three")
+                p!![0] = "zero"
+                return p!!.Count.ToString() + ":" + p!![0].ToString()
+            }
+
+            var values = List[object]{ "one", "two" }
+            Console.WriteLine(CountText[List[object]](values))
+            Console.WriteLine(MutateText[List[object]](values))
+            """;
+
+        Assert.Equal("2\n3:zero\n", CompileVerifyAndRun(Source));
+    }
+
+    [Fact]
+    public void IncompatibleConstraintArgument_RemainsRejected()
+    {
+        var syntax = SyntaxTree.Parse(SourceText.From(
+            """
+            package Oahu.Core.Negative
+            import System.Collections.Generic
+
+            func CountText[T ICollection[object]](p T?) string {
+                return p!!.Count.ToString()
+            }
+
+            let invalid = CountText[int32](1)
+            """));
+        var compilation = new Compilation(syntax);
+
+        using var output = new MemoryStream();
+        var result = compilation.Emit(output, pdbStream: null, refStream: null, assemblyName: "Issue2725.Negative");
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0152");
+    }
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2725Emit", ExactOahuCoreFingerprint);
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            Assert.True(
+                exitCode == 0,
+                $"Exact GS9998 fingerprint {ExactOahuCoreFingerprint} must fall from 1 to 0.\n"
+                + $"compile failed ({exitCode}):\n{stdout}\n{stderr}");
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        IlVerifier.Verify(outputPath);
+
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                outputPath,
+            },
+            WorkingDirectory = directory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(process.ExitCode == 0, error);
+        return output.Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
Fixes #2725

## Summary
- plan spills for type-parameter receivers whose address is consumed by constrained dispatch
- cover expression-based constrained index assignments alongside calls and member reads
- prove Oahu.Core fingerprint `2f128c1866ee` with runtime, ILVerify, and negative constraint coverage

## Validation
- `dotnet build GSharp.sln --configuration Release --no-restore -graph`
- 18 related constrained-receiver tests
- full solution run: 9,464 tests passed before the long-running Compiler.Tests host was stopped; targeted Compiler.Tests are green