### PR TITLE
Preserve constrained interface setters through spills

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -500,7 +500,14 @@ public static class SpillSequenceSpiller
                         clrPropAssign,
                         clrPropAssign.Receiver,
                         clrPropAssign.Value,
-                        (recv, val) => new BoundClrPropertyAssignmentExpression(null, recv, clrPropAssign.Member, val, clrPropAssign.Type));
+                        (recv, val) => new BoundClrPropertyAssignmentExpression(
+                            null,
+                            recv,
+                            clrPropAssign.Member,
+                            val,
+                            clrPropAssign.Type,
+                            clrPropAssign.ConstrainedReceiverTypeParameter,
+                            clrPropAssign.ConstrainedInterfaceType));
                 case BoundClrBinaryOperatorExpression clrBinary:
                     // Issue #2388: preserve whichever of Method (imported CLR
                     // type) / Function (nullable-lifted same-compilation

--- a/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
@@ -274,7 +274,9 @@ internal sealed class SideEffectSpiller : NestedFunctionBodyRewriter
             receiver,
             rewritten.Member,
             value,
-            rewritten.Type);
+            rewritten.Type,
+            rewritten.ConstrainedReceiverTypeParameter,
+            rewritten.ConstrainedInterfaceType);
 
         return new BoundBlockExpression(rewritten.Syntax, statements.ToImmutable(), assignment);
     }

--- a/test/Compiler.Tests/Emit/Issue2514ImportedInterfaceConstraintMemberTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2514ImportedInterfaceConstraintMemberTests.cs
@@ -210,6 +210,88 @@ public sealed class Issue2514ImportedInterfaceConstraintMemberTests
             Run(consumerPath));
     }
 
+    [Fact]
+    public void ConstrainedObjectInitializer_WithSpilledSetterValue_RunsAndVerifies()
+    {
+        const string source = """
+            package Issue2741
+            import System
+            import System.Collections.Generic
+            import Issue2514.Contracts
+
+            func Next(value string) string -> value + "!"
+
+            func Add[T IContract[string] class init()](items ICollection[T], names IEnumerable[string]) {
+                for name in names {
+                    var item = T{Name: Next(name)}
+                    items.Add(item)
+                }
+            }
+
+            func Main() {
+                var items = List[RefContract]()
+                var names = List[string]()
+                names.Add("Ada")
+                names.Add("Grace")
+                Add[RefContract](items, names)
+                Console.WriteLine(items[0].Name)
+                Console.WriteLine(items[1].Name)
+            }
+            """;
+
+        using var result = Compile(source, "exe");
+        Assert.Equal("Ada!\nGrace!\n", Run(result.OutputPath));
+        IlVerifier.Verify(result.OutputPath, additionalReferences: new[] { result.ContractsPath });
+    }
+
+    [Fact]
+    public void OrdinaryInterfaceReceiver_WithSpilledSetterValue_RunsAndVerifies()
+    {
+        const string source = """
+            package Issue2741Control
+            import System
+            import Issue2514.Contracts
+
+            func Next(value string) string -> value + "!"
+            func SetName(value IContract[string], name string) { value.Name = Next(name) }
+
+            func Main() {
+                var value = RefContract()
+                SetName(value, "ordinary")
+                Console.WriteLine(value.Name)
+            }
+            """;
+
+        using var result = Compile(source, "exe");
+        Assert.Equal("ordinary!\n", Run(result.OutputPath));
+        IlVerifier.Verify(result.OutputPath, additionalReferences: new[] { result.ContractsPath });
+    }
+
+    [Fact]
+    public void ConstrainedObjectInitializer_WithAwaitedSetterValue_RunsAndVerifies()
+    {
+        const string source = """
+            package Issue2741Async
+            import System
+            import System.Threading.Tasks
+            import Issue2514.Contracts
+
+            async func Make[T IContract[string] class init()](name string) T {
+                var pending = Task.FromResult[string](name + "!")
+                return T{Name: await pending}
+            }
+
+            func Main() {
+                var value = Make[RefContract]("async").Result
+                Console.WriteLine(value.Name)
+            }
+            """;
+
+        using var result = Compile(source, "exe");
+        Assert.Equal("async!\n", Run(result.OutputPath));
+        IlVerifier.Verify(result.OutputPath, additionalReferences: new[] { result.ContractsPath });
+    }
+
     [Theory]
     [InlineData(
         "func Bad[T IContract[string]](value T) string -> value.Missing",


### PR DESCRIPTION
## Summary
- preserve constrained type-parameter/interface metadata when CLR property assignments are rebuilt by synchronous or async spill lowering
- keep ordinary interface receivers on the existing non-constrained path
- cover looped object initializers, ordinary receivers, and awaited initializer values with runtime + ILVerify tests

## Validation
- focused regressions: 3 passed (runtime and ILVerify)
- `Core.Tests`: 6,691 passed, 1 skipped
- `Compiler.Tests`: 3,404 passed
- all suites run sequentially with `MSBUILDDISABLENODEREUSE=1`

## Oahu proof
- cycle-13 `Oahu.Core.dll` baseline: 64 ILVerify errors, 2 in `BookLibrary::AddPersons`
- rebuilt with this compiler: 62 ILVerify errors, 0 in `BookLibrary::AddPersons`
- fixed IL now emits `ldloca` + `constrained. !!TPerson` before both interface setters; fingerprint `sha256:4d566c0d76371f805c1e11e8847eaa0f6c90365b740e98ff648d9189e76f30b2` is absent

## Deferred work
- none for #2741; the remaining 62 Oahu ILVerify findings are unrelated cycle-13 roots

Fixes #2741