### PR TITLE
Fix nullable object initializer widening

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2743NullableObjectInitializerWideningPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2743NullableObjectInitializerWideningPipelineTests.cs
@@ -1,0 +1,162 @@
+// <copyright file="Issue2743NullableObjectInitializerWideningPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2743NullableObjectInitializerWideningPipelineTests
+{
+    [Fact]
+    public async Task Pipeline_NullableObjectInitializerValues_RemainNullAtRuntime()
+    {
+        string compiler = FindSiblingTool("Compiler", "gsc.dll");
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectDirectory = Path.Combine(sourceRoot, "Issue2743");
+        Directory.CreateDirectory(projectDirectory);
+        string projectPath = Path.Combine(projectDirectory, "Issue2743.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <OutputType>Exe</OutputType>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDirectory, "Program.cs"), """
+            using System;
+            using System.Collections.Generic;
+
+            namespace Issue2743;
+
+            public sealed class Config
+            {
+                public string? Value { get; set; }
+            }
+
+            public static class Program
+            {
+                private static T? Maybe<T>() where T : class => null;
+
+                private static Dictionary<string, object?> BuildDictionary(Config config) =>
+                    new Dictionary<string, object?>
+                    {
+                        ["value"] = config.Value,
+                        ["conditional"] = config.Value?.ToString(),
+                        ["generic"] = Maybe<string>(),
+                    };
+
+                private static List<object?> BuildCollection(Config config) =>
+                    new List<object?>
+                    {
+                        config.Value,
+                        config.Value?.ToString(),
+                        Maybe<string>(),
+                    };
+
+                public static void Main()
+                {
+                    var config = new Config();
+                    var dictionary = BuildDictionary(config);
+                    var collection = BuildCollection(config);
+                    Console.WriteLine(dictionary.Count);
+                    Console.WriteLine(dictionary["value"] == null);
+                    Console.WriteLine(dictionary["conditional"] == null);
+                    Console.WriteLine(dictionary["generic"] == null);
+                    Console.WriteLine(collection.Count);
+                    Console.WriteLine(collection[0] == null);
+                    Console.WriteLine(collection[1] == null);
+                    Console.WriteLine(collection[2] == null);
+                }
+            }
+            """);
+        string goldenPath = Path.Combine(projectDirectory, "baseline.stdout.golden");
+        File.WriteAllText(goldenPath, "3\nTrue\nTrue\nTrue\n3\nTrue\nTrue\nTrue\n");
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp(
+            "test/Issue2743",
+            projectPath,
+            TargetKind.Exe,
+            stdoutGolden: goldenPath);
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[] { new TranslateStage(), new CompileStage(), new TestParityStage() });
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+        string emitted = string.Join(
+            Environment.NewLine,
+            Directory.GetFiles(
+                    Path.Combine(
+                        outputRoot,
+                        result.RunId,
+                        MigrationPipeline.SanitizeAppId(app.Id)),
+                    "*.gs",
+                    SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+
+        Assert.DoesNotContain("config.Value!!", emitted, StringComparison.Ordinal);
+        Assert.DoesNotContain("Maybe[string]()!!", emitted, StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            "Expected nullable initializer values to compile and remain null at runtime. Stages: "
+                + string.Join("; ", appResult.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2743",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindSiblingTool(string projectDirName, string dllName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    projectDirName,
+                    dllName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2743NullableObjectInitializerWideningTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2743NullableObjectInitializerWideningTranslationTests.cs
@@ -1,0 +1,135 @@
+// <copyright file="Issue2743NullableObjectInitializerWideningTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public sealed class Issue2743NullableObjectInitializerWideningTranslationTests
+{
+    private const string Source = """
+        #nullable enable
+        using System.Collections.Generic;
+
+        namespace Issue2743;
+
+        public sealed class Config
+        {
+            public string? Value { get; set; }
+        }
+
+        public static class Repro
+        {
+            private static T? Maybe<T>() where T : class => null;
+
+            public static Dictionary<string, object?> Dictionary(Config config) =>
+                new Dictionary<string, object?>
+                {
+                    ["value"] = config.Value,
+                    ["conditional"] = config.Value?.ToString(),
+                    ["generic"] = Maybe<string>(),
+                };
+
+            public static Dictionary<string, object?> KeyedDictionary(Config config) =>
+                new Dictionary<string, object?> { { "value", config.Value } };
+
+            public static List<object?> Collection(Config config) =>
+                new List<object?> { config.Value, config.Value?.ToString(), Maybe<string>() };
+
+            public static Dictionary<string, object> RequiredDictionary(Config config) =>
+                new Dictionary<string, object> { ["value"] = config.Value };
+
+            public static List<string> RequiredCollection(Config config) =>
+                new List<string> { config.Value };
+        }
+        """;
+
+    [Fact]
+    public void Dictionary_NullableReferenceWidening_PreservesNull()
+    {
+        string translated = Compact(Translate());
+
+        Assert.Contains("[\"value\"] = config.Value", translated, StringComparison.Ordinal);
+        Assert.Contains("\"value\": config.Value", translated, StringComparison.Ordinal);
+        Assert.DoesNotContain("config.Value!!", NullableDictionarySection(translated), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Dictionary_ConditionalAccessWidening_PreservesNull()
+    {
+        string translated = NullableDictionarySection(Compact(Translate()));
+
+        Assert.Contains("config.Value?.ToString()", translated, StringComparison.Ordinal);
+        Assert.DoesNotContain("ToString()!!", translated, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Dictionary_GenericNullableReferenceWidening_PreservesNull()
+    {
+        string translated = NullableDictionarySection(Compact(Translate()));
+
+        Assert.Contains("Maybe[string]()", translated, StringComparison.Ordinal);
+        Assert.DoesNotContain("Maybe[string]()!!", translated, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Collection_NullableElements_PreserveNull()
+    {
+        string translated = Compact(Translate());
+        string collection = translated[
+            translated.IndexOf("func Collection", StringComparison.Ordinal)..
+            translated.IndexOf("func RequiredDictionary", StringComparison.Ordinal)];
+
+        Assert.Contains(
+            "List[object?]{ config.Value, config.Value?.ToString(), Maybe[string]() }",
+            collection,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("!!", collection, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RequiredDictionaryAndCollection_RetainAssertions()
+    {
+        string translated = Compact(Translate());
+
+        Assert.Contains(
+            "Dictionary[string, object]{ [\"value\"] = config.Value!! }",
+            translated,
+            StringComparison.Ordinal);
+        Assert.Contains("List[string]{ config.Value!! }", translated, StringComparison.Ordinal);
+    }
+
+    private static string NullableDictionarySection(string translated) =>
+        translated[
+            translated.IndexOf("func Dictionary", StringComparison.Ordinal)..
+            translated.IndexOf("func RequiredDictionary", StringComparison.Ordinal)];
+
+    private static string Translate()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Repro.cs", Source) },
+            CSharpProjectLoader.RuntimeReferences(),
+            "Issue2743");
+        Assert.True(
+            project.BoundWithoutErrors,
+            string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        string printed = GSharpPrinter.Print(
+            new CSharpToGSharpTranslator().TranslateDocument(document));
+        RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+        Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
+        return printed;
+    }
+
+    private static string Compact(string value) =>
+        string.Join(
+            " ",
+            value.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries));
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1770,15 +1770,13 @@ public sealed partial class CSharpToGSharpTranslator
                         return null;
                     }
 
-                    // Issue #2429: the indexer's VALUE type/promotion state is
-                    // resolved exactly like a plain `arr[i] = value` element-access
-                    // assignment (`ForgiveElementAccessAssignmentRhs`, issue
-                    // #2259) — `GetTypeInfo` on the (implicit) indexer access
-                    // itself gives the indexer's converted value type, and the
-                    // indexer PROPERTY symbol (not the value) is what the taint
-                    // fixpoint may have promoted.
-                    ITypeSymbol indexerValueType = this.context.GetTypeInfo(indexAccess).Type;
+                    // The constructed property symbol carries the indexer's
+                    // nullable substitution (`TValue` -> `object?`); type info
+                    // for the implicit access can lose that annotation.
                     ISymbol indexerSymbol = this.context.GetSymbolInfo(indexAccess).Symbol;
+                    ITypeSymbol indexerValueType =
+                        (indexerSymbol as IPropertySymbol)?.Type
+                        ?? this.context.GetTypeInfo(indexAccess).Type;
                     GExpression indexedValue = this.ForgiveInitializerElementValue(
                         indexedAssignment.Right,
                         this.TranslateExpression(indexedAssignment.Right),


### PR DESCRIPTION
## Summary
- preserve the nullable substitution from constructed indexer properties when translating indexed collection initializers
- avoid spurious runtime `!!` assertions for nullable references widened into `object?` while retaining assertions for `object`/other required sinks
- cover nullable references, conditional access, generics, dictionary/collection forms, negative strict sinks, and migrated runtime behavior

## Validation
- focused issue tests: 6 passed
- related #2429/#2521 regression tests: 28 passed
- full `Cs2Gs.Tests`: 1,720 passed
- actual Oahu CLI migration: translate/compile/ILVerify/test-parity green
- fully migrated Oahu `config get --json` and `download B000000001 --dry-run`: exit 0; nullable config values preserved

## Deferred work
- RC-C13 findings unrelated to nullable initializer widening (compiler metadata/ABI, ILVerify observability, and other isolated roots) remain tracked separately and are intentionally unchanged.

Fixes #2743