### PR TITLE
Fix generic async result double wrapping

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -624,6 +624,7 @@ public abstract class BoundTreeRewriter
         {
             StaticGenericOwnerType = node.StaticGenericOwnerType,
             StaticGenericInterfaceOwnerType = node.StaticGenericInterfaceOwnerType,
+            MethodTypeArguments = node.MethodTypeArguments,
         };
     }
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
@@ -493,6 +493,7 @@ internal sealed partial class StatementBinder
                 {
                     StaticGenericOwnerType = call.StaticGenericOwnerType,
                     StaticGenericInterfaceOwnerType = call.StaticGenericInterfaceOwnerType,
+                    MethodTypeArguments = call.MethodTypeArguments,
                 };
             case BoundIndirectCallExpression call:
                 return new BoundIndirectCallExpression(null, CaptureExpression(call.Target, prefix), call.FunctionType, CaptureArguments(call.Arguments, prefix));

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -218,9 +218,10 @@ internal sealed class UserTokenResolver
         }
 
         var args = new TypeSymbol[tps.Length];
+        var inferenceReturn = AsyncReturnTypeNormalizer.GetDeclaredResultType(call.Function, call.ReturnType);
         for (int i = 0; i < tps.Length; i++)
         {
-            args[i] = InferMethodTypeArgument(call.Function, call.Arguments, call.ReturnType, tps[i]);
+            args[i] = InferMethodTypeArgument(call.Function, call.Arguments, inferenceReturn, tps[i]);
         }
 
         return this.BuildMethodSpec(openMethod, args);
@@ -252,6 +253,7 @@ internal sealed class UserTokenResolver
 
         var args = new TypeSymbol[tps.Length];
         var calleeParameterOffset = call.Method.ExplicitReceiverParameter == null ? 0 : 1;
+        var inferenceReturn = AsyncReturnTypeNormalizer.GetDeclaredResultType(call.Method, call.Type);
 
         // The user-instance call's Arguments excludes the receiver,
         // but Method.Parameters includes the explicit receiver (when
@@ -265,7 +267,7 @@ internal sealed class UserTokenResolver
 
         for (int i = 0; i < tps.Length; i++)
         {
-            args[i] = InferMethodTypeArgument(userParams, call.Arguments, call.Type, call.Method.Type, tps[i]);
+            args[i] = InferMethodTypeArgument(userParams, call.Arguments, inferenceReturn, call.Method.Type, tps[i]);
         }
 
         return this.BuildMethodSpec(openMethod, args);

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -928,7 +928,12 @@ public static class SpillSequenceSpiller
                 return Trivial(call);
             }
 
-            var value = new BoundCallExpression(null, call.Function, args.ToImmutable(), call.ReturnType);
+            var value = new BoundCallExpression(null, call.Function, args.ToImmutable(), call.ReturnType, call.IsConditionalElided)
+            {
+                StaticGenericOwnerType = call.StaticGenericOwnerType,
+                StaticGenericInterfaceOwnerType = call.StaticGenericInterfaceOwnerType,
+                MethodTypeArguments = call.MethodTypeArguments,
+            };
             return new BoundSpillSequenceExpression(
                 null,
                 locals.ToImmutable(),

--- a/src/Core/CodeAnalysis/Symbols/AsyncReturnTypeNormalizer.cs
+++ b/src/Core/CodeAnalysis/Symbols/AsyncReturnTypeNormalizer.cs
@@ -21,6 +21,20 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 internal static class AsyncReturnTypeNormalizer
 {
     /// <summary>
+    /// Returns the declared result represented by a call-site return type.
+    /// Async calls carry one observable Task/ValueTask wrapper, which is
+    /// removed exactly once; all other calls and shapes pass through.
+    /// </summary>
+    /// <param name="function">The called function.</param>
+    /// <param name="callSiteReturnType">The bound call's observable return type.</param>
+    /// <returns>The declared result type used for generic substitution.</returns>
+    public static TypeSymbol GetDeclaredResultType(FunctionSymbol function, TypeSymbol callSiteReturnType)
+        => function?.IsAsync == true
+            && TryUnwrapTaskReturnType(callSiteReturnType, out var declaredResult)
+                ? declaredResult
+                : callSiteReturnType;
+
+    /// <summary>
     /// Unwraps the awaited result of a <c>Task</c> / <c>Task[T]</c> /
     /// <c>ValueTask</c> / <c>ValueTask[T]</c> return type symbol: the
     /// non-generic forms resolve to <see cref="TypeSymbol.Void"/>, the generic

--- a/test/Compiler.Tests/Emit/Issue2751GenericAsyncResultEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2751GenericAsyncResultEmitTests.cs
@@ -1,0 +1,200 @@
+// <copyright file="Issue2751GenericAsyncResultEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2751: generic async calls must expose one Task wrapper at both open
+/// and closed call sites.
+/// </summary>
+public sealed class Issue2751GenericAsyncResultEmitTests
+{
+    [Fact]
+    public void OverloadedOpenAndClosedGenericAsyncCalls_VerifyAndRun()
+    {
+        _ = typeof(System.Text.Json.JsonSerializer).Assembly;
+        const string source = """
+            package Issue2751Exact
+
+            import System
+            import System.Threading.Tasks
+            import System.Text.Json
+
+            async func Read[T](json string) T {
+                await Task.Yield()
+                return JsonSerializer.Deserialize[T](json)
+            }
+
+            async func Read[T](prefix string, json string) T {
+                let text = prefix + json
+                return await Read[T](text)
+            }
+
+            async func Closed() int32 {
+                let json = "4" + "2"
+                return await Read[int32]("", json)
+            }
+
+            Console.WriteLine(Closed().GetAwaiter().GetResult())
+            """;
+
+        Assert.Equal("42\n", CompileVerifyAndRun(source, "exact"));
+    }
+
+    [Fact]
+    public void OpenGenericAsyncCall_VerifiesAndRuns()
+    {
+        const string source = """
+            package Issue2751Open
+
+            import System
+            import System.Threading.Tasks
+
+            async func Read[T](value T) T {
+                await Task.Yield()
+                return value
+            }
+
+            async func Forward[T](value T) T {
+                return await Read[T](value)
+            }
+
+            Console.WriteLine(Forward[string]("open").GetAwaiter().GetResult())
+            """;
+
+        Assert.Equal("open\n", CompileVerifyAndRun(source, "open"));
+    }
+
+    [Fact]
+    public void ClosedGenericAsyncCall_VerifiesAndRuns()
+    {
+        const string source = """
+            package Issue2751Closed
+
+            import System
+            import System.Threading.Tasks
+
+            async func Read[T](value T) T {
+                await Task.Yield()
+                return value
+            }
+
+            async func Run() int32 {
+                return await Read[int32](42)
+            }
+
+            Console.WriteLine(Run().GetAwaiter().GetResult())
+            """;
+
+        Assert.Equal("42\n", CompileVerifyAndRun(source, "closed"));
+    }
+
+    [Fact]
+    public void NonGenericImportedNestedTaskAndTupleControls_VerifyAndRun()
+    {
+        const string source = """
+            package Issue2751Controls
+
+            import System
+            import System.Threading.Tasks
+
+            async func NonGeneric() int32 {
+                return 1
+            }
+
+            async func Nested[T](value T) Task[Task[T]] {
+                await Task.Yield()
+                return Task.FromResult[T](value)
+            }
+
+            async func Pair[T](value T) (T, T) {
+                await Task.Yield()
+                return (value, value)
+            }
+
+            async func PairFirst[T](value T) T {
+                let (first, second) = await Pair[T](value)
+                return first
+            }
+
+            async func Controls() int32 {
+                let imported = await Task.FromResult[int32](2)
+                let inner = await Nested[int32](3)
+                let nested = await inner
+                let tuple = await PairFirst[int32](4)
+                let plain = await NonGeneric()
+                return imported + nested + tuple + plain
+            }
+
+            Console.WriteLine(Controls().GetAwaiter().GetResult())
+            """;
+
+        Assert.Equal("10\n", CompileVerifyAndRun(source, "controls"));
+    }
+
+    private static string CompileVerifyAndRun(string source, string name)
+    {
+        var (directory, outputPath) = CompileAndVerify(source, name);
+
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                outputPath,
+            },
+            WorkingDirectory = directory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        var output = process!.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(process.ExitCode == 0, error);
+        return output.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static (string Directory, string OutputPath) CompileAndVerify(string source, string name)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2751Emit", name);
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            Assert.True(exitCode == 0, $"compile failed ({exitCode}):{Environment.NewLine}{stdout}{stderr}");
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        IlVerifier.Verify(outputPath);
+        return (directory, outputPath);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2751GenericAsyncResultTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2751GenericAsyncResultTests.cs
@@ -1,0 +1,86 @@
+// <copyright file="Issue2751GenericAsyncResultTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2751GenericAsyncResultTests
+{
+    [Fact]
+    public void OverloadedGenericAsyncCall_HasSingleTaskWrapper()
+    {
+        const string source = """
+            package Issue2751
+            import System
+            import System.Threading.Tasks
+
+            async func Read[T](path string) T {
+                await Task.Yield()
+                throw Exception(path)
+            }
+
+            async func Read[T](directory string, filename string) T {
+                return await Read[T](directory + filename)
+            }
+            """;
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source))) { IsLibrary = true };
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(diagnostic => diagnostic.IsError));
+
+        var overload = compilation.BoundProgram.Functions.Keys.Single(
+            function => function.Name == "Read" && function.Parameters.Length == 2);
+        var collector = new CallCollector();
+        collector.Visit(compilation.BoundProgram.Functions[overload]);
+        var call = Assert.Single(collector.Calls);
+        var task = Assert.IsType<ImportedTypeSymbol>(call.Type);
+
+        Assert.Equal("System.Threading.Tasks.Task`1", task.OpenDefinition.FullName);
+        Assert.Equal("T", Assert.Single(task.TypeArguments).Name);
+        Assert.Equal("T", Assert.Single(call.MethodTypeArguments).Name);
+        Assert.IsType<TypeParameterSymbol>(call.Function.Type);
+    }
+
+    [Fact]
+    public void NonAsyncGenericCall_RemainsNonAwaitable()
+    {
+        const string source = """
+            package Issue2751Negative
+
+            func Read[T](value T) T {
+                return value
+            }
+
+            async func Run() int32 {
+                return await Read[int32](42)
+            }
+            """;
+
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source))) { IsLibrary = true };
+
+        Assert.Contains(compilation.BoundProgram.Diagnostics, diagnostic => diagnostic.Id == "GS0133");
+    }
+
+    private sealed class CallCollector : BoundTreeWalker
+    {
+        public List<BoundCallExpression> Calls { get; } = [];
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node is BoundCallExpression call)
+            {
+                Calls.Add(call);
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- preserve authoritative generic method arguments through bound-tree rewrites and async spilling
- infer fallback MethodSpec arguments from the declared async result by removing exactly one observable Task/ValueTask wrapper
- cover open/closed generic runtime + ILVerify, non-generic, imported, nested Task, tuple, and non-async negative controls

## Verification
- baseline exact repro: 2 `StackUnexpected` findings (`Task<Task<T0>>` and `Task<Task<int32>>`)
- fixed exact repro: ILVerify clean and runtime output `42`
- targeted Core.Tests: 2 passed
- targeted Compiler.Tests: 4 passed
- full Core.Tests: 6,693 passed, 1 skipped
- full Compiler.Tests: 3,405 passed (after building the required Gsharp.Extensions prerequisite)

## Deferred work
- None

Fixes #2751