### PR TITLE
Fix constructed generic coalescing

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -153,6 +153,9 @@ public sealed class Conversion
         // conversion as identity rather than reporting a confusing "Cannot
         // convert type 'X' to 'X'"-looking error.
         if (IsImportedTypeIdentity(from) && IsImportedTypeIdentity(to)
+            && (!(from is ImportedTypeSymbol { OpenDefinition: not null, HasSubstitutableTypeArgument: true }
+                    || to is ImportedTypeSymbol { OpenDefinition: not null, HasSubstitutableTypeArgument: true })
+                || TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(from, to))
             && ClrTypeUtilities.AreSame(from.ClrType, to.ClrType))
         {
             return Conversion.Identity;
@@ -1224,6 +1227,18 @@ public sealed class Conversion
         // target) case was already handled above and never reaches this arm.
         if (from is NullableTypeSymbol fromNullableUpcastSrc
             && IsReferenceLikeTarget(fromNullableUpcastSrc.UnderlyingType))
+        {
+            return Conversion.None;
+        }
+
+        // Issue #2735: an object-erased constructed generic must not fall
+        // through to the CLR assignability check below after its symbolic
+        // arguments failed the hierarchy/variance checks above. For example,
+        // NullLogger<Other>'s probe type NullLogger<object> implements the
+        // probe ILogger<object>, but it does not implement ILogger<Store>.
+        if (from is ImportedTypeSymbol { OpenDefinition: not null, HasSubstitutableTypeArgument: true }
+            && to is ImportedTypeSymbol mismatchedConstructedTarget
+            && TryGetConstructedGenericShape(mismatchedConstructedTarget, out _, out _))
         {
             return Conversion.None;
         }

--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -1682,6 +1682,38 @@ internal sealed class ImportedMemberRefFactory
         return handle;
     }
 
+    internal MemberReferenceHandle GetFieldReference(FieldInfo field, TypeSymbol containingTypeSymbol)
+    {
+        if (!TryNormalizeToSymbolicContainer(containingTypeSymbol, out var openDefinition, out var typeArguments))
+        {
+            return this.GetFieldReference(field);
+        }
+
+        var openField = openDefinition.GetField(
+            field.Name,
+            BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                $"Open generic type '{openDefinition.FullName}' has no field '{field.Name}'.");
+        var symbolicView = ImportedTypeSymbol.GetConstructed(
+            openDefinition.MakeGenericType(this.GetErasedObjectArgs(openDefinition)),
+            openDefinition,
+            typeArguments);
+        var parentBlob = new BlobBuilder();
+        this.signatures.EncodeTypeSymbol(
+            new BlobEncoder(parentBlob).TypeSpecificationSignature(),
+            symbolicView);
+        var parent = this.emitCtx.Metadata.AddTypeSpecification(
+            this.emitCtx.Metadata.GetOrAddBlob(parentBlob));
+        var sigBlob = new BlobBuilder();
+        this.signatures.EncodeClrType(
+            new BlobEncoder(sigBlob).FieldSignature(),
+            openField.FieldType);
+        return this.emitCtx.Metadata.AddMemberReference(
+            parent,
+            this.emitCtx.Metadata.GetOrAddString(field.Name),
+            this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+    }
+
     /// <summary>
     /// Issue #649: Gets a MemberRef for a field on a constructed generic type without
     /// calling <c>.GetField()</c> on the closed generic (which throws

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -1076,7 +1076,9 @@ internal sealed partial class MethodBodyEmitter
                     access.Type);
                 break;
             case FieldInfo field:
-                var fieldRef = this.outer.memberRefs.GetFieldReference(field);
+                var fieldRef = access.StaticContainerType != null
+                    ? this.outer.memberRefs.GetFieldReference(field, access.StaticContainerType)
+                    : this.outer.memberRefs.GetFieldReference(field);
                 this.il.OpCode(isStatic ? ILOpCode.Ldsfld : ILOpCode.Ldfld);
                 this.il.Token(fieldRef);
                 break;

--- a/test/Compiler.Tests/Emit/Issue2735ConstructedGenericCoalesceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2735ConstructedGenericCoalesceEmitTests.cs
@@ -1,0 +1,229 @@
+// <copyright file="Issue2735ConstructedGenericCoalesceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue2735ConstructedGenericCoalesceEmitTests
+{
+    [Fact]
+    public void OahuServiceProbe_PreservesUserFrameworkAndNestedCategoryTypesAtRuntime()
+    {
+        const string source = """
+            package Issue2735
+            import System
+            import System.Collections.Generic
+            import Microsoft.Extensions.Logging
+            import Microsoft.Extensions.Logging.Abstractions
+
+            class Store {}
+
+            class Service {
+                private let logger ILogger[Store]
+
+                init(logger ILogger[Store]?) {
+                    this.logger = logger ?? NullLogger[Store].Instance
+                }
+
+                func LoggerType() string -> logger!!.GetType().ToString()!!
+            }
+
+            func Main() {
+                Console.WriteLine(Service(nil).LoggerType())
+                let framework ILogger[string] = nil ?? NullLogger[string].Instance
+                Console.WriteLine(framework!!.GetType().ToString())
+                let nested ILogger[List[Store]] = nil ?? NullLogger[List[Store]].Instance
+                Console.WriteLine(nested!!.GetType().ToString())
+            }
+            """;
+
+        using var result = Compile(source, "exe");
+        Assert.Equal(
+            "Microsoft.Extensions.Logging.Abstractions.NullLogger`1[Issue2735.Store]\n"
+                + "Microsoft.Extensions.Logging.Abstractions.NullLogger`1[System.String]\n"
+                + "Microsoft.Extensions.Logging.Abstractions.NullLogger`1[System.Collections.Generic.List`1[Issue2735.Store]]\n",
+            Run(result.OutputPath));
+        IlVerifier.Verify(result.OutputPath, additionalReferences: result.References);
+    }
+
+    [Fact]
+    public void DifferentUserCategory_DoesNotBindThroughObjectErasure()
+    {
+        const string source = """
+            package Issue2735.UserNegative
+            import Microsoft.Extensions.Logging
+            import Microsoft.Extensions.Logging.Abstractions
+
+            class Store {}
+            class Other {}
+
+            func Bad(logger ILogger[Store]?) ILogger[Store] {
+                return logger ?? NullLogger[Other].Instance
+            }
+            """;
+
+        using var result = Compile(source, "library", expectSuccess: false);
+        Assert.Contains("GS0129", result.Diagnostics, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DifferentNestedCategory_DoesNotBindThroughObjectErasure()
+    {
+        const string source = """
+            package Issue2735.NestedNegative
+            import System.Collections.Generic
+            import Microsoft.Extensions.Logging
+            import Microsoft.Extensions.Logging.Abstractions
+
+            class Store {}
+            class Other {}
+
+            func Bad(logger ILogger[List[Store]]?) ILogger[List[Store]] {
+                return logger ?? NullLogger[List[Other]].Instance
+            }
+            """;
+
+        using var result = Compile(source, "library", expectSuccess: false);
+        Assert.Contains("GS0129", result.Diagnostics, StringComparison.Ordinal);
+    }
+
+    private static CompilationResult Compile(string source, string target, bool expectSuccess = true)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2735-artifacts",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var references = GetFrameworkReferences();
+        var args = new List<string>
+        {
+            "/out:" + outputPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+        args.AddRange(references.Select(path => "/reference:" + path));
+        args.Add(sourcePath);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        var diagnostics = stdout.ToString() + stderr;
+        Assert.True(
+            expectSuccess == (exitCode == 0),
+            $"expected success: {expectSuccess}; exit code: {exitCode}\n{diagnostics}");
+        return new CompilationResult(directory, outputPath, references, diagnostics);
+    }
+
+    private static string Run(string outputPath)
+    {
+        File.WriteAllText(
+            Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+            """
+            {
+              "runtimeOptions": {
+                "tfm": "net10.0",
+                "frameworks": [
+                  { "name": "Microsoft.NETCore.App", "version": "10.0.0" },
+                  { "name": "Microsoft.AspNetCore.App", "version": "10.0.0" }
+                ]
+              }
+            }
+            """);
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(outputPath)!,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+        startInfo.ArgumentList.Add(outputPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n");
+    }
+
+    private static string[] GetFrameworkReferences()
+    {
+        var coreDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var sharedDirectory = Directory.GetParent(coreDirectory)!.Parent!.FullName;
+        var aspNetDirectory = Path.Combine(
+            sharedDirectory,
+            "Microsoft.AspNetCore.App",
+            Path.GetFileName(coreDirectory));
+        Assert.True(Directory.Exists(aspNetDirectory), $"Missing ASP.NET Core runtime: {aspNetDirectory}");
+        return Directory.GetFiles(coreDirectory, "*.dll")
+            .Concat(Directory.GetFiles(aspNetDirectory, "*.dll"))
+            .ToArray();
+    }
+
+    private sealed class CompilationResult : IDisposable
+    {
+        public CompilationResult(
+            string directory,
+            string outputPath,
+            string[] references,
+            string diagnostics)
+        {
+            Directory = directory;
+            OutputPath = outputPath;
+            References = references;
+            Diagnostics = diagnostics;
+        }
+
+        public string Directory { get; }
+
+        public string OutputPath { get; }
+
+        public string[] References { get; }
+
+        public string Diagnostics { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                System.IO.Directory.Delete(Directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- preserve symbolic constructed-generic identity before CLR erasure-based conversion fallbacks
- emit static generic field references against the real symbolic container instead of `<object>`
- add executable Oahu logger proofs for user, framework, and nested arguments plus mismatch negatives

## Validation
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore` (6,688 passed, 1 skipped)
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --no-build --no-restore` (3,394 passed)

Fixes #2735