### PR TITLE
Fix user-generic metadata cache scoping across lambda remaps

### DIFF
--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -76,15 +76,26 @@ internal sealed class UserTokenResolver
     private readonly SignatureEncoder signatures;
     private readonly ImportedMemberRefFactory memberRefs;
 
-    private readonly Dictionary<(StructSymbol Sym, object Remap), EntityHandle> userStructTypeSpecCache = new();
-    private readonly Dictionary<(StructSymbol Containing, FieldSymbol DefField, object Remap), EntityHandle> userStructFieldRefCache = new();
-    private readonly Dictionary<(StructSymbol Containing, EntityHandle OpenMember, object Remap), EntityHandle> userStructMethodRefCache = new();
-    private readonly Dictionary<InterfaceSymbol, EntityHandle> userInterfaceTypeSpecCache = new(ReferenceEqualityComparer.Instance);
-    private readonly Dictionary<(InterfaceSymbol Containing, EntityHandle OpenMember), EntityHandle> userInterfaceMethodRefCache = new();
-    private readonly Dictionary<(InterfaceSymbol Containing, FieldSymbol DefField), EntityHandle> userInterfaceFieldRefCache = new();
-    private readonly Dictionary<DelegateTypeSymbol, EntityHandle> userDelegateTypeSpecCache = new(ReferenceEqualityComparer.Instance);
-    private readonly Dictionary<DelegateTypeSymbol, EntityHandle> userDelegateCtorRefCache = new(ReferenceEqualityComparer.Instance);
-    private readonly Dictionary<DelegateTypeSymbol, EntityHandle> userDelegateInvokeRefCache = new(ReferenceEqualityComparer.Instance);
+    // Issue #2793: user-declared generic metadata is encoding-sensitive to
+    // BOTH active remap channels — the class/state-machine remap
+    // (ActiveIteratorStateMachineRemap, VAR) and the generic-promoted-lambda
+    // remap (ActiveLambdaMethodTypeParamRemap, MVAR). The same user generic
+    // struct referenced inside a generic-promoted lambda encodes its type
+    // arguments under the lambda method's own MVAR ordinals, which differ from
+    // the enclosing method's MVAR ordinals at its outer use site. Keying only
+    // on the class remap let a lambda-scope TypeSpec/MemberRef leak into the
+    // enclosing scope (and vice versa), producing an out-of-range MVAR index
+    // (ilverify get_GenericParameters IndexOutOfRange / runtime
+    // BadImageFormatException). Both channels are part of every key.
+    private readonly Dictionary<(StructSymbol Sym, object ClassRemap, object MethodRemap), EntityHandle> userStructTypeSpecCache = new();
+    private readonly Dictionary<(StructSymbol Containing, FieldSymbol DefField, object ClassRemap, object MethodRemap), EntityHandle> userStructFieldRefCache = new();
+    private readonly Dictionary<(StructSymbol Containing, EntityHandle OpenMember, object ClassRemap, object MethodRemap), EntityHandle> userStructMethodRefCache = new();
+    private readonly Dictionary<(InterfaceSymbol Sym, object ClassRemap, object MethodRemap), EntityHandle> userInterfaceTypeSpecCache = new();
+    private readonly Dictionary<(InterfaceSymbol Containing, EntityHandle OpenMember, object ClassRemap, object MethodRemap), EntityHandle> userInterfaceMethodRefCache = new();
+    private readonly Dictionary<(InterfaceSymbol Containing, FieldSymbol DefField, object ClassRemap, object MethodRemap), EntityHandle> userInterfaceFieldRefCache = new();
+    private readonly Dictionary<(DelegateTypeSymbol Sym, object ClassRemap, object MethodRemap), EntityHandle> userDelegateTypeSpecCache = new();
+    private readonly Dictionary<(DelegateTypeSymbol Sym, object ClassRemap, object MethodRemap), EntityHandle> userDelegateCtorRefCache = new();
+    private readonly Dictionary<(DelegateTypeSymbol Sym, object ClassRemap, object MethodRemap), EntityHandle> userDelegateInvokeRefCache = new();
 
     // Issue #2118: per-lambda-function ordered ORIGINAL enclosing type
     // parameters used as the MethodSpec type arguments when the lambda is
@@ -787,6 +798,40 @@ internal sealed class UserTokenResolver
     }
 
     /// <summary>
+    /// Issue #2793: builds the user-struct <c>TypeSpec</c> cache key for
+    /// <paramref name="structSym"/> under the two encoding-sensitive remap
+    /// channels — the class/state-machine remap
+    /// (<see cref="GenericRemapState.ActiveIteratorStateMachineRemap"/>, VAR)
+    /// and the generic-promoted-lambda remap
+    /// (<see cref="GenericRemapState.ActiveLambdaMethodTypeParamRemap"/>, MVAR).
+    /// The object identity of each active remap distinguishes the same symbol
+    /// encoded under different scopes so a lambda-scope encoding is never
+    /// reused at an enclosing-method use site.
+    /// </summary>
+    private (StructSymbol Sym, object ClassRemap, object MethodRemap) GetUserStructRemapKey(StructSymbol structSym)
+        => (structSym, this.remaps.ActiveIteratorStateMachineRemap, this.remaps.ActiveLambdaMethodTypeParamRemap);
+
+    /// <summary>
+    /// Issue #2793: user-interface variant of <see cref="GetUserStructRemapKey"/>.
+    /// A user-declared generic interface's <c>TypeSpec</c>/<c>MemberRef</c> is
+    /// equally sensitive to both active remap channels through its encoded type
+    /// arguments (directly for the TypeSpec, transitively via the parent
+    /// TypeSpec for its member refs).
+    /// </summary>
+    private (InterfaceSymbol Sym, object ClassRemap, object MethodRemap) GetUserInterfaceRemapKey(InterfaceSymbol ifaceSym)
+        => (ifaceSym, this.remaps.ActiveIteratorStateMachineRemap, this.remaps.ActiveLambdaMethodTypeParamRemap);
+
+    /// <summary>
+    /// Issue #2793: user-delegate variant of <see cref="GetUserStructRemapKey"/>.
+    /// A user-declared generic named delegate's <c>TypeSpec</c>, <c>.ctor</c>
+    /// and <c>Invoke</c> refs are sensitive to both active remap channels
+    /// through the encoded type arguments of the (possibly shared) parent
+    /// TypeSpec.
+    /// </summary>
+    private (DelegateTypeSymbol Sym, object ClassRemap, object MethodRemap) GetUserDelegateRemapKey(DelegateTypeSymbol delegateSym)
+        => (delegateSym, this.remaps.ActiveIteratorStateMachineRemap, this.remaps.ActiveLambdaMethodTypeParamRemap);
+
+    /// <summary>
     /// ADR-0087 §3 R3: returns a <c>TypeSpec</c> EntityHandle for a
     /// user-declared generic type. When <paramref name="structSym"/>
     /// carries <see cref="StructSymbol.TypeArguments"/> the spec
@@ -797,7 +842,8 @@ internal sealed class UserTokenResolver
     /// </summary>
     internal EntityHandle GetUserStructTypeSpec(StructSymbol structSym)
     {
-        if (this.userStructTypeSpecCache.TryGetValue((structSym, this.remaps.ActiveIteratorStateMachineRemap), out var cached))
+        var cacheKey = this.GetUserStructRemapKey(structSym);
+        if (this.userStructTypeSpecCache.TryGetValue(cacheKey, out var cached))
         {
             return cached;
         }
@@ -820,7 +866,7 @@ internal sealed class UserTokenResolver
         }
 
         var spec = (EntityHandle)this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.userStructTypeSpecCache[(structSym, this.remaps.ActiveIteratorStateMachineRemap)] = spec;
+        this.userStructTypeSpecCache[cacheKey] = spec;
         return spec;
     }
 
@@ -968,7 +1014,8 @@ internal sealed class UserTokenResolver
     /// <returns>The TypeSpec handle.</returns>
     internal EntityHandle GetUserDelegateTypeSpec(DelegateTypeSymbol delegateSym)
     {
-        if (this.userDelegateTypeSpecCache.TryGetValue(delegateSym, out var cached))
+        var cacheKey = this.GetUserDelegateRemapKey(delegateSym);
+        if (this.userDelegateTypeSpecCache.TryGetValue(cacheKey, out var cached))
         {
             return cached;
         }
@@ -990,7 +1037,7 @@ internal sealed class UserTokenResolver
         }
 
         var spec = (EntityHandle)this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.userDelegateTypeSpecCache[delegateSym] = spec;
+        this.userDelegateTypeSpecCache[cacheKey] = spec;
         return spec;
     }
 
@@ -1017,7 +1064,7 @@ internal sealed class UserTokenResolver
             return ctorHandle;
         }
 
-        if (this.userDelegateCtorRefCache.TryGetValue(delegateSym, out var cached))
+        if (this.userDelegateCtorRefCache.TryGetValue(this.GetUserDelegateRemapKey(delegateSym), out var cached))
         {
             return cached;
         }
@@ -1038,7 +1085,7 @@ internal sealed class UserTokenResolver
             parent: parent,
             name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.userDelegateCtorRefCache[delegateSym] = memberRef;
+        this.userDelegateCtorRefCache[this.GetUserDelegateRemapKey(delegateSym)] = memberRef;
         return memberRef;
     }
 
@@ -1066,7 +1113,7 @@ internal sealed class UserTokenResolver
             return invokeHandle;
         }
 
-        if (this.userDelegateInvokeRefCache.TryGetValue(delegateSym, out var cached))
+        if (this.userDelegateInvokeRefCache.TryGetValue(this.GetUserDelegateRemapKey(delegateSym), out var cached))
         {
             return cached;
         }
@@ -1089,7 +1136,7 @@ internal sealed class UserTokenResolver
             parent: parent,
             name: this.emitCtx.Metadata.GetOrAddString("Invoke"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.userDelegateInvokeRefCache[delegateSym] = memberRef;
+        this.userDelegateInvokeRefCache[this.GetUserDelegateRemapKey(delegateSym)] = memberRef;
         return memberRef;
     }
 
@@ -1148,7 +1195,7 @@ internal sealed class UserTokenResolver
             defField = fieldOnContaining;
         }
 
-        var key = (containingType, defField, (object)this.remaps.ActiveIteratorStateMachineRemap);
+        var key = (containingType, defField, (object)this.remaps.ActiveIteratorStateMachineRemap, (object)this.remaps.ActiveLambdaMethodTypeParamRemap);
         if (this.userStructFieldRefCache.TryGetValue(key, out var cached))
         {
             return cached;
@@ -1235,7 +1282,7 @@ internal sealed class UserTokenResolver
         var def = containingInterface.Definition ?? containingInterface;
         var defField = def.GetStaticField(fieldOnContaining.Name) ?? fieldOnContaining;
 
-        var key = (containingInterface, defField);
+        var key = (containingInterface, defField, (object)this.remaps.ActiveIteratorStateMachineRemap, (object)this.remaps.ActiveLambdaMethodTypeParamRemap);
         if (this.userInterfaceFieldRefCache.TryGetValue(key, out var cached))
         {
             return cached;
@@ -1266,7 +1313,7 @@ internal sealed class UserTokenResolver
         string methodName,
         BlobBuilder signature)
     {
-        var key = (containingType, openMethodDef, (object)this.remaps.ActiveIteratorStateMachineRemap);
+        var key = (containingType, openMethodDef, (object)this.remaps.ActiveIteratorStateMachineRemap, (object)this.remaps.ActiveLambdaMethodTypeParamRemap);
         if (this.userStructMethodRefCache.TryGetValue(key, out var cached))
         {
             return cached;
@@ -1511,7 +1558,7 @@ internal sealed class UserTokenResolver
         string methodName,
         BlobBuilder signature)
     {
-        var key = (containingInterface, openMethodDef);
+        var key = (containingInterface, openMethodDef, (object)this.remaps.ActiveIteratorStateMachineRemap, (object)this.remaps.ActiveLambdaMethodTypeParamRemap);
         if (this.userInterfaceMethodRefCache.TryGetValue(key, out var cached))
         {
             return cached;
@@ -1667,7 +1714,8 @@ internal sealed class UserTokenResolver
     /// </summary>
     internal EntityHandle GetUserInterfaceTypeSpec(InterfaceSymbol ifaceSym)
     {
-        if (this.userInterfaceTypeSpecCache.TryGetValue(ifaceSym, out var cached))
+        var cacheKey = this.GetUserInterfaceRemapKey(ifaceSym);
+        if (this.userInterfaceTypeSpecCache.TryGetValue(cacheKey, out var cached))
         {
             return cached;
         }
@@ -1705,7 +1753,7 @@ internal sealed class UserTokenResolver
         }
 
         var spec = (EntityHandle)this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.userInterfaceTypeSpecCache[ifaceSym] = spec;
+        this.userInterfaceTypeSpecCache[cacheKey] = spec;
         return spec;
     }
 
@@ -1730,7 +1778,7 @@ internal sealed class UserTokenResolver
             return openDef;
         }
 
-        var key = (containingInterface, openDef);
+        var key = (containingInterface, openDef, (object)this.remaps.ActiveIteratorStateMachineRemap, (object)this.remaps.ActiveLambdaMethodTypeParamRemap);
         if (this.userInterfaceMethodRefCache.TryGetValue(key, out var cached))
         {
             return cached;

--- a/test/Compiler.Tests/Emit/Issue2793UserGenericLambdaCacheEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2793UserGenericLambdaCacheEmitTests.cs
@@ -1,0 +1,257 @@
+// <copyright file="Issue2793UserGenericLambdaCacheEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2793 — the user generic <c>TypeSpec</c>, field <c>MemberRef</c>, and
+/// method <c>MemberRef</c> caches in <c>UserTokenResolver</c> keyed only on the
+/// class/state-machine remap (<c>ActiveIteratorStateMachineRemap</c>) and
+/// ignored the generic-promoted-lambda remap
+/// (<c>ActiveLambdaMethodTypeParamRemap</c>). A user-declared generic struct
+/// referenced with an enclosing method type-parameter argument both inside a
+/// generic-promoted lambda (where that parameter is cloned to the lambda
+/// method's own <c>MVAR</c> ordinal) and at the enclosing method's own use site
+/// (where the same parameter keeps a different <c>MVAR</c> ordinal) therefore
+/// reused metadata encoded under the wrong MVAR scope. The emitted
+/// <c>TypeSpec</c>/<c>MemberRef</c> then referenced an out-of-range
+/// generic-method parameter — ilverify crashed in
+/// <c>get_GenericParameters</c> (IndexOutOfRange) and the JIT threw
+/// <see cref="System.BadImageFormatException"/> at run time — the user-generic
+/// analog of the #2785/#2791 function-delegate cache leak.
+///
+/// The trigger requires an ordinal mismatch between the two scopes: the lambda
+/// references only the SECOND enclosing type parameter, so its own single
+/// method type parameter is <c>MVAR(0)</c> while the enclosing method encodes
+/// the same parameter as <c>MVAR(1)</c>. Both scopes construct the same
+/// <c>Box[TB]</c> and call its <c>Get()</c>, exercising all three caches.
+///
+/// Both facets ilverify clean and JIT-run correctly after the fix. The
+/// interface and named-delegate facets exercise the sibling caches
+/// (<c>userInterface*</c> / <c>userDelegate*</c>) that shared the same latent
+/// leak and are keyed on the complete remap context by the same fix.
+/// </summary>
+public class Issue2793UserGenericLambdaCacheEmitTests
+{
+    [Fact]
+    public void GenericStruct_InPromotedLambda_AndEnclosingScope_IntString_Runs()
+    {
+        var source = """
+            package Probe2793a
+            import System
+
+            struct Box[T] {
+                var Value T
+                func Get() T { return Value }
+            }
+
+            func Build[TA, TB](a TA, b TB) TB {
+                var outer = Box[TB]{ Value: b }
+                let f (TB) -> TB = (x TB) -> Box[TB]{ Value: x }.Get()
+                return f(outer.Get())
+            }
+
+            func Main() {
+                Console.WriteLine(Build[int32, string](1, "hello"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\n", output);
+    }
+
+    [Fact]
+    public void GenericStruct_EnclosingUseAfterLambda_DifferentTypeArgs_Runs()
+    {
+        // Generalization: the enclosing Box[TB] use site follows the lambda
+        // (order independence), a third leading type parameter widens the
+        // ordinal gap (lambda MVAR(0) vs enclosing MVAR(2)), and the type
+        // argument differs. Regardless of use order the two scopes must not
+        // share a cached encoding.
+        var source = """
+            package Probe2793b
+            import System
+
+            struct Box[T] {
+                var Value T
+                func Get() T { return Value }
+            }
+
+            func Build[TA, TB, TC](a TA, b TB, c TC) TC {
+                let f (TC) -> TC = (x TC) -> Box[TC]{ Value: x }.Get()
+                var lambdaResult = f(c)
+                var outer = Box[TC]{ Value: lambdaResult }
+                return outer.Get()
+            }
+
+            func Main() {
+                Console.WriteLine(Build[int32, string, int64](1, "s", 42L))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void GenericInterface_InPromotedLambda_AndEnclosingScope_Runs()
+    {
+        // Issue #2793 deferred-work sibling: the user-interface TypeSpec /
+        // member-ref caches (GetUserInterfaceTypeSpec /
+        // GetUserInterfaceMethodRef / GetUserInterfaceFieldRef) keyed on
+        // nothing remap-related, so a generic interface referenced with an
+        // enclosing type-parameter argument leaked its encoding across the
+        // lambda/enclosing MVAR boundary the same way.
+        var source = """
+            package Probe2793i
+            import System
+
+            interface IBox[T] {
+                func Get() T;
+            }
+
+            struct Box[T] : IBox[T] {
+                var Value T
+                func Get() T { return Value }
+            }
+
+            func Build[TA, TB](a TA, b TB) TB {
+                var outer IBox[TB] = Box[TB]{ Value: b }
+                let f (TB) -> TB = (x TB) -> {
+                    var inner IBox[TB] = Box[TB]{ Value: x }
+                    return inner.Get()
+                }
+                return f(outer.Get())
+            }
+
+            func Main() {
+                Console.WriteLine(Build[int32, string](1, "hello"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\n", output);
+    }
+
+    [Fact]
+    public void GenericNamedDelegate_InPromotedLambda_AndEnclosingScope_Runs()
+    {
+        // Issue #2793 deferred-work sibling: the user named-delegate TypeSpec /
+        // .ctor / Invoke caches (GetUserDelegateTypeSpec /
+        // ResolveDelegateCtorToken / ResolveDelegateInvokeToken) keyed only on
+        // the delegate symbol, so a generic named delegate constructed with an
+        // enclosing type-parameter argument leaked its parent-TypeSpec encoding
+        // across the lambda/enclosing MVAR boundary.
+        var source = """
+            package Probe2793d
+            import System
+
+            type Holder[T] = delegate func(value T) T
+
+            func Build[TA, TB](a TA, b TB) TB {
+                var outer Holder[TB] = (v TB) -> v
+                let f (TB) -> TB = (x TB) -> {
+                    var inner Holder[TB] = (v TB) -> v
+                    return inner(x)
+                }
+                return f(outer(b))
+            }
+
+            func Main() {
+                Console.WriteLine(Build[int32, string](1, "hello"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2793_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
The user-generic `TypeSpec`, field `MemberRef`, and method `MemberRef` caches in `UserTokenResolver` keyed only on the class/state-machine remap (`ActiveIteratorStateMachineRemap`) and ignored the generic-promoted-lambda remap (`ActiveLambdaMethodTypeParamRemap`). A user-declared generic struct referenced with an enclosing method type parameter both inside a generic-promoted lambda (where that parameter is cloned to the lambda method's own MVAR ordinal) and at the enclosing method's own use site (a different MVAR ordinal) reused metadata encoded under the wrong MVAR scope. The emitted `TypeSpec`/`MemberRef` then referenced an out-of-range generic-method parameter:

- **ILVerify** crashed in `Internal.TypeSystem.Instantiation.get_GenericParameters` (`IndexOutOfRangeException`), via `SignatureMethodVariable.InstantiateSignature`.
- The **JIT** threw `System.BadImageFormatException` at run time inside the promoted lambda.

This is the user-generic analog of the #2785/#2791 function-delegate (`Func`/`Action`) cache leak.

## Fix
Key **every** encoding-sensitive user-generic metadata cache on the complete remap context — both the class/state-machine channel (VAR) and the generic-promoted-lambda channel (MVAR):

- `userStructTypeSpecCache`, `userStructFieldRefCache`, `userStructMethodRefCache` (the caches named in the issue).
- **Related deferred work, completed on this branch:** the sibling user **interface** caches (`userInterfaceTypeSpecCache` / method-ref / field-ref) and user **named-delegate** caches (`userDelegateTypeSpecCache` / `.ctor` / `Invoke`) shared the identical latent leak — in fact they keyed on *nothing* remap-related — and are hardened by the same change. Each was reproduced failing (ILVerify `get_GenericParameters` crash + runtime `BadImageFormatException`) before the fix.

The trigger requires an ordinal mismatch between the two scopes: the lambda references only the *second* enclosing type parameter, so its own single method type parameter is `MVAR(0)` while the enclosing method encodes the same parameter as `MVAR(1)`.

## Repro (fails before, passes after)

    struct Box[T] { var Value T; func Get() T { return Value } }

    func Build[TA, TB](a TA, b TB) TB {
        var outer = Box[TB]{ Value: b }
        let f (TB) -> TB = (x TB) -> Box[TB]{ Value: x }.Get()
        return f(outer.Get())
    }

## Tests
New `Issue2793UserGenericLambdaCacheEmitTests` with 4 facets (struct x2, generic interface, generic named delegate), each compiling, **ILVerify**-verifying, and JIT-running end-to-end.

- New regression class: 4/4 pass.
- Full `Compiler.Tests`: **3467 passed, 0 failed**.
- `Core.Tests` emit suite (`CodeAnalysis.Emit`): 741 passed, 1 skipped (`RegenerateBaseline`).

All runs used `MSBUILDDISABLENODEREUSE=1`.

## Deferred work
Zero deferred work. All encoding-sensitive user-generic metadata caches in `UserTokenResolver` are now keyed on the complete remap context.

Fixes #2793
