### PR TITLE
Convert non-generic enumerator Current values

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -940,7 +940,10 @@ public sealed class Lowerer : BoundTreeRewriter
             // continues to destructure into `Current.Key` / `Current.Value`.
             if (node.KeyVariable == null)
             {
-                statements.Add(new BoundVariableDeclaration(node.Syntax, node.ValueVariable, currentAccess));
+                statements.Add(new BoundVariableDeclaration(
+                    node.Syntax,
+                    node.ValueVariable,
+                    ConvertEnumeratorCurrent(currentAccess, node.ValueVariable.Type)));
             }
             else
             {
@@ -986,7 +989,10 @@ public sealed class Lowerer : BoundTreeRewriter
                 statements.Add(new BoundVariableDeclaration(node.Syntax, node.KeyVariable, new BoundVariableExpression(node.Syntax, indexSymbol)));
             }
 
-            statements.Add(new BoundVariableDeclaration(node.Syntax, node.ValueVariable, currentAccess));
+            statements.Add(new BoundVariableDeclaration(
+                node.Syntax,
+                node.ValueVariable,
+                ConvertEnumeratorCurrent(currentAccess, node.ValueVariable.Type)));
         }
 
         statements.Add(node.Body);
@@ -1053,6 +1059,13 @@ public sealed class Lowerer : BoundTreeRewriter
         }
 
         return new BoundBlockStatement(node.Syntax, statements.ToImmutable());
+    }
+
+    private static BoundExpression ConvertEnumeratorCurrent(BoundExpression current, TypeSymbol elementType)
+    {
+        return current.Type == TypeSymbol.Object || current.Type?.ClrType.IsSameAs(typeof(object)) == true
+            ? new BoundConversionExpression(current.Syntax, elementType, current)
+            : current;
     }
 
     private static BoundExpression TryBuildEnumeratorDisposeCall(LocalVariableSymbol enumeratorSymbol)

--- a/test/Compiler.Tests/Emit/Issue1462ListEnumeratorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1462ListEnumeratorEmitTests.cs
@@ -51,6 +51,28 @@ namespace GSharp.Compiler.Tests.Emit;
 public class Issue1462ListEnumeratorEmitTests
 {
     [Fact]
+    public void NonGenericEnumeratorCurrent_IsConvertedToTheInferredElementType()
+    {
+        var source = """
+            package Issue2752
+            import System
+            import System.Text.RegularExpressions
+
+            var count = 0
+            for match in Regex.Matches("<input><span><input>", "<input>") {
+                if match.Success {
+                    count = count + 1
+                }
+            }
+
+            Console.WriteLine(count)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
     public void EndToEnd_ForeachOverListOfSameCompilationTypes_VerifiesAndRuns()
     {
         // Exercises every body shape the corpus hit: a sync foreach over a


### PR DESCRIPTION
Fixes #2752

Routes `IEnumerator.Current` values through the existing bound conversion emitter before assigning them to inferred foreach element locals. This emits the required `castclass`/`unbox.any` while leaving typed generic enumerators unchanged.

Adds runtime and ILVerify coverage for the Regex.MatchCollection cycle-13 failure shape.