### PR TITLE
Fix lexical lifetime of using declarations

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -312,7 +312,7 @@ public sealed class Binder
             reportObsoleteUseIfApplicable: ReportObsoleteUseIfApplicable,
             isAsyncIteratorReturnType: IsAsyncIteratorReturnType,
             getCurrentFunction: () => this.function,
-            bindStatement: syntax => statements.BindStatement(syntax));
+            bindStatementList: (syntax, trailing) => statements.BindStatementList(syntax, trailingStatement: trailing));
 
         // statements/declarations still reference this.expressions through
         // the callbacks above; expressions is wired last so its constructor
@@ -1102,12 +1102,36 @@ public sealed class Binder
             // types / functions remain visible while the new binder's own
             // RootScope owns the `args` parameter declaration.
             var tlsBinder = new Binder(binder.scope, synthesizedEntryPoint);
-            foreach (var globalStatement in globalStatements)
+            string previousPackage = null;
+            SyntaxTree previousTree = null;
+            var contextSet = false;
+            try
             {
-                RunWithPackage(
-                    packageByTree[globalStatement.SyntaxTree],
-                    globalStatement.SyntaxTree,
-                    () => statements.Add(tlsBinder.statements.BindStatement(globalStatement.Statement)));
+                statements.AddRange(tlsBinder.statements.BindStatementList(
+                    globalStatements.Select(s => s.Statement).ToImmutableArray(),
+                    statement =>
+                    {
+                        var tree = statement.SyntaxTree;
+                        if (!contextSet)
+                        {
+                            previousPackage = binder.scope.SetCurrentDeclaringPackage(packageByTree[tree]?.Name);
+                            previousTree = binder.scope.SetCurrentReferencingSyntaxTree(tree);
+                            contextSet = true;
+                        }
+                        else
+                        {
+                            binder.scope.SetCurrentDeclaringPackage(packageByTree[tree]?.Name);
+                            binder.scope.SetCurrentReferencingSyntaxTree(tree);
+                        }
+                    }));
+            }
+            finally
+            {
+                if (contextSet)
+                {
+                    binder.scope.SetCurrentDeclaringPackage(previousPackage);
+                    binder.scope.SetCurrentReferencingSyntaxTree(previousTree);
+                }
             }
 
             // Issue #1884: all TLS global statements share the synthesized

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -903,6 +903,46 @@ internal sealed partial class ExpressionBinder
     /// a <see cref="BoundBlockExpression"/> wrapping the prefix statements and
     /// the trailing value.
     /// </summary>
+    private (ImmutableArray<BoundStatement> Statements, BoundExpression Expression) BindBlockExpressionParts(
+        ImmutableArray<StatementSyntax> statements,
+        ExpressionSyntax expression,
+        bool canBeVoid)
+    {
+        if (!statements.Any(statement =>
+            statement is UsingStatementSyntax
+                or AwaitUsingStatementSyntax
+                or DeferStatementSyntax))
+        {
+            return (bindStatementList(statements, null), BindExpression(expression, canBeVoid));
+        }
+
+        BoundExpression boundExpression = null;
+        VariableSymbol result = null;
+        var boundStatements = bindStatementList(
+            statements,
+            () =>
+            {
+                boundExpression = BindExpression(expression, canBeVoid);
+                if (boundExpression is BoundErrorExpression || boundExpression.Type == TypeSymbol.Void)
+                {
+                    return new BoundExpressionStatement(expression, boundExpression);
+                }
+
+                result = new LocalVariableSymbol(
+                    $"<blockResult{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
+                    isReadOnly: true,
+                    boundExpression.Type ?? TypeSymbol.Error);
+                scope.TryDeclareVariable(result);
+                return new BoundVariableDeclaration(expression, result, boundExpression);
+            });
+        var resultExpression = result != null
+            ? (BoundExpression)new BoundVariableExpression(expression, result)
+            : boundExpression is BoundErrorExpression
+                ? boundExpression
+                : new BoundLiteralExpression(expression, value: 0, TypeSymbol.Void);
+        return (boundStatements, resultExpression);
+    }
+
     private BoundExpression BindBlockExpressionValue(BlockExpressionSyntax syntax, bool canBeVoid = false)
     {
         if (syntax.Expression == null)
@@ -918,20 +958,14 @@ internal sealed partial class ExpressionBinder
         }
 
         // Bind prefix statements.
-        var boundStatements = ImmutableArray.CreateBuilder<BoundStatement>();
-        foreach (var stmt in syntax.Statements)
-        {
-            var boundStmt = bindStatement(stmt);
-            boundStatements.Add(boundStmt);
-        }
-
-        var boundExpression = BindExpression(syntax.Expression, canBeVoid);
+        var (boundStatements, boundExpression) =
+            BindBlockExpressionParts(syntax.Statements, syntax.Expression, canBeVoid);
         if (boundExpression is BoundErrorExpression)
         {
             return boundExpression;
         }
 
-        return new BoundBlockExpression(null, boundStatements.ToImmutable(), boundExpression);
+        return new BoundBlockExpression(null, boundStatements, boundExpression);
     }
 
     /// <summary>
@@ -955,23 +989,18 @@ internal sealed partial class ExpressionBinder
             // Lambda body block: a missing trailing expression means a void
             // lambda. Bind any prefix statements; if there is a trailing
             // expression, use it as the value; otherwise the value is void.
-            var boundStatements = ImmutableArray.CreateBuilder<BoundStatement>();
-            if (!block.Statements.IsDefaultOrEmpty)
-            {
-                foreach (var stmt in block.Statements)
-                {
-                    boundStatements.Add(bindStatement(stmt));
-                }
-            }
-
             if (block.Expression == null)
             {
+                var voidStatements = block.Statements.IsDefaultOrEmpty
+                    ? ImmutableArray<BoundStatement>.Empty
+                    : bindStatementList(block.Statements, null);
+
                 // No trailing expression — surface as a void-returning body.
                 // Re-package the prefix statements via a BoundBlockExpression
                 // wrapping a synthetic void placeholder; the LambdaBinder
                 // treats void bodies by emitting an ExpressionStatement +
                 // void return.
-                if (boundStatements.Count == 0)
+                if (voidStatements.Length == 0)
                 {
                     // Empty body `{ }` — synthesize a no-op void expression.
                     return new BoundLiteralExpression(bodySyntax, value: 0, TypeSymbol.Void);
@@ -979,17 +1008,29 @@ internal sealed partial class ExpressionBinder
 
                 return new BoundBlockExpression(
                     bodySyntax,
-                    boundStatements.ToImmutable(),
+                    voidStatements,
                     new BoundLiteralExpression(bodySyntax, value: 0, TypeSymbol.Void));
             }
 
-            var trailing = BindExpression(block.Expression, canBeVoid: true);
-            if (boundStatements.Count == 0)
+            ImmutableArray<BoundStatement> boundStatements;
+            BoundExpression trailing;
+            if (block.Statements.IsDefaultOrEmpty)
+            {
+                boundStatements = ImmutableArray<BoundStatement>.Empty;
+                trailing = BindExpression(block.Expression, canBeVoid: true);
+            }
+            else
+            {
+                (boundStatements, trailing) =
+                    BindBlockExpressionParts(block.Statements, block.Expression, canBeVoid: true);
+            }
+
+            if (boundStatements.Length == 0)
             {
                 return trailing;
             }
 
-            return new BoundBlockExpression(bodySyntax, boundStatements.ToImmutable(), trailing);
+            return new BoundBlockExpression(bodySyntax, boundStatements, trailing);
         }
 
         return BindExpression(bodySyntax, canBeVoid: true);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -69,7 +69,7 @@ internal sealed partial class ExpressionBinder
     private readonly Action<TextLocation, Symbol, string> reportObsoleteUseIfApplicable;
     private readonly Func<TypeSymbol, bool> isAsyncIteratorReturnType;
     private readonly Func<FunctionSymbol> getCurrentFunction;
-    private readonly Func<StatementSyntax, BoundStatement> bindStatement;
+    private readonly Func<ImmutableArray<StatementSyntax>, Func<BoundStatement>, ImmutableArray<BoundStatement>> bindStatementList;
 
     // Issue #1502 follow-up: when true, a same-compilation enum (or `Enum?`)
     // appearing inside a delegate shape is erased to `object` (the covariant
@@ -96,7 +96,7 @@ internal sealed partial class ExpressionBinder
         Action<TextLocation, Symbol, string> reportObsoleteUseIfApplicable,
         Func<TypeSymbol, bool> isAsyncIteratorReturnType,
         Func<FunctionSymbol> getCurrentFunction,
-        Func<StatementSyntax, BoundStatement> bindStatement = null)
+        Func<ImmutableArray<StatementSyntax>, Func<BoundStatement>, ImmutableArray<BoundStatement>> bindStatementList = null)
     {
         this.binderCtx = binderCtx ?? throw new ArgumentNullException(nameof(binderCtx));
         this.memberLookup = memberLookup ?? throw new ArgumentNullException(nameof(memberLookup));
@@ -110,7 +110,7 @@ internal sealed partial class ExpressionBinder
         this.reportObsoleteUseIfApplicable = reportObsoleteUseIfApplicable ?? throw new ArgumentNullException(nameof(reportObsoleteUseIfApplicable));
         this.isAsyncIteratorReturnType = isAsyncIteratorReturnType ?? throw new ArgumentNullException(nameof(isAsyncIteratorReturnType));
         this.getCurrentFunction = getCurrentFunction ?? throw new ArgumentNullException(nameof(getCurrentFunction));
-        this.bindStatement = bindStatement;
+        this.bindStatementList = bindStatementList;
     }
 
     private DiagnosticBag Diagnostics => binderCtx.Diagnostics;

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -268,7 +268,22 @@ internal sealed partial class StatementBinder
         return new BoundBlockStatement(syntax, statements.ToImmutable());
     }
 
-    private void BindBlockStatements(ImmutableArray<StatementSyntax> statementSyntaxes, int startIndex, ImmutableArray<BoundStatement>.Builder statements)
+    internal ImmutableArray<BoundStatement> BindStatementList(
+        ImmutableArray<StatementSyntax> statementSyntaxes,
+        Action<StatementSyntax> beforeBind = null,
+        Func<BoundStatement> trailingStatement = null)
+    {
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        BindBlockStatements(statementSyntaxes, 0, statements, beforeBind, trailingStatement);
+        return statements.ToImmutable();
+    }
+
+    private void BindBlockStatements(
+        ImmutableArray<StatementSyntax> statementSyntaxes,
+        int startIndex,
+        ImmutableArray<BoundStatement>.Builder statements,
+        Action<StatementSyntax> beforeBind = null,
+        Func<BoundStatement> trailingStatement = null)
     {
         // Issue #208: push a persistent narrowing frame for this statement list.
         // After each call statement whose method carries [MemberNotNull], the
@@ -281,6 +296,7 @@ internal sealed partial class StatementBinder
             for (var i = startIndex; i < statementSyntaxes.Length; i++)
             {
                 var statementSyntax = statementSyntaxes[i];
+                beforeBind?.Invoke(statementSyntax);
 
                 if (statementSyntax is DeferStatementSyntax deferSyntax)
                 {
@@ -295,7 +311,7 @@ internal sealed partial class StatementBinder
 
                     InvalidateNarrowingsForAssignedVariables(statementSyntax);
                     var innerStatements = ImmutableArray.CreateBuilder<BoundStatement>();
-                    BindBlockStatements(statementSyntaxes, i + 1, innerStatements);
+                    BindBlockStatements(statementSyntaxes, i + 1, innerStatements, beforeBind, trailingStatement);
                     statements.Add(BuildCleanupTryStatement(innerStatements.ToImmutable(), defer.Cleanup));
                     return;
                 }
@@ -317,7 +333,7 @@ internal sealed partial class StatementBinder
 
                     InvalidateNarrowingsForAssignedVariables(statementSyntax);
                     var innerStatements = ImmutableArray.CreateBuilder<BoundStatement>();
-                    BindBlockStatements(statementSyntaxes, i + 1, innerStatements);
+                    BindBlockStatements(statementSyntaxes, i + 1, innerStatements, beforeBind, trailingStatement);
                     statements.Add(BuildCleanupTryStatement(innerStatements.ToImmutable(), usingLowering.Cleanup));
                     return;
                 }
@@ -339,7 +355,7 @@ internal sealed partial class StatementBinder
 
                     InvalidateNarrowingsForAssignedVariables(statementSyntax);
                     var innerStatements = ImmutableArray.CreateBuilder<BoundStatement>();
-                    BindBlockStatements(statementSyntaxes, i + 1, innerStatements);
+                    BindBlockStatements(statementSyntaxes, i + 1, innerStatements, beforeBind, trailingStatement);
                     statements.Add(BuildCleanupTryStatement(innerStatements.ToImmutable(), awaitUsingLowering.Cleanup));
                     return;
                 }
@@ -393,6 +409,11 @@ internal sealed partial class StatementBinder
                 // type. Runs after invalidation for the same reason as the
                 // assignment narrowing above.
                 ApplyIfJoinNarrowings(statement, memberNotNullFrame);
+            }
+
+            if (trailingStatement != null)
+            {
+                statements.Add(trailingStatement());
             }
         }
         finally

--- a/test/Compiler.Tests/Emit/Issue2753TopLevelUsingLifetimeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2753TopLevelUsingLifetimeEmitTests.cs
@@ -1,0 +1,326 @@
+// <copyright file="Issue2753TopLevelUsingLifetimeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public class Issue2753TopLevelUsingLifetimeEmitTests
+{
+    [Fact]
+    public void AsyncTopLevelUsing_ClosureAndReturn_DisposesInReverseOrderAtProgramEnd()
+    {
+        const string source = """
+            package Probe
+            import System
+            import System.Threading.Tasks
+
+            class Outer : IDisposable {
+                func Dispose() {
+                    Console.WriteLine("dispose:outer")
+                }
+                func Ping() {
+                    Console.WriteLine("ping:outer")
+                }
+            }
+
+            class Inner : IDisposable {
+                func Dispose() {
+                    Console.WriteLine("dispose:inner")
+                }
+            }
+
+            class Holder {
+                var Factory (() -> Outer)? = nil
+                async func Invoke() Task[int32] {
+                    await Task.Yield()
+                    Factory!!().Ping()
+                    return 0
+                }
+            }
+
+            using let outer = Outer()
+            using let inner = Inner()
+            let holder = Holder()
+            holder.Factory = () -> outer
+            Console.WriteLine("before")
+            return await holder.Invoke()
+            """;
+
+        var result = CompileAndRun(source);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("before\nping:outer\ndispose:inner\ndispose:outer\n", result.StandardOutput);
+    }
+
+    [Fact]
+    public void AsyncTopLevelUsing_ExplicitTryCatchFinally_KeepsClosureAlive()
+    {
+        const string source = """
+            package Probe
+            import System
+            import System.Threading.Tasks
+
+            class Res : IDisposable {
+                var Disposed bool = false
+                func Dispose() {
+                    Disposed = true
+                    Console.WriteLine("disposed")
+                }
+                func Ping() {
+                    if Disposed {
+                        throw ObjectDisposedException("Res")
+                    }
+                    Console.WriteLine("ping")
+                }
+            }
+
+            class Holder {
+                var Factory (() -> Res)? = nil
+                async func Invoke() Task[int32] {
+                    await Task.Yield()
+                    Factory!!().Ping()
+                    return 0
+                }
+            }
+
+            using let resource = Res()
+            let holder = Holder()
+            holder.Factory = () -> resource
+            try {
+                return await holder.Invoke()
+            } catch (ex Exception) {
+                Console.WriteLine("caught")
+                return 1
+            } finally {
+                Console.WriteLine("restore")
+            }
+            """;
+
+        var result = CompileAndRun(source);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("ping\nrestore\ndisposed\n", result.StandardOutput);
+    }
+
+    [Fact]
+    public void AsyncLambdaUsingDeclaration_KeepsResourceAliveAcrossAwait()
+    {
+        const string source = """
+            package Probe
+            import System
+            import System.Threading.Tasks
+
+            class Res : IDisposable {
+                var Disposed bool = false
+                func Dispose() {
+                    Disposed = true
+                    Console.WriteLine("disposed")
+                }
+                func Ping() {
+                    if Disposed {
+                        throw ObjectDisposedException("Res")
+                    }
+                    Console.WriteLine("ping")
+                }
+            }
+
+            await Task.Run(async () -> {
+                using let resource = Res()
+                await Task.Yield()
+                resource.Ping()
+            })
+            """;
+
+        var result = CompileAndRun(source);
+        Assert.True(
+            result.ExitCode == 0,
+            $"exited {result.ExitCode}\nstdout:\n{result.StandardOutput}\nstderr:\n{result.StandardError}");
+        Assert.Equal("ping\ndisposed\n", result.StandardOutput);
+    }
+
+    [Fact]
+    public void AsyncTopLevelUsing_UnhandledException_StillDisposes()
+    {
+        const string source = """
+            package Probe
+            import System
+            import System.Threading.Tasks
+
+            class Res : IDisposable {
+                func Dispose() {
+                    Console.WriteLine("disposed")
+                }
+            }
+
+            using let resource = Res()
+            Console.WriteLine("before")
+            await Task.Yield()
+            throw Exception("boom")
+            """;
+
+        var result = CompileAndRun(source);
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Equal("before\ndisposed\n", result.StandardOutput);
+        Assert.Contains("boom", result.StandardError);
+    }
+
+    [Fact]
+    public void MethodUsingDeclarations_PreserveNestedLexicalLifetimes()
+    {
+        const string source = """
+            package Probe
+            import System
+
+            class Outer : IDisposable {
+                func Dispose() {
+                    Console.WriteLine("dispose:outer")
+                }
+            }
+
+            class Inner : IDisposable {
+                func Dispose() {
+                    Console.WriteLine("dispose:inner")
+                }
+            }
+
+            func Run() {
+                using let outer = Outer()
+                {
+                    using let inner = Inner()
+                    Console.WriteLine("body")
+                }
+                Console.WriteLine("after")
+            }
+
+            Run()
+            """;
+
+        var result = CompileAndRun(source);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("body\ndispose:inner\nafter\ndispose:outer\n", result.StandardOutput);
+    }
+
+    [Fact]
+    public void AsyncTopLevelUsing_MoveNextCleanupRegionsProtectRemainingStatements()
+    {
+        const string source = """
+            package Probe
+            import System
+            import System.Threading.Tasks
+
+            class Res : IDisposable {
+                func Dispose() {}
+                func Ping() {}
+            }
+
+            using let outer = Res()
+            using let inner = Res()
+            await Task.Yield()
+            outer.Ping()
+            inner.Ping()
+            """;
+
+        var assemblyPath = Compile(source);
+        try
+        {
+            using var stream = File.OpenRead(assemblyPath);
+            using var pe = new PEReader(stream);
+            var metadata = pe.GetMetadataReader();
+            var moveNext = metadata.TypeDefinitions
+                .Select(handle => metadata.GetTypeDefinition(handle))
+                .Where(type => metadata.GetString(type.Name).Contains("<Main>$", StringComparison.Ordinal))
+                .SelectMany(type => type.GetMethods())
+                .Select(handle => metadata.GetMethodDefinition(handle))
+                .Single(method => metadata.GetString(method.Name) == "MoveNext");
+            var body = pe.GetMethodBody(moveNext.RelativeVirtualAddress);
+            var cleanupRegions = body.ExceptionRegions
+                .Where(region => region.Kind == ExceptionRegionKind.Catch)
+                .ToArray();
+
+            Assert.Contains(
+                cleanupRegions,
+                outer => cleanupRegions.Any(middle =>
+                    Contains(outer, middle)
+                    && cleanupRegions.Any(inner => Contains(middle, inner))));
+        }
+        finally
+        {
+            Directory.Delete(Path.GetDirectoryName(assemblyPath)!, recursive: true);
+        }
+    }
+
+    private static bool Contains(ExceptionRegion outer, ExceptionRegion inner) =>
+        outer.TryOffset < inner.TryOffset
+        && outer.TryOffset + outer.TryLength >= inner.TryOffset + inner.TryLength;
+
+    private static (int ExitCode, string StandardOutput, string StandardError) CompileAndRun(string source)
+    {
+        var assemblyPath = Compile(source);
+        var directory = Path.GetDirectoryName(assemblyPath)!;
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo("dotnet")
+            {
+                ArgumentList =
+                {
+                    "exec",
+                    "--runtimeconfig",
+                    Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                    assemblyPath,
+                },
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            })!;
+            var standardOutput = process.StandardOutput.ReadToEnd().Replace("\r\n", "\n");
+            var standardError = process.StandardError.ReadToEnd().Replace("\r\n", "\n");
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            return (process.ExitCode, standardOutput, standardError);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string Compile(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue2753_").FullName;
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var standardOutput = new StringWriter();
+        using var standardError = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(standardOutput);
+        Console.SetError(standardError);
+        try
+        {
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            Assert.True(exitCode == 0, $"compile failed ({exitCode}):\n{standardOutput}\n{standardError}");
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        IlVerifier.Verify(outputPath);
+        return outputPath;
+    }
+}


### PR DESCRIPTION
## Summary
- bind top-level statements and block-expression prefixes as lexical statement lists
- keep using/defer cleanup around trailing expressions, awaits, returns, and exceptions
- add runtime ordering and async MoveNext IL coverage for closures and nested resources

## Validation
- related using/async tests: 25 passed
- Core.Tests: 6,691 passed, 1 skipped
- Compiler.Tests: 3,407 passed
- patched migrated Oahu CLI: `doctor --skip-network` reports all checks passed

## Deferred work
- None.

Fixes #2753