### PR TITLE
Fix async null-conditional capture hoisting

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -46,6 +46,17 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #2771: emitter-owned variable operations (notably `?.`
+        // captures) bypass MoveNextBodyRewriter's bound-node substitution.
+        if (this.asyncFieldMap != null
+            && this.asyncFieldMap.TryGetHoistedField(variable, out var hoistedField))
+        {
+            this.il.OpCode(ILOpCode.Ldarg_0);
+            this.il.OpCode(ILOpCode.Ldfld);
+            this.il.Token(this.ResolveCurrentStateMachineFieldToken(hoistedField));
+            return;
+        }
+
         if (variable is ParameterSymbol ps && this.parameters.TryGetValue(ps, out var argIndex))
         {
             this.il.LoadArgument(argIndex);
@@ -194,6 +205,20 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitStoreVariable(VariableSymbol variable)
     {
+        if (this.asyncFieldMap != null
+            && this.asyncFieldMap.TryGetHoistedField(variable, out var hoistedField))
+        {
+            // stfld needs the receiver below the value; the planned fallback
+            // local provides the stack reorder without changing value identity.
+            var valueSlot = this.locals[variable];
+            this.il.StoreLocal(valueSlot);
+            this.il.OpCode(ILOpCode.Ldarg_0);
+            this.il.LoadLocal(valueSlot);
+            this.il.OpCode(ILOpCode.Stfld);
+            this.il.Token(this.ResolveCurrentStateMachineFieldToken(hoistedField));
+            return;
+        }
+
         if (variable is ParameterSymbol ps && this.parameters.TryGetValue(ps, out var argIndex))
         {
             this.il.StoreArgument(argIndex);

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -1473,23 +1473,9 @@ public static class SpillSequenceSpiller
             // nor WhenNotNull contains an await. `nc.Capture` is declared as
             // the unwrapped `T` (so member-access binding resolves against
             // `T`), so it can never directly hold the real `Nullable<T>`
-            // receiver value; and since this whole method reachable via
-            // SpillExpression only runs inside an async method body,
-            // MoveNextBodyRewriter's hoisting walk may promote `nc.Capture`
-            // to a state-machine field regardless of whether *this specific*
-            // access spans a suspension point — and it only redirects
-            // bound-tree-visible reads/writes (BoundVariableExpression /
-            // BoundAssignmentExpression / BoundVariableDeclaration nodes),
-            // never the emitter's direct EmitStoreVariable/EmitLoadVariable
-            // calls. Leaving the node's own capture-write to
-            // EmitNullConditionalAccess (as the Trivial passthrough would)
-            // risks a silent dead store into an unused fallback local while
-            // every real read resolves to a never-written hoisted field —
-            // wrong runtime value with still-valid IL (ilverify cannot see
-            // this). Building the write as a genuine
-            // BoundAssignmentExpression here (mirroring the existing
-            // reference-type Leg-1/2/3 patterns below) keeps it visible to
-            // the hoisting walk regardless of leg.
+            // receiver value. The shared variable emitter routes hoisted
+            // captures to state-machine fields (issue #2771), but it cannot
+            // reconcile this wrapper/unwrapped type mismatch.
             var isValueTypeNullableReceiver = nc.Receiver.Type is NullableTypeSymbol ncReceiverNullable
                 && NullableLifting.IsAnyValueTypeNullable(ncReceiverNullable);
 
@@ -1517,28 +1503,9 @@ public static class SpillSequenceSpiller
             {
                 // Reference-type (or non-nullable-collapse) receiver, only
                 // the receiver needed spilling — WhenNotNull is still
-                // await-free. EmitNullConditionalAccess writes/reads
-                // nc.Capture via direct EmitStoreVariable/EmitLoadVariable
-                // calls, not through bound-tree Assignment/Variable nodes —
-                // so MoveNextBodyRewriter's hoisted-field substitution (which
-                // only rewrites nodes it can see in the tree) never touches
-                // that write, and it would land in a plain local while every
-                // *read* of nc.Capture nested inside nc.WhenNotNull (a real
-                // BoundVariableExpression the rewriter *does* see) gets
-                // redirected to the hoisted field instead — reading an
-                // never-written field. Declaring the capture explicitly here
-                // (a real BoundVariableDeclaration the rewriter recognizes)
-                // and feeding the capture variable back in as its own
-                // receiver makes emitter's redundant internal store a
-                // harmless no-op dead store into the (unused) plain-local
-                // fallback slot, while every real read still consistently
-                // resolves to the (already correctly written) hoisted field.
-                // `nc.Capture` shares the CLR representation of `receiver`
-                // for reference types, so this workaround remains sound.
-                sideEffects.Add(new BoundVariableDeclaration(null, (LocalVariableSymbol)nc.Capture, receiver));
-                locals.Add((LocalVariableSymbol)nc.Capture);
-                var captureRef = new BoundVariableExpression(null, nc.Capture);
-                var rebuiltNc = new BoundNullConditionalAccessExpression(null, captureRef, nc.Capture, nc.WhenNotNull, nc.Type, nc.ResultSlot);
+                // await-free. The emitter's shared variable load/store path
+                // preserves nc.Capture whether it remains local or is hoisted.
+                var rebuiltNc = new BoundNullConditionalAccessExpression(null, receiver, nc.Capture, nc.WhenNotNull, nc.Type, nc.ResultSlot);
                 return new BoundSpillSequenceExpression(null, locals.ToImmutable(), sideEffects.ToImmutable(), rebuiltNc);
             }
 

--- a/test/Compiler.Tests/Emit/Issue2771AsyncNullConditionalHoistEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2771AsyncNullConditionalHoistEmitTests.cs
@@ -1,0 +1,335 @@
+// <copyright file="Issue2771AsyncNullConditionalHoistEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2771: emitter-owned null-conditional capture stores must target
+/// state-machine fields when async lowering hoists those captures.
+/// </summary>
+public class Issue2771AsyncNullConditionalHoistEmitTests
+{
+    public static IEnumerable<object[]> RuntimeMatrix()
+    {
+        yield return Case(
+            "method, null and non-null receivers, ConfigureAwait, before and after await",
+            """
+            class Svc {
+                async func Tick() Task[bool] {
+                    await Task.Yield()
+                    return true
+                }
+            }
+
+            class Runner {
+                async func Run(raw string?) Task[string] {
+                    let value string? = raw?.Trim()
+                    let before = value ?? "nil"
+                    let ok = await Svc().Tick().ConfigureAwait(false)
+                    return before + ":" + (value ?? "nil") + ":" + ok.ToString()
+                }
+            }
+
+            let runner = Runner()
+            Console.WriteLine(runner.Run("  method  ").Result)
+            Console.WriteLine(runner.Run(nil).Result)
+            """,
+            "method:method:True\nnil:nil:True\n");
+
+        yield return Case(
+            "property with nullable value result",
+            """
+            class Runner {
+                async func Run(raw string?) Task[int32] {
+                    let length int32? = raw?.Length
+                    let before = length ?? 0
+                    await Task.Delay(1)
+                    return before + (length ?? 0)
+                }
+            }
+
+            let runner = Runner()
+            Console.WriteLine(runner.Run("four").Result)
+            Console.WriteLine(runner.Run(nil).Result)
+            """,
+            "8\n0\n");
+
+        yield return Case(
+            "property with nullable reference result",
+            """
+            class Box {
+                private let text string?
+
+                init(text string?) {
+                    this.text = text
+                }
+
+                prop Text string? {
+                    get { return this.text }
+                }
+            }
+
+            class Runner {
+                async func Run(box Box?) Task[string] {
+                    let text string? = box?.Text
+                    await Task.Yield()
+                    return text ?? "none"
+                }
+            }
+
+            let runner = Runner()
+            Console.WriteLine(runner.Run(Box("property")).Result)
+            Console.WriteLine(runner.Run(nil).Result)
+            """,
+            "property\nnone\n");
+
+        yield return Case(
+            "loop preserves each conditional local",
+            """
+            class Runner {
+                async func Run(items []string) Task[int32] {
+                    var total = 0
+                    for raw in items {
+                        let value string? = raw?.Trim()
+                        await Task.Yield()
+                        if value != nil {
+                            total = total + value!!.Length
+                        }
+                    }
+
+                    return total
+                }
+            }
+
+            Console.WriteLine(Runner().Run([]string{" a ", "bc", ""}).Result)
+            """,
+            "3\n");
+
+        yield return Case(
+            "async closure preserves method result",
+            """
+            class Nav {
+                private let label string
+
+                init(label string) {
+                    this.label = label
+                }
+
+                func Label() string {
+                    return this.label
+                }
+            }
+
+            class Runner {
+                func Run(nav Nav?) Task[string] {
+                    return Task.Run(async () -> {
+                        let label string? = nav?.Label()
+                        await Task.Delay(1).ConfigureAwait(false)
+                        return label ?? "none"
+                    })
+                }
+            }
+
+            let runner = Runner()
+            Console.WriteLine(runner.Run(Nav("closure")).Result)
+            Console.WriteLine(runner.Run(nil).Result)
+            """,
+            "closure\nnone\n");
+
+        yield return Case(
+            "plain nullable and await-free controls",
+            """
+            class Runner {
+                async func Plain(raw string?) Task[string] {
+                    let value = raw
+                    await Task.Yield()
+                    return value ?? "none"
+                }
+
+                func ConditionalWithoutAwait(raw string?) string {
+                    let value string? = raw?.Trim()
+                    return value ?? "none"
+                }
+            }
+
+            let runner = Runner()
+            Console.WriteLine(runner.Plain("plain").Result)
+            Console.WriteLine(runner.Plain(nil).Result)
+            Console.WriteLine(runner.ConditionalWithoutAwait(" control "))
+            Console.WriteLine(runner.ConditionalWithoutAwait(nil))
+            """,
+            "plain\nnone\ncontrol\nnone\n");
+    }
+
+    [Theory]
+    [MemberData(nameof(RuntimeMatrix))]
+    public void NullConditionalMatrix_VerifiesAndRuns(string _, string body, string expected)
+    {
+        Assert.Equal(expected, CompileVerifyAndRun(Wrap(body)));
+    }
+
+    [Fact]
+    public void HoistedFields_PreserveNullableIdentity()
+    {
+        var source = Wrap(
+            """
+            class Runner {
+                async func Ref(raw string?) Task[string?] {
+                    let value string? = raw?.Trim()
+                    await Task.Yield()
+                    return value
+                }
+
+                async func Val(raw string?) Task[int32?] {
+                    let value int32? = raw?.Length
+                    await Task.Yield()
+                    return value
+                }
+            }
+            """);
+
+        var (directory, outputPath) = Compile(source);
+        try
+        {
+            IlVerifier.Verify(outputPath);
+            var loadContext = new AssemblyLoadContext("Issue2771FieldShape", isCollectible: true);
+            try
+            {
+                var assembly = loadContext.LoadFromAssemblyPath(outputPath);
+                var stateMachines = assembly.GetTypes()
+                    .Where(type => type.Name.Contains("d__", StringComparison.Ordinal))
+                    .ToArray();
+                var refMachine = Assert.Single(stateMachines, type => type.Name.Contains("<Ref>", StringComparison.Ordinal));
+                var valMachine = Assert.Single(stateMachines, type => type.Name.Contains("<Val>", StringComparison.Ordinal));
+
+                Assert.Contains(
+                    refMachine.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic),
+                    field => field.Name.Contains("<value>5__", StringComparison.Ordinal)
+                        && field.FieldType == typeof(string));
+                Assert.Contains(
+                    refMachine.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic),
+                    field => field.Name.Contains("<$ncap_", StringComparison.Ordinal)
+                        && field.FieldType == typeof(string));
+                Assert.Contains(
+                    valMachine.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic),
+                    field => field.Name.Contains("<value>5__", StringComparison.Ordinal)
+                        && field.FieldType == typeof(int?));
+                Assert.Contains(
+                    valMachine.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic),
+                    field => field.Name.Contains("<$ncap_", StringComparison.Ordinal)
+                        && field.FieldType == typeof(string));
+            }
+            finally
+            {
+                loadContext.Unload();
+            }
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    private static object[] Case(string name, string body, string expected) =>
+        new object[] { name, body, expected };
+
+    private static string Wrap(string body) =>
+        """
+        package issue2771
+        import System
+        import System.Threading.Tasks
+
+        """ + body;
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var (directory, outputPath) = Compile(source);
+        try
+        {
+            IlVerifier.Verify(outputPath);
+            using var process = Process.Start(new ProcessStartInfo("dotnet")
+            {
+                ArgumentList =
+                {
+                    "exec",
+                    "--runtimeconfig",
+                    Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                    outputPath,
+                },
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            });
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, error);
+            return output.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    private static (string Directory, string OutputPath) Compile(string source)
+    {
+        var directory = Path.GetFullPath(Path.Combine(
+            Directory.GetCurrentDirectory(),
+            "out",
+            "test-artifacts",
+            "issue2771-" + Guid.NewGuid().ToString("N")));
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(exitCode == 0, $"compile failed ({exitCode}):\n{stdout}\n{stderr}");
+        return (directory, outputPath);
+    }
+
+    private static void DeleteDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- route emitter-owned variable loads/stores through async state-machine fields when captures are hoisted
- remove the null-conditional spiller workaround now covered by the shared emitter path
- add runtime and ILVerify coverage for receiver/result nullability, methods/properties, loops, closures, ConfigureAwait, and controls

## Validation
- 7 issue matrix tests passed
- 24 targeted async/null-conditional tests passed
- Core.Tests: 6,694 passed, 1 skipped
- Compiler.Tests: 3,438 passed
- 6 affected Oahu tests passed

Fixes #2771