### PR TITLE
Fix generic delegate metadata cache scoping

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -2024,18 +2024,21 @@ internal sealed class ImportedMemberRefFactory
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
     }
 
-    // ADR-0087 §3 R6: cache for reified delegate (Func/Action) TypeSpecs
-    // keyed by a stable function-type symbol identity. A FunctionTypeSymbol
-    // is cached by its parameter/return symbol identities (see
-    // FunctionTypeSymbol.Get) so reference-equality is sufficient.
-    private readonly Dictionary<FunctionTypeSymbol, EntityHandle> functionDelegateTypeSpecCache =
-        new Dictionary<FunctionTypeSymbol, EntityHandle>(ReferenceEqualityComparer.Instance);
+    // ADR-0087 §3 R6: cache reified delegate metadata by function shape and
+    // active generic-remap scopes. The same interned FunctionTypeSymbol can
+    // encode as VAR inside a synthesized generic class and MVAR at its outer
+    // generic-method use site.
+    private readonly Dictionary<(FunctionTypeSymbol Type, object ClassRemap, object MethodRemap), EntityHandle>
+        functionDelegateTypeSpecCache = new();
 
-    private readonly Dictionary<FunctionTypeSymbol, EntityHandle> functionDelegateCtorRefCache =
-        new Dictionary<FunctionTypeSymbol, EntityHandle>(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<(FunctionTypeSymbol Type, object ClassRemap, object MethodRemap), EntityHandle>
+        functionDelegateCtorRefCache = new();
 
-    private readonly Dictionary<FunctionTypeSymbol, EntityHandle> functionDelegateInvokeRefCache =
-        new Dictionary<FunctionTypeSymbol, EntityHandle>(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<(FunctionTypeSymbol Type, object ClassRemap, object MethodRemap), EntityHandle>
+        functionDelegateInvokeRefCache = new();
+
+    private (FunctionTypeSymbol Type, object ClassRemap, object MethodRemap) GetFunctionDelegateCacheKey(FunctionTypeSymbol fnType)
+        => (fnType, this.remaps.ActiveIteratorStateMachineRemap, this.remaps.ActiveLambdaMethodTypeParamRemap);
 
     /// <summary>
     /// ADR-0087 §3 R6: returns a <c>TypeSpec</c> EntityHandle for the
@@ -2045,7 +2048,8 @@ internal sealed class ImportedMemberRefFactory
     /// </summary>
     internal EntityHandle GetFunctionDelegateTypeSpec(FunctionTypeSymbol fnType)
     {
-        if (this.functionDelegateTypeSpecCache.TryGetValue(fnType, out var cached))
+        var cacheKey = this.GetFunctionDelegateCacheKey(fnType);
+        if (this.functionDelegateTypeSpecCache.TryGetValue(cacheKey, out var cached))
         {
             return cached;
         }
@@ -2053,7 +2057,7 @@ internal sealed class ImportedMemberRefFactory
         var sigBlob = new BlobBuilder();
         this.signatures.EncodeFunctionTypeSymbol(new BlobEncoder(sigBlob).TypeSpecificationSignature(), fnType);
         var spec = (EntityHandle)this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.functionDelegateTypeSpecCache[fnType] = spec;
+        this.functionDelegateTypeSpecCache[cacheKey] = spec;
         return spec;
     }
 
@@ -2099,7 +2103,8 @@ internal sealed class ImportedMemberRefFactory
     /// </summary>
     internal EntityHandle GetFunctionDelegateCtorRef(FunctionTypeSymbol fnType)
     {
-        if (this.functionDelegateCtorRefCache.TryGetValue(fnType, out var cached))
+        var cacheKey = this.GetFunctionDelegateCacheKey(fnType);
+        if (this.functionDelegateCtorRefCache.TryGetValue(cacheKey, out var cached))
         {
             return cached;
         }
@@ -2124,7 +2129,7 @@ internal sealed class ImportedMemberRefFactory
             parent: parent,
             name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.functionDelegateCtorRefCache[fnType] = handle;
+        this.functionDelegateCtorRefCache[cacheKey] = handle;
         return handle;
     }
 
@@ -2143,7 +2148,8 @@ internal sealed class ImportedMemberRefFactory
     /// </summary>
     internal EntityHandle GetFunctionDelegateInvokeRef(FunctionTypeSymbol fnType)
     {
-        if (this.functionDelegateInvokeRefCache.TryGetValue(fnType, out var cached))
+        var cacheKey = this.GetFunctionDelegateCacheKey(fnType);
+        if (this.functionDelegateInvokeRefCache.TryGetValue(cacheKey, out var cached))
         {
             return cached;
         }
@@ -2187,7 +2193,7 @@ internal sealed class ImportedMemberRefFactory
             parent: parent,
             name: this.emitCtx.Metadata.GetOrAddString("Invoke"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.functionDelegateInvokeRefCache[fnType] = handle;
+        this.functionDelegateInvokeRefCache[cacheKey] = handle;
         return handle;
     }
 

--- a/test/Compiler.Tests/Emit/Issue1467GenericEncodingResidualEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1467GenericEncodingResidualEmitTests.cs
@@ -187,6 +187,29 @@ public class Issue1467GenericEncodingResidualEmitTests
         Assert.Equal("okC\n", output);
     }
 
+    [Fact]
+    public void Issue2785_GenericExtensionDelegateTypeSpecUsesMethodParameters()
+    {
+        var source = """
+            package Probe2785
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            func (source IEnumerable[TSource]) Flat[TSource, TResult](selector (TSource) -> IEnumerable[TResult]) IEnumerable[IEnumerable[TResult]] {
+                return source.Select((s TSource) -> selector(s)).ToArray()
+            }
+
+            func Main() {
+                var result = [1, 2].Flat((x int32) -> [x, x + 1])
+                Console.WriteLine(result.SelectMany((values IEnumerable[int32]) -> values).Sum())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("8\n", output);
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_1467_exe_").FullName;

--- a/test/Compiler.Tests/Emit/Issue1467GenericEncodingResidualEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1467GenericEncodingResidualEmitTests.cs
@@ -201,8 +201,14 @@ public class Issue1467GenericEncodingResidualEmitTests
             }
 
             func Main() {
-                var result = [1, 2].Flat((x int32) -> [x, x + 1])
-                Console.WriteLine(result.SelectMany((values IEnumerable[int32]) -> values).Sum())
+                var result = [2]int32{1, 2}.Flat((x int32) -> [2]int32{x, x + 1})
+                var total int32
+                for values in result {
+                    for value in values {
+                        total += value
+                    }
+                }
+                Console.WriteLine(total)
             }
             """;
 


### PR DESCRIPTION
Summary:
- scope symbolic Func/Action TypeSpec, constructor, and Invoke caches by active generic remaps
- prevent a closure-body VAR encoding from being reused at the enclosing generic-method MVAR use site
- add runtime and ILVerify coverage for a multi-parameter generic extension using Select/ToArray

Root cause: The same interned function type is emitted inside a reified generic closure and at its enclosing generic method. Delegate metadata was cached only by function-type identity, so the closure VAR TypeSpec could leak into the outer method where MVAR is required. ILVerify then indexed a nonexistent enclosing-type generic parameter and crashed.

Fixes #2785