### PR TITLE
Fix value-returning field-like event null-conditional invocation NRE

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
@@ -1030,9 +1030,32 @@ internal sealed partial class OverloadResolver
             && delegateTargetType.ClrType is System.Type delegateClrType
             && ClrTypeUtilities.IsDelegateType(delegateClrType))
         {
-            var receiver = delegateVar is ImplicitFieldVariableSymbol clrImplicitField
-                ? BuildImplicitFieldLoad(clrImplicitField)
-                : (BoundExpression)new BoundVariableExpression(null, delegateVar);
+            // Issue #2799 follow-up: the receiver load must honor every
+            // implicit-member variable kind, not only a plain local/parameter
+            // (a bare `BoundVariableExpression`) and the field-like event's
+            // implicit backing field. A nominal CLR delegate-typed value
+            // exposed as a bare static field or instance/static property
+            // (`ImplicitStaticFieldVariableSymbol` /
+            // `ImplicitPropertyVariableSymbol` /
+            // `ImplicitStaticPropertyVariableSymbol`) has no local slot, so a
+            // bare `BoundVariableExpression` ICE-d with GS9998 ("no local slot")
+            // on any invocation — conditional or not. `TryBuildImplicitMemberLoad`
+            // resolves each such symbol to the correct field/property access
+            // (the same helper the structural `FunctionTypeSymbol` path uses),
+            // leaving locals/parameters to the bare-variable fallback.
+            BoundExpression receiver;
+            if (delegateVar is ImplicitFieldVariableSymbol clrImplicitField)
+            {
+                receiver = BuildImplicitFieldLoad(clrImplicitField);
+            }
+            else if (TryBuildImplicitMemberLoad(delegateVar, syntax.Identifier.Location, out var clrMemberLoad))
+            {
+                receiver = clrMemberLoad;
+            }
+            else
+            {
+                receiver = new BoundVariableExpression(null, delegateVar);
+            }
 
             // Issue #2796 / #2798: a null-conditional raise `Evt?(args)` of a
             // CLR delegate-typed value — canonically a field-like event's
@@ -1062,24 +1085,7 @@ internal sealed partial class OverloadResolver
                 if (tryBindInheritedClrInstanceCall(eventRaiseCaptureRef, delegateClrType, "Invoke", boundArguments.ToImmutable(), syntax, out var guardedInvoke, null, default, argumentNames)
                     && guardedInvoke is not BoundErrorExpression)
                 {
-                    if (ReferenceEquals(guardedInvoke.Type, TypeSymbol.Void))
-                    {
-                        return new BoundNullConditionalAccessExpression(syntax, receiver, eventRaiseCapture, guardedInvoke, TypeSymbol.Void, resultSlot: null);
-                    }
-
-                    var resultType = guardedInvoke.Type is NullableTypeSymbol
-                        ? guardedInvoke.Type
-                        : (TypeSymbol)NullableTypeSymbol.Get(guardedInvoke.Type);
-                    LocalVariableSymbol resultSlot = null;
-                    if (resultType is NullableTypeSymbol nullableResult
-                        && GSharp.Core.CodeAnalysis.Emit.ReflectionMetadataEmitter.IsValueTypeSymbol(nullableResult.UnderlyingType))
-                    {
-                        var resultSlotName = "$nres_" + binderCtx.NullConditionalCaptureCounter
-                            .ToString(System.Globalization.CultureInfo.InvariantCulture);
-                        resultSlot = new LocalVariableSymbol(resultSlotName, isReadOnly: false, type: resultType);
-                    }
-
-                    return new BoundNullConditionalAccessExpression(syntax, receiver, eventRaiseCapture, guardedInvoke, resultType, resultSlot);
+                    return BuildNullConditionalDelegateResult(syntax, receiver, eventRaiseCapture, guardedInvoke, guardedInvoke.Type);
                 }
             }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
@@ -1034,22 +1034,25 @@ internal sealed partial class OverloadResolver
                 ? BuildImplicitFieldLoad(clrImplicitField)
                 : (BoundExpression)new BoundVariableExpression(null, delegateVar);
 
-            // Issue #2796: a null-conditional raise `Evt?(args)` of a CLR
-            // delegate-typed value — canonically a field-like event's backing
-            // delegate, which PR #2792 (fix/2726) now emits as a nominal
-            // `System.EventHandler`/`EventHandler<T>` — must short-circuit to a
-            // no-op when the delegate is null, mirroring C# `Evt?.Invoke(args)`.
-            // Without the guard the emitted `callvirt Invoke` dereferences a
-            // null delegate and NREs on a fresh event with no subscribers. The
+            // Issue #2796 / #2798: a null-conditional raise `Evt?(args)` of a
+            // CLR delegate-typed value — canonically a field-like event's
+            // backing delegate, which PR #2792 (fix/2726) now emits as a
+            // nominal `System.EventHandler`/`EventHandler<T>` or a canonicalized
+            // CLR `Func<...>`/named delegate — must short-circuit when the
+            // delegate is null, mirroring C# `Evt?.Invoke(args)`. Without the
+            // guard the emitted `callvirt Invoke` dereferences a null delegate
+            // and NREs on a fresh event with no subscribers. The
             // FunctionTypeSymbol and named-delegate call paths above already
-            // guard the `void`-returning raise via BuildIndirectDelegateCall;
-            // the CLR-delegate path — reached once a structural
-            // `(object?, EventArgs) -> void` or nominal `EventHandler` event is
-            // a CLR delegate — must do the same. Only the canonical
-            // `void`-returning event-raise form is guarded here: the invoke
-            // leaves no value on the stack, so the null branch is a plain no-op.
-            // Value-returning conditional invocations keep their existing
-            // lowering and fall through to the plain Invoke path below.
+            // guard the raise via BuildIndirectDelegateCall; the CLR-delegate
+            // path — reached once a structural `(object?, EventArgs) -> void`,
+            // nominal `EventHandler`, or nominal `Func<int, int>` event is a CLR
+            // delegate — must do the same for both the `void`-returning raise
+            // (a plain no-op null branch) and the value-returning raise
+            // (Issue #2798: the null branch must yield the correct
+            // optional/null result via the established result-slot lowering, so
+            // `var r = Evt?(x)` on a subscriber-less event produces null/default
+            // instead of NRE-ing). The receiver is evaluated once into
+            // `eventRaiseCapture`; a non-null delegate invokes normally.
             if (syntax.NullableQuestionToken != null)
             {
                 var eventRaiseCaptureName = "$ncap_" + (++binderCtx.NullConditionalCaptureCounter)
@@ -1057,10 +1060,26 @@ internal sealed partial class OverloadResolver
                 var eventRaiseCapture = new LocalVariableSymbol(eventRaiseCaptureName, isReadOnly: true, type: delegateTargetType);
                 var eventRaiseCaptureRef = new BoundVariableExpression(null, eventRaiseCapture);
                 if (tryBindInheritedClrInstanceCall(eventRaiseCaptureRef, delegateClrType, "Invoke", boundArguments.ToImmutable(), syntax, out var guardedInvoke, null, default, argumentNames)
-                    && guardedInvoke is not BoundErrorExpression
-                    && ReferenceEquals(guardedInvoke.Type, TypeSymbol.Void))
+                    && guardedInvoke is not BoundErrorExpression)
                 {
-                    return new BoundNullConditionalAccessExpression(syntax, receiver, eventRaiseCapture, guardedInvoke, TypeSymbol.Void, resultSlot: null);
+                    if (ReferenceEquals(guardedInvoke.Type, TypeSymbol.Void))
+                    {
+                        return new BoundNullConditionalAccessExpression(syntax, receiver, eventRaiseCapture, guardedInvoke, TypeSymbol.Void, resultSlot: null);
+                    }
+
+                    var resultType = guardedInvoke.Type is NullableTypeSymbol
+                        ? guardedInvoke.Type
+                        : (TypeSymbol)NullableTypeSymbol.Get(guardedInvoke.Type);
+                    LocalVariableSymbol resultSlot = null;
+                    if (resultType is NullableTypeSymbol nullableResult
+                        && GSharp.Core.CodeAnalysis.Emit.ReflectionMetadataEmitter.IsValueTypeSymbol(nullableResult.UnderlyingType))
+                    {
+                        var resultSlotName = "$nres_" + binderCtx.NullConditionalCaptureCounter
+                            .ToString(System.Globalization.CultureInfo.InvariantCulture);
+                        resultSlot = new LocalVariableSymbol(resultSlotName, isReadOnly: false, type: resultType);
+                    }
+
+                    return new BoundNullConditionalAccessExpression(syntax, receiver, eventRaiseCapture, guardedInvoke, resultType, resultSlot);
                 }
             }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
@@ -31,10 +31,14 @@ internal sealed partial class OverloadResolver
     /// (e.g. <c>ldfld Base::Changed</c>) — including the backing field declared
     /// on a base class, so an inherited event can be raised from a derived type
     /// — rather than a (non-existent) local slot.</description></item>
-    /// <item><description>The conditional raise form <c>Ev?(args)</c> on a
-    /// <c>void</c> delegate is guarded by a null check (a
+    /// <item><description>The conditional raise form <c>Ev?(args)</c> is
+    /// guarded by a null check (a
     /// <see cref="BoundNullConditionalAccessExpression"/>), so raising an event
-    /// with no subscribers is a safe no-op, mirroring <c>Ev?.Invoke(args)</c>.
+    /// with no subscribers is a safe short-circuit, mirroring
+    /// <c>Ev?.Invoke(args)</c>. A <c>void</c> delegate yields a plain no-op;
+    /// Issue #2798: a value-returning delegate yields the correct optional/null
+    /// result via the established result-slot lowering instead of NRE-ing on a
+    /// null backing delegate.
     /// </description></item>
     /// </list>
     /// </summary>
@@ -47,20 +51,52 @@ internal sealed partial class OverloadResolver
     {
         if (variable is ImplicitFieldVariableSymbol implicitField)
         {
-            if (syntax.NullableQuestionToken != null
-                && ReferenceEquals(fnType.ReturnType, TypeSymbol.Void))
+            // Issue #1213 / #2798: the null-conditional raise form `Ev?(args)`
+            // of a field-like event's implicit backing delegate must
+            // short-circuit when the delegate is null (no subscribers). The
+            // `void`-returning raise is a plain no-op; a value-returning raise
+            // (Issue #2798: e.g. a structural `(int32) -> int32` event) must
+            // yield the correct optional/null result via the established
+            // result-slot lowering rather than NRE-ing on a null backing
+            // delegate. The receiver is evaluated once into `capture`; a
+            // non-null delegate invokes normally.
+            if (syntax.NullableQuestionToken != null)
             {
                 var captureName = "$ncap_" + (++binderCtx.NullConditionalCaptureCounter)
                     .ToString(System.Globalization.CultureInfo.InvariantCulture);
                 var capture = new LocalVariableSymbol(captureName, isReadOnly: true, type: implicitField.Field.Type);
                 var invoke = new BoundIndirectCallExpression(null, new BoundVariableExpression(null, capture), fnType, args);
+
+                if (ReferenceEquals(fnType.ReturnType, TypeSymbol.Void))
+                {
+                    return new BoundNullConditionalAccessExpression(
+                        syntax,
+                        BuildImplicitFieldLoad(implicitField),
+                        capture,
+                        invoke,
+                        TypeSymbol.Void,
+                        resultSlot: null);
+                }
+
+                var resultType = fnType.ReturnType is NullableTypeSymbol
+                    ? fnType.ReturnType
+                    : (TypeSymbol)NullableTypeSymbol.Get(fnType.ReturnType);
+                LocalVariableSymbol resultSlot = null;
+                if (resultType is NullableTypeSymbol nullableResult
+                    && GSharp.Core.CodeAnalysis.Emit.ReflectionMetadataEmitter.IsValueTypeSymbol(nullableResult.UnderlyingType))
+                {
+                    var resultSlotName = "$nres_" + binderCtx.NullConditionalCaptureCounter
+                        .ToString(System.Globalization.CultureInfo.InvariantCulture);
+                    resultSlot = new LocalVariableSymbol(resultSlotName, isReadOnly: false, type: resultType);
+                }
+
                 return new BoundNullConditionalAccessExpression(
                     syntax,
                     BuildImplicitFieldLoad(implicitField),
                     capture,
                     invoke,
-                    TypeSymbol.Void,
-                    resultSlot: null);
+                    resultType,
+                    resultSlot);
             }
 
             return new BoundIndirectCallExpression(null, BuildImplicitFieldLoad(implicitField), fnType, args);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
@@ -23,24 +23,25 @@ internal sealed partial class OverloadResolver
 {
     /// <summary>
     /// Issue #1213 / #1221: lowers a call through a delegate/function-typed
-    /// variable to a <see cref="BoundIndirectCallExpression"/>, with two
-    /// event-raise refinements when the variable is the implicit backing-field
-    /// of a field-like event (an <see cref="ImplicitFieldVariableSymbol"/>):
-    /// <list type="bullet">
-    /// <item><description>The callee is loaded as a field read on <c>this</c>
-    /// (e.g. <c>ldfld Base::Changed</c>) — including the backing field declared
-    /// on a base class, so an inherited event can be raised from a derived type
-    /// — rather than a (non-existent) local slot.</description></item>
-    /// <item><description>The conditional raise form <c>Ev?(args)</c> is
-    /// guarded by a null check (a
-    /// <see cref="BoundNullConditionalAccessExpression"/>), so raising an event
-    /// with no subscribers is a safe short-circuit, mirroring
-    /// <c>Ev?.Invoke(args)</c>. A <c>void</c> delegate yields a plain no-op;
-    /// Issue #2798: a value-returning delegate yields the correct optional/null
-    /// result via the established result-slot lowering instead of NRE-ing on a
-    /// null backing delegate.
-    /// </description></item>
-    /// </list>
+    /// variable to a <see cref="BoundIndirectCallExpression"/>. When the
+    /// variable is the implicit backing-field of a field-like event (an
+    /// <see cref="ImplicitFieldVariableSymbol"/>) the callee is loaded as a
+    /// field read on <c>this</c> (e.g. <c>ldfld Base::Changed</c>) — including a
+    /// backing field declared on a base class, so an inherited event can be
+    /// raised from a derived type — rather than a (non-existent) local slot.
+    /// <para>
+    /// The null-conditional invocation form <c>Ev?(args)</c> is guarded by a
+    /// null check (a <see cref="BoundNullConditionalAccessExpression"/>) so a
+    /// null delegate short-circuits, mirroring <c>Ev?.Invoke(args)</c>. A
+    /// <c>void</c> delegate yields a plain no-op; Issue #2798: a value-returning
+    /// delegate yields the correct optional/null result via the established
+    /// result-slot lowering instead of NRE-ing (or silently dropping the
+    /// <c>?</c> and producing a non-optional result). Issue #2799 follow-up:
+    /// this guard applies uniformly across <b>every</b> receiver kind reaching
+    /// this path — implicit field-like event backing field, bare static field
+    /// or property, and a plain local or parameter — not only the field-like
+    /// event originally handled. The receiver is evaluated exactly once.
+    /// </para>
     /// </summary>
     private BoundExpression BuildIndirectDelegateCall(
         CallExpressionSyntax syntax,
@@ -49,72 +50,107 @@ internal sealed partial class OverloadResolver
         ImmutableArray<BoundExpression> args,
         TypeSymbol narrowedTargetType = null)
     {
+        // Compute the receiver load and its static type for each variable
+        // kind. Every non-null-conditional call below reduces to a plain
+        // `BoundIndirectCallExpression` on this receiver load; the null-
+        // conditional form additionally guards it (see below).
+        //
+        // Issue #2066: a smart-cast-narrowed local (and, for the fallthrough
+        // below, any local/parameter) carries the narrowed (non-nullable,
+        // possibly named-delegate) type so the emitter's
+        // `call.Target.Type is DelegateTypeSymbol` check in EmitIndirectCall
+        // dispatches through the named delegate's own Invoke MethodDef instead
+        // of the type-erased native-function Invoke, which would otherwise
+        // mismatch the value's actual runtime (named-delegate) shape and fail
+        // IL verification.
+        BoundExpression receiverLoad;
+        TypeSymbol receiverType;
         if (variable is ImplicitFieldVariableSymbol implicitField)
         {
-            // Issue #1213 / #2798: the null-conditional raise form `Ev?(args)`
-            // of a field-like event's implicit backing delegate must
-            // short-circuit when the delegate is null (no subscribers). The
-            // `void`-returning raise is a plain no-op; a value-returning raise
-            // (Issue #2798: e.g. a structural `(int32) -> int32` event) must
-            // yield the correct optional/null result via the established
-            // result-slot lowering rather than NRE-ing on a null backing
-            // delegate. The receiver is evaluated once into `capture`; a
-            // non-null delegate invokes normally.
-            if (syntax.NullableQuestionToken != null)
+            receiverLoad = BuildImplicitFieldLoad(implicitField);
+            receiverType = implicitField.Field.Type;
+        }
+        else if (TryBuildImplicitMemberLoad(variable, syntax.Identifier.Location, out var memberLoad))
+        {
+            receiverLoad = memberLoad;
+            receiverType = memberLoad.Type ?? narrowedTargetType ?? variable.Type;
+        }
+        else
+        {
+            receiverLoad = new BoundVariableExpression(null, variable, narrowedTargetType);
+            receiverType = narrowedTargetType ?? variable.Type;
+        }
+
+        // Issue #1213 / #2798 / #2799 follow-up: the null-conditional
+        // invocation form `Ev?(args)` of a structural function-typed value
+        // must short-circuit when the delegate is null, evaluating the
+        // receiver exactly once. The `void`-returning form is a plain no-op;
+        // a value-returning form yields the correct optional/null result via
+        // the established result-slot lowering rather than NRE-ing (or, worse,
+        // silently dropping the `?` and producing a non-optional result). This
+        // applies uniformly across every receiver kind that reaches this path
+        // — implicit backing field of a field-like event, bare static field or
+        // property, and a plain local or parameter — not just the field-like
+        // event handled originally.
+        if (syntax.NullableQuestionToken != null)
+        {
+            if (receiverLoad is BoundErrorExpression)
             {
-                var captureName = "$ncap_" + (++binderCtx.NullConditionalCaptureCounter)
-                    .ToString(System.Globalization.CultureInfo.InvariantCulture);
-                var capture = new LocalVariableSymbol(captureName, isReadOnly: true, type: implicitField.Field.Type);
-                var invoke = new BoundIndirectCallExpression(null, new BoundVariableExpression(null, capture), fnType, args);
-
-                if (ReferenceEquals(fnType.ReturnType, TypeSymbol.Void))
-                {
-                    return new BoundNullConditionalAccessExpression(
-                        syntax,
-                        BuildImplicitFieldLoad(implicitField),
-                        capture,
-                        invoke,
-                        TypeSymbol.Void,
-                        resultSlot: null);
-                }
-
-                var resultType = fnType.ReturnType is NullableTypeSymbol
-                    ? fnType.ReturnType
-                    : (TypeSymbol)NullableTypeSymbol.Get(fnType.ReturnType);
-                LocalVariableSymbol resultSlot = null;
-                if (resultType is NullableTypeSymbol nullableResult
-                    && GSharp.Core.CodeAnalysis.Emit.ReflectionMetadataEmitter.IsValueTypeSymbol(nullableResult.UnderlyingType))
-                {
-                    var resultSlotName = "$nres_" + binderCtx.NullConditionalCaptureCounter
-                        .ToString(System.Globalization.CultureInfo.InvariantCulture);
-                    resultSlot = new LocalVariableSymbol(resultSlotName, isReadOnly: false, type: resultType);
-                }
-
-                return new BoundNullConditionalAccessExpression(
-                    syntax,
-                    BuildImplicitFieldLoad(implicitField),
-                    capture,
-                    invoke,
-                    resultType,
-                    resultSlot);
+                return receiverLoad;
             }
 
-            return new BoundIndirectCallExpression(null, BuildImplicitFieldLoad(implicitField), fnType, args);
+            var captureName = "$ncap_" + (++binderCtx.NullConditionalCaptureCounter)
+                .ToString(System.Globalization.CultureInfo.InvariantCulture);
+            var capture = new LocalVariableSymbol(captureName, isReadOnly: true, type: receiverType);
+            var invoke = new BoundIndirectCallExpression(null, new BoundVariableExpression(null, capture), fnType, args);
+            return BuildNullConditionalDelegateResult(syntax, receiverLoad, capture, invoke, fnType.ReturnType);
         }
 
-        if (TryBuildImplicitMemberLoad(variable, syntax.Identifier.Location, out var memberLoad))
+        return new BoundIndirectCallExpression(null, receiverLoad, fnType, args);
+    }
+
+    /// <summary>
+    /// Wraps a null-conditional delegate/event invocation in a
+    /// <see cref="BoundNullConditionalAccessExpression"/> that short-circuits
+    /// when the captured receiver is null. A <c>void</c>-returning invocation
+    /// leaves no value (a plain no-op null branch); a value-returning
+    /// invocation adopts the established result-slot lowering — the result type
+    /// is the nullable wrapping of <paramref name="returnType"/>, and a
+    /// value-type return additionally allocates a <c>$nres_</c> slot so the null
+    /// branch can materialize <c>default(Nullable&lt;T&gt;)</c>. Shared by the
+    /// CLR-delegate call path (<c>OverloadResolver.CallBinding</c>) and the
+    /// structural <see cref="FunctionTypeSymbol"/> path
+    /// (<see cref="BuildIndirectDelegateCall"/>). The caller must have already
+    /// incremented <c>binderCtx.NullConditionalCaptureCounter</c> for the
+    /// capture; this method reuses that same value for the result slot.
+    /// </summary>
+    private BoundExpression BuildNullConditionalDelegateResult(
+        CallExpressionSyntax syntax,
+        BoundExpression receiverLoad,
+        LocalVariableSymbol capture,
+        BoundExpression whenNotNull,
+        TypeSymbol returnType)
+    {
+        if (ReferenceEquals(returnType, TypeSymbol.Void))
         {
-            return new BoundIndirectCallExpression(null, memberLoad, fnType, args);
+            return new BoundNullConditionalAccessExpression(
+                syntax, receiverLoad, capture, whenNotNull, TypeSymbol.Void, resultSlot: null);
         }
 
-        // Issue #2066: a smart-cast-narrowed local carries the narrowed
-        // (non-nullable, possibly named-delegate) type so the emitter's
-        // `call.Target.Type is DelegateTypeSymbol` check in EmitIndirectCall
-        // dispatches through the named delegate's own Invoke MethodDef
-        // instead of the type-erased native-function Invoke, which would
-        // otherwise mismatch the value's actual runtime (named-delegate)
-        // shape and fail IL verification.
-        return new BoundIndirectCallExpression(null, new BoundVariableExpression(null, variable, narrowedTargetType), fnType, args);
+        var resultType = returnType is NullableTypeSymbol
+            ? returnType
+            : (TypeSymbol)NullableTypeSymbol.Get(returnType);
+        LocalVariableSymbol resultSlot = null;
+        if (resultType is NullableTypeSymbol nullableResult
+            && GSharp.Core.CodeAnalysis.Emit.ReflectionMetadataEmitter.IsValueTypeSymbol(nullableResult.UnderlyingType))
+        {
+            var resultSlotName = "$nres_" + binderCtx.NullConditionalCaptureCounter
+                .ToString(System.Globalization.CultureInfo.InvariantCulture);
+            resultSlot = new LocalVariableSymbol(resultSlotName, isReadOnly: false, type: resultType);
+        }
+
+        return new BoundNullConditionalAccessExpression(
+            syntax, receiverLoad, capture, whenNotNull, resultType, resultSlot);
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue2798NullConditionalValueEventRaiseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2798NullConditionalValueEventRaiseEmitTests.cs
@@ -1,0 +1,353 @@
+// <copyright file="Issue2798NullConditionalValueEventRaiseEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2798: the null-conditional raise form <c>Evt?(args)</c> of a
+/// field-like event whose delegate <b>returns a value</b> must short-circuit to
+/// the correct optional/null result when the backing delegate is null (no
+/// subscribers), mirroring C# <c>Evt?.Invoke(args)</c>. PR #2797 (issue #2796)
+/// fixed the <c>void</c>-returning raise on both the nominal CLR-delegate path
+/// (<c>OverloadResolver.CallBinding</c>) and the structural
+/// <see cref="Symbols.FunctionTypeSymbol"/> path
+/// (<c>OverloadResolver.Invocations.BuildIndirectDelegateCall</c>), but both
+/// guarded only the <c>void</c> result and emitted an unconditional
+/// <c>callvirt Invoke</c> for value-returning delegates — NRE-ing on a fresh
+/// event with no subscribers.
+/// <para>
+/// This fix generalizes the established nullable-delegate invocation result-slot
+/// lowering (the same lowering <c>TryBindNullableDelegateInvocation</c> uses for
+/// nullable delegate properties, issue #2772) to both paths so a null receiver
+/// yields <c>null</c>/<c>default</c>, the receiver is evaluated once, and a
+/// non-null delegate invokes normally. These tests cover nominal
+/// <c>Func&lt;...&gt;</c> and structural function delegates, reference- and
+/// value-returning shapes, zero-subscriber / subscribed / unsubscribe-then-call
+/// cases, side-effectful argument single-evaluation and short-circuit, natural
+/// <c>??</c> fallback consumption (including value-type null coalescing), runtime
+/// behavior, metadata, and ILVerify.
+/// </para>
+/// </summary>
+public class Issue2798NullConditionalValueEventRaiseEmitTests
+{
+    [Fact]
+    public void NominalFuncValueReturn_NoSubscribers_YieldsNullFallback()
+    {
+        // Nominal CLR `Func<int, int>` event, value-returning. With no
+        // subscribers the null-conditional raise must produce a null optional
+        // whose `?? -1` fallback yields -1 rather than throwing NRE.
+        var source = """
+            package MyLib
+            import System
+
+            class Poll {
+                event Ask Func[int32,int32]
+                func Run() int32 {
+                    var r = Ask?(5)
+                    return r ?? -1
+                }
+            }
+            """;
+
+        var poll = CompilePollType(source, out _);
+        var instance = Activator.CreateInstance(poll)!;
+        var run = poll.GetMethod("Run")!;
+
+        Assert.Equal(-1, run.Invoke(instance, null));
+    }
+
+    [Fact]
+    public void NominalFuncValueReturn_WithSubscriber_InvokesAndReturnsValue()
+    {
+        var source = """
+            package MyLib
+            import System
+
+            class Poll {
+                event Ask Func[int32,int32]
+                func Run() int32 {
+                    var r = Ask?(5)
+                    return r ?? -1
+                }
+            }
+            """;
+
+        var poll = CompilePollType(source, out _);
+        var instance = Activator.CreateInstance(poll)!;
+        var run = poll.GetMethod("Run")!;
+
+        Subscribe(poll, instance, nameof(IntDoubler));
+        Assert.Equal(10, run.Invoke(instance, null));
+    }
+
+    [Fact]
+    public void StructuralFunctionValueReturn_NoSubscribers_YieldsNullFallback()
+    {
+        // Structural `(int32) -> int32` event routes through
+        // BuildIndirectDelegateCall. The value-returning raise must yield the
+        // null fallback with no subscribers.
+        var source = """
+            package MyLib
+
+            class Poll {
+                event Ask (int32) -> int32
+                func Run() int32 {
+                    var r = Ask?(5)
+                    return r ?? -1
+                }
+            }
+            """;
+
+        var poll = CompilePollType(source, out _);
+        var instance = Activator.CreateInstance(poll)!;
+        var run = poll.GetMethod("Run")!;
+
+        Assert.Equal(-1, run.Invoke(instance, null));
+    }
+
+    [Fact]
+    public void StructuralFunctionValueReturn_WithSubscriber_InvokesAndReturnsValue()
+    {
+        var source = """
+            package MyLib
+
+            class Poll {
+                event Ask (int32) -> int32
+                func Run() int32 {
+                    var r = Ask?(5)
+                    return r ?? -1
+                }
+            }
+            """;
+
+        var poll = CompilePollType(source, out _);
+        var instance = Activator.CreateInstance(poll)!;
+        var run = poll.GetMethod("Run")!;
+
+        Subscribe(poll, instance, nameof(IntDoubler));
+        Assert.Equal(10, run.Invoke(instance, null));
+    }
+
+    [Fact]
+    public void NominalFuncReferenceReturn_ZeroSubscriberAndSubscribed_Behaves()
+    {
+        // Reference-returning shape: the null branch leaves `ldnull` (a valid
+        // Nullable<ref>), no value-type result slot involved.
+        var source = """
+            package MyLib
+            import System
+
+            class Poll {
+                event Ask Func[string,string]
+                func Run() string {
+                    var r = Ask?("hi")
+                    return r ?? "none"
+                }
+            }
+            """;
+
+        var poll = CompilePollType(source, out _);
+        var instance = Activator.CreateInstance(poll)!;
+        var run = poll.GetMethod("Run")!;
+
+        Assert.Equal("none", run.Invoke(instance, null));
+
+        Subscribe(poll, instance, nameof(StringShout));
+        Assert.Equal("HI", run.Invoke(instance, null));
+    }
+
+    [Fact]
+    public void StructuralFunctionReferenceReturn_ZeroSubscriberAndSubscribed_Behaves()
+    {
+        var source = """
+            package MyLib
+
+            class Poll {
+                event Ask (string) -> string
+                func Run() string {
+                    var r = Ask?("hi")
+                    return r ?? "none"
+                }
+            }
+            """;
+
+        var poll = CompilePollType(source, out _);
+        var instance = Activator.CreateInstance(poll)!;
+        var run = poll.GetMethod("Run")!;
+
+        Assert.Equal("none", run.Invoke(instance, null));
+
+        Subscribe(poll, instance, nameof(StringShout));
+        Assert.Equal("HI", run.Invoke(instance, null));
+    }
+
+    [Fact]
+    public void ValueReturn_BareResult_IsNilWhenNoSubscribers()
+    {
+        // Without a `??` fallback the null-conditional result is a genuine
+        // optional; `r == nil` must be true with no subscribers and false once
+        // a subscriber is attached.
+        var source = """
+            package MyLib
+            import System
+
+            class Poll {
+                event Ask Func[int32,int32]
+                func IsNil() bool {
+                    var r = Ask?(5)
+                    return r == nil
+                }
+            }
+            """;
+
+        var poll = CompilePollType(source, out _);
+        var instance = Activator.CreateInstance(poll)!;
+        var isNil = poll.GetMethod("IsNil")!;
+
+        Assert.Equal(true, isNil.Invoke(instance, null));
+
+        Subscribe(poll, instance, nameof(IntDoubler));
+        Assert.Equal(false, isNil.Invoke(instance, null));
+    }
+
+    [Fact]
+    public void ValueReturn_UnsubscribeThenCall_YieldsNullFallbackAgain()
+    {
+        // After the last subscriber is removed the backing delegate is null
+        // again, so a subsequent value-returning raise must yield the null
+        // fallback rather than NRE (the SettingsBase.OnChange failure mode,
+        // value-returning variant).
+        var source = """
+            package MyLib
+            import System
+
+            class Poll {
+                event Ask Func[int32,int32]
+                func Run() int32 {
+                    var r = Ask?(5)
+                    return r ?? -1
+                }
+            }
+            """;
+
+        var poll = CompilePollType(source, out _);
+        var instance = Activator.CreateInstance(poll)!;
+        var run = poll.GetMethod("Run")!;
+        var ev = poll.GetEvent("Ask")!;
+        var handler = Delegate.CreateDelegate(ev.EventHandlerType!, typeof(Issue2798NullConditionalValueEventRaiseEmitTests).GetMethod(nameof(IntDoubler))!);
+
+        ev.AddEventHandler(instance, handler);
+        Assert.Equal(10, run.Invoke(instance, null));
+
+        ev.RemoveEventHandler(instance, handler);
+        Assert.Equal(-1, run.Invoke(instance, null));
+    }
+
+    [Fact]
+    public void ValueReturn_SideEffectfulArgument_EvaluatedOnceAndShortCircuits()
+    {
+        // The raised argument must be evaluated exactly once on the non-null
+        // path and not at all when the receiver is null (C# `Evt?.Invoke(arg)`
+        // short-circuit). `Bump()` increments an observable counter.
+        var source = """
+            package MyLib
+            import System
+
+            class Poll {
+                var counter int32
+                event Ask Func[int32,int32]
+                func Bump() int32 {
+                    counter = counter + 1
+                    return counter
+                }
+                func Count() int32 { return counter }
+                func Run() int32 {
+                    var r = Ask?(Bump())
+                    return r ?? -1
+                }
+            }
+            """;
+
+        var poll = CompilePollType(source, out _);
+        var instance = Activator.CreateInstance(poll)!;
+        var run = poll.GetMethod("Run")!;
+        var count = poll.GetMethod("Count")!;
+
+        // No subscriber: the argument (Bump) must NOT be evaluated.
+        Assert.Equal(-1, run.Invoke(instance, null));
+        Assert.Equal(0, count.Invoke(instance, null));
+
+        // Subscribed: the argument is evaluated exactly once (counter -> 1),
+        // and the doubled result (2) is returned.
+        Subscribe(poll, instance, nameof(IntDoubler));
+        Assert.Equal(2, run.Invoke(instance, null));
+        Assert.Equal(1, count.Invoke(instance, null));
+    }
+
+    /// <summary>Doubles its argument; bound to `Func&lt;int, int&gt;` / `(int32) -&gt; int32` events.</summary>
+    public static int IntDoubler(int x) => x * 2;
+
+    /// <summary>Uppercases its argument; bound to `Func&lt;string, string&gt;` / `(string) -&gt; string` events.</summary>
+    public static string StringShout(string s) => s.ToUpperInvariant();
+
+    private static void Subscribe(Type pollType, object instance, string handlerMethodName)
+    {
+        var ev = pollType.GetEvent("Ask")!;
+        var handler = Delegate.CreateDelegate(
+            ev.EventHandlerType!,
+            typeof(Issue2798NullConditionalValueEventRaiseEmitTests).GetMethod(handlerMethodName)!);
+        ev.AddEventHandler(instance, handler);
+    }
+
+    private static Type CompilePollType(string source, out Assembly assembly)
+    {
+        assembly = CompileToAssembly(source);
+        return assembly.GetTypes().Single(t => t.Name == "Poll");
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2798_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2799NullConditionalStructuralDelegateReceiverEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2799NullConditionalStructuralDelegateReceiverEmitTests.cs
@@ -1,0 +1,500 @@
+// <copyright file="Issue2799NullConditionalStructuralDelegateReceiverEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// PR #2799 follow-up: the null-conditional invocation form <c>f?(args)</c> of a
+/// non-nullable <b>structural function</b>-typed receiver
+/// (<c>(int32) -&gt; int32</c>) was only guarded in
+/// <c>OverloadResolver.Invocations.BuildIndirectDelegateCall</c> when the
+/// receiver was the implicit backing field of a field-like event (an
+/// <c>ImplicitFieldVariableSymbol</c>). Every other receiver kind reaching that
+/// path — a bare static field (<c>ImplicitStaticFieldVariableSymbol</c>), a bare
+/// instance/static property (<c>ImplicitPropertyVariableSymbol</c> /
+/// <c>ImplicitStaticPropertyVariableSymbol</c>), and a plain local, parameter,
+/// or top-level global (<c>LocalVariableSymbol</c> / <c>ParameterSymbol</c> /
+/// <c>GlobalVariableSymbol</c>) — fell through to an <b>unguarded</b>
+/// <c>BoundIndirectCallExpression</c>, silently dropping the <c>?</c>: the result
+/// was bound as the non-optional return type (so <c>r == nil</c> and value-type
+/// <c>??</c> misbehaved) and a null receiver NRE-d instead of short-circuiting.
+/// <para>
+/// The fix generalizes the null-conditional guard across all receiver kinds,
+/// evaluating the receiver exactly once and applying the established result-slot
+/// lowering (nullable result type, <c>$nres_</c> slot for value-type returns).
+/// These tests prove — for a receiver kind whose runtime value can legally be
+/// null (an uninitialized function-typed field's CLR default, read through a
+/// local copy / property / static member) — that a null receiver short-circuits
+/// to the null/optional result and a non-null receiver invokes once, with clean
+/// ILVerify, for both value- and void-returning shapes.
+/// </para>
+/// <para>
+/// This branch additionally fixes a distinct, tightly-related pre-existing
+/// defect in the <b>nominal</b> CLR-delegate call path
+/// (<c>OverloadResolver.CallBinding</c>): it computed its receiver as a bare
+/// <c>BoundVariableExpression</c> and never used <c>TryBuildImplicitMemberLoad</c>,
+/// so a nominal <c>Func&lt;...&gt;</c> value exposed as a bare static field or
+/// instance/static property ICE-d with GS9998 ("no local slot") on <b>any</b>
+/// invocation (conditional or not). The receiver-load fix mirrors the structural
+/// path, so those nominal member receivers now invoke — and short-circuit under
+/// <c>?</c> — correctly.
+/// </para>
+/// </summary>
+public class Issue2799NullConditionalStructuralDelegateReceiverEmitTests
+{
+    [Fact]
+    public void LocalReceiver_NullShortCircuits_NonNullInvokes()
+    {
+        // Fallthrough (LocalVariableSymbol) path. The local copies an
+        // uninitialized function-typed field whose CLR default is null, so the
+        // null branch is genuinely runtime-reachable.
+        var source = """
+            package MyLib
+            class C {
+                var backing (int32) -> int32
+                func SetBacking(fn (int32) -> int32) { backing = fn }
+                func Run() int32 {
+                    var f (int32) -> int32 = backing
+                    var r = f?(5)
+                    return r ?? -1
+                }
+            }
+            """;
+
+        var c = CompileType(source, "C");
+        var instance = Activator.CreateInstance(c)!;
+        var run = c.GetMethod("Run")!;
+
+        Assert.Equal(-1, run.Invoke(instance, null));
+
+        SetDelegate(c, instance, "SetBacking", nameof(IntDoubler));
+        Assert.Equal(10, run.Invoke(instance, null));
+    }
+
+    [Fact]
+    public void ParameterReceiver_HonorsQuestion_AndInvokesNonNull()
+    {
+        // Fallthrough (ParameterSymbol) path. A non-nullable function parameter
+        // cannot be assigned `nil` by language rules (GS0155/GS0129), so its
+        // null branch is not reachable via a literal; the `?` is still honored
+        // (the result is optional) and a non-null argument invokes once.
+        var source = """
+            package MyLib
+            class C {
+                func Run(f (int32) -> int32) int32 {
+                    var r = f?(5)
+                    return r ?? -1
+                }
+            }
+            """;
+
+        var c = CompileType(source, "C");
+        var instance = Activator.CreateInstance(c)!;
+        var run = c.GetMethod("Run")!;
+        var del = MakeDelegate(run.GetParameters()[0].ParameterType, nameof(IntDoubler));
+
+        Assert.Equal(10, run.Invoke(instance, new object[] { del }));
+    }
+
+    [Fact]
+    public void InstancePropertyReceiver_NullShortCircuits_NonNullInvokes()
+    {
+        // Implicit-member (ImplicitPropertyVariableSymbol) path via
+        // TryBuildImplicitMemberLoad.
+        var source = """
+            package MyLib
+            class C {
+                var backing (int32) -> int32
+                prop P (int32) -> int32 {
+                    get -> this.backing
+                }
+                func SetBacking(fn (int32) -> int32) { backing = fn }
+                func Run() int32 {
+                    var r = P?(5)
+                    return r ?? -1
+                }
+            }
+            """;
+
+        var c = CompileType(source, "C");
+        var instance = Activator.CreateInstance(c)!;
+        var run = c.GetMethod("Run")!;
+
+        Assert.Equal(-1, run.Invoke(instance, null));
+
+        SetDelegate(c, instance, "SetBacking", nameof(IntDoubler));
+        Assert.Equal(10, run.Invoke(instance, null));
+    }
+
+    [Fact]
+    public void StaticFieldAndStaticPropertyReceivers_NullShortCircuit_NonNullInvoke()
+    {
+        // Implicit-member (ImplicitStaticFieldVariableSymbol /
+        // ImplicitStaticPropertyVariableSymbol) paths via
+        // TryBuildImplicitMemberLoad.
+        var source = """
+            package MyLib
+            class C {
+                shared {
+                    var sf (int32) -> int32
+                    prop SP (int32) -> int32 {
+                        get -> C.sf
+                    }
+                    func SetSf(fn (int32) -> int32) { sf = fn }
+                    func RunField() int32 {
+                        var r = sf?(5)
+                        return r ?? -1
+                    }
+                    func RunProp() int32 {
+                        var r = SP?(5)
+                        return r ?? -1
+                    }
+                }
+            }
+            """;
+
+        var c = CompileType(source, "C");
+        var runField = c.GetMethod("RunField")!;
+        var runProp = c.GetMethod("RunProp")!;
+
+        Assert.Equal(-1, runField.Invoke(null, null));
+        Assert.Equal(-1, runProp.Invoke(null, null));
+
+        var setSf = c.GetMethod("SetSf")!;
+        setSf.Invoke(null, new object[] { MakeDelegate(setSf.GetParameters()[0].ParameterType, nameof(IntDoubler)) });
+
+        Assert.Equal(10, runField.Invoke(null, null));
+        Assert.Equal(10, runProp.Invoke(null, null));
+    }
+
+    [Fact]
+    public void GlobalReceiver_HonorsQuestion_AndInvokesNonNull()
+    {
+        // Fallthrough (GlobalVariableSymbol) path: a top-level script variable.
+        var source = """
+            package MyLib
+            import System
+
+            func Ident(x int32) int32 { return x }
+
+            var f (int32) -> int32 = Ident
+            var r = f?(5)
+            Console.WriteLine((r ?? -1).ToString())
+            """;
+
+        var output = CompileAndRunExe(source);
+        Assert.Equal("5", output.Trim());
+    }
+
+    [Fact]
+    public void VoidReturn_LocalReceiver_NullNoOps_NonNullInvokes()
+    {
+        // Void-returning structural delegate through a local whose value is a
+        // genuinely-null uninitialized field default: the null branch is a safe
+        // no-op (no NRE), the non-null branch invokes exactly once.
+        var source = """
+            package MyLib
+            class C {
+                var sink (int32) -> void
+                func SetSink(fn (int32) -> void) { sink = fn }
+                func Run() {
+                    var s (int32) -> void = sink
+                    s?(5)
+                }
+            }
+            """;
+
+        var c = CompileType(source, "C");
+        var instance = Activator.CreateInstance(c)!;
+        var run = c.GetMethod("Run")!;
+
+        // Null sink: raising must be a safe no-op.
+        Assert.Null(Record.Exception(() => run.Invoke(instance, null)));
+
+        var counter = new SinkCounter();
+        var setSink = c.GetMethod("SetSink")!;
+        var del = Delegate.CreateDelegate(
+            setSink.GetParameters()[0].ParameterType,
+            counter,
+            typeof(SinkCounter).GetMethod(nameof(SinkCounter.Sink))!);
+        setSink.Invoke(instance, new object[] { del });
+
+        run.Invoke(instance, null);
+        Assert.Equal(1, counter.Hits);
+    }
+
+    [Fact]
+    public void SideEffectfulPropertyReceiver_EvaluatedExactlyOnce()
+    {
+        // The receiver (property getter) must be evaluated exactly once on both
+        // the null (short-circuit) and non-null (invoke) paths — single
+        // evaluation preserved across the generalized guard.
+        var source = """
+            package MyLib
+            class C {
+                var backing (int32) -> int32
+                var getCount int32
+                prop P (int32) -> int32 {
+                    get {
+                        getCount = getCount + 1
+                        return backing
+                    }
+                }
+                func SetBacking(fn (int32) -> int32) { backing = fn }
+                func GetCount() int32 { return getCount }
+                func Run() int32 {
+                    var r = P?(5)
+                    return r ?? -1
+                }
+            }
+            """;
+
+        var c = CompileType(source, "C");
+        var instance = Activator.CreateInstance(c)!;
+        var run = c.GetMethod("Run")!;
+        var getCount = c.GetMethod("GetCount")!;
+
+        // Null backing: getter runs once, then short-circuits.
+        Assert.Equal(-1, run.Invoke(instance, null));
+        Assert.Equal(1, getCount.Invoke(instance, null));
+
+        // Non-null: getter runs once more, then invokes.
+        SetDelegate(c, instance, "SetBacking", nameof(IntDoubler));
+        Assert.Equal(10, run.Invoke(instance, null));
+        Assert.Equal(2, getCount.Invoke(instance, null));
+    }
+
+    [Fact]
+    public void BareResult_IsOptional_NullYieldsNil_NonNullYieldsValue()
+    {
+        // Proves the `?` is honored semantically: without a `??` fallback the
+        // result of `f?(5)` is a genuine optional (`int32?`), so `r == nil` is
+        // legal and true with a null receiver, false once assigned. Before the
+        // fix `r` was bound as non-optional `int32`, and `r == nil` failed to
+        // bind (GS0129).
+        var source = """
+            package MyLib
+            class C {
+                var backing (int32) -> int32
+                func SetBacking(fn (int32) -> int32) { backing = fn }
+                func IsNil() bool {
+                    var f (int32) -> int32 = backing
+                    var r = f?(5)
+                    return r == nil
+                }
+            }
+            """;
+
+        var c = CompileType(source, "C");
+        var instance = Activator.CreateInstance(c)!;
+        var isNil = c.GetMethod("IsNil")!;
+
+        Assert.Equal(true, isNil.Invoke(instance, null));
+
+        SetDelegate(c, instance, "SetBacking", nameof(IntDoubler));
+        Assert.Equal(false, isNil.Invoke(instance, null));
+    }
+
+    [Fact]
+    public void NominalFuncInstancePropertyReceiver_NullShortCircuits_NonNullInvokes()
+    {
+        // Distinct pre-existing defect also fixed on this branch: the nominal
+        // CLR-delegate call path (OverloadResolver.CallBinding) computed its
+        // receiver as a bare BoundVariableExpression and never used
+        // TryBuildImplicitMemberLoad, so a nominal `Func<int, int>` value
+        // exposed as a bare instance property ICE-d with GS9998 ("no local
+        // slot") on ANY invocation. It now short-circuits on null and invokes
+        // when non-null.
+        var source = """
+            package MyLib
+            import System
+            class C {
+                var backing Func[int32,int32]
+                prop P Func[int32,int32] {
+                    get -> this.backing
+                }
+                func SetBacking(fn Func[int32,int32]) { backing = fn }
+                func Run() int32 {
+                    var r = P?(5)
+                    return r ?? -1
+                }
+            }
+            """;
+
+        var c = CompileType(source, "C");
+        var instance = Activator.CreateInstance(c)!;
+        var run = c.GetMethod("Run")!;
+
+        Assert.Equal(-1, run.Invoke(instance, null));
+
+        SetDelegate(c, instance, "SetBacking", nameof(IntDoubler));
+        Assert.Equal(10, run.Invoke(instance, null));
+    }
+
+    [Fact]
+    public void NominalFuncInstancePropertyReceiver_NonConditional_Invokes()
+    {
+        // Non-null-conditional invocation `P(5)` of a nominal CLR-delegate
+        // instance property previously ICE-d (GS9998); the receiver-load fix
+        // makes it a normal invoke.
+        var source = """
+            package MyLib
+            import System
+            class C {
+                var backing Func[int32,int32]
+                prop P Func[int32,int32] {
+                    get -> this.backing
+                }
+                func SetBacking(fn Func[int32,int32]) { backing = fn }
+                func Run() int32 {
+                    return P(5)
+                }
+            }
+            """;
+
+        var c = CompileType(source, "C");
+        var instance = Activator.CreateInstance(c)!;
+        SetDelegate(c, instance, "SetBacking", nameof(IntDoubler));
+
+        Assert.Equal(10, c.GetMethod("Run")!.Invoke(instance, null));
+    }
+
+    [Fact]
+    public void NominalFuncStaticFieldAndPropertyReceivers_NullShortCircuit_NonNullInvoke()
+    {
+        var source = """
+            package MyLib
+            import System
+            class C {
+                shared {
+                    var sf Func[int32,int32]
+                    prop SP Func[int32,int32] {
+                        get -> C.sf
+                    }
+                    func SetSf(fn Func[int32,int32]) { sf = fn }
+                    func RunField() int32 {
+                        var r = sf?(5)
+                        return r ?? -1
+                    }
+                    func RunProp() int32 {
+                        var r = SP?(5)
+                        return r ?? -1
+                    }
+                }
+            }
+            """;
+
+        var c = CompileType(source, "C");
+        var runField = c.GetMethod("RunField")!;
+        var runProp = c.GetMethod("RunProp")!;
+
+        Assert.Equal(-1, runField.Invoke(null, null));
+        Assert.Equal(-1, runProp.Invoke(null, null));
+
+        var setSf = c.GetMethod("SetSf")!;
+        setSf.Invoke(null, new object[] { MakeDelegate(setSf.GetParameters()[0].ParameterType, nameof(IntDoubler)) });
+
+        Assert.Equal(10, runField.Invoke(null, null));
+        Assert.Equal(10, runProp.Invoke(null, null));
+    }
+
+    /// <summary>Doubles its argument; bound to <c>(int32) -&gt; int32</c> receivers.</summary>
+    public static int IntDoubler(int x) => x * 2;
+
+    private sealed class SinkCounter
+    {
+        public int Hits { get; private set; }
+
+        public void Sink(int x) => this.Hits++;
+    }
+
+    private static void SetDelegate(Type owner, object instance, string setterName, string handlerName)
+    {
+        var setter = owner.GetMethod(setterName)!;
+        var del = MakeDelegate(setter.GetParameters()[0].ParameterType, handlerName);
+        setter.Invoke(instance, new object[] { del });
+    }
+
+    private static Delegate MakeDelegate(Type delegateType, string handlerName) =>
+        Delegate.CreateDelegate(
+            delegateType,
+            typeof(Issue2799NullConditionalStructuralDelegateReceiverEmitTests).GetMethod(handlerName)!);
+
+    private static Type CompileType(string source, string typeName) =>
+        CompileToAssembly(source, "library").GetTypes().Single(t => t.Name == typeName);
+
+    private static string CompileAndRunExe(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2799_exe_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+        CompileFile(srcPath, outPath, "exe");
+        IlVerifier.Verify(outPath);
+
+        var psi = new System.Diagnostics.ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = tempDir,
+        };
+        psi.ArgumentList.Add(outPath);
+        using var proc = System.Diagnostics.Process.Start(psi)!;
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(proc.ExitCode == 0, $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n");
+    }
+
+    private static Assembly CompileToAssembly(string source, string target)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2799_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+        CompileFile(srcPath, outPath, target);
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+
+    private static void CompileFile(string srcPath, string outPath, string target)
+    {
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+    }
+}


### PR DESCRIPTION
## Summary
A null-conditional invocation `Evt?(args)` of a **subscriber-less field-like event whose delegate returns a value** threw `NullReferenceException` instead of producing a null/optional result. PR #2797 (issue #2796) fixed the **void-returning** raise on both the nominal CLR-delegate path and the structural `FunctionTypeSymbol` path, but both guarded only the `void` result and emitted an unconditional `callvirt Invoke` for value-returning delegates — dereferencing a null backing delegate on a fresh event with no subscribers.

### Repros (both threw NRE with no subscribers)
```
package MyLib
import System
class Poll {
    event Ask Func[int32,int32]        // nominal CLR delegate
    func Run() { var r = Ask?(5) }
}
```
```
package MyLib
class Poll {
    event Ask (int32) -> int32         // structural function delegate
    func Run() { var r = Ask?(5) }
}
```

### Root cause
- `OverloadResolver.CallBinding.cs`: the nominal CLR-delegate null-conditional block guarded only `void` results, falling through to a plain `callvirt Invoke` for value-returning delegates.
- `OverloadResolver.Invocations.cs` (`BuildIndirectDelegateCall`): guarded only `void` `FunctionTypeSymbol` results.

### Fix
Generalize the **established nullable-delegate invocation result-slot lowering** (the same lowering `TryBindNullableDelegateInvocation` uses for nullable delegate properties, #2772) to **both** paths. A value-returning conditional invocation is wrapped in a `BoundNullConditionalAccessExpression` whose result type is the nullable wrapping of the delegate's return type, allocating a `$nres_` result slot for value-typed returns. A null receiver yields `null`/`default`, the receiver is evaluated once, and a non-null delegate invokes normally. This is a **general** binder/emitter fix with **no Oahu-specific logic**.

Emitted lowering now matches C# `Evt?.Invoke(args)`: value-type returns materialize `default(Nullable<T>)` on the null branch and wrap `T` on the not-null branch; reference-type returns leave `ldnull`.

## Tests
New `Issue2798NullConditionalValueEventRaiseEmitTests` (runtime + ILVerify via the shared `IlVerifier.Verify` helper):
- nominal `Func<int,int>` value-returning: zero-subscriber → null (`?? -1` ⇒ -1); subscribed → invokes (10)
- structural `(int32) -> int32` value-returning: zero-subscriber → null fallback; subscribed → invokes
- nominal `Func<string,string>` and structural `(string) -> string` reference-returning: zero-subscriber → null (`?? "none"`); subscribed → invokes
- bare result (no `??`): `r == nil` true with no subscribers, false once subscribed
- unsubscribe-then-call: value-returning raise yields the null fallback again (the `SettingsBase.OnChange` failure mode, value-returning variant)
- side-effectful argument: evaluated **exactly once** on the non-null path and **not at all** when the receiver is null (short-circuit)

## Validation
- `Compiler.Tests`: **3504 passed, 0 failed**
- `Core.Tests`: **6704 passed, 1 skipped, 0 failed**
- All 5 repro shapes (nominal/structural × value/reference, plus bare) compile, run correctly, and pass ILVerify clean
- Value-type null coalescing (`Nullable<int> ?? -1`) over the null-conditional result verifies and runs clean, so **no separate emitter defect** is exposed by the value-type fallback
- All suites run with `MSBUILDDISABLENODEREUSE=1`

Fixes #2798
