### PR TITLE
Fix null-conditional field-like event raise NRE with no subscribers

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
@@ -1026,12 +1026,44 @@ internal sealed partial class OverloadResolver
         // invocation of the delegate's `Invoke` method, identical in behavior
         // to the explicit `f.Invoke(x)` form.
         if (symbol is VariableSymbol delegateVar
-            && (narrowedCallTargetType ?? delegateVar.Type)?.ClrType is System.Type delegateClrType
+            && (narrowedCallTargetType ?? delegateVar.Type) is TypeSymbol delegateTargetType
+            && delegateTargetType.ClrType is System.Type delegateClrType
             && ClrTypeUtilities.IsDelegateType(delegateClrType))
         {
             var receiver = delegateVar is ImplicitFieldVariableSymbol clrImplicitField
                 ? BuildImplicitFieldLoad(clrImplicitField)
                 : (BoundExpression)new BoundVariableExpression(null, delegateVar);
+
+            // Issue #2796: a null-conditional raise `Evt?(args)` of a CLR
+            // delegate-typed value — canonically a field-like event's backing
+            // delegate, which PR #2792 (fix/2726) now emits as a nominal
+            // `System.EventHandler`/`EventHandler<T>` — must short-circuit to a
+            // no-op when the delegate is null, mirroring C# `Evt?.Invoke(args)`.
+            // Without the guard the emitted `callvirt Invoke` dereferences a
+            // null delegate and NREs on a fresh event with no subscribers. The
+            // FunctionTypeSymbol and named-delegate call paths above already
+            // guard the `void`-returning raise via BuildIndirectDelegateCall;
+            // the CLR-delegate path — reached once a structural
+            // `(object?, EventArgs) -> void` or nominal `EventHandler` event is
+            // a CLR delegate — must do the same. Only the canonical
+            // `void`-returning event-raise form is guarded here: the invoke
+            // leaves no value on the stack, so the null branch is a plain no-op.
+            // Value-returning conditional invocations keep their existing
+            // lowering and fall through to the plain Invoke path below.
+            if (syntax.NullableQuestionToken != null)
+            {
+                var eventRaiseCaptureName = "$ncap_" + (++binderCtx.NullConditionalCaptureCounter)
+                    .ToString(System.Globalization.CultureInfo.InvariantCulture);
+                var eventRaiseCapture = new LocalVariableSymbol(eventRaiseCaptureName, isReadOnly: true, type: delegateTargetType);
+                var eventRaiseCaptureRef = new BoundVariableExpression(null, eventRaiseCapture);
+                if (tryBindInheritedClrInstanceCall(eventRaiseCaptureRef, delegateClrType, "Invoke", boundArguments.ToImmutable(), syntax, out var guardedInvoke, null, default, argumentNames)
+                    && guardedInvoke is not BoundErrorExpression
+                    && ReferenceEquals(guardedInvoke.Type, TypeSymbol.Void))
+                {
+                    return new BoundNullConditionalAccessExpression(syntax, receiver, eventRaiseCapture, guardedInvoke, TypeSymbol.Void, resultSlot: null);
+                }
+            }
+
             if (tryBindInheritedClrInstanceCall(receiver, delegateClrType, "Invoke", boundArguments.ToImmutable(), syntax, out var invokeCall, null, default, argumentNames))
             {
                 return invokeCall;

--- a/test/Compiler.Tests/Emit/Issue2796NullConditionalEventRaiseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2796NullConditionalEventRaiseEmitTests.cs
@@ -1,0 +1,234 @@
+// <copyright file="Issue2796NullConditionalEventRaiseEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2796: the null-conditional raise form <c>Evt?(args)</c> of a
+/// field-like event must short-circuit to a no-op when the backing delegate is
+/// null (no subscribers), mirroring C# <c>Evt?.Invoke(args)</c>. PR #2792
+/// (fix/2726) canonicalizes conventional structural event shapes
+/// (<c>(object?, EventArgs) -> void</c>) and nominal <c>EventHandler</c> events
+/// to the CLR <c>System.EventHandler</c>/<c>EventHandler&lt;T&gt;</c> delegates,
+/// which routes the invocation through the CLR-delegate call path. That path
+/// lacked the null guard the FunctionTypeSymbol / named-delegate paths already
+/// carried, so a fresh event with no subscribers threw
+/// <see cref="NullReferenceException"/> instead of no-opping. These tests prove
+/// the emitted IL verifies and runs for the zero-subscriber, subscribed,
+/// unsubscribe-then-raise, and generic <c>EventHandler&lt;T&gt;</c> shapes.
+/// </summary>
+public class Issue2796NullConditionalEventRaiseEmitTests
+{
+    [Fact]
+    public void NominalEventHandlerRaise_NoSubscribers_IsSafeNoOp()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            class Bell {
+                event Rang EventHandler
+                func Ring() { Rang?(this, EventArgs.Empty) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var bellType = assembly.GetTypes().Single(t => t.Name == "Bell");
+        var instance = Activator.CreateInstance(bellType)!;
+
+        // No subscriber: the backing delegate is null, so raising must be a
+        // no-op rather than throwing a NullReferenceException.
+        var ring = bellType.GetMethod("Ring")!;
+        var ex = Record.Exception(() => ring.Invoke(instance, null));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void NominalEventHandlerRaise_WithSubscriber_InvokesHandler()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            class Bell {
+                event Rang EventHandler
+                func Ring() { Rang?(this, EventArgs.Empty) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var bellType = assembly.GetTypes().Single(t => t.Name == "Bell");
+        var instance = Activator.CreateInstance(bellType)!;
+
+        int hits = 0;
+        var ev = bellType.GetEvent("Rang")!;
+        EventHandler handler = (_, _) => hits++;
+        ev.AddEventHandler(instance, handler);
+
+        bellType.GetMethod("Ring")!.Invoke(instance, null);
+        Assert.Equal(1, hits);
+    }
+
+    [Fact]
+    public void StructuralEventArgsRaise_NoSubscribers_IsSafeNoOp()
+    {
+        // A conventional structural `(object?, EventArgs) -> void` event is
+        // canonicalized to nominal `System.EventHandler` by PR #2792; the raise
+        // must still no-op with no subscribers (regression the fix restores).
+        var source = """
+            package MyLib
+            import System
+
+            class Bell {
+                event Rang (object?, EventArgs) -> void
+                func Ring() { Rang?(this, EventArgs.Empty) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var bellType = assembly.GetTypes().Single(t => t.Name == "Bell");
+        var instance = Activator.CreateInstance(bellType)!;
+
+        var ring = bellType.GetMethod("Ring")!;
+        var ex = Record.Exception(() => ring.Invoke(instance, null));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void StructuralEventArgsRaise_WithSubscriber_InvokesHandler()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            class Bell {
+                event Rang (object?, EventArgs) -> void
+                func Ring() { Rang?(this, EventArgs.Empty) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var bellType = assembly.GetTypes().Single(t => t.Name == "Bell");
+        var instance = Activator.CreateInstance(bellType)!;
+
+        int hits = 0;
+        var ev = bellType.GetEvent("Rang")!;
+        EventHandler handler = (_, _) => hits++;
+        ev.AddEventHandler(instance, handler);
+
+        bellType.GetMethod("Ring")!.Invoke(instance, null);
+        Assert.Equal(1, hits);
+    }
+
+    [Fact]
+    public void NominalEventHandlerRaise_UnsubscribeThenRaise_IsSafeNoOp()
+    {
+        // The canonical `SettingsBase.OnChange` failure mode: after the last
+        // subscriber is removed the backing delegate is null again, so a
+        // subsequent raise must no-op rather than NRE.
+        var source = """
+            package MyLib
+            import System
+
+            class Bell {
+                event Rang EventHandler
+                func Ring() { Rang?(this, EventArgs.Empty) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var bellType = assembly.GetTypes().Single(t => t.Name == "Bell");
+        var instance = Activator.CreateInstance(bellType)!;
+        var ring = bellType.GetMethod("Ring")!;
+        var ev = bellType.GetEvent("Rang")!;
+
+        int hits = 0;
+        EventHandler handler = (_, _) => hits++;
+        ev.AddEventHandler(instance, handler);
+        ring.Invoke(instance, null);
+        Assert.Equal(1, hits);
+
+        ev.RemoveEventHandler(instance, handler);
+        var ex = Record.Exception(() => ring.Invoke(instance, null));
+        Assert.Null(ex);
+        Assert.Equal(1, hits);
+    }
+
+    [Fact]
+    public void GenericEventHandlerRaise_NoSubscribersAndWithSubscriber_Behaves()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            class Bus[T EventArgs] {
+                event Msg EventHandler[T]
+                func Fire(a T) { Msg?(this, a) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var openBus = assembly.GetTypes().Single(t => t.Name == "Bus`1");
+        var closedBus = openBus.MakeGenericType(typeof(EventArgs));
+        var instance = Activator.CreateInstance(closedBus)!;
+        var fire = closedBus.GetMethod("Fire")!;
+
+        // No subscriber: raising the generic event must no-op.
+        var ex = Record.Exception(() => fire.Invoke(instance, new object[] { EventArgs.Empty }));
+        Assert.Null(ex);
+
+        // With a subscriber the handler is invoked with the raised argument.
+        int hits = 0;
+        var ev = closedBus.GetEvent("Msg")!;
+        EventHandler<EventArgs> handler = (_, _) => hits++;
+        ev.AddEventHandler(instance, handler);
+        fire.Invoke(instance, new object[] { EventArgs.Empty });
+        Assert.Equal(1, hits);
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2796_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}


### PR DESCRIPTION
## Summary
A null-conditional raise `Evt?(args)` of a field-like event threw `NullReferenceException` when the event had **no subscribers** instead of being a no-op. This broke the canonical `Evt?(...)` / `Evt?.Invoke(...)` short-circuit for both **nominal `EventHandler`** and **structural `(object?, EventArgs) -> void`** events, and blocked 3 migrated Oahu tests at `Oahu.Core.SettingsBase.OnChange`.

### Root cause (regression of #2792)
PR #2792 (`fix/2726`) canonicalizes conventional structural event shapes and nominal `EventHandler` events to the CLR `System.EventHandler` / `EventHandler<T>` delegates. Their invocation therefore now routes through the **CLR-delegate call path** in `OverloadResolver.BindCallExpression` (dispatch via `Invoke`). Unlike the `FunctionTypeSymbol` and named-delegate paths — which already guard the void raise via `BuildIndirectDelegateCall` — that path emitted an unconditional `callvirt Invoke`, dereferencing a null backing delegate on a fresh event.

Commit bisect (from the issue): structural `evt_struct_null` raise works at `2621fa0a` (#2791) and breaks at `c84ca771` (#2792); both nominal and structural fail at the cycle-16 tip.

### Fix
In the CLR-delegate call path, when a null-conditional invocation targets a **void-returning** CLR delegate, bind `Invoke` against a captured receiver and wrap it in a `BoundNullConditionalAccessExpression`, so a null backing delegate short-circuits to a safe no-op — matching C# `Evt?.Invoke(args)`. This covers both nominal and structural field-like events with **no Oahu-specific logic**. Value-returning conditional invocations keep their existing lowering.

Emitted IL for the raise now becomes the standard null guard:
```
ldfld <event>; stloc.0; ldloc.0; brtrue not_null; br end; not_null: ...callvirt Invoke; end:
```

## Tests
New `Issue2796NullConditionalEventRaiseEmitTests` (runtime + ILVerify via the shared `IlVerifier.Verify` helper):
- nominal `EventHandler` zero-subscriber raise no-ops; with a subscriber invokes
- structural `(object?, EventArgs) -> void` zero-subscriber raise no-ops; with a subscriber invokes
- unsubscribe-then-raise no-ops (the `SettingsBase.OnChange` failure mode)
- generic `EventHandler<T>` zero-subscriber no-op and subscribed invoke

## Validation
- `Compiler.Tests`: **3495 passed, 0 failed**
- `Core.Tests`: **6704 passed, 1 skipped**
- Minimal repros (`evt_raise.gs`, `evt_struct_null.gs` no-op & exit 0; `evt_nonnull.gs` hits=1) pass and ILVerify clean
- Migrated Oahu.Core (recompiled with the patched gsc): the 3 previously-failing tests pass; full migrated `Oahu.Cli.Tests` **342/342 pass** (was 339/342)
- All suites run with `MSBUILDDISABLENODEREUSE=1`

Fixes #2796