### PR TITLE
Fix explicit lambda parameter conversions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -978,7 +978,7 @@ internal sealed partial class ExpressionBinder
         // `List[T]`/`sequence[T]` paths do) purely for the purpose of inferring
         // the deferred lambda targets; the finally-bound call keeps the original
         // slice/array receiver expression.
-        var receiverType = receiver?.Type;
+        var receiverType = receiver?.Type ?? classSymbol?.SymbolicReceiver;
         if (receiverType != null
             && TryNormalizeSliceArrayReceiverForLambdaInference(receiverType, out var normalizedReceiverType))
         {
@@ -1423,8 +1423,11 @@ internal sealed partial class ExpressionBinder
             try
             {
                 if (receiverOpenDefinition != null
-                    && !method.IsStatic
-                    && TryResolveOpenInstanceMethod(receiverOpenDefinition, method, out var resolvedOpenMethod))
+                    && TryResolveOpenMethodByToken(
+                        receiverOpenDefinition,
+                        method,
+                        method.IsStatic ? BindingFlags.Static : BindingFlags.Instance,
+                        out var resolvedOpenMethod))
                 {
                     openMethod = resolvedOpenMethod;
                 }
@@ -1943,15 +1946,17 @@ internal sealed partial class ExpressionBinder
                 // (delegate-reshaping conversions still make it applicable to a
                 // concrete CLR delegate parameter when that path is chosen).
                 var argName = argumentNames.IsDefault ? null : argumentNames[argSlot];
+                var symbolicReceiver = receiver?.Type as ImportedTypeSymbol
+                    ?? classSymbol?.SymbolicReceiver;
                 if (argumentNames.IsDefault
-                    && receiver?.Type is ImportedTypeSymbol symbolicReceiver
+                    && symbolicReceiver != null
                     && !symbolicReceiver.TypeArguments.IsDefaultOrEmpty
                     && symbolicReceiver.TypeArguments.Any(TypeSymbol.RequiresSymbolicProjection))
                 {
-                    // Issue #2673: a constructed imported receiver can erase a
-                    // same-compilation type argument to object in reflection.
-                    // Defer the lambda so the existing symbolic-target pass
-                    // recovers the open method's reified delegate signature.
+                    // Issue #2673 / #2810: a constructed imported instance or
+                    // static receiver can erase a symbolic type argument to
+                    // object in reflection. Defer the lambda so the symbolic
+                    // target pass recovers the open delegate signature.
                     deferredArrowLambdaIndices.Add(argSlot);
                     boundArguments.Add(new BoundErrorExpression(inner));
                 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -965,6 +965,7 @@ internal sealed partial class ExpressionBinder
         string methodName,
         CallExpressionSyntax ce,
         System.Type[] explicitTypeArgs,
+        ImmutableArray<TypeSymbol> explicitTypeArgSymbols,
         List<int> deferredIndices,
         BoundExpression[] boundArgs)
     {
@@ -1005,12 +1006,21 @@ internal sealed partial class ExpressionBinder
         // (`c.Id` → GS0158). Try a symbol-based inference first that recovers
         // the real element type from the receiver's symbolic `TypeArguments`,
         // builds a `FunctionTypeSymbol` target carrying that type, and binds the
-        // lambda against it. This path only succeeds (and pre-empts the CLR
-        // paths) when it actually recovers a same-compilation user type, so the
-        // referenced-element-type and primitive cases are untouched.
+        // lambda against it. Issue #2810 also uses this path for explicit
+        // method type arguments whose CLR placeholder is `object`.
         foreach (var probe in probes)
         {
-            if (TryMapDeferredLambdaTargetsSymbolic(probe.Methods, probe.ReceiverParameterOffset, receiverType, ce, deferredIndices, boundArgs, deferred, out var symbolicTargets, out var exactReturnIndices))
+            if (TryMapDeferredLambdaTargetsSymbolic(
+                probe.Methods,
+                probe.ReceiverParameterOffset,
+                receiverType,
+                ce,
+                explicitTypeArgSymbols,
+                deferredIndices,
+                boundArgs,
+                deferred,
+                out var symbolicTargets,
+                out var exactReturnIndices))
             {
                 foreach (var idx in deferredIndices)
                 {
@@ -1338,6 +1348,7 @@ internal sealed partial class ExpressionBinder
         int offset,
         TypeSymbol receiverType,
         CallExpressionSyntax ce,
+        ImmutableArray<TypeSymbol> explicitTypeArgSymbols,
         List<int> deferredIndices,
         BoundExpression[] boundArgs,
         HashSet<int> deferred,
@@ -1355,9 +1366,9 @@ internal sealed partial class ExpressionBinder
         // type carried by a non-deferred argument such as `items : List[Item]`.
         // An extension probe (offset == 1) places the receiver in slot 0, so it
         // genuinely needs a receiver; a static/instance probe (offset == 0) does
-        // not. The success gate below (`anySameCompilationType`) still ensures
-        // this path only fires — and pre-empts the CLR erasure paths — when a
-        // real same-compilation user type is recovered.
+        // not. The success gate below ensures this path only pre-empts the CLR
+        // path when the recovered shape contains symbolic information that
+        // reflection cannot faithfully represent.
         if (offset == 1 && receiverType == null)
         {
             return false;
@@ -1398,7 +1409,7 @@ internal sealed partial class ExpressionBinder
 
         Dictionary<int, ImmutableArray<TypeSymbol>> agreed = null;
         Dictionary<int, TypeSymbol> agreedReturnTypes = null;
-        var anySameCompilationType = false;
+        var anySymbolicType = false;
 
         foreach (var method in methods)
         {
@@ -1411,15 +1422,15 @@ internal sealed partial class ExpressionBinder
             ParameterInfo[] openParameters;
             try
             {
-                if (method.IsGenericMethod)
-                {
-                    openMethod = method.IsGenericMethodDefinition ? method : method.GetGenericMethodDefinition();
-                }
-                else if (receiverOpenDefinition != null
+                if (receiverOpenDefinition != null
                     && !method.IsStatic
                     && TryResolveOpenInstanceMethod(receiverOpenDefinition, method, out var resolvedOpenMethod))
                 {
                     openMethod = resolvedOpenMethod;
+                }
+                else if (method.IsGenericMethod)
+                {
+                    openMethod = method.IsGenericMethodDefinition ? method : method.GetGenericMethodDefinition();
                 }
                 else
                 {
@@ -1438,13 +1449,16 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            var inferred = MemberLookup.InferSymbolicMethodTypeArguments(openMethod, symbolicArgVector);
+            var inferred = !explicitTypeArgSymbols.IsDefaultOrEmpty
+                && openMethod.GetGenericArguments().Length == explicitTypeArgSymbols.Length
+                    ? explicitTypeArgSymbols.ToArray()
+                    : MemberLookup.InferSymbolicMethodTypeArguments(openMethod, symbolicArgVector);
             var methodTypeArgs = ImmutableArray.Create(inferred);
 
             var slotTargets = new Dictionary<int, ImmutableArray<TypeSymbol>>();
             var slotReturnTypes = new Dictionary<int, TypeSymbol>();
             var candidateUsable = true;
-            var candidateHasSameCompilationType = false;
+            var candidateHasSymbolicType = false;
 
             foreach (var idx in deferredIndices)
             {
@@ -1460,6 +1474,11 @@ internal sealed partial class ExpressionBinder
                 try
                 {
                     var delegateType = openParameters[paramIndex].ParameterType;
+                    if (MemberLookup.TryGetExpressionTreeDelegateType(delegateType, out var unwrappedDelegateType))
+                    {
+                        delegateType = unwrappedDelegateType;
+                    }
+
                     invoke = delegateType?.GetMethodSafe("Invoke");
                     invokeParameters = invoke?.GetParameters();
                 }
@@ -1506,22 +1525,22 @@ internal sealed partial class ExpressionBinder
                 var slotUsable = true;
                 foreach (var invokeParameter in invokeParameters)
                 {
-                    var mapped = MemberLookup.MapOpenClrTypeToSymbolic(
+                    var mapped = MemberLookup.MapOpenClrParameterTypeToSymbolic(
                         invokeParameter.ParameterType,
                         receiverOpenDefinition,
                         receiverTypeArguments,
                         openMethod,
                         methodTypeArgs);
-                    if (mapped == null || mapped == TypeSymbol.Error || TypeSymbol.ContainsTypeParameter(mapped))
+                    if (mapped == null || mapped == TypeSymbol.Error)
                     {
                         slotUsable = false;
                         break;
                     }
 
                     parameterTypes.Add(mapped);
-                    if (TypeSymbol.ContainsSameCompilationUserType(mapped))
+                    if (TypeSymbol.RequiresSymbolicProjection(mapped))
                     {
-                        candidateHasSameCompilationType = true;
+                        candidateHasSymbolicType = true;
                     }
                 }
 
@@ -1552,9 +1571,9 @@ internal sealed partial class ExpressionBinder
                 if (mappedReturn != null && mappedReturn != TypeSymbol.Error && !TypeSymbol.ContainsTypeParameter(mappedReturn))
                 {
                     slotReturnTypes[idx] = mappedReturn;
-                    if (TypeSymbol.ContainsSameCompilationUserType(mappedReturn))
+                    if (TypeSymbol.RequiresSymbolicProjection(mappedReturn))
                     {
-                        candidateHasSameCompilationType = true;
+                        candidateHasSymbolicType = true;
                     }
                 }
             }
@@ -1592,10 +1611,10 @@ internal sealed partial class ExpressionBinder
                 }
             }
 
-            anySameCompilationType |= candidateHasSameCompilationType;
+            anySymbolicType |= candidateHasSymbolicType;
         }
 
-        if (agreed == null || !anySameCompilationType)
+        if (agreed == null || !anySymbolicType)
         {
             return false;
         }
@@ -1997,7 +2016,15 @@ internal sealed partial class ExpressionBinder
         if (deferredArrowLambdaIndices.Count > 0)
         {
             var mutableArgs = boundArguments.ToArray();
-            ResolveDeferredArrowLambdaArguments(receiver, classSymbol, methodName, ce, explicitTypeArgs, deferredArrowLambdaIndices, mutableArgs);
+            ResolveDeferredArrowLambdaArguments(
+                receiver,
+                classSymbol,
+                methodName,
+                ce,
+                explicitTypeArgs,
+                typeArgSymbols,
+                deferredArrowLambdaIndices,
+                mutableArgs);
 
             // Issue #951: the reflection-driven resolution above only covers CLR
             // (imported) methods. When the receiver is a user-declared

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -622,6 +622,9 @@ internal sealed class LambdaBinder
         var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(syntax.Parameters.Count);
         var parameterSymbols = ImmutableArray.CreateBuilder<ParameterSymbol>(syntax.Parameters.Count);
         var seen = new HashSet<string>();
+        var hasIncompatibleExplicitParameter = false;
+        var needsExplicitParameterAdapter = false;
+        var exactTargetParameterSlots = new bool[syntax.Parameters.Count];
         for (var i = 0; i < syntax.Parameters.Count; i++)
         {
             var p = syntax.Parameters[i];
@@ -664,6 +667,59 @@ internal sealed class LambdaBinder
                 ptype = SliceTypeSymbol.Get(ptype);
             }
 
+            var refKind = conversions.BindAndValidateParameterRefKind(
+                p,
+                pname,
+                ptype,
+                isVariadic,
+                isAsync ? "async" : null);
+
+            // Issue #2810: an explicit lambda parameter type is a contract,
+            // not a hint. The target delegate supplies its slot type, so that
+            // type must convert implicitly to the written parameter type before
+            // an adapter may be synthesized. By-reference parameters require a
+            // runtime-identical type because a value conversion cannot preserve
+            // aliasing. Reference nullability and named-delegate/function
+            // pairs retain their existing runtime-compatible behavior.
+            if (p.Type != null
+                && arityMatchesTarget
+                && ptype != TypeSymbol.Error
+                && targetFunctionType.ParameterTypes[i] is TypeSymbol targetParameterType
+                && targetParameterType != TypeSymbol.Error)
+            {
+                var runtimeEquivalent = TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(
+                    targetParameterType,
+                    ptype);
+                var conversion = Conversion.ClassifyNonStructural(targetParameterType, ptype);
+                var structurallyCompatibleDelegate = ptype is FunctionTypeSymbol writtenFunctionType
+                    && targetParameterType is not FunctionTypeSymbol
+                    && MemberLookup.TryGetDelegateFunctionTypeFromSymbol(targetParameterType, out var targetDelegateFunctionType)
+                    && Conversion.ClassifyNonStructural(targetDelegateFunctionType, writtenFunctionType).IsImplicit;
+                var compatible = runtimeEquivalent
+                    || structurallyCompatibleDelegate
+                    || (refKind == RefKind.None
+                        && (conversion.IsImplicit
+                            || conversions.HasUserDefinedImplicitConversion(targetParameterType, ptype)));
+                if (!compatible)
+                {
+                    if (conversion.Exists)
+                    {
+                        Diagnostics.ReportCannotConvertImplicitly(p.Type.Location, targetParameterType, ptype);
+                    }
+                    else
+                    {
+                        Diagnostics.ReportCannotConvert(p.Type.Location, targetParameterType, ptype);
+                    }
+
+                    hasIncompatibleExplicitParameter = true;
+                }
+                else if (!runtimeEquivalent && !structurallyCompatibleDelegate)
+                {
+                    needsExplicitParameterAdapter = true;
+                    exactTargetParameterSlots[i] = true;
+                }
+            }
+
             // Issue #1262: skip the uniqueness check for the discard `_` so a
             // second discard parameter is permitted (C# `(_, _) => ...`). Each
             // `_` still occupies its positional slot.
@@ -678,7 +734,7 @@ internal sealed class LambdaBinder
                 isVariadic,
                 declaringSyntax: p.Identifier,
                 isScoped: p.IsScoped,
-                refKind: conversions.BindAndValidateParameterRefKind(p, pname, ptype, isVariadic, isAsync ? "async" : null));
+                refKind: refKind);
 
             // ADR-0063 §5: arrow-lambda parameters can also declare a default
             // value; the conversion classifier validates the constant-folded
@@ -688,6 +744,11 @@ internal sealed class LambdaBinder
             AttachParameterAttributes(p, lambdaParam);
             parameterSymbols.Add(lambdaParam);
             parameterTypes.Add(ptype);
+        }
+
+        if (hasIncompatibleExplicitParameter)
+        {
+            return new BoundErrorExpression(null);
         }
 
         // ADR-0101 follow-up / issue #812: enforce variadic structural rules.
@@ -841,7 +902,20 @@ internal sealed class LambdaBinder
             }
         }
 
-        return new BoundFunctionLiteralExpression(syntax, synthetic, fnType, bodyBlock, captured);
+        var literal = new BoundFunctionLiteralExpression(syntax, synthetic, fnType, bodyBlock, captured);
+        if (!needsExplicitParameterAdapter)
+        {
+            return literal;
+        }
+
+        var adapterTarget = FunctionTypeSymbol.Get(
+            targetFunctionType.ParameterTypes,
+            targetFunctionType.IsVariadic,
+            observableReturnType);
+        return CreateErasedFunctionLiteralAdapter(
+            literal,
+            adapterTarget,
+            ImmutableArray.Create(exactTargetParameterSlots));
     }
 
     /// <summary>
@@ -860,12 +934,15 @@ internal sealed class LambdaBinder
     /// signature needs to widen to a delegate-typed target.</param>
     /// <param name="targetFunctionType">The function-type shape the
     /// adapter must present to the delegate-typed parameter.</param>
+    /// <param name="exactTargetParameterSlots">Parameter slots that must use
+    /// their target type without generic-erasure preservation.</param>
     /// <returns>The adapter literal; its
     /// <see cref="BoundFunctionLiteralExpression.CapturedVariables"/>
     /// match the original literal's captures.</returns>
     public BoundFunctionLiteralExpression CreateErasedFunctionLiteralAdapter(
         BoundFunctionLiteralExpression literal,
-        FunctionTypeSymbol targetFunctionType)
+        FunctionTypeSymbol targetFunctionType,
+        ImmutableArray<bool> exactTargetParameterSlots = default)
     {
         // ADR-0087 §3 R6: if the literal's declared signature already
         // matches the (possibly substituted) target, the adapter would
@@ -880,13 +957,19 @@ internal sealed class LambdaBinder
 
         var adapterParameters = ImmutableArray.CreateBuilder<ParameterSymbol>(literal.Function.Parameters.Length);
         var replacementMap = new Dictionary<VariableSymbol, BoundExpression>();
+        var adapterPrefix = ImmutableArray.CreateBuilder<BoundStatement>();
         for (var i = 0; i < literal.Function.Parameters.Length; i++)
         {
             var original = literal.Function.Parameters[i];
             var targetSlot = i < targetFunctionType.ParameterTypes.Length
                 ? targetFunctionType.ParameterTypes[i]
                 : TypeSymbol.Object;
-            var adapterParameterType = GetAdapterSlotType(original.Type, targetSlot);
+            var useExactTargetParameterType = !exactTargetParameterSlots.IsDefault
+                && i < exactTargetParameterSlots.Length
+                && exactTargetParameterSlots[i];
+            var adapterParameterType = useExactTargetParameterType
+                ? targetSlot
+                : GetAdapterSlotType(original.Type, targetSlot);
             var adapterParameter = new ParameterSymbol(
                 original.Name,
                 adapterParameterType,
@@ -895,10 +978,36 @@ internal sealed class LambdaBinder
                 refKind: original.RefKind);
             adapterParameter.SetAttributes(original.Attributes);
             adapterParameters.Add(adapterParameter);
-            replacementMap[original] = new BoundConversionExpression(
-                null,
-                original.Type,
-                new BoundVariableExpression(null, adapterParameter));
+            var adapterRead = new BoundVariableExpression(null, adapterParameter);
+            var bindConvertedLocal = (useExactTargetParameterType
+                    && !TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(
+                        adapterParameterType,
+                        original.Type))
+                || conversions.HasUserDefinedImplicitConversion(adapterParameterType, original.Type);
+            if (bindConvertedLocal)
+            {
+                var converted = conversions.BindConversion(
+                    original.DeclaringSyntax?.Location ?? literal.Syntax.Location,
+                    adapterRead,
+                    original.Type);
+                var convertedLocal = new LocalVariableSymbol(
+                    $"<lambda_parameter{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
+                    isReadOnly: true,
+                    original.Type,
+                    original.DeclaringSyntax);
+                adapterPrefix.Add(new BoundVariableDeclaration(
+                    original.DeclaringSyntax,
+                    convertedLocal,
+                    converted));
+                replacementMap[original] = new BoundVariableExpression(null, convertedLocal);
+            }
+            else
+            {
+                replacementMap[original] = new BoundConversionExpression(
+                    null,
+                    original.Type,
+                    adapterRead);
+            }
         }
 
         var adapterReturnType = targetFunctionType.ReturnType == TypeSymbol.Void
@@ -957,6 +1066,11 @@ internal sealed class LambdaBinder
 
         var body = (BoundBlockStatement)new ErasedFunctionLiteralAdapterRewriter(replacementMap, adapterResultType)
             .RewriteStatement(literal.Body);
+        if (adapterPrefix.Count > 0)
+        {
+            adapterPrefix.AddRange(body.Statements);
+            body = new BoundBlockStatement(body.Syntax, adapterPrefix.ToImmutable());
+        }
 
         return new BoundFunctionLiteralExpression(
             literal.Syntax,

--- a/test/Compiler.Tests/Emit/Issue2810ExplicitLambdaParameterConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2810ExplicitLambdaParameterConversionEmitTests.cs
@@ -1,0 +1,150 @@
+// <copyright file="Issue2810ExplicitLambdaParameterConversionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+public sealed class Issue2810ExplicitLambdaParameterConversionEmitTests
+{
+    [Fact]
+    public void ExplicitParameterImplicitConversion_Runs()
+    {
+        const string Source = """
+            package Issue2810
+
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            class Number(val int32) {
+                func Get() int32 {
+                    return val
+                }
+
+                func operator implicit(value Number) int32 {
+                    return value.Get()
+                }
+            }
+
+            let nums = List[Number]()
+            nums.Add(Number(1))
+            nums.Add(Number(2))
+            nums.Add(Number(3))
+            nums.Add(Number(4))
+
+            for value in nums.Where((x int32) -> x % 2 == 0) {
+                Console.WriteLine(value.Get())
+            }
+            """;
+
+        Assert.Equal("2\n4\n", CompileAndRun(Source));
+    }
+
+    [Fact]
+    public void ExplicitUserTypeParameterImplicitConstruction_Runs()
+    {
+        const string Source = """
+            package Issue2810Reverse
+
+            import System
+            import System.Collections.Generic
+            class Wrapped(val int32) {
+                func Get() int32 {
+                    return val
+                }
+
+                func operator implicit(value int32) Wrapped {
+                    return Wrapped(value)
+                }
+            }
+
+            let nums = List[int32]()
+            nums.Add(1)
+            nums.Add(2)
+            nums.Add(3)
+            nums.Add(4)
+
+            nums.ForEach((x Wrapped) -> Console.WriteLine(x.Get()))
+            """;
+
+        Assert.Equal("1\n2\n3\n4\n", CompileAndRun(Source));
+    }
+
+    [Fact]
+    public void ExplicitParameterConversion_RunsOncePerInvocation()
+    {
+        const string Source = """
+            package Issue2810Once
+
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            class Number(val int32) {
+                func operator implicit(value Number) int32 {
+                    Console.WriteLine("convert")
+                    return value.val
+                }
+            }
+
+            let nums = List[Number]()
+            nums.Add(Number(1))
+            nums.Add(Number(2))
+
+            for value in nums.Where((x int32) -> x > 0 && x % 2 == 0) {
+            }
+            """;
+
+        Assert.Equal("convert\nconvert\n", CompileAndRun(Source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue2810_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            Assert.Equal(0, exitCode);
+            IlVerifier.Verify(outputPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            Assert.True(process.ExitCode == 0, $"exited {process.ExitCode}\n{stderr}");
+            return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2810ExplicitLambdaParameterConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2810ExplicitLambdaParameterConversionTests.cs
@@ -1,0 +1,158 @@
+// <copyright file="Issue2810ExplicitLambdaParameterConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+public sealed class Issue2810ExplicitLambdaParameterConversionTests
+{
+    private const string Declarations = """
+        interface Value {
+            func Get() int32;
+        }
+
+        class Int(val int32) : Value {
+            func Get() int32 {
+                return val
+            }
+
+            func operator implicit(value Int) int32 {
+                return value.Get()
+            }
+        }
+
+        class Wrapped(val int32) {
+            func Get() int32 {
+                return val
+            }
+
+            func operator implicit(value int32) Wrapped {
+                return Wrapped(value)
+            }
+        }
+        """;
+
+    [Fact]
+    public void TargetValue_ExplicitIntParameter_IsRejected()
+    {
+        var diagnostics = Bind($$"""
+            import System.Collections.Generic
+            import System.Linq
+
+            {{Declarations}}
+
+            func Test(nums List[Value]) {
+                nums.Where((x int32) -> x % 2 == 0)
+            }
+            """);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0155");
+    }
+
+    [Fact]
+    public void TargetIntClass_ExplicitIntParameter_UsesImplicitConversion()
+    {
+        var diagnostics = Bind($$"""
+            import System.Collections.Generic
+            import System.Linq
+
+            {{Declarations}}
+
+            func Test(nums List[Int]) {
+                nums.Where((x int32) -> x % 2 == 0)
+            }
+            """);
+
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void TargetInt_ExplicitClassParameter_UsesImplicitConversion()
+    {
+        var diagnostics = Bind($$"""
+            import System.Collections.Generic
+            import System.Linq
+
+            {{Declarations}}
+
+            func Test(nums List[int32]) {
+                nums.ForEach((x Wrapped) -> x.Get())
+            }
+            """);
+
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void TargetValue_UntypedParameter_RemainsTargetTyped()
+    {
+        var diagnostics = Bind($$"""
+            import System.Collections.Generic
+            import System.Linq
+
+            {{Declarations}}
+
+            func Test(nums List[Value]) {
+                nums.Where(x -> x.Get() % 2 == 0)
+            }
+            """);
+
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void TargetObject_ExplicitUserParameter_IsRejected()
+    {
+        var diagnostics = Bind($$"""
+            import System.Collections.Generic
+
+            {{Declarations}}
+
+            func Test(values List[object]) {
+                values.ForEach((x Wrapped) -> x.Get())
+            }
+            """);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0155");
+    }
+
+    [Fact]
+    public void NullableTarget_ExplicitNonNullableParameter_RemainsRuntimeCompatible()
+    {
+        var diagnostics = Bind("""
+            import System.Collections.Generic
+
+            func Test(values List[string?]) {
+                values.ForEach((x string) -> x.Length)
+            }
+            """);
+
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    private static System.Collections.Immutable.ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
+    {
+        using var references = ReferenceResolver.WithReferences(
+            Directory.EnumerateFiles(
+                RuntimeEnvironment.GetRuntimeDirectory(),
+                "*.dll",
+                SearchOption.TopDirectoryOnly));
+        var compilation = new Compilation(
+            references,
+            SyntaxTree.Parse(SourceText.From(source)));
+        return compilation.SyntaxTrees.SelectMany(tree => tree.Diagnostics)
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .ToImmutableArray();
+    }
+}


### PR DESCRIPTION
## Summary
- validate explicitly typed lambda parameters from the target delegate slot type
- synthesize target-shaped adapters and materialize implicit conversions once per invocation
- preserve symbolic generic, expression-tree, variadic, nullable, and by-reference behavior

## Testing
- full Core.Tests suite
- targeted compiler emit and IL verification regressions

Fixes #2810