### PR TITLE
Fix inherited C# property chains in unqualified member access

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -206,7 +206,7 @@ internal sealed partial class ExpressionBinder
             // value/instance path — both unchanged.
             if (variableHit != null
                 && rightPart is CallExpressionSyntax colorColorCall
-                && TryResolveColorColorType(name, leftName, out _, out var unifiedColorStruct, out _)
+                && TryResolveColorColorType(name, leftName, out _, out var unifiedColorStruct, out _, out _)
                 && unifiedColorStruct != null
                 && TryBindColorColorUnifiedCall(unifiedColorStruct, leftName, colorColorCall, out var unifiedColorResult))
             {
@@ -220,8 +220,19 @@ internal sealed partial class ExpressionBinder
             // to the value interpretation otherwise so instance access continues
             // to bind as today (`field.InstanceMethod()`).
             if (variableHit != null
-                && TryResolveColorColorType(name, leftName, out var colorClassSymbol, out var colorStructSymbol, out var colorEnumSymbol)
-                && RightPartLooksLikeStaticMember(colorClassSymbol, colorStructSymbol, colorEnumSymbol, rightPart))
+                && TryResolveColorColorType(
+                    name,
+                    leftName,
+                    out var colorClassSymbol,
+                    out var colorStructSymbol,
+                    out var colorInterfaceSymbol,
+                    out var colorEnumSymbol)
+                && RightPartLooksLikeStaticMember(
+                    colorClassSymbol,
+                    colorStructSymbol,
+                    colorInterfaceSymbol,
+                    colorEnumSymbol,
+                    rightPart))
             {
                 if (colorClassSymbol != null)
                 {
@@ -230,6 +241,10 @@ internal sealed partial class ExpressionBinder
                 else if (colorStructSymbol != null)
                 {
                     userStructSymbol = colorStructSymbol;
+                }
+                else if (colorInterfaceSymbol != null)
+                {
+                    userInterfaceSymbol = colorInterfaceSymbol;
                 }
                 else
                 {
@@ -351,9 +366,32 @@ internal sealed partial class ExpressionBinder
             {
                 // Issue #2809: an unqualified accessor chain whose head is an
                 // inherited CLR property/field (`Clients.All()`) must bind as
-                // `this.Clients.All()` before the fallback reclassifies the head
-                // as a type/import qualifier.
-                return BindAccessorStep(inheritedClrHead, null, rightPart);
+                // `this.Clients.All()`. Preserve #687's type/value collision
+                // rule: a same-named type still wins when the right side is one
+                // of its static members (`Path.Combine(...)`).
+                if (TryResolveColorColorType(
+                        name,
+                        leftName,
+                        out var inheritedColorClass,
+                        out var inheritedColorStruct,
+                        out var inheritedColorInterface,
+                        out var inheritedColorEnum)
+                    && RightPartLooksLikeStaticMember(
+                        inheritedColorClass,
+                        inheritedColorStruct,
+                        inheritedColorInterface,
+                        inheritedColorEnum,
+                        rightPart))
+                {
+                    classSymbol = inheritedColorClass;
+                    userStructSymbol = inheritedColorStruct;
+                    userInterfaceSymbol = inheritedColorInterface;
+                    enumSymbol = inheritedColorEnum;
+                }
+                else
+                {
+                    return BindAccessorStep(inheritedClrHead, null, rightPart);
+                }
             }
             else if (scope.TryLookupImport(name, out var matchedImport)
                 && TryBindImportAccessor(matchedImport, ref rightPart, out var typeFromImport))
@@ -1509,10 +1547,12 @@ internal sealed partial class ExpressionBinder
         NameExpressionSyntax leftName,
         out ImportedClassSymbol importedClassSymbol,
         out StructSymbol userStructSymbol,
+        out InterfaceSymbol interfaceSymbol,
         out EnumSymbol enumSymbol)
     {
         importedClassSymbol = null;
         userStructSymbol = null;
+        interfaceSymbol = null;
         enumSymbol = null;
 
         // Issue #2394: check the same-compilation SOURCE type (struct/enum)
@@ -1530,6 +1570,12 @@ internal sealed partial class ExpressionBinder
             if (typeAlias is EnumSymbol foundEnum)
             {
                 enumSymbol = foundEnum;
+                return true;
+            }
+
+            if (typeAlias is InterfaceSymbol foundInterface)
+            {
+                interfaceSymbol = foundInterface;
                 return true;
             }
         }
@@ -1648,6 +1694,7 @@ internal sealed partial class ExpressionBinder
     private bool RightPartLooksLikeStaticMember(
         ImportedClassSymbol importedClassSymbol,
         StructSymbol userStructSymbol,
+        InterfaceSymbol interfaceSymbol,
         EnumSymbol enumSymbol,
         ExpressionSyntax rightPart)
     {
@@ -1664,6 +1711,11 @@ internal sealed partial class ExpressionBinder
         if (userStructSymbol != null)
         {
             return HasUserTypeStaticMember(userStructSymbol, headName, isCall);
+        }
+
+        if (interfaceSymbol != null)
+        {
+            return HasUserTypeStaticMember(interfaceSymbol, headName, isCall);
         }
 
         if (enumSymbol != null)
@@ -1762,25 +1814,50 @@ internal sealed partial class ExpressionBinder
         return false;
     }
 
-    private static bool HasUserTypeStaticMember(StructSymbol structSym, string headName, bool isCall)
+    private static bool HasUserTypeStaticMember(TypeSymbol type, string headName, bool isCall)
     {
-        if (structSym == null)
+        if (type == null)
         {
             return false;
+        }
+
+        if (type is InterfaceSymbol interfaceType)
+        {
+            var fieldOwner = interfaceType.Definition ?? interfaceType;
+            fieldOwner.EnsureMembersResolved();
+            if (isCall)
+            {
+                return !TypeMemberModel.GetMethods(
+                    interfaceType,
+                    headName,
+                    MemberQuery.Static(MemberKinds.Method)).IsEmpty;
+            }
+
+            return fieldOwner.GetStaticField(headName) != null
+                || fieldOwner.Properties.Any(
+                    property => property.IsStatic
+                        && !property.IsIndexer
+                        && property.Name == headName)
+                || !TypeMemberModel.GetMethods(
+                    interfaceType,
+                    headName,
+                    MemberQuery.Static(MemberKinds.Method)).IsEmpty;
         }
 
         // ADR-0112: route through the canonical member-resolution layer.
         if (isCall)
         {
-            return !TypeMemberModel.GetMethods(structSym, headName, MemberQuery.InheritedStatic(MemberKinds.Method)).IsEmpty
-                || ClrTypeExposesStaticMember(TypeMemberModel.GetNearestImportedBase(structSym)?.ClrType, headName);
+            return !TypeMemberModel.GetMethods(type, headName, MemberQuery.InheritedStatic(MemberKinds.Method)).IsEmpty
+                || (type is StructSymbol structType
+                    && ClrTypeExposesStaticMember(TypeMemberModel.GetNearestImportedBase(structType)?.ClrType, headName));
         }
 
         return TypeMemberModel.LookupMember(
-            structSym,
+            type,
             headName,
             MemberQuery.InheritedStatic(MemberKinds.Field | MemberKinds.Property)) != null
-            || ClrTypeExposesStaticMember(TypeMemberModel.GetNearestImportedBase(structSym)?.ClrType, headName);
+            || (type is StructSymbol structType
+                && ClrTypeExposesStaticMember(TypeMemberModel.GetNearestImportedBase(structType)?.ClrType, headName));
     }
 
     private BoundExpression BindEnumAccessorStep(EnumSymbol enumSymbol, ExpressionSyntax rightPart)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -347,6 +347,14 @@ internal sealed partial class ExpressionBinder
                         narrowed => new BoundVariableExpression(null, variable, narrowed));
                 }
             }
+            else if (TryBindInheritedClrInstanceMemberByBareName(name, out var inheritedClrHead))
+            {
+                // Issue #2809: an unqualified accessor chain whose head is an
+                // inherited CLR property/field (`Clients.All()`) must bind as
+                // `this.Clients.All()` before the fallback reclassifies the head
+                // as a type/import qualifier.
+                return BindAccessorStep(inheritedClrHead, null, rightPart);
+            }
             else if (scope.TryLookupImport(name, out var matchedImport)
                 && TryBindImportAccessor(matchedImport, ref rightPart, out var typeFromImport))
             {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -1856,8 +1856,8 @@ internal sealed partial class ExpressionBinder
             type,
             headName,
             MemberQuery.InheritedStatic(MemberKinds.Field | MemberKinds.Property)) != null
-            || (type is StructSymbol structType
-                && ClrTypeExposesStaticMember(TypeMemberModel.GetNearestImportedBase(structType)?.ClrType, headName));
+            || (type is StructSymbol nonCallStructType
+                && ClrTypeExposesStaticMember(TypeMemberModel.GetNearestImportedBase(nonCallStructType)?.ClrType, headName));
     }
 
     private BoundExpression BindEnumAccessorStep(EnumSymbol enumSymbol, ExpressionSyntax rightPart)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -431,10 +431,12 @@ internal sealed partial class ExpressionBinder
                 receiver,
                 out var importedType,
                 out var sourceType,
+                out var interfaceType,
                 out var enumType)
             && RightPartLooksLikeStaticMember(
                 importedType,
                 sourceType,
+                interfaceType,
                 enumType,
                 rightPart);
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2809InheritedClrPropertyAccessorChainTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2809InheritedClrPropertyAccessorChainTests.cs
@@ -1,0 +1,107 @@
+// <copyright file="Issue2809InheritedClrPropertyAccessorChainTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2809InheritedClrPropertyAccessorChainTests
+{
+    private static readonly string LibraryPath = EmitLibrary();
+
+    [Fact]
+    public void ImportedBaseProperty_HeadOfUnqualifiedAccessorChain_Binds()
+    {
+        Assert.Empty(Bind("""
+            package Consumer
+            import Project1
+
+            class ChatHub : A {
+                func Join() int32 {
+                    return Clients.All()
+                }
+            }
+            """));
+    }
+
+    [Fact]
+    public void ImportedBaseProperty_ThroughUserBase_HeadOfUnqualifiedAccessorChain_Binds()
+    {
+        Assert.Empty(Bind("""
+            package Consumer
+            import Project1
+
+            open class Mid : A {
+            }
+
+            class ChatHub : Mid {
+                func Join() int32 {
+                    return Clients.All()
+                }
+            }
+            """));
+    }
+
+    private static IReadOnlyList<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
+    {
+        using var resolver = ReferenceResolver.WithReferences(new[] { LibraryPath });
+        var tree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GsCompilation(resolver, tree) { IsLibrary = true };
+        return tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .Where(d => d.IsError)
+            .ToList();
+    }
+
+    private static string EmitLibrary()
+    {
+        string outputDirectory = Path.Combine(AppContext.BaseDirectory, "Issue2809Binding");
+        Directory.CreateDirectory(outputDirectory);
+        string libraryPath = Path.Combine(outputDirectory, "Issue2809.Library.dll");
+
+        const string source = """
+            namespace Project1
+            {
+                public class A
+                {
+                    public B Clients { get; } = new B();
+                }
+
+                public class B
+                {
+                    public int All() => 1;
+                }
+            }
+            """;
+
+        var trustedPlatformAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        var references = trustedPlatformAssemblies == null
+            ? Array.Empty<MetadataReference>()
+            : trustedPlatformAssemblies
+                .Split(Path.PathSeparator)
+                .Where(path => !string.IsNullOrWhiteSpace(path))
+                .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+                .ToArray();
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "Issue2809.Library",
+            syntaxTrees: new[] { CSharpSyntaxTree.ParseText(source) },
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var emit = compilation.Emit(libraryPath);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics.Select(d => d.ToString())));
+        return libraryPath;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2809InheritedClrPropertyAccessorChainTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2809InheritedClrPropertyAccessorChainTests.cs
@@ -52,6 +52,43 @@ public sealed class Issue2809InheritedClrPropertyAccessorChainTests
             """));
     }
 
+    [Fact]
+    public void ImportedBaseProperty_DoesNotShadowStaticTypeMember()
+    {
+        Assert.Empty(Bind("""
+            package Consumer
+            import Project1
+            import System.IO
+
+            class ChatHub : A {
+                func Join() string {
+                    return Path.Combine("first", "second")
+                }
+            }
+            """));
+    }
+
+    [Fact]
+    public void ImportedBaseProperty_DoesNotShadowStaticInterfaceMember()
+    {
+        Assert.Empty(Bind("""
+            package Consumer
+            import Project1
+
+            interface Path {
+                shared {
+                    const Kind string = "path"
+                }
+            }
+
+            class ChatHub : A {
+                func Join() string {
+                    return Path.Kind
+                }
+            }
+            """));
+    }
+
     private static IReadOnlyList<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
     {
         using var resolver = ReferenceResolver.WithReferences(new[] { LibraryPath });
@@ -76,6 +113,7 @@ public sealed class Issue2809InheritedClrPropertyAccessorChainTests
                 public class A
                 {
                     public B Clients { get; } = new B();
+                    public B Path { get; } = new B();
                 }
 
                 public class B


### PR DESCRIPTION
## Summary

- bind unqualified accessor chains beginning with inherited CLR properties or fields as instance access
- preserve existing type/value collision rules so static type members still win over same-named inherited values
- cover direct imported bases, intermediate G# bases, imported static types, and source-interface static members

## Validation

- targeted inherited-member and type-collision binding coverage
- existing PR checks passed before the follow-up; the update will trigger fresh CI

Fixes #2809