### PR TITLE
Fix async conditional reference spill defaults

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -1412,9 +1412,8 @@ public static class SpillSequenceSpiller
 
                 if (!firstArmResultDeclared)
                 {
-                    // Declare resultLocal with a real initializer here (rather
-                    // than relying on FlushSideEffects' generic int-0 default
-                    // fallback, which is wrong for non-numeric result types).
+                    // Declare resultLocal where the selected arm first assigns
+                    // it, avoiding a redundant default initialization.
                     sideEffects.Add(new BoundVariableDeclaration(null, resultLocal, spilledResult.Value));
                     firstArmResultDeclared = true;
                 }
@@ -1570,11 +1569,8 @@ public static class SpillSequenceSpiller
             }
             else
             {
-                // It is declared (not just assigned) with the real receiver
-                // value as its initializer so FlushSideEffects never falls
-                // back to its int32-literal-0 default — which is the wrong
-                // CLR type for a reference-typed capture and would fail IL
-                // verification.
+                // Declare the capture with the real receiver value so the
+                // following null guard observes that value directly.
                 locals.Add((LocalVariableSymbol)nc.Capture);
                 sideEffects.Add(new BoundVariableDeclaration(null, (LocalVariableSymbol)nc.Capture, receiver));
                 guardCondition = new BoundVariableExpression(null, nc.Capture);
@@ -2299,7 +2295,7 @@ public static class SpillSequenceSpiller
 
                 if (!alreadyDeclared)
                 {
-                    builder.Add(new BoundVariableDeclaration(null, local, GetDefaultValue(local.Type)));
+                    builder.Add(new BoundVariableDeclaration(null, local, new BoundDefaultExpression(null, local.Type)));
                 }
             }
 
@@ -2307,28 +2303,6 @@ public static class SpillSequenceSpiller
             {
                 builder.Add(stmt);
             }
-        }
-
-        private static BoundExpression GetDefaultValue(TypeSymbol type)
-        {
-            if (type == TypeSymbol.Int32)
-            {
-                return new BoundLiteralExpression(null, 0);
-            }
-
-            if (type == TypeSymbol.Bool)
-            {
-                return new BoundLiteralExpression(null, false);
-            }
-
-            if (type == TypeSymbol.String)
-            {
-                return new BoundLiteralExpression(null, string.Empty);
-            }
-
-            // For reference types or unknown types, use default(int) as placeholder.
-            // The actual value will be overwritten before use.
-            return new BoundLiteralExpression(null, 0);
         }
 
         private bool HasAwait(BoundStatement statement) => AsyncBoundTreeQueries.HasAwait(statement, awaitMemo);

--- a/test/Compiler.Tests/Emit/Issue2734AsyncConditionalReferenceLocalEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2734AsyncConditionalReferenceLocalEmitTests.cs
@@ -1,0 +1,171 @@
+// <copyright file="Issue2734AsyncConditionalReferenceLocalEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2734: the translated <c>SignInFlow</c> combination of an async
+/// <c>Task.Run</c> lambda, a reference-valued conditional with awaited arms,
+/// and a later await makes <c>SpillConditional</c> synthesize an
+/// <c>AuthSession</c> spill local. <c>FlushSideEffects</c> used to initialize
+/// that local with an <c>int32</c> zero before the selected arm assigned it.
+/// Async capture then hoisted the local to an <c>AuthSession</c> field, yielding
+/// ILVerify <c>StackUnexpected: found Int32, expected ref AuthSession</c>.
+/// </summary>
+public class Issue2734AsyncConditionalReferenceLocalEmitTests
+{
+    [Fact]
+    public void ExactSignInFlow_D1205f3d4b51_VerifiesAndRuns()
+    {
+        const string HelperSource = """
+            using System.Threading.Tasks;
+
+            namespace Oahu.Cli.App.Auth;
+
+            public sealed class AuthSession
+            {
+                public AuthSession(string profileAlias) => ProfileAlias = profileAlias;
+                public string ProfileAlias { get; }
+            }
+
+            public static class AuthService
+            {
+                public static int CredentialCalls { get; private set; }
+                public static int BrowserCalls { get; private set; }
+
+                public static async Task<AuthSession> LoginWithCredentialsAsync()
+                {
+                    CredentialCalls++;
+                    await Task.Yield();
+                    return new AuthSession("credentials");
+                }
+
+                public static async Task<AuthSession> LoginAsync()
+                {
+                    BrowserCalls++;
+                    await Task.Yield();
+                    return new AuthSession("browser");
+                }
+
+                public static async Task<int> SyncAsync(string profileAlias)
+                {
+                    await Task.Yield();
+                    return profileAlias.Length;
+                }
+            }
+            """;
+        const string Source = """
+            package Oahu.Cli.Tui.Auth
+
+            import System
+            import System.Threading.Tasks
+            import Oahu.Cli.App.Auth
+
+            class SignInFlow() {
+                func StartCore(hasCredentials bool) Task[string] {
+                    return Task.Run(async () -> {
+                        let session = hasCredentials
+                            ? await AuthService.LoginWithCredentialsAsync().ConfigureAwait(false)
+                            : await AuthService.LoginAsync().ConfigureAwait(false)
+
+                        let count = await AuthService.SyncAsync(session.ProfileAlias).ConfigureAwait(false)
+                        return "${session.ProfileAlias}:${count}"
+                    })
+                }
+            }
+
+            let flow = SignInFlow()
+            Console.WriteLine(flow.StartCore(true).GetAwaiter().GetResult())
+            Console.WriteLine(flow.StartCore(false).GetAwaiter().GetResult())
+            Console.WriteLine("${AuthService.CredentialCalls}:${AuthService.BrowserCalls}")
+            """;
+
+        Assert.Equal(
+            "credentials:11\nbrowser:7\n1:1\n",
+            CompileVerifyAndRun(Source, HelperSource));
+    }
+
+    private static string CompileVerifyAndRun(string source, string helperSource)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2734Emit");
+        Directory.CreateDirectory(directory);
+        var helperPath = BuildHelper(directory, helperSource);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/reference:" + helperPath,
+                sourcePath,
+            });
+            Assert.True(exitCode == 0, $"compile failed ({exitCode}):\n{stdout}\n{stderr}");
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        IlVerifier.Verify(outputPath, new[] { helperPath });
+
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                outputPath,
+            },
+            WorkingDirectory = directory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(process.ExitCode == 0, error);
+        return output.Replace("\r\n", "\n");
+    }
+
+    private static string BuildHelper(string directory, string source)
+    {
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(File.Exists)
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "Oahu.Cli.App",
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var path = Path.Combine(directory, "Oahu.Cli.App.dll");
+        using var stream = File.Create(path);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return path;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/SpillSequenceSpillerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/SpillSequenceSpillerTests.cs
@@ -28,6 +28,35 @@ public class SpillSequenceSpillerTests
         BoundBinaryOperator.Bind(SyntaxKind.PipePipeToken, TypeSymbol.Bool, TypeSymbol.Bool);
 
     [Fact]
+    public void ConditionalReferenceResult_UsesTypePreservingDefault()
+    {
+        var referenceType = TypeSymbol.FromClrType(typeof(object));
+        var conditional = new BoundConditionalExpression(
+            null,
+            new BoundLiteralExpression(null, true),
+            new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), referenceType),
+            new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), referenceType),
+            referenceType);
+        var resultVariable = new LocalVariableSymbol("result", false, referenceType);
+        var body = new BoundBlockStatement(
+            null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundVariableDeclaration(null, resultVariable, conditional)));
+
+        var result = SpillSequenceSpiller.Rewrite(body);
+
+        var spillDeclaration = Assert.IsType<BoundVariableDeclaration>(Assert.Single(
+            result.Statements,
+            statement => statement is BoundVariableDeclaration declaration
+                && declaration.Variable != resultVariable
+                && declaration.Variable.Type == referenceType
+                && declaration.Initializer is BoundDefaultExpression));
+        var initializer = Assert.IsType<BoundDefaultExpression>(spillDeclaration.Initializer);
+        Assert.Equal(referenceType, initializer.Type);
+        Assert.IsNotType<BoundLiteralExpression>(initializer);
+    }
+
+    [Fact]
     public void Pure_BinaryExpression_With_AwaitOnRight_SpillsLeft()
     {
         // Arrange: left is a call (not pure), right is await


### PR DESCRIPTION
## Summary
- initialize every synthesized async spill local with `default(T)` instead of an `int32` placeholder
- fix the full trigger: an async `Task.Run` lambda whose awaited conditional produces an imported reference local that is used across a later await
- reproduce fingerprint `d1205f3d4b51` exactly: `MoveNext` offset `0x25`, `Int32` versus `ref AuthSession`
- add runtime, ILVerify, branch-negative, and structural type-negative proof

## Validation
- `dotnet build GSharp.sln --configuration Release --no-restore --verbosity minimal`
- Core.Tests: 6,689 passed, 1 skipped
- related Compiler.Tests: 18 passed
- exact regression and structural tests passed independently after the final edit

Fixes #2734