### PR TITLE
Fix infinite-loop ILVerify crash

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -1105,6 +1105,16 @@ internal sealed partial class MethodBodyEmitter
         var crossesRegion = this.protectedRegionStack.Count > 0
             && !this.protectedRegionStack.Peek().Contains(target);
 
+        if (conditional is BoundLiteralExpression { Value: bool value })
+        {
+            if (value == jumpIfTrue)
+            {
+                this.il.Branch(crossesRegion ? ILOpCode.Leave : ILOpCode.Br, targetHandle);
+            }
+
+            return;
+        }
+
         if (conditional == null)
         {
             this.il.Branch(crossesRegion ? ILOpCode.Leave : ILOpCode.Br, targetHandle);

--- a/test/Compiler.Tests/Emit/Issue2283SwitchAllTerminalArmsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2283SwitchAllTerminalArmsEmitTests.cs
@@ -43,6 +43,34 @@ namespace GSharp.Compiler.Tests.Emit;
 public class Issue2283SwitchAllTerminalArmsEmitTests
 {
     [Fact]
+    public void LiteralTrueLoopEndingInReturn_VerifiesAndRuns()
+    {
+        const string source = """
+            package Issue2747.InfiniteLoop
+            import System
+
+            class Login {
+                func Callback() Uri {
+                    while true {
+                        let text = "https://example.com"
+                        var uri Uri? = nil
+                        if !Uri.TryCreate(text, UriKind.Absolute, out uri) {
+                            continue
+                        }
+
+                        return uri!!
+                    }
+                }
+            }
+
+            Console.WriteLine(Login().Callback().Host)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("example.com\n", output);
+    }
+
+    [Fact]
     public void AllArmsTerminal_AsLastStatement_VerifiesAndRuns()
     {
         // The exact minimal repro from the issue's confirmed-root-cause


### PR DESCRIPTION
Fixes #2747

Fold literal conditional gotos during emission so `while true` uses an unconditional back-edge instead of exposing an impossible fallthrough at the end of a non-void method. Adds runtime and ILVerify coverage for the cycle-13 failure shape.

Targeted regression tests pass. The isolated full Compiler.Tests run passed 3,383 tests; 19 environment-dependent tests could not locate the separately built Gsharp.Extensions.dll and are left to the complete CI build.