### PR TITLE
Fix eager enumerable method classification

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
@@ -303,7 +304,8 @@ internal sealed partial class DeclarationBinder
                 methodReceiverStruct,
                 explicitReceiverParameter);
             function.TypeParameters = typeParameters;
-            function.IsAsync = syntax.IsAsync || isAsyncIteratorReturnType(type);
+            function.IsAsync = syntax.IsAsync
+                || (isAsyncIteratorReturnType(type) && IteratorDetection.ContainsYield(syntax.Body));
             function.AsyncReturnsValueTask = typeIsValueTask;
             function.IsUnsafe = syntax.IsUnsafe;
             function.ReturnRefKind = returnRefKind;
@@ -336,7 +338,8 @@ internal sealed partial class DeclarationBinder
 
         function = new FunctionSymbol(syntax.Identifier.Text, parameters.ToImmutable(), type, syntax, package, accessibility);
         function.TypeParameters = typeParameters;
-        function.IsAsync = syntax.IsAsync || isAsyncIteratorReturnType(type);
+        function.IsAsync = syntax.IsAsync
+            || (isAsyncIteratorReturnType(type) && IteratorDetection.ContainsYield(syntax.Body));
         function.AsyncReturnsValueTask = typeIsValueTask;
         function.IsUnsafe = syntax.IsUnsafe;
         function.ReturnRefKind = returnRefKind;
@@ -1408,6 +1411,12 @@ internal sealed partial class DeclarationBinder
         IReadOnlyDictionary<TypeParameterSymbol, TypeSymbol> typeParamMap)
     {
         var baseIsAsync = baseMethod.IsAsync;
+        if (AsyncIteratorDetection.IsAsyncIteratorReturnType(baseMethod.Type)
+            && AsyncIteratorDetection.IsAsyncIteratorReturnType(derivedReturnType))
+        {
+            return TypeSignaturesEquivalent(baseMethod.Type, derivedReturnType, typeParamMap);
+        }
+
         if (baseIsAsync == derivedIsAsync)
         {
             return TypeSignaturesEquivalent(baseMethod.Type, derivedReturnType, typeParamMap);

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
@@ -329,6 +329,9 @@ internal sealed partial class DeclarationBinder
                 methodAccessibility,
                 receiverType: isStaticInterfaceMethod ? null : (TypeSymbol)interfaceSymbol);
             methodSymbol.ReturnRefKind = methodReturnRefKind;
+
+            // Bodyless interface declarations describe an async-iterator ABI;
+            // executable implementations are classified from their own yield.
             methodSymbol.IsAsync = methodSyntax.IsAsync || isAsyncIteratorReturnType(returnType);
             methodSymbol.AsyncReturnsValueTask = returnTypeIsValueTask;
             methodSymbol.IsUnsafe = methodSyntax.IsUnsafe;

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -1032,7 +1032,8 @@ internal sealed partial class DeclarationBinder
                     // Issue #1071: the effective async flag (mirrors
                     // FunctionSymbol.IsAsync below) so override / shadow matching
                     // compares the async-normalized effective return type.
-                    var methodIsAsync = methodSyntax.IsAsync || isAsyncIteratorReturnType(returnType);
+                    var methodIsAsync = methodSyntax.IsAsync
+                        || (isAsyncIteratorReturnType(returnType) && IteratorDetection.ContainsYield(methodSyntax.Body));
 
                     // Issue #2361: now that the parameter list/return type are
                     // bound, validate a data class/struct's ToString shape.
@@ -1191,7 +1192,8 @@ internal sealed partial class DeclarationBinder
                     methodSymbol.ExternalOverrideContainingType = externalOverrideContainingType;
                     methodSymbol.TypeParameters = methodTypeParameters;
                     methodSymbol.ReturnRefKind = methodReturnRefKind;
-                    methodSymbol.IsAsync = methodSyntax.IsAsync || isAsyncIteratorReturnType(returnType);
+                    methodSymbol.IsAsync = methodSyntax.IsAsync
+                        || (isAsyncIteratorReturnType(returnType) && IteratorDetection.ContainsYield(methodSyntax.Body));
                     methodSymbol.AsyncReturnsValueTask = returnTypeIsValueTask;
                     methodSymbol.IsUnsafe = methodSyntax.IsUnsafe || syntax.IsUnsafe;
 
@@ -2237,7 +2239,8 @@ internal sealed partial class DeclarationBinder
                     methodSymbol.StaticOwnerType = structSymbol;
                     methodSymbol.TypeParameters = methodTypeParameters;
                     methodSymbol.ReturnRefKind = methodReturnRefKind;
-                    methodSymbol.IsAsync = methodSyntax.IsAsync || isAsyncIteratorReturnType(returnType);
+                    methodSymbol.IsAsync = methodSyntax.IsAsync
+                        || (isAsyncIteratorReturnType(returnType) && IteratorDetection.ContainsYield(methodSyntax.Body));
                     methodSymbol.AsyncReturnsValueTask = returnTypeIsValueTask;
                     methodSymbol.IsUnsafe = methodSyntax.IsUnsafe || syntax.IsUnsafe;
 

--- a/src/Core/CodeAnalysis/Binding/IteratorDetection.cs
+++ b/src/Core/CodeAnalysis/Binding/IteratorDetection.cs
@@ -1,0 +1,72 @@
+// <copyright file="IteratorDetection.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>Detects whether a function body is an iterator body.</summary>
+public static class IteratorDetection
+{
+    /// <summary>
+    /// Returns whether <paramref name="body"/> contains a yield in its own
+    /// lexical scope. Nested function and lambda bodies are opaque.
+    /// </summary>
+    /// <param name="body">The bound function body to inspect.</param>
+    /// <returns><see langword="true"/> when the body's own lexical scope contains a yield.</returns>
+    public static bool ContainsYield(BoundStatement body)
+    {
+        var detector = new BoundYieldDetector();
+        detector.Visit(body);
+        return detector.Found;
+    }
+
+    /// <summary>
+    /// Returns whether <paramref name="body"/> contains a yield in its own
+    /// lexical scope. Nested function and lambda bodies are opaque.
+    /// </summary>
+    /// <param name="body">The function body syntax to inspect.</param>
+    /// <returns><see langword="true"/> when the body's own lexical scope contains a yield.</returns>
+    public static bool ContainsYield(SyntaxNode body) => ContainsYieldSyntax(body);
+
+    private static bool ContainsYieldSyntax(SyntaxNode node)
+    {
+        if (node == null)
+        {
+            return false;
+        }
+
+        foreach (var child in node.GetChildren())
+        {
+            if (child is YieldStatementSyntax)
+            {
+                return true;
+            }
+
+            if (child is FunctionDeclarationSyntax
+                or FunctionLiteralExpressionSyntax
+                or LambdaExpressionSyntax)
+            {
+                continue;
+            }
+
+            if (ContainsYieldSyntax(child))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private sealed class BoundYieldDetector : BoundTreeWalker
+    {
+        public bool Found { get; private set; }
+
+        protected override void VisitYieldStatement(BoundYieldStatement node)
+        {
+            Found = true;
+        }
+    }
+}

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -269,6 +269,8 @@ internal sealed class LambdaBinder
 
         var returnType = syntax.ReturnTypeClause != null ? bindReturnTypeClause(syntax.ReturnTypeClause, syntax.IsAsync) : TypeSymbol.Void;
         returnType ??= TypeSymbol.Void;
+        var isAsync = syntax.IsAsync
+            || (isAsyncIteratorReturnType(returnType) && IteratorDetection.ContainsYield(syntax.Body));
 
         // ADR-0058: a managed-pointer (*T) cannot be used as a lambda return type
         // because CLR Func<> delegates cannot carry by-ref type arguments.
@@ -285,7 +287,7 @@ internal sealed class LambdaBinder
         // with the iterator carve-out (ADR-0041): an async iterator lambda
         // returning IAsyncEnumerable[T] does not get a Task wrap.
         var observableReturnType = returnType;
-        if (syntax.IsAsync && !isAsyncIteratorReturnType(returnType))
+        if (isAsync && !isAsyncIteratorReturnType(returnType))
         {
             observableReturnType = WrapAsTask(returnType);
         }
@@ -295,7 +297,7 @@ internal sealed class LambdaBinder
             explicitName ?? $"<lambda{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
             parameterSymbols.ToImmutable(),
             returnType);
-        synthetic.IsAsync = syntax.IsAsync;
+        synthetic.IsAsync = isAsync;
 
         // Snapshot current binder state, then push a child scope and bind
         // the body as if we were inside this synthetic function.

--- a/src/Core/CodeAnalysis/Emit/MethodInfoHelpers.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodInfoHelpers.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
 using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Emit;
@@ -255,6 +256,12 @@ internal static class MethodInfoHelpers
     /// </summary>
     private static bool ReturnTypesMatch(FunctionSymbol interfaceMethod, FunctionSymbol implementationMethod)
     {
+        if (AsyncIteratorDetection.IsAsyncIteratorReturnType(interfaceMethod.Type)
+            && AsyncIteratorDetection.IsAsyncIteratorReturnType(implementationMethod.Type))
+        {
+            return AwaitedTypesMatch(interfaceMethod.Type, implementationMethod.Type);
+        }
+
         if (interfaceMethod.IsAsync == implementationMethod.IsAsync)
         {
             return ReferenceEquals(interfaceMethod.Type, implementationMethod.Type);

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncEmitPrecheck.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncEmitPrecheck.cs
@@ -44,15 +44,16 @@ public static class AsyncEmitPrecheck
 
         var builder = ImmutableArray.CreateBuilder<Diagnostic>();
 
-        foreach (var function in program.Functions.Keys)
+        foreach (var pair in program.Functions)
         {
+            var function = pair.Key;
             if (!function.IsAsync)
             {
                 continue;
             }
 
             // Async iterators are now supported — no gate needed.
-            if (IsAsyncIterator(function))
+            if (AsyncIteratorDetection.IsAsyncIteratorFunction(function, pair.Value))
             {
                 continue;
             }
@@ -69,7 +70,7 @@ public static class AsyncEmitPrecheck
 
         if (program.EntryPoint is { } entry && entry.IsAsync && !program.Functions.ContainsKey(entry))
         {
-            if (!IsAsyncIterator(entry) && entry.StateMachineType == null)
+            if (entry.StateMachineType == null)
             {
                 builder.Add(new Diagnostic(LocateAsyncFunction(entry), "GS0190", DiagnosticSeverity.Error, AsyncStateMachineUnavailableMessage));
             }
@@ -77,15 +78,6 @@ public static class AsyncEmitPrecheck
 
         return builder.ToImmutable();
     }
-
-    /// <summary>
-    /// Determines whether the given async function is an async iterator
-    /// (returns IAsyncEnumerable or IAsyncEnumerator), including the symbolic
-    /// open-generic forms (issue #1489) via the shared
-    /// <see cref="AsyncIteratorDetection"/> helper.
-    /// </summary>
-    private static bool IsAsyncIterator(FunctionSymbol function)
-        => AsyncIteratorDetection.IsAsyncIteratorFunction(function);
 
     private static TextLocation LocateAsyncFunction(FunctionSymbol function)
     {

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncIteratorDetection.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncIteratorDetection.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Lowering.Async;
@@ -31,15 +32,18 @@ public static class AsyncIteratorDetection
 {
     /// <summary>
     /// Determines whether <paramref name="function"/> is an async iterator —
-    /// one whose declared return type is <c>sequence[T]</c>
+    /// one whose body contains <c>yield</c> and whose declared return type is <c>sequence[T]</c>
     /// (<see cref="AsyncSequenceTypeSymbol"/>) or
     /// <c>IAsyncEnumerable[T]</c> / <c>IAsyncEnumerator[T]</c> in any of its
     /// closed-CLR, open-imported, or user-element forms.
     /// </summary>
     /// <param name="function">The function symbol to inspect.</param>
+    /// <param name="body">The function's bound body.</param>
     /// <returns><see langword="true"/> when the function is an async iterator.</returns>
-    public static bool IsAsyncIteratorFunction(FunctionSymbol function)
-        => function != null && GetElementType(function.Type) != null;
+    public static bool IsAsyncIteratorFunction(FunctionSymbol function, BoundStatement body)
+        => function != null
+            && GetElementType(function.Type) != null
+            && IteratorDetection.ContainsYield(body);
 
     /// <summary>
     /// Determines whether <paramref name="type"/> is an async-iterator return

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriter.cs
@@ -51,7 +51,7 @@ public static class AsyncStateMachineRewriter
             }
 
             // Skip async iterators — they are handled by the async iterator rewriter.
-            if (IsAsyncIteratorFunction(function))
+            if (AsyncIteratorDetection.IsAsyncIteratorFunction(function, pair.Value))
             {
                 continue;
             }
@@ -151,9 +151,6 @@ public static class AsyncStateMachineRewriter
         var parameterTypes = string.Join(",", function.Parameters.Select(parameter => parameter.Type?.Name ?? string.Empty));
         return packageName + ":" + function.Name + ":" + function.Parameters.Length + ":" + parameterTypes;
     }
-
-    private static bool IsAsyncIteratorFunction(FunctionSymbol function)
-        => AsyncIteratorDetection.IsAsyncIteratorFunction(function);
 
     private sealed class AwaitStateCollector : BoundTreeWalker
     {

--- a/src/Core/CodeAnalysis/Lowering/BaseCallForwarderRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/BaseCallForwarderRewriter.cs
@@ -67,7 +67,7 @@ public static class BaseCallForwarderRewriter
                 continue;
             }
 
-            var isStateMachine = function.IsAsync || ContainsYield(body);
+            var isStateMachine = function.IsAsync || IteratorDetection.ContainsYield(body);
             if (!isStateMachine)
             {
                 continue;
@@ -134,26 +134,6 @@ public static class BaseCallForwarderRewriter
             FriendAssemblies = program.FriendAssemblies,
             AssemblyAttributes = program.AssemblyAttributes,
         };
-    }
-
-    private static bool ContainsYield(BoundStatement statement)
-    {
-        var walker = new YieldWalker();
-        walker.Visit(statement);
-        return walker.Found;
-    }
-
-    private sealed class YieldWalker : BoundTreeRewriter
-    {
-        public bool Found { get; private set; }
-
-        public void Visit(BoundStatement statement) => this.RewriteStatement(statement);
-
-        protected override BoundStatement RewriteYieldStatement(BoundYieldStatement node)
-        {
-            this.Found = true;
-            return node;
-        }
     }
 
     private sealed class Rewriter : BoundTreeRewriter

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriter.cs
@@ -49,7 +49,7 @@ public static class AsyncIteratorRewriter
             var function = pair.Key;
             var body = pair.Value;
 
-            if (!IsAsyncIteratorFunction(function))
+            if (!AsyncIteratorDetection.IsAsyncIteratorFunction(function, body))
             {
                 continue;
             }
@@ -102,16 +102,6 @@ public static class AsyncIteratorRewriter
         return new AsyncIteratorRewriteResult(program, plans.ToImmutable());
     }
 
-    private static bool IsAsyncIteratorFunction(FunctionSymbol function)
-        => AsyncIteratorDetection.IsAsyncIteratorFunction(function);
-
-    private static bool ContainsYield(BoundStatement statement)
-    {
-        var walker = new YieldWalker();
-        walker.Visit(statement);
-        return walker.Found;
-    }
-
     private static TypeSymbol GetAsyncIteratorElementType(TypeSymbol type)
         => AsyncIteratorDetection.GetElementType(type);
 
@@ -144,16 +134,6 @@ public static class AsyncIteratorRewriter
         }
 
         return result.ToImmutable();
-    }
-
-    private sealed class YieldWalker : BoundTreeWalker
-    {
-        public bool Found { get; private set; }
-
-        protected override void VisitYieldStatement(BoundYieldStatement node)
-        {
-            Found = true;
-        }
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Lowering.Async;
 using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Lowering.Iterators;
@@ -41,13 +42,13 @@ public static class IteratorRewriter
             var function = pair.Key;
             var body = pair.Value;
 
-            if (!ContainsYield(body))
+            if (!IteratorDetection.ContainsYield(body))
             {
                 continue;
             }
 
             // Skip async iterators — they go through the async iterator rewriter path.
-            if (IsAsyncIteratorFunction(function))
+            if (AsyncIteratorDetection.IsAsyncIteratorFunction(function, body))
             {
                 continue;
             }
@@ -63,37 +64,6 @@ public static class IteratorRewriter
         }
 
         return new IteratorRewriteResult(program, plans.ToImmutable());
-    }
-
-    private static bool IsAsyncIteratorFunction(FunctionSymbol function)
-    {
-        // Issue #798: a generic `async sequence[T]` function is an
-        // AsyncSequenceTypeSymbol whose ClrType is null for open T (the
-        // CLR projection erases the element type). Recognize the symbolic
-        // form so the sync IteratorRewriter correctly skips it and the
-        // function flows to AsyncIteratorRewriter.
-        if (function.Type is AsyncSequenceTypeSymbol)
-        {
-            return true;
-        }
-
-        var clr = function.Type?.ClrType;
-        if (clr == null || !clr.IsGenericType || clr.IsGenericTypeDefinition)
-        {
-            return false;
-        }
-
-        var def = clr.GetGenericTypeDefinition();
-        var fullName = def?.FullName;
-        return fullName == "System.Collections.Generic.IAsyncEnumerable`1"
-            || fullName == "System.Collections.Generic.IAsyncEnumerator`1";
-    }
-
-    private static bool ContainsYield(BoundStatement statement)
-    {
-        var walker = new YieldWalker();
-        walker.Visit(statement);
-        return walker.Found;
     }
 
     private static TypeSymbol GetIteratorElementType(TypeSymbol type)
@@ -168,16 +138,6 @@ public static class IteratorRewriter
         var collector = new LocalCollector();
         collector.Visit(body);
         return collector.Locals.ToImmutableArray();
-    }
-
-    private sealed class YieldWalker : BoundTreeWalker
-    {
-        public bool Found { get; private set; }
-
-        protected override void VisitYieldStatement(BoundYieldStatement node)
-        {
-            Found = true;
-        }
     }
 
     private sealed class YieldStateCollector : BoundTreeWalker

--- a/test/Compiler.Tests/Emit/Issue2773EagerEnumerableReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2773EagerEnumerableReturnEmitTests.cs
@@ -1,0 +1,180 @@
+// <copyright file="Issue2773EagerEnumerableReturnEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue2773EagerEnumerableReturnEmitTests
+{
+    [Fact]
+    public void NoYieldWrappersExecuteEagerly_WhileYieldBodiesRemainLazy_VerifyAndRun()
+    {
+        const string source = """
+            package Issue2773
+
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class Item(Value int32) { }
+
+            interface AsyncSource {
+                func Async() IAsyncEnumerable[int32];
+            }
+
+            class Probe : AsyncSource {
+                let events List[string] = List[string]()
+
+                func Sync() IEnumerable[int32] {
+                    events.Add("sync-call")
+                    return SyncIterator()
+                }
+
+                func UserSequence() sequence[Item] {
+                    events.Add("user-call")
+                    return UserIterator()
+                }
+
+                func Async() IAsyncEnumerable[int32] {
+                    events.Add("async-call")
+                    return AsyncIterator()
+                }
+
+                private func SyncIterator() IEnumerable[int32] {
+                    try {
+                        events.Add("sync-yield")
+                        yield 1
+                    } finally {
+                        events.Add("sync-finally")
+                    }
+                }
+
+                private func UserIterator() sequence[Item] {
+                    try {
+                        events.Add("user-yield")
+                        yield Item(2)
+                    } finally {
+                        events.Add("user-finally")
+                    }
+                }
+
+                private async func AsyncIterator() IAsyncEnumerable[int32] {
+                    try {
+                        events.Add("async-yield")
+                        await Task.Yield()
+                        yield 3
+                    } finally {
+                        events.Add("async-finally")
+                    }
+                }
+
+                async func Run() int32 {
+                    let syncValues = Sync()
+                    let userValues = UserSequence()
+                    let source AsyncSource = this
+                    let asyncValues = source.Async()
+                    Console.WriteLine(String.Join("|", events))
+
+                    var sum = 0
+                    for value in syncValues {
+                        sum += value
+                    }
+                    for value in userValues {
+                        sum += value.Value
+                    }
+                    await for value in asyncValues {
+                        sum += value
+                    }
+
+                    Console.WriteLine(String.Join("|", events))
+                    return sum
+                }
+            }
+
+            Console.WriteLine(Probe().Run().GetAwaiter().GetResult())
+            """;
+
+        Assert.Equal(
+            "sync-call|user-call|async-call\n" +
+            "sync-call|user-call|async-call|sync-yield|sync-finally|user-yield|user-finally|async-yield|async-finally\n" +
+            "6\n",
+            CompileVerifyAndRun(source));
+    }
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var directory = Path.Combine(
+            Directory.GetCurrentDirectory(),
+            "out",
+            "test-artifacts",
+            "issue2773-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    "/nowarn:GS9100",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(exitCode == 0, $"gsc failed:\n{compileOut}\n{compileErr}");
+            IlVerifier.Verify(outputPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo)!;
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}\n{stderr}");
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/AsyncIteratorEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/AsyncIteratorEmitTests.cs
@@ -71,6 +71,9 @@ import System.Collections.Generic
 import System.Threading.Tasks
 
 func empty() IAsyncEnumerable[int32] {
+    if false {
+        yield 0
+    }
 }
 ";
         var items = CompileAndEnumerate<int>(Source, "empty", nameof(AsyncIterator_Empty_ProducesNoValues));

--- a/test/Core.Tests/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriterTests.cs
@@ -167,6 +167,23 @@ public class AsyncIteratorRewriterTests
     }
 
     [Fact]
+    public void Rewrite_AsyncEnumerableWithoutYield_ProducesNoPlan()
+    {
+        var function = new FunctionSymbol(
+            "eager",
+            ImmutableArray<ParameterSymbol>.Empty,
+            TypeSymbol.FromClrType(typeof(IAsyncEnumerable<int>)),
+            package: Package);
+        var body = Block(new BoundReturnStatement(
+            null,
+            new BoundLiteralExpression(null, null, function.Type)));
+
+        var result = AsyncIteratorRewriter.Rewrite(MakeProgram(function, body));
+
+        Assert.Empty(result.Plans);
+    }
+
+    [Fact]
     public void Rewrite_IsEnumerable_TrueForIAsyncEnumerable()
     {
         // Arrange

--- a/test/Core.Tests/CodeAnalysis/Lowering/Iterators/IteratorRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Iterators/IteratorRewriterTests.cs
@@ -138,6 +138,44 @@ public class IteratorRewriterTests
         Assert.Empty(result.Plans);
     }
 
+    [Fact]
+    public void Detection_TraversesBranchesAndTryFinally_ButNotNestedFunctions()
+    {
+        var yield = new BoundYieldStatement(null, new BoundLiteralExpression(null, 1));
+        var branch = new BoundIfStatement(
+            null,
+            new BoundLiteralExpression(null, true),
+            Block(yield),
+            Block());
+        var tryFinally = new BoundTryStatement(
+            null,
+            Block(branch),
+            ImmutableArray<BoundCatchClause>.Empty,
+            Block());
+
+        Assert.True(IteratorDetection.ContainsYield(Block(tryFinally)));
+
+        var sequenceType = SequenceTypeSymbol.Get(TypeSymbol.Int32);
+        var nestedFunction = new FunctionSymbol(
+            "nested",
+            ImmutableArray<ParameterSymbol>.Empty,
+            sequenceType,
+            package: Package);
+        var functionType = FunctionTypeSymbol.Get(ImmutableArray<TypeSymbol>.Empty, sequenceType);
+        var literal = new BoundFunctionLiteralExpression(
+            null,
+            nestedFunction,
+            functionType,
+            Block(yield),
+            ImmutableArray<VariableSymbol>.Empty);
+        var lambda = new LocalVariableSymbol("lambda", isReadOnly: true, functionType);
+
+        Assert.False(IteratorDetection.ContainsYield(Block(
+            new BoundVariableDeclaration(null, lambda, literal))));
+        Assert.False(IteratorDetection.ContainsYield(Block(
+            new BoundLocalFunctionDeclaration(null, literal))));
+    }
+
     #region Helpers
 
     private static BoundBlockStatement Block(params BoundStatement[] statements)


### PR DESCRIPTION
## Scope

Fixes #2773 only: methods are iterators when their own lexical body contains `yield`, not because their return type is `IEnumerable<T>` / `IAsyncEnumerable<T>`.

- classify executable declarations from lexical `yield` while excluding nested functions/lambdas
- share bound-body yield detection across sync/async lowering and state-machine gates
- preserve eager interface dispatch and lazy true iterators, including async and try/finally paths

## #2773 proof

- `eager2.gs`: subscriber count `0 -> 1`
- `eageriter.gs`: `got= -> got=1,2,3`
- runtime + ILVerify regression covers `IEnumerable<T>`, `IAsyncEnumerable<T>`, `sequence<T>`, interface dispatch, eager side-effect order, async/task consumption, and true iterator `try/finally`
- nested local-function/lambda yields do not classify the outer method; branch yields do
- Oahu RC-C14-5 replay: **14/18 originally attributed tests pass** on this branch (targeted rerun: 14 passed in 599 ms)

The remaining four were reproduced against this branch and do not call the no-yield enumerable wrappers:

| Remaining test | Independent proven root |
|---|---|
| `JobSchedulerTests.History_Receives_Terminal_Records` | #2771: non-null `history?.Append(...)` in async `finally` after awaits fails; explicit nil test makes it pass |
| `JobSchedulerTests.Cancel_Stops_Job_And_Records_Canceled` | #2771 masks the write; after that workaround it records `Failed` because awaited catch dispatch falls through (#2781). Single-await catch rewrite makes it pass |
| `HttpServerIntegrationTests.With_Token_Library_Endpoint_Returns_Items` | #2782: imported overload candidates erase endpoint `Task<object>` lambda to `Task`; explicit typed handler makes it pass |
| `HttpServerIntegrationTests.Queue_Add_Then_List_Then_Clear_Requires_Confirm` | #2771 (`raw?.Trim()` across await) plus #2782 (HTTP result handlers); both workarounds make it pass |

Proof for the #2771 mappings is recorded at https://github.com/DavidObando/gsharp/issues/2771#issuecomment-5053791823. New generalized roots:

- #2781 — async catch resume dispatch falls through to a later awaited branch
- #2782 — losing overload candidate erases winning `Delegate` lambda result `Task<T>` to `Task`

Both new issues contain deterministic repros, cycle-13/current proof, shared code paths, acceptance criteria, and priority. Therefore **#2773 has zero deferred work**; the report over-attributed four failures now fully assigned to independent roots.

## Validation

- targeted iterator lowering: 15 passed
- targeted runtime/ILVerify: 1 passed
- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --nologo`: 6,696 passed, 1 skipped
- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Compiler.Tests/Compiler.Tests.csproj --no-restore --nologo`: 3,432 passed
- required PR checks: green

Fixes #2773