### PR TITLE
Fix optional parameter metadata emission

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -2531,28 +2531,80 @@ internal sealed class ConversionClassifier
             return false;
         }
 
-        // Numeric / bool / char / string / enum-underlying types are CLR Constant-table representable.
-        switch (value)
+        if (!Conversion.Classify(inner.Type, parameterType).IsImplicit)
         {
-            case bool:
-            case sbyte:
-            case byte:
-            case short:
-            case ushort:
-            case int:
-            case uint:
-            case long:
-            case ulong:
-            case float:
-            case double:
-            case char:
-            case string:
-                return true;
-            default:
-                reason = $"the default value type '{value.GetType().Name}' is not representable in CLR parameter metadata.";
-                value = null;
-                return false;
+            reason = $"the default value of type '{inner.Type.Name}' is not implicitly convertible to parameter type '{parameterType.Name}'.";
+            value = null;
+            return false;
         }
+
+        return TryNormalizeMetadataConstant(value, parameterType, out value, out reason);
+    }
+
+    // Constant rows carry the parameter's converted primitive value, not the
+    // source literal's type (for example, `int64 x = 1` requires an I8 row).
+    private static bool TryNormalizeMetadataConstant(object value, TypeSymbol parameterType, out object normalized, out string reason)
+    {
+        normalized = null;
+        reason = null;
+        var target = parameterType is NullableTypeSymbol nullable ? nullable.UnderlyingType : parameterType;
+
+        try
+        {
+            if (target.ClrType is System.Type clrType && TryNormalizeClrConstant(value, clrType, out normalized))
+            {
+                return true;
+            }
+            else if (target is EnumSymbol)
+            {
+                normalized = Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture);
+            }
+            else if ((target == TypeSymbol.NInt || target == TypeSymbol.NUInt)
+                && value is sbyte or byte or short or ushort or int or uint or long or ulong)
+            {
+                normalized = value;
+            }
+        }
+        catch (Exception)
+        {
+            normalized = null;
+        }
+
+        if (normalized != null)
+        {
+            return true;
+        }
+
+        reason = $"the default value type '{value.GetType().Name}' is not representable for parameter type '{parameterType.Name}' in CLR metadata.";
+        return false;
+    }
+
+    private static bool TryNormalizeClrConstant(object value, System.Type targetType, out object normalized)
+    {
+        normalized = null;
+        if (targetType.IsEnum)
+        {
+            targetType = Enum.GetUnderlyingType(targetType);
+        }
+
+        normalized = Type.GetTypeCode(targetType) switch
+        {
+            TypeCode.Boolean when value is bool => value,
+            TypeCode.Char when value is char => value,
+            TypeCode.SByte => Convert.ToSByte(value, System.Globalization.CultureInfo.InvariantCulture),
+            TypeCode.Byte => Convert.ToByte(value, System.Globalization.CultureInfo.InvariantCulture),
+            TypeCode.Int16 => Convert.ToInt16(value, System.Globalization.CultureInfo.InvariantCulture),
+            TypeCode.UInt16 => Convert.ToUInt16(value, System.Globalization.CultureInfo.InvariantCulture),
+            TypeCode.Int32 => Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture),
+            TypeCode.UInt32 => Convert.ToUInt32(value, System.Globalization.CultureInfo.InvariantCulture),
+            TypeCode.Int64 => Convert.ToInt64(value, System.Globalization.CultureInfo.InvariantCulture),
+            TypeCode.UInt64 => Convert.ToUInt64(value, System.Globalization.CultureInfo.InvariantCulture),
+            TypeCode.Single => Convert.ToSingle(value, System.Globalization.CultureInfo.InvariantCulture),
+            TypeCode.Double => Convert.ToDouble(value, System.Globalization.CultureInfo.InvariantCulture),
+            TypeCode.String when value is string => value,
+            _ => null,
+        };
+        return normalized != null;
     }
 
     // Issue #1182: extracts the constant default for a value-type `default(T)` /

--- a/src/Core/CodeAnalysis/Emit/FunctionEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/FunctionEmitter.cs
@@ -693,27 +693,10 @@ internal sealed class FunctionEmitter
             // `out`, .In for `in`. `ref` carries neither (the CLR distinguishes ref from
             // out only via the .out flag); the `in` parameter also gets an
             // IsReadOnlyAttribute custom attribute below.
-            var paramAttributes = ParameterAttributes.None;
-            if (p.RefKind == RefKind.Out)
-            {
-                paramAttributes |= ParameterAttributes.Out;
-            }
-            else if (p.RefKind == RefKind.In)
-            {
-                paramAttributes |= ParameterAttributes.In;
-            }
-
-            // ADR-0063 §10: optional parameters with a compile-time constant
-            // default get the Optional+HasDefault flags plus a Constant row.
-            if (p.HasExplicitDefaultValue)
-            {
-                paramAttributes |= ParameterAttributes.Optional | ParameterAttributes.HasDefault;
-            }
-
-            var paramHandle = this.emitCtx.Metadata.AddParameter(
-                attributes: paramAttributes,
-                name: this.emitCtx.Metadata.GetOrAddString(p.Name ?? string.Empty),
-                sequenceNumber: sequenceNumber++);
+            var paramHandle = ParameterMetadataEmitter.AddParameter(
+                this.emitCtx,
+                p,
+                sequenceNumber++);
 
             if (p.RefKind == RefKind.In)
             {
@@ -728,12 +711,6 @@ internal sealed class FunctionEmitter
             if (p.IsVariadic)
             {
                 this.outer.customAttrEncoder.EmitParamArrayAttributeOnParameter(paramHandle);
-            }
-
-            // ADR-0063 §10: emit the Constant row carrying the default value.
-            if (p.HasExplicitDefaultValue)
-            {
-                this.emitCtx.Metadata.AddConstant(paramHandle, p.ExplicitDefaultValue);
             }
 
             paramHandles.Add((p, paramHandle, paramFlagsList[flagsIndex++]));
@@ -1038,10 +1015,11 @@ internal sealed class FunctionEmitter
                 paramAttrs |= ParameterAttributes.HasFieldMarshal;
             }
 
-            var paramHandle = this.emitCtx.Metadata.AddParameter(
-                attributes: paramAttrs,
-                name: this.emitCtx.Metadata.GetOrAddString(p.Name ?? string.Empty),
-                sequenceNumber: sequenceNumber++);
+            var paramHandle = ParameterMetadataEmitter.AddParameter(
+                this.emitCtx,
+                p,
+                sequenceNumber++,
+                paramAttrs);
             paramHandles.Add((p, paramHandle));
 
             if (p.MarshalAsMetadata != null)
@@ -1258,10 +1236,11 @@ internal sealed class FunctionEmitter
                 outerParamAttrs |= ParameterAttributes.HasFieldMarshal;
             }
 
-            var paramHandle = this.emitCtx.Metadata.AddParameter(
-                attributes: outerParamAttrs,
-                name: this.emitCtx.Metadata.GetOrAddString(p.Name ?? string.Empty),
-                sequenceNumber: outerSeq++);
+            var paramHandle = ParameterMetadataEmitter.AddParameter(
+                this.emitCtx,
+                p,
+                outerSeq++,
+                outerParamAttrs);
             outerParamHandles.Add((p, paramHandle));
 
             if (p.MarshalAsMetadata != null)

--- a/src/Core/CodeAnalysis/Emit/ParameterMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ParameterMetadataEmitter.cs
@@ -1,0 +1,55 @@
+// <copyright file="ParameterMetadataEmitter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Reflection;
+using System.Reflection.Metadata;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Emit;
+
+/// <summary>Emits metadata shared by user-declared method and constructor parameters.</summary>
+internal static class ParameterMetadataEmitter
+{
+    /// <summary>Adds a parameter row, including ref-kind and optional-default metadata.</summary>
+    /// <param name="emitCtx">The active emit context.</param>
+    /// <param name="parameter">The source parameter.</param>
+    /// <param name="sequenceNumber">The one-based parameter sequence number.</param>
+    /// <param name="attributes">Additional attributes required by the caller.</param>
+    /// <param name="fallbackName">The metadata name used when the source parameter is unnamed.</param>
+    /// <returns>The emitted parameter handle.</returns>
+    public static ParameterHandle AddParameter(
+        EmitContext emitCtx,
+        ParameterSymbol parameter,
+        int sequenceNumber,
+        ParameterAttributes attributes = ParameterAttributes.None,
+        string fallbackName = "")
+    {
+        if (parameter.RefKind == RefKind.Out)
+        {
+            attributes |= ParameterAttributes.Out;
+        }
+        else if (parameter.RefKind == RefKind.In)
+        {
+            attributes |= ParameterAttributes.In;
+        }
+
+        if (parameter.HasExplicitDefaultValue)
+        {
+            attributes |= ParameterAttributes.Optional | ParameterAttributes.HasDefault;
+        }
+
+        var handle = emitCtx.Metadata.AddParameter(
+            attributes,
+            emitCtx.Metadata.GetOrAddString(parameter.Name ?? fallbackName),
+            sequenceNumber);
+
+        if (parameter.HasExplicitDefaultValue)
+        {
+            emitCtx.Metadata.AddConstant(handle, parameter.ExplicitDefaultValue);
+        }
+
+        return handle;
+    }
+}

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -1062,22 +1062,11 @@ internal sealed class TypeDefEmitter
         {
             var p = delegateSym.Parameters[i];
 
-            // ADR-0060 §12: stamp the Parameter row with .Out / .In for ref-kind delegate
-            // parameters, and attach IsReadOnlyAttribute for `in`.
-            var paramAttributes = ParameterAttributes.None;
-            if (p.RefKind == RefKind.Out)
-            {
-                paramAttributes |= ParameterAttributes.Out;
-            }
-            else if (p.RefKind == RefKind.In)
-            {
-                paramAttributes |= ParameterAttributes.In;
-            }
-
-            var paramHandle = this.emitCtx.Metadata.AddParameter(
-                attributes: paramAttributes,
-                name: this.emitCtx.Metadata.GetOrAddString(p.Name ?? $"arg{i + 1}"),
-                sequenceNumber: (ushort)(i + 1));
+            var paramHandle = ParameterMetadataEmitter.AddParameter(
+                this.emitCtx,
+                p,
+                i + 1,
+                fallbackName: $"arg{i + 1}");
             invokeParamHandles.Add(paramHandle);
 
             if (p.RefKind == RefKind.In)
@@ -1306,20 +1295,7 @@ internal sealed class TypeDefEmitter
         for (var i = 0; i < parameters.Length; i++)
         {
             var p = parameters[i];
-            var paramAttributes = ParameterAttributes.None;
-            if (p.RefKind == RefKind.Out)
-            {
-                paramAttributes |= ParameterAttributes.Out;
-            }
-            else if (p.RefKind == RefKind.In)
-            {
-                paramAttributes |= ParameterAttributes.In;
-            }
-
-            var paramHandle = this.emitCtx.Metadata.AddParameter(
-                attributes: paramAttributes,
-                name: this.emitCtx.Metadata.GetOrAddString(p.Name ?? string.Empty),
-                sequenceNumber: i + 1);
+            var paramHandle = ParameterMetadataEmitter.AddParameter(this.emitCtx, p, i + 1);
             handles.Add(paramHandle);
 
             if (p.RefKind == RefKind.In)
@@ -1628,19 +1604,8 @@ internal sealed class TypeDefEmitter
         for (var i = 0; i < parameters.Length; i++)
         {
             var p = parameters[i];
-            var attributes = p.HasExplicitDefaultValue
-                ? ParameterAttributes.Optional | ParameterAttributes.HasDefault
-                : ParameterAttributes.None;
-            var paramHandle = this.emitCtx.Metadata.AddParameter(
-                attributes: attributes,
-                name: this.emitCtx.Metadata.GetOrAddString(p.Name ?? string.Empty),
-                sequenceNumber: i + 1);
+            var paramHandle = ParameterMetadataEmitter.AddParameter(this.emitCtx, p, i + 1);
             handles.Add(paramHandle);
-
-            if (p.HasExplicitDefaultValue)
-            {
-                this.emitCtx.Metadata.AddConstant(paramHandle, p.ExplicitDefaultValue);
-            }
 
             if (p.IsVariadic)
             {

--- a/test/Compiler.Tests/Emit/Issue2745OptionalParameterMetadataEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2745OptionalParameterMetadataEmitTests.cs
@@ -1,0 +1,200 @@
+// <copyright file="Issue2745OptionalParameterMetadataEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Regression coverage for issue #2745.</summary>
+public sealed class Issue2745OptionalParameterMetadataEmitTests
+{
+    [Fact]
+    public void MethodsAndConstructors_ExposeDefaultsToReflectionAndCSharpConsumers()
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2745OptionalParameterMetadataEmitTests));
+        Directory.CreateDirectory(directory);
+        var libraryPath = Path.Combine(directory, "Issue2745.Library.dll");
+        var consumerPath = Path.Combine(directory, "Issue2745.Consumer.dll");
+
+        const string source = """
+            package Issue2745
+            import System
+
+            class Defaults {
+                init(count int64 = 5, title string = "ctor", day DayOfWeek = DayOfWeek.Monday) {
+                }
+
+                func Score(enabled bool = true, marker char = 'A', scale float64 = 2.5, note string? = nil) int32 {
+                    if enabled && marker == 'A' && scale == 2.5 && note == nil {
+                        return 42
+                    }
+                    return 0
+                }
+            }
+
+            func RunGSharp() int32 -> Defaults().Score()
+            """;
+
+        EmitGSharpLibrary(source, libraryPath);
+        AssertParameterMetadata(libraryPath);
+        EmitCSharpConsumer(libraryPath, consumerPath);
+
+        var loadContext = new AssemblyLoadContext("Issue2745", isCollectible: true);
+        try
+        {
+            var library = loadContext.LoadFromAssemblyPath(libraryPath);
+            var defaults = library.GetType("Issue2745.Defaults", throwOnError: true)!;
+            AssertReflectionDefaults(defaults);
+
+            var program = library.GetTypes().Single(type => type.Name == "<Program>");
+            Assert.Equal(42, program.GetMethod("RunGSharp", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!.Invoke(null, null));
+
+            var consumer = loadContext.LoadFromAssemblyPath(consumerPath);
+            Assert.Equal(42, consumer.GetType("Issue2745Consumer", throwOnError: true)!.GetMethod("Run")!.Invoke(null, null));
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    [Fact]
+    public void UnsupportedOrMismatchedMetadataConstants_AreRejected()
+    {
+        const string source = """
+            package Issue2745
+
+            func WrongType(value string = 1) {
+            }
+
+            func DecimalValue(value decimal = 1.5m) {
+            }
+            """;
+
+        using var resolver = ReferenceResolver.WithReferences(Array.Empty<string>());
+        var compilation = new GsCompilation(resolver, GsSyntaxTree.Parse(SourceText.From(source)))
+        {
+            IsLibrary = true,
+        };
+        using var output = new MemoryStream();
+        var result = compilation.Emit(output, pdbStream: null, refStream: null, assemblyName: "Issue2745.Invalid");
+
+        Assert.False(result.Success);
+        Assert.Equal(2, result.Diagnostics.Count(diagnostic => diagnostic.Id == "GS0265"));
+    }
+
+    private static void EmitGSharpLibrary(string source, string outputPath)
+    {
+        using var resolver = ReferenceResolver.WithReferences(Array.Empty<string>());
+        var compilation = new GsCompilation(resolver, GsSyntaxTree.Parse(SourceText.From(source)))
+        {
+            IsLibrary = true,
+        };
+        GSharp.Core.CodeAnalysis.Compilation.EmitResult result;
+        using (var output = File.Create(outputPath))
+        {
+            result = compilation.Emit(output, pdbStream: null, refStream: null, assemblyName: "Issue2745.Library");
+        }
+
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        IlVerifier.Verify(outputPath);
+    }
+
+    private static void AssertParameterMetadata(string libraryPath)
+    {
+        using var stream = File.OpenRead(libraryPath);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var defaultsType = reader.TypeDefinitions
+            .Select(reader.GetTypeDefinition)
+            .Single(type => reader.GetString(type.Name) == "Defaults");
+
+        var methods = defaultsType.GetMethods()
+            .Select(reader.GetMethodDefinition)
+            .Where(method => reader.GetString(method.Name) is ".ctor" or "Score")
+            .ToArray();
+        Assert.Equal(2, methods.Length);
+
+        foreach (var parameter in methods.SelectMany(method => method.GetParameters()).Select(reader.GetParameter))
+        {
+            Assert.True((parameter.Attributes & ParameterAttributes.Optional) != 0);
+            Assert.True((parameter.Attributes & ParameterAttributes.HasDefault) != 0);
+            Assert.False(parameter.GetDefaultValue().IsNil);
+        }
+    }
+
+    private static void AssertReflectionDefaults(Type defaults)
+    {
+        var constructor = defaults.GetConstructors().Single();
+        var ctorParameters = constructor.GetParameters();
+        Assert.Collection(
+            ctorParameters,
+            parameter => AssertDefault(parameter, 5L),
+            parameter => AssertDefault(parameter, "ctor"),
+            parameter =>
+            {
+                Assert.True(parameter.IsOptional);
+                Assert.True(parameter.HasDefaultValue);
+                Assert.Equal(1, Convert.ToInt32(parameter.DefaultValue));
+            });
+
+        var methodParameters = defaults.GetMethod("Score")!.GetParameters();
+        Assert.Collection(
+            methodParameters,
+            parameter => AssertDefault(parameter, true),
+            parameter => AssertDefault(parameter, 'A'),
+            parameter => AssertDefault(parameter, 2.5),
+            parameter => AssertDefault(parameter, null));
+    }
+
+    private static void AssertDefault(ParameterInfo parameter, object expected)
+    {
+        Assert.True(parameter.IsOptional);
+        Assert.True(parameter.HasDefaultValue);
+        Assert.Equal(expected, parameter.DefaultValue);
+    }
+
+    private static void EmitCSharpConsumer(string libraryPath, string outputPath)
+    {
+        const string source = """
+            public static class Issue2745Consumer
+            {
+                public static int Run()
+                {
+                    var value = new Issue2745.Defaults();
+                    return value.Score();
+                }
+            }
+            """;
+
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .Append(MetadataReference.CreateFromFile(libraryPath));
+        var compilation = CSharpCompilation.Create(
+            "Issue2745.Consumer",
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var output = File.Create(outputPath);
+        var result = compilation.Emit(output);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+}


### PR DESCRIPTION
## Summary
- centralize source parameter-row emission so methods, explicit/primary constructors, interfaces, delegates, and managed interop surfaces emit CLR `Optional`/`HasDefault` flags plus Constant rows
- normalize constants to the declared parameter type and reject mismatched or unsupported CLR metadata constants without changing G# omitted-argument materialization
- add metadata, reflection, ILVerify, G# runtime, and real Roslyn C# consumer regressions across numeric, string, enum, bool, char, floating-point, and nil defaults

## Validation
- targeted optional emit tests: 16 passed
- targeted optional binding tests: 16 passed
- full Core.Tests: 6,691 passed, 1 skipped
- full Compiler.Tests: 3,384 passed; 19 environment-only failures because Gsharp.Extensions.dll had not been built; after building it, all affected classes passed (128/128)
- RC-C13-6 Oahu rerun: rebuilt Oahu.Cli.App and Oahu.Cli.Tui with this compiler, then compiled the full C# test corpus against them; CS7036 fell from 12 reported failures to 0

## Deferred
- Oahu still reports unrelated ABI/nullability families (CS1729, CS1739, CS8858, CS8602/CS8604, CS8613, CS8766); these map to the separately reported RC-C13-5/7 and nullable-fidelity work.

Fixes #2745