### PR TITLE
Preserve gsgen compilation-unit attributes

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -77,11 +77,11 @@ public sealed class Binder
         ImmutableHashSet.Create(AttributeTargetKind.Field);
 
     /// <summary>
-    /// Targets permitted on a file-level <c>@assembly:</c> annotation lead-in
-    /// (ADR-0047 §2/§10, issue #2237): only <c>assembly</c>.
+    /// Targets permitted on a file-level annotation lead-in (ADR-0047 §2):
+    /// <c>assembly</c> and <c>module</c>.
     /// </summary>
-    internal static readonly ImmutableHashSet<AttributeTargetKind> AssemblyDeclarationAllowedTargets =
-        ImmutableHashSet.Create(AttributeTargetKind.Assembly);
+    internal static readonly ImmutableHashSet<AttributeTargetKind> FileDeclarationAllowedTargets =
+        ImmutableHashSet.Create(AttributeTargetKind.Assembly, AttributeTargetKind.Module);
 
     // PR-B-1: cross-cutting binder state lives on BinderContext so the
     // upcoming Binder-component extractions (MemberLookup, ConversionClassifier,
@@ -1189,7 +1189,7 @@ public sealed class Binder
             ?? ResolveEntryPointPackage(packageByTree, globalStatements, functions, packagesInOrder);
         var entryPoint = ResolveEntryPoint(binder, functions, structs, globalStatements, syntaxTrees, entryPointPackage, synthesizedEntryPoint);
 
-        // Issue #2237: bind every `@assembly:` annotation EXCEPT
+        // Issue #2237/#2815: bind every file-level annotation EXCEPT
         // InternalsVisibleTo (which keeps its own early, syntactic
         // fast path below via FriendAssemblyDeclarations.Collect) through
         // the SAME general attribute binder used for every other
@@ -1200,13 +1200,19 @@ public sealed class Binder
         // `[assembly: ...]`. Must run before the diagnostics snapshot below
         // so any reported diagnostics (e.g. "attribute type not found") are
         // captured.
-        var otherAssemblyAnnotations = FriendAssemblyDeclarations.CollectOtherAnnotations(syntaxTrees);
-        var boundAssemblyAttributes = binder.declarations.BindAttributes(
-            otherAssemblyAnnotations,
+        var otherFileAnnotations = FriendAssemblyDeclarations.CollectOtherAnnotations(syntaxTrees);
+        var boundFileAttributes = binder.declarations.BindAttributes(
+            otherFileAnnotations,
             AttributeTargetKind.Assembly,
-            AssemblyDeclarationAllowedTargets,
-            "assembly declaration",
+            FileDeclarationAllowedTargets,
+            "file-level declaration",
             System.AttributeTargets.Assembly);
+        var boundAssemblyAttributes = boundFileAttributes
+            .Where(attribute => attribute.Target == AttributeTargetKind.Assembly)
+            .ToImmutableArray();
+        var boundModuleAttributes = boundFileAttributes
+            .Where(attribute => attribute.Target == AttributeTargetKind.Module)
+            .ToImmutableArray();
 
         var diagnostics = binder.Diagnostics.ToImmutableArray();
 
@@ -1222,6 +1228,9 @@ public sealed class Binder
         result.AssemblyAttributes = previous == null
             ? boundAssemblyAttributes
             : previous.AssemblyAttributes.AddRange(boundAssemblyAttributes);
+        result.ModuleAttributes = previous == null
+            ? boundModuleAttributes
+            : previous.ModuleAttributes.AddRange(boundModuleAttributes);
 
         // Issue #2224: anonymous-class literals (`object { let ... }`) bound
         // anywhere during this pass — top-level statements included —
@@ -1255,6 +1264,7 @@ public sealed class Binder
                 PreprocessorSymbols = result.PreprocessorSymbols,
                 FriendAssemblies = result.FriendAssemblies,
                 AssemblyAttributes = result.AssemblyAttributes,
+                ModuleAttributes = result.ModuleAttributes,
                 AnonymousTypes = result.AnonymousTypes,
                 RichAnonymousClassMap = result.RichAnonymousClassMap,
             };
@@ -1801,6 +1811,7 @@ public sealed class Binder
             Imports = globalScope.GetCumulativeImports(),
             FriendAssemblies = globalScope.FriendAssemblies,
             AssemblyAttributes = globalScope.AssemblyAttributes,
+            ModuleAttributes = globalScope.ModuleAttributes,
         };
     }
 

--- a/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundGlobalScope.cs
@@ -302,6 +302,12 @@ public sealed class BoundGlobalScope
     public ImmutableArray<BoundAttribute> AssemblyAttributes { get; internal set; } = ImmutableArray<BoundAttribute>.Empty;
 
     /// <summary>
+    /// Gets every file-level <c>@module:</c> annotation, bound through the
+    /// general attribute binder for emission on the module metadata row.
+    /// </summary>
+    public ImmutableArray<BoundAttribute> ModuleAttributes { get; internal set; } = ImmutableArray<BoundAttribute>.Empty;
+
+    /// <summary>
     /// Gets or sets every anonymous-class type (issue #2224) synthesized
     /// while binding this compilation's top-level statements and (once
     /// <c>Binder.BindProgram</c> runs) its function/method bodies.

--- a/src/Core/CodeAnalysis/Binding/BoundProgram.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundProgram.cs
@@ -279,4 +279,10 @@ public sealed class BoundProgram
     /// used for every other declaration-level attribute.
     /// </summary>
     public ImmutableArray<BoundAttribute> AssemblyAttributes { get; internal set; } = ImmutableArray<BoundAttribute>.Empty;
+
+    /// <summary>
+    /// Gets every file-level <c>@module:</c> annotation. The emitter writes
+    /// one real <c>CustomAttribute</c> row on the module metadata row per entry.
+    /// </summary>
+    public ImmutableArray<BoundAttribute> ModuleAttributes { get; internal set; } = ImmutableArray<BoundAttribute>.Empty;
 }

--- a/src/Core/CodeAnalysis/Binding/FriendAssemblyDeclarations.cs
+++ b/src/Core/CodeAnalysis/Binding/FriendAssemblyDeclarations.cs
@@ -41,7 +41,7 @@ internal static class FriendAssemblyDeclarations
     private const string AnnotationNameWithSuffix = "InternalsVisibleToAttribute";
 
     /// <summary>
-    /// Collects every file-level <c>@assembly:</c> annotation across
+    /// Collects every file-level <c>@assembly:</c> or <c>@module:</c> annotation across
     /// <paramref name="syntaxTrees"/> EXCEPT <c>InternalsVisibleTo</c> (which
     /// <see cref="Collect"/> already handles via its own syntactic,
     /// string-literal-only fast path). Used by <c>Binder.BindGlobalScope</c>
@@ -60,12 +60,13 @@ internal static class FriendAssemblyDeclarations
         var builder = ImmutableArray.CreateBuilder<AnnotationSyntax>();
         foreach (var tree in syntaxTrees)
         {
-            var annotations = tree.Root?.AssemblyAttributes ?? ImmutableArray<AnnotationSyntax>.Empty;
+            var annotations = tree.Root?.FileAttributes ?? ImmutableArray<AnnotationSyntax>.Empty;
             foreach (var annotation in annotations)
             {
                 var name = annotation.GetNameText();
-                if (string.Equals(name, AnnotationName, StringComparison.Ordinal)
-                    || string.Equals(name, AnnotationNameWithSuffix, StringComparison.Ordinal))
+                if (annotation.Target?.KindIdentifier.Text == "assembly"
+                    && (string.Equals(name, AnnotationName, StringComparison.Ordinal)
+                        || string.Equals(name, AnnotationNameWithSuffix, StringComparison.Ordinal)))
                 {
                     continue;
                 }

--- a/src/Core/CodeAnalysis/Emit/AssemblyAttributeEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/AssemblyAttributeEmitter.cs
@@ -240,6 +240,17 @@ internal sealed class AssemblyAttributeEmitter
         return emitted.ToImmutable();
     }
 
+    /// <summary>
+    /// Emits every user-declared <c>@module:</c> annotation on the module row.
+    /// </summary>
+    public void EmitUserModuleAttributes(ModuleDefinitionHandle moduleHandle)
+    {
+        foreach (var attr in this.emitCtx.Program.ModuleAttributes)
+        {
+            this.attrEncoder.EmitBoundAttribute(moduleHandle, attr);
+        }
+    }
+
     private void EmitFriendAssemblyAttributes(AssemblyDefinitionHandle assemblyHandle)
     {
         foreach (var friend in this.emitCtx.Program.FriendAssemblies)

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -3767,12 +3767,13 @@ internal sealed class ReflectionMetadataEmitter
         // patch it with a content-derived value after PE serialization.
         var assemblyName = this.emitCtx.AssemblyNameOverride ?? this.emitCtx.Program.PackageName ?? "Default";
         var mvidFixup = this.emitCtx.Metadata.ReserveGuid();
-        this.emitCtx.Metadata.AddModule(
+        var moduleHandle = this.emitCtx.Metadata.AddModule(
             generation: 0,
             moduleName: this.emitCtx.Metadata.GetOrAddString(assemblyName + ".dll"),
             mvid: mvidFixup.Handle,
             encId: default(GuidHandle),
             encBaseId: default(GuidHandle));
+        this.assemblyAttrs.EmitUserModuleAttributes(moduleHandle);
 
         var assemblyHandle = this.emitCtx.Metadata.AddAssembly(
             name: this.emitCtx.Metadata.GetOrAddString(assemblyName),

--- a/src/Core/CodeAnalysis/Lowering/BaseCallForwarderRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/BaseCallForwarderRewriter.cs
@@ -133,6 +133,7 @@ public static class BaseCallForwarderRewriter
             Imports = program.Imports,
             FriendAssemblies = program.FriendAssemblies,
             AssemblyAttributes = program.AssemblyAttributes,
+            ModuleAttributes = program.ModuleAttributes,
         };
     }
 

--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -152,6 +152,7 @@ internal static class CaptureBoxingRewriter
             Imports = program.Imports,
             FriendAssemblies = program.FriendAssemblies,
             AssemblyAttributes = program.AssemblyAttributes,
+            ModuleAttributes = program.ModuleAttributes,
         };
 
         return result;

--- a/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/ExpressionTreeLowerer.cs
@@ -260,6 +260,7 @@ internal sealed class ExpressionTreeLowerer : NestedFunctionBodyRewriter
             Imports = program.Imports,
             FriendAssemblies = program.FriendAssemblies,
             AssemblyAttributes = program.AssemblyAttributes,
+            ModuleAttributes = program.ModuleAttributes,
         };
     }
 

--- a/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
@@ -114,6 +114,7 @@ internal sealed class InterpolatedStringHandlerLowerer : NestedFunctionBodyRewri
             Imports = program.Imports,
             FriendAssemblies = program.FriendAssemblies,
             AssemblyAttributes = program.AssemblyAttributes,
+            ModuleAttributes = program.ModuleAttributes,
         };
 
         return result;

--- a/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
@@ -123,6 +123,7 @@ internal sealed class SideEffectSpiller : NestedFunctionBodyRewriter
             Imports = program.Imports,
             FriendAssemblies = program.FriendAssemblies,
             AssemblyAttributes = program.AssemblyAttributes,
+            ModuleAttributes = program.ModuleAttributes,
         };
     }
 

--- a/src/Core/CodeAnalysis/Syntax/CompilationUnitSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/CompilationUnitSyntax.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace GSharp.Core.CodeAnalysis.Syntax;
 
@@ -26,13 +27,19 @@ public class CompilationUnitSyntax : SyntaxNode
     /// Initializes a new instance of the <see cref="CompilationUnitSyntax"/> class.
     /// </summary>
     /// <param name="syntaxTree">The parent syntax tree.</param>
-    /// <param name="assemblyAttributes">The file-level <c>@assembly:</c> annotations declared before the first member (producer-side friend-assembly opt-in, see ADR-0047 §2/§7).</param>
+    /// <param name="fileAttributes">The file-level <c>@assembly:</c> and <c>@module:</c> annotations declared before the first member.</param>
     /// <param name="members">The members of this compilation unit.</param>
     /// <param name="endOfFileToken">The end of file token.</param>
-    public CompilationUnitSyntax(SyntaxTree syntaxTree, ImmutableArray<AnnotationSyntax> assemblyAttributes, ImmutableArray<MemberSyntax> members, SyntaxToken endOfFileToken)
+    public CompilationUnitSyntax(SyntaxTree syntaxTree, ImmutableArray<AnnotationSyntax> fileAttributes, ImmutableArray<MemberSyntax> members, SyntaxToken endOfFileToken)
         : base(syntaxTree)
     {
-        AssemblyAttributes = assemblyAttributes;
+        FileAttributes = fileAttributes.IsDefault ? ImmutableArray<AnnotationSyntax>.Empty : fileAttributes;
+        AssemblyAttributes = FileAttributes
+            .Where(attribute => attribute.Target?.KindIdentifier.Text == "assembly")
+            .ToImmutableArray();
+        ModuleAttributes = FileAttributes
+            .Where(attribute => attribute.Target?.KindIdentifier.Text == "module")
+            .ToImmutableArray();
         Members = members;
         EndOfFileToken = endOfFileToken;
     }
@@ -46,7 +53,21 @@ public class CompilationUnitSyntax : SyntaxNode
     /// These are producer-declared, assembly-scoped custom attributes — not
     /// attached to any single declaration.
     /// </summary>
+    [SyntaxChildIgnore]
     public ImmutableArray<AnnotationSyntax> AssemblyAttributes { get; }
+
+    /// <summary>
+    /// Gets the file-level <c>@module:</c> annotations declared before the
+    /// first member.
+    /// </summary>
+    [SyntaxChildIgnore]
+    public ImmutableArray<AnnotationSyntax> ModuleAttributes { get; }
+
+    /// <summary>
+    /// Gets all file-level <c>@assembly:</c> and <c>@module:</c> annotations
+    /// in source order.
+    /// </summary>
+    public ImmutableArray<AnnotationSyntax> FileAttributes { get; }
 
     /// <summary>
     /// Gets the members of this compilation unit.

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -206,7 +206,7 @@ public partial class Parser
     {
         var package = ParsePackage();
         var imports = ParseImports();
-        var assemblyAttributes = ParseFileLevelAssemblyAttributes();
+        var fileAttributes = ParseFileLevelAttributes();
         var members = ParseMembers();
         var endOfFileToken = MatchToken(SyntaxKind.EndOfFileToken);
         var junction = ImmutableArray.CreateBuilder<MemberSyntax>();
@@ -221,20 +221,21 @@ public partial class Parser
         }
 
         junction.AddRange(members);
-        return new CompilationUnitSyntax(syntaxTree, assemblyAttributes, junction.ToImmutable(), endOfFileToken);
+        return new CompilationUnitSyntax(syntaxTree, fileAttributes, junction.ToImmutable(), endOfFileToken);
     }
 
     /// <summary>
-    /// Parses a leading run of file-level <c>@assembly:Name(...)</c>
+    /// Parses a leading run of file-level <c>@assembly:Name(...)</c> and
+    /// <c>@module:Name(...)</c>
     /// annotations, sitting after <c>import</c>s and before the first member.
     /// This is the producer-side opt-in surface for assembly-scoped custom
     /// attributes (chiefly <c>@assembly:InternalsVisibleTo("Foo.Tests")</c> —
     /// see ADR-0047 §2/§7 and issue #1929/#1953). Only annotations that
-    /// explicitly carry the <c>assembly:</c> use-site target are consumed
+    /// explicitly carry an <c>assembly:</c> or <c>module:</c> use-site target are consumed
     /// here; anything else is left for <see cref="ParseMembers"/> to attach
     /// to the next declaration as usual.
     /// </summary>
-    private ImmutableArray<AnnotationSyntax> ParseFileLevelAssemblyAttributes()
+    private ImmutableArray<AnnotationSyntax> ParseFileLevelAttributes()
     {
         if (Current.Kind != SyntaxKind.AtToken)
         {
@@ -244,7 +245,7 @@ public partial class Parser
         var builder = ImmutableArray.CreateBuilder<AnnotationSyntax>();
         while (Current.Kind == SyntaxKind.AtToken
             && Peek(1).Kind == SyntaxKind.IdentifierToken
-            && Peek(1).Text == "assembly"
+            && Peek(1).Text is "assembly" or "module"
             && Peek(2).Kind == SyntaxKind.ColonToken)
         {
             builder.Add(ParseAnnotation());

--- a/src/Core/CodeAnalysis/Syntax/SyntaxChildIgnoreAttribute.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxChildIgnoreAttribute.cs
@@ -1,0 +1,16 @@
+// <copyright file="SyntaxChildIgnoreAttribute.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Marks a derived convenience property whose syntax nodes are already exposed
+/// through another canonical child property.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+internal sealed class SyntaxChildIgnoreAttribute : Attribute
+{
+}

--- a/src/Core/CodeAnalysis/Syntax/SyntaxNode.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxNode.cs
@@ -203,7 +203,8 @@ public abstract class SyntaxNode
         var childProperties = new List<PropertyInfo>(properties.Length);
         foreach (var property in properties)
         {
-            if (TryClassifyChildProperty(property, out _))
+            if (property.GetCustomAttribute<SyntaxChildIgnoreAttribute>() == null
+                && TryClassifyChildProperty(property, out _))
             {
                 childProperties.Add(property);
             }

--- a/test/Core.Tests/CodeAnalysis/Syntax/AnnotationParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/AnnotationParserTests.cs
@@ -101,7 +101,6 @@ func Foo() {
     [InlineData("method")]
     [InlineData("property")]
     [InlineData("event")]
-    [InlineData("module")]
     [InlineData("genericparam")]
     public void Parses_All_Canonical_Use_Site_Targets(string kind)
     {
@@ -163,6 +162,43 @@ func F() {
 
         var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
         Assert.Empty(fn.Annotations);
+    }
+
+    [Fact]
+    public void Module_Target_Annotation_Attaches_At_File_Scope_Not_To_Next_Member()
+    {
+        const string source = @"
+package P
+
+@module:System.CLSCompliantAttribute(true)
+func F() {
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var annotation = Assert.Single(tree.Root.ModuleAttributes);
+        Assert.NotNull(annotation.Target);
+        Assert.Equal("module", annotation.Target.KindIdentifier.Text);
+        Assert.Equal("System.CLSCompliantAttribute", annotation.GetNameText());
+
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        Assert.Empty(fn.Annotations);
+    }
+
+    [Fact]
+    public void File_Target_Annotations_AppearOnce_InSourceOrder_InChildTraversal()
+    {
+        const string source = @"
+@module:System.CLSCompliantAttribute(true)
+@assembly:System.Reflection.AssemblyTitleAttribute(""Oahu"")
+";
+        var tree = SyntaxTree.Parse(source);
+
+        var annotations = tree.Root.GetChildren().OfType<AnnotationSyntax>().ToArray();
+        Assert.Equal(2, annotations.Length);
+        Assert.Equal("module", annotations[0].Target.KindIdentifier.Text);
+        Assert.Equal("assembly", annotations[1].Target.KindIdentifier.Text);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1675SyntaxNodeChildEnumerationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1675SyntaxNodeChildEnumerationTests.cs
@@ -321,13 +321,14 @@ public class Issue1675SyntaxNodeChildEnumerationTests
 
     private static IEnumerable<PropertyInfo> LegacyChildProperties(Type nodeType)
     {
-        // Verbatim filter from the pre-#1675 GetChildren implementation.
+        // Historical filter plus explicit derived-property exclusions.
         var properties = nodeType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
         foreach (var property in properties)
         {
-            if (typeof(SyntaxNode).IsAssignableFrom(property.PropertyType)
+            if (property.GetCustomAttribute<SyntaxChildIgnoreAttribute>() == null
+                && (typeof(SyntaxNode).IsAssignableFrom(property.PropertyType)
                 || typeof(SeparatedSyntaxList).IsAssignableFrom(property.PropertyType)
-                || typeof(IEnumerable<SyntaxNode>).IsAssignableFrom(property.PropertyType))
+                || typeof(IEnumerable<SyntaxNode>).IsAssignableFrom(property.PropertyType)))
             {
                 yield return property;
             }
@@ -336,11 +337,16 @@ public class Issue1675SyntaxNodeChildEnumerationTests
 
     private static IEnumerable<SyntaxNode> LegacyGetChildren(SyntaxNode node)
     {
-        // Verbatim copy of the pre-#1675 reflection-based implementation.
+        // Historical implementation plus explicit derived-property exclusions.
         var properties = node.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
         foreach (var property in properties)
         {
+            if (property.GetCustomAttribute<SyntaxChildIgnoreAttribute>() != null)
+            {
+                continue;
+            }
+
             if (typeof(SyntaxNode).IsAssignableFrom(property.PropertyType))
             {
                 var child = (SyntaxNode)property.GetValue(node);

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/CompilationUnit.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/CompilationUnit.cs
@@ -20,16 +20,19 @@ public sealed class CompilationUnit : GNode
     /// <param name="imports">The import directives, in original order.</param>
     /// <param name="members">The ordered top-level members and statements.</param>
     /// <param name="leadingComments">Optional file-leading comment lines (without the <c>//</c> prefix).</param>
+    /// <param name="fileAttributes">Assembly- or module-targeted file-level attributes, in source order.</param>
     public CompilationUnit(
         string package = null,
         IReadOnlyList<ImportDirective> imports = null,
         IReadOnlyList<GNode> members = null,
-        IReadOnlyList<string> leadingComments = null)
+        IReadOnlyList<string> leadingComments = null,
+        IReadOnlyList<AttributeUse> fileAttributes = null)
     {
         Package = package;
         Imports = imports ?? new List<ImportDirective>();
         Members = members ?? new List<GNode>();
         LeadingComments = leadingComments ?? new List<string>();
+        FileAttributes = fileAttributes ?? new List<AttributeUse>();
     }
 
     /// <summary>Gets the package name, or <see langword="null"/> for none.</summary>
@@ -43,6 +46,9 @@ public sealed class CompilationUnit : GNode
 
     /// <summary>Gets the file-leading comment lines (without the <c>//</c> prefix).</summary>
     public IReadOnlyList<string> LeadingComments { get; }
+
+    /// <summary>Gets assembly- or module-targeted file-level attributes.</summary>
+    public IReadOnlyList<AttributeUse> FileAttributes { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1220,6 +1220,22 @@ public static class GSharpPrinter
             needsBlank = true;
         }
 
+        if (unit.FileAttributes.Count > 0)
+        {
+            if (needsBlank)
+            {
+                sb.Append('\n');
+            }
+
+            foreach (var attribute in unit.FileAttributes)
+            {
+                sb.Append(RenderAttributeInline(attribute));
+                sb.Append('\n');
+            }
+
+            needsBlank = true;
+        }
+
         string previousText = null;
         foreach (var node in unit.Members)
         {

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -309,7 +309,8 @@ public sealed class TranslateStage : IMigrationStage
                         : new CSharpToGSharpTranslator(
                             markMergedTypePartial: hasAnalyzerReferences,
                             retainedFilePaths: retainedFilePaths,
-                            packageFilter: package);
+                            packageFilter: package,
+                            includeFileAttributes: unitIndex == 0);
                     string printed = GSharpPrinter.Print(
                         unitTranslator.TranslateDocument(document, translationContext));
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2585SemanticQualificationPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2585SemanticQualificationPipelineTests.cs
@@ -22,6 +22,8 @@ public sealed class Issue2585SemanticQualificationPipelineTests
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
         {
             ("AudioQuality.cs", """
+                [assembly: System.Reflection.AssemblyTitleAttribute("Oahu")]
+
                 namespace Oahu.BooksDatabase
                 {
                     namespace Ex
@@ -42,14 +44,18 @@ public sealed class Issue2585SemanticQualificationPipelineTests
         Assert.Equal(new[] { "Oahu.BooksDatabase.Ex", "Oahu.BooksDatabase" }, packages);
 
         string parent = GSharpPrinter.Print(new CSharpToGSharpTranslator(
-            packageFilter: "Oahu.BooksDatabase").TranslateDocument(document));
+            packageFilter: "Oahu.BooksDatabase",
+            includeFileAttributes: true).TranslateDocument(document));
         string nested = GSharpPrinter.Print(new CSharpToGSharpTranslator(
-            packageFilter: "Oahu.BooksDatabase.Ex").TranslateDocument(document));
+            packageFilter: "Oahu.BooksDatabase.Ex",
+            includeFileAttributes: false).TranslateDocument(document));
 
         Assert.Contains("package Oahu.BooksDatabase", parent);
+        Assert.Contains("@assembly:System.Reflection.AssemblyTitleAttribute(\"Oahu\")", parent);
         Assert.Contains("data class AudioQuality", parent);
         Assert.DoesNotContain("ExCodec", parent);
         Assert.Contains("package Oahu.BooksDatabase.Ex", nested);
+        Assert.DoesNotContain("@assembly:", nested);
         Assert.Contains("func Parse()", nested);
         Assert.DoesNotContain("AudioQuality", nested);
     }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -93,6 +93,7 @@ public sealed partial class CSharpToGSharpTranslator
     // (GS0102). Null (default) preserves the exact prior no-filter behavior.
     private readonly HashSet<string> retainedFilePaths;
     private readonly string packageFilter;
+    private readonly bool includeFileAttributes;
 
     // One registry per resolved G# package deduplicates declarations across
     // documents (#2292). Synthetic names themselves are derived from the full
@@ -130,11 +131,17 @@ public sealed partial class CSharpToGSharpTranslator
     /// When supplied, emits only declarations whose containing namespace
     /// matches this package.
     /// </param>
+    /// <param name="includeFileAttributes">
+    /// When <see langword="false"/>, omits compilation-unit assembly/module
+    /// attributes. Used for secondary package-split outputs so file-level
+    /// metadata is emitted once.
+    /// </param>
     public CSharpToGSharpTranslator(
         bool preservePartialParts = false,
         bool markMergedTypePartial = false,
         IReadOnlyCollection<string> retainedFilePaths = null,
-        string packageFilter = null)
+        string packageFilter = null,
+        bool includeFileAttributes = true)
     {
         this.preservePartialParts = preservePartialParts;
         this.markMergedTypePartial = markMergedTypePartial;
@@ -142,6 +149,7 @@ public sealed partial class CSharpToGSharpTranslator
             ? null
             : new HashSet<string>(retainedFilePaths, StringComparer.Ordinal);
         this.packageFilter = packageFilter;
+        this.includeFileAttributes = includeFileAttributes;
     }
 
     /// <summary>
@@ -240,6 +248,12 @@ public sealed partial class CSharpToGSharpTranslator
             this.preservePartialParts,
             this.markMergedTypePartial);
 
+        IReadOnlyList<AttributeUse> fileAttributes = this.includeFileAttributes
+            ? visitor.MapFileAttributes(
+                root.AttributeLists.Where(list =>
+                    list.Target?.Identifier.ValueText is "assembly" or "module"))
+            : Array.Empty<AttributeUse>();
+
         // Issue #2382: a NATIVE C# top-level-statements program (`GlobalStatementSyntax`
         // members directly under the compilation unit — no enclosing class/method
         // syntax at all, unlike the explicit-`Main` case handled by `entryType`
@@ -336,7 +350,7 @@ public sealed partial class CSharpToGSharpTranslator
             }
         }
 
-        return new CompilationUnit(package, allImports, members);
+        return new CompilationUnit(package, allImports, members, fileAttributes: fileAttributes);
     }
 
     /// <summary>Gets the distinct source namespaces declared by a document.</summary>
@@ -822,6 +836,9 @@ public sealed partial class CSharpToGSharpTranslator
             // document (once by the caller, once here).
             this.entryType = entryPoint?.ContainingType;
         }
+
+        public IReadOnlyList<AttributeUse> MapFileAttributes(IEnumerable<AttributeListSyntax> attributeLists) =>
+            this.MapAttributes(attributeLists);
 
         public override GMember VisitClassDeclaration(ClassDeclarationSyntax node) => this.VisitAggregate(node);
 

--- a/tools/gsgen/GSharp.GeneratorHost.Tests/GsgenCliTests.cs
+++ b/tools/gsgen/GSharp.GeneratorHost.Tests/GsgenCliTests.cs
@@ -6,11 +6,16 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using GSharp.Gsgen.Cli;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
 using Xunit;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSourceText = GSharp.Core.CodeAnalysis.Text.SourceText;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
 
 namespace GSharp.GeneratorHost.Tests;
 
@@ -302,6 +307,94 @@ public class GsgenCliTests : IDisposable
     }
 
     [Fact]
+    public void ForeignCsFile_PreservesCompilationUnitAssemblyAttribute()
+    {
+        var outDir = Path.Combine(this.workDir, "gen");
+        var gs = this.WriteGs("Input.gs", "package Probe\n\nfunc Placeholder() {\n}\n");
+        var cs = this.WriteCs(
+            "Test2.cs",
+            """
+            using System.Reflection;
+
+            [assembly: System.Reflection.AssemblyTitleAttribute("Oahu")]
+
+            namespace Probe2
+            {
+                internal class Holder
+                {
+                    internal const string X = "y";
+                }
+            }
+            """);
+
+        var args = new List<string> { $"/gs:{gs}", $"/csfile:{cs}", $"/out:{outDir}" };
+        args.AddRange(RuntimeReferencePaths().Select(p => $"/r:{p}"));
+
+        var stdout = new StringWriter();
+        int exit = GsgenProgram.Run(args.ToArray(), stdout);
+
+        Assert.True(exit == 0, stdout.ToString());
+        string content = File.ReadAllText(Assert.Single(Directory.EnumerateFiles(outDir, "*.g.gs")));
+        Assert.Contains("package Probe2", content);
+        Assert.Contains("import System.Reflection", content);
+        Assert.Contains("@assembly:System.Reflection.AssemblyTitleAttribute(\"Oahu\")", content);
+        Assert.Contains("internal class Holder", content);
+    }
+
+    [Fact]
+    public void ForeignCsFile_WithOnlyFileAttributes_WritesCompilableOutput()
+    {
+        var outDir = Path.Combine(this.workDir, "gen");
+        var gs = this.WriteGs("Input.gs", "package Probe\n\nfunc Placeholder() {\n}\n");
+        var cs = this.WriteCs(
+            "AssemblyAttributes.cs",
+            """
+            using System;
+            using System.Reflection;
+
+            [assembly: System.Reflection.AssemblyTitleAttribute("Oahu")]
+            [module: System.CLSCompliantAttribute(true)]
+            """);
+
+        var args = new List<string> { $"/gs:{gs}", $"/csfile:{cs}", $"/out:{outDir}" };
+        args.AddRange(RuntimeReferencePaths().Select(p => $"/r:{p}"));
+
+        var stdout = new StringWriter();
+        int exit = GsgenProgram.Run(args.ToArray(), stdout);
+
+        Assert.True(exit == 0, stdout.ToString());
+        string content = File.ReadAllText(Assert.Single(Directory.EnumerateFiles(outDir, "*.g.gs")));
+        Assert.Contains("import System", content);
+        Assert.Contains("import System.Reflection", content);
+        Assert.Contains("@assembly:System.Reflection.AssemblyTitleAttribute(\"Oahu\")", content);
+        Assert.Contains("@module:System.CLSCompliantAttribute(true)", content);
+
+        var tree = GsSyntaxTree.Parse(GsSourceText.From(content));
+        Assert.Empty(tree.Diagnostics);
+
+        using var pe = new MemoryStream();
+        var compilation = new GsCompilation(tree) { IsLibrary = true };
+        var emit = compilation.Emit(
+            pe,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: "Issue2815FileAttributes");
+        Assert.True(
+            emit.Success,
+            "generated file should compile: " + string.Join("; ", emit.Diagnostics.Select(d => d.Message)));
+
+        pe.Position = 0;
+        using var peReader = new PEReader(pe, PEStreamOptions.LeaveOpen);
+        MetadataReader metadata = peReader.GetMetadataReader();
+        Assert.Contains(
+            "System.Reflection.AssemblyTitleAttribute",
+            GetAttributeTypeNames(metadata, metadata.GetAssemblyDefinition().GetCustomAttributes()));
+        Assert.Contains(
+            "System.CLSCompliantAttribute",
+            GetAttributeTypeNames(metadata, metadata.GetModuleDefinition().GetCustomAttributes()));
+    }
+
+    [Fact]
     public void NoAnalyzersNoCsFiles_FastPath_Unaffected()
     {
         // Guard: a project with no generators AND no stray .cs (the universal
@@ -381,6 +474,30 @@ public class GsgenCliTests : IDisposable
             .OrderByDescending(d => d, StringComparer.OrdinalIgnoreCase)
             .FirstOrDefault();
         return refDir is null ? Array.Empty<string>() : Directory.GetFiles(refDir, "*.dll");
+    }
+
+    private static IReadOnlyList<string> GetAttributeTypeNames(
+        MetadataReader metadata,
+        CustomAttributeHandleCollection attributes)
+    {
+        var names = new List<string>();
+        foreach (CustomAttributeHandle handle in attributes)
+        {
+            CustomAttribute attribute = metadata.GetCustomAttribute(handle);
+            if (attribute.Constructor.Kind != HandleKind.MemberReference)
+            {
+                continue;
+            }
+
+            MemberReference constructor = metadata.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+            if (constructor.Parent.Kind == HandleKind.TypeReference)
+            {
+                TypeReference type = metadata.GetTypeReference((TypeReferenceHandle)constructor.Parent);
+                names.Add(metadata.GetString(type.Namespace) + "." + metadata.GetString(type.Name));
+            }
+        }
+
+        return names;
     }
 
     /// <summary>

--- a/tools/gsgen/GSharp.GeneratorHost/GeneratedDocTranslator.cs
+++ b/tools/gsgen/GSharp.GeneratorHost/GeneratedDocTranslator.cs
@@ -36,7 +36,7 @@ public static class GeneratedDocTranslator
     /// <param name="stubCSharp">The declaration-only C# stub the generators ran against.</param>
     /// <param name="generated">The generated C# documents.</param>
     /// <param name="references">The metadata references used to bind stub + generated code.</param>
-    /// <returns>The back-translated G# parts, one per non-empty generated document.</returns>
+    /// <returns>The back-translated G# parts, one per generated document with members or file-level attributes.</returns>
     public static IReadOnlyList<TranslatedGsDocument> Translate(
         string stubCSharp,
         IReadOnlyList<GeneratedCsDocument> generated,
@@ -83,8 +83,8 @@ public static class GeneratedDocTranslator
             CompilationUnit unit = new CSharpToGSharpTranslator(preservePartialParts: true)
                 .TranslateDocument(loaded);
 
-            // Skip a generated document that carried no translatable members.
-            if (unit.Members.Count == 0)
+            // Skip a generated document that carried no translatable content.
+            if (unit.Members.Count == 0 && unit.FileAttributes.Count == 0)
             {
                 continue;
             }


### PR DESCRIPTION
## Summary
- translate C# compilation-unit `assembly` and `module` attribute lists into G# file-level annotations
- emit `.g.gs` output for attribute-only generated or foreign C# documents
- bind and emit G# `@module:` annotations, while preventing duplicate file attributes in namespace-split output and syntax traversal

## Tests
- `dotnet test tools/gsgen/GSharp.GeneratorHost.Tests/GSharp.GeneratorHost.Tests.csproj --no-restore` (31 passed)
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore` (6765 passed, 1 skipped)
- `dotnet build src/Compiler/Compiler.csproj -c Release --no-restore && dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-build --no-restore` (1788 passed)

Fixes #2815