### PR TITLE
Fix generic async state-machine field tokens

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -1009,15 +1009,9 @@ internal sealed partial class MethodBodyEmitter
             || (this.asyncIteratorEmitCtx != null && this.asyncIteratorEmitCtx.FieldMap.TryGetValue(captured, out hoistedField)))
         {
             // Load from the state machine: ldarg.0; ldfld <smStruct>::<hoistedField>
-            if (!this.outer.cache.StructFieldDefs.TryGetValue(hoistedField, out var hoistedHandle))
-            {
-                throw new InvalidOperationException(
-                    $"Hoisted field '{hoistedField.Name}' has no emitted FieldDef.");
-            }
-
             this.il.OpCode(ILOpCode.Ldarg_0);
             this.il.OpCode(ILOpCode.Ldfld);
-            this.il.Token(hoistedHandle);
+            this.il.Token(this.ResolveCurrentStateMachineFieldToken(hoistedField));
             return;
         }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -111,14 +111,8 @@ internal sealed partial class MethodBodyEmitter
         // field to the closure before loading the captured value.
         if (this.asyncFieldMap?.ThisField is FieldSymbol thisField)
         {
-            if (!this.outer.cache.StructFieldDefs.TryGetValue(thisField, out var thisFieldHandle))
-            {
-                throw new InvalidOperationException(
-                    $"Hoisted field '{thisField.Name}' has no emitted FieldDef.");
-            }
-
             this.il.OpCode(ILOpCode.Ldfld);
-            this.il.Token(thisFieldHandle);
+            this.il.Token(this.ResolveCurrentStateMachineFieldToken(thisField));
         }
 
         this.il.OpCode(ILOpCode.Ldfld);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -192,6 +192,20 @@ internal sealed partial class MethodBodyEmitter
         this.stackAllocResultSlots = stackAllocResultSlots ?? new Dictionary<BoundStackAllocExpression, int>();
     }
 
+    private EntityHandle ResolveCurrentStateMachineFieldToken(FieldSymbol field)
+    {
+        var stateMachine = this.asyncFieldMap?.StructType ?? this.asyncIteratorEmitCtx?.SmClass;
+        if (stateMachine == null)
+        {
+            throw new InvalidOperationException(
+                $"Hoisted field '{field.Name}' was loaded outside a state machine.");
+        }
+
+        // Generic state machines require a MemberRef parented at their
+        // self-instantiated TypeSpec; a raw FieldDef changes the byref identity.
+        return this.outer.userTokens.ResolveFieldToken(stateMachine, field);
+    }
+
     public IReadOnlyList<SequencePoint> SequencePoints => this.sequencePoints;
 
     /// <summary>Issue #306: emits a single value expression onto the IL stack. Used by the constructor emitter to evaluate base-constructor argument expressions.</summary>

--- a/test/Compiler.Tests/Emit/Issue2749GenericClassAsyncEmitterTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2749GenericClassAsyncEmitterTests.cs
@@ -1,0 +1,207 @@
+// <copyright file="Issue2749GenericClassAsyncEmitterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2749: async state-machine field references must use the canonical
+/// generic identity of the state machine and its hoisted receiver.
+/// </summary>
+public class Issue2749GenericClassAsyncEmitterTests
+{
+    public static IEnumerable<object[]> AsyncGenericMatrix()
+    {
+        yield return Case(
+            "non-generic class",
+            """
+            class Job2749 {
+                async func Run(value string) string {
+                    let hoisted = value
+                    await Task.Delay(1)
+                    return hoisted
+                }
+            }
+            Console.WriteLine(Job2749().Run("plain").Result)
+            """,
+            "plain\n");
+        yield return Case(
+            "generic class",
+            """
+            class Job2749[T](Seed T) {
+                async func Run(value T) T {
+                    let hoisted = value
+                    await Task.Delay(1)
+                    Console.WriteLine(Seed)
+                    return hoisted
+                }
+            }
+            Console.WriteLine(Job2749[string]("class").Run("hoisted").Result)
+            """,
+            "class\nhoisted\n");
+        yield return Case(
+            "generic method",
+            """
+            async func Run2749[T](value T) T {
+                let hoisted = value
+                await Task.Delay(1)
+                return hoisted
+            }
+            Console.WriteLine(Run2749("method").Result)
+            """,
+            "method\n");
+        yield return Case(
+            "generic class and method",
+            """
+            class Job2749[T](Seed T) {
+                async func Run[U](value U) T {
+                    let hoistedT = Seed
+                    let hoistedU = value
+                    await Task.Delay(1)
+                    Console.WriteLine(hoistedU)
+                    return hoistedT
+                }
+            }
+            Console.WriteLine(Job2749[string]("class-method").Run(42).Result)
+            """,
+            "42\nclass-method\n");
+        yield return Case(
+            "generic class with async captures",
+            """
+            class Job2749[T](Seed T, Callback (T) -> void) {
+                private let Values List[T] = List[T]()
+
+                async func Run(value T) T {
+                    let hoisted = value
+                    let action = () -> Callback(hoisted)
+                    await Task.Delay(1)
+                    action()
+                    Values.Add(hoisted)
+                    return Seed
+                }
+            }
+            let job = Job2749[string]("captured", (value string) -> Console.WriteLine(value))
+            Console.WriteLine(job.Run("callback").Result)
+            """,
+            "callback\ncaptured\n");
+        yield return Case(
+            "nested generic class",
+            """
+            class Outer2749[T](Seed T) {
+                class Job2749(Seed T) {
+                    async func Run(value T) T {
+                        let hoisted = value
+                        let action = () -> Console.WriteLine(hoisted)
+                        await Task.Delay(1)
+                        action()
+                        return Seed
+                    }
+                }
+
+                func Run(value T) T {
+                    return Job2749(Seed).Run(value).Result
+                }
+            }
+            Console.WriteLine(Outer2749[string]("nested").Run("captured-nested"))
+            """,
+            "captured-nested\nnested\n");
+    }
+
+    [Theory]
+    [MemberData(nameof(AsyncGenericMatrix))]
+    public void AwaitAndHoistedLocals_VerifyAndRun(string _, string source, string expected)
+    {
+        Assert.Equal(expected, CompileVerifyAndRun(source));
+    }
+
+    private static object[] Case(string name, string body, string expected) =>
+        new object[]
+        {
+            name,
+            """
+            package issue2749
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            """ + body,
+            expected,
+        };
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var directory = Path.Combine(
+            Directory.GetCurrentDirectory(),
+            "out",
+            "test-artifacts",
+            "issue2749-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousErr);
+            }
+
+            Assert.True(exitCode == 0, $"gsc failed:\n{compileOut}\n{compileErr}");
+            IlVerifier.Verify(outputPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo);
+            var stdout = process!.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}\n{stderr}");
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2749

## Summary
- route hoisted closure captures through the canonical generic state-machine field-token resolver
- preserve non-generic, method-generic, combined, and nested-generic async emission
- add strict ILVerify/runtime coverage for awaits and hoisted type-parameter locals

## Validation
- targeted issue matrix: 6/6 passed
- Core.Tests: 6,691 passed, 1 skipped
- Compiler.Tests: 3,407 passed
- rebuilt Oahu.Core: DownloadDecryptJob<T> ILVerify findings reduced from 35 to 0

## Deferred
Oahu.Core still reports two unrelated BookLibrary.AddPersons generic-interface findings; ILVerify also ends with its existing verifier IndexOutOfRangeException.