### PR TITLE
Fix nominal CLR event delegate identity

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
@@ -693,6 +693,8 @@ internal sealed partial class DeclarationBinder
                     continue;
                 }
 
+                handlerType = MemberLookup.CanonicalizeWellKnownEventHandler(handlerType);
+
                 var eventSymbol = new EventSymbol(
                     eventName,
                     handlerType,

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -1704,6 +1704,7 @@ internal sealed partial class DeclarationBinder
                     baseBinding,
                     eventName,
                     handlerType);
+                handlerType = MemberLookup.CanonicalizeWellKnownEventHandler(handlerType);
 
                 var eventAccessibility = resolveAccessibility(eventSyntax.AccessibilityModifier);
                 bool isFieldLike = eventSyntax.OpenBraceToken == null;
@@ -1844,7 +1845,7 @@ internal sealed partial class DeclarationBinder
                 if (eventSyntax.Accessors.Any(a => a.IsRaise))
                 {
                     var raiseParams = ImmutableArray<ParameterSymbol>.Empty;
-                    if (handlerType is FunctionTypeSymbol fnType)
+                    if (MemberLookup.TryGetDelegateFunctionTypeFromSymbol(handlerType, out var fnType))
                     {
                         var builder = ImmutableArray.CreateBuilder<ParameterSymbol>(fnType.ParameterTypes.Length);
                         for (int pi = 0; pi < fnType.ParameterTypes.Length; pi++)
@@ -2550,6 +2551,8 @@ internal sealed partial class DeclarationBinder
                     continue;
                 }
 
+                handlerType = MemberLookup.CanonicalizeWellKnownEventHandler(handlerType);
+
                 var eventAccessibility = resolveAccessibility(eventSyntax.AccessibilityModifier);
                 bool isFieldLike = eventSyntax.OpenBraceToken == null;
 
@@ -2623,7 +2626,7 @@ internal sealed partial class DeclarationBinder
                 if (eventSyntax.Accessors.Any(a => a.IsRaise))
                 {
                     var raiseParams = ImmutableArray<ParameterSymbol>.Empty;
-                    if (handlerType is FunctionTypeSymbol fnType)
+                    if (MemberLookup.TryGetDelegateFunctionTypeFromSymbol(handlerType, out var fnType))
                     {
                         var builder = ImmutableArray.CreateBuilder<ParameterSymbol>(fnType.ParameterTypes.Length);
                         for (int pi = 0; pi < fnType.ParameterTypes.Length; pi++)

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2036,6 +2036,78 @@ internal sealed class MemberLookup
     }
 
     /// <summary>
+    /// Reifies the conventional structural CLR event shape as
+    /// <see cref="EventHandler"/> or <see cref="EventHandler{TEventArgs}"/>.
+    /// This is intentionally event-only: the same function shape in a method,
+    /// field, or local remains an <see cref="Action{T1,T2}"/>.
+    /// </summary>
+    /// <param name="handlerType">The declared event handler type.</param>
+    /// <returns>The matching nominal event delegate, or <paramref name="handlerType"/>.</returns>
+    public static TypeSymbol CanonicalizeWellKnownEventHandler(TypeSymbol handlerType)
+    {
+        if (handlerType is not FunctionTypeSymbol function
+            || function.Arity != 2
+            || function.HasVariadic
+            || !FunctionTypeSymbol.IsVoidReturn(function.ReturnType))
+        {
+            return handlerType;
+        }
+
+        var senderType = function.ParameterTypes[0] switch
+        {
+            NullableTypeSymbol nullable => nullable.UnderlyingType,
+            NullabilityAnnotatedTypeSymbol annotated => annotated.BaseType,
+            _ => null,
+        };
+        if (senderType == null
+            || !TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(senderType, TypeSymbol.Object))
+        {
+            return handlerType;
+        }
+
+        var eventArgsType = function.ParameterTypes[1];
+        var eventArgsClr = NullableLifting.GetEffectiveClrType(eventArgsType);
+        if (!IsEventArgsType(eventArgsType, eventArgsClr))
+        {
+            return handlerType;
+        }
+
+        if (eventArgsClr != null
+            && string.Equals(eventArgsClr.FullName, typeof(EventArgs).FullName, StringComparison.Ordinal))
+        {
+            return TypeSymbol.FromClrType(typeof(EventHandler));
+        }
+
+        var closedEventHandler = eventArgsClr == null
+            ? typeof(EventHandler<EventArgs>)
+            : typeof(EventHandler<>).MakeGenericType(eventArgsClr);
+        return ImportedTypeSymbol.GetConstructed(
+            closedEventHandler,
+            typeof(EventHandler<>),
+            ImmutableArray.Create(eventArgsType));
+
+        static bool IsEventArgsType(TypeSymbol type, Type clrType)
+        {
+            if (clrType != null)
+            {
+                return ClrTypeUtilities.IsAssignableByName(typeof(EventArgs), clrType);
+            }
+
+            for (var current = type as StructSymbol; current != null; current = current.BaseClass)
+            {
+                var importedBaseClr = NullableLifting.GetEffectiveClrType(current.ImportedBaseType);
+                if (importedBaseClr != null
+                    && ClrTypeUtilities.IsAssignableByName(typeof(EventArgs), importedBaseClr))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Issue #2130: resolves the effective lambda target shape for any target
     /// type that may consume a source lambda — a native function type, a
     /// delegate, or <c>System.Linq.Expressions.Expression&lt;TDelegate&gt;</c>.

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1948,21 +1948,15 @@ internal sealed class MemberLookup
             // `TryGetDelegateFunctionType(Type, ...)` below therefore widens
             // that argument to `object`. When the symbolic
             // `OpenDefinition`/`TypeArguments` shape (#313 construction) is
-            // available and every argument is fully resolved (no leftover
-            // open <see cref="TypeParameterSymbol"/>), build the
-            // `FunctionTypeSymbol` directly from that symbolic shape instead,
-            // preserving the real argument types. Falls through to the
+            // available, build the `FunctionTypeSymbol` directly from that
+            // symbolic shape instead, preserving real user types and open
+            // <see cref="TypeParameterSymbol"/> slots. Falls through to the
             // reflection-based path below for anything that isn't a simple
             // `Invoke(...)` shape mapping directly onto the delegate's own
-            // generic parameters (e.g. an Invoke signature that nests a type
-            // parameter inside another generic), and for genuinely-open
-            // generic parameters (still-unresolved method type parameters),
-            // which keep their existing (deliberate) `object`-widening
-            // behavior unchanged.
+            // generic parameters.
             case ImportedTypeSymbol imported
                 when imported.OpenDefinition != null
                     && !imported.TypeArguments.IsDefaultOrEmpty
-                    && !imported.TypeArguments.Any(TypeSymbol.ContainsTypeParameter)
                     && TryGetDelegateFunctionTypeFromOpenDefinition(imported.OpenDefinition, imported.TypeArguments, out functionType):
                 return true;
             default:
@@ -2091,6 +2085,13 @@ internal sealed class MemberLookup
             if (clrType != null)
             {
                 return ClrTypeUtilities.IsAssignableByName(typeof(EventArgs), clrType);
+            }
+
+            if (type is TypeParameterSymbol { ClassConstraint: TypeSymbol classConstraint })
+            {
+                return IsEventArgsType(
+                    classConstraint,
+                    NullableLifting.GetEffectiveClrType(classConstraint));
             }
 
             for (var current = type as StructSymbol; current != null; current = current.BaseClass)
@@ -3966,7 +3967,7 @@ internal sealed class MemberLookup
                 typeArguments,
                 openMethodDefinition: null,
                 methodTypeArguments: default);
-            if (mappedParam == null || mappedParam == TypeSymbol.Error || TypeSymbol.ContainsTypeParameter(mappedParam))
+            if (mappedParam == null || mappedParam == TypeSymbol.Error)
             {
                 return false;
             }
@@ -3995,7 +3996,7 @@ internal sealed class MemberLookup
                 typeArguments,
                 openMethodDefinition: null,
                 methodTypeArguments: default);
-            if (returnType == null || returnType == TypeSymbol.Error || TypeSymbol.ContainsTypeParameter(returnType))
+            if (returnType == null || returnType == TypeSymbol.Error)
             {
                 return false;
             }

--- a/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
@@ -1319,19 +1319,27 @@ internal sealed class MemberDefEmitter
         }
 
         // Build signature: parameters match the handler type's parameters, return void.
+        // Issue #2726 follow-up: resolve the raise parameters through the general
+        // delegate-shape helper so canonicalized nominal CLR handler types
+        // (`EventHandler`/`EventHandler<T>`) — which are `ImportedTypeSymbol`s, not
+        // `FunctionTypeSymbol`s — expose their real `(object, EventArgs)` /
+        // `(object, T)` parameters instead of falling through to a zero-parameter
+        // shape.
         int paramCount = 0;
-        if (ev.Type is FunctionTypeSymbol fnType)
+        FunctionTypeSymbol raiseShape = null;
+        if (MemberLookup.TryGetDelegateFunctionTypeFromSymbol(ev.Type, out var resolvedShape))
         {
-            paramCount = fnType.ParameterTypes.Length;
+            raiseShape = resolvedShape;
+            paramCount = resolvedShape.ParameterTypes.Length;
         }
 
         var sigBlob = new BlobBuilder();
         new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: !isStatic)
             .Parameters(paramCount, r => r.Void(), ps =>
             {
-                if (ev.Type is FunctionTypeSymbol fn)
+                if (raiseShape != null)
                 {
-                    foreach (var pt in fn.ParameterTypes)
+                    foreach (var pt in raiseShape.ParameterTypes)
                     {
                         this.encodeTypeSymbol(ps.AddParameter().Type(), pt);
                     }
@@ -1697,19 +1705,25 @@ internal sealed class MemberDefEmitter
             // Issue #257: emit abstract raise_X MethodDef if present.
             if (ev.RaiseMethodSymbol != null)
             {
+                // Issue #2726 follow-up: mirror the class/struct raise-signature fix
+                // so canonicalized nominal CLR handler types on interface events
+                // (`EventHandler`/`EventHandler<T>`) expose their real parameters
+                // instead of a zero-parameter shape.
                 int raiseParamCount = 0;
-                if (ev.Type is FunctionTypeSymbol fnType)
+                FunctionTypeSymbol raiseShape = null;
+                if (MemberLookup.TryGetDelegateFunctionTypeFromSymbol(ev.Type, out var resolvedShape))
                 {
-                    raiseParamCount = fnType.ParameterTypes.Length;
+                    raiseShape = resolvedShape;
+                    raiseParamCount = resolvedShape.ParameterTypes.Length;
                 }
 
                 var raiseSigBlob = new BlobBuilder();
                 new BlobEncoder(raiseSigBlob).MethodSignature(isInstanceMethod: true)
                     .Parameters(raiseParamCount, r => r.Void(), ps =>
                     {
-                        if (ev.Type is FunctionTypeSymbol fn)
+                        if (raiseShape != null)
                         {
-                            foreach (var pt in fn.ParameterTypes)
+                            foreach (var pt in raiseShape.ParameterTypes)
                             {
                                 this.encodeTypeSymbol(ps.AddParameter().Type(), pt);
                             }

--- a/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
@@ -1009,6 +1009,11 @@ internal sealed class MemberDefEmitter
             return this.GetEventTypeSpecHandle(type);
         }
 
+        if (type is ImportedTypeSymbol { OpenDefinition: not null, TypeArguments.IsDefaultOrEmpty: false })
+        {
+            return this.GetEventTypeSpecHandle(type);
+        }
+
         if (type.ClrType != null)
         {
             return this.getTypeHandleForMember(type.ClrType);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -602,7 +602,10 @@ internal sealed partial class MethodBodyEmitter
         if (node.Handler is BoundFunctionLiteralExpression literalHandler
             && node.EventType?.ClrType != null)
         {
-            var mappedDelegateType = this.outer.signatures.MapToReferenceClrType(node.EventType.ClrType);
+            var eventDelegateType = node.EventType is ImportedTypeSymbol imported
+                ? imported.ReifyClosedClrType()
+                : node.EventType.ClrType;
+            var mappedDelegateType = this.outer.signatures.MapToReferenceClrType(eventDelegateType);
             this.EmitFunctionLiteral(literalHandler, mappedDelegateType);
         }
         else

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -600,13 +600,18 @@ internal sealed partial class MethodBodyEmitter
         // and non-capturing lambdas both flow through the closure builder
         // with the correct target delegate ctor (object, IntPtr).
         if (node.Handler is BoundFunctionLiteralExpression literalHandler
+            && node.EventType is ImportedTypeSymbol { OpenDefinition: not null } symbolicDelegate)
+        {
+            this.EmitFunctionLiteral(
+                literalHandler,
+                overrideDelegateType: null,
+                symbolicDelegateCtorRef: this.outer.memberRefs.GetConstructedDelegateCtorRef(symbolicDelegate));
+        }
+        else if (node.Handler is BoundFunctionLiteralExpression literalHandlerWithClrType
             && node.EventType?.ClrType != null)
         {
-            var eventDelegateType = node.EventType is ImportedTypeSymbol imported
-                ? imported.ReifyClosedClrType()
-                : node.EventType.ClrType;
-            var mappedDelegateType = this.outer.signatures.MapToReferenceClrType(eventDelegateType);
-            this.EmitFunctionLiteral(literalHandler, mappedDelegateType);
+            var mappedDelegateType = this.outer.signatures.MapToReferenceClrType(node.EventType.ClrType);
+            this.EmitFunctionLiteral(literalHandlerWithClrType, mappedDelegateType);
         }
         else
         {
@@ -625,6 +630,20 @@ internal sealed partial class MethodBodyEmitter
             {
                 var accessorToken = this.outer.userTokens.ResolveUserStaticMethodToken(staticOwner, accessorMethodSymbol, accessorHandle);
                 this.il.OpCode(ILOpCode.Call);
+                this.il.Token(accessorToken);
+                return;
+            }
+
+            if (node.Receiver != null
+                && node.StructType is StructSymbol instanceOwner
+                && ReflectionMetadataEmitter.IsUserGenericTypeReference(instanceOwner)
+                && accessorMethodSymbol != null)
+            {
+                var accessorToken = this.outer.userTokens.ResolveUserInstanceMethodToken(
+                    instanceOwner,
+                    accessorMethodSymbol,
+                    accessorHandle);
+                this.il.OpCode(node.Event.IsVirtual || node.Event.IsOverride ? ILOpCode.Callvirt : ILOpCode.Call);
                 this.il.Token(accessorToken);
                 return;
             }

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -1366,6 +1366,22 @@ internal sealed class UserTokenResolver
                 $"Instance method '{method.Name}' has no emitted handle.");
         }
 
+        return this.ResolveUserInstanceMethodToken(containingType, method, openDef);
+    }
+
+    /// <summary>
+    /// Resolves a user instance method token when the caller owns a separately
+    /// planned MethodDef handle, such as a synthesized event accessor.
+    /// </summary>
+    /// <param name="containingType">The method's declaring type.</param>
+    /// <param name="method">The method symbol whose signature is encoded.</param>
+    /// <param name="openDef">The open MethodDef handle.</param>
+    /// <returns>The MethodDef or a MemberRef parented at the constructed type.</returns>
+    internal EntityHandle ResolveUserInstanceMethodToken(
+        StructSymbol containingType,
+        FunctionSymbol method,
+        MethodDefinitionHandle openDef)
+    {
         if (!ReflectionMetadataEmitter.IsUserGenericTypeReference(containingType))
         {
             return openDef;

--- a/test/Compiler.Tests/Emit/Issue2726NominalEventDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2726NominalEventDelegateEmitTests.cs
@@ -3,10 +3,13 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using System.Runtime.Loader;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -148,6 +151,106 @@ public sealed class Issue2726NominalEventDelegateEmitTests
         Assert.Equal(1, closedRaiser.GetMethod("Run")!.Invoke(
             instance,
             new[] { Activator.CreateInstance(localArgs) }));
+    }
+
+    [Fact]
+    public void ExplicitRaiseAccessors_ExposeIdenticalParameterSignaturesInOutAndRefoutMetadata()
+    {
+        // Issue #2726 follow-up: canonicalized nominal `EventHandler`/`EventHandler<T>`
+        // events with explicit `raise` accessors must expose the same raise_X
+        // parameter signature in the implementation (`/out`) assembly and the
+        // reference (`/refout`, MetadataOnly) assembly. The metadata-only fallback
+        // previously emitted zero-parameter raise_X methods because it only
+        // recognized `FunctionTypeSymbol` handler types, not canonicalized nominal
+        // CLR delegates.
+        const string source = """
+            package Issue2726.Refout
+            import System
+
+            class LocalArgs : EventArgs { }
+
+            class Raiser {
+                event ExplicitChanged (object?, EventArgs) -> void {
+                    add { }
+                    remove { }
+                    raise { }
+                }
+
+                event ExplicitLocal (object?, LocalArgs) -> void {
+                    add { }
+                    remove { }
+                    raise { }
+                }
+
+                event NominalChanged EventHandler[LocalArgs] {
+                    add { }
+                    remove { }
+                    raise { }
+                }
+            }
+
+            class GenericRaiser[T EventArgs] {
+                event OpenChanged EventHandler[T] {
+                    add { }
+                    remove { }
+                    raise { }
+                }
+            }
+            """;
+
+        using var artifacts = CompileGSharpWithReference(source, "RefoutRaise.dll");
+        IlVerifier.Verify(artifacts.OutputPath);
+
+        var implementationSignatures = ReadRaiseSignatureBlobs(artifacts.OutputPath);
+        var referenceSignatures = ReadRaiseSignatureBlobs(artifacts.ReferenceOutputPath);
+
+        var expectedRaiseMethods = new[]
+        {
+            "Raiser.raise_ExplicitChanged",
+            "Raiser.raise_ExplicitLocal",
+            "Raiser.raise_NominalChanged",
+            "GenericRaiser`1.raise_OpenChanged",
+        };
+
+        // The implementation assembly emits each explicit raise_X accessor.
+        Assert.Equal(
+            expectedRaiseMethods.OrderBy(name => name, StringComparer.Ordinal),
+            implementationSignatures.Keys.OrderBy(name => name, StringComparer.Ordinal));
+
+        // The reference assembly exposes the identical set of raise_X accessors...
+        Assert.Equal(
+            implementationSignatures.Keys.OrderBy(name => name, StringComparer.Ordinal),
+            referenceSignatures.Keys.OrderBy(name => name, StringComparer.Ordinal));
+
+        // ...with byte-for-byte identical parameter signatures, and a non-zero
+        // parameter count proving the metadata-only fallback no longer collapses
+        // canonicalized nominal handlers to a zero-parameter shape.
+        foreach (var raiseMethod in expectedRaiseMethods)
+        {
+            var implementationSignature = implementationSignatures[raiseMethod];
+            var referenceSignature = referenceSignatures[raiseMethod];
+            Assert.Equal(implementationSignature.Blob, referenceSignature.Blob);
+            Assert.Equal(2, implementationSignature.ParameterCount);
+            Assert.Equal(2, referenceSignature.ParameterCount);
+        }
+
+        // Tie the shared metadata back to concrete CLR parameter types on the
+        // loadable implementation assembly for the closed shapes.
+        var assembly = Assembly.LoadFrom(artifacts.OutputPath);
+        var raiser = assembly.GetType("Issue2726.Refout.Raiser")!;
+        var localArgs = assembly.GetType("Issue2726.Refout.LocalArgs")!;
+        Assert.Equal(
+            new[] { typeof(object), typeof(EventArgs) },
+            raiser.GetEvent("ExplicitChanged")!.GetRaiseMethod()!
+                .GetParameters().Select(parameter => parameter.ParameterType).ToArray());
+        Assert.Equal(
+            new[] { typeof(object), localArgs },
+            raiser.GetEvent("ExplicitLocal")!.GetRaiseMethod()!
+                .GetParameters().Select(parameter => parameter.ParameterType).ToArray());
+        Assert.Equal(
+            new[] { typeof(object), localArgs },
+            raiser.GetEvent("NominalChanged")!.GetRaiseMethod()!
+                .GetParameters().Select(parameter => parameter.ParameterType).ToArray());
     }
 
     [Fact]
@@ -337,6 +440,62 @@ public sealed class Issue2726NominalEventDelegateEmitTests
         return new CompilationArtifacts(directory, outputPath);
     }
 
+    private static ReferenceCompilationArtifacts CompileGSharpWithReference(string source, string outputName)
+    {
+        var directory = ArtifactDirectory();
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, outputName);
+        var referenceOutputPath = Path.Combine(
+            directory,
+            Path.GetFileNameWithoutExtension(outputName) + ".ref" + Path.GetExtension(outputName));
+        File.WriteAllText(sourcePath, source);
+        var result = RunCompiler(new[]
+        {
+            "/out:" + outputPath,
+            "/refout:" + referenceOutputPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            sourcePath,
+        });
+        Assert.True(result.ExitCode == 0, $"gsc failed:\n{result.Stdout}\n{result.Stderr}");
+        return new ReferenceCompilationArtifacts(directory, outputPath, referenceOutputPath);
+    }
+
+    private static Dictionary<string, RaiseSignature> ReadRaiseSignatureBlobs(string assemblyPath)
+    {
+        var signatures = new Dictionary<string, RaiseSignature>(StringComparer.Ordinal);
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            var typeName = reader.GetString(type.Name);
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                var methodName = reader.GetString(method.Name);
+                if (!methodName.StartsWith("raise_", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var blob = reader.GetBlobBytes(method.Signature);
+
+                // ECMA-335 II.23.2.1: the second byte of a non-generic method
+                // signature is the compressed parameter count (single-byte for the
+                // small counts used here).
+                signatures[$"{typeName}.{methodName}"] = new RaiseSignature(
+                    Convert.ToHexString(blob),
+                    blob[1]);
+            }
+        }
+
+        return signatures;
+    }
+
+    private readonly record struct RaiseSignature(string Blob, int ParameterCount);
+
     private static void CompileGSharpFile(string sourcePath, string outputPath)
     {
         var result = RunCompiler(new[]
@@ -404,6 +563,24 @@ public sealed class Issue2726NominalEventDelegateEmitTests
         public string Directory { get; }
 
         public string OutputPath { get; }
+
+        public void Dispose() => DeleteDirectory(Directory);
+    }
+
+    private sealed class ReferenceCompilationArtifacts : IDisposable
+    {
+        public ReferenceCompilationArtifacts(string directory, string outputPath, string referenceOutputPath)
+        {
+            Directory = directory;
+            OutputPath = outputPath;
+            ReferenceOutputPath = referenceOutputPath;
+        }
+
+        public string Directory { get; }
+
+        public string OutputPath { get; }
+
+        public string ReferenceOutputPath { get; }
 
         public void Dispose() => DeleteDirectory(Directory);
     }

--- a/test/Compiler.Tests/Emit/Issue2726NominalEventDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2726NominalEventDelegateEmitTests.cs
@@ -1,0 +1,407 @@
+// <copyright file="Issue2726NominalEventDelegateEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>Issue #2726: public events preserve nominal CLR delegate identity.</summary>
+public sealed class Issue2726NominalEventDelegateEmitTests
+{
+    [Fact]
+    public void StructuralEventHandlerEvents_ExposeNominalMetadataAndVerify()
+    {
+        const string source = """
+            package Issue2726
+            import System
+            import System.ComponentModel
+
+            interface IChanges {
+                event InterfaceChanged (object?, EventArgs) -> void
+            }
+
+            class LocalArgs : EventArgs { }
+
+            class Raiser {
+                event Changed (object?, EventArgs) -> void
+
+                event ExplicitChanged (object?, EventArgs) -> void {
+                    add { }
+                    remove { }
+                    raise { }
+                }
+
+                event DetailedChanged (object?, ListChangedEventArgs) -> void
+                event LocalChanged (object?, LocalArgs) -> void
+
+                func KeepStructural(callback (object?, EventArgs) -> void) { }
+
+                func SubscribeGenericHandlers() {
+                    DetailedChanged += (sender object?, args ListChangedEventArgs) -> { }
+                    LocalChanged += (sender object?, args LocalArgs) -> { }
+                }
+            }
+            """;
+
+        using var artifacts = CompileGSharp(source, "NominalEvents.dll");
+        IlVerifier.Verify(artifacts.OutputPath);
+
+        var assembly = Assembly.LoadFrom(artifacts.OutputPath);
+        var interfaceEvent = assembly.GetType("Issue2726.IChanges")!.GetEvent("InterfaceChanged")!;
+        var raiser = assembly.GetType("Issue2726.Raiser")!;
+
+        AssertEventAbi(interfaceEvent, typeof(EventHandler));
+        AssertEventAbi(raiser.GetEvent("Changed")!, typeof(EventHandler));
+        AssertEventAbi(raiser.GetEvent("ExplicitChanged")!, typeof(EventHandler));
+        AssertEventAbi(raiser.GetEvent("DetailedChanged")!, typeof(EventHandler<ListChangedEventArgs>));
+        AssertEventAbi(
+            raiser.GetEvent("LocalChanged")!,
+            typeof(EventHandler<>).MakeGenericType(assembly.GetType("Issue2726.LocalArgs")!));
+        Assert.Equal(
+            new[] { typeof(object), typeof(EventArgs) },
+            raiser.GetEvent("ExplicitChanged")!.GetRaiseMethod()!
+                .GetParameters()
+                .Select(parameter => parameter.ParameterType)
+                .ToArray());
+        Assert.Equal(
+            typeof(Action<object, EventArgs>),
+            raiser.GetMethod("KeepStructural")!.GetParameters().Single().ParameterType);
+    }
+
+    [Fact]
+    public void UnrelatedStructuralAndNamedDelegates_AreNotCanonicalized()
+    {
+        const string source = """
+            package Issue2726.Negative
+            import System
+
+            class Raiser {
+                event NonNullableSender (object, EventArgs) -> void
+                event OtherPayload (object?, string) -> void
+                event NamedAction Action[object, EventArgs]
+            }
+            """;
+
+        using var artifacts = CompileGSharp(source, "NegativeEvents.dll");
+        IlVerifier.Verify(artifacts.OutputPath);
+
+        var raiser = Assembly.LoadFrom(artifacts.OutputPath).GetType("Issue2726.Negative.Raiser")!;
+        AssertEventAbi(raiser.GetEvent("NonNullableSender")!, typeof(Action<object, EventArgs>));
+        AssertEventAbi(raiser.GetEvent("OtherPayload")!, typeof(Action<object, string>));
+        AssertEventAbi(raiser.GetEvent("NamedAction")!, typeof(Action<object, EventArgs>));
+    }
+
+    [Fact]
+    public void Override_Wins_Over_Inner_Quality()
+    {
+        using var artifacts = CompileBaselineConsumerAndMigratedContract();
+        using var loaded = LoadConsumer(artifacts);
+
+        var inner = Activator.CreateInstance(loaded.Contract.GetType("Oahu.Core.DownloadSettings")!, "inner")!;
+        var wrapper = Activator.CreateInstance(
+            loaded.Contract.GetType("Oahu.Core.PerJobDownloadSettings")!,
+            inner,
+            "override")!;
+
+        Assert.Equal("override", wrapper.GetType().GetMethod("GetQuality")!.Invoke(wrapper, null));
+    }
+
+    [Fact]
+    public void ChangedSettings_Subscription_Forwards_To_Inner()
+    {
+        using var artifacts = CompileBaselineConsumerAndMigratedContract();
+        using var loaded = LoadConsumer(artifacts);
+
+        var innerType = loaded.Contract.GetType("Oahu.Core.DownloadSettings")!;
+        var inner = Activator.CreateInstance(innerType, "inner")!;
+        var wrapper = Activator.CreateInstance(
+            loaded.Contract.GetType("Oahu.Core.PerJobDownloadSettings")!,
+            new object[] { inner, null })!;
+        var hits = 0;
+        EventHandler handler = (_, _) => hits++;
+
+        wrapper.GetType().GetEvent("ChangedSettings")!.AddEventHandler(wrapper, handler);
+        innerType.GetMethod("Raise")!.Invoke(inner, null);
+        wrapper.GetType().GetEvent("ChangedSettings")!.RemoveEventHandler(wrapper, handler);
+        innerType.GetMethod("Raise")!.Invoke(inner, null);
+
+        Assert.Equal(1, hits);
+    }
+
+    [Fact]
+    public void BaselineCompiledCSharpConsumer_BindsAndRunsAgainstMigratedContract()
+    {
+        using var artifacts = CompileBaselineConsumerAndMigratedContract();
+        using var loaded = LoadConsumer(artifacts);
+
+        var innerType = loaded.Contract.GetType("Oahu.Core.DownloadSettings")!;
+        var inner = Activator.CreateInstance(innerType, "inner")!;
+        var wrapper = Activator.CreateInstance(
+            loaded.Consumer.GetType("App.PerJobDownloadSettings")!,
+            new object[] { inner, null })!;
+        var hits = 0;
+        EventHandler handler = (_, _) => hits++;
+
+        wrapper.GetType().GetEvent("ChangedSettings")!.AddEventHandler(wrapper, handler);
+        innerType.GetMethod("Raise")!.Invoke(inner, null);
+
+        Assert.Equal(1, hits);
+    }
+
+    private static void AssertEventAbi(EventInfo @event, Type expectedHandler)
+    {
+        Assert.Equal(expectedHandler, @event.EventHandlerType);
+        Assert.Equal(expectedHandler, @event.GetAddMethod()!.GetParameters().Single().ParameterType);
+        Assert.Equal(expectedHandler, @event.GetRemoveMethod()!.GetParameters().Single().ParameterType);
+    }
+
+    private static CrossAssemblyArtifacts CompileBaselineConsumerAndMigratedContract()
+    {
+        var directory = ArtifactDirectory();
+        var baselinePath = Path.Combine(directory, "baseline", "Oahu.Core.dll");
+        var consumerPath = Path.Combine(directory, "consumer", "App.dll");
+        var migratedPath = Path.Combine(directory, "migrated", "Oahu.Core.dll");
+        Directory.CreateDirectory(Path.GetDirectoryName(baselinePath)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(consumerPath)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(migratedPath)!);
+
+        EmitCSharp(
+            """
+            using System;
+
+            namespace Oahu.Core;
+
+            public interface IDownloadSettings
+            {
+                event EventHandler ChangedSettings;
+                string GetQuality();
+            }
+            """,
+            baselinePath);
+
+        EmitCSharp(
+            """
+            using System;
+            using Oahu.Core;
+
+            namespace App;
+
+            public sealed class PerJobDownloadSettings
+            {
+                private readonly IDownloadSettings inner;
+                private readonly string quality;
+
+                public PerJobDownloadSettings(IDownloadSettings inner, string quality)
+                {
+                    this.inner = inner;
+                    this.quality = quality;
+                }
+
+                public string Quality => quality ?? inner.GetQuality();
+
+                public event EventHandler ChangedSettings
+                {
+                    add => inner.ChangedSettings += value;
+                    remove => inner.ChangedSettings -= value;
+                }
+            }
+            """,
+            consumerPath,
+            baselinePath);
+
+        const string migratedSource = """
+            package Oahu.Core
+            import System
+
+            interface IDownloadSettings {
+                event ChangedSettings (object?, EventArgs) -> void
+                func GetQuality() string;
+            }
+
+            class DownloadSettings : IDownloadSettings {
+                private var quality string
+                event ChangedSettings (object?, EventArgs) -> void
+
+                init(quality string) {
+                    this.quality = quality
+                }
+
+                func GetQuality() string { return quality }
+                func Raise() { this.ChangedSettings?.Invoke(this, EventArgs.Empty) }
+            }
+
+            class PerJobDownloadSettings : IDownloadSettings {
+                private var inner IDownloadSettings
+                private var quality string?
+
+                init(inner IDownloadSettings, quality string?) {
+                    this.inner = inner
+                    this.quality = quality
+                }
+
+                event ChangedSettings (object?, EventArgs) -> void {
+                    add { inner.ChangedSettings += value }
+                    remove { inner.ChangedSettings -= value }
+                }
+
+                func GetQuality() string { return quality ?? inner.GetQuality() }
+            }
+            """;
+
+        var sourcePath = Path.Combine(directory, "migrated", "Oahu.Core.gs");
+        File.WriteAllText(sourcePath, migratedSource);
+        CompileGSharpFile(sourcePath, migratedPath);
+
+        IlVerifier.Verify(migratedPath);
+        IlVerifier.Verify(consumerPath, additionalReferences: new[] { migratedPath });
+        return new CrossAssemblyArtifacts(directory, consumerPath, migratedPath);
+    }
+
+    private static LoadedConsumer LoadConsumer(CrossAssemblyArtifacts artifacts)
+    {
+        var context = new AssemblyLoadContext("Issue2726-" + Guid.NewGuid().ToString("N"), isCollectible: true);
+        context.Resolving += (_, name) => name.Name == "Oahu.Core"
+            ? context.LoadFromAssemblyPath(artifacts.MigratedPath)
+            : null;
+        var contract = context.LoadFromAssemblyPath(artifacts.MigratedPath);
+        var consumer = context.LoadFromAssemblyPath(artifacts.ConsumerPath);
+        return new LoadedConsumer(context, contract, consumer);
+    }
+
+    private static CompilationArtifacts CompileGSharp(string source, string outputName)
+    {
+        var directory = ArtifactDirectory();
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, outputName);
+        File.WriteAllText(sourcePath, source);
+        CompileGSharpFile(sourcePath, outputPath);
+        return new CompilationArtifacts(directory, outputPath);
+    }
+
+    private static void CompileGSharpFile(string sourcePath, string outputPath)
+    {
+        var result = RunCompiler(new[]
+        {
+            "/out:" + outputPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            sourcePath,
+        });
+        Assert.True(result.ExitCode == 0, $"gsc failed:\n{result.Stdout}\n{result.Stderr}");
+    }
+
+    private static void EmitCSharp(string source, string outputPath, params string[] additionalReferences)
+    {
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(path => MetadataReference.CreateFromFile(path))
+            .Concat(additionalReferences.Select(path => MetadataReference.CreateFromFile(path)));
+        var compilation = CSharpCompilation.Create(
+            Path.GetFileNameWithoutExtension(outputPath),
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var result = compilation.Emit(outputPath);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunCompiler(string[] args)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            return (Program.Main(args), stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string ArtifactDirectory()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2726-artifacts",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private sealed class CompilationArtifacts : IDisposable
+    {
+        public CompilationArtifacts(string directory, string outputPath)
+        {
+            Directory = directory;
+            OutputPath = outputPath;
+        }
+
+        public string Directory { get; }
+
+        public string OutputPath { get; }
+
+        public void Dispose() => DeleteDirectory(Directory);
+    }
+
+    private sealed class CrossAssemblyArtifacts : IDisposable
+    {
+        public CrossAssemblyArtifacts(string directory, string consumerPath, string migratedPath)
+        {
+            Directory = directory;
+            ConsumerPath = consumerPath;
+            MigratedPath = migratedPath;
+        }
+
+        public string Directory { get; }
+
+        public string ConsumerPath { get; }
+
+        public string MigratedPath { get; }
+
+        public void Dispose() => DeleteDirectory(Directory);
+    }
+
+    private sealed class LoadedConsumer : IDisposable
+    {
+        public LoadedConsumer(AssemblyLoadContext context, Assembly contract, Assembly consumer)
+        {
+            Context = context;
+            Contract = contract;
+            Consumer = consumer;
+        }
+
+        public AssemblyLoadContext Context { get; }
+
+        public Assembly Contract { get; }
+
+        public Assembly Consumer { get; }
+
+        public void Dispose() => Context.Unload();
+    }
+
+    private static void DeleteDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2726NominalEventDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2726NominalEventDelegateEmitTests.cs
@@ -101,6 +101,56 @@ public sealed class Issue2726NominalEventDelegateEmitTests
     }
 
     [Fact]
+    public void ConstrainedGenericStructuralEvent_PreservesOpenAbiAndLambdaRuns()
+    {
+        const string source = """
+            package Issue2726.Generic
+            import System
+
+            class LocalArgs : EventArgs { }
+
+            class GenericRaiser[T EventArgs] {
+                event Changed (object?, T) -> void
+                event NominalChanged EventHandler[T]
+
+                func Run(args T) int32 {
+                    var hits int32 = 0
+                    NominalChanged += (sender object?, value T) -> { hits += 1 }
+                    this.NominalChanged?.Invoke(this, args)
+                    return hits
+                }
+            }
+
+            class UnconstrainedRaiser[T any] {
+                event Changed (object?, T) -> void
+            }
+            """;
+
+        using var artifacts = CompileGSharp(source, "GenericEvents.dll");
+        IlVerifier.Verify(artifacts.OutputPath);
+
+        var assembly = Assembly.LoadFrom(artifacts.OutputPath);
+        var openRaiser = assembly.GetType("Issue2726.Generic.GenericRaiser`1")!;
+        var typeParameter = openRaiser.GetGenericArguments().Single();
+        var expectedHandler = typeof(EventHandler<>).MakeGenericType(typeParameter);
+        AssertEventAbi(openRaiser.GetEvent("Changed")!, expectedHandler);
+        AssertEventAbi(openRaiser.GetEvent("NominalChanged")!, expectedHandler);
+
+        var openUnconstrained = assembly.GetType("Issue2726.Generic.UnconstrainedRaiser`1")!;
+        var unconstrainedParameter = openUnconstrained.GetGenericArguments().Single();
+        AssertEventAbi(
+            openUnconstrained.GetEvent("Changed")!,
+            typeof(Action<,>).MakeGenericType(typeof(object), unconstrainedParameter));
+
+        var localArgs = assembly.GetType("Issue2726.Generic.LocalArgs")!;
+        var closedRaiser = openRaiser.MakeGenericType(localArgs);
+        var instance = Activator.CreateInstance(closedRaiser)!;
+        Assert.Equal(1, closedRaiser.GetMethod("Run")!.Invoke(
+            instance,
+            new[] { Activator.CreateInstance(localArgs) }));
+    }
+
+    [Fact]
     public void Override_Wins_Over_Inner_Quality()
     {
         using var artifacts = CompileBaselineConsumerAndMigratedContract();

--- a/test/Compiler.Tests/Emit/Issue2742InheritedInterfaceEventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2742InheritedInterfaceEventEmitTests.cs
@@ -50,11 +50,13 @@ public sealed class Issue2742InheritedInterfaceEventEmitTests
         var map = type.GetInterfaceMap(contract);
 
         var hits = 0;
-        Action<object, EventArgs> handler = (_, _) => hits++;
-        contract.GetEvent("ChangedSettings")!.AddEventHandler(instance, handler);
+        EventHandler handler = (_, _) => hits++;
+        var changedSettings = contract.GetEvent("ChangedSettings")!;
+        changedSettings.AddEventHandler(instance, handler);
         type.GetMethod("Raise")!.Invoke(instance, null);
 
         Assert.Equal(1, hits);
+        Assert.Equal(typeof(EventHandler), changedSettings.EventHandlerType);
         Assert.Equal(
             new[] { "add_ChangedSettings", "get_Flag", "Ping", "remove_ChangedSettings" },
             map.TargetMethods.Select(method => method.Name).OrderBy(name => name).ToArray());

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1899DelegateEventTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1899DelegateEventTranslationTests.cs
@@ -76,7 +76,7 @@ namespace Corpus.Issue1899
 }
 ");
 
-        Assert.Contains("event Ticked (object?, EventArgs) -> void", rendered, StringComparison.Ordinal);
+        Assert.Contains("event Ticked EventHandler", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1960DelegateEventFollowUpTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1960DelegateEventFollowUpTests.cs
@@ -198,12 +198,8 @@ namespace Corpus.Issue1960
     }
 
     [Fact]
-    public void EventFieldDeclaration_WithBclDelegate_StillUsesArrowForm()
+    public void EventFieldDeclaration_WithBclDelegate_PreservesNominalType()
     {
-        // A BCL delegate (EventHandler, Action, Func, ...) has no G# alias
-        // declaration to preserve, so it must keep lowering to the
-        // structural arrow form — the item-3 fix is scoped to
-        // SOURCE-declared delegates only.
         string rendered = Render(@"
 using System;
 
@@ -212,11 +208,16 @@ namespace Corpus.Issue1960
     public class TickSource
     {
         public event EventHandler? Ticked;
+        public event EventHandler<EventArgs>? Detailed;
+        public event Action<object, EventArgs>? ExplicitAction;
     }
 }
 ");
 
-        Assert.Contains("event Ticked (object?, EventArgs) -> void", rendered, StringComparison.Ordinal);
+        Assert.Contains("event Ticked EventHandler", rendered, StringComparison.Ordinal);
+        Assert.Contains("event Detailed EventHandler[EventArgs]", rendered, StringComparison.Ordinal);
+        Assert.Contains("event ExplicitAction Action[object, EventArgs]", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("event Ticked (object?, EventArgs) -> void", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2726GenericEventPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2726GenericEventPipelineTests.cs
@@ -1,0 +1,157 @@
+// <copyright file="Issue2726GenericEventPipelineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>Issue #2726: translated generic EventHandler events retain their open delegate identity.</summary>
+public sealed class Issue2726GenericEventPipelineTests
+{
+    [Fact]
+    public async Task TranslatedGenericEventHandler_LambdaRunsAndIlVerifies()
+    {
+        string compiler = FindCompiler();
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        if (compiler is null
+            || repoRoot is null
+            || GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null
+            || !IlVerifyToolAvailable())
+        {
+            return;
+        }
+
+        string sourceRoot = NewDirectory("scratch-projects");
+        string projectDirectory = Path.Combine(sourceRoot, "Issue2726");
+        Directory.CreateDirectory(projectDirectory);
+        string projectPath = Path.Combine(projectDirectory, "Issue2726.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <OutputType>Exe</OutputType>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(projectDirectory, "Program.cs"), """
+            using System;
+
+            namespace Issue2726;
+
+            public sealed class GenericRaiser<T> where T : EventArgs
+            {
+                public event EventHandler<T>? Changed;
+
+                public int Run(T args)
+                {
+                    var hits = 0;
+                    Changed += (sender, value) => { hits++; };
+                    Changed?.Invoke(this, args);
+                    return hits;
+                }
+            }
+
+            public static class Program
+            {
+                public static void Main() =>
+                    Console.WriteLine(new GenericRaiser<EventArgs>().Run(EventArgs.Empty));
+            }
+            """);
+        string goldenPath = Path.Combine(projectDirectory, "baseline.stdout.golden");
+        File.WriteAllText(goldenPath, "1\n");
+
+        string outputRoot = NewDirectory("pipeline-tests");
+        var app = new CorpusApp(
+            "test/Issue2726",
+            projectPath,
+            TargetKind.Exe,
+            stdoutGolden: goldenPath);
+        var pipeline = new MigrationPipeline(
+            new PipelineOptions
+            {
+                GscPath = compiler,
+                OutputRoot = outputRoot,
+                SourceRoot = sourceRoot,
+            },
+            new IMigrationStage[]
+            {
+                new TranslateStage(),
+                new CompileStage(),
+                new IlVerifyStage(),
+                new TestParityStage(),
+            });
+
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+        string appDirectory = Path.Combine(
+            outputRoot,
+            result.RunId,
+            MigrationPipeline.SanitizeAppId(app.Id));
+        string translated = File.ReadAllText(
+            Directory.GetFiles(appDirectory, "Program.gs", SearchOption.AllDirectories).Single());
+
+        Assert.Contains("event Changed EventHandler[T]", translated, StringComparison.Ordinal);
+        Assert.True(
+            appResult.Succeeded,
+            string.Join("; ", appResult.Stages.Select(stage => stage.Stage + "=" + stage.Status)));
+        Assert.Equal(
+            new[] { "passed", "passed", "passed", "passed" },
+            appResult.Stages.Select(stage => stage.Status).ToArray());
+    }
+
+    private static bool IlVerifyToolAvailable()
+    {
+        try
+        {
+            return !IlVerifyRunner.IsEnabled || new IlVerifyRunner().EnsureToolAvailable();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            category,
+            "issue2726",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindCompiler()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    directory.FullName,
+                    "out",
+                    "bin",
+                    configuration,
+                    "Compiler",
+                    "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -338,7 +338,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("event Changed (object?, int32) -> void", printed);
+        Assert.Contains("event Changed EventHandler[int32]", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -342,20 +342,9 @@ public sealed class CSharpTypeMapper
     }
 
     /// <summary>
-    /// Issue #1960 item 3: maps an event's handler type, preferring a
-    /// SOURCE-DECLARED named delegate's own name over the structural
-    /// <c>func(...)</c> arrow form that <see cref="Map"/> always uses for
-    /// delegate types. An event declared as <c>event Ticked TickHandler;</c>
-    /// round-trips higher-fidelity than the anonymous <c>event Ticked (int32)
-    /// -&gt; void</c> shape, and it matches C#'s own event-type story (named
-    /// delegates document the handler shape for consumers). Scoped to events
-    /// only (not <see cref="Map"/> generally) — a plain local/field/parameter
-    /// of a same-package named-delegate type still lowers through the arrow
-    /// form, since referencing a named delegate type from outside its own
-    /// declaration currently trips a gsc emitter bug ("Delegate 'X' has no
-    /// emitted TypeDef") for those positions; only the event accessor shape
-    /// has been verified to compile with the named form (see corpus
-    /// G07-Members-Console).
+    /// Maps an event's handler type without erasing its nominal delegate
+    /// identity. Event metadata and add/remove signatures are ABI-sensitive:
+    /// structurally equivalent delegates are not interchangeable in the CLR.
     /// </summary>
     /// <param name="type">The event's declared handler type.</param>
     /// <param name="context">The translation context that accumulates diagnostics.</param>
@@ -363,8 +352,7 @@ public sealed class CSharpTypeMapper
     /// <returns>The canonical G# type reference for the event's handler type.</returns>
     public GTypeReference MapEventType(ITypeSymbol type, TranslationContext context, Location location)
     {
-        if (type is INamedTypeSymbol { TypeKind: TypeKind.Delegate, DelegateInvokeMethod: not null } named &&
-            named.DeclaringSyntaxReferences.Length > 0)
+        if (type is INamedTypeSymbol { TypeKind: TypeKind.Delegate, DelegateInvokeMethod: not null } named)
         {
             if (named.IsGenericType)
             {


### PR DESCRIPTION
## Summary
- canonicalize conventional structural public event shapes to exact `EventHandler` / `EventHandler<TEventArgs>` identities, including EventArgs-derived class-constrained type parameters
- emit symbolic constructed delegate constructors and generic event accessor MemberRefs so enclosing `T` remains `!0`, never `object`
- preserve named delegate identities in cs2gs while leaving unrelated structural functions as `Action` / `Func`
- cover open generic EventDef/add/remove ABI, generic lambda runtime + ILVerify, translated generic-class parity + ILVerify, nullability negatives, migrated PerJobDownloadSettings behavior, and baseline-compiled C# consumption

## Validation
- `Compiler.Tests`: 3468 passed
- `Core.Tests`: 6701 passed, 1 skipped
- `Cs2Gs.Tests`: 1732 passed
- targeted generic ABI and translated pipeline tests passed after rebasing onto latest main

Fixes #2726