### PR TITLE
Filter SDK-generated friend assembly attributes

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
@@ -451,16 +451,27 @@ public class GsharpTestProjectRunner
         return sha256.ComputeHash(stream);
     }
 
-    private static string LibraryProject(GsharpTestProject project, string sdkVersion) =>
-        $"<Project Sdk=\"{SdkPackageId}/{sdkVersion}\">\n" +
-        "\n" +
-        "  <PropertyGroup>\n" +
-        "    <OutputType>Library</OutputType>\n" +
-        "    <TargetFramework>net10.0</TargetFramework>\n" +
-        $"    <RootNamespace>{project.LibraryRootNamespace}</RootNamespace>\n" +
-        "  </PropertyGroup>\n" +
-        "\n" +
-        "</Project>\n";
+    private static string LibraryProject(GsharpTestProject project, string sdkVersion)
+    {
+        string friendAssemblies = project.LibraryFriendAssemblies.Count == 0
+            ? string.Empty
+            : "\n  <ItemGroup>\n" +
+                string.Concat(project.LibraryFriendAssemblies.Select(name =>
+                    "    <InternalsVisibleTo Include=\"" +
+                    System.Security.SecurityElement.Escape(name) +
+                    "\" />\n")) +
+                "  </ItemGroup>\n";
+        return $"<Project Sdk=\"{SdkPackageId}/{sdkVersion}\">\n" +
+            "\n" +
+            "  <PropertyGroup>\n" +
+            "    <OutputType>Library</OutputType>\n" +
+            "    <TargetFramework>net10.0</TargetFramework>\n" +
+            $"    <RootNamespace>{project.LibraryRootNamespace}</RootNamespace>\n" +
+            "  </PropertyGroup>\n" +
+            friendAssemblies +
+            "\n" +
+            "</Project>\n";
+    }
 
     private static string TestsProject(GsharpTestProject project, string sdkVersion) =>
         $"<Project Sdk=\"{SdkPackageId}/{sdkVersion}\">\n" +
@@ -533,6 +544,9 @@ public sealed class GsharpTestProject
 
     /// <summary>Gets or sets the translated G# library source files.</summary>
     public IReadOnlyList<GsharpSourceFile> LibraryFiles { get; set; } = Array.Empty<GsharpSourceFile>();
+
+    /// <summary>Gets or sets friend assemblies declared by the source library project.</summary>
+    public IReadOnlyList<string> LibraryFriendAssemblies { get; set; } = Array.Empty<string>();
 
     /// <summary>Gets or sets the test project name (folder + assembly).</summary>
     public string TestsName { get; set; } = "Library.Tests";

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -191,6 +191,13 @@ public sealed class StageExecutionContext
     public List<DeclaredProjectItem> ProjectReferences { get; } = new List<DeclaredProjectItem>();
 
     /// <summary>
+    /// Gets friend assemblies contributed by generated C# sources, including
+    /// SDK-generated <c>InternalsVisibleTo</c> items.
+    /// </summary>
+    public ISet<string> GeneratedFriendAssemblies { get; } =
+        new HashSet<string>(StringComparer.Ordinal);
+
+    /// <summary>
     /// Gets or sets the absolute path of the assembly emitted by the Compile
     /// stage, published for the IL-verify stage to read (ADR-0115 §C). It is
     /// <see langword="null"/> until a green stage-2 compile has run.

--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
@@ -251,6 +251,10 @@ public sealed class TestParityStage : IMigrationStage
             LibraryFiles = context.EmittedFiles
                 .Select(f => new GsharpSourceFile(Path.GetFileName(f.GsPath), f.GSharpSource))
                 .ToList(),
+            LibraryFriendAssemblies =
+                context.Options.OutputLayout == MigrationOutputLayout.Repository
+                    ? context.GeneratedFriendAssemblies.OrderBy(name => name, StringComparer.Ordinal).ToList()
+                    : Array.Empty<string>(),
             TestsName = libraryName + ".Tests",
             TestsRootNamespace = libraryName.Replace('-', '_') + ".Tests",
             TestFiles = tests.Files,

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -468,11 +468,16 @@ public sealed class TranslateStage : IMigrationStage
         ISet<string> usedOutputPaths)
     {
         const string attributeName = "System.Runtime.CompilerServices.InternalsVisibleToAttribute";
+
+        // Documents are loader-classified hand-authored sources; generated obj
+        // AssemblyInfo trees remain in the compilation but are excluded here.
         List<string> friendAssemblies = project.Compilation.Assembly.GetAttributes()
             .Where(attribute =>
                 attribute.AttributeClass?.ToDisplayString() == attributeName &&
                 attribute.ConstructorArguments.Length == 1 &&
-                attribute.ConstructorArguments[0].Value is string)
+                attribute.ConstructorArguments[0].Value is string &&
+                attribute.ApplicationSyntaxReference is { SyntaxTree: { } syntaxTree } &&
+                project.Documents.Any(document => document.SyntaxTree == syntaxTree))
             .Select(attribute => (string)attribute.ConstructorArguments[0].Value)
             .Distinct(StringComparer.Ordinal)
             .ToList();

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -273,7 +273,7 @@ public sealed class TranslateStage : IMigrationStage
                 markMergedTypePartial: hasAnalyzerReferences,
                 retainedFilePaths: retainedFilePaths);
 
-            EmitFriendAssemblyAnnotations(
+            PreserveGeneratedFriendAssemblyAnnotations(
                 context,
                 currentProject,
                 isReferencedProject,
@@ -461,26 +461,38 @@ public sealed class TranslateStage : IMigrationStage
         return artifacts.Count == 0 ? StageOutcome.Passed() : StageOutcome.Failed(artifacts);
     }
 
-    private static void EmitFriendAssemblyAnnotations(
+    private static void PreserveGeneratedFriendAssemblyAnnotations(
         StageExecutionContext context,
         LoadedCSharpProject project,
         bool isReferencedProject,
         ISet<string> usedOutputPaths)
     {
         const string attributeName = "System.Runtime.CompilerServices.InternalsVisibleToAttribute";
-
-        // Documents are loader-classified hand-authored sources; generated obj
-        // AssemblyInfo trees remain in the compilation but are excluded here.
+        var handAuthoredTrees = project.Documents
+            .Select(document => document.SyntaxTree)
+            .ToHashSet();
         List<string> friendAssemblies = project.Compilation.Assembly.GetAttributes()
             .Where(attribute =>
                 attribute.AttributeClass?.ToDisplayString() == attributeName &&
                 attribute.ConstructorArguments.Length == 1 &&
                 attribute.ConstructorArguments[0].Value is string &&
-                attribute.ApplicationSyntaxReference is { SyntaxTree: { } syntaxTree } &&
-                project.Documents.Any(document => document.SyntaxTree == syntaxTree))
+                !handAuthoredTrees.Contains(attribute.ApplicationSyntaxReference?.SyntaxTree))
             .Select(attribute => (string)attribute.ConstructorArguments[0].Value)
             .Distinct(StringComparer.Ordinal)
             .ToList();
+        if (!isReferencedProject)
+        {
+            foreach (string friendAssembly in friendAssemblies)
+            {
+                context.GeneratedFriendAssemblies.Add(friendAssembly);
+            }
+        }
+
+        if (context.Options.OutputLayout == MigrationOutputLayout.Repository)
+        {
+            return;
+        }
+
         if (friendAssemblies.Count == 0)
         {
             return;

--- a/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -201,11 +202,11 @@ public class MigrationPipelineTests
     }
 
     /// <summary>
-    /// MSBuild-generated friend-assembly metadata must become the equivalent
-    /// G# assembly annotation so migrated test projects can access internals.
+    /// SDK-generated and hand-authored friend-assembly declarations must each
+    /// reach the compiled G# assembly exactly once.
     /// </summary>
     [Fact]
-    public async Task L2_Translate_PreservesInternalsVisibleTo()
+    public async Task L2_Compile_EmitsInternalsVisibleToExactlyOnce()
     {
         string compiler = FindCompiler();
         if (compiler is null)
@@ -214,22 +215,86 @@ public class MigrationPipelineTests
         }
 
         string corpus = ResolveCorpusDir();
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        (string NupkgPath, string Version)? sdk =
+            GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot);
+        if (sdk is null)
+        {
+            return;
+        }
+
+        CorpusApp originalL2 = CorpusDiscovery.FindById(corpus, "corpus/L2-Library");
+        string sourceRoot = NewOutputRoot("l2-friend-source");
+        string sourceProjectDir = Path.Combine(sourceRoot, "L2-Library");
+        Directory.CreateDirectory(sourceProjectDir);
+        File.Copy(
+            Path.Combine(corpus, "Directory.Build.props"),
+            Path.Combine(sourceRoot, "Directory.Build.props"));
+        string projectPath = Path.Combine(sourceProjectDir, Path.GetFileName(originalL2.ProjectPath));
+        File.Copy(originalL2.ProjectPath, projectPath);
+        File.WriteAllText(
+            projectPath,
+            File.ReadAllText(projectPath).Replace(
+                "<PropertyGroup>",
+                "<PropertyGroup>" + Environment.NewLine + "    <TargetFramework>net10.0</TargetFramework>",
+                StringComparison.Ordinal));
+        File.WriteAllText(Path.Combine(sourceProjectDir, "FriendAssembly.cs"), """
+            using System.Runtime.CompilerServices;
+
+            [assembly: InternalsVisibleTo("L2-Library.Source.Tests")]
+
+            public sealed class Marker
+            {
+            }
+            """);
+        var l2 = new CorpusApp(
+            originalL2.Id,
+            projectPath,
+            originalL2.TargetKind);
         string outRoot = NewOutputRoot("l2-friend-assembly");
         var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
         var pipeline = new MigrationPipeline(options, new IMigrationStage[] { new TranslateStage() });
 
-        CorpusApp l2 = CorpusDiscovery.FindById(corpus, "corpus/L2-Library");
         RunResult result = await pipeline.RunAsync(new[] { l2 });
         AppResult app = Assert.Single(result.Apps);
 
         Assert.True(app.Succeeded);
-        string assemblyInfo = Directory.GetFiles(
-            Path.Combine(outRoot, result.RunId, MigrationPipeline.SanitizeAppId(l2.Id)),
-            "AssemblyInfo.gs",
-            SearchOption.AllDirectories).Single();
+        string appDir = Path.Combine(outRoot, result.RunId, MigrationPipeline.SanitizeAppId(l2.Id));
+        string generatedProjectPath = Path.Combine(appDir, "L2-Library.gsproj");
+        GSharpProjectTransformer.Transform(
+            projectPath,
+            appDir,
+            "Gsharp.NET.Sdk/" + sdk.Value.Version,
+            generatedProjectPaths: null).Save(
+                generatedProjectPath,
+                System.Xml.Linq.SaveOptions.DisableFormatting);
+        GsharpTestProjectRunner.EnsureInLocalFeed(repoRoot, sdk.Value.NupkgPath);
+        GsharpTestProjectRunner.WriteIsolationBoundary(appDir);
+        ProcessRunResult build = ProcessRunner.Run(
+            "dotnet",
+            new[]
+            {
+                "build",
+                generatedProjectPath,
+                "-c",
+                "Release",
+                "-p:RestoreConfigFile=" + Path.Combine(repoRoot, "nuget.config"),
+            },
+            appDir,
+            TimeSpan.FromMinutes(5));
+        Assert.True(build.ExitCode == 0, build.Output);
+
+        string assemblyPath = Path.Combine(appDir, "bin", "Release", "net10.0", "L2-Library.dll");
+        Assembly assembly = Assembly.LoadFile(assemblyPath);
+        string[] friendAssemblies = assembly.GetCustomAttributesData()
+            .Where(attribute => attribute.AttributeType == typeof(InternalsVisibleToAttribute))
+            .Select(attribute => (string)Assert.Single(attribute.ConstructorArguments).Value)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
         Assert.Equal(
-            "@assembly:InternalsVisibleTo(\"L2-Library.Tests\")" + Environment.NewLine,
-            File.ReadAllText(assemblyInfo));
+            new[] { "L2-Library.Source.Tests", "L2-Library.Tests" },
+            friendAssemblies);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
@@ -202,11 +202,12 @@ public class MigrationPipelineTests
     }
 
     /// <summary>
-    /// SDK-generated and hand-authored friend-assembly declarations must each
-    /// reach the compiled G# assembly exactly once.
+    /// Diagnostic-run projects disable SDK AssemblyInfo generation, so the
+    /// translator must retain only generated friend declarations while the
+    /// hand-authored fully-qualified attribute stays in its translated source.
     /// </summary>
     [Fact]
-    public async Task L2_Compile_EmitsInternalsVisibleToExactlyOnce()
+    public async Task L2_DiagnosticCompile_EmitsInternalsVisibleToExactlyOnce()
     {
         string compiler = FindCompiler();
         if (compiler is null)
@@ -216,60 +217,96 @@ public class MigrationPipelineTests
 
         string corpus = ResolveCorpusDir();
         string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
-        (string NupkgPath, string Version)? sdk =
-            GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot);
-        if (sdk is null)
+        if (GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot) is null)
         {
             return;
         }
 
-        CorpusApp originalL2 = CorpusDiscovery.FindById(corpus, "corpus/L2-Library");
         string sourceRoot = NewOutputRoot("l2-friend-source");
-        string sourceProjectDir = Path.Combine(sourceRoot, "L2-Library");
-        Directory.CreateDirectory(sourceProjectDir);
-        File.Copy(
-            Path.Combine(corpus, "Directory.Build.props"),
-            Path.Combine(sourceRoot, "Directory.Build.props"));
-        string projectPath = Path.Combine(sourceProjectDir, Path.GetFileName(originalL2.ProjectPath));
-        File.Copy(originalL2.ProjectPath, projectPath);
-        File.WriteAllText(
-            projectPath,
-            File.ReadAllText(projectPath).Replace(
-                "<PropertyGroup>",
-                "<PropertyGroup>" + Environment.NewLine + "    <TargetFramework>net10.0</TargetFramework>",
-                StringComparison.Ordinal));
-        File.WriteAllText(Path.Combine(sourceProjectDir, "FriendAssembly.cs"), """
-            using System.Runtime.CompilerServices;
-
-            [assembly: InternalsVisibleTo("L2-Library.Source.Tests")]
-
-            public sealed class Marker
-            {
-            }
-            """);
-        var l2 = new CorpusApp(
-            originalL2.Id,
-            projectPath,
-            originalL2.TargetKind);
-        string outRoot = NewOutputRoot("l2-friend-assembly");
+        CorpusApp l2 = CreateFriendAssemblyFixture(corpus, sourceRoot);
+        string outRoot = NewOutputRoot("l2-friend-diagnostic");
         var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
-        var pipeline = new MigrationPipeline(options, new IMigrationStage[] { new TranslateStage() });
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), new CompileStage() });
 
         RunResult result = await pipeline.RunAsync(new[] { l2 });
         AppResult app = Assert.Single(result.Apps);
 
-        Assert.True(app.Succeeded);
+        Assert.True(app.Succeeded, string.Join(Environment.NewLine, app.Artifacts));
         string appDir = Path.Combine(outRoot, result.RunId, MigrationPipeline.SanitizeAppId(l2.Id));
-        string generatedProjectPath = Path.Combine(appDir, "L2-Library.gsproj");
+        Assert.Equal(
+            "@assembly:InternalsVisibleTo(\"L2-Library.Tests\")" + Environment.NewLine,
+            File.ReadAllText(Path.Combine(appDir, "AssemblyInfo.gs")));
+        Assert.Contains(
+            "@assembly:System.Runtime.CompilerServices.InternalsVisibleTo(\"L2-Library.Source.Tests\")",
+            File.ReadAllText(Path.Combine(appDir, "FriendAssembly.gs")),
+            StringComparison.Ordinal);
+
+        string assemblyPath = Path.Combine(appDir, "bin", "Release", "net10.0", "L2-Library.dll");
+        AssertFriendAssemblies(assemblyPath);
+    }
+
+    /// <summary>
+    /// Repository projects preserve the MSBuild item and must not receive a
+    /// second generated G# annotation from translation.
+    /// </summary>
+    [Fact]
+    public async Task L2_RepositoryCompile_EmitsInternalsVisibleToExactlyOnce()
+    {
+        string compiler = FindCompiler();
+        string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
+        (string NupkgPath, string Version)? sdk =
+            GsharpTestProjectRunner.ResolveLocalSdkPackage(repoRoot);
+        if (compiler is null || sdk is null)
+        {
+            return;
+        }
+
+        string corpus = ResolveCorpusDir();
+        string sourceRoot = NewOutputRoot("l2-friend-repository-source");
+        CorpusApp l2 = CreateFriendAssemblyFixture(corpus, sourceRoot);
+        string destinationRoot = NewOutputRoot("l2-friend-repository");
+        string projectDir = Path.Combine(destinationRoot, "L2-Library");
+        Directory.CreateDirectory(projectDir);
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            SourceRoot = sourceRoot,
+            OutputRoot = destinationRoot,
+            OutputLayout = MigrationOutputLayout.Repository,
+        };
+        var context = new StageExecutionContext(
+            l2,
+            options,
+            new GscInvoker(compiler),
+            projectDir,
+            new TriageBuilder("run", "2026-07-28T00:00:00Z", "test", l2.Id));
+        StageOutcome translation = await new TranslateStage().ExecuteAsync(context);
+
+        Assert.Equal(StageStatus.Passed, translation.Status);
+        Assert.False(File.Exists(Path.Combine(projectDir, "AssemblyInfo.gs")));
+        Assert.Contains(
+            "@assembly:System.Runtime.CompilerServices.InternalsVisibleTo(\"L2-Library.Source.Tests\")",
+            File.ReadAllText(Path.Combine(projectDir, "FriendAssembly.gs")),
+            StringComparison.Ordinal);
+
+        string generatedProjectPath = Path.Combine(projectDir, "L2-Library.gsproj");
         GSharpProjectTransformer.Transform(
-            projectPath,
-            appDir,
+            l2.ProjectPath,
+            projectDir,
             "Gsharp.NET.Sdk/" + sdk.Value.Version,
             generatedProjectPaths: null).Save(
                 generatedProjectPath,
                 System.Xml.Linq.SaveOptions.DisableFormatting);
+        Assert.Single(
+            System.Xml.Linq.XDocument.Load(generatedProjectPath).Descendants(),
+            element =>
+                element.Name.LocalName == "InternalsVisibleTo" &&
+                element.Attribute("Include")?.Value == "L2-Library.Tests");
+
         GsharpTestProjectRunner.EnsureInLocalFeed(repoRoot, sdk.Value.NupkgPath);
-        GsharpTestProjectRunner.WriteIsolationBoundary(appDir);
+        GsharpTestProjectRunner.WriteIsolationBoundary(projectDir);
         ProcessRunResult build = ProcessRunner.Run(
             "dotnet",
             new[]
@@ -280,21 +317,12 @@ public class MigrationPipelineTests
                 "Release",
                 "-p:RestoreConfigFile=" + Path.Combine(repoRoot, "nuget.config"),
             },
-            appDir,
+            projectDir,
             TimeSpan.FromMinutes(5));
         Assert.True(build.ExitCode == 0, build.Output);
 
-        string assemblyPath = Path.Combine(appDir, "bin", "Release", "net10.0", "L2-Library.dll");
-        Assembly assembly = Assembly.LoadFile(assemblyPath);
-        string[] friendAssemblies = assembly.GetCustomAttributesData()
-            .Where(attribute => attribute.AttributeType == typeof(InternalsVisibleToAttribute))
-            .Select(attribute => (string)Assert.Single(attribute.ConstructorArguments).Value)
-            .OrderBy(name => name, StringComparer.Ordinal)
-            .ToArray();
-
-        Assert.Equal(
-            new[] { "L2-Library.Source.Tests", "L2-Library.Tests" },
-            friendAssemblies);
+        string assemblyPath = Path.Combine(projectDir, "bin", "Release", "net10.0", "L2-Library.dll");
+        AssertFriendAssemblies(assemblyPath);
     }
 
     /// <summary>
@@ -557,6 +585,50 @@ public class MigrationPipelineTests
 
         public Task<StageOutcome> ExecuteAsync(StageExecutionContext context, CancellationToken cancellationToken = default) =>
             Task.FromResult(StageOutcome.Failed(Array.Empty<TriageArtifact>()));
+    }
+
+    private static CorpusApp CreateFriendAssemblyFixture(string corpus, string sourceRoot)
+    {
+        CorpusApp original = CorpusDiscovery.FindById(corpus, "corpus/L2-Library");
+        string projectDir = Path.Combine(sourceRoot, "L2-Library");
+        Directory.CreateDirectory(projectDir);
+        File.Copy(
+            Path.Combine(corpus, "Directory.Build.props"),
+            Path.Combine(sourceRoot, "Directory.Build.props"));
+        string projectPath = Path.Combine(projectDir, Path.GetFileName(original.ProjectPath));
+        File.Copy(original.ProjectPath, projectPath);
+        File.WriteAllText(
+            projectPath,
+            File.ReadAllText(projectPath).Replace(
+                "<PropertyGroup>",
+                "<PropertyGroup>" + Environment.NewLine + "    <TargetFramework>net10.0</TargetFramework>",
+                StringComparison.Ordinal));
+        File.WriteAllText(Path.Combine(projectDir, "FriendAssembly.cs"), """
+            [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("L2-Library.Source.Tests")]
+
+            public sealed class Marker
+            {
+            }
+            """);
+        return new CorpusApp(
+            original.Id,
+            projectPath,
+            original.TargetKind,
+            relativeProjectPath: Path.Combine("L2-Library", Path.GetFileName(projectPath)));
+    }
+
+    private static void AssertFriendAssemblies(string assemblyPath)
+    {
+        Assembly assembly = Assembly.LoadFile(assemblyPath);
+        string[] friendAssemblies = assembly.GetCustomAttributesData()
+            .Where(attribute => attribute.AttributeType == typeof(InternalsVisibleToAttribute))
+            .Select(attribute => (string)Assert.Single(attribute.ConstructorArguments).Value)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(
+            new[] { "L2-Library.Source.Tests", "L2-Library.Tests" },
+            friendAssemblies);
     }
 
     private static string FingerprintShort(string fingerprint)

--- a/tools/cs2gs/Cs2Gs.Tests/TestParityLibraryLiveTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TestParityLibraryLiveTests.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using Cs2Gs.Pipeline;
 using Xunit;
 
@@ -35,6 +37,12 @@ public class TestParityLibraryLiveTests
         "    func Subtract(a int, b int) int {\n" +
         "        return a - b\n" +
         "    }\n" +
+        "\n" +
+        "    shared {\n" +
+        "        internal func AddInternal(a int, b int) int {\n" +
+        "            return a + b\n" +
+        "        }\n" +
+        "    }\n" +
         "}\n";
 
     private const string TestSource =
@@ -54,6 +62,11 @@ public class TestParityLibraryLiveTests
         "    func Subtract_Returns_Difference() {\n" +
         "        var calc = Calculator()\n" +
         "        Assert.Equal(1, calc.Subtract(3, 2))\n" +
+        "    }\n" +
+        "\n" +
+        "    @Fact\n" +
+        "    func FriendAssembly_Can_Call_Internal_Method() {\n" +
+        "        Assert.Equal(5, Calculator.AddInternal(2, 3))\n" +
         "    }\n" +
         "\n" +
         "    @Theory\n" +
@@ -89,6 +102,7 @@ public class TestParityLibraryLiveTests
             {
                 new GsharpSourceFile("Calculator.gs", LibrarySource),
             },
+            LibraryFriendAssemblies = new[] { "CalcLib.Tests" },
             TestsName = "CalcLib.Tests",
             TestsRootNamespace = "CalcLib.Tests",
             TestFiles = new List<GsharpSourceFile>
@@ -106,12 +120,20 @@ public class TestParityLibraryLiveTests
             run.Status == GsharpTestRunStatus.Ran,
             "Expected a live dotnet test run with a TRX. Status=" + run.Status +
                 "; output tail:\n" + run.Output);
+        Assembly library = Assembly.LoadFile(
+            Path.Combine(workDir, "CalcLib", "bin", "Release", "net10.0", "CalcLib.dll"));
+        Assert.Single(
+            library.GetCustomAttributesData(),
+            attribute =>
+                attribute.AttributeType == typeof(InternalsVisibleToAttribute) &&
+                (string)Assert.Single(attribute.ConstructorArguments).Value == "CalcLib.Tests");
 
         var oracle = new[]
         {
             new TestCaseOutcome("CalcLib.Tests.CalculatorTests.Add_Cases(a: 1, b: 2, expected: 3)", "Passed"),
             new TestCaseOutcome("CalcLib.Tests.CalculatorTests.Add_Cases(a: 2, b: 2, expected: 4)", "Passed"),
             new TestCaseOutcome("CalcLib.Tests.CalculatorTests.Add_Returns_Sum", "Passed"),
+            new TestCaseOutcome("CalcLib.Tests.CalculatorTests.FriendAssembly_Can_Call_Internal_Method", "Passed"),
             new TestCaseOutcome("CalcLib.Tests.CalculatorTests.Subtract_Returns_Difference", "Passed"),
         };
 


### PR DESCRIPTION
## Summary
- classify `InternalsVisibleTo` attributes by source provenance before emitting `AssemblyInfo.gs`
- skip SDK-generated `obj` assembly attributes already reproduced from preserved MSBuild items
- verify SDK-derived and hand-authored friend declarations each appear exactly once in compiled metadata

## Tests
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --filter FullyQualifiedName~Cs2Gs.Tests.MigrationPipelineTests --no-restore --verbosity minimal` (12 passed)
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-build --no-restore --verbosity minimal` (1788 passed)

Fixes #2816