### PR TITLE
Fix async awaiter result identity

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -211,8 +211,7 @@ internal sealed class ImportedMemberRefFactory
         // body throws GS9998 from the EnumSymbol/throw tail below.
         if (element is TupleTypeSymbol symbolicTuple
             && symbolicTuple.ClrType == null
-            && symbolicTuple.Arity >= 2
-            && symbolicTuple.Arity <= 7)
+            && symbolicTuple.Arity >= 2)
         {
             return this.GetTupleTypeSpec(symbolicTuple);
         }
@@ -1847,30 +1846,8 @@ internal sealed class ImportedMemberRefFactory
     /// </summary>
     private EntityHandle GetTupleTypeSpec(TupleTypeSymbol tupleType)
     {
-        var arity = tupleType.Arity;
-        var openType = arity switch
-        {
-            2 => typeof(ValueTuple<,>),
-            3 => typeof(ValueTuple<,,>),
-            4 => typeof(ValueTuple<,,,>),
-            5 => typeof(ValueTuple<,,,,>),
-            6 => typeof(ValueTuple<,,,,,>),
-            7 => typeof(ValueTuple<,,,,,,>),
-            _ => throw new NotSupportedException(
-                $"Symbolic tuple TypeSpec not supported for arity {arity}."),
-        };
-
         var sigBlob = new BlobBuilder();
-        var genInst = new BlobEncoder(sigBlob).TypeSpecificationSignature()
-            .GenericInstantiation(
-                this.GetTypeReference(openType),
-                arity,
-                isValueType: true);
-        foreach (var elemType in tupleType.ElementTypes)
-        {
-            this.signatures.EncodeTypeSymbol(genInst.AddArgument(), elemType);
-        }
-
+        this.signatures.EncodeTypeSymbol(new BlobEncoder(sigBlob).TypeSpecificationSignature(), tupleType);
         return this.emitCtx.Metadata.AddTypeSpecification(
             this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
     }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1582,9 +1582,8 @@ internal sealed partial class MethodBodyEmitter
     {
         // Phase 4.5 emit parity: `(e1, e2, ...)` lowers to
         // `newobj ValueTuple<T1, T2, ...>::.ctor(T1, T2, ...)`. The CLR
-        // backing type is set by TupleTypeSymbol.BuildClrType for arities
-        // 2–7; higher arities have a null ClrType when element types include
-        // G#-defined types (StructSymbol) that don't yet have a runtime Type.
+        // backing type is set by TupleTypeSymbol.BuildClrType; arity 8+
+        // recursively constructs the CLR's canonical TRest chain.
         var clrType = tuple.TupleType.ClrType;
         var arity = tuple.TupleType.Arity;
 
@@ -1608,41 +1607,7 @@ internal sealed partial class MethodBodyEmitter
                 $"Tuple of arity {arity} has no CLR backing type; emit not supported.");
         }
 
-        foreach (var elem in tuple.Elements)
-        {
-            this.EmitExpression(elem);
-        }
-
-        this.il.OpCode(ILOpCode.Newobj);
-
-        // Issue #649: When a tuple's type arguments include a type loaded via
-        // MetadataLoadContext (e.g. a project-referenced CLR class), calling
-        // .GetConstructors() on the closed generic throws NotSupportedException.
-        // Resolve the ctor from the open generic type definition instead.
-        if (clrType.IsConstructedGenericType)
-        {
-            this.il.Token(this.outer.memberRefs.GetCtorReferenceOnConstructedGeneric(clrType, tuple.Elements.Length));
-        }
-        else
-        {
-            ConstructorInfo ctor = null;
-            foreach (var c in clrType.GetConstructors())
-            {
-                if (c.GetParameters().Length == tuple.Elements.Length)
-                {
-                    ctor = c;
-                    break;
-                }
-            }
-
-            if (ctor == null)
-            {
-                throw new InvalidOperationException(
-                    $"ValueTuple type '{clrType.FullName}' has no constructor of arity {tuple.Elements.Length}.");
-            }
-
-            this.il.Token(this.outer.memberRefs.GetCtorReference(ctor));
-        }
+        this.EmitTupleLiteral(tuple.Elements, 0, tuple.Elements.Length, clrType);
     }
 
     private void EmitTupleElementAccess(BoundTupleElementAccessExpression access)
@@ -1674,23 +1639,72 @@ internal sealed partial class MethodBodyEmitter
         }
 
         this.EmitInstanceReceiver(access.Receiver);
-        this.il.OpCode(ILOpCode.Ldfld);
+        var remainingIndex = access.Index;
+        while (remainingIndex >= 7)
+        {
+            this.il.OpCode(ILOpCode.Ldflda);
+            this.il.Token(this.outer.memberRefs.GetFieldReferenceOnConstructedGeneric(clrType, "Rest"));
+            clrType = clrType.GetGenericArguments()[7];
+            remainingIndex -= 7;
+        }
 
-        // Issue #649: When a tuple's type arguments include a type loaded via
-        // MetadataLoadContext (e.g. a project-referenced CLR class), calling
-        // .GetField() on the closed generic throws NotSupportedException.
-        // Resolve the field from the open generic type definition instead.
+        fieldName = "Item" + (remainingIndex + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
+        this.il.OpCode(ILOpCode.Ldfld);
         if (clrType.IsConstructedGenericType)
         {
             this.il.Token(this.outer.memberRefs.GetFieldReferenceOnConstructedGeneric(clrType, fieldName));
+            return;
         }
-        else
+
+        var field = clrType.GetField(fieldName)
+            ?? throw new InvalidOperationException(
+                $"ValueTuple type '{clrType.FullName}' has no public field '{fieldName}'.");
+        this.il.Token(this.outer.memberRefs.GetFieldReference(field));
+    }
+
+    private void EmitTupleLiteral(
+        ImmutableArray<BoundExpression> elements,
+        int start,
+        int count,
+        Type clrType)
+    {
+        var directCount = Math.Min(count, 7);
+        for (var i = 0; i < directCount; i++)
         {
-            var field = clrType.GetField(fieldName)
-                ?? throw new InvalidOperationException(
-                    $"ValueTuple type '{clrType.FullName}' has no public field '{fieldName}'.");
-            this.il.Token(this.outer.memberRefs.GetFieldReference(field));
+            this.EmitExpression(elements[start + i]);
         }
+
+        if (count > 7)
+        {
+            var restType = clrType.GetGenericArguments()[7];
+            this.EmitTupleLiteral(elements, start + 7, count - 7, restType);
+        }
+
+        var parameterCount = count > 7 ? 8 : count;
+        this.il.OpCode(ILOpCode.Newobj);
+        if (clrType.IsConstructedGenericType)
+        {
+            this.il.Token(this.outer.memberRefs.GetCtorReferenceOnConstructedGeneric(clrType, parameterCount));
+            return;
+        }
+
+        ConstructorInfo ctor = null;
+        foreach (var candidate in clrType.GetConstructors())
+        {
+            if (candidate.GetParameters().Length == parameterCount)
+            {
+                ctor = candidate;
+                break;
+            }
+        }
+
+        if (ctor == null)
+        {
+            throw new InvalidOperationException(
+                $"ValueTuple type '{clrType.FullName}' has no constructor of arity {parameterCount}.");
+        }
+
+        this.il.Token(this.outer.memberRefs.GetCtorReference(ctor));
     }
 
     /// <summary>ADR-0039: Emits address-of by dispatching on the operand shape.</summary>

--- a/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
@@ -494,31 +494,11 @@ internal sealed class SignatureEncoder
             var channelClr = typeof(System.Threading.Channels.Channel<>).MakeGenericType(elementClr);
             this.EncodeClrType(encoder, channelClr);
         }
-        else if (type is TupleTypeSymbol tupleWithNullClr && tupleWithNullClr.ClrType == null
-            && tupleWithNullClr.Arity >= 2 && tupleWithNullClr.Arity <= 7)
+        else if (type is TupleTypeSymbol tupleWithNullClr && tupleWithNullClr.ClrType == null)
         {
-            // Issue #649: Tuple containing G#-defined types whose ClrType is null.
-            // Encode as ValueTuple<...> generic instantiation using EncodeTypeSymbol
-            // for each element so user-defined types reference their TypeDef handles.
-            var openType = tupleWithNullClr.Arity switch
-            {
-                2 => typeof(ValueTuple<,>),
-                3 => typeof(ValueTuple<,,>),
-                4 => typeof(ValueTuple<,,,>),
-                5 => typeof(ValueTuple<,,,,>),
-                6 => typeof(ValueTuple<,,,,,>),
-                7 => typeof(ValueTuple<,,,,,,>),
-                _ => throw new NotSupportedException("unreachable"),
-            };
-
-            var genericInst = encoder.GenericInstantiation(
-                this.outer.memberRefs.GetTypeReference(openType),
-                tupleWithNullClr.Arity,
-                isValueType: true);
-            foreach (var elemType in tupleWithNullClr.ElementTypes)
-            {
-                this.EncodeTypeSymbol(genericInst.AddArgument(), elemType);
-            }
+            // Issues #649/#2750: encode symbolic tuples recursively so arity
+            // 8+ uses ValueTuple<T1,...,T7,TRest> without erasing elements.
+            this.EncodeTupleType(encoder, tupleWithNullClr.ElementTypes, 0, tupleWithNullClr.Arity);
         }
         else if (type is FunctionPointerTypeSymbol fnPtr)
         {
@@ -577,6 +557,30 @@ internal sealed class SignatureEncoder
         else
         {
             throw new NotSupportedException($"Cannot encode signature for type '{type?.Name}' yet.");
+        }
+    }
+
+    private void EncodeTupleType(
+        SignatureTypeEncoder encoder,
+        ImmutableArray<TypeSymbol> elementTypes,
+        int start,
+        int count)
+    {
+        var physicalArity = count <= 7 ? count : 8;
+        var genericInst = encoder.GenericInstantiation(
+            this.outer.memberRefs.GetTypeReference(TupleTypeSymbol.GetOpenClrType(physicalArity)),
+            physicalArity,
+            isValueType: true);
+
+        var directCount = Math.Min(count, 7);
+        for (var i = 0; i < directCount; i++)
+        {
+            this.EncodeTypeSymbol(genericInst.AddArgument(), elementTypes[start + i]);
+        }
+
+        if (count > 7)
+        {
+            this.EncodeTupleType(genericInst.AddArgument(), elementTypes, start + 7, count - 7);
         }
     }
 

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
@@ -171,22 +171,23 @@ public static class AsyncStateMachineTypeBuilder
         return sm;
     }
 
-    private static List<(Type PoolKey, TypeSymbol FieldType)> CollectAwaiterPoolFields(BoundStatement body)
+    private static List<(string PoolKey, TypeSymbol FieldType)> CollectAwaiterPoolFields(BoundStatement body)
     {
         var collector = new AwaiterTypeCollector();
         collector.Walk(body);
 
-        var result = new List<(Type PoolKey, TypeSymbol FieldType)>();
-        var seen = new HashSet<Type>();
+        var result = new List<(string PoolKey, TypeSymbol FieldType)>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
         bool hasReferenceAwaiter = false;
 
         foreach (var (awaiterClrType, awaiterTypeSymbol) in collector.AwaiterTypes)
         {
             if (awaiterClrType.IsValueType)
             {
-                if (seen.Add(awaiterClrType))
+                var poolKey = SynthesizedStateMachineType.GetAwaiterPoolKey(awaiterClrType, awaiterTypeSymbol);
+                if (seen.Add(poolKey))
                 {
-                    result.Add((awaiterClrType, awaiterTypeSymbol));
+                    result.Add((poolKey, awaiterTypeSymbol));
                 }
             }
             else
@@ -194,7 +195,7 @@ public static class AsyncStateMachineTypeBuilder
                 if (!hasReferenceAwaiter)
                 {
                     hasReferenceAwaiter = true;
-                    result.Add((typeof(object), awaiterTypeSymbol));
+                    result.Add((SynthesizedStateMachineType.ReferenceAwaiterPoolKey, awaiterTypeSymbol));
                 }
             }
         }

--- a/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
@@ -713,7 +713,7 @@ public static class MoveNextBodyRewriter
                 ctx.allLocals.Add(awaiterLocal);
 
                 // Get the pooled awaiter field.
-                var awaiterField = ctx.plan.StateMachine.GetAwaiterPoolField(awaiterClrType);
+                var awaiterField = ctx.plan.StateMachine.GetAwaiterPoolField(awaiterClrType, awaiterTypeSymbol);
                 if (awaiterField == null)
                 {
                     throw new InvalidOperationException(

--- a/src/Core/CodeAnalysis/Lowering/Async/SynthesizedStateMachineType.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SynthesizedStateMachineType.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Text;
 using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Lowering.Async;
@@ -35,8 +36,10 @@ namespace GSharp.Core.CodeAnalysis.Lowering.Async;
 /// </remarks>
 public sealed class SynthesizedStateMachineType : TypeSymbol
 {
+    internal const string ReferenceAwaiterPoolKey = "!reference-awaiter";
+
     private readonly List<FieldSymbol> fields = new List<FieldSymbol>();
-    private readonly Dictionary<Type, FieldSymbol> awaiterPoolFields = new Dictionary<Type, FieldSymbol>();
+    private readonly Dictionary<string, FieldSymbol> awaiterPoolFields = new Dictionary<string, FieldSymbol>(StringComparer.Ordinal);
     private StructSymbol materializedStruct;
 
     /// <summary>
@@ -111,12 +114,10 @@ public sealed class SynthesizedStateMachineType : TypeSymbol
         fields.Add(field);
     }
 
-    /// <summary>Registers a pooled awaiter field keyed by CLR type.
-    /// Value-type awaiters are keyed by their actual type; reference-typed
-    /// awaiters are keyed by <c>typeof(object)</c>.</summary>
-    /// <param name="poolKey">The CLR type key for the awaiter pool.</param>
+    /// <summary>Registers a pooled awaiter field keyed by its emitted type identity.</summary>
+    /// <param name="poolKey">The emitted type identity key for the awaiter pool.</param>
     /// <param name="field">The field symbol for the pool slot.</param>
-    public void RegisterAwaiterPoolField(Type poolKey, FieldSymbol field)
+    public void RegisterAwaiterPoolField(string poolKey, FieldSymbol field)
     {
         if (poolKey == null)
         {
@@ -131,19 +132,18 @@ public sealed class SynthesizedStateMachineType : TypeSymbol
         awaiterPoolFields[poolKey] = field;
     }
 
-    /// <summary>Gets the pooled awaiter field for the given CLR awaiter type.
-    /// For reference-typed awaiters, pass <c>typeof(object)</c>.</summary>
-    /// <param name="awaiterClrType">The CLR awaiter type (value type) or
-    /// <c>typeof(object)</c> for reference-typed awaiters.</param>
+    /// <summary>Gets the pooled awaiter field for the given emitted awaiter type.</summary>
+    /// <param name="awaiterClrType">The CLR awaiter type.</param>
+    /// <param name="awaiterTypeSymbol">The symbolic awaiter type retained for emission.</param>
     /// <returns>The awaiter pool field, or <see langword="null"/> if not registered.</returns>
-    public FieldSymbol GetAwaiterPoolField(Type awaiterClrType)
+    public FieldSymbol GetAwaiterPoolField(Type awaiterClrType, TypeSymbol awaiterTypeSymbol)
     {
         if (awaiterClrType == null)
         {
             return null;
         }
 
-        var key = awaiterClrType.IsValueType ? awaiterClrType : typeof(object);
+        var key = GetAwaiterPoolKey(awaiterClrType, awaiterTypeSymbol);
         return awaiterPoolFields.TryGetValue(key, out var field) ? field : null;
     }
 
@@ -177,5 +177,21 @@ public sealed class SynthesizedStateMachineType : TypeSymbol
             isClass: ContainerKind == StateMachineContainerKind.Class);
 
         return materializedStruct;
+    }
+
+    internal static string GetAwaiterPoolKey(Type awaiterClrType, TypeSymbol awaiterTypeSymbol)
+    {
+        if (!awaiterClrType.IsValueType)
+        {
+            return ReferenceAwaiterPoolKey;
+        }
+
+        // Issue #2750: distinct symbolic Task<T> results can share the erased
+        // TaskAwaiter<object> CLR shape, but their emitted fields cannot.
+        var builder = new StringBuilder();
+        FunctionTypeSymbol.AppendIdentityKey(
+            builder,
+            awaiterTypeSymbol ?? TypeSymbol.FromClrType(awaiterClrType));
+        return builder.ToString();
     }
 }

--- a/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
@@ -296,7 +296,14 @@ public sealed class FunctionTypeSymbol : TypeSymbol
             case ArrayTypeSymbol:
             case PinnedTypeSymbol:
             case NullabilityAnnotatedTypeSymbol:
+            case TupleTypeSymbol:
                 AppendStructuralKey(builder, type);
+                break;
+
+            // Issue #2750: TypeArguments retain emit identity that an erased
+            // constructed generic's ClrType cannot represent.
+            case ImportedTypeSymbol imported when !imported.TypeArguments.IsDefaultOrEmpty:
+                AppendStructuralKey(builder, imported);
                 break;
 
             // Issue #1620: a composite type (List[T], []T, T?, (T, int32), ...)

--- a/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
@@ -16,9 +16,8 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// <remarks>
 /// Backed by the CLR <c>System.ValueTuple&lt;...&gt;</c> family. Instances are
 /// cached per element-type sequence so identical tuple types compare by
-/// reference. The CLR backing type is only set for tuple arities 1–8 (the
-/// generic ValueTuple shapes shipped in the BCL); higher arities currently
-/// have a <c>null</c> ClrType and are interpreter-only.
+/// reference. Arity 8 and higher use the CLR's canonical
+/// <c>ValueTuple&lt;T1,...,T7,TRest&gt;</c> nesting.
 /// </remarks>
 public sealed class TupleTypeSymbol : TypeSymbol
 {
@@ -77,6 +76,20 @@ public sealed class TupleTypeSymbol : TypeSymbol
     /// </summary>
     internal static void ClearCache() => Cache.Clear();
 
+    internal static Type GetOpenClrType(int arity)
+        => arity switch
+        {
+            1 => typeof(ValueTuple<>),
+            2 => typeof(ValueTuple<,>),
+            3 => typeof(ValueTuple<,,>),
+            4 => typeof(ValueTuple<,,,>),
+            5 => typeof(ValueTuple<,,,,>),
+            6 => typeof(ValueTuple<,,,,,>),
+            7 => typeof(ValueTuple<,,,,,,>),
+            8 => typeof(ValueTuple<,,,,,,,>),
+            _ => throw new ArgumentOutOfRangeException(nameof(arity)),
+        };
+
     private static string BuildName(ImmutableArray<TypeSymbol> elementTypes)
     {
         var sb = new StringBuilder("(");
@@ -105,15 +118,19 @@ public sealed class TupleTypeSymbol : TypeSymbol
         }
 
         var clrTypes = elementTypes.Select(t => t.ClrType).ToArray();
-        switch (clrTypes.Length)
+        return BuildClrType(clrTypes, 0, clrTypes.Length);
+    }
+
+    private static Type BuildClrType(Type[] elementTypes, int start, int count)
+    {
+        if (count <= 7)
         {
-            case 2: return typeof(ValueTuple<,>).MakeGenericType(clrTypes);
-            case 3: return typeof(ValueTuple<,,>).MakeGenericType(clrTypes);
-            case 4: return typeof(ValueTuple<,,,>).MakeGenericType(clrTypes);
-            case 5: return typeof(ValueTuple<,,,,>).MakeGenericType(clrTypes);
-            case 6: return typeof(ValueTuple<,,,,,>).MakeGenericType(clrTypes);
-            case 7: return typeof(ValueTuple<,,,,,,>).MakeGenericType(clrTypes);
-            default: return null;
+            return GetOpenClrType(count).MakeGenericType(elementTypes[start..(start + count)]);
         }
+
+        var arguments = new Type[8];
+        Array.Copy(elementTypes, start, arguments, 0, 7);
+        arguments[7] = BuildClrType(elementTypes, start + 7, count - 7);
+        return GetOpenClrType(8).MakeGenericType(arguments);
     }
 }

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -175,8 +175,8 @@ public class TypeSymbol : Symbol
         // parsed from G# tuple-literal syntax) must map back onto GSharp's own
         // `TupleTypeSymbol` — not a plain `ImportedTypeSymbol` — so downstream
         // binders (deconstruction, member access) recognize it as a tuple.
-        // Same arity ceiling as `TupleTypeSymbol.BuildClrType` (2–7): higher
-        // arities and the `Rest`-chained 8+ shapes are left as imported types.
+        // Issue #2750: canonical Rest-chained arity-8+ shapes are flattened
+        // back into the source-level positional tuple symbol.
         if (TryGetTupleTypeSymbol(clrType, out var tupleTypeSymbol))
         {
             return tupleTypeSymbol;
@@ -960,10 +960,9 @@ public class TypeSymbol : Symbol
 
     /// <summary>
     /// Issue #1922: recognizes a closed generic <c>System.ValueTuple&lt;...&gt;</c>
-    /// or <c>System.Tuple&lt;...&gt;</c> CLR type (arity 2–7, matching
-    /// <see cref="TupleTypeSymbol"/>'s own CLR-backing ceiling) and maps it onto
-    /// the equivalent <see cref="TupleTypeSymbol"/> by recursively resolving
-    /// each generic argument through <see cref="FromClrType"/>.
+    /// or <c>System.Tuple&lt;...&gt;</c> CLR type and maps it onto the equivalent
+    /// flat <see cref="TupleTypeSymbol"/>, including canonical arity-8+
+    /// <c>TRest</c> nesting.
     /// </summary>
     /// <param name="clrType">The candidate CLR type.</param>
     /// <param name="tupleTypeSymbol">The resulting tuple symbol, if matched.</param>
@@ -976,18 +975,58 @@ public class TypeSymbol : Symbol
             return false;
         }
 
-        var defName = clrType.GetGenericTypeDefinition().FullName;
-        var isTupleFamily = defName is "System.ValueTuple`2" or "System.ValueTuple`3" or "System.ValueTuple`4"
-            or "System.ValueTuple`5" or "System.ValueTuple`6" or "System.ValueTuple`7"
-            or "System.Tuple`2" or "System.Tuple`3" or "System.Tuple`4"
-            or "System.Tuple`5" or "System.Tuple`6" or "System.Tuple`7";
-        if (!isTupleFamily)
+        var elementTypes = ImmutableArray.CreateBuilder<TypeSymbol>();
+        if (!TryCollectTupleElements(clrType, elementTypes, allowSingleElementRest: false))
         {
             return false;
         }
 
-        var elementTypes = clrType.GetGenericArguments().Select(FromClrType).ToImmutableArray();
-        tupleTypeSymbol = TupleTypeSymbol.Get(elementTypes);
+        tupleTypeSymbol = TupleTypeSymbol.Get(elementTypes.ToImmutable());
         return true;
+    }
+
+    private static bool TryCollectTupleElements(
+        Type clrType,
+        ImmutableArray<TypeSymbol>.Builder elementTypes,
+        bool allowSingleElementRest)
+    {
+        if (!clrType.IsGenericType || clrType.IsGenericTypeDefinition)
+        {
+            return false;
+        }
+
+        var definitionName = clrType.GetGenericTypeDefinition().FullName;
+        var isValueTuple = definitionName?.StartsWith("System.ValueTuple`", StringComparison.Ordinal) == true;
+        var isReferenceTuple = definitionName?.StartsWith("System.Tuple`", StringComparison.Ordinal) == true;
+        if (!isValueTuple && !isReferenceTuple)
+        {
+            return false;
+        }
+
+        var arguments = clrType.GetGenericArguments();
+        if (arguments.Length == 1)
+        {
+            if (!allowSingleElementRest)
+            {
+                return false;
+            }
+
+            elementTypes.Add(FromClrType(arguments[0]));
+            return true;
+        }
+
+        if (arguments.Length is < 2 or > 8)
+        {
+            return false;
+        }
+
+        var directCount = arguments.Length == 8 ? 7 : arguments.Length;
+        for (var i = 0; i < directCount; i++)
+        {
+            elementTypes.Add(FromClrType(arguments[i]));
+        }
+
+        return arguments.Length != 8
+            || TryCollectTupleElements(arguments[7], elementTypes, allowSingleElementRest: true);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue2750AsyncTupleAwaiterEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2750AsyncTupleAwaiterEmitTests.cs
@@ -32,6 +32,20 @@ public sealed class Issue2750AsyncTupleAwaiterEmitTests
                     await Task.Yield();
                     return (new Uri("https://example.test"), new HttpResponseMessage());
                 }
+
+                public static async Task<(
+                    int One, int Two, int Three, int Four,
+                    int Five, int Six, int Seven, int Eight)> NamedEightAsync()
+                {
+                    await Task.Yield();
+                    return (1, 2, 3, 4, 5, 6, 7, 8);
+                }
+
+                public static async Task<(T, T, T, T, T, T, T, T)> GenericEightAsync<T>(T value)
+                {
+                    await Task.Yield();
+                    return (value, value, value, value, value, value, value, value);
+                }
             }
             """;
         const string source = """
@@ -62,6 +76,21 @@ public sealed class Issue2750AsyncTupleAwaiterEmitTests
                 return (1, 2, 3, 4, 5, 6, 7)
             }
 
+            async func EightAsync() (int32, int32, int32, int32, int32, int32, int32, int32) {
+                await Task.Yield()
+                return (1, 2, 3, 4, 5, 6, 7, 8)
+            }
+
+            async func NineAsync() (int32, int32, int32, int32, int32, int32, int32, int32, int32) {
+                await Task.Yield()
+                return (1, 2, 3, 4, 5, 6, 7, 8, 9)
+            }
+
+            async func FifteenAsync() (int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32) {
+                await Task.Yield()
+                return (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+            }
+
             async func NestedAsync() ((int32, string), (bool, float64)) {
                 await Task.Yield()
                 return ((4, "nested"), (true, 2.5))
@@ -87,10 +116,19 @@ public sealed class Issue2750AsyncTupleAwaiterEmitTests
                 Console.WriteLine("$three:$tripleText:$flag")
                 let (_, _, _, _, _, _, seven) = await SevenAsync()
                 Console.WriteLine(seven)
+                let eight = await EightAsync()
+                Console.WriteLine(eight.Item8)
+                let nine = await NineAsync()
+                Console.WriteLine(nine.Item9)
+                let fifteen = await FifteenAsync()
+                Console.WriteLine(fifteen.Item15)
+                let namedEight = await TupleApi.NamedEightAsync()
+                Console.WriteLine(namedEight.Item8)
                 let nested = await NestedAsync()
                 Console.WriteLine("${nested.Item1.Item2}:${nested.Item2.Item2}")
                 let (genericLeft, genericRight) = await GenericPairAsync[string]("generic-pair")
                 Console.WriteLine("$genericLeft:$genericRight")
+                let genericEight = await TupleApi.GenericEightAsync[string]("unused")
                 Console.WriteLine(number)
                 return await FinalAddressAsync()
             }
@@ -99,7 +137,7 @@ public sealed class Issue2750AsyncTupleAwaiterEmitTests
             """;
 
         Assert.Equal(
-            "first.test\nexample.test\ngeneric\nnullable.test\n3:triple:True\n7\nnested:2.5\ngeneric-pair:generic-pair\n8\nfinal.test\n",
+            "first.test\nexample.test\ngeneric\nnullable.test\n3:triple:True\n7\n8\n9\n15\n8\nnested:2.5\ngeneric-pair:generic-pair\n8\nfinal.test\n",
             CompileVerifyAndRun(source, helperSource));
     }
 

--- a/test/Compiler.Tests/Emit/Issue2750AsyncTupleAwaiterEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2750AsyncTupleAwaiterEmitTests.cs
@@ -1,0 +1,219 @@
+// <copyright file="Issue2750AsyncTupleAwaiterEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue2750AsyncTupleAwaiterEmitTests
+{
+    [Fact]
+    public void Await_TaskOfTuple_VerifiesAndRuns()
+    {
+        const string helperSource = """
+            using System;
+            using System.Net.Http;
+            using System.Threading.Tasks;
+
+            namespace ImportedTuples;
+
+            public static class TupleApi
+            {
+                public static async Task<(Uri Address, HttpResponseMessage Response)> FetchAsync()
+                {
+                    await Task.Yield();
+                    return (new Uri("https://example.test"), new HttpResponseMessage());
+                }
+            }
+            """;
+        const string source = """
+            package Issue2750
+
+            import System
+            import System.Net.Http
+            import System.Threading.Tasks
+            import ImportedTuples
+
+            async func NullablePairAsync() (Uri?, HttpResponseMessage?) {
+                await Task.Yield()
+                return (Uri("https://nullable.test"), HttpResponseMessage())
+            }
+
+            async func FinalAddressAsync() Uri? {
+                await Task.Yield()
+                return Uri("https://final.test")
+            }
+
+            async func TripleAsync() (int32, string, bool) {
+                await Task.Yield()
+                return (3, "triple", true)
+            }
+
+            async func SevenAsync() (int32, int32, int32, int32, int32, int32, int32) {
+                await Task.Yield()
+                return (1, 2, 3, 4, 5, 6, 7)
+            }
+
+            async func NestedAsync() ((int32, string), (bool, float64)) {
+                await Task.Yield()
+                return ((4, "nested"), (true, 2.5))
+            }
+
+            async func GenericPairAsync[T](value T) (T, T) {
+                await Task.Yield()
+                return (value, value)
+            }
+
+            async func RunAsync() Uri? {
+                let firstAddress = await Task.FromResult(Uri("https://first.test"))
+                Console.WriteLine(firstAddress.Host)
+                let (address, response) = await TupleApi.FetchAsync()
+                Console.WriteLine(address.Host)
+                response.Dispose()
+                let (number, text) = await Task.FromResult((8, "generic"))
+                Console.WriteLine(text)
+                let (nullableAddress, nullableResponse) = await NullablePairAsync()
+                Console.WriteLine(nullableAddress!!.Host)
+                nullableResponse!!.Dispose()
+                let (three, tripleText, flag) = await TripleAsync()
+                Console.WriteLine("$three:$tripleText:$flag")
+                let (_, _, _, _, _, _, seven) = await SevenAsync()
+                Console.WriteLine(seven)
+                let nested = await NestedAsync()
+                Console.WriteLine("${nested.Item1.Item2}:${nested.Item2.Item2}")
+                let (genericLeft, genericRight) = await GenericPairAsync[string]("generic-pair")
+                Console.WriteLine("$genericLeft:$genericRight")
+                Console.WriteLine(number)
+                return await FinalAddressAsync()
+            }
+
+            Console.WriteLine(RunAsync().GetAwaiter().GetResult()!!.Host)
+            """;
+
+        Assert.Equal(
+            "first.test\nexample.test\ngeneric\nnullable.test\n3:triple:True\n7\nnested:2.5\ngeneric-pair:generic-pair\n8\nfinal.test\n",
+            CompileVerifyAndRun(source, helperSource));
+    }
+
+    [Fact]
+    public void Await_DistinctNonTupleSymbolicResults_VerifiesAndRuns()
+    {
+        const string source = """
+            package Issue2750Controls
+
+            import System
+            import System.Threading.Tasks
+
+            class Box(Value string) { }
+
+            async func BoxAsync() Box? {
+                await Task.Yield()
+                return Box("box")
+            }
+
+            async func AddressAsync() Uri? {
+                await Task.Yield()
+                return Uri("https://control.test")
+            }
+
+            async func RunAsync() Uri? {
+                let box = await BoxAsync()
+                Console.WriteLine(box!!.Value)
+                let number = await Task.FromResult(42)
+                Console.WriteLine(number)
+                return await AddressAsync()
+            }
+
+            Console.WriteLine(RunAsync().GetAwaiter().GetResult()!!.Host)
+            """;
+
+        Assert.Equal("box\n42\ncontrol.test\n", CompileVerifyAndRun(source));
+    }
+
+    private static string CompileVerifyAndRun(string source, string helperSource = null)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2750Emit");
+        Directory.CreateDirectory(directory);
+        var helperPath = helperSource == null ? null : BuildHelper(directory, helperSource);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var args = new List<string>
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+            if (helperPath != null)
+            {
+                args.Add("/r:" + helperPath);
+            }
+
+            args.Add(sourcePath);
+            var exitCode = Program.Main(args.ToArray());
+            Assert.True(exitCode == 0, $"compile failed ({exitCode}):{Environment.NewLine}{stdout}{stderr}");
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        IlVerifier.Verify(outputPath, helperPath == null ? null : new[] { helperPath });
+
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                outputPath,
+            },
+            WorkingDirectory = directory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(process.ExitCode == 0, error);
+        return output.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static string BuildHelper(string directory, string source)
+    {
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(File.Exists)
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "ImportedTuples",
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var path = Path.Combine(directory, "ImportedTuples.dll");
+        using var stream = File.Create(path);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return path;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/TupleTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/TupleTests.cs
@@ -14,7 +14,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>
 /// Phase 4.5 — tuple types <c>(T1, T2, ...)</c>, tuple literals, and tuple
-/// element access via <c>.Item1</c>..<c>.ItemN</c> (interpreter-only).
+/// element access via <c>.Item1</c>..<c>.ItemN</c>.
 /// </summary>
 public class TupleTests
 {
@@ -38,6 +38,18 @@ p.Item2
 ");
         Assert.Empty(result.Diagnostics);
         Assert.Equal("x", result.Value);
+    }
+
+    [Fact]
+    public void TupleLiteral_ArityEight_ParsesAndBinds()
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(@"
+let values = (1, 2, 3, 4, 5, 6, 7, 8)
+values.Item8
+"));
+        var compilation = new Compilation(syntaxTree);
+
+        Assert.Empty(compilation.BoundProgram.Diagnostics);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- preserve symbolic result identity when pooling async state-machine awaiter fields
- structurally key tuple and constructed generic projections instead of collapsing erased CLR shapes
- encode arity-8+ tuples with canonical nested `ValueTuple<T1,...,T7,TRest>` construction, signatures, imported flattening, and `ItemN` access
- cover arities 2, 3, 7, 8, 9, and 15; nested, generic, nullable, imported named tuples; and non-tuple controls with runtime + ILVerify tests

## Validation
- targeted/related Core tests: 21 passed
- targeted/related Compiler tests: 12 passed
- Core.Tests: 6,692 passed, 1 skipped
- Compiler.Tests: 3,403 passed
- RC-C13-10 Oahu replay: 24 findings before, 0 after
- all required CI checks green

## Deferred
- none

Parser/binder already represented arity-8+ tuples, so no prerequisite issue was needed. Interpreter behavior remains unchanged per the requested compiler/emitter scope.

Fixes #2750