### PR TITLE
Fix single-element overloaded collection initializers

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -273,14 +273,12 @@ internal sealed partial class ExpressionBinder
         }
 
         var resultType = target.Type;
-        var clrType = resultType.ClrType;
         var hasNonIndexedElement = syntax.Elements.Any(e => e is not IndexedCollectionElementSyntax);
 
         // A collection initializer requires an accessible instance `Add` for the
         // bare / key:value element forms. Indexed `[k] = v` entries go through
         // the indexer-set path, which reports its own GS0226/indexability errors.
-        var hasAdd = clrType != null && MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(clrType, "Add").Count > 0;
-        if (clrType == null || (hasNonIndexedElement && !hasAdd))
+        if (hasNonIndexedElement && !HasCollectionAdd(resultType))
         {
             Diagnostics.ReportTypeNotCollectionInitializable(syntax.OpenBraceToken.Location, resultType);
             BindCollectionElementsForDiagnostics(syntax);
@@ -366,10 +364,8 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var clrType = propRead.Type.ClrType;
         var hasNonIndexedElement = braced.Elements.Any(e => e is not IndexedCollectionElementSyntax);
-        var hasAdd = clrType != null && MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(clrType, "Add").Count > 0;
-        if (clrType == null || (hasNonIndexedElement && !hasAdd))
+        if (hasNonIndexedElement && !HasCollectionAdd(propRead.Type))
         {
             return false;
         }
@@ -380,6 +376,17 @@ internal sealed partial class ExpressionBinder
         statements.Add(new BoundVariableDeclaration(braced, memberLocal, propRead));
         EmitCollectionElementAddStatements(memberLocal, braced.Elements, statements);
         return true;
+    }
+
+    private static bool HasCollectionAdd(TypeSymbol type)
+    {
+        if (!TypeMemberModel.GetMethods(type, "Add", MemberQuery.Instance(MemberKinds.Method)).IsDefaultOrEmpty)
+        {
+            return true;
+        }
+
+        return type.ClrType is { } clrType
+            && MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(clrType, "Add").Count > 0;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
@@ -1142,11 +1142,11 @@ public partial class Parser
     }
 
     // Issue #479 / ADR-0117: recognises a collection-initializer `{` after a
-    // constructor call (`List[int32](){…}`, `Dictionary[K, V](cmp){…}`). To
-    // avoid colliding with a statement body (`foo() { stmt }`) we require an
-    // unambiguous collection marker: an indexed-entry `[`, a single literal
-    // element, or a top-level `,`/`:` separator inside the braces.
-    private bool LooksLikeCollectionInitializerBrace()
+    // constructor call (`List[int32](){…}`, `Dictionary[K, V](cmp){…}`). An
+    // arbitrary single expression is accepted when its brace starts on the same
+    // line as the call; a brace on the next line may instead be a standalone
+    // block. Indexed, literal, keyed, and multi-element forms stay unambiguous.
+    private bool LooksLikeCollectionInitializerBrace(ExpressionSyntax target)
     {
         var k1 = Peek(1).Kind;
         if (k1 == SyntaxKind.CloseBraceToken)
@@ -1188,7 +1188,8 @@ public partial class Parser
             {
                 if (depth == 0)
                 {
-                    return false;
+                    return target is CallExpressionSyntax call
+                        && !IsTokenOnNewLineAfter(Current, call.CloseParenthesisToken);
                 }
 
                 depth--;

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
@@ -1143,9 +1143,10 @@ public partial class Parser
 
     // Issue #479 / ADR-0117: recognises a collection-initializer `{` after a
     // constructor call (`List[int32](){…}`, `Dictionary[K, V](cmp){…}`). An
-    // arbitrary single expression is accepted when its brace starts on the same
-    // line as the call; a brace on the next line may instead be a standalone
-    // block. Indexed, literal, keyed, and multi-element forms stay unambiguous.
+    // arbitrary single expression is accepted when its brace and element start
+    // on the call's line; a line break may instead indicate a standalone block
+    // or an incomplete object initializer in editor input. Indexed, literal,
+    // keyed, and multi-element forms stay unambiguous.
     private bool LooksLikeCollectionInitializerBrace(ExpressionSyntax target)
     {
         var k1 = Peek(1).Kind;
@@ -1189,7 +1190,8 @@ public partial class Parser
                 if (depth == 0)
                 {
                     return target is CallExpressionSyntax call
-                        && !IsTokenOnNewLineAfter(Current, call.CloseParenthesisToken);
+                        && !IsTokenOnNewLineAfter(Current, call.CloseParenthesisToken)
+                        && !IsTokenOnNewLineAfter(Peek(1), Current);
                 }
 
                 depth--;

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Literals.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Literals.cs
@@ -62,7 +62,7 @@ public partial class Parser
         {
             // Issue #479 / ADR-0117: a collection initializer applied to a
             // constructor call (`List[int32](){…}`, `Dictionary[K, V](cmp){…}`).
-            if (LooksLikeCollectionInitializerBrace())
+            if (LooksLikeCollectionInitializerBrace(target))
             {
                 return ParseCollectionInitializerExpression(target);
             }

--- a/test/Compiler.Tests/Compiler.Tests.csproj
+++ b/test/Compiler.Tests/Compiler.Tests.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\tools\gsgen\Gsgen.Cli\Gsgen.Cli.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageReference Include="Spectre.Console" Version="0.55.2" />
+    <PackageReference Include="System.CommandLine" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/test/Compiler.Tests/Emit/Issue2774CollectionInitializerOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2774CollectionInitializerOverloadEmitTests.cs
@@ -1,0 +1,472 @@
+// <copyright file="Issue2774CollectionInitializerOverloadEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2774: a single non-literal collection element must be parsed and
+/// lowered through the normal overloaded <c>Add</c> call path.
+/// </summary>
+public sealed class Issue2774CollectionInitializerOverloadEmitTests
+{
+    private const string ContractsSource = """
+        using System;
+        using System.Collections;
+        using System.Collections.Generic;
+
+        namespace Issue2774.Contracts
+        {
+            public class BaseItem { }
+            public interface IItem { }
+            public sealed class DerivedItem : BaseItem, IItem { }
+
+            public sealed class OverloadBag : IEnumerable
+            {
+                public string Choice { get; private set; } = "";
+                public void Add(object value) => Choice = "object";
+                public void Add(BaseItem value) => Choice = "base";
+                public IEnumerator GetEnumerator() => Array.Empty<object>().GetEnumerator();
+            }
+
+            public sealed class InterfaceBag : IEnumerable
+            {
+                public string Choice { get; private set; } = "";
+                public void Add(object value) => Choice = "object";
+                public void Add(IItem value) => Choice = "interface";
+                public IEnumerator GetEnumerator() => Array.Empty<object>().GetEnumerator();
+            }
+
+            public sealed class NullableBag : IEnumerable
+            {
+                public string Choice { get; private set; } = "";
+                public void Add(int? value) => Choice = "nullable";
+                public void Add(string value) => Choice = "string";
+                public IEnumerator GetEnumerator() => Array.Empty<object>().GetEnumerator();
+            }
+
+            public sealed class NumericBag : IEnumerable
+            {
+                public string Choice { get; private set; } = "";
+                public void Add(long value) => Choice = "long";
+                public void Add(string value) => Choice = "string";
+                public IEnumerator GetEnumerator() => Array.Empty<object>().GetEnumerator();
+            }
+
+            public sealed class AmbiguousBag : IEnumerable
+            {
+                public void Add(BaseItem value) { }
+                public void Add(IItem value) { }
+                public IEnumerator GetEnumerator() => Array.Empty<object>().GetEnumerator();
+            }
+
+            public sealed class NoApplicableBag : IEnumerable
+            {
+                public void Add(BaseItem value) { }
+                public void Add(IItem value) { }
+                public IEnumerator GetEnumerator() => Array.Empty<object>().GetEnumerator();
+            }
+
+            public static class Order
+            {
+                public static readonly List<string> Events = new();
+                public static int Eval(int value)
+                {
+                    Events.Add("eval" + value);
+                    return value;
+                }
+            }
+
+            public sealed class OrderedBag : IEnumerable
+            {
+                public OrderedBag() => Order.Events.Add("ctor");
+                public void Add(int? value) => Order.Events.Add("add" + value);
+                public void Add(string value) => Order.Events.Add("string");
+                public IEnumerator GetEnumerator() => Array.Empty<object>().GetEnumerator();
+            }
+        }
+        """;
+
+    [Fact]
+    public void ImportedOverloads_SelectBestBaseInterfaceAndNullableConversions()
+    {
+        const string source = """
+            package Issue2774.App
+            import System
+            import Issue2774.Contracts
+
+            let item = DerivedItem()
+            let byBase = OverloadBag(){ item }
+            let byInterface = InterfaceBag(){ item }
+            let number int32 = 7
+            let byNullable = NullableBag(){ number }
+            let byNumeric = NumericBag(){ number }
+            Console.WriteLine(byBase.Choice)
+            Console.WriteLine(byInterface.Choice)
+            Console.WriteLine(byNullable.Choice)
+            Console.WriteLine(byNumeric.Choice)
+            """;
+
+        using var result = Compile(source, includeContracts: true);
+        Assert.Equal("base\ninterface\nnullable\nlong\n", Run(result.OutputPath));
+    }
+
+    [Fact]
+    public void SourceDeclaredAddDetection_MatchesNormalCallBinding()
+    {
+        const string source = """
+            package Issue2774.Local
+            import System
+            import System.Collections
+            import System.Collections.Generic
+
+            open class BaseItem {}
+            class DerivedItem : BaseItem {}
+
+            class LocalBag : IEnumerable {
+                let items List[object] = List[object]()
+                func Add(value object) { items.Add(value) }
+                func GetEnumerator() IEnumerator -> items.GetEnumerator()
+                prop Count int32 -> items.Count
+            }
+
+            class LocalOverloadBag : IEnumerable {
+                let choice List[string] = List[string]()
+                func Add(value object) { choice.Add("object") }
+                func Add(value BaseItem) { choice.Add("base") }
+                func GetEnumerator() IEnumerator -> choice.GetEnumerator()
+                prop Choice string -> choice[0]
+            }
+
+            let item = DerivedItem()
+            let bag = LocalBag(){ item, "value" }
+            let overloaded = LocalOverloadBag(){ item }
+            Console.WriteLine(bag.Count)
+            Console.WriteLine(overloaded.Choice)
+            """;
+
+        using var result = Compile(source);
+        Assert.Equal("2\nbase\n", Run(result.OutputPath));
+    }
+
+    [Fact]
+    public void SingleAddListAndHashSet_WithIdentifierElements_StillRun()
+    {
+        const string source = """
+            package Issue2774.Collections
+            import System
+            import System.Collections.Generic
+
+            let number int32 = 42
+            let text = "value"
+            let list = List[int32](){ number }
+            let set = HashSet[string](){ text }
+            Console.WriteLine(list.Count)
+            Console.WriteLine(list[0])
+            Console.WriteLine(set.Count)
+            Console.WriteLine(set.Contains(text))
+            """;
+
+        using var result = Compile(source);
+        Assert.Equal("1\n42\n1\nTrue\n", Run(result.OutputPath));
+    }
+
+    [Fact]
+    public void InitializerEvaluationOrder_RemainsConstructorThenElementThenAdd()
+    {
+        const string source = """
+            package Issue2774.Ordering
+            import System
+            import Issue2774.Contracts
+
+            let bag = OrderedBag(){ Order.Eval(1), Order.Eval(2) }
+            Console.WriteLine(String.Join(",", Order.Events))
+            """;
+
+        using var result = Compile(source, includeContracts: true);
+        Assert.Equal("ctor,eval1,add1,eval2,add2\n", Run(result.OutputPath));
+    }
+
+    [Fact]
+    public void SystemCommandLine_SingleElementBuilders_RegisterAllElements()
+    {
+        const string source = """
+            package Issue2774.Commands
+            import System
+            import System.CommandLine
+
+            let historyShowArg = Argument[string]("id")
+            let historyShow = Command("show", "history show"){ historyShowArg }
+            let retryArg = Argument[string]("id")
+            let historyRetry = Command("retry", "history retry"){ retryArg }
+            let asinArg = Argument[string]("asin")
+            let libraryShow = Command("show", "library show"){ asinArg }
+            let removeArg = Argument[string]("asin")
+            let queueRemove = Command("remove", "queue remove"){ removeArg }
+            let profileOpt = Option[string]("--profile")
+            let authLogout = Command("logout", "auth logout"){ profileOpt }
+            let shellArg = Argument[string]("shell")
+            let completion = Command("completion", "completion"){ shellArg }
+            let keyArg = Argument[string]("key")
+            let configGet = Command("get", "config get"){ keyArg }
+
+            Console.WriteLine(historyShow.Arguments.Count)
+            Console.WriteLine(historyRetry.Arguments.Count)
+            Console.WriteLine(libraryShow.Arguments.Count)
+            Console.WriteLine(queueRemove.Arguments.Count)
+            Console.WriteLine(authLogout.Options.Count)
+            Console.WriteLine(completion.Arguments.Count)
+            Console.WriteLine(configGet.Arguments.Count)
+            Console.WriteLine(historyRetry.Parse([]string{"job-1"}).Errors.Count)
+            Console.WriteLine(libraryShow.Parse([]string{"asin-1"}).Errors.Count)
+            """;
+
+        using var result = Compile(
+            source,
+            additionalReferences: new[] { Path.Combine(AppContext.BaseDirectory, "System.CommandLine.dll") },
+            outOfProcess: true,
+            useExplicitBclReferences: true);
+        Assert.Equal("1\n1\n1\n1\n1\n1\n1\n0\n0\n", Run(result.OutputPath));
+    }
+
+    [Fact]
+    public void AmbiguousAdd_IsRejected()
+    {
+        const string source = """
+            package Issue2774.Ambiguous
+            import Issue2774.Contracts
+
+            let item = DerivedItem()
+            let bag = AmbiguousBag(){ item }
+            """;
+
+        using var result = Compile(source, includeContracts: true, expectSuccess: false);
+        Assert.Contains("GS0160", result.Diagnostics);
+    }
+
+    [Fact]
+    public void NoApplicableAdd_IsRejected()
+    {
+        const string source = """
+            package Issue2774.NoApplicable
+            import Issue2774.Contracts
+
+            let text = "value"
+            let bag = NoApplicableBag(){ text }
+            """;
+
+        using var result = Compile(source, includeContracts: true, expectSuccess: false);
+        Assert.Contains("GS0159", result.Diagnostics);
+    }
+
+    private static CompilationResult Compile(
+        string source,
+        bool includeContracts = false,
+        IReadOnlyList<string> additionalReferences = null,
+        bool expectSuccess = true,
+        bool outOfProcess = false,
+        bool useExplicitBclReferences = false)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2774",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var references = new List<string>();
+        if (includeContracts)
+        {
+            references.Add(EmitContracts(directory));
+        }
+
+        if (additionalReferences != null)
+        {
+            references.AddRange(additionalReferences);
+        }
+
+        var args = new List<string>
+        {
+            "/out:" + outputPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+        if (useExplicitBclReferences)
+        {
+            args.AddRange(GetBclReferences().Select(reference => "/reference:" + reference));
+        }
+
+        args.AddRange(references.Select(reference => "/reference:" + reference));
+        args.Add(sourcePath);
+
+        int exitCode;
+        string stdout;
+        string stderr;
+        if (outOfProcess)
+        {
+            var processInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            processInfo.ArgumentList.Add(Path.GetFullPath(
+                Path.Combine(AppContext.BaseDirectory, "..", "Compiler", "gsc.dll")));
+            foreach (var argument in args)
+            {
+                processInfo.ArgumentList.Add(argument);
+            }
+
+            using var process = Process.Start(processInfo)!;
+            stdout = process.StandardOutput.ReadToEnd();
+            stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            exitCode = process.ExitCode;
+        }
+        else
+        {
+            using var capturedOut = new StringWriter();
+            using var capturedError = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(capturedOut);
+            Console.SetError(capturedError);
+            try
+            {
+                exitCode = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            stdout = capturedOut.ToString();
+            stderr = capturedError.ToString();
+        }
+
+        var diagnostics = stdout + stderr;
+        if (expectSuccess)
+        {
+            Assert.True(exitCode == 0, diagnostics);
+            IlVerifier.Verify(outputPath, additionalReferences: references);
+            foreach (var reference in references)
+            {
+                var destination = Path.Combine(directory, Path.GetFileName(reference));
+                if (!string.Equals(reference, destination, StringComparison.Ordinal))
+                {
+                    File.Copy(reference, destination, overwrite: true);
+                }
+            }
+        }
+        else
+        {
+            Assert.NotEqual(0, exitCode);
+        }
+
+        return new CompilationResult(directory, outputPath, diagnostics);
+    }
+
+    private static string EmitContracts(string directory)
+    {
+        var outputPath = Path.Combine(directory, "Issue2774.Contracts.dll");
+        var references = TrustedPlatformAssemblies()
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "Issue2774.Contracts",
+            new[] { CSharpSyntaxTree.ParseText(ContractsSource, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return outputPath;
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var value = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        Assert.False(string.IsNullOrWhiteSpace(value));
+        return value!.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static IReadOnlyList<string> GetBclReferences()
+    {
+        var runtimeDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var dotnetRoot = Directory.GetParent(runtimeDirectory)!.Parent!.Parent!.FullName;
+        var tfm = $"net{Environment.Version.Major}.0";
+        var packsRoot = Path.Combine(dotnetRoot, "packs", "Microsoft.NETCore.App.Ref");
+        var referenceDirectory = Directory.EnumerateDirectories(packsRoot, Environment.Version.Major + ".*")
+            .OrderByDescending(path => path, StringComparer.Ordinal)
+            .Select(path => Path.Combine(path, "ref", tfm))
+            .First(Directory.Exists);
+        return Directory.EnumerateFiles(referenceDirectory, "*.dll").ToList();
+    }
+
+    private static string Run(string outputPath)
+    {
+        File.WriteAllText(Path.ChangeExtension(outputPath, "runtimeconfig.json"), """
+            {
+              "runtimeOptions": {
+                "tfm": "net10.0",
+                "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+              }
+            }
+            """);
+
+        var processInfo = new ProcessStartInfo("dotnet", "exec \"" + outputPath + "\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        using var process = Process.Start(processInfo)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n");
+    }
+
+    private sealed class CompilationResult : IDisposable
+    {
+        public CompilationResult(string directoryPath, string outputPath, string diagnostics)
+        {
+            DirectoryPath = directoryPath;
+            OutputPath = outputPath;
+            Diagnostics = diagnostics;
+        }
+
+        public string DirectoryPath { get; }
+
+        public string OutputPath { get; }
+
+        public string Diagnostics { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(DirectoryPath, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue479CollectionInitializerParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue479CollectionInitializerParserTests.cs
@@ -69,6 +69,32 @@ let hs = HashSet[int32](){ 1, 2, 3 }
     }
 
     [Fact]
+    public void ConstructorInitializer_SingleIdentifier_ParsesBareElement()
+    {
+        var init = ParseInitializer(@"
+let bag = Bag(){ item }
+");
+        Assert.Single(init.Elements);
+        var element = Assert.IsType<ExpressionCollectionElementSyntax>(init.Elements[0]);
+        Assert.IsType<NameExpressionSyntax>(element.Expression);
+    }
+
+    [Fact]
+    public void CallFollowedByBlockOnNextLine_StaysSeparate()
+    {
+        var tree = SyntaxTree.Parse(@"
+Reset()
+{
+    defer Record()
+}
+");
+        Assert.Empty(tree.Diagnostics);
+        var statement = tree.Root.Members.OfType<GlobalStatementSyntax>().First().Statement;
+        var expression = Assert.IsType<ExpressionStatementSyntax>(statement).Expression;
+        Assert.IsType<CallExpressionSyntax>(expression);
+    }
+
+    [Fact]
     public void DictionaryInitializer_KeyedPairs_ParsesKeyedElements()
     {
         var init = ParseInitializer(@"

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue479CollectionInitializerParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue479CollectionInitializerParserTests.cs
@@ -95,6 +95,20 @@ Reset()
     }
 
     [Fact]
+    public void CallAndBraceFollowedByElementOnNextLine_StaysSeparate()
+    {
+        var tree = SyntaxTree.Parse(@"
+Reset() {
+    Record
+}
+");
+        Assert.Empty(tree.Diagnostics);
+        var statement = tree.Root.Members.OfType<GlobalStatementSyntax>().First().Statement;
+        var expression = Assert.IsType<ExpressionStatementSyntax>(statement).Expression;
+        Assert.IsType<CallExpressionSyntax>(expression);
+    }
+
+    [Fact]
     public void DictionaryInitializer_KeyedPairs_ParsesKeyedElements()
     {
         var init = ParseInitializer(@"


### PR DESCRIPTION
## Summary
- parse same-line single-expression collection initializers through the existing collection lowering path
- detect source-declared and imported `Add` methods consistently
- cover overload conversions, evaluation order, System.CommandLine builders, and negative resolution cases with runtime/ILVerify tests
- preserve standalone-block and incomplete object-initializer parsing for editor completion

## Migrated Oahu acceptance evidence
Rebuilt the faithful cycle-14 `corpus_Oahu.Cli` sources with this PR's Release `gsc` and its generated `Oahu.Cli.rsp`; the C# dependency assemblies were retained as controls so only the migrated `Oahu.Cli` compiler output changed.

**Before** (`migrated-refs/Oahu.Cli.dll`, SHA-1 `faec3fb02654840e390aad0313bdbd695dcf0555`):
- builder probe: `history show`, `history retry`, `library show`, `queue remove`, `auth logout`, `completion`, and `config get` each reported `Arguments=0, Options=0`
- `Retry_UnknownId_ExitsOne`: failed because stderr was `Unrecognized command or argument 'does-not-exist'` instead of reaching the body
- `LibraryShow_FoundAsin_EmitsJson`: failed with exit `1` instead of `0`
- focused run: **0 passed, 2 failed**

**After** (PR-built `Oahu.Cli.dll`, SHA-1 `58455cb0a96cf9e0513a5d5f46a6f27e42d706bb`):
- `history show`: `Arguments=1 [jobId]`
- `history retry`: `Arguments=1 [jobId]`; parse errors `0`; body returned exit `1` with `no history record with id 'does-not-exist'`
- `library show`: `Arguments=1 [asin]`; seeded JSON body test passed
- `queue remove`: `Arguments=1 [asin]`
- `auth logout`: `Options=1 [--profile]`
- `completion`: `Arguments=1 [shell]`
- `config get`: `Arguments=1 [key]`
- focused migrated tests: **2 passed, 0 failed**

## Local G# Add detection
The noted local-type disagreement is the same collection-initializer root and is covered by this PR's shared `HasCollectionAdd` path plus `SourceDeclaredAddDetection_MatchesNormalCallBinding`; no separate issue is warranted.

- before (main compiler): `collinit.gs` exited `1` with `GS0369` for source-declared `BagSingle` / `BagOverload`
- after: `BagSingle(Add(object)) Count = 2`, `BagOverload(Add(Base) via Derived) Count = 1`, `BagOverload(Add(string) exact) Count = 1`

## Validation
- targeted parser/runtime/ILVerify/completion tests
- Core.Tests: 6,697 passed, 1 skipped
- LanguageServer.Tests: 450 passed
- Compiler.Tests: 3,438 passed
- migrated Oahu focused tests: 2 passed
- CI: green

Zero untracked deferred work.

Fixes #2774
