### PR TITLE
fix: bind lambdas to imported byref delegates

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundIndirectCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundIndirectCallExpression.cs
@@ -18,12 +18,18 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundIndirectCallExpression : BoundExpression
 {
-    public BoundIndirectCallExpression(SyntaxNode syntax, BoundExpression target, FunctionTypeSymbol functionType, ImmutableArray<BoundExpression> arguments)
+    public BoundIndirectCallExpression(
+        SyntaxNode syntax,
+        BoundExpression target,
+        FunctionTypeSymbol functionType,
+        ImmutableArray<BoundExpression> arguments,
+        ImmutableArray<RefKind> argumentRefKinds = default)
         : base(syntax)
     {
         Target = target;
         FunctionType = functionType;
         Arguments = arguments;
+        ArgumentRefKinds = argumentRefKinds;
     }
 
     public BoundExpression Target { get; }
@@ -31,6 +37,8 @@ public sealed class BoundIndirectCallExpression : BoundExpression
     public FunctionTypeSymbol FunctionType { get; }
 
     public ImmutableArray<BoundExpression> Arguments { get; }
+
+    public ImmutableArray<RefKind> ArgumentRefKinds { get; }
 
     public override TypeSymbol Type => FunctionType.ReturnType;
 

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -2201,7 +2201,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundIndirectCallExpression(null, target, node.FunctionType, builder?.ToImmutable() ?? node.Arguments);
+        return new BoundIndirectCallExpression(null, target, node.FunctionType, builder?.ToImmutable() ?? node.Arguments, node.ArgumentRefKinds);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -439,9 +439,8 @@ internal sealed class ConversionClassifier
             return new BoundConversionExpression(null, type, expressionTreeLiteral);
         }
 
-        if (expression is BoundFunctionLiteralExpression refKindLiteral
-            && type?.ClrType is Type delegateType
-            && HasDelegateParameterRefKindMismatch(delegateType, refKindLiteral))
+        if (type?.ClrType is Type delegateType
+            && HasDelegateParameterRefKindMismatch(delegateType, expression))
         {
             Diagnostics.ReportCannotConvert(diagnosticLocation, expression.Type, type);
             return new BoundErrorExpression(expression.Syntax);
@@ -2223,26 +2222,56 @@ internal sealed class ConversionClassifier
 
     private static bool HasDelegateParameterRefKindMismatch(
         Type targetType,
-        BoundFunctionLiteralExpression literal)
+        BoundExpression expression)
     {
         if (!ClrTypeUtilities.IsDelegateType(targetType))
         {
             return false;
         }
 
-        var sourceParameters = literal.Function.Parameters;
-        var targetRefKinds = GetMethodGroupTargetRefKinds(
-            TypeSymbol.FromClrType(targetType),
-            sourceParameters.Length,
-            out _);
-        if (targetRefKinds.Length != sourceParameters.Length)
+        ImmutableArray<RefKind> sourceRefKinds;
+        if (expression is BoundFunctionLiteralExpression literal)
+        {
+            sourceRefKinds = literal.Function.Parameters
+                .Select(parameter => parameter.RefKind)
+                .ToImmutableArray();
+        }
+        else if (expression.Type is DelegateTypeSymbol sourceDelegate)
+        {
+            sourceRefKinds = sourceDelegate.Parameters
+                .Select(parameter => parameter.RefKind)
+                .ToImmutableArray();
+        }
+        else if (expression.Type?.ClrType is Type sourceType
+            && ClrTypeUtilities.IsDelegateType(sourceType))
+        {
+            sourceRefKinds = GetMethodGroupTargetRefKinds(
+                expression.Type,
+                parameterCount: 0,
+                out _);
+        }
+        else if (expression.Type is FunctionTypeSymbol sourceFunction)
+        {
+            sourceRefKinds = ImmutableArray.CreateRange(
+                Enumerable.Repeat(RefKind.None, sourceFunction.Arity));
+        }
+        else
         {
             return false;
         }
 
-        for (var i = 0; i < sourceParameters.Length; i++)
+        var targetRefKinds = GetMethodGroupTargetRefKinds(
+            TypeSymbol.FromClrType(targetType),
+            sourceRefKinds.Length,
+            out _);
+        if (targetRefKinds.Length != sourceRefKinds.Length)
         {
-            if (sourceParameters[i].RefKind != targetRefKinds[i])
+            return false;
+        }
+
+        for (var i = 0; i < sourceRefKinds.Length; i++)
+        {
+            if (sourceRefKinds[i] != targetRefKinds[i])
             {
                 return true;
             }

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -439,6 +439,14 @@ internal sealed class ConversionClassifier
             return new BoundConversionExpression(null, type, expressionTreeLiteral);
         }
 
+        if (expression is BoundFunctionLiteralExpression refKindLiteral
+            && type?.ClrType is Type delegateType
+            && HasDelegateParameterRefKindMismatch(delegateType, refKindLiteral))
+        {
+            Diagnostics.ReportCannotConvert(diagnosticLocation, expression.Type, type);
+            return new BoundErrorExpression(expression.Syntax);
+        }
+
         if (expression is BoundFunctionLiteralExpression literal
             && type is FunctionTypeSymbol targetFunctionType
             && TypeSymbol.ContainsTypeParameter(targetFunctionType))
@@ -2211,6 +2219,36 @@ internal sealed class ConversionClassifier
             allowExplicit: false);
         var call = new BoundCallExpression(null, method, ImmutableArray.Create(operand));
         return BindConversion(diagnosticLocation, call, targetType, allowExplicit);
+    }
+
+    private static bool HasDelegateParameterRefKindMismatch(
+        Type targetType,
+        BoundFunctionLiteralExpression literal)
+    {
+        if (!ClrTypeUtilities.IsDelegateType(targetType))
+        {
+            return false;
+        }
+
+        var sourceParameters = literal.Function.Parameters;
+        var targetRefKinds = GetMethodGroupTargetRefKinds(
+            TypeSymbol.FromClrType(targetType),
+            sourceParameters.Length,
+            out _);
+        if (targetRefKinds.Length != sourceParameters.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < sourceParameters.Length; i++)
+        {
+            if (sourceParameters[i].RefKind != targetRefKinds[i])
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -439,8 +439,7 @@ internal sealed class ConversionClassifier
             return new BoundConversionExpression(null, type, expressionTreeLiteral);
         }
 
-        if (type?.ClrType is Type delegateType
-            && HasDelegateParameterRefKindMismatch(delegateType, expression))
+        if (HasDelegateParameterRefKindMismatch(type, expression))
         {
             Diagnostics.ReportCannotConvert(diagnosticLocation, expression.Type, type);
             return new BoundErrorExpression(expression.Syntax);
@@ -2221,10 +2220,12 @@ internal sealed class ConversionClassifier
     }
 
     private static bool HasDelegateParameterRefKindMismatch(
-        Type targetType,
+        TypeSymbol targetType,
         BoundExpression expression)
     {
-        if (!ClrTypeUtilities.IsDelegateType(targetType))
+        if (targetType is not DelegateTypeSymbol
+            && (targetType?.ClrType is not Type targetClrType
+                || !ClrTypeUtilities.IsDelegateType(targetClrType)))
         {
             return false;
         }
@@ -2236,14 +2237,9 @@ internal sealed class ConversionClassifier
                 .Select(parameter => parameter.RefKind)
                 .ToImmutableArray();
         }
-        else if (expression.Type is DelegateTypeSymbol sourceDelegate)
-        {
-            sourceRefKinds = sourceDelegate.Parameters
-                .Select(parameter => parameter.RefKind)
-                .ToImmutableArray();
-        }
-        else if (expression.Type?.ClrType is Type sourceType
-            && ClrTypeUtilities.IsDelegateType(sourceType))
+        else if (expression.Type is DelegateTypeSymbol
+            || (expression.Type?.ClrType is Type sourceType
+                && ClrTypeUtilities.IsDelegateType(sourceType)))
         {
             sourceRefKinds = GetMethodGroupTargetRefKinds(
                 expression.Type,
@@ -2261,7 +2257,7 @@ internal sealed class ConversionClassifier
         }
 
         var targetRefKinds = GetMethodGroupTargetRefKinds(
-            TypeSymbol.FromClrType(targetType),
+            targetType,
             sourceRefKinds.Length,
             out _);
         if (targetRefKinds.Length != sourceRefKinds.Length)

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1398,6 +1398,7 @@ internal sealed class ConversionClassifier
         }
 
         var invokeParams = invoke.GetParameters();
+        var targetParameterRefKinds = DelegateRefKindUtilities.GetParameterRefKinds(invoke);
         var closesExtensionReceiver = group.Receiver != null
             && group.Candidates.All(candidate => candidate.IsStatic);
         var argTypes = new Type[invokeParams.Length + (closesExtensionReceiver ? 1 : 0)];
@@ -1428,6 +1429,14 @@ internal sealed class ConversionClassifier
             }
 
             if (!IsMethodGroupReturnCompatible(candidate.ReturnType, invoke.ReturnType))
+            {
+                continue;
+            }
+
+            if (!DelegateRefKindUtilities.GetParameterRefKinds(
+                    candidate,
+                    skipFirstParameter: closesExtensionReceiver)
+                .SequenceEqual(targetParameterRefKinds))
             {
                 continue;
             }
@@ -2230,28 +2239,9 @@ internal sealed class ConversionClassifier
             return false;
         }
 
-        ImmutableArray<RefKind> sourceRefKinds;
-        if (expression is BoundFunctionLiteralExpression literal)
-        {
-            sourceRefKinds = literal.Function.Parameters
-                .Select(parameter => parameter.RefKind)
-                .ToImmutableArray();
-        }
-        else if (expression.Type is DelegateTypeSymbol
-            || (expression.Type?.ClrType is Type sourceType
-                && ClrTypeUtilities.IsDelegateType(sourceType)))
-        {
-            sourceRefKinds = GetMethodGroupTargetRefKinds(
-                expression.Type,
-                parameterCount: 0,
-                out _);
-        }
-        else if (expression.Type is FunctionTypeSymbol sourceFunction)
-        {
-            sourceRefKinds = ImmutableArray.CreateRange(
-                Enumerable.Repeat(RefKind.None, sourceFunction.Arity));
-        }
-        else
+        if (!DelegateRefKindUtilities.TryGetSourceParameterRefKinds(
+            expression,
+            out var sourceRefKinds))
         {
             return false;
         }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
@@ -197,7 +197,8 @@ internal sealed partial class DeclarationBinder
                 argTypes,
                 interpolatedStringArgs: interpolatedStringArgs,
                 constantNarrowingArgumentCheck: ExpressionBinder.MakeConstantNarrowingArgumentCheck(boundArguments),
-                structuralProjectionArgumentCheck: ExpressionBinder.MakeStructuralProjectionArgumentCheck(boundArguments));
+                structuralProjectionArgumentCheck: ExpressionBinder.MakeStructuralProjectionArgumentCheck(boundArguments),
+                delegateRefKindArgumentCheck: ExpressionBinder.MakeDelegateRefKindArgumentCheck(boundArguments));
             switch (resolution.Outcome)
             {
                 case OverloadResolution.ResolutionOutcome.Resolved:

--- a/src/Core/CodeAnalysis/Binding/DelegateRefKindUtilities.cs
+++ b/src/Core/CodeAnalysis/Binding/DelegateRefKindUtilities.cs
@@ -1,0 +1,143 @@
+// <copyright file="DelegateRefKindUtilities.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+internal static class DelegateRefKindUtilities
+{
+    internal static bool TryGetSourceParameterRefKinds(
+        BoundExpression expression,
+        out ImmutableArray<RefKind> refKinds)
+    {
+        while (expression is BoundConversionExpression conversion)
+        {
+            expression = conversion.Expression;
+        }
+
+        switch (expression)
+        {
+            case BoundFunctionLiteralExpression literal:
+                refKinds = GetParameterRefKinds(literal.Function, receiver: null);
+                return true;
+            case BoundMethodGroupExpression group:
+                return TryGetMethodGroupParameterRefKinds(group, out refKinds);
+            case BoundClrMethodGroupExpression group:
+                return TryGetClrMethodGroupParameterRefKinds(group, out refKinds);
+            case { Type: DelegateTypeSymbol sourceDelegate }:
+                refKinds = sourceDelegate.Parameters
+                    .Select(parameter => parameter.RefKind)
+                    .ToImmutableArray();
+                return true;
+            case { Type.ClrType: System.Type sourceType }
+                when ClrTypeUtilities.IsDelegateType(sourceType):
+                var sourceInvoke = sourceType.GetMethodSafe("Invoke");
+                if (sourceInvoke != null)
+                {
+                    refKinds = GetParameterRefKinds(sourceInvoke);
+                    return true;
+                }
+
+                break;
+            case { Type: FunctionTypeSymbol sourceFunction }:
+                refKinds = ImmutableArray.CreateRange(
+                    Enumerable.Repeat(RefKind.None, sourceFunction.Arity));
+                return true;
+        }
+
+        refKinds = default;
+        return false;
+    }
+
+    internal static ImmutableArray<RefKind> GetParameterRefKinds(
+        MethodInfo method,
+        bool skipFirstParameter = false)
+    {
+        var parameters = method.GetParameters();
+        return parameters
+            .Skip(skipFirstParameter ? 1 : 0)
+            .Select(GetParameterRefKind)
+            .ToImmutableArray();
+    }
+
+    private static bool TryGetMethodGroupParameterRefKinds(
+        BoundMethodGroupExpression group,
+        out ImmutableArray<RefKind> refKinds)
+    {
+        if (group.FunctionType != null && group.Function != null)
+        {
+            refKinds = GetParameterRefKinds(group.Function, group.Receiver);
+            return true;
+        }
+
+        return TryGetCommonParameterRefKinds(
+            group.Candidates.Select(candidate => GetParameterRefKinds(candidate, group.Receiver)),
+            out refKinds);
+    }
+
+    private static bool TryGetClrMethodGroupParameterRefKinds(
+        BoundClrMethodGroupExpression group,
+        out ImmutableArray<RefKind> refKinds)
+    {
+        if (group.ResolvedMethod != null)
+        {
+            refKinds = GetParameterRefKinds(
+                group.ResolvedMethod,
+                skipFirstParameter: group.Receiver != null && group.ResolvedMethod.IsStatic);
+            return true;
+        }
+
+        return TryGetCommonParameterRefKinds(
+            group.Candidates.Select(candidate => GetParameterRefKinds(
+                candidate,
+                skipFirstParameter: group.Receiver != null && candidate.IsStatic)),
+            out refKinds);
+    }
+
+    private static ImmutableArray<RefKind> GetParameterRefKinds(
+        FunctionSymbol function,
+        BoundExpression receiver)
+    {
+        var parameterOffset = function.IsExtension && receiver != null ? 1 : 0;
+        return function.Parameters
+            .Skip(parameterOffset)
+            .Select(parameter => parameter.RefKind)
+            .ToImmutableArray();
+    }
+
+    private static bool TryGetCommonParameterRefKinds(
+        IEnumerable<ImmutableArray<RefKind>> candidates,
+        out ImmutableArray<RefKind> refKinds)
+    {
+        refKinds = default;
+        foreach (var candidate in candidates)
+        {
+            if (refKinds.IsDefault)
+            {
+                refKinds = candidate;
+            }
+            else if (!refKinds.SequenceEqual(candidate))
+            {
+                refKinds = default;
+                return false;
+            }
+        }
+
+        return !refKinds.IsDefault;
+    }
+
+    private static RefKind GetParameterRefKind(ParameterInfo parameter) =>
+        !parameter.ParameterType.IsByRef
+            ? RefKind.None
+            : parameter.IsOut
+                ? RefKind.Out
+                : parameter.IsIn
+                    ? RefKind.In
+                    : RefKind.Ref;
+}

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -991,6 +991,7 @@ internal sealed partial class ExpressionBinder
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
             constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
             structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments),
+            delegateRefKindArgumentCheck: MakeDelegateRefKindArgumentCheck(arguments),
             methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution),
             methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments));
 
@@ -1427,6 +1428,7 @@ internal sealed partial class ExpressionBinder
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
             constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments, argumentOffset: 1),
             structuralProjectionArgumentCheck: ExtensionStructuralProjectionCheck,
+            delegateRefKindArgumentCheck: MakeDelegateRefKindArgumentCheck(arguments, argumentOffset: 1),
             methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution, argumentOffset: 1),
             methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments, argumentOffset: 1),
             deferredInferenceArgs: deferredInferenceArgs);
@@ -2936,6 +2938,7 @@ internal sealed partial class ExpressionBinder
             argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
             constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
             structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments),
+            delegateRefKindArgumentCheck: MakeDelegateRefKindArgumentCheck(arguments),
             methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution),
             methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments));
         if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -518,6 +518,35 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
+        if (callableType is DelegateTypeSymbol namedDelegate)
+        {
+            if (!overloads.TryBindNamedDelegateArguments(
+                methodName,
+                namedDelegate,
+                ce,
+                arguments,
+                out var namedArguments,
+                out var namedRefKinds))
+            {
+                result = new BoundErrorExpression(null);
+                return true;
+            }
+
+            BoundExpression namedMemberLoad = matchedField != null
+                ? isStatic
+                    ? new BoundFieldAccessExpression(null, receiver, declaringType, matchedField, memberType)
+                    : new BoundFieldAccessExpression(null, receiver, declaringType, matchedField)
+                : new BoundPropertyAccessExpression(null, receiver, declaringType, matchedProperty);
+            result = BuildDelegateMemberInvocation(
+                ce,
+                namedMemberLoad,
+                callableType,
+                functionType,
+                namedArguments,
+                namedRefKinds);
+            return true;
+        }
+
         // ADR-0102 follow-up / issue #818: when the field's declared
         // function type spells a trailing variadic parameter, pack /
         // pass-through trailing args at the call site.
@@ -600,11 +629,12 @@ internal sealed partial class ExpressionBinder
         BoundExpression delegateLoad,
         TypeSymbol delegateType,
         FunctionTypeSymbol functionType,
-        ImmutableArray<BoundExpression> arguments)
+        ImmutableArray<BoundExpression> arguments,
+        ImmutableArray<RefKind> argumentRefKinds = default)
     {
         if (syntax.NullableQuestionToken == null)
         {
-            return new BoundIndirectCallExpression(null, delegateLoad, functionType, arguments);
+            return new BoundIndirectCallExpression(null, delegateLoad, functionType, arguments, argumentRefKinds);
         }
 
         var captureName = "$ncap_" + (++binderCtx.NullConditionalCaptureCounter)
@@ -614,7 +644,8 @@ internal sealed partial class ExpressionBinder
             null,
             new BoundVariableExpression(null, capture),
             functionType,
-            arguments);
+            arguments,
+            argumentRefKinds);
         return BuildNullConditionalDelegateInvocation(syntax, delegateLoad, capture, invoke);
     }
 
@@ -1109,64 +1140,23 @@ internal sealed partial class ExpressionBinder
     /// </summary>
     private BoundExpression BindNamedDelegateInvokeCall(BoundExpression receiver, DelegateTypeSymbol delegateSym, ImmutableArray<BoundExpression> arguments, CallExpressionSyntax ce)
     {
-        // ADR-0101 follow-up / issue #812: a named delegate may declare a
-        // trailing variadic parameter. Apply the same arity + pack /
-        // pass-through rule that we use for the direct-call (`del(args)`)
-        // path so the explicit `.Invoke(args)` spelling behaves identically.
-        var isVariadic = delegateSym.Parameters.Length > 0
-            && delegateSym.Parameters[delegateSym.Parameters.Length - 1].IsVariadic;
-        var fixedParamCount = isVariadic ? delegateSym.Parameters.Length - 1 : delegateSym.Parameters.Length;
-
-        if (isVariadic)
+        if (!overloads.TryBindNamedDelegateArguments(
+            delegateSym.Name,
+            delegateSym,
+            ce,
+            arguments,
+            out var convertedArgs,
+            out var argumentRefKinds))
         {
-            if (arguments.Length < fixedParamCount)
-            {
-                Diagnostics.ReportTooFewArgumentsForVariadic(ce.Location, delegateSym.Name, fixedParamCount, arguments.Length);
-                return new BoundErrorExpression(null);
-            }
-        }
-        else if (arguments.Length != delegateSym.Parameters.Length)
-        {
-            Diagnostics.ReportWrongArgumentCount(ce.Location, delegateSym.Name, delegateSym.Parameters.Length, arguments.Length);
             return new BoundErrorExpression(null);
         }
 
-        var permutedArgs = arguments;
-        if (isVariadic)
-        {
-            var variadicParam = delegateSym.Parameters[delegateSym.Parameters.Length - 1];
-            var sliceType = (SliceTypeSymbol)variadicParam.Type;
-            var hasVariadicErrors = false;
-
-            // Issue #1823: route through the #1630 canonical helper so
-            // trailing elements get the same per-element coercion applied
-            // at every other variadic pack site (previously packed raw,
-            // uncoerced elements here).
-            permutedArgs = OverloadResolver.PackOrPassThroughVariadicArguments(
-                conversions,
-                Diagnostics,
-                ce,
-                arguments,
-                fixedParamCount,
-                sliceType,
-                variadicParam.Name,
-                i => i < ce.Arguments.Count ? ce.Arguments[i].Location : ce.Location,
-                ref hasVariadicErrors);
-
-            if (hasVariadicErrors)
-            {
-                return new BoundErrorExpression(null);
-            }
-        }
-
-        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(permutedArgs.Length);
-        for (var i = 0; i < permutedArgs.Length; i++)
-        {
-            var argLoc = i < ce.Arguments.Count ? ce.Arguments[i].Location : ce.Location;
-            convertedArgs.Add(conversions.BindConversion(argLoc, permutedArgs[i], delegateSym.Parameters[i].Type));
-        }
-
-        return new BoundIndirectCallExpression(null, receiver, delegateSym.EquivalentFunctionType, convertedArgs.MoveToImmutable());
+        return new BoundIndirectCallExpression(
+            null,
+            receiver,
+            delegateSym.EquivalentFunctionType,
+            convertedArgs,
+            argumentRefKinds);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2588,6 +2588,7 @@ internal sealed partial class ExpressionBinder
                     supplementaryInterfaceCheck: supplementaryInterfaceCheck,
                     constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments),
                     structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(arguments),
+                    delegateRefKindArgumentCheck: MakeDelegateRefKindArgumentCheck(arguments),
                     methodGroupInference: MakeMethodGroupInference(arguments, GetEffectiveArgumentClrTypeForOverloadResolution),
                     methodGroupArgumentCheck: MakeMethodGroupArgumentCheck(arguments));
                 switch (resolution.Outcome)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -808,7 +808,7 @@ internal sealed partial class ExpressionBinder
         var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(invokeParameters.Length);
         foreach (var parameter in invokeParameters)
         {
-            parameterTypes.Add(MemberLookup.MapOpenClrTypeToSymbolic(parameter.ParameterType, openDefinition, symbolicArgs));
+            parameterTypes.Add(MemberLookup.MapOpenClrParameterTypeToSymbolic(parameter.ParameterType, openDefinition, symbolicArgs));
         }
 
         var returnType = invoke.ReturnType.IsSameAs(typeof(void))
@@ -935,7 +935,7 @@ internal sealed partial class ExpressionBinder
         var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(invokeParameters.Length);
         foreach (var parameter in invokeParameters)
         {
-            parameterTypes.Add(MemberLookup.MapOpenClrTypeToSymbolic(
+            parameterTypes.Add(MemberLookup.MapOpenClrParameterTypeToSymbolic(
                 parameter.ParameterType, receiverOpenDef, receiverTypeArgs, openMethod, symbolicMethodTypeArgs));
         }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1151,7 +1151,8 @@ internal sealed partial class ExpressionBinder
                 argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
                 supplementaryInterfaceCheck: supplementaryInterfaceCheck,
                 constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(boundArguments),
-                structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(boundArguments));
+                structuralProjectionArgumentCheck: MakeStructuralProjectionArgumentCheck(boundArguments),
+                delegateRefKindArgumentCheck: MakeDelegateRefKindArgumentCheck(boundArguments));
             switch (resolution.Outcome)
             {
                 case OverloadResolution.ResolutionOutcome.Resolved:

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -2534,4 +2534,90 @@ internal sealed partial class ExpressionBinder
                 || StructuralProjectionPlanner.CanProject(sourceType, targetType);
         };
     }
+
+    internal static Func<int, System.Type, bool?> MakeDelegateRefKindArgumentCheck(
+        IReadOnlyList<BoundExpression> boundArguments,
+        int argumentOffset = 0)
+    {
+        if (boundArguments == null)
+        {
+            return null;
+        }
+
+        return (index, clrParameterType) =>
+        {
+            var argIndex = index - argumentOffset;
+            if (argIndex < 0
+                || argIndex >= boundArguments.Count
+                || clrParameterType == null
+                || !ClrTypeUtilities.IsDelegateType(clrParameterType))
+            {
+                return null;
+            }
+
+            var argument = boundArguments[argIndex];
+            while (argument is BoundConversionExpression conversion)
+            {
+                argument = conversion.Expression;
+            }
+
+            ImmutableArray<RefKind> sourceRefKinds;
+            if (argument is BoundFunctionLiteralExpression literal)
+            {
+                sourceRefKinds = literal.Function.Parameters
+                    .Select(parameter => parameter.RefKind)
+                    .ToImmutableArray();
+            }
+            else if (argument.Type is DelegateTypeSymbol sourceDelegate)
+            {
+                sourceRefKinds = sourceDelegate.Parameters
+                    .Select(parameter => parameter.RefKind)
+                    .ToImmutableArray();
+            }
+            else if (argument.Type?.ClrType is System.Type sourceType
+                && ClrTypeUtilities.IsDelegateType(sourceType))
+            {
+                var sourceInvoke = sourceType.GetMethodSafe("Invoke");
+                if (sourceInvoke == null)
+                {
+                    return null;
+                }
+
+                sourceRefKinds = sourceInvoke.GetParameters()
+                    .Select(GetClrParameterRefKind)
+                    .ToImmutableArray();
+            }
+            else if (argument.Type is FunctionTypeSymbol sourceFunction)
+            {
+                sourceRefKinds = ImmutableArray.CreateRange(
+                    Enumerable.Repeat(RefKind.None, sourceFunction.Arity));
+            }
+            else
+            {
+                return null;
+            }
+
+            var targetInvoke = clrParameterType.GetMethodSafe("Invoke");
+            if (targetInvoke == null)
+            {
+                return null;
+            }
+
+            var targetRefKinds = targetInvoke.GetParameters()
+                .Select(GetClrParameterRefKind)
+                .ToImmutableArray();
+            return sourceRefKinds.Length == targetRefKinds.Length
+                ? sourceRefKinds.SequenceEqual(targetRefKinds)
+                : null;
+        };
+    }
+
+    private static RefKind GetClrParameterRefKind(System.Reflection.ParameterInfo parameter) =>
+        !parameter.ParameterType.IsByRef
+            ? RefKind.None
+            : parameter.IsOut
+                ? RefKind.Out
+                : parameter.IsIn
+                    ? RefKind.In
+                    : RefKind.Ref;
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -2555,44 +2555,9 @@ internal sealed partial class ExpressionBinder
                 return null;
             }
 
-            var argument = boundArguments[argIndex];
-            while (argument is BoundConversionExpression conversion)
-            {
-                argument = conversion.Expression;
-            }
-
-            ImmutableArray<RefKind> sourceRefKinds;
-            if (argument is BoundFunctionLiteralExpression literal)
-            {
-                sourceRefKinds = literal.Function.Parameters
-                    .Select(parameter => parameter.RefKind)
-                    .ToImmutableArray();
-            }
-            else if (argument.Type is DelegateTypeSymbol sourceDelegate)
-            {
-                sourceRefKinds = sourceDelegate.Parameters
-                    .Select(parameter => parameter.RefKind)
-                    .ToImmutableArray();
-            }
-            else if (argument.Type?.ClrType is System.Type sourceType
-                && ClrTypeUtilities.IsDelegateType(sourceType))
-            {
-                var sourceInvoke = sourceType.GetMethodSafe("Invoke");
-                if (sourceInvoke == null)
-                {
-                    return null;
-                }
-
-                sourceRefKinds = sourceInvoke.GetParameters()
-                    .Select(GetClrParameterRefKind)
-                    .ToImmutableArray();
-            }
-            else if (argument.Type is FunctionTypeSymbol sourceFunction)
-            {
-                sourceRefKinds = ImmutableArray.CreateRange(
-                    Enumerable.Repeat(RefKind.None, sourceFunction.Arity));
-            }
-            else
+            if (!DelegateRefKindUtilities.TryGetSourceParameterRefKinds(
+                boundArguments[argIndex],
+                out var sourceRefKinds))
             {
                 return null;
             }
@@ -2603,21 +2568,10 @@ internal sealed partial class ExpressionBinder
                 return null;
             }
 
-            var targetRefKinds = targetInvoke.GetParameters()
-                .Select(GetClrParameterRefKind)
-                .ToImmutableArray();
+            var targetRefKinds = DelegateRefKindUtilities.GetParameterRefKinds(targetInvoke);
             return sourceRefKinds.Length == targetRefKinds.Length
                 ? sourceRefKinds.SequenceEqual(targetRefKinds)
                 : null;
         };
     }
-
-    private static RefKind GetClrParameterRefKind(System.Reflection.ParameterInfo parameter) =>
-        !parameter.ParameterType.IsByRef
-            ? RefKind.None
-            : parameter.IsOut
-                ? RefKind.Out
-                : parameter.IsIn
-                    ? RefKind.In
-                    : RefKind.Ref;
 }

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -254,7 +254,13 @@ internal sealed class LambdaBinder
                 Diagnostics.ReportParameterAlreadyDeclared(p.Location, pname);
             }
 
-            var lambdaParam = new ParameterSymbol(pname, ptype, isVariadic, declaringSyntax: p.Identifier, isScoped: p.IsScoped);
+            var lambdaParam = new ParameterSymbol(
+                pname,
+                ptype,
+                isVariadic,
+                declaringSyntax: p.Identifier,
+                isScoped: p.IsScoped,
+                refKind: conversions.BindAndValidateParameterRefKind(p, pname, ptype, isVariadic, syntax.IsAsync ? "async" : null));
 
             // ADR-0063 §5: function-literal (lambda) parameters can declare a
             // default value; lambdas can be invoked through their delegate type
@@ -659,7 +665,13 @@ internal sealed class LambdaBinder
                 Diagnostics.ReportParameterAlreadyDeclared(p.Location, pname);
             }
 
-            var lambdaParam = new ParameterSymbol(pname, ptype, isVariadic, declaringSyntax: p.Identifier, isScoped: p.IsScoped);
+            var lambdaParam = new ParameterSymbol(
+                pname,
+                ptype,
+                isVariadic,
+                declaringSyntax: p.Identifier,
+                isScoped: p.IsScoped,
+                refKind: conversions.BindAndValidateParameterRefKind(p, pname, ptype, isVariadic, isAsync ? "async" : null));
 
             // ADR-0063 §5: arrow-lambda parameters can also declare a default
             // value; the conversion classifier validates the constant-folded
@@ -871,7 +883,8 @@ internal sealed class LambdaBinder
                 original.Name,
                 adapterParameterType,
                 declaringSyntax: original.DeclaringSyntax,
-                isScoped: original.IsScoped);
+                isScoped: original.IsScoped,
+                refKind: original.RefKind);
             adapterParameters.Add(adapterParameter);
             replacementMap[original] = new BoundConversionExpression(
                 null,

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -847,6 +847,33 @@ internal sealed class MemberLookup
         => MapOpenClrTypeToSymbolic(openClr, openDefinition, typeArguments, openMethodDefinition: null, methodTypeArguments: default);
 
     /// <summary>
+    /// Maps a CLR parameter's value type into the symbolic type model. CLR
+    /// <c>ref</c>/<c>out</c>/<c>in</c> parameters expose <c>T&amp;</c>, but
+    /// G# stores the pointee type and <see cref="RefKind"/> separately.
+    /// </summary>
+    /// <param name="openClr">The open CLR parameter type.</param>
+    /// <param name="openDefinition">The open generic declaring type, if any.</param>
+    /// <param name="typeArguments">The declaring type's symbolic arguments.</param>
+    /// <param name="openMethodDefinition">The open generic method, if any.</param>
+    /// <param name="methodTypeArguments">The method's symbolic arguments.</param>
+    /// <returns>The symbolic parameter value type.</returns>
+    public static TypeSymbol MapOpenClrParameterTypeToSymbolic(
+        Type openClr,
+        Type openDefinition,
+        ImmutableArray<TypeSymbol> typeArguments,
+        MethodInfo openMethodDefinition = null,
+        ImmutableArray<TypeSymbol> methodTypeArguments = default)
+    {
+        var parameterType = openClr?.IsByRef == true ? openClr.GetElementType() : openClr;
+        return MapOpenClrTypeToSymbolic(
+            parameterType,
+            openDefinition,
+            typeArguments,
+            openMethodDefinition,
+            methodTypeArguments);
+    }
+
+    /// <summary>
     /// Issue #833: extended mapping entry point that also substitutes
     /// <em>method</em> generic parameters (<c>MVar(idx)</c>) using the
     /// symbolic arguments at the corresponding ordinals on
@@ -3961,7 +3988,7 @@ internal sealed class MemberLookup
         var anyVariadic = false;
         foreach (var parameter in parameters)
         {
-            var mappedParam = MapOpenClrTypeToSymbolic(
+            var mappedParam = MapOpenClrParameterTypeToSymbolic(
                 parameter.ParameterType,
                 openDefinition,
                 typeArguments,

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2255,7 +2255,7 @@ internal sealed class MemberLookup
         {
             parameterTypes.Add(parameter.ParameterType.ContainsGenericParameters
                 ? TypeSymbol.Object
-                : TypeSymbol.FromClrType(parameter.ParameterType));
+                : ClrNullability.GetParameterTypeSymbol(parameter));
 
             // ADR-0102 follow-up / issue #818: a delegate whose CLR Invoke
             // parameter carries [ParamArrayAttribute] is variadic from the

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -180,6 +180,14 @@ internal static class OverloadResolution
         /// built-in, and user-defined implicit conversion.
         /// </summary>
         StructuralProjection = 14,
+
+        /// <summary>
+        /// A delegate-shaped argument whose value/return types match but whose
+        /// ref/out/in parameter metadata does not. Kept applicable so binding
+        /// can report the conversion error, but ranked behind an exact ref-kind
+        /// overload.
+        /// </summary>
+        DelegateRefKindMismatch = 15,
     }
 
     /// <summary>
@@ -650,6 +658,10 @@ internal static class OverloadResolution
     /// Optional binder callback that recognizes an argument's symbolic object
     /// shape as projectable to a candidate CLR parameter type.
     /// </param>
+    /// <param name="delegateRefKindArgumentCheck">
+    /// Optional binder callback comparing delegate argument and parameter
+    /// ref/out/in metadata for applicability ranking.
+    /// </param>
     /// <param name="methodGroupInference">
     /// Optional callback that resolves a deferred method group from the input
     /// types of the candidate's delegate parameter for generic inference.
@@ -663,7 +675,7 @@ internal static class OverloadResolution
     /// therefore must not contribute erased evidence to generic inference.
     /// Their original CLR types still participate in applicability and ranking.
     /// </param>
-    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null, Func<int, bool> methodGroupArgumentCheck = null, IReadOnlyList<bool> deferredInferenceArgs = null)
+    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, Type, bool?> delegateRefKindArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null, Func<int, bool> methodGroupArgumentCheck = null, IReadOnlyList<bool> deferredInferenceArgs = null)
         where T : MethodBase
     {
         var applicable = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)>();
@@ -687,7 +699,7 @@ internal static class OverloadResolution
             // rest.
             try
             {
-                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck, structuralProjectionArgumentCheck, methodGroupInference, methodGroupArgumentCheck, deferredInferenceArgs);
+                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck, structuralProjectionArgumentCheck, delegateRefKindArgumentCheck, methodGroupInference, methodGroupArgumentCheck, deferredInferenceArgs);
             }
             catch (Exception ex) when (IsMetadataLoadFailure(ex))
             {
@@ -706,7 +718,7 @@ internal static class OverloadResolution
             {
                 try
                 {
-                    EvaluateExpandedParamsCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck, structuralProjectionArgumentCheck);
+                    EvaluateExpandedParamsCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck, structuralProjectionArgumentCheck, delegateRefKindArgumentCheck);
                 }
                 catch (Exception ex) when (IsMetadataLoadFailure(ex))
                 {
@@ -2178,9 +2190,9 @@ internal static class OverloadResolution
     {
         var parameterType = parameter.ParameterType;
 
-        // Issue #2802: an `in` slot's function shape is its pointee type;
-        // readonly-by-ref remains parameter metadata, not a managed-pointer value type.
-        return parameterType.IsByRef && parameter.IsIn && !parameter.IsOut
+        // Issue #2802: a by-ref slot's function shape is its pointee type;
+        // ref/out/in remain parameter metadata, not managed-pointer value types.
+        return parameterType.IsByRef
             ? parameterType.GetElementType()
             : parameterType;
     }
@@ -2269,7 +2281,7 @@ internal static class OverloadResolution
     /// so the per-candidate work can be guarded against reflection load
     /// failures (issue #321) without disturbing the surrounding control flow.
     /// </summary>
-    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null, Func<int, bool> methodGroupArgumentCheck = null, IReadOnlyList<bool> deferredInferenceArgs = null)
+    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, Type, bool?> delegateRefKindArgumentCheck = null, Func<int, IReadOnlyList<Type>, Tuple<Type[], Type>> methodGroupInference = null, Func<int, bool> methodGroupArgumentCheck = null, IReadOnlyList<bool> deferredInferenceArgs = null)
         where T : MethodBase
     {
         {
@@ -2587,6 +2599,12 @@ internal static class OverloadResolution
                     }
                 }
 
+                if (conv != ImplicitConversionKind.None
+                    && delegateRefKindArgumentCheck?.Invoke(i, paramTypes[i]) == false)
+                {
+                    conv = ImplicitConversionKind.DelegateRefKindMismatch;
+                }
+
                 conversions[i] = conv;
             }
 
@@ -2637,7 +2655,7 @@ internal static class OverloadResolution
     /// applicability check in <see cref="EvaluateCandidate"/> but rewrites the
     /// trailing parameter type to the element type for ranking purposes.
     /// </summary>
-    private static void EvaluateExpandedParamsCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null)
+    private static void EvaluateExpandedParamsCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, bool, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null, Func<int, Type, bool> structuralProjectionArgumentCheck = null, Func<int, Type, bool?> delegateRefKindArgumentCheck = null)
         where T : MethodBase
     {
         T candidate = rawCandidate;
@@ -2861,6 +2879,12 @@ internal static class OverloadResolution
                 {
                     return;
                 }
+            }
+
+            if (conv != ImplicitConversionKind.None
+                && delegateRefKindArgumentCheck?.Invoke(i, target) == false)
+            {
+                conv = ImplicitConversionKind.DelegateRefKindMismatch;
             }
 
             conversions[i] = conv;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -2539,7 +2539,9 @@ internal static class OverloadResolution
                         break;
                     }
 
-                    conversions[i] = ImplicitConversionKind.Identity;
+                    conversions[i] = delegateRefKindArgumentCheck?.Invoke(i, paramTypes[i]) == false
+                        ? ImplicitConversionKind.DelegateRefKindMismatch
+                        : ImplicitConversionKind.Identity;
                     continue;
                 }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -2090,7 +2090,7 @@ internal static class OverloadResolution
                 var result = new Type[ps.Length];
                 for (var i = 0; i < ps.Length; i++)
                 {
-                    result[i] = ps[i].ParameterType;
+                    result[i] = GetDelegateCompatibilityParameterType(ps[i]);
                 }
 
                 parameterTypes = result;
@@ -2159,7 +2159,9 @@ internal static class OverloadResolution
             var resolvedParams = new Type[defParams.Length];
             for (var i = 0; i < defParams.Length; i++)
             {
-                resolvedParams[i] = SubstituteGenericParameter(defParams[i].ParameterType, genericArgs);
+                resolvedParams[i] = SubstituteGenericParameter(
+                    GetDelegateCompatibilityParameterType(defParams[i]),
+                    genericArgs);
             }
 
             parameterTypes = resolvedParams;
@@ -2170,6 +2172,17 @@ internal static class OverloadResolution
         {
             return false;
         }
+    }
+
+    private static Type GetDelegateCompatibilityParameterType(ParameterInfo parameter)
+    {
+        var parameterType = parameter.ParameterType;
+
+        // Issue #2802: an `in` slot's function shape is its pointee type;
+        // readonly-by-ref remains parameter metadata, not a managed-pointer value type.
+        return parameterType.IsByRef && parameter.IsIn && !parameter.IsOut
+            ? parameterType.GetElementType()
+            : parameterType;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
@@ -940,84 +940,24 @@ internal sealed partial class OverloadResolver
                 return new BoundErrorExpression(null);
             }
 
-            // ADR-0101 follow-up / issue #812: a named delegate can declare a
-            // trailing variadic parameter. Pack / pass-through happens at the
-            // direct-call site so the lowered Invoke receives one slice
-            // argument, matching the delegate's Invoke signature.
-            var ndIsVariadic = namedDelegateSym.Parameters.Length > 0
-                && namedDelegateSym.Parameters[namedDelegateSym.Parameters.Length - 1].IsVariadic;
-            var ndFixedCount = ndIsVariadic
-                ? namedDelegateSym.Parameters.Length - 1
-                : namedDelegateSym.Parameters.Length;
-
-            if (ndIsVariadic)
+            if (!TryBindNamedDelegateArguments(
+                namedDelegateVar.Name,
+                namedDelegateSym,
+                syntax,
+                boundArguments.ToImmutable(),
+                out var convertedNamedArgs,
+                out var namedRefKinds))
             {
-                if (syntax.Arguments.Count < ndFixedCount)
-                {
-                    Diagnostics.ReportTooFewArgumentsForVariadic(syntax.Identifier.Location, namedDelegateVar.Name, ndFixedCount, syntax.Arguments.Count);
-                    return new BoundErrorExpression(null);
-                }
-            }
-            else if (syntax.Arguments.Count != namedDelegateSym.Parameters.Length)
-            {
-                var requiredCount = namedDelegateSym.Parameters.Length;
-                while (requiredCount > 0 && namedDelegateSym.Parameters[requiredCount - 1].HasExplicitDefaultValue)
-                {
-                    requiredCount--;
-                }
-
-                if (syntax.Arguments.Count < requiredCount || syntax.Arguments.Count > namedDelegateSym.Parameters.Length)
-                {
-                    Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, namedDelegateVar.Name, namedDelegateSym.Parameters.Length, syntax.Arguments.Count);
-                    return new BoundErrorExpression(null);
-                }
+                return new BoundErrorExpression(null);
             }
 
-            ImmutableArray<BoundExpression> ndPermutedArgs = boundArguments.ToImmutable();
-            if (ndIsVariadic)
-            {
-                // Issue #1630: pack/pass-through through the canonical helper
-                // (applies #1493 element coercion when packing — this path
-                // used to pack raw, uncoerced elements).
-                var ndVariadicParam = namedDelegateSym.Parameters[namedDelegateSym.Parameters.Length - 1];
-                var ndSliceType = (SliceTypeSymbol)ndVariadicParam.Type;
-                var hasNdElementErrors = false;
-                ndPermutedArgs = PackOrPassThroughVariadicArguments(
-                    conversions,
-                    Diagnostics,
-                    syntax,
-                    ndPermutedArgs,
-                    ndFixedCount,
-                    ndSliceType,
-                    ndVariadicParam.Name,
-                    i => syntax.Arguments[i].Location,
-                    ref hasNdElementErrors);
-
-                if (hasNdElementErrors)
-                {
-                    return new BoundErrorExpression(null);
-                }
-            }
-            else if (ndPermutedArgs.Length < namedDelegateSym.Parameters.Length)
-            {
-                var padded = ImmutableArray.CreateBuilder<BoundExpression>(namedDelegateSym.Parameters.Length);
-                padded.AddRange(ndPermutedArgs);
-                for (var i = ndPermutedArgs.Length; i < namedDelegateSym.Parameters.Length; i++)
-                {
-                    padded.Add(CreateOptionalUserDefaultArgument(namedDelegateSym.Parameters[i]));
-                }
-
-                ndPermutedArgs = padded.MoveToImmutable();
-            }
-
-            var convertedNamedArgs = ImmutableArray.CreateBuilder<BoundExpression>(ndPermutedArgs.Length);
-            for (var i = 0; i < ndPermutedArgs.Length; i++)
-            {
-                var argLoc = i < syntax.Arguments.Count ? syntax.Arguments[i].Location : syntax.Identifier.Location;
-                convertedNamedArgs.Add(conversions.BindConversion(argLoc, ndPermutedArgs[i], namedDelegateSym.Parameters[i].Type));
-            }
-
-            return BuildIndirectDelegateCall(syntax, namedDelegateVar, namedDelegateSym.EquivalentFunctionType, convertedNamedArgs.MoveToImmutable(), narrowedCallTargetType);
+            return BuildIndirectDelegateCall(
+                syntax,
+                namedDelegateVar,
+                namedDelegateSym.EquivalentFunctionType,
+                convertedNamedArgs,
+                narrowedCallTargetType,
+                namedRefKinds);
         }
 
         // #325: a variable whose type is a CLR delegate (e.g. `Func[int32,

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
@@ -48,7 +48,8 @@ internal sealed partial class OverloadResolver
         VariableSymbol variable,
         FunctionTypeSymbol fnType,
         ImmutableArray<BoundExpression> args,
-        TypeSymbol narrowedTargetType = null)
+        TypeSymbol narrowedTargetType = null,
+        ImmutableArray<RefKind> argumentRefKinds = default)
     {
         // Compute the receiver load and its static type for each variable
         // kind. Every non-null-conditional call below reduces to a plain
@@ -102,11 +103,11 @@ internal sealed partial class OverloadResolver
             var captureName = "$ncap_" + (++binderCtx.NullConditionalCaptureCounter)
                 .ToString(System.Globalization.CultureInfo.InvariantCulture);
             var capture = new LocalVariableSymbol(captureName, isReadOnly: true, type: receiverType);
-            var invoke = new BoundIndirectCallExpression(null, new BoundVariableExpression(null, capture), fnType, args);
+            var invoke = new BoundIndirectCallExpression(null, new BoundVariableExpression(null, capture), fnType, args, argumentRefKinds);
             return BuildNullConditionalDelegateResult(syntax, receiverLoad, capture, invoke, fnType.ReturnType);
         }
 
-        return new BoundIndirectCallExpression(null, receiverLoad, fnType, args);
+        return new BoundIndirectCallExpression(null, receiverLoad, fnType, args, argumentRefKinds);
     }
 
     /// <summary>
@@ -225,13 +226,25 @@ internal sealed partial class OverloadResolver
                 return true;
             }
 
-            if (!TryBindFunctionTypeArguments(variable.Name, functionType, syntax, boundArguments, out var convertedArgs))
+            if (nullable.UnderlyingType is DelegateTypeSymbol namedDelegate)
+            {
+                if (!TryBindNamedDelegateArguments(variable.Name, namedDelegate, syntax, boundArguments, out var namedArgs, out var namedRefKinds))
+                {
+                    result = new BoundErrorExpression(null);
+                    return true;
+                }
+
+                whenNotNull = new BoundIndirectCallExpression(null, captureRef, functionType, namedArgs, namedRefKinds);
+            }
+            else if (!TryBindFunctionTypeArguments(variable.Name, functionType, syntax, boundArguments, out var convertedArgs))
             {
                 result = new BoundErrorExpression(null);
                 return true;
             }
-
-            whenNotNull = new BoundIndirectCallExpression(null, captureRef, functionType, convertedArgs);
+            else
+            {
+                whenNotNull = new BoundIndirectCallExpression(null, captureRef, functionType, convertedArgs);
+            }
         }
 
         if (ReferenceEquals(functionType.ReturnType, TypeSymbol.Void))
@@ -335,6 +348,176 @@ internal sealed partial class OverloadResolver
         }
 
         convertedArgs = convertedBuilder.MoveToImmutable();
+        return true;
+    }
+
+    internal bool TryBindNamedDelegateArguments(
+        string calleeName,
+        DelegateTypeSymbol delegateType,
+        CallExpressionSyntax syntax,
+        ImmutableArray<BoundExpression> boundArguments,
+        out ImmutableArray<BoundExpression> convertedArgs,
+        out ImmutableArray<RefKind> argumentRefKinds)
+    {
+        convertedArgs = default;
+        argumentRefKinds = default;
+
+        var parameters = delegateType.Parameters;
+        var isVariadic = parameters.Length > 0 && parameters[parameters.Length - 1].IsVariadic;
+        var fixedCount = isVariadic ? parameters.Length - 1 : parameters.Length;
+        if (isVariadic)
+        {
+            if (syntax.Arguments.Count < fixedCount)
+            {
+                Diagnostics.ReportTooFewArgumentsForVariadic(syntax.Identifier.Location, calleeName, fixedCount, syntax.Arguments.Count);
+                return false;
+            }
+        }
+        else if (syntax.Arguments.Count != parameters.Length)
+        {
+            var requiredCount = parameters.Length;
+            while (requiredCount > 0 && parameters[requiredCount - 1].HasExplicitDefaultValue)
+            {
+                requiredCount--;
+            }
+
+            if (syntax.Arguments.Count < requiredCount || syntax.Arguments.Count > parameters.Length)
+            {
+                Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, calleeName, parameters.Length, syntax.Arguments.Count);
+                return false;
+            }
+        }
+
+        var arguments = boundArguments;
+        if (isVariadic)
+        {
+            var variadicParameter = parameters[parameters.Length - 1];
+            var hasElementErrors = false;
+            arguments = PackOrPassThroughVariadicArguments(
+                conversions,
+                Diagnostics,
+                syntax,
+                arguments,
+                fixedCount,
+                (SliceTypeSymbol)variadicParameter.Type,
+                variadicParameter.Name,
+                i => i < syntax.Arguments.Count ? syntax.Arguments[i].Location : syntax.Location,
+                ref hasElementErrors);
+            if (hasElementErrors)
+            {
+                return false;
+            }
+        }
+        else if (arguments.Length < parameters.Length)
+        {
+            var padded = ImmutableArray.CreateBuilder<BoundExpression>(parameters.Length);
+            padded.AddRange(arguments);
+            for (var i = arguments.Length; i < parameters.Length; i++)
+            {
+                padded.Add(CreateOptionalUserDefaultArgument(parameters[i]));
+            }
+
+            arguments = padded.MoveToImmutable();
+        }
+
+        var hasRefKinds = false;
+        var refKinds = ImmutableArray.CreateBuilder<RefKind>(parameters.Length);
+        var converted = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
+        var hasErrors = false;
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var parameter = parameters[i];
+            refKinds.Add(parameter.RefKind);
+            hasRefKinds |= parameter.RefKind != RefKind.None;
+
+            var argument = arguments[i];
+            var argumentSyntax = i < syntax.Arguments.Count ? UnwrapNamedArgumentValue(syntax.Arguments[i]) : null;
+            var argumentLocation = argumentSyntax?.Location ?? syntax.Identifier.Location;
+            if (parameter.RefKind != RefKind.None || argumentSyntax is RefArgumentExpressionSyntax)
+            {
+                var argumentRefKind = argumentSyntax is RefArgumentExpressionSyntax refArgument
+                    ? getRefKindFromModifier(refArgument.RefKindModifier)
+                    : RefKind.None;
+                if (argumentRefKind == RefKind.None
+                    && argument is BoundAddressOfExpression or BoundConditionalAddressExpression
+                    && parameter.RefKind != RefKind.None)
+                {
+                    argumentRefKind = parameter.RefKind;
+                }
+
+                if (argumentRefKind != parameter.RefKind)
+                {
+                    if (parameter.RefKind == RefKind.In && argumentRefKind == RefKind.None)
+                    {
+                        Diagnostics.ReportInArgumentMissingInModifier(argumentLocation, i + 1, parameter.Name);
+                    }
+                    else
+                    {
+                        Diagnostics.ReportRefKindMismatch(
+                            argumentLocation,
+                            i + 1,
+                            parameter.Name,
+                            refKindToString(parameter.RefKind),
+                            refKindToString(argumentRefKind));
+                    }
+
+                    hasErrors = true;
+                    converted.Add(argument);
+                    continue;
+                }
+
+                if (argument is BoundAddressOfExpression address)
+                {
+                    if (address.Operand.Type == TypeSymbol.Error
+                        && argumentSyntax is RefArgumentExpressionSyntax inlineOut
+                        && inlineOut.IsInlineDeclaration
+                        && inlineOut.DeclaredType == null)
+                    {
+                        argument = bindRefArgumentExpression(inlineOut, parameter);
+                    }
+                    else if (address.Operand.Type != parameter.Type && address.Operand.Type != TypeSymbol.Error)
+                    {
+                        Diagnostics.ReportWrongArgumentType(argumentLocation, parameter.Name, parameter.Type, address.Operand.Type);
+                        hasErrors = true;
+                    }
+                }
+                else if (argument is BoundConditionalAddressExpression conditionalAddress)
+                {
+                    if (conditionalAddress.PointeeType != parameter.Type
+                        && conditionalAddress.PointeeType != TypeSymbol.Error)
+                    {
+                        Diagnostics.ReportWrongArgumentType(argumentLocation, parameter.Name, parameter.Type, conditionalAddress.PointeeType);
+                        hasErrors = true;
+                    }
+                }
+                else
+                {
+                    Diagnostics.ReportWrongArgumentType(argumentLocation, parameter.Name, parameter.Type, argument.Type);
+                    hasErrors = true;
+                }
+
+                converted.Add(argument);
+                continue;
+            }
+
+            if (argumentSyntax != null
+                && bindLambdaWithTarget != null
+                && IsUntypedArrowLambda(argumentSyntax)
+                && parameter.Type is FunctionTypeSymbol lambdaTarget)
+            {
+                argument = bindLambdaWithTarget((LambdaExpressionSyntax)argumentSyntax, lambdaTarget);
+            }
+
+            converted.Add(conversions.BindConversion(argumentLocation, argument, parameter.Type));
+        }
+
+        if (hasErrors)
+        {
+            return false;
+        }
+
+        convertedArgs = converted.MoveToImmutable();
+        argumentRefKinds = hasRefKinds ? refKinds.MoveToImmutable() : default;
         return true;
     }
 
@@ -537,12 +720,23 @@ internal sealed partial class OverloadResolver
 
         if (callee.Type is DelegateTypeSymbol delegateSym)
         {
-            if (!TryBindFunctionTypeArguments(calleeName, delegateSym.EquivalentFunctionType, syntax, boundArguments.ToImmutable(), out var convertedDelegateArgs))
+            if (!TryBindNamedDelegateArguments(
+                calleeName,
+                delegateSym,
+                syntax,
+                boundArguments.ToImmutable(),
+                out var convertedDelegateArgs,
+                out var delegateRefKinds))
             {
                 return new BoundErrorExpression(null);
             }
 
-            return new BoundIndirectCallExpression(syntax, callee, delegateSym.EquivalentFunctionType, convertedDelegateArgs);
+            return new BoundIndirectCallExpression(
+                syntax,
+                callee,
+                delegateSym.EquivalentFunctionType,
+                convertedDelegateArgs,
+                delegateRefKinds);
         }
 
         // A value whose CLR type is a delegate (e.g. `Func[int32, int32]`) is

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
@@ -514,7 +514,7 @@ internal sealed partial class StatementBinder
     // a BoundAddressOfExpression or BoundConditionalAddressExpression — for
     // every deferable call kind (user function, imported function/method).
     // Detecting the argument shape directly (rather than only consulting
-    // ArgumentRefKinds, which only imported call kinds carry) catches every
+    // ArgumentRefKinds, which not every call kind historically carried) catches every
     // by-ref argument regardless of which call kind wraps it.
     private static bool HasByRefArgument(BoundExpression expression)
     {
@@ -558,7 +558,7 @@ internal sealed partial class StatementBinder
                     MethodTypeArguments = call.MethodTypeArguments,
                 };
             case BoundIndirectCallExpression call:
-                return new BoundIndirectCallExpression(null, CaptureExpression(call.Target, prefix), call.FunctionType, CaptureArguments(call.Arguments, prefix));
+                return new BoundIndirectCallExpression(null, CaptureExpression(call.Target, prefix), call.FunctionType, CaptureArguments(call.Arguments, prefix), call.ArgumentRefKinds);
             case BoundUserInstanceCallExpression call:
                 return new BoundUserInstanceCallExpression(
                     null,

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -396,10 +396,7 @@ internal sealed partial class MethodBodyEmitter
             var namedInvokeHandle = this.outer.userTokens.ResolveDelegateInvokeToken(namedDelegate);
 
             this.EmitExpression(call.Target);
-            foreach (var arg in call.Arguments)
-            {
-                this.EmitExpression(arg);
-            }
+            this.EmitImportedCallArguments(call.Arguments, call.ArgumentRefKinds);
 
             this.il.OpCode(ILOpCode.Callvirt);
             this.il.Token(namedInvokeHandle);
@@ -416,10 +413,7 @@ internal sealed partial class MethodBodyEmitter
         if (this.outer.userTokens.FunctionTypeNeedsSymbolicDelegate(call.FunctionType))
         {
             this.EmitExpression(call.Target);
-            foreach (var arg in call.Arguments)
-            {
-                this.EmitExpression(arg);
-            }
+            this.EmitImportedCallArguments(call.Arguments, call.ArgumentRefKinds);
 
             this.il.OpCode(ILOpCode.Callvirt);
             this.il.Token(this.outer.memberRefs.GetFunctionDelegateInvokeRef(call.FunctionType));
@@ -427,10 +421,7 @@ internal sealed partial class MethodBodyEmitter
         }
 
         this.EmitExpression(call.Target);
-        foreach (var arg in call.Arguments)
-        {
-            this.EmitExpression(arg);
-        }
+        this.EmitImportedCallArguments(call.Arguments, call.ArgumentRefKinds);
 
         var delegateType = this.outer.signatures.ResolveDelegateClrType(call.FunctionType);
 

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -1255,12 +1255,12 @@ internal sealed class TypeDefEmitter
     /// additionally carries a
     /// <c>modreq(System.Runtime.CompilerServices.IsReadOnlyAttribute)</c> so
     /// consumers (e.g. C#) treat the call site as readonly (ADR-0060).
-    /// This is the single canonical encoding shared by every MethodDef
-    /// signature path — class/struct methods
+    /// This is the single canonical encoding shared by every user-method
+    /// signature path — class/struct MethodDefs
     /// (<c>ReflectionMetadataEmitter.EmitFunction</c>), interface abstract and
-    /// static-virtual slots, delegate <c>Invoke</c>, and explicit
-    /// constructors — so the interface slot and its implementation can never
-    /// drift apart again.
+    /// static-virtual slots, delegate <c>Invoke</c> MethodDefs and MemberRefs,
+    /// and explicit constructors — so definitions and call-site references
+    /// can never drift apart again.
     /// </summary>
     /// <param name="ps">The signature's parameters encoder.</param>
     /// <param name="parameter">The parameter symbol to encode.</param>

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -1127,7 +1127,7 @@ internal sealed class UserTokenResolver
                 {
                     foreach (var p in def.Parameters)
                     {
-                        this.signatures.EncodeTypeSymbol(ps.AddParameter().Type(isByRef: p.RefKind != RefKind.None), p.Type);
+                        TypeDefEmitter.EncodeParameterSignature(ps, p, this.signatures.EncodeTypeSymbol, this.outer.wellKnown);
                     }
                 });
 

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -1383,7 +1383,7 @@ internal sealed class UserTokenResolver
                             continue;
                         }
 
-                        this.signatures.EncodeTypeSymbol(ps.AddParameter().Type(isByRef: p.RefKind != RefKind.None), p.Type);
+                        TypeDefEmitter.EncodeParameterSignature(ps, p, this.signatures.EncodeTypeSymbol, this.outer.wellKnown);
                     }
                 });
         return sigBlob;

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -1834,7 +1834,7 @@ public static class SpillSequenceSpiller
                 call,
                 call.Target,
                 call.Arguments,
-                (target, args) => new BoundIndirectCallExpression(null, target, call.FunctionType, args));
+                (target, args) => new BoundIndirectCallExpression(null, target, call.FunctionType, args, call.ArgumentRefKinds));
         }
 
         private BoundSpillSequenceExpression SpillFunctionPointerInvocation(BoundFunctionPointerInvocationExpression call)

--- a/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
@@ -106,8 +106,11 @@ public static class ClrNullability
     /// <returns>The mapped type symbol.</returns>
     public static TypeSymbol GetParameterTypeSymbol(ParameterInfo parameter)
     {
-        var baseSymbol = TypeSymbol.FromClrType(parameter.ParameterType);
-        return ApplyReferenceNullabilityFull(baseSymbol, parameter.ParameterType, parameter, parameter.Member);
+        var parameterType = parameter.ParameterType.IsByRef
+            ? parameter.ParameterType.GetElementType()
+            : parameter.ParameterType;
+        var baseSymbol = TypeSymbol.FromClrType(parameterType);
+        return ApplyReferenceNullabilityFull(baseSymbol, parameterType, parameter, parameter.Member);
     }
 
     internal static bool TryGetNotNullWhen(ParameterInfo parameter, out bool returnValue)

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -351,6 +351,7 @@ public sealed class ImportedClassSymbol : Symbol
                 isExpanded),
             supplementaryInterfaceCheck: supplementaryInterfaceCheck,
             constantNarrowingArgumentCheck: ExpressionBinder.MakeConstantNarrowingArgumentCheck(arguments),
+            delegateRefKindArgumentCheck: ExpressionBinder.MakeDelegateRefKindArgumentCheck(arguments),
             methodGroupInference: ExpressionBinder.MakeMethodGroupInference(arguments, ProjectMethodGroupType));
 
         switch (result.Outcome)

--- a/test/Compiler.Tests/ImportedMemberMatrixTests.cs
+++ b/test/Compiler.Tests/ImportedMemberMatrixTests.cs
@@ -416,6 +416,122 @@ public class ImportedMemberMatrixTests
     }
 
     [Fact]
+    public void ImportedMemberMatrix_GenericRefOutInParameterDelegates_LambdasCompileAndRun()
+    {
+        const string csSource = """
+            namespace ImportedGenericRefDelegates.CSharp
+            {
+                public delegate void RefAction<T>(ref T value);
+                public delegate bool OutPredicate<T>(out T value);
+                public delegate bool InPredicate<T>(in T value);
+
+                public static class Api
+                {
+                    public static T Apply<T>(T value, RefAction<T> action)
+                    {
+                        action(ref value);
+                        return value;
+                    }
+
+                    public static T Read<T>(OutPredicate<T> predicate)
+                    {
+                        predicate(out var value);
+                        return value;
+                    }
+
+                    public static bool Test<T>(T value, InPredicate<T> predicate) =>
+                        predicate(in value);
+                }
+            }
+            """;
+
+        const string gsSource = """
+            package ImportedGenericRefDelegates.Probe
+            import ImportedGenericRefDelegates.CSharp
+            import System
+
+            func Apply[T](value T, replacement T) T {
+                return Api.Apply[T](value, (ref current T) -> { current = replacement })
+            }
+
+            func Read[T](value T) T {
+                var predicate OutPredicate[T] = (out result T) -> {
+                    result = value
+                    return true
+                }
+                return Api.Read[T](predicate)
+            }
+
+            func Test[T](value T) bool {
+                var predicate InPredicate[T] = (in current T) -> current.ToString() == value.ToString()
+                return Api.Test[T](value, predicate)
+            }
+
+            Console.WriteLine(Apply[int32](40, 42))
+            Console.WriteLine(Read[int32](42))
+            Console.WriteLine(Test[int32](42))
+            """;
+
+        Assert.Equal("42\n42\nTrue\n", CompileAndRunWithSiblingCs(
+            csSource,
+            gsSource,
+            "ImportedGenericRefDelegates.CSharp"));
+    }
+
+    [Fact]
+    public void ImportedMemberMatrix_GenericRefOutInParameterDelegates_ReportRefKindMismatches()
+    {
+        const string csSource = """
+            namespace ImportedGenericRefDelegateMismatch.CSharp
+            {
+                public delegate void RefAction<T>(ref T value);
+                public delegate bool OutPredicate<T>(out T value);
+                public delegate bool InPredicate<T>(in T value);
+            }
+            """;
+
+        var sources = new[]
+        {
+            """
+            package ImportedGenericRefDelegateMismatch.RefProbe
+            import ImportedGenericRefDelegateMismatch.CSharp
+
+            func Bad[T]() {
+                var callback RefAction[T] = (value T) -> { }
+            }
+            """,
+            """
+            package ImportedGenericRefDelegateMismatch.OutProbe
+            import ImportedGenericRefDelegateMismatch.CSharp
+
+            func Bad[T]() {
+                var callback OutPredicate[T] = (ref value T) -> true
+            }
+            """,
+            """
+            package ImportedGenericRefDelegateMismatch.InProbe
+            import ImportedGenericRefDelegateMismatch.CSharp
+
+            func Bad[T]() {
+                var callback InPredicate[T] = (out value T) -> {
+                    return true
+                }
+            }
+            """,
+        };
+
+        foreach (var source in sources)
+        {
+            var diagnostics = CompileExpectingErrorsWithSiblingCs(
+                csSource,
+                source,
+                "ImportedGenericRefDelegateMismatch.CSharp");
+            Assert.Contains(diagnostics, d => d.Contains("GS0155", StringComparison.Ordinal));
+            Assert.DoesNotContain(diagnostics, d => d.Contains("GS9998", StringComparison.Ordinal));
+        }
+    }
+
+    [Fact]
     public void ImportedMemberMatrix_RefAndOutParameterDelegates_ReportConversionDiagnosticForMismatchedRefKinds()
     {
         const string csSource = """

--- a/test/Compiler.Tests/ImportedMemberMatrixTests.cs
+++ b/test/Compiler.Tests/ImportedMemberMatrixTests.cs
@@ -527,6 +527,7 @@ public class ImportedMemberMatrixTests
                 source,
                 "ImportedGenericRefDelegateMismatch.CSharp");
             Assert.Contains(diagnostics, d => d.Contains("GS0155", StringComparison.Ordinal));
+            Assert.DoesNotContain(diagnostics, d => d.Contains("GS0159", StringComparison.Ordinal));
             Assert.DoesNotContain(diagnostics, d => d.Contains("GS9998", StringComparison.Ordinal));
         }
     }

--- a/test/Compiler.Tests/ImportedMemberMatrixTests.cs
+++ b/test/Compiler.Tests/ImportedMemberMatrixTests.cs
@@ -312,6 +312,65 @@ public class ImportedMemberMatrixTests
     }
 
     [Fact]
+    public void ImportedMemberMatrix_InParameterDelegate_LambdaCompilesAndRuns()
+    {
+        const string csSource = """
+            namespace ImportedInDelegate.CSharp
+            {
+                public delegate bool Predicate(in int value);
+
+                public static class Api
+                {
+                    public static bool Invoke(Predicate predicate)
+                    {
+                        var value = 100;
+                        return predicate(in value);
+                    }
+                }
+            }
+            """;
+
+        const string gsSource = """
+            package ImportedInDelegate.Probe
+            import ImportedInDelegate.CSharp
+            import System
+
+            Console.WriteLine(Api.Invoke((in value int32) -> value == 100))
+            """;
+
+        Assert.Equal("True\n", CompileAndRunWithSiblingCs(csSource, gsSource, "ImportedInDelegate.CSharp"));
+    }
+
+    [Fact]
+    public void ImportedMemberMatrix_InParameterDelegate_RejectsMismatchedLambdaRefKind()
+    {
+        const string csSource = """
+            namespace ImportedInDelegateMismatch.CSharp
+            {
+                public delegate bool Predicate(in int value);
+
+                public static class Api
+                {
+                    public static bool Invoke(Predicate predicate) => true;
+                }
+            }
+            """;
+
+        const string gsSource = """
+            package ImportedInDelegateMismatch.Probe
+            import ImportedInDelegateMismatch.CSharp
+
+            var result = Api.Invoke((ref value int32) -> value == 100)
+            """;
+
+        var diagnostics = CompileExpectingErrorsWithSiblingCs(
+            csSource,
+            gsSource,
+            "ImportedInDelegateMismatch.CSharp");
+        Assert.Contains(diagnostics, d => d.Contains("GS0155", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void NamedDelegate_OmittedOptionalArgument_UsesDeclaredDefault()
     {
         const string source = """

--- a/test/Compiler.Tests/ImportedMemberMatrixTests.cs
+++ b/test/Compiler.Tests/ImportedMemberMatrixTests.cs
@@ -618,6 +618,243 @@ public class ImportedMemberMatrixTests
     }
 
     [Fact]
+    public void SourceNamedRefOutInParameterDelegates_MethodGroupsCompileAndRun()
+    {
+        const string source = """
+            package SourceRefKindMethodGroups.Probe
+            import System
+
+            type RefAction = delegate func(ref value int32)
+            type OutAction = delegate func(out value int32)
+            type InPredicate = delegate func(in value int32) bool
+            type GenericRefAction[T] = delegate func(ref value T)
+            type GenericOutAction[T] = delegate func(out value T)
+            type GenericInPredicate[T] = delegate func(in value T) bool
+
+            func AddOne(ref value int32) { value = value + 1 }
+            func Set42(out value int32) { value = 42 }
+            func Is42(in value int32) bool { return value == 42 }
+
+            var refAction RefAction = AddOne
+            var outAction OutAction = Set42
+            var inPredicate InPredicate = Is42
+            var genericRefAction GenericRefAction[int32] = AddOne
+            var genericOutAction GenericOutAction[int32] = Set42
+            var genericInPredicate GenericInPredicate[int32] = Is42
+
+            var value = 41
+            refAction(ref value)
+            Console.WriteLine(value)
+            outAction(out value)
+            Console.WriteLine(value)
+            Console.WriteLine(inPredicate(in value))
+            value = 41
+            genericRefAction(ref value)
+            Console.WriteLine(value)
+            genericOutAction(out value)
+            Console.WriteLine(value)
+            Console.WriteLine(genericInPredicate(in value))
+            """;
+
+        Assert.Equal("42\n42\nTrue\n42\n42\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ImportedRefOutInParameterDelegates_SourceMethodGroupsCompileAndRun()
+    {
+        const string csSource = """
+            using System;
+
+            namespace ImportedDelegateSourceMethodGroups.CSharp
+            {
+                public delegate void RefAction(ref int value);
+                public delegate void OutAction(out int value);
+                public delegate bool InPredicate(in int value);
+                public delegate void GenericRefAction<T>(ref T value);
+
+                public static class Api
+                {
+                    public static void Apply(RefAction action, ref int value) => action(ref value);
+                    public static void Fill(OutAction action, out int value) => action(out value);
+                    public static bool Test(InPredicate predicate, in int value) => predicate(in value);
+                    public static string Pick(RefAction action) => "ref";
+                    public static string Pick(Action<int> action) => "value";
+                }
+            }
+            """;
+
+        const string source = """
+            package ImportedDelegateSourceMethodGroups.Probe
+            import System
+            import ImportedDelegateSourceMethodGroups.CSharp
+
+            func AddOne(ref value int32) { value = value + 1 }
+            func Set42(out value int32) { value = 42 }
+            func Is42(in value int32) bool { return value == 42 }
+
+            var genericRefAction GenericRefAction[int32] = AddOne
+            var value = 41
+            Api.Apply(AddOne, ref value)
+            Console.WriteLine(value)
+            Api.Fill(Set42, out value)
+            Console.WriteLine(value)
+            Console.WriteLine(Api.Test(Is42, in value))
+            value = 41
+            genericRefAction(ref value)
+            Console.WriteLine(value)
+            Console.WriteLine(Api.Pick(AddOne))
+            """;
+
+        Assert.Equal(
+            "42\n42\nTrue\n42\nref\n",
+            CompileAndRunWithSiblingCs(
+                csSource,
+                source,
+                "ImportedDelegateSourceMethodGroups.CSharp"));
+    }
+
+    [Fact]
+    public void ImportedRefOutInParameterDelegates_ClrMethodGroupsCompileAndRun()
+    {
+        const string csSource = """
+            namespace ImportedClrMethodGroups.CSharp
+            {
+                public delegate void RefAction(ref int value);
+                public delegate void OutAction(out int value);
+                public delegate bool InPredicate(in int value);
+                public delegate void GenericRefAction<T>(ref T value);
+
+                public static class Methods
+                {
+                    public static void AddOne(ref int value) => value++;
+                    public static void Set42(out int value) => value = 42;
+                    public static bool Is42(in int value) => value == 42;
+                }
+
+                public static class Api
+                {
+                    public static void Apply(RefAction action, ref int value) => action(ref value);
+                    public static void Fill(OutAction action, out int value) => action(out value);
+                    public static bool Test(InPredicate predicate, in int value) => predicate(in value);
+                }
+            }
+            """;
+
+        const string source = """
+            package ImportedClrMethodGroups.Probe
+            import System
+            import ImportedClrMethodGroups.CSharp
+
+            var refAction RefAction = Methods.AddOne
+            var outAction OutAction = Methods.Set42
+            var inPredicate InPredicate = Methods.Is42
+            var genericRefAction GenericRefAction[int32] = Methods.AddOne
+
+            var value = 41
+            refAction(ref value)
+            Console.WriteLine(value)
+            outAction(out value)
+            Console.WriteLine(value)
+            Console.WriteLine(Api.Test(inPredicate, in value))
+            value = 41
+            Api.Apply(Methods.AddOne, ref value)
+            Console.WriteLine(value)
+            Api.Fill(Methods.Set42, out value)
+            Console.WriteLine(value)
+            Console.WriteLine(Api.Test(Methods.Is42, in value))
+            value = 41
+            genericRefAction(ref value)
+            Console.WriteLine(value)
+            """;
+
+        Assert.Equal(
+            "42\n42\nTrue\n42\n42\nTrue\n42\n",
+            CompileAndRunWithSiblingCs(
+                csSource,
+                source,
+                "ImportedClrMethodGroups.CSharp"));
+    }
+
+    [Fact]
+    public void SourceAndImportedMethodGroups_RefKindMismatchesStayDiagnosed()
+    {
+        const string sourceDefined = """
+            package SourceMethodGroupRefKindMismatch.Probe
+
+            type RefAction = delegate func(ref value int32)
+            type OutAction = delegate func(out value int32)
+            type InPredicate = delegate func(in value int32) bool
+
+            func AddOne(ref value int32) { value = value + 1 }
+            func Set42(out value int32) { value = 42 }
+            func Is42Ref(ref value int32) bool { return value == 42 }
+
+            var refCallback RefAction = Set42
+            var outCallback OutAction = AddOne
+            var inCallback InPredicate = Is42Ref
+            """;
+
+        const string csSource = """
+            namespace ImportedMethodGroupRefKindMismatch.CSharp
+            {
+                public delegate void RefAction(ref int value);
+                public delegate void OutAction(out int value);
+                public delegate bool InPredicate(in int value);
+
+                public static class Methods
+                {
+                    public static void AddOne(ref int value) => value++;
+                    public static void Set42(out int value) => value = 42;
+                    public static bool Is42Ref(ref int value) => value == 42;
+                }
+
+                public static class Api
+                {
+                    public static void Apply(RefAction action) { }
+                }
+            }
+            """;
+
+        const string imported = """
+            package ImportedMethodGroupRefKindMismatch.Probe
+            import ImportedMethodGroupRefKindMismatch.CSharp
+
+            func SetSource42(out value int32) { value = 42 }
+
+            var refCallback RefAction = Methods.Set42
+            var outCallback OutAction = Methods.AddOne
+            var inCallback InPredicate = Methods.Is42Ref
+            Api.Apply(SetSource42)
+            Api.Apply(Methods.Set42)
+            """;
+
+        var workDir = CreateWorkDir("method_group_ref_kind_mismatch_");
+        try
+        {
+            var siblingDll = BuildCsLibrary(
+                workDir,
+                csSource,
+                "ImportedMethodGroupRefKindMismatch.CSharp");
+            var sourceDiagnostics = CompileExpectingErrors(
+                sourceDefined,
+                Array.Empty<string>(),
+                workDir);
+            var importedDiagnostics = CompileExpectingErrors(
+                imported,
+                new[] { siblingDll },
+                workDir);
+            Assert.Equal(Enumerable.Repeat("GS0155", 3), GetDiagnosticIds(sourceDiagnostics));
+            Assert.Equal(
+                new[] { "GS0218", "GS0218", "GS0218", "GS0155", "GS0218" },
+                GetDiagnosticIds(importedDiagnostics));
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    [Fact]
     public void SourceNamedRefOutInParameterDelegates_MatchImportedMismatchDiagnostics()
     {
         const string csSource = """

--- a/test/Compiler.Tests/ImportedMemberMatrixTests.cs
+++ b/test/Compiler.Tests/ImportedMemberMatrixTests.cs
@@ -371,6 +371,102 @@ public class ImportedMemberMatrixTests
     }
 
     [Fact]
+    public void ImportedMemberMatrix_RefAndOutParameterDelegates_LambdasCompileAndRun()
+    {
+        const string csSource = """
+            namespace ImportedRefOutDelegates.CSharp
+            {
+                public delegate void RefAction(ref int value);
+                public delegate bool OutPredicate(out int value);
+                public delegate void ValueAction(int value);
+
+                public static class Api
+                {
+                    public static int Apply(RefAction action)
+                    {
+                        var value = 40;
+                        action(ref value);
+                        return value;
+                    }
+
+                    public static int Read(OutPredicate predicate) =>
+                        predicate(out var value) ? value : -1;
+
+                    public static string Kind(RefAction action) => "ref";
+                    public static string Kind(ValueAction action) => "value";
+                }
+            }
+            """;
+
+        const string gsSource = """
+            package ImportedRefOutDelegates.Probe
+            import ImportedRefOutDelegates.CSharp
+            import System
+
+            Console.WriteLine(Api.Apply((ref value int32) -> { value = value + 2 }))
+            Console.WriteLine(Api.Read((out value int32) -> {
+                value = 42
+                return true
+            }))
+            Console.WriteLine(Api.Kind((ref value int32) -> { value = value + 1 }))
+            Console.WriteLine(Api.Kind((value int32) -> { }))
+            """;
+
+        Assert.Equal("42\n42\nref\nvalue\n", CompileAndRunWithSiblingCs(csSource, gsSource, "ImportedRefOutDelegates.CSharp"));
+    }
+
+    [Fact]
+    public void ImportedMemberMatrix_RefAndOutParameterDelegates_RejectMismatchedRefKinds()
+    {
+        const string csSource = """
+            namespace ImportedRefOutDelegateMismatch.CSharp
+            {
+                public delegate void RefAction(ref int value);
+                public delegate bool OutPredicate(out int value);
+
+                public static class Api
+                {
+                    public static void Apply(RefAction action) { }
+                    public static bool Read(OutPredicate predicate) => true;
+                }
+            }
+            """;
+
+        var sources = new[]
+        {
+            """
+            package ImportedRefOutDelegateMismatch.RefProbe
+            import ImportedRefOutDelegateMismatch.CSharp
+
+            Api.Apply((value int32) -> { })
+            """,
+            """
+            package ImportedRefOutDelegateMismatch.OutProbe
+            import ImportedRefOutDelegateMismatch.CSharp
+
+            var result = Api.Read((ref value int32) -> true)
+            """,
+            """
+            package ImportedRefOutDelegateMismatch.ValueProbe
+            import ImportedRefOutDelegateMismatch.CSharp
+
+            let callback (int32) -> void = (value int32) -> { }
+            Api.Apply(callback)
+            """,
+        };
+
+        foreach (var source in sources)
+        {
+            var diagnostics = CompileExpectingErrorsWithSiblingCs(
+                csSource,
+                source,
+                "ImportedRefOutDelegateMismatch.CSharp");
+            Assert.Contains(diagnostics, d => d.Contains("GS0155", StringComparison.Ordinal));
+            Assert.DoesNotContain(diagnostics, d => d.Contains("GS0159", StringComparison.Ordinal));
+        }
+    }
+
+    [Fact]
     public void NamedDelegate_OmittedOptionalArgument_UsesDeclaredDefault()
     {
         const string source = """

--- a/test/Compiler.Tests/ImportedMemberMatrixTests.cs
+++ b/test/Compiler.Tests/ImportedMemberMatrixTests.cs
@@ -584,6 +584,100 @@ public class ImportedMemberMatrixTests
     }
 
     [Fact]
+    public void SourceNamedRefOutInParameterDelegates_LambdasCompileAndRun()
+    {
+        const string source = """
+            package SourceRefKindDelegates.Probe
+            import System
+
+            type RefAction = delegate func(ref value int32)
+            type OutAction = delegate func(out value int32)
+            type InPredicate = delegate func(in value int32) bool
+            type GenericRefAction[T] = delegate func(ref value T)
+            type GenericOutAction[T] = delegate func(out value T)
+            type GenericInPredicate[T] = delegate func(in value T) bool
+
+            var refAction RefAction = (ref value int32) -> { value = value + 1 }
+            var outAction OutAction = (out value int32) -> { value = 42 }
+            var inPredicate InPredicate = (in value int32) -> value == 42
+            var genericRefAction GenericRefAction[int32] = (ref value int32) -> { value = value + 1 }
+            var genericOutAction GenericOutAction[int32] = (out value int32) -> { value = 42 }
+            var genericInPredicate GenericInPredicate[int32] = (in value int32) -> value == 42
+
+            var value = 41
+            refAction(ref value)
+            outAction(out value)
+            Console.WriteLine(inPredicate(in value))
+            value = 41
+            genericRefAction(ref value)
+            genericOutAction(out value)
+            Console.WriteLine(genericInPredicate(in value))
+            """;
+
+        Assert.Equal("True\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void SourceNamedRefOutInParameterDelegates_MatchImportedMismatchDiagnostics()
+    {
+        const string csSource = """
+            namespace RefKindDelegateParity.CSharp
+            {
+                public delegate void RefAction(ref int value);
+                public delegate void OutAction(out int value);
+                public delegate bool InPredicate(in int value);
+                public delegate void GenericRefAction<T>(ref T value);
+                public delegate void GenericOutAction<T>(out T value);
+                public delegate bool GenericInPredicate<T>(in T value);
+            }
+            """;
+
+        const string sourceDefined = """
+            package SourceRefKindDelegateMismatch.Probe
+
+            type RefAction = delegate func(ref value int32)
+            type OutAction = delegate func(out value int32)
+            type InPredicate = delegate func(in value int32) bool
+            type GenericRefAction[T] = delegate func(ref value T)
+            type GenericOutAction[T] = delegate func(out value T)
+            type GenericInPredicate[T] = delegate func(in value T) bool
+
+            var refCallback RefAction = (value int32) -> { }
+            var outCallback OutAction = (ref value int32) -> { }
+            var inCallback InPredicate = (value int32) -> true
+            var genericRefCallback GenericRefAction[int32] = (value int32) -> { }
+            var genericOutCallback GenericOutAction[int32] = (ref value int32) -> { }
+            var genericInCallback GenericInPredicate[int32] = (value int32) -> true
+            """;
+
+        const string imported = """
+            package ImportedRefKindDelegateMismatch.Probe
+            import RefKindDelegateParity.CSharp
+
+            var refCallback RefAction = (value int32) -> { }
+            var outCallback OutAction = (ref value int32) -> { }
+            var inCallback InPredicate = (value int32) -> true
+            var genericRefCallback GenericRefAction[int32] = (value int32) -> { }
+            var genericOutCallback GenericOutAction[int32] = (ref value int32) -> { }
+            var genericInCallback GenericInPredicate[int32] = (value int32) -> true
+            """;
+
+        var workDir = CreateWorkDir("ref_kind_delegate_parity_");
+        try
+        {
+            var siblingDll = BuildCsLibrary(workDir, csSource, "RefKindDelegateParity.CSharp");
+            var sourceDiagnostics = CompileExpectingErrors(sourceDefined, Array.Empty<string>(), workDir);
+            var importedDiagnostics = CompileExpectingErrors(imported, new[] { siblingDll }, workDir);
+            Assert.Equal(Enumerable.Repeat("GS0155", 6), GetDiagnosticIds(sourceDiagnostics));
+            Assert.Equal(GetDiagnosticIds(importedDiagnostics), GetDiagnosticIds(sourceDiagnostics));
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    [Fact]
     public void NamedDelegate_OmittedOptionalArgument_UsesDeclaredDefault()
     {
         const string source = """
@@ -698,6 +792,21 @@ public class ImportedMemberMatrixTests
         var (exitCode, diagnostics) = RunCompiler(GscArgs(outPath, "exe", references, srcPath));
         Assert.True(exitCode != 0, "expected gsc to report errors but it succeeded");
         return diagnostics.Split('\n', StringSplitOptions.RemoveEmptyEntries).ToList();
+    }
+
+    private static List<string> GetDiagnosticIds(IEnumerable<string> diagnostics)
+    {
+        var ids = new List<string>();
+        foreach (var diagnostic in diagnostics)
+        {
+            var index = diagnostic.IndexOf("GS", StringComparison.Ordinal);
+            if (index >= 0 && diagnostic.Length >= index + 6)
+            {
+                ids.Add(diagnostic.Substring(index, 6));
+            }
+        }
+
+        return ids;
     }
 
     private static string[] GscArgs(string outPath, string target, IReadOnlyCollection<string> references, string srcPath)

--- a/test/Compiler.Tests/ImportedMemberMatrixTests.cs
+++ b/test/Compiler.Tests/ImportedMemberMatrixTests.cs
@@ -416,7 +416,7 @@ public class ImportedMemberMatrixTests
     }
 
     [Fact]
-    public void ImportedMemberMatrix_RefAndOutParameterDelegates_RejectMismatchedRefKinds()
+    public void ImportedMemberMatrix_RefAndOutParameterDelegates_ReportConversionDiagnosticForMismatchedRefKinds()
     {
         const string csSource = """
             namespace ImportedRefOutDelegateMismatch.CSharp

--- a/test/Core.Tests/CodeAnalysis/Binding/RefKindParameterSitesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefKindParameterSitesTests.cs
@@ -106,6 +106,62 @@ type StructInObserver = delegate func(in box int32)
     }
 
     [Fact]
+    public void NamedDelegate_RefKindInvocationMismatches_ReportGS0235NotGS0155()
+    {
+        var sources = new[]
+        {
+            @"
+package RefDelegateMismatch
+
+type RefAction = delegate func(ref value int32)
+var callback RefAction = (ref value int32) -> { }
+var value = 0
+callback(out value)
+0
+",
+            @"
+package GenericOutDelegateMismatch
+
+type OutAction[T] = delegate func(out value T) bool
+func Bad[T](callback OutAction[T], ref value T) {
+    callback(ref value)
+}
+0
+",
+            @"
+package GenericInDelegateMismatch
+
+type InAction[T] = delegate func(in value T) bool
+func Bad[T](callback InAction[T], ref value T) {
+    callback(ref value)
+}
+0
+",
+        };
+
+        foreach (var source in sources)
+        {
+            var result = Evaluate(source);
+            Assert.True(
+                result.Diagnostics.Any(d => d.Id == "GS0235"),
+                source + "\n" + string.Join("\n", result.Diagnostics.Select(d => $"{d.Id}: {d.Message}")));
+            Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0155");
+        }
+
+        var missingIn = Evaluate(@"
+package InDelegateMissingModifier
+
+type InAction = delegate func(in value int32)
+var callback InAction = (in value int32) -> { }
+var value = 0
+callback(value)
+0
+");
+        Assert.Contains(missingIn.Diagnostics, d => d.Id == "GS0242");
+        Assert.DoesNotContain(missingIn.Diagnostics, d => d.Id == "GS0155");
+    }
+
+    [Fact]
     public void PrimaryCtor_RefParameter_Rejected()
     {
         var source = @"

--- a/test/Core.Tests/CodeAnalysis/Emit/RefKindParameterEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/RefKindParameterEmitTests.cs
@@ -409,6 +409,69 @@ type IntInObserver = delegate func(in value int32)
         Assert.Contains(modreqs, t => t.FullName == "System.Runtime.CompilerServices.IsReadOnlyAttribute");
     }
 
+    [Fact]
+    public void NamedDelegate_RefOutInInvocations_CompileAndRun()
+    {
+        const string Source = @"package DelegateByRefInvoke
+import System
+
+type RefAction = delegate func(ref value int32)
+type OutAction = delegate func(out value int32)
+type InPredicate = delegate func(in value int32) bool
+
+var refAction RefAction = (ref value int32) -> { value = value + 2 }
+var outAction OutAction = (out value int32) -> { value = 42 }
+var inPredicate InPredicate = (in value int32) -> value == 42
+
+var value = 40
+refAction(ref value)
+Console.WriteLine(value)
+outAction.Invoke(out value)
+Console.WriteLine(value)
+Console.WriteLine(inPredicate(in value))
+Console.WriteLine(inPredicate.Invoke(in value))
+";
+
+        Assert.Equal("42\n42\nTrue\nTrue\n", CompileAndRun(Source, "DelegateByRefInvoke"));
+    }
+
+    [Fact]
+    public void GenericNamedDelegate_RefOutInInvocations_CompileAndRun()
+    {
+        const string Source = @"package GenericDelegateByRefInvoke
+import System
+
+type RefAction[T] = delegate func(ref value T)
+type OutAction[T] = delegate func(out value T)
+type InPredicate[T] = delegate func(in value T) bool
+
+func Apply[T](action RefAction[T], ref value T) {
+    action(ref value)
+}
+
+func Read[T](action OutAction[T], ref value T) {
+    action.Invoke(out value)
+}
+
+func Test[T](predicate InPredicate[T], in value T) bool {
+    return predicate(in value) && predicate.Invoke(in value)
+}
+
+var refAction RefAction[int32] = (ref value int32) -> { value = value + 2 }
+var outAction OutAction[int32] = (out value int32) -> { value = 42 }
+var inPredicate InPredicate[int32] = (in value int32) -> value == 42
+
+var value = 40
+Apply[int32](refAction, ref value)
+Console.WriteLine(value)
+Read[int32](outAction, ref value)
+Console.WriteLine(value)
+Console.WriteLine(Test[int32](inPredicate, in value))
+";
+
+        Assert.Equal("42\n42\nTrue\n", CompileAndRun(Source, "GenericDelegateByRefInvoke"));
+    }
+
     private static string CompileAndRun(string source, string contextName)
     {
         using var peStream = new MemoryStream();


### PR DESCRIPTION
## Summary
- normalize imported delegate byref parameter value shapes while preserving exact `in`/`ref`/`out` metadata
- propagate ref-kinds through lambda binding, overload resolution, lowering, closure emission, and delegate invocation
- use canonical parameter signature encoding so `in` modreqs match between definitions and member references
- support generic imported and source-defined byref delegates and method-group conversions
- report precise ref-kind mismatches instead of GS0159 or GS9998

## Security
Exact ref-kind validation prevents unsafe byref aliasing, mutation, overload confusion, and signature drift. Independent Opus 4.8 reviews found no remaining security or correctness issues.

## Tests
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --filter FullyQualifiedName~ImportedMemberMatrix --no-restore --nologo`
- `dotnet test test/Core.Tests/Core.Tests.csproj --filter FullyQualifiedName~RefKindParameter --no-restore --nologo`
- full Core suite and focused delegate/method-group regressions were also exercised during review

Closes #2802