### PR TITLE
Fix null-conditional delegate invocation

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -484,6 +484,11 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
+        var callableType = ce.NullableQuestionToken != null
+            && memberType is NullableTypeSymbol nullableMember
+            ? nullableMember.UnderlyingType
+            : memberType;
+
         if (isStatic)
         {
             var accessibility = matchedField?.Accessibility ?? matchedProperty.Accessibility;
@@ -494,15 +499,15 @@ internal sealed partial class ExpressionBinder
         }
 
         FunctionTypeSymbol functionType;
-        if (memberType is FunctionTypeSymbol fts)
+        if (callableType is FunctionTypeSymbol fts)
         {
             functionType = fts;
         }
-        else if (memberType is DelegateTypeSymbol nds)
+        else if (callableType is DelegateTypeSymbol nds)
         {
             functionType = nds.EquivalentFunctionType;
         }
-        else if (memberType.ClrType is System.Type memberClrType
+        else if (callableType.ClrType is System.Type memberClrType
             && ClrTypeUtilities.IsDelegateType(memberClrType)
             && MemberLookup.TryGetDelegateFunctionType(memberClrType, out var clrFn))
         {
@@ -581,8 +586,74 @@ internal sealed partial class ExpressionBinder
                 ? new BoundFieldAccessExpression(null, receiver, declaringType, matchedField, memberType)
                 : new BoundFieldAccessExpression(null, receiver, declaringType, matchedField)
             : new BoundPropertyAccessExpression(null, receiver, declaringType, matchedProperty);
-        result = new BoundIndirectCallExpression(null, memberLoad, functionType, convertedArgs.MoveToImmutable());
+        result = BuildDelegateMemberInvocation(
+            ce,
+            memberLoad,
+            callableType,
+            functionType,
+            convertedArgs.MoveToImmutable());
         return true;
+    }
+
+    private BoundExpression BuildDelegateMemberInvocation(
+        CallExpressionSyntax syntax,
+        BoundExpression delegateLoad,
+        TypeSymbol delegateType,
+        FunctionTypeSymbol functionType,
+        ImmutableArray<BoundExpression> arguments)
+    {
+        if (syntax.NullableQuestionToken == null)
+        {
+            return new BoundIndirectCallExpression(null, delegateLoad, functionType, arguments);
+        }
+
+        var captureName = "$ncap_" + (++binderCtx.NullConditionalCaptureCounter)
+            .ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var capture = new LocalVariableSymbol(captureName, isReadOnly: true, type: delegateType);
+        var invoke = new BoundIndirectCallExpression(
+            null,
+            new BoundVariableExpression(null, capture),
+            functionType,
+            arguments);
+        return BuildNullConditionalDelegateInvocation(syntax, delegateLoad, capture, invoke);
+    }
+
+    private BoundExpression BuildNullConditionalDelegateInvocation(
+        CallExpressionSyntax syntax,
+        BoundExpression delegateLoad,
+        LocalVariableSymbol capture,
+        BoundExpression invoke)
+    {
+        if (ReferenceEquals(invoke.Type, TypeSymbol.Void))
+        {
+            return new BoundNullConditionalAccessExpression(
+                syntax,
+                delegateLoad,
+                capture,
+                invoke,
+                TypeSymbol.Void,
+                resultSlot: null);
+        }
+
+        var resultType = invoke.Type is NullableTypeSymbol
+            ? invoke.Type
+            : (TypeSymbol)NullableTypeSymbol.Get(invoke.Type);
+        LocalVariableSymbol resultSlot = null;
+        if (resultType is NullableTypeSymbol nullableResult
+            && GSharp.Core.CodeAnalysis.Emit.ReflectionMetadataEmitter.IsValueTypeSymbol(nullableResult.UnderlyingType))
+        {
+            var resultSlotName = "$nres_" + binderCtx.NullConditionalCaptureCounter
+                .ToString(System.Globalization.CultureInfo.InvariantCulture);
+            resultSlot = new LocalVariableSymbol(resultSlotName, isReadOnly: false, type: resultType);
+        }
+
+        return new BoundNullConditionalAccessExpression(
+            syntax,
+            delegateLoad,
+            capture,
+            invoke,
+            resultType,
+            resultSlot);
     }
 
     /// <summary>
@@ -651,19 +722,31 @@ internal sealed partial class ExpressionBinder
         // a CLR struct field).
         var delegateLoad = new BoundClrPropertyAccessExpression(null, receiver, member, memberTypeSymbol);
 
-        // Strip nullable annotation when dispatching through Invoke — the
-        // delegate value is loaded as-is from the field; the call would
-        // dereference null at runtime if the member is unassigned. This
-        // matches CLR semantics for `del()` on a null `Func<T>`.
+        // Strip nullable annotation when dispatching through Invoke.
         var underlyingDelegateClr = memberClrType;
+
+        LocalVariableSymbol capture = null;
+        BoundExpression invokeReceiver = delegateLoad;
+        if (ce.NullableQuestionToken != null)
+        {
+            var captureType = memberTypeSymbol is NullableTypeSymbol nullableMember
+                ? nullableMember.UnderlyingType
+                : memberTypeSymbol;
+            var captureName = "$ncap_" + (++binderCtx.NullConditionalCaptureCounter)
+                .ToString(System.Globalization.CultureInfo.InvariantCulture);
+            capture = new LocalVariableSymbol(captureName, isReadOnly: true, type: captureType);
+            invokeReceiver = new BoundVariableExpression(null, capture);
+        }
 
         // Reuse the same Invoke-overload-resolution path that the bare
         // delegate-variable call uses at #325 (BindCallExpression), so
         // generic delegate arguments, named arguments, and ref/in/out are
         // all handled uniformly.
-        if (TryBindInheritedClrInstanceCall(delegateLoad, underlyingDelegateClr, "Invoke", arguments, ce, out var invokeCall, argumentNames: argumentNames))
+        if (TryBindInheritedClrInstanceCall(invokeReceiver, underlyingDelegateClr, "Invoke", arguments, ce, out var invokeCall, argumentNames: argumentNames))
         {
-            result = invokeCall;
+            result = capture == null
+                ? invokeCall
+                : BuildNullConditionalDelegateInvocation(ce, delegateLoad, capture, invokeCall);
             return true;
         }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
@@ -110,19 +110,6 @@ internal sealed partial class OverloadResolver
             return false;
         }
 
-        if (!argumentNames.IsDefault)
-        {
-            Diagnostics.ReportNamedArgumentParameterNotFound(syntax.Identifier.Location, variable.Name, FirstNamedArgumentName(argumentNames));
-            result = new BoundErrorExpression(null);
-            return true;
-        }
-
-        if (!TryBindFunctionTypeArguments(variable.Name, functionType, syntax, boundArguments, out var convertedArgs))
-        {
-            result = new BoundErrorExpression(null);
-            return true;
-        }
-
         var delegateLoad = TryBuildImplicitMemberLoad(variable, syntax.Identifier.Location, out var implicitLoad)
             ? implicitLoad
             : new BoundVariableExpression(null, variable);
@@ -136,7 +123,44 @@ internal sealed partial class OverloadResolver
             .ToString(System.Globalization.CultureInfo.InvariantCulture);
         var capture = new LocalVariableSymbol(captureName, isReadOnly: true, type: nullable.UnderlyingType);
         var captureRef = new BoundVariableExpression(null, capture);
-        var whenNotNull = new BoundIndirectCallExpression(null, captureRef, functionType, convertedArgs);
+        BoundExpression whenNotNull;
+        if (nullable.UnderlyingType is not FunctionTypeSymbol
+            && nullable.UnderlyingType is not DelegateTypeSymbol
+            && nullable.UnderlyingType.ClrType is System.Type delegateClr
+            && ClrTypeUtilities.IsDelegateType(delegateClr))
+        {
+            if (!tryBindInheritedClrInstanceCall(
+                captureRef,
+                delegateClr,
+                "Invoke",
+                boundArguments,
+                syntax,
+                out whenNotNull,
+                explicitTypeArgs: null,
+                typeArgSymbols: default,
+                argumentNames))
+            {
+                result = new BoundErrorExpression(null);
+                return true;
+            }
+        }
+        else
+        {
+            if (!argumentNames.IsDefault)
+            {
+                Diagnostics.ReportNamedArgumentParameterNotFound(syntax.Identifier.Location, variable.Name, FirstNamedArgumentName(argumentNames));
+                result = new BoundErrorExpression(null);
+                return true;
+            }
+
+            if (!TryBindFunctionTypeArguments(variable.Name, functionType, syntax, boundArguments, out var convertedArgs))
+            {
+                result = new BoundErrorExpression(null);
+                return true;
+            }
+
+            whenNotNull = new BoundIndirectCallExpression(null, captureRef, functionType, convertedArgs);
+        }
 
         if (ReferenceEquals(functionType.ReturnType, TypeSymbol.Void))
         {
@@ -155,7 +179,7 @@ internal sealed partial class OverloadResolver
             : (TypeSymbol)NullableTypeSymbol.Get(functionType.ReturnType);
         LocalVariableSymbol resultSlot = null;
         if (resultType is NullableTypeSymbol nullableResult
-            && nullableResult.UnderlyingType?.ClrType is { IsValueType: true })
+            && GSharp.Core.CodeAnalysis.Emit.ReflectionMetadataEmitter.IsValueTypeSymbol(nullableResult.UnderlyingType))
         {
             var resultSlotName = "$nres_" + binderCtx.NullConditionalCaptureCounter
                 .ToString(System.Globalization.CultureInfo.InvariantCulture);

--- a/test/Compiler.Tests/Emit/Issue1410NullableDelegatePropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1410NullableDelegatePropertyEmitTests.cs
@@ -10,8 +10,8 @@ using Xunit;
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>
-/// Issue #1410: null-conditional invocation of a nullable function-typed
-/// property must load the property getter result before invoking the delegate.
+/// Issues #1410 and #2772: null-conditional delegate invocation must capture
+/// the receiver once and skip both argument evaluation and Invoke when null.
 /// </summary>
 public class Issue1410NullableDelegatePropertyEmitTests
 {
@@ -71,6 +71,155 @@ public class Issue1410NullableDelegatePropertyEmitTests
             """;
 
         Assert.Equal("True\n42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void QualifiedDelegateProperty_NullConditionalInvoke_EvaluatesGetterAndArgumentsExactlyOnce()
+    {
+        var source = """
+            package P
+            import System
+
+            var argumentCalls = 0
+            func Argument() int32 {
+                argumentCalls = argumentCalls + 1
+                return 21
+            }
+
+            class Box {
+                var reads int32
+                var calls int32
+                var stored ((int32) -> int32)?
+
+                prop Transform ((int32) -> int32)? {
+                    get {
+                        reads = reads + 1
+                        return stored
+                    }
+                    set { stored = value }
+                }
+
+                func Install() {
+                    Transform = (x int32) -> {
+                        calls = calls + 1
+                        return x * 2
+                    }
+                }
+            }
+
+            let box = Box()
+            Console.WriteLine(box.Transform?(Argument()) ?? -1)
+            Console.WriteLine("${box.reads}:${argumentCalls}:${box.calls}")
+
+            box.Install()
+            Console.WriteLine(box.Transform?(Argument()) ?? -1)
+            Console.WriteLine("${box.reads}:${argumentCalls}:${box.calls}")
+            """;
+
+        Assert.Equal("-1\n1:0:0\n42\n2:1:1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableStructuralNamedAndImportedDelegateLocals_ShortCircuitAndInvoke()
+    {
+        var source = """
+            package P
+            import System
+
+            type Getter = delegate func() string
+
+            func NamedValue() string -> "named"
+
+            class Box {
+                prop Named Getter? { get; set; }
+                prop Imported Func[int32]? { get; set; }
+            }
+
+            let structuralMissing (() -> int32)? = nil
+            let structuralPresent (() -> int32)? = () -> 7
+            Console.WriteLine(structuralMissing?() ?? -1)
+            Console.WriteLine(structuralPresent?() ?? -1)
+
+            let namedMissing Getter? = nil
+            let namedValue Getter = NamedValue
+            let namedPresent Getter? = namedValue
+            Console.WriteLine(namedMissing?() ?? "missing")
+            Console.WriteLine(namedPresent?() ?? "missing")
+
+            let importedMissing Func[int32]? = nil
+            let importedPresent Func[int32]? = () -> 9
+            Console.WriteLine(importedMissing?() ?? -1)
+            Console.WriteLine(importedPresent?() ?? -1)
+
+            let box = Box()
+            Console.WriteLine(box.Named?() ?? "property-missing")
+            Console.WriteLine(box.Imported?() ?? -1)
+            box.Named = namedValue
+            box.Imported = () -> 11
+            Console.WriteLine(box.Named?() ?? "property-missing")
+            Console.WriteLine(box.Imported?() ?? -1)
+            """;
+
+        Assert.Equal("-1\n7\nmissing\nnamed\n-1\n9\nproperty-missing\n-1\nnamed\n11\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableVoidAndReferenceReturningDelegateProperties_ShortCircuitAndPlainCallStillThrows()
+    {
+        var source = """
+            package P
+            import System
+
+            class Box {
+                prop Notify ((string) -> void)? { get; set }
+                prop Text (() -> string)? { get; set }
+            }
+
+            let empty = Box()
+            empty.Notify?("skipped")
+            Console.WriteLine(empty.Text?() ?? "fallback")
+
+            let full = Box()
+            full.Notify = (value string) -> Console.WriteLine(value)
+            full.Text = () -> "value"
+            full.Notify?("called")
+            Console.WriteLine(full.Text?() ?? "fallback")
+
+            try {
+                empty.Text()
+            } catch (e NullReferenceException) {
+                Console.WriteLine("plain-call-threw")
+            }
+            """;
+
+        Assert.Equal("fallback\ncalled\nvalue\nplain-call-threw\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableDelegateProperty_InAsyncContext_ShortCircuitsAndInvokes()
+    {
+        var source = """
+            package P
+            import System
+            import System.Threading.Tasks
+
+            class Options {
+                prop ActivityVerb (() -> string)? { get; set; }
+            }
+
+            async func Read(options Options) string {
+                await Task.Delay(1)
+                return options.ActivityVerb?() ?? "idle"
+            }
+
+            let empty = Options()
+            let full = Options()
+            full.ActivityVerb = () -> "busy"
+            Console.WriteLine(Read(empty).GetAwaiter().GetResult())
+            Console.WriteLine(Read(full).GetAwaiter().GetResult())
+            """;
+
+        Assert.Equal("idle\nbusy\n", CompileAndRun(source));
     }
 
     private static string CompileAndRun(string source)


### PR DESCRIPTION
Fixes #2772

- Capture nullable delegate locals and members once before conditional Invoke
- Preserve argument short-circuiting, lifted results, imported/named delegates, and async state-machine captures
- Add runtime and ILVerify coverage with plain-call negative controls

Validation:
- Core.Tests: 6694 passed, 1 skipped
- Compiler.Tests: 3435 passed
- Oahu AppShell regression tests: 3 passed