### PR TITLE
Fix natural method groups in interpolation

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1383,7 +1383,7 @@ internal sealed class ConversionClassifier
         var argTypes = new Type[invokeParams.Length + (closesExtensionReceiver ? 1 : 0)];
         if (closesExtensionReceiver)
         {
-            var receiverClr = group.Receiver.Type?.ClrType;
+            var receiverClr = NullableTypeSymbol.GetEffectiveClrType(group.Receiver.Type);
             if (receiverClr == null
                 && !MemberLookup.TryProjectErasedClrType(group.Receiver.Type, out receiverClr))
             {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -449,6 +449,7 @@ internal sealed partial class ExpressionBinder
             if (segment.IsExpression)
             {
                 var bound = BindExpression(segment.Expression);
+                bound = BindNaturalMethodGroupValue(bound, segment.Expression.Location);
                 if (bound is BoundErrorExpression)
                 {
                     return bound;
@@ -469,6 +470,127 @@ internal sealed partial class ExpressionBinder
         }
 
         return new BoundInterpolatedStringExpression(syntax, parts.ToImmutable());
+    }
+
+    private BoundExpression BindNaturalMethodGroupValue(BoundExpression expression, TextLocation location)
+    {
+        if (expression is BoundClrMethodGroupExpression { ResolvedMethod: null } clrGroup)
+        {
+            if (TryGetNaturalClrMethodGroupType(clrGroup, out var naturalType))
+            {
+                return conversions.BindConversion(location, clrGroup, naturalType);
+            }
+
+            Diagnostics.ReportCannotConvertMethodGroup(location, clrGroup.MethodName, TypeSymbol.Error);
+            return new BoundErrorExpression(null);
+        }
+
+        if (expression is BoundMethodGroupExpression { FunctionType: null } userGroup)
+        {
+            if (TryGetNaturalUserMethodGroupType(userGroup, out var naturalType))
+            {
+                return conversions.BindConversion(location, userGroup, naturalType);
+            }
+
+            Diagnostics.ReportCannotConvertMethodGroup(
+                location,
+                userGroup.Function?.Name ?? "<method group>",
+                TypeSymbol.Error);
+            return new BoundErrorExpression(null);
+        }
+
+        return expression;
+    }
+
+    private bool TryGetNaturalClrMethodGroupType(
+        BoundClrMethodGroupExpression group,
+        out FunctionTypeSymbol naturalType)
+    {
+        naturalType = null;
+        var closesReceiver = group.Receiver != null && group.Candidates.All(candidate => candidate.IsStatic);
+        var receiverClr = closesReceiver
+            ? NullableTypeSymbol.GetEffectiveClrType(group.Receiver.Type)
+            : null;
+        var matches = new List<(MethodInfo Method, OverloadResolution.ImplicitConversionKind ReceiverConversion)>();
+
+        foreach (var candidate in group.Candidates)
+        {
+            if (candidate.ContainsGenericParameters || candidate.ReturnType.IsByRef)
+            {
+                continue;
+            }
+
+            var parameters = candidate.GetParameters();
+            if (parameters.Any(parameter => parameter.ParameterType.IsByRef)
+                || (closesReceiver && (parameters.Length == 0 || receiverClr == null)))
+            {
+                continue;
+            }
+
+            var receiverConversion = closesReceiver
+                ? OverloadResolution.ClassifyImplicit(parameters[0].ParameterType, receiverClr)
+                : OverloadResolution.ImplicitConversionKind.Identity;
+            if (receiverConversion != OverloadResolution.ImplicitConversionKind.None)
+            {
+                matches.Add((candidate, receiverConversion));
+            }
+        }
+
+        if (matches.Count == 0)
+        {
+            return false;
+        }
+
+        var bestReceiverConversion = matches.Min(match => (int)match.ReceiverConversion);
+        var best = matches.Where(match => (int)match.ReceiverConversion == bestReceiverConversion).ToArray();
+        if (best.Length != 1)
+        {
+            return false;
+        }
+
+        var method = best[0].Method;
+        var methodParameters = method.GetParameters();
+        var offset = closesReceiver ? 1 : 0;
+        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(methodParameters.Length - offset);
+        for (var i = offset; i < methodParameters.Length; i++)
+        {
+            parameterTypes.Add(ClrNullability.GetParameterTypeSymbol(methodParameters[i]));
+        }
+
+        var returnType = method.ReturnType.IsSameAs(typeof(void))
+            ? TypeSymbol.Void
+            : ClrNullability.GetReturnTypeSymbol(method);
+        naturalType = FunctionTypeSymbol.Get(parameterTypes.MoveToImmutable(), returnType);
+        return naturalType.ClrType != null;
+    }
+
+    private bool TryGetNaturalUserMethodGroupType(
+        BoundMethodGroupExpression group,
+        out FunctionTypeSymbol naturalType)
+    {
+        naturalType = null;
+        if (group.Candidates.Length != 1
+            || group.Candidates[0] is not { IsGeneric: false } candidate)
+        {
+            return false;
+        }
+
+        var offset = candidate.IsExtension && group.Receiver != null ? 1 : 0;
+        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(candidate.Parameters.Length - offset);
+        for (var i = offset; i < candidate.Parameters.Length; i++)
+        {
+            if (candidate.Parameters[i].RefKind != RefKind.None)
+            {
+                return false;
+            }
+
+            parameterTypes.Add(candidate.Parameters[i].Type);
+        }
+
+        naturalType = FunctionTypeSymbol.Get(
+            parameterTypes.MoveToImmutable(),
+            MethodGroupObservableReturnType(candidate));
+        return naturalType.ClrType != null;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue2731NaturalMethodGroupInterpolationEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2731NaturalMethodGroupInterpolationEmitTests.cs
@@ -1,0 +1,115 @@
+// <copyright file="Issue2731NaturalMethodGroupInterpolationEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Runtime and ILVerify coverage for issue #2731.</summary>
+public sealed class Issue2731NaturalMethodGroupInterpolationEmitTests
+{
+    [Fact]
+    public void OahuCoreImportedExtensionMethodGroup_Interpolation_InfersFuncAndRuns()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue2731NaturalMethodGroupInterpolationEmitTests));
+        Directory.CreateDirectory(directory);
+        var libraryPath = EmitOahuCoreLibrary(directory);
+        var consumerPath = Path.Combine(directory, "Issue2731.Consumer.dll");
+
+        const string source = """
+            package Issue2731
+            import Oahu.Core
+
+            func SourceChecksum() uint32 -> 42u
+
+            data class Profile(AccountName string?) {
+                func Render() string ->
+                    "imported=${AccountName!!.Checksum32}; source=${SourceChecksum}"
+            }
+
+            func Run() string -> Profile("account").Render()
+            """;
+
+        using (var resolver = ReferenceResolver.WithReferences(new[] { libraryPath }))
+        {
+            var compilation = new GsCompilation(
+                resolver,
+                GsSyntaxTree.Parse(SourceText.From(source)))
+            {
+                IsLibrary = true,
+            };
+
+            using var output = File.Create(consumerPath);
+            var result = compilation.Emit(
+                output,
+                pdbStream: null,
+                refStream: null,
+                assemblyName: "Issue2731.Consumer");
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
+
+        var loadContext = new AssemblyLoadContext("Issue2731", isCollectible: true);
+        try
+        {
+            _ = loadContext.LoadFromAssemblyPath(libraryPath);
+            var consumer = loadContext.LoadFromAssemblyPath(consumerPath);
+            var run = consumer.GetTypes()
+                .Single(type => type.Name == "<Program>")
+                .GetMethod("Run", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(run);
+            Assert.Equal(
+                "imported=System.Func`1[System.UInt32]; source=System.Func`1[System.UInt32]",
+                run!.Invoke(null, null));
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static string EmitOahuCoreLibrary(string directory)
+    {
+        const string source = """
+            namespace Oahu.Core;
+
+            public static class ChecksumExtensions
+            {
+                public static uint Checksum32(this string value) => (uint)value.Length;
+            }
+            """;
+
+        var libraryPath = Path.Combine(directory, "Oahu.Core.dll");
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "Oahu.Core",
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var output = File.Create(libraryPath);
+        var result = compilation.Emit(output);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return libraryPath;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2731NaturalMethodGroupInterpolationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2731NaturalMethodGroupInterpolationTests.cs
@@ -1,0 +1,55 @@
+// <copyright file="Issue2731NaturalMethodGroupInterpolationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2731NaturalMethodGroupInterpolationTests
+{
+    [Fact]
+    public void AmbiguousMethodGroupInInterpolation_ReportsUserDiagnostic()
+    {
+        const string source = """
+            package Issue2731Negative
+            import System
+
+            func Convert(value string) int32 -> value.Length
+            func Convert(value int32) string -> value.ToString()
+
+            func Render() string -> "value=${Convert}"
+            """;
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        using var output = new MemoryStream();
+        var result = compilation.Emit(output);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0218");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS9998");
+    }
+
+    [Fact]
+    public void ImportedOverloadSetInInterpolation_ReportsUserDiagnostic()
+    {
+        const string source = """
+            package Issue2731ImportedNegative
+            import System
+
+            func Render() string -> "value=${Convert.ToString}"
+            """;
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        using var output = new MemoryStream();
+        var result = compilation.Emit(output);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0218");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS9998");
+    }
+}


### PR DESCRIPTION
## Summary
- infer natural `Func`/`Action` types for unambiguous imported and source method groups used as interpolation holes
- preserve nullable extension receiver shape and reject ambiguous overload sets before emit
- add exact Oahu.Core `AccountName!!.Checksum32` runtime/ILVerify proof and negative diagnostics coverage

## Tests
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore` (6690 passed, 1 skipped)
- issue #2731 Compiler runtime/ILVerify test (passed)
- related method-group regression set (22 passed)
- issue #750 baseline rerun after building Gsharp.Extensions (5 passed)

Fixes #2731