### PR TITLE
Fix async catch branch continuation

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
@@ -454,7 +454,10 @@ public static class AsyncExceptionHandlerRewriter
 
             // Emit lifted catch handlers (for catch-with-await in try/catch/finally).
             // Each handler is guarded by its per-clause capture so it only runs
-            // when that specific typed catch actually fired.
+            // when that specific typed catch actually fired. Keep the lifted
+            // handlers in a try/catch so a rethrow (or a new exception from an
+            // awaited handler) is captured until the lifted finally has run.
+            var liftedHandlerStatements = ImmutableArray.CreateBuilder<BoundStatement>();
             foreach (var (original, body, captureLocal) in liftedCatchHandlers)
             {
                 var endLabel = MakeLabel("liftcatch_end");
@@ -469,34 +472,56 @@ public static class AsyncExceptionHandlerRewriter
                         TypeSymbol.Null),
                     nullLit);
 
-                statements.Add(new BoundConditionalGotoStatement(null, endLabel, condition, jumpIfTrue: true));
+                liftedHandlerStatements.Add(new BoundConditionalGotoStatement(null, endLabel, condition, jumpIfTrue: true));
 
                 var rebind = new BoundVariableDeclaration(
                     null,
                     original.Variable,
                     new BoundVariableExpression(null, captureLocal));
-                statements.Add(rebind);
+                liftedHandlerStatements.Add(rebind);
 
                 if (body is BoundBlockStatement block)
                 {
                     foreach (var stmt in block.Statements)
                     {
-                        statements.Add(stmt);
+                        liftedHandlerStatements.Add(stmt);
                     }
                 }
                 else
                 {
-                    statements.Add(body);
+                    liftedHandlerStatements.Add(body);
                 }
 
                 // Clear pendingException after handling so the rethrow below doesn't fire
-                statements.Add(new BoundExpressionStatement(
+                liftedHandlerStatements.Add(new BoundExpressionStatement(
                     null,
                     new BoundAssignmentExpression(
                         null,
                         pendingExLocal,
                         new BoundLiteralExpression(null, null, TypeSymbol.Null))));
-                statements.Add(new BoundLabelStatement(null, endLabel));
+                liftedHandlerStatements.Add(new BoundLabelStatement(null, endLabel));
+            }
+
+            if (liftedHandlerStatements.Count > 0)
+            {
+                var liftedEx = new LocalVariableSymbol(
+                    $"<>ex_lifted_{localOrdinal++}", isReadOnly: false, exceptionType);
+                var captureLiftedEx = new BoundExpressionStatement(
+                    null,
+                    new BoundAssignmentExpression(
+                        null,
+                        pendingExLocal,
+                        new BoundVariableExpression(null, liftedEx)));
+                statements.Add(new BoundTryStatement(
+                    null,
+                    new BoundBlockStatement(null, liftedHandlerStatements.ToImmutable()),
+                    ImmutableArray.Create(new BoundCatchClause(
+                        exceptionType,
+                        liftedEx,
+                        new BoundBlockStatement(
+                            null,
+                            ImmutableArray.Create<BoundStatement>(captureLiftedEx)))),
+                    finallyBlock: null));
             }
 
             // Pattern C: place the lifted-finally tail label that funneled exits

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -1458,20 +1458,14 @@ public sealed class Lowerer : BoundTreeRewriter
             case BoundGotoStatement:
                 return true;
             case BoundBlockStatement block:
-                {
-                    for (int i = block.Statements.Length - 1; i >= 0; i--)
-                    {
-                        var s = block.Statements[i];
-                        if (s is BoundLabelStatement)
-                        {
-                            continue;
-                        }
-
-                        return EndsInUnconditionalTransfer(s);
-                    }
-
-                    return false;
-                }
+                // A trailing label is a reachable continuation for branches
+                // inside the block, so the block can fall through even when
+                // the statement preceding that label is a throw/goto. Keeping
+                // that continuation preserves the branch around a later else
+                // arm when async catch awaits resume (#2781).
+                return block.Statements.Length > 0
+                    && block.Statements[block.Statements.Length - 1] is not BoundLabelStatement
+                    && EndsInUnconditionalTransfer(block.Statements[block.Statements.Length - 1]);
 
             default:
                 return false;

--- a/test/Compiler.Tests/Emit/Issue2781AsyncCatchBranchFallthroughEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2781AsyncCatchBranchFallthroughEmitTests.cs
@@ -1,0 +1,207 @@
+// <copyright file="Issue2781AsyncCatchBranchFallthroughEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2781: mutually exclusive catch branches must remain exclusive after
+/// awaited handlers are lifted into an async state machine.
+/// </summary>
+public class Issue2781AsyncCatchBranchFallthroughEmitTests
+{
+    [Fact]
+    public void AwaitedCatchBranches_PreserveFilteringRethrowFinallyAndControls()
+    {
+        const string Source = """
+            package Issue2781
+            import System
+            import System.Threading.Tasks
+
+            async func Step() ValueTask { await Task.Delay(1) }
+
+            async func Filtered(mode int32) string {
+                var result = "unset"
+                try {
+                    await Task.Yield()
+                    if mode == 0 { throw OperationCanceledException("cancel") }
+                    if mode == 1 { throw InvalidOperationException("general") }
+                    if mode == 2 { throw OperationCanceledException("other-cancel") }
+                    throw ArgumentException("rethrow")
+                } catch (__caught Exception) {
+                    if __caught is OperationCanceledException {
+                        let cancel = __caught
+                        if mode == 0 {
+                            result = "canceled"
+                            await Step().ConfigureAwait(false)
+                        } else {
+                            if cancel is Exception {
+                                let ex = cancel
+                                result = "failed-inner:" + ex.Message
+                                await Step().ConfigureAwait(false)
+                            } else { throw cancel }
+                        }
+                    } else {
+                        if __caught is InvalidOperationException {
+                            let ex = __caught
+                            result = "failed-outer:" + ex.Message
+                            await Step().ConfigureAwait(false)
+                        } else { throw __caught }
+                    }
+                } finally {
+                    Console.WriteLine("finally:${mode}")
+                }
+                return result
+            }
+
+            async func Typed(mode int32) string {
+                try {
+                    await Task.Yield()
+                    if mode == 0 { throw OperationCanceledException("cancel") }
+                    throw InvalidOperationException("general")
+                } catch (c OperationCanceledException) {
+                    await Step()
+                    return "typed-canceled:" + c.Message
+                } catch (e Exception) {
+                    await Step()
+                    return "typed-general:" + e.Message
+                }
+            }
+
+            func SyncFiltered(mode int32) string {
+                var result = "unset"
+                try {
+                    if mode == 0 { throw OperationCanceledException("cancel") }
+                    throw InvalidOperationException("general")
+                } catch (__caught Exception) {
+                    if __caught is OperationCanceledException {
+                        let cancel = __caught
+                        if mode == 0 { result = "sync-canceled" } else {
+                            if cancel is Exception { result = "sync-inner" } else { throw cancel }
+                        }
+                    } else {
+                        if __caught is InvalidOperationException {
+                            result = "sync-general"
+                        } else { throw __caught }
+                    }
+                }
+                return result
+            }
+
+            async func NonAwaitedHandler(mode int32) string {
+                var result = "unset"
+                try {
+                    await Task.Yield()
+                    if mode == 0 { throw OperationCanceledException("cancel") }
+                    throw InvalidOperationException("general")
+                } catch (__caught Exception) {
+                    if __caught is OperationCanceledException {
+                        let cancel = __caught
+                        if mode == 0 { result = "plain-canceled" } else {
+                            if cancel is Exception { result = "plain-inner" } else { throw cancel }
+                        }
+                    } else {
+                        if __caught is InvalidOperationException {
+                            result = "plain-general"
+                        } else { throw __caught }
+                    }
+                }
+                return result
+            }
+
+            Console.WriteLine(Filtered(0).GetAwaiter().GetResult())
+            Console.WriteLine(Filtered(1).GetAwaiter().GetResult())
+            Console.WriteLine(Filtered(2).GetAwaiter().GetResult())
+            try {
+                Console.WriteLine(Filtered(3).GetAwaiter().GetResult())
+            } catch (e ArgumentException) {
+                Console.WriteLine("rethrown:" + e.Message)
+            }
+            Console.WriteLine(Typed(0).GetAwaiter().GetResult())
+            Console.WriteLine(Typed(1).GetAwaiter().GetResult())
+            Console.WriteLine(SyncFiltered(0))
+            Console.WriteLine(SyncFiltered(1))
+            Console.WriteLine(NonAwaitedHandler(0).GetAwaiter().GetResult())
+            Console.WriteLine(NonAwaitedHandler(1).GetAwaiter().GetResult())
+            """;
+
+        Assert.Equal(
+            """
+            finally:0
+            canceled
+            finally:1
+            failed-outer:general
+            finally:2
+            failed-inner:other-cancel
+            finally:3
+            rethrown:rethrow
+            typed-canceled:cancel
+            typed-general:general
+            sync-canceled
+            sync-general
+            plain-canceled
+            plain-general
+
+            """.Replace("\r\n", "\n"),
+            CompileVerifyAndRun(Source));
+    }
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, "Issue2781Emit");
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            Assert.True(exitCode == 0, $"compile failed ({exitCode}):\n{stdout}\n{stderr}");
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        IlVerifier.Verify(outputPath);
+
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                outputPath,
+            },
+            WorkingDirectory = directory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(process.ExitCode == 0, error);
+        return output.Replace("\r\n", "\n");
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriterTests.cs
@@ -526,7 +526,9 @@ ImmutableArray.Create<BoundStatement>(
 
         // Assert
         var innerBlock = Assert.IsType<BoundBlockStatement>(result.Statements[0]);
-        var rewrittenTry = innerBlock.Statements.OfType<BoundTryStatement>().Single();
+        var rewrittenTries = innerBlock.Statements.OfType<BoundTryStatement>().ToArray();
+        Assert.Equal(2, rewrittenTries.Length);
+        var rewrittenTry = rewrittenTries[0];
         Assert.Null(rewrittenTry.FinallyBlock);
 
         // Two clauses: typed [ArgumentException] then catch-all [Exception]
@@ -534,6 +536,11 @@ ImmutableArray.Create<BoundStatement>(
         Assert.Equal(2, rewrittenTry.CatchClauses.Length);
         Assert.Same(argExType, rewrittenTry.CatchClauses[0].ExceptionType);
         Assert.Same(ExceptionType, rewrittenTry.CatchClauses[1].ExceptionType);
+
+        // The lifted handler is protected too, so a rethrow cannot bypass the
+        // lifted finally; its exception is captured and rethrown afterward.
+        Assert.Single(rewrittenTries[1].CatchClauses);
+        Assert.Same(ExceptionType, rewrittenTries[1].CatchClauses[0].ExceptionType);
     }
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- preserve reachable trailing labels when lowering nested mutually exclusive branches so awaited catch resumptions cannot enter a later branch
- capture exceptions from lifted awaited handlers until the lifted finally completes
- add runtime and ILVerify coverage for multiple awaited branches, translated type filters, nested conditions, cancellation/general ordering, rethrow/finally, and sync/non-awaited controls

## Validation
- targeted Compiler.Tests: 12 passed
- targeted Core.Tests: 23 passed
- full Compiler.Tests: 3,443 passed
- full Core.Tests: 6,698 passed, 1 skipped baseline
- Release solution build: 0 warnings, 0 errors
- migrated Oahu.Cli.App: ILVerify clean
- Oahu `JobSchedulerTests.Cancel_Stops_Job_And_Records_Canceled`: passed and asserted `JobPhase.Canceled` against the rebuilt migrated assembly

All test suites ran sequentially with `MSBUILDDISABLENODEREUSE=1`.

Fixes #2781