### PR TITLE
Fix inherited interface event metadata

### DIFF
--- a/src/Core/CodeAnalysis/Emit/InterfaceImplEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/InterfaceImplEmitter.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Symbols;
 
@@ -43,6 +44,7 @@ internal sealed class InterfaceImplEmitter
     private readonly ReflectionMetadataEmitter outer;
     private readonly EmitContext emitCtx;
     private readonly MetadataTokenCache cache;
+    private readonly Dictionary<StructSymbol, List<InheritedEventBridge>> inheritedEventBridges = new();
 
     public InterfaceImplEmitter(ReflectionMetadataEmitter outer)
     {
@@ -460,111 +462,375 @@ internal sealed class InterfaceImplEmitter
     }
 
     /// <summary>
-    /// Issue #2718: custom event accessors are emitted through the general
-    /// function path, so their metadata shape must not rely on the field-like
-    /// event emitter's implicit-interface promotion. Bind every matching
-    /// ordinary custom event directly to its user or imported interface slots.
+    /// Issues #2718/#2742: binds interface event slots whose implementation
+    /// cannot be wired by ordinary name-based dispatch. This includes custom
+    /// event accessors and events inherited from a base class that did not
+    /// itself declare the interface.
     /// </summary>
-    internal void EmitImplicitCustomEventMethodImpls(StructSymbol structSymbol)
+    internal void EmitImplicitEventMethodImpls(StructSymbol structSymbol)
     {
         if (structSymbol == null
-            || structSymbol.Events.IsDefaultOrEmpty
             || !this.cache.StructTypeDefs.TryGetValue(structSymbol, out var implTypeDef))
         {
             return;
         }
 
-        foreach (var ev in structSymbol.Events)
+        foreach (var iface in structSymbol.Interfaces)
         {
-            if (ev.IsFieldLike
-                || ev.HasExplicitInterfaceClause
-                || !this.cache.EventAccessorHandles.TryGetValue(ev, out var implAccessors))
+            var defIface = iface.Definition ?? iface;
+            foreach (var slotEvent in defIface.Events)
             {
-                continue;
-            }
-
-            foreach (var iface in structSymbol.Interfaces)
-            {
-                var defIface = iface.Definition ?? iface;
-                foreach (var slotEvent in defIface.Events)
-                {
-                    if (slotEvent.Name != ev.Name
-                        || !DeclarationBinder.InterfaceEventTypesEquivalent(iface, slotEvent, ev)
-                        || IsExplicitlyImplemented(structSymbol, slotEvent))
-                    {
-                        continue;
-                    }
-
-                    var isGenericIface = ReflectionMetadataEmitter.IsUserGenericInterfaceReference(iface);
-                    if (slotEvent.AddMethodSymbol != null)
-                    {
-                        EntityHandle? declaration = isGenericIface
-                            ? this.outer.userTokens.ResolveUserInterfaceInstanceMethodToken(iface, slotEvent.AddMethodSymbol)
-                            : this.cache.MethodHandles.TryGetValue(slotEvent.AddMethodSymbol, out var handle)
-                                ? handle
-                                : (EntityHandle?)null;
-                        if (declaration.HasValue)
-                        {
-                            this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implAccessors.Add, declaration.Value);
-                        }
-                    }
-
-                    if (slotEvent.RemoveMethodSymbol != null)
-                    {
-                        EntityHandle? declaration = isGenericIface
-                            ? this.outer.userTokens.ResolveUserInterfaceInstanceMethodToken(iface, slotEvent.RemoveMethodSymbol)
-                            : this.cache.MethodHandles.TryGetValue(slotEvent.RemoveMethodSymbol, out var handle)
-                                ? handle
-                                : (EntityHandle?)null;
-                        if (declaration.HasValue)
-                        {
-                            this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implAccessors.Remove, declaration.Value);
-                        }
-                    }
-                }
-            }
-
-            var emittedClrSlots = new HashSet<MethodInfo>();
-            foreach (var ifaceSymbol in structSymbol.ImplementedClrInterfaces)
-            {
-                var declaredInterface = ifaceSymbol?.ClrType;
-                if (declaredInterface?.IsInterface != true)
+                if (IsExplicitlyImplemented(structSymbol, slotEvent)
+                    || !TryFindImplicitEvent(structSymbol, iface, slotEvent, out var ev, out var declaringType)
+                    || (ReferenceEquals(declaringType, structSymbol) && ev.IsFieldLike)
+                    || !this.cache.EventAccessorHandles.TryGetValue(ev, out var implAccessors))
                 {
                     continue;
                 }
 
-                var interfaces = new List<Type> { declaredInterface };
-                interfaces.AddRange(declaredInterface.GetInterfaces());
-                foreach (var clrInterface in interfaces)
+                var isGenericIface = ReflectionMetadataEmitter.IsUserGenericInterfaceReference(iface);
+                if (slotEvent.AddMethodSymbol != null)
                 {
-                    var containingType = ReferenceEquals(clrInterface, declaredInterface)
-                        ? ifaceSymbol
-                        : TypeSymbol.FromClrType(clrInterface);
-                    foreach (var slotEvent in clrInterface.GetEvents(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                    EntityHandle? declaration = isGenericIface
+                        ? this.outer.userTokens.ResolveUserInterfaceInstanceMethodToken(iface, slotEvent.AddMethodSymbol)
+                        : this.cache.MethodHandles.TryGetValue(slotEvent.AddMethodSymbol, out var handle)
+                            ? handle
+                            : (EntityHandle?)null;
+                    if (declaration.HasValue)
                     {
-                        var slotType = MemberLookup.GetClrEventHandlerTypeSymbol(containingType, slotEvent);
-                        if (slotEvent.Name != ev.Name
-                            || !DeclarationBinder.TypeSignaturesEquivalent(slotType, ev.Type)
-                            || IsImportedSlotExplicitlyImplemented(structSymbol, slotEvent))
-                        {
-                            continue;
-                        }
+                        var body = this.GetEventAccessorBody(
+                            structSymbol,
+                            declaringType,
+                            ev,
+                            isAdd: true,
+                            implAccessors.Add);
+                        this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, body, declaration.Value);
+                    }
+                }
 
-                        if (slotEvent.AddMethod != null && emittedClrSlots.Add(slotEvent.AddMethod))
-                        {
-                            var declaration = this.outer.memberRefs.GetMethodEntityHandle(slotEvent.AddMethod, containingType);
-                            this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implAccessors.Add, declaration);
-                        }
-
-                        if (slotEvent.RemoveMethod != null && emittedClrSlots.Add(slotEvent.RemoveMethod))
-                        {
-                            var declaration = this.outer.memberRefs.GetMethodEntityHandle(slotEvent.RemoveMethod, containingType);
-                            this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implAccessors.Remove, declaration);
-                        }
+                if (slotEvent.RemoveMethodSymbol != null)
+                {
+                    EntityHandle? declaration = isGenericIface
+                        ? this.outer.userTokens.ResolveUserInterfaceInstanceMethodToken(iface, slotEvent.RemoveMethodSymbol)
+                        : this.cache.MethodHandles.TryGetValue(slotEvent.RemoveMethodSymbol, out var handle)
+                            ? handle
+                            : (EntityHandle?)null;
+                    if (declaration.HasValue)
+                    {
+                        var body = this.GetEventAccessorBody(
+                            structSymbol,
+                            declaringType,
+                            ev,
+                            isAdd: false,
+                            implAccessors.Remove);
+                        this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, body, declaration.Value);
                     }
                 }
             }
         }
+
+        var emittedClrSlots = new HashSet<MethodInfo>();
+        foreach (var ifaceSymbol in structSymbol.ImplementedClrInterfaces)
+        {
+            var declaredInterface = ifaceSymbol?.ClrType;
+            if (declaredInterface?.IsInterface != true)
+            {
+                continue;
+            }
+
+            var interfaces = new List<Type> { declaredInterface };
+            interfaces.AddRange(declaredInterface.GetInterfaces());
+            foreach (var clrInterface in interfaces)
+            {
+                var containingType = ReferenceEquals(clrInterface, declaredInterface)
+                    ? ifaceSymbol
+                    : TypeSymbol.FromClrType(clrInterface);
+                foreach (var slotEvent in clrInterface.GetEvents(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                {
+                    var slotType = MemberLookup.GetClrEventHandlerTypeSymbol(containingType, slotEvent);
+                    if (IsImportedSlotExplicitlyImplemented(structSymbol, slotEvent)
+                        || !TryFindImplicitEvent(structSymbol, slotEvent.Name, slotType, out var ev, out var declaringType)
+                        || (ReferenceEquals(declaringType, structSymbol) && ev.IsFieldLike)
+                        || !this.cache.EventAccessorHandles.TryGetValue(ev, out var implAccessors))
+                    {
+                        continue;
+                    }
+
+                    if (slotEvent.AddMethod != null && emittedClrSlots.Add(slotEvent.AddMethod))
+                    {
+                        var declaration = this.outer.memberRefs.GetMethodEntityHandle(slotEvent.AddMethod, containingType);
+                        var body = this.GetEventAccessorBody(
+                            structSymbol,
+                            declaringType,
+                            ev,
+                            isAdd: true,
+                            implAccessors.Add);
+                        this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, body, declaration);
+                    }
+
+                    if (slotEvent.RemoveMethod != null && emittedClrSlots.Add(slotEvent.RemoveMethod))
+                    {
+                        var declaration = this.outer.memberRefs.GetMethodEntityHandle(slotEvent.RemoveMethod, containingType);
+                        var body = this.GetEventAccessorBody(
+                            structSymbol,
+                            declaringType,
+                            ev,
+                            isAdd: false,
+                            implAccessors.Remove);
+                        this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, body, declaration);
+                    }
+                }
+            }
+        }
+    }
+
+    internal int PlanInheritedEventBridges(StructSymbol structSymbol, int firstMethodRow)
+    {
+        var nextMethodRow = firstMethodRow;
+
+        foreach (var iface in structSymbol.Interfaces)
+        {
+            var defIface = iface.Definition ?? iface;
+            foreach (var slotEvent in defIface.Events)
+            {
+                if (!IsExplicitlyImplemented(structSymbol, slotEvent)
+                    && TryFindImplicitEvent(structSymbol, iface, slotEvent, out var ev, out var declaringType)
+                    && !ReferenceEquals(declaringType, structSymbol))
+                {
+                    PlanBridge(ev);
+                }
+            }
+        }
+
+        foreach (var ifaceSymbol in structSymbol.ImplementedClrInterfaces)
+        {
+            var declaredInterface = ifaceSymbol?.ClrType;
+            if (declaredInterface?.IsInterface != true)
+            {
+                continue;
+            }
+
+            var interfaces = new List<Type> { declaredInterface };
+            interfaces.AddRange(declaredInterface.GetInterfaces());
+            foreach (var clrInterface in interfaces)
+            {
+                var containingType = ReferenceEquals(clrInterface, declaredInterface)
+                    ? ifaceSymbol
+                    : TypeSymbol.FromClrType(clrInterface);
+                foreach (var slotEvent in clrInterface.GetEvents(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                {
+                    var slotType = MemberLookup.GetClrEventHandlerTypeSymbol(containingType, slotEvent);
+                    if (!IsImportedSlotExplicitlyImplemented(structSymbol, slotEvent)
+                        && TryFindImplicitEvent(structSymbol, slotEvent.Name, slotType, out var ev, out var declaringType)
+                        && !ReferenceEquals(declaringType, structSymbol))
+                    {
+                        PlanBridge(ev);
+                    }
+                }
+            }
+        }
+
+        return nextMethodRow - firstMethodRow;
+
+        void PlanBridge(EventSymbol ev)
+        {
+            if (!this.inheritedEventBridges.TryGetValue(structSymbol, out var bridges))
+            {
+                bridges = new List<InheritedEventBridge>();
+                this.inheritedEventBridges[structSymbol] = bridges;
+            }
+
+            foreach (var existing in bridges)
+            {
+                if (ReferenceEquals(existing.Event, ev))
+                {
+                    return;
+                }
+            }
+
+            bridges.Add(new InheritedEventBridge(
+                ev,
+                MetadataTokens.MethodDefinitionHandle(nextMethodRow++),
+                MetadataTokens.MethodDefinitionHandle(nextMethodRow++)));
+        }
+    }
+
+    internal void EmitInheritedEventBridges(StructSymbol structSymbol)
+    {
+        if (!this.inheritedEventBridges.TryGetValue(structSymbol, out var bridges))
+        {
+            return;
+        }
+
+        foreach (var bridge in bridges)
+        {
+            var declaringType = FindDeclaringType(structSymbol, bridge.Event);
+            this.EmitInheritedEventBridge(
+                declaringType,
+                bridge.Event,
+                bridge.Add,
+                isAdd: true);
+            this.EmitInheritedEventBridge(
+                declaringType,
+                bridge.Event,
+                bridge.Remove,
+                isAdd: false);
+        }
+    }
+
+    private static bool TryFindImplicitEvent(
+        StructSymbol type,
+        InterfaceSymbol iface,
+        EventSymbol slot,
+        out EventSymbol implementation,
+        out StructSymbol declaringType)
+    {
+        for (var current = type; current != null; current = current.BaseClass)
+        {
+            foreach (var candidate in current.Events)
+            {
+                if (!candidate.HasExplicitInterfaceClause
+                    && candidate.Name == slot.Name
+                    && (ReferenceEquals(current, type) || candidate.Accessibility == Accessibility.Public)
+                    && DeclarationBinder.InterfaceEventTypesEquivalent(iface, slot, candidate))
+                {
+                    implementation = candidate;
+                    declaringType = current;
+                    return true;
+                }
+            }
+        }
+
+        implementation = null;
+        declaringType = null;
+        return false;
+    }
+
+    private static bool TryFindImplicitEvent(
+        StructSymbol type,
+        string name,
+        TypeSymbol slotType,
+        out EventSymbol implementation,
+        out StructSymbol declaringType)
+    {
+        for (var current = type; current != null; current = current.BaseClass)
+        {
+            foreach (var candidate in current.Events)
+            {
+                if (!candidate.HasExplicitInterfaceClause
+                    && candidate.Name == name
+                    && (ReferenceEquals(current, type) || candidate.Accessibility == Accessibility.Public)
+                    && DeclarationBinder.TypeSignaturesEquivalent(slotType, candidate.Type))
+                {
+                    implementation = candidate;
+                    declaringType = current;
+                    return true;
+                }
+            }
+        }
+
+        implementation = null;
+        declaringType = null;
+        return false;
+    }
+
+    private EntityHandle GetEventAccessorBody(
+        StructSymbol implementingType,
+        StructSymbol declaringType,
+        EventSymbol ev,
+        bool isAdd,
+        MethodDefinitionHandle definition)
+    {
+        if (ReferenceEquals(implementingType, declaringType))
+        {
+            return definition;
+        }
+
+        foreach (var bridge in this.inheritedEventBridges[implementingType])
+        {
+            if (ReferenceEquals(bridge.Event, ev))
+            {
+                return isAdd ? bridge.Add : bridge.Remove;
+            }
+        }
+
+        throw new InvalidOperationException("Inherited event bridge was not planned.");
+    }
+
+    private void EmitInheritedEventBridge(
+        StructSymbol declaringType,
+        EventSymbol ev,
+        MethodDefinitionHandle expectedHandle,
+        bool isAdd)
+    {
+        var accessors = this.cache.EventAccessorHandles[ev];
+        var accessor = isAdd ? ev.AddMethodSymbol : ev.RemoveMethodSymbol;
+        EntityHandle target = declaringType.Definition != null
+            && !ReferenceEquals(declaringType.Definition, declaringType)
+            && accessor != null
+                ? this.outer.userTokens.ResolveUserInstanceMethodToken(declaringType, accessor)
+                : isAdd ? accessors.Add : accessors.Remove;
+
+        var bodyOffset = -1;
+        if (!this.emitCtx.MetadataOnly)
+        {
+            var il = new InstructionEncoder(new BlobBuilder());
+            il.LoadArgument(0);
+            il.LoadArgument(1);
+            il.OpCode(ILOpCode.Call);
+            il.Token(target);
+            il.OpCode(ILOpCode.Ret);
+            bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(
+                il,
+                maxStack: MaxStackTracker.ComputeMaxStack(il));
+        }
+
+        var eventType = declaringType.SubstituteMemberType(ev.Type);
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                1,
+                returnType => returnType.Void(),
+                parameters => this.outer.signatures.EncodeTypeSymbol(parameters.AddParameter().Type(), eventType));
+        var firstParameter = this.outer.customAttrEncoder.NextParameterHandle();
+        this.emitCtx.Metadata.AddParameter(
+            ParameterAttributes.None,
+            this.emitCtx.Metadata.GetOrAddString("value"),
+            sequenceNumber: 1);
+
+        var emittedHandle = this.emitCtx.Metadata.AddMethodDefinition(
+            MethodAttributes.Private
+                | MethodAttributes.Final
+                | MethodAttributes.Virtual
+                | MethodAttributes.HideBySig
+                | MethodAttributes.NewSlot
+                | MethodAttributes.SpecialName,
+            MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            this.emitCtx.Metadata.GetOrAddString((isAdd ? "add_" : "remove_") + ev.Name),
+            this.emitCtx.Metadata.GetOrAddBlob(signature),
+            bodyOffset,
+            firstParameter);
+
+        if (emittedHandle != expectedHandle)
+        {
+            throw new InvalidOperationException("Inherited event bridge MethodDef row was not emitted in planned order.");
+        }
+    }
+
+    private static StructSymbol FindDeclaringType(StructSymbol type, EventSymbol ev)
+    {
+        for (var current = type.BaseClass; current != null; current = current.BaseClass)
+        {
+            foreach (var candidate in current.Events)
+            {
+                if (ReferenceEquals(candidate, ev))
+                {
+                    return current;
+                }
+            }
+        }
+
+        throw new InvalidOperationException("Inherited event declaring type was not found.");
     }
 
     private static bool IsExplicitlyImplemented(StructSymbol type, EventSymbol slot)
@@ -908,4 +1174,9 @@ internal sealed class InterfaceImplEmitter
 
         return true;
     }
+
+    private sealed record InheritedEventBridge(
+        EventSymbol Event,
+        MethodDefinitionHandle Add,
+        MethodDefinitionHandle Remove);
 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1925,6 +1925,8 @@ internal sealed class ReflectionMetadataEmitter
                 this.cache.EventAccessorHandles[ev] = (addHandle, removeHandle, raiseHandle);
             }
 
+            methodRow += this.interfaceImpls.PlanInheritedEventBridges(c, methodRow);
+
             // ADR-0053: plan method rows for static methods on classes.
             if (!c.StaticMethods.IsDefaultOrEmpty)
             {
@@ -3330,6 +3332,7 @@ internal sealed class ReflectionMetadataEmitter
 
             // ADR-0052: emit event accessor methods for classes.
             this.memberDefEmitter.EmitEventAccessors(c);
+            this.interfaceImpls.EmitInheritedEventBridges(c);
 
             // ADR-0053: emit static methods for classes.
             if (!c.StaticMethods.IsDefaultOrEmpty)
@@ -3385,9 +3388,9 @@ internal sealed class ReflectionMetadataEmitter
             // event implementations (add/remove/raise accessors).
             this.interfaceImpls.EmitExplicitInterfaceEventMethodImpls(c);
 
-            // Issue #2718: bind ordinary custom event accessors directly to
-            // matching user/imported interface event slots.
-            this.interfaceImpls.EmitImplicitCustomEventMethodImpls(c);
+            // Issues #2718/#2742: bind custom and inherited event accessors
+            // directly to matching user/imported interface event slots.
+            this.interfaceImpls.EmitImplicitEventMethodImpls(c);
         }
 
         foreach (var c in topClasses)
@@ -3493,8 +3496,8 @@ internal sealed class ReflectionMetadataEmitter
             // event implementations (add/remove/raise accessors).
             this.interfaceImpls.EmitExplicitInterfaceEventMethodImpls(s);
 
-            // Issue #2718: see the class path above.
-            this.interfaceImpls.EmitImplicitCustomEventMethodImpls(s);
+            // Issues #2718/#2742: see the class path above.
+            this.interfaceImpls.EmitImplicitEventMethodImpls(s);
         }
 
         foreach (var s in topStructs)

--- a/test/Compiler.Tests/Emit/Issue2742InheritedInterfaceEventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2742InheritedInterfaceEventEmitTests.cs
@@ -1,0 +1,236 @@
+// <copyright file="Issue2742InheritedInterfaceEventEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Issue #2742: inherited events must fill interface accessor slots.</summary>
+public sealed class Issue2742InheritedInterfaceEventEmitTests
+{
+    [Fact]
+    public void OahuDownloadSettings_InheritedFieldLikeEvent_TypeLoadsDispatchesAndIlVerifies()
+    {
+        const string source = """
+            package Oahu.Core
+            import System
+
+            interface IDownloadSettings {
+                event ChangedSettings (object?, EventArgs) -> void
+                func Ping() int32;
+                prop Flag bool { get; }
+            }
+
+            open class SettingsBase {
+                event ChangedSettings (object?, EventArgs) -> void
+                func Raise() { this.ChangedSettings?.Invoke(this, EventArgs.Empty) }
+                func Ping() int32 -> 42
+                prop Flag bool { get -> true }
+            }
+
+            class DownloadSettings : SettingsBase, IDownloadSettings {
+            }
+            """;
+
+        using var artifacts = Compile(source);
+        IlVerifier.Verify(artifacts.OutputPath);
+
+        var assembly = Assembly.Load(File.ReadAllBytes(artifacts.OutputPath));
+        var type = assembly.GetType("Oahu.Core.DownloadSettings", throwOnError: true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var contract = assembly.GetType("Oahu.Core.IDownloadSettings", throwOnError: true)!;
+        var map = type.GetInterfaceMap(contract);
+
+        var hits = 0;
+        Action<object, EventArgs> handler = (_, _) => hits++;
+        contract.GetEvent("ChangedSettings")!.AddEventHandler(instance, handler);
+        type.GetMethod("Raise")!.Invoke(instance, null);
+
+        Assert.Equal(1, hits);
+        Assert.Equal(
+            new[] { "add_ChangedSettings", "get_Flag", "Ping", "remove_ChangedSettings" },
+            map.TargetMethods.Select(method => method.Name).OrderBy(name => name).ToArray());
+        Assert.All(
+            map.TargetMethods.Where(method => method.Name is "Ping" or "get_Flag"),
+            method => Assert.Equal("SettingsBase", method.DeclaringType!.Name));
+        Assert.All(
+            map.TargetMethods.Where(method => method.Name.StartsWith("add_", StringComparison.Ordinal)
+                || method.Name.StartsWith("remove_", StringComparison.Ordinal)),
+            method => Assert.Equal("DownloadSettings", method.DeclaringType!.Name));
+        Assert.Equal(
+            new[] { "add_ChangedSettings", "remove_ChangedSettings" },
+            GetMethodImplBodyNames(artifacts.OutputPath, "DownloadSettings"));
+    }
+
+    [Fact]
+    public void MultiLevelInheritedCustomEvent_TypeLoadsDispatchesAndIlVerifies()
+    {
+        const string source = """
+            package Issue2742.Custom
+
+            interface IChanges {
+                event Changed (int32) -> void
+            }
+
+            open class Base {
+                private var handler ((int32) -> void)?
+
+                event Changed (int32) -> void {
+                    add { handler = value }
+                    remove { handler = nil }
+                }
+
+                func Raise(value int32) { handler?.Invoke(value) }
+            }
+
+            open class Middle : Base {
+            }
+
+            class Derived : Middle, IChanges {
+            }
+            """;
+
+        using var artifacts = Compile(source);
+        IlVerifier.Verify(artifacts.OutputPath);
+
+        var assembly = Assembly.Load(File.ReadAllBytes(artifacts.OutputPath));
+        var type = assembly.GetType("Issue2742.Custom.Derived", throwOnError: true)!;
+        var contract = assembly.GetType("Issue2742.Custom.IChanges", throwOnError: true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var observed = 0;
+        Action<int> handler = value => observed = value;
+        contract.GetEvent("Changed")!.AddEventHandler(instance, handler);
+        type.GetMethod("Raise")!.Invoke(instance, new object[] { 17 });
+
+        Assert.Equal(17, observed);
+        Assert.All(type.GetInterfaceMap(contract).TargetMethods, method => Assert.Equal("Derived", method.DeclaringType!.Name));
+        Assert.Equal(
+            new[] { "add_Changed", "remove_Changed" },
+            GetMethodImplBodyNames(artifacts.OutputPath, "Derived"));
+    }
+
+    [Fact]
+    public void ImportedInterface_InheritedFieldLikeEvent_TypeLoadsAndIlVerifies()
+    {
+        const string source = """
+            package Issue2742.Imported
+            import System.ComponentModel
+
+            open class Base {
+                event PropertyChanged PropertyChangedEventHandler
+            }
+
+            class Derived : Base, INotifyPropertyChanged {
+            }
+            """;
+
+        using var artifacts = Compile(source);
+        IlVerifier.Verify(artifacts.OutputPath);
+
+        var assembly = Assembly.Load(File.ReadAllBytes(artifacts.OutputPath));
+        var type = assembly.GetType("Issue2742.Imported.Derived", throwOnError: true)!;
+        var instance = Activator.CreateInstance(type)!;
+        var map = type.GetInterfaceMap(typeof(INotifyPropertyChanged));
+
+        Assert.NotNull(instance);
+        Assert.All(map.TargetMethods, method => Assert.Equal("Derived", method.DeclaringType!.Name));
+        Assert.Equal(
+            new[] { "add_PropertyChanged", "remove_PropertyChanged" },
+            GetMethodImplBodyNames(artifacts.OutputPath, "Derived"));
+    }
+
+    private static string[] GetMethodImplBodyNames(string assemblyPath, string typeName)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var type = reader.TypeDefinitions
+            .Select(reader.GetTypeDefinition)
+            .Single(definition => reader.GetString(definition.Name) == typeName);
+        return type.GetMethodImplementations()
+            .Select(reader.GetMethodImplementation)
+            .Select(implementation => GetMethodName(reader, implementation.MethodBody))
+            .OrderBy(name => name)
+            .ToArray();
+    }
+
+    private static string GetMethodName(MetadataReader reader, EntityHandle handle)
+        => handle.Kind switch
+        {
+            HandleKind.MethodDefinition => reader.GetString(reader.GetMethodDefinition((MethodDefinitionHandle)handle).Name),
+            HandleKind.MemberReference => reader.GetString(reader.GetMemberReference((MemberReferenceHandle)handle).Name),
+            _ => throw new InvalidOperationException($"Unexpected method handle: {handle.Kind}"),
+        };
+
+    private static CompilationArtifacts Compile(string source)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2742-artifacts",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(
+            exitCode == 0,
+            $"compile failed\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return new CompilationArtifacts(directory, outputPath);
+    }
+
+    private sealed class CompilationArtifacts : IDisposable
+    {
+        public CompilationArtifacts(string directory, string outputPath)
+        {
+            Directory = directory;
+            OutputPath = outputPath;
+        }
+
+        public string Directory { get; }
+
+        public string OutputPath { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                System.IO.Directory.Delete(Directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- synthesize derived forwarding accessors when an interface event is satisfied by an inherited user event
- wire those accessors with MethodImpl rows for user and imported interfaces, including multi-level and custom-event inheritance
- preserve ordinary inherited method/property dispatch and existing declared custom-event wiring

## Validation
- issue #2742 regression matrix: 3/3 (runtime TypeLoad/dispatch + ILVerify + MethodImpl inspection)
- related event emit tests: 66/66
- Compiler.Tests: 3404/3404
- actual cycle-13 Oahu.Core: `Oahu.Core.DownloadSettings TypeLoaded; interface targets=10`; crash-corrected ILVerify reports 0 DownloadSettings and 0 `[MD]` findings (64 unrelated pre-existing StackUnexpected findings remain)

Fixes #2742