### PR TITLE
Fix cs2gs ownership for same-package members

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1735AssignmentTargetNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1735AssignmentTargetNullForgivenessTranslationTests.cs
@@ -26,9 +26,8 @@ namespace Cs2Gs.Tests;
 /// <c>this.Prop!!.Member = v</c>.
 /// </item>
 /// <item>
-/// That same branch hard-coded <c>this</c> even inside a lifted owned-struct
-/// receiver-clause method (issue #938), where the receiver is not <c>this</c>
-/// but the receiver-clause parameter (<c>self</c>).
+/// Owned struct methods now stay in-body, so that same branch must qualify
+/// their nullable instance receivers through real <c>this</c>.
 /// </item>
 /// <item>
 /// A delegate/event invoked via the explicit <c>.Invoke(...)</c> spelling
@@ -86,13 +85,10 @@ namespace Demo
     }
 
     [Fact]
-    public void OwnedStructReceiverClause_ImplicitThisNullableField_UsesActualReceiverNotThis()
+    public void OwnedStructInBodyMethod_ImplicitThisNullableField_UsesThis()
     {
-        // Issue #938: a struct instance method is lifted to the receiver-clause
-        // form (`func (self Vec) F()`), so an implicit-this reference inside the
-        // body must qualify through the receiver-clause parameter, not `this`
-        // (which does not exist there). Combined with the nullable-receiver
-        // assertion, the assignment target must read `self.Child!!.Value = 5`.
+        // Issue #2821: owned struct methods now use the canonical in-body form.
+        // Nullable assignment-target qualification therefore uses real `this`.
         string printed = TranslateUnit(@"
 #nullable enable
 namespace Demo
@@ -109,8 +105,8 @@ namespace Demo
     }
 }");
 
-        Assert.DoesNotContain("this.Child", printed);
-        Assert.Contains("self.Child!!.Value = 5", printed);
+        Assert.DoesNotContain("func (self Vec)", printed);
+        Assert.Contains("this.Child!!.Value = 5", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1909PrimaryConstructorTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1909PrimaryConstructorTranslationTests.cs
@@ -110,9 +110,6 @@ namespace Corpus.Issue1909
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
-        // ignore the pre-existing "receiver-clause form" info diagnostic
-        // (issue #938, unrelated to primary constructors) that every
-        // struct instance-method translation emits.
         string rendered = GSharpPrinter.Print(unit);
 
         Assert.Contains("struct Point(x int32, y int32) {", rendered, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2452ExtensionMethodGroupTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2452ExtensionMethodGroupTranslationTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.IO;
 using System.Linq;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.Translator;
@@ -10,6 +11,9 @@ using Cs2Gs.Translator.Loading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
+using GSharpCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GSharpSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+using GSharpSourceText = GSharp.Core.CodeAnalysis.Text.SourceText;
 
 namespace Cs2Gs.Tests;
 
@@ -113,7 +117,10 @@ public class Issue2452ExtensionMethodGroupTranslationTests
 
         string printed = Translate(source);
         Assert.Contains("host.Shape + shape.Shape + host.Measure()", printed, StringComparison.Ordinal);
+        Assert.Contains("func (host Host) Shape()", printed, StringComparison.Ordinal);
+        Assert.Contains("func (host Host) Measure(unused int32 = 0)", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("host.Shape()", printed, StringComparison.Ordinal);
+        AssertCompilesWithoutErrors(printed);
     }
 
     private static string Translate(string source)
@@ -127,5 +134,21 @@ public class Issue2452ExtensionMethodGroupTranslationTests
         LoadedDocument document = Assert.Single(project.Documents);
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         return GSharpPrinter.Print(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static void AssertCompilesWithoutErrors(string source)
+    {
+        var compilation = new GSharpCompilation(
+            GSharpSyntaxTree.Parse(GSharpSourceText.From(source)))
+        {
+            IsLibrary = true,
+        };
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "Emit failed:\n" + string.Join("\n", result.Diagnostics.Select(d => d.ToString())));
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2452ExtensionMethodGroupTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2452ExtensionMethodGroupTranslationTests.cs
@@ -110,14 +110,19 @@ public class Issue2452ExtensionMethodGroupTranslationTests
                 public sealed class Consumer
                 {
                     public int Read(Host host, IShape shape) =>
-                        host.Shape + shape.Shape + host.Measure();
+                        host.Shape + shape.Shape + host.Measure() + Extensions.Shape(host);
                 }
             }
             """;
 
         string printed = Translate(source);
-        Assert.Contains("host.Shape + shape.Shape + host.Measure()", printed, StringComparison.Ordinal);
-        Assert.Contains("func (host Host) Shape()", printed, StringComparison.Ordinal);
+        Assert.Contains(
+            "host.Shape + shape.Shape + host.Measure() + Extensions.Shape(host)",
+            printed,
+            StringComparison.Ordinal);
+        Assert.Contains("class Extensions", printed, StringComparison.Ordinal);
+        Assert.Contains("func Shape(host Host)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("func (host Host) Shape", printed, StringComparison.Ordinal);
         Assert.Contains("func (host Host) Measure(unused int32 = 0)", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("host.Shape()", printed, StringComparison.Ordinal);
         AssertCompilesWithoutErrors(printed);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -467,6 +467,183 @@ public static class User
     }
 
     [Fact]
+    public void NullConditionalVoidStaticHelper_UsesStatementGuard()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Host.cs", @"
+#nullable enable
+namespace Demo;
+
+public sealed class Host
+{
+}"),
+            ("Extensions.cs", @"
+#nullable enable
+namespace Demo;
+
+public static class FirstExtensions
+{
+    public static void Touch(this Host host)
+    {
+    }
+}
+
+public static class SecondExtensions
+{
+    public static void Touch(this Host host, int value)
+    {
+    }
+}"),
+            ("User.cs", @"
+#nullable enable
+namespace Demo;
+
+public static class User
+{
+    public static void Run(Host? host) => host?.Touch();
+}"));
+
+        string user = Compact(printed["User.cs"]);
+
+        Assert.Contains("if host != nil { FirstExtensions.Touch(host!!) }", user);
+        Assert.DoesNotContain("else { nil }", user);
+        Assert.DoesNotContain("default(void", user);
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(printed.Values);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void NullConditionalStaticHelper_UsesTypedDefaultsForCompositeResults()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Host.cs", @"
+#nullable enable
+namespace Demo;
+
+public sealed class Host
+{
+}"),
+            ("Extensions.cs", @"
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Demo;
+
+public static class FirstExtensions
+{
+    public static List<int> Items(this Host host) => new List<int>();
+
+    public static int[] Values(this Host host) => new int[0];
+
+    public static (int, string) Pair(this Host host) => (1, ""one"");
+
+    public static Func<int, string> Formatter(this Host host) =>
+        value => value.ToString();
+}
+
+public static class SecondExtensions
+{
+    public static List<int> Items(this Host host, int value) => new List<int>();
+
+    public static int[] Values(this Host host, int value) => new int[0];
+
+    public static (int, string) Pair(this Host host, int value) => (1, ""one"");
+
+    public static Func<int, string> Formatter(this Host host, int value) =>
+        item => item.ToString();
+}"),
+            ("User.cs", @"
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Demo;
+
+public static class User
+{
+    public static List<int>? Items(Host? host) => host?.Items();
+
+    public static int[]? Values(Host? host) => host?.Values();
+
+    public static (int, string)? Pair(Host? host) => host?.Pair();
+
+    public static Func<int, string>? Formatter(Host? host) => host?.Formatter();
+}"));
+
+        string user = Compact(printed["User.cs"]);
+
+        Assert.Contains("default(List[int32]?)", user);
+        Assert.Contains("default([]?int32)", user);
+        Assert.Contains("default((int32, string)?)", user);
+        Assert.Contains("default(((int32) -> string)?)", user);
+        Assert.DoesNotContain("List[int32]?(", user);
+        Assert.DoesNotContain("[]?int32(", user);
+        Assert.DoesNotContain("(int32, string)?(", user);
+        Assert.DoesNotContain("-> string)?(", user);
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(printed.Values);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void NullConditionalStaticHelper_ChainedReceiverKeepsWholePrefix()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Config.cs", @"
+#nullable enable
+namespace Demo;
+
+public sealed class Config
+{
+    public Options Options = new Options();
+}
+
+public sealed class Options
+{
+}"),
+            ("Extensions.cs", @"
+#nullable enable
+namespace Demo;
+
+public static class FirstExtensions
+{
+    public static string Describe(this Options options) => ""first"";
+}
+
+public static class SecondExtensions
+{
+    public static string Describe(this Options options, int value) => ""second"";
+}"),
+            ("User.cs", @"
+#nullable enable
+namespace Demo;
+
+public static class User
+{
+    public static Config? GetConfig() => null;
+
+    public static string Run() => GetConfig()?.Options.Describe() ?? ""none"";
+}"));
+
+        string user = Compact(printed["User.cs"]);
+
+        Assert.Equal(1, CountOccurrences(user, "User.GetConfig()"));
+        Assert.Contains("let __spill", user);
+        Assert.Contains("FirstExtensions.Describe(__spill", user);
+        Assert.Contains("!!.Options)", user);
+        Assert.DoesNotContain("FirstExtensions.Describe(.Options", user);
+        Assert.DoesNotContain(".Options.Describe()", user);
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(printed.Values);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
     public void RefReceiverStaticHelper_PassesReceiverAddress()
     {
         IReadOnlyDictionary<string, string> printed = TranslateFiles(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
@@ -14,6 +15,8 @@ using Cs2Gs.Translator.Loading;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -335,6 +338,88 @@ public static class User
     }
 
     [Fact]
+    public void CrossProjectStaticHelpers_PreserveInvocationStaticAndMethodGroupForms()
+    {
+        LoadedCSharpProject producer = CSharpProjectLoader.LoadInMemory(
+            new[]
+            {
+                ("Producer.cs", @"
+namespace Demo;
+
+public sealed class Host
+{
+}
+
+public static class FirstExtensions
+{
+    public static string Describe(this Host host, object value) => ""object"";
+}
+
+public static class SecondExtensions
+{
+    public static string Describe(this Host host, string value) => ""string"";
+}"),
+            },
+            CSharpProjectLoader.RuntimeReferences(),
+            "Producer");
+
+        using var image = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult emit = producer.Compilation.Emit(image);
+        Assert.True(
+            emit.Success,
+            "Producer should emit with no C# errors: " +
+                string.Join(Environment.NewLine, emit.Diagnostics));
+
+        MetadataReference producerReference = MetadataReference.CreateFromImage(image.ToArray());
+        LoadedCSharpProject consumer = CSharpProjectLoader.LoadInMemory(
+            new[]
+            {
+                ("Consumer.cs", @"
+using System;
+using Demo;
+
+namespace Client;
+
+public static class User
+{
+    public static string Invoke(Host host, string value) => host.Describe(value);
+
+    public static string Static(Host host, string value) =>
+        SecondExtensions.Describe(host, value);
+
+    public static Func<string, string> BindString(Host host) => host.Describe;
+
+    public static Func<object, string> BindObject(Host host) => host.Describe;
+}"),
+            },
+            CSharpProjectLoader.RuntimeReferences().Append(producerReference).ToList(),
+            "Consumer");
+
+        Assert.True(
+            consumer.BoundWithoutErrors,
+            "Consumer should bind with no C# errors: " +
+                string.Join(Environment.NewLine, consumer.ErrorDiagnostics));
+
+        var siblings = new[] { producer.Compilation, consumer.Compilation };
+        string printedProducer = TranslateProject(producer, siblings);
+        string printedConsumer = TranslateProject(consumer, siblings);
+        string compactConsumer = Compact(printedConsumer);
+
+        Assert.Contains("func Describe(host Host, value object)", printedProducer);
+        Assert.Contains("func Describe(host Host, value string)", printedProducer);
+        Assert.Equal(
+            2,
+            CountOccurrences(compactConsumer, "SecondExtensions.Describe(host, value)"));
+        Assert.Contains("SecondExtensions.Describe(__spill", compactConsumer);
+        Assert.Contains("FirstExtensions.Describe(__spill", compactConsumer);
+        Assert.DoesNotContain("host.Describe", compactConsumer);
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(new[] { printedProducer, printedConsumer });
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
     public void ExternalReceiver_RetainsReceiverClause()
     {
         string printed = TranslateFiles(
@@ -465,6 +550,30 @@ public static class MeterExtensions
             .Concat(Binder.BindProgram(scope).Diagnostics)
             .ToImmutableArray();
     }
+
+    private static string TranslateProject(
+        LoadedCSharpProject project,
+        IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        var translator = new CSharpToGSharpTranslator();
+        var output = new List<string>();
+        foreach (LoadedDocument document in project.Documents)
+        {
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath,
+                siblingCompilations);
+            output.Add(GSharpPrinter.Print(translator.TranslateDocument(document, context)));
+        }
+
+        return string.Join(Environment.NewLine, output);
+    }
+
+    private static string Compact(string printed) =>
+        string.Join(" ", printed.Split(
+            new[] { ' ', '\t', '\r', '\n' },
+            StringSplitOptions.RemoveEmptyEntries));
 
     private static int CountOccurrences(string haystack, string needle)
     {

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -144,6 +144,50 @@ public static class HostExtensions
     }
 
     [Fact]
+    public void InterfaceInstanceAndExtensionOverloads_RetainReceiverClause()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Host.cs", @"
+namespace Demo;
+
+public interface IA
+{
+}
+
+public interface IB
+{
+}
+
+public sealed class Both : IA, IB
+{
+}
+
+public sealed class Host
+{
+    public int M(IA value) => 1;
+}"),
+            ("Extensions.cs", @"
+namespace Demo;
+
+public static class HostExtensions
+{
+    public static int M(this Host host, IB value) => 2;
+}"),
+            ("User.cs", @"
+namespace Demo;
+
+public static class User
+{
+    public static int Run(Host host, Both value) => host.M(value);
+}"));
+
+        Assert.Contains("func M(value IA)", printed["Host.cs"]);
+        Assert.DoesNotContain("func M(value IB)", printed["Host.cs"]);
+        Assert.Contains("func (host Host) M(value IB)", printed["Extensions.cs"]);
+        Assert.Contains("host.M(value)", printed["User.cs"]);
+    }
+
+    [Fact]
     public void ExactReducedSignatureCollision_StaysStatic()
     {
         IReadOnlyDictionary<string, string> printed = TranslateFiles(
@@ -175,6 +219,60 @@ public static class User
         Assert.Contains("func M(host Host, value int32)", printed["Extensions.cs"]);
         Assert.DoesNotContain("func (host Host) M", combined);
         Assert.Contains("HostExtensions.M(host, 1)", printed["User.cs"]);
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(printed.Values);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id is "GS0264" or "GS0314");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void DistinctOverloads_FromDifferentStaticClasses_StayStatic()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Host.cs", @"
+namespace Demo;
+
+public sealed class Host
+{
+}"),
+            ("FirstExtensions.cs", @"
+namespace Demo;
+
+public static class FirstExtensions
+{
+    public static string Describe(this Host host, object value) => ""object"";
+}"),
+            ("SecondExtensions.cs", @"
+namespace Demo;
+
+public static class SecondExtensions
+{
+    public static string Describe(this Host host, string value) => ""string"";
+}"),
+            ("User.cs", @"
+namespace Demo;
+
+public static class User
+{
+    public static string Run(Host host, string value) =>
+        FirstExtensions.Describe(host, value) +
+        SecondExtensions.Describe(host, value) +
+        host.Describe(value);
+}"));
+
+        string combined = string.Join(Environment.NewLine, printed.Values);
+
+        Assert.Contains("class FirstExtensions", combined);
+        Assert.Contains("class SecondExtensions", combined);
+        Assert.Contains("func Describe(host Host, value object)", printed["FirstExtensions.cs"]);
+        Assert.Contains("func Describe(host Host, value string)", printed["SecondExtensions.cs"]);
+        Assert.DoesNotContain("func Describe(value ", printed["Host.cs"]);
+        Assert.DoesNotContain("func (host Host) Describe", combined);
+        Assert.Contains("FirstExtensions.Describe(host, value)", printed["User.cs"]);
+        Assert.Equal(
+            2,
+            CountOccurrences(printed["User.cs"], "SecondExtensions.Describe(host, value)"));
 
         ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
             BindDiagnostics(printed.Values);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -92,6 +92,52 @@ public static class TextExtensions
     }
 
     [Fact]
+    public void OpenGenericOwnedReceiver_RetainsReceiverClause()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Box.cs", @"
+namespace Demo;
+
+public sealed class Box<T>
+{
+    public T Value;
+}"),
+            ("Extensions.cs", @"
+namespace Demo;
+
+public static class BoxExtensions
+{
+    public static T Read<T>(this Box<T> box) => box.Value;
+}"));
+
+        Assert.Contains("func (box Box[T]) Read[T]()", printed["Extensions.cs"]);
+        Assert.DoesNotContain("func Read", printed["Box.cs"]);
+    }
+
+    [Fact]
+    public void ClosedGenericOwnedReceiver_RetainsReceiverClause()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Box.cs", @"
+namespace Demo;
+
+public sealed class Box<T>
+{
+    public T Value;
+}"),
+            ("Extensions.cs", @"
+namespace Demo;
+
+public static class BoxExtensions
+{
+    public static int Read(this Box<int> box) => box.Value;
+}"));
+
+        Assert.Contains("func (box Box[int32]) Read()", printed["Extensions.cs"]);
+        Assert.DoesNotContain("func Read", printed["Box.cs"]);
+    }
+
+    [Fact]
     public void ExcludedGeneratedExtension_DoesNotMoveIntoRetainedTarget()
     {
         IReadOnlyDictionary<string, string> printed = TranslateFiles(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -515,6 +515,61 @@ public static class User
     }
 
     [Fact]
+    public void NullConditionalVoidStaticHelper_InSyncActionLambda_UsesStatementGuard()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Host.cs", @"
+#nullable enable
+namespace Demo;
+
+public sealed class Host
+{
+}"),
+            ("Extensions.cs", @"
+#nullable enable
+namespace Demo;
+
+public static class FirstExtensions
+{
+    public static void Touch(this Host host)
+    {
+    }
+}
+
+public static class SecondExtensions
+{
+    public static void Touch(this Host host, int value)
+    {
+    }
+}"),
+            ("User.cs", @"
+#nullable enable
+using System;
+
+namespace Demo;
+
+public static class User
+{
+    public static Host? GetHost() => null;
+
+    public static Action Bind() => () => GetHost()?.Touch();
+}"));
+
+        string user = Compact(printed["User.cs"]);
+
+        Assert.Equal(1, CountOccurrences(user, "User.GetHost()"));
+        Assert.Contains("() -> { let __spill", user);
+        Assert.Contains("if __spill", user);
+        Assert.Contains("FirstExtensions.Touch(__spill", user);
+        Assert.DoesNotContain("() -> User.GetHost()?.Touch()", user);
+        Assert.DoesNotContain("default(void", user);
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(printed.Values);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
     public void NullConditionalStaticHelper_UsesTypedDefaultsForCompositeResults()
     {
         IReadOnlyDictionary<string, string> printed = TranslateFiles(
@@ -641,6 +696,183 @@ public static class User
         ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
             BindDiagnostics(printed.Values);
         Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void NullConditionalStaticHelper_NestedConditionalChain_BailsWithoutBareSpill()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Host.cs", @"
+#nullable enable
+namespace Demo;
+
+public sealed class Root
+{
+    public Host? Host;
+
+    public Host? GetHost() => Host;
+}
+
+public sealed class Host
+{
+}"),
+            ("Extensions.cs", @"
+#nullable enable
+namespace Demo;
+
+public static class FirstExtensions
+{
+    public static string Describe(this Host host) => ""first"";
+}
+
+public static class SecondExtensions
+{
+    public static string Describe(this Host host, int value) => ""second"";
+}"),
+            ("User.cs", @"
+#nullable enable
+namespace Demo;
+
+public static class User
+{
+    public static string Field(Root? root) => root?.Host?.Describe() ?? ""none"";
+
+    public static string Call(Root? root) => root?.GetHost()?.Describe() ?? ""none"";
+}"));
+
+        string user = Compact(printed["User.cs"]);
+
+        Assert.Contains(".Host?.Describe()", user);
+        Assert.Contains(".GetHost()?.Describe()", user);
+        Assert.DoesNotContain("let __spill = .", user);
+        Assert.DoesNotContain("FirstExtensions.Describe(.", user);
+    }
+
+    [Fact]
+    public void NullConditionalStaticHelper_ChainedPrefixUsesNormalMemberTranslation()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Types.cs", @"
+#nullable enable
+namespace Demo;
+
+public readonly struct Node
+{
+}
+
+public sealed class Holder
+{
+    public Node Value;
+}
+
+public sealed class Config
+{
+    public (Node Node, int Other) Pair;
+
+    public Node? Maybe;
+
+    public Holder Holder = new Holder();
+}
+
+public static class HolderExtensions
+{
+    extension(Holder holder)
+    {
+        public Node Current => holder.Value;
+    }
+}"),
+            ("Extensions.cs", @"
+#nullable enable
+namespace Demo;
+
+public static class FirstExtensions
+{
+    public static string Describe(this Node node) => ""first"";
+}
+
+public static class SecondExtensions
+{
+    public static string Describe(this Node node, int value) => ""second"";
+}"),
+            ("User.cs", @"
+#nullable enable
+namespace Demo;
+
+public static class User
+{
+    public static string Tuple(Config? config) =>
+        config?.Pair.Node.Describe() ?? ""none"";
+
+    public static string Nullable(Config? config) =>
+        config?.Maybe.Value.Describe() ?? ""none"";
+
+    public static string ExtensionProperty(Config? config) =>
+        config?.Holder.Current.Describe() ?? ""none"";
+}"));
+
+        string user = Compact(printed["User.cs"]);
+
+        Assert.Equal(3, CountOccurrences(user, "FirstExtensions.Describe("));
+        Assert.Contains(".Pair.Item1)", user);
+        Assert.Contains(".Maybe!!)", user);
+        Assert.Contains(".Holder.Current())", user);
+        Assert.DoesNotContain(".Pair.Node", user);
+        Assert.DoesNotContain(".Maybe.Value", user);
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(printed.Values);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void NullConditionalStaticHelper_ChainedPrefixPreservesPointerAccess()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Types.cs", @"
+#nullable enable
+namespace Demo;
+
+public struct Node
+{
+}
+
+public struct PointerHolder
+{
+    public Node Value;
+}
+
+public sealed unsafe class Config
+{
+    public PointerHolder* Pointer;
+}"),
+            ("Extensions.cs", @"
+#nullable enable
+namespace Demo;
+
+public static class FirstExtensions
+{
+    public static string Describe(this Node node) => ""first"";
+}
+
+public static class SecondExtensions
+{
+    public static string Describe(this Node node, int value) => ""second"";
+}"),
+            ("User.cs", @"
+#nullable enable
+namespace Demo;
+
+public static class User
+{
+    public static unsafe string Run(Config? config) =>
+        config?.Pointer->Value.Describe() ?? ""none"";
+}"));
+
+        string user = Compact(printed["User.cs"]);
+
+        Assert.Contains("FirstExtensions.Describe(", user);
+        Assert.Contains(".Pointer->Value)", user);
+        Assert.DoesNotContain(".Pointer.Value", user);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -36,9 +36,14 @@ public readonly record struct Value(int Number)
 
         Assert.Contains("data struct Value", printed);
         Assert.Contains("    func Double()", printed);
-        Assert.Contains("    override func ToString()", printed);
+        Assert.Contains("    func ToString()", printed);
+        Assert.DoesNotContain("override func ToString()", printed);
         Assert.DoesNotContain("func (self Value)", printed);
         Assert.DoesNotContain("func (self Value) ToString", printed);
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(new[] { printed });
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -1,0 +1,168 @@
+// <copyright file="Issue2821OwnedExtensionMemberTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+public class Issue2821OwnedExtensionMemberTranslationTests
+{
+    [Fact]
+    public void OwnedStructInstanceMethods_StayInsideTypeBody()
+    {
+        string printed = TranslateFiles(
+            ("Value.cs", @"
+namespace Demo;
+
+public readonly record struct Value(int Number)
+{
+    public int Double() => Number * 2;
+
+    public override string ToString() => Number.ToString();
+}"))["Value.cs"];
+
+        Assert.Contains("data struct Value", printed);
+        Assert.Contains("    func Double()", printed);
+        Assert.Contains("    override func ToString()", printed);
+        Assert.DoesNotContain("func (self Value)", printed);
+        Assert.DoesNotContain("func (self Value) ToString", printed);
+    }
+
+    [Fact]
+    public void SamePackageExtension_OnSplitPartialType_MovesIntoOwnedType()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("A.Target.cs", @"
+namespace Demo;
+
+public partial class Meter
+{
+    public int Value;
+}"),
+            ("B.Target.cs", @"
+namespace Demo;
+
+public partial class Meter
+{
+    public int Double() => Value * 2;
+}"),
+            ("Extensions.cs", @"
+using System;
+
+namespace Demo;
+
+public static class MeterExtensions
+{
+    public static int Adjust(this Meter meter) =>
+        meter.Value >= 0 ? meter.Value : throw new InvalidOperationException();
+}"));
+
+        string combined = string.Join(Environment.NewLine, printed.Values);
+        string target = Assert.Single(printed.Values, text => text.Contains("class Meter", StringComparison.Ordinal));
+
+        Assert.Equal(1, CountOccurrences(combined, "func Adjust("));
+        Assert.Contains("import System", target);
+        Assert.Contains("    func Adjust()", target);
+        Assert.Contains("var meter = this", target);
+        Assert.DoesNotContain("func (meter Meter) Adjust", combined);
+        Assert.DoesNotContain("class MeterExtensions", combined);
+    }
+
+    [Fact]
+    public void ExternalReceiver_RetainsReceiverClause()
+    {
+        string printed = TranslateFiles(
+            ("Extensions.cs", @"
+namespace Demo;
+
+public static class TextExtensions
+{
+    public static int TwiceLength(this string value) => value.Length * 2;
+}"))["Extensions.cs"];
+
+        Assert.Contains("func (value string) TwiceLength()", printed);
+    }
+
+    [Fact]
+    public void ExcludedGeneratedExtension_DoesNotMoveIntoRetainedTarget()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            new CSharpToGSharpTranslator(retainedFilePaths: new[] { "Target.cs" }),
+            ("Target.cs", @"
+namespace Demo;
+
+public partial class Meter
+{
+    public int Value;
+}"),
+            ("GeneratedExtensions.cs", @"
+namespace Demo;
+
+public static class MeterExtensions
+{
+    public static int Adjust(this Meter meter) => meter.Value;
+}"));
+
+        Assert.DoesNotContain("func Adjust(", printed["Target.cs"]);
+    }
+
+    private static IReadOnlyDictionary<string, string> TranslateFiles(
+        params (string FileName, string Source)[] files)
+    {
+        return TranslateFiles(new CSharpToGSharpTranslator(), files);
+    }
+
+    private static IReadOnlyDictionary<string, string> TranslateFiles(
+        CSharpToGSharpTranslator translator,
+        params (string FileName, string Source)[] files)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(files);
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (LoadedDocument document in project.Documents)
+        {
+            var context = new TranslationContext(
+                project.Compilation,
+                document.SemanticModel,
+                document.FilePath);
+            CompilationUnit unit = translator.TranslateDocument(document, context);
+            string printed = GSharpPrinter.Print(unit);
+            RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);
+            Assert.True(
+                roundTrip.Success,
+                "Translated G# must round-trip. Errors:\n" +
+                    string.Join("\n", roundTrip.Errors) + "\n\nPrinted:\n" + printed);
+            Assert.DoesNotContain(
+                roundTrip.Errors,
+                error => error.Contains("GS0314", StringComparison.Ordinal));
+            result.Add(document.FilePath, printed);
+        }
+
+        return result;
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -4,11 +4,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -74,6 +79,156 @@ public static class MeterExtensions
         Assert.Contains("var meter = this", target);
         Assert.DoesNotContain("func (meter Meter) Adjust", combined);
         Assert.DoesNotContain("class MeterExtensions", combined);
+    }
+
+    [Fact]
+    public void ArityDisjointInstanceOverload_DoesNotBlockOwnedLowering()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Host.cs", @"
+namespace Demo;
+
+public sealed class Host
+{
+    public int M() => 1;
+}"),
+            ("Extensions.cs", @"
+namespace Demo;
+
+public static class HostExtensions
+{
+    public static int M(this Host host, int value) => value;
+}"));
+
+        string combined = string.Join(Environment.NewLine, printed.Values);
+        string host = printed["Host.cs"];
+
+        Assert.Contains("func M()", host);
+        Assert.Contains("func M(value int32)", host);
+        Assert.DoesNotContain("func (host Host) M", combined);
+        Assert.DoesNotContain("class HostExtensions", combined);
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(printed.Values);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id is "GS0264" or "GS0314");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void ApplicableInstanceOverload_RetainsReceiverClause()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Host.cs", @"
+namespace Demo;
+
+public sealed class Host
+{
+    public int M(object value) => 1;
+}"),
+            ("Extensions.cs", @"
+namespace Demo;
+
+public static class HostExtensions
+{
+    public static int M(this Host host, string value) => value.Length;
+}"));
+
+        Assert.DoesNotContain("func M(value string)", printed["Host.cs"]);
+        Assert.Contains("func (host Host) M(value string)", printed["Extensions.cs"]);
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(printed.Values);
+        Assert.Single(diagnostics.Where(diagnostic => diagnostic.Id == "GS0314"));
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == "GS0264");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void ExactReducedSignatureCollision_StaysStatic()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Host.cs", @"
+namespace Demo;
+
+public sealed class Host
+{
+    public int M(int value) => value;
+}"),
+            ("Extensions.cs", @"
+namespace Demo;
+
+public static class HostExtensions
+{
+    public static int M(this Host host, int value) => value + 1;
+}"),
+            ("User.cs", @"
+namespace Demo;
+
+public static class User
+{
+    public static int Run(Host host) => HostExtensions.M(host, 1);
+}"));
+
+        string combined = string.Join(Environment.NewLine, printed.Values);
+
+        Assert.Contains("class HostExtensions", combined);
+        Assert.Contains("func M(host Host, value int32)", printed["Extensions.cs"]);
+        Assert.DoesNotContain("func (host Host) M", combined);
+        Assert.Contains("HostExtensions.M(host, 1)", printed["User.cs"]);
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(printed.Values);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id is "GS0264" or "GS0314");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void DuplicateReducedSignatures_FromDifferentStaticClasses_StayStatic()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Host.cs", @"
+namespace Demo;
+
+public sealed class Host
+{
+}"),
+            ("FirstExtensions.cs", @"
+namespace Demo;
+
+public static class FirstExtensions
+{
+    public static string Describe(this Host host, int value) => ""first"";
+}"),
+            ("SecondExtensions.cs", @"
+namespace Demo;
+
+public static class SecondExtensions
+{
+    public static string Describe(this Host host, int value) => ""second"";
+}"),
+            ("User.cs", @"
+namespace Demo;
+
+public static class User
+{
+    public static string Run(Host host) =>
+        FirstExtensions.Describe(host, 1) + SecondExtensions.Describe(host, 2);
+}"));
+
+        string combined = string.Join(Environment.NewLine, printed.Values);
+
+        Assert.Contains("class FirstExtensions", combined);
+        Assert.Contains("class SecondExtensions", combined);
+        Assert.Equal(2, CountOccurrences(combined, "func Describe(host Host, value int32)"));
+        Assert.DoesNotContain("func (host Host) Describe", combined);
+        Assert.DoesNotContain("func Describe(value int32)", printed["Host.cs"]);
+        Assert.Contains("FirstExtensions.Describe(host, 1)", printed["User.cs"]);
+        Assert.Contains("SecondExtensions.Describe(host, 2)", printed["User.cs"]);
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(printed.Values);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id is "GS0264" or "GS0314");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
     }
 
     [Fact]
@@ -190,13 +345,22 @@ public static class MeterExtensions
                 roundTrip.Success,
                 "Translated G# must round-trip. Errors:\n" +
                     string.Join("\n", roundTrip.Errors) + "\n\nPrinted:\n" + printed);
-            Assert.DoesNotContain(
-                roundTrip.Errors,
-                error => error.Contains("GS0314", StringComparison.Ordinal));
             result.Add(document.FilePath, printed);
         }
 
         return result;
+    }
+
+    private static ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> BindDiagnostics(
+        IEnumerable<string> sources)
+    {
+        ImmutableArray<GSharp.Core.CodeAnalysis.Syntax.SyntaxTree> trees = sources
+            .Select(source => GSharp.Core.CodeAnalysis.Syntax.SyntaxTree.Parse(SourceText.From(source)))
+            .ToImmutableArray();
+        BoundGlobalScope scope = Binder.BindGlobalScope(previous: null, trees);
+        return scope.Diagnostics
+            .Concat(Binder.BindProgram(scope).Diagnostics)
+            .ToImmutableArray();
     }
 
     private static int CountOccurrences(string haystack, string needle)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -456,10 +456,10 @@ public static class User
 
         string user = Compact(printed["User.cs"]);
 
-        Assert.Equal(2, CountOccurrences(user, "GetHost()"));
+        Assert.Equal(1, CountOccurrences(user, "User.GetHost()"));
         Assert.Contains("let __spill", user);
         Assert.Contains("FirstExtensions.Describe(__spill", user);
-        Assert.DoesNotContain("if GetHost() != nil", user);
+        Assert.DoesNotContain("if User.GetHost() != nil", user);
 
         ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
             BindDiagnostics(printed.Values);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -534,26 +534,26 @@ namespace Demo;
 
 public static class FirstExtensions
 {
-    public static List<int> Items(this Host host) => new List<int>();
+    public static List<int> Items(this Host host) => throw new InvalidOperationException();
 
-    public static int[] Values(this Host host) => new int[0];
+    public static int[] Values(this Host host) => throw new InvalidOperationException();
 
-    public static (int, string) Pair(this Host host) => (1, ""one"");
+    public static (int, string) Pair(this Host host) => throw new InvalidOperationException();
 
     public static Func<int, string> Formatter(this Host host) =>
-        value => value.ToString();
+        throw new InvalidOperationException();
 }
 
 public static class SecondExtensions
 {
-    public static List<int> Items(this Host host, int value) => new List<int>();
+    public static List<int> Items(this Host host, int value) => throw new InvalidOperationException();
 
-    public static int[] Values(this Host host, int value) => new int[0];
+    public static int[] Values(this Host host, int value) => throw new InvalidOperationException();
 
-    public static (int, string) Pair(this Host host, int value) => (1, ""one"");
+    public static (int, string) Pair(this Host host, int value) => throw new InvalidOperationException();
 
     public static Func<int, string> Formatter(this Host host, int value) =>
-        item => item.ToString();
+        throw new InvalidOperationException();
 }"),
             ("User.cs", @"
 #nullable enable

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -451,7 +451,7 @@ public static class User
 {
     public static Host? GetHost() => null;
 
-    public static string? Run() => GetHost()?.Describe();
+    public static string Run() => GetHost()?.Describe() ?? ""none"";
 }"));
 
         string user = Compact(printed["User.cs"]);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2821OwnedExtensionMemberTranslationTests.cs
@@ -420,6 +420,142 @@ public static class User
     }
 
     [Fact]
+    public void NullConditionalStaticHelper_EvaluatesReceiverOnce()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Host.cs", @"
+#nullable enable
+namespace Demo;
+
+public sealed class Host
+{
+}"),
+            ("Extensions.cs", @"
+#nullable enable
+namespace Demo;
+
+public static class FirstExtensions
+{
+    public static string Describe(this Host host) => ""first"";
+}
+
+public static class SecondExtensions
+{
+    public static string Describe(this Host host, int value) => ""second"";
+}"),
+            ("User.cs", @"
+#nullable enable
+namespace Demo;
+
+public static class User
+{
+    public static Host? GetHost() => null;
+
+    public static string? Run() => GetHost()?.Describe();
+}"));
+
+        string user = Compact(printed["User.cs"]);
+
+        Assert.Equal(2, CountOccurrences(user, "GetHost()"));
+        Assert.Contains("let __spill", user);
+        Assert.Contains("FirstExtensions.Describe(__spill", user);
+        Assert.DoesNotContain("if GetHost() != nil", user);
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(printed.Values);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void RefReceiverStaticHelper_PassesReceiverAddress()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Counter.cs", @"
+namespace Demo;
+
+public struct Counter
+{
+    public int Value;
+}"),
+            ("Extensions.cs", @"
+namespace Demo;
+
+public static class FirstExtensions
+{
+    public static void Increment(this ref Counter counter) => counter.Value++;
+}
+
+public static class SecondExtensions
+{
+    public static void Increment(this ref Counter counter, int amount) =>
+        counter.Value += amount;
+}"),
+            ("User.cs", @"
+namespace Demo;
+
+public static class User
+{
+    public static void Run(ref Counter counter) => counter.Increment();
+}"));
+
+        Assert.Contains("FirstExtensions.Increment(&counter)", Compact(printed["User.cs"]));
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(printed.Values);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void NullableStaticHelperReceivers_PreserveNullForgiveness()
+    {
+        IReadOnlyDictionary<string, string> printed = TranslateFiles(
+            ("Host.cs", @"
+#nullable enable
+namespace Demo;
+
+public sealed class Host
+{
+}"),
+            ("Extensions.cs", @"
+#nullable enable
+namespace Demo;
+
+public static class FirstExtensions
+{
+    public static string Describe(this Host host, object value) => ""object"";
+}
+
+public static class SecondExtensions
+{
+    public static string Describe(this Host host, string value) => ""string"";
+}"),
+            ("User.cs", @"
+#nullable enable
+using System;
+
+namespace Demo;
+
+public sealed class User
+{
+    public Host? Current;
+
+    public string Invoke(string value) => Current.Describe(value);
+
+    public Func<string, string> Bind() => Current.Describe;
+}"));
+
+        string user = Compact(printed["User.cs"]);
+
+        Assert.Contains("SecondExtensions.Describe(Current!!, value)", user);
+        Assert.Contains("= Current!!", user);
+        Assert.Contains("SecondExtensions.Describe(__spill", user);
+
+        ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> diagnostics =
+            BindDiagnostics(printed.Values);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
     public void ExternalReceiver_RetainsReceiverClause()
     {
         string printed = TranslateFiles(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -23,9 +23,9 @@ public sealed partial class CSharpToGSharpTranslator
     private sealed partial class DeclarationVisitor
     {
         /// <summary>
-        /// Removes and returns the top-level declarations (lifted owned-struct
-        /// receiver methods, issue #938) collected while translating the most
-        /// recent aggregate, so the document translator can emit them as siblings.
+        /// Removes and returns top-level declarations collected while translating
+        /// the most recent aggregate, so the document translator can emit them as
+        /// siblings.
         /// </summary>
         /// <returns>The collected top-level declarations (possibly empty).</returns>
         public IReadOnlyList<GMember> DrainPendingTopLevel()
@@ -1210,13 +1210,28 @@ public sealed partial class CSharpToGSharpTranslator
                 this.state.StaticFieldInitializers.Keys, SymbolEqualityComparer.Default);
             this.CollectStaticFieldInitializers(mergedMembers, symbol);
 
+            var membersToTranslate = mergedMembers
+                .Select(member => (Member: member, OwnedExtensionTarget: (INamedTypeSymbol)null))
+                .ToList();
+            if (symbol != null &&
+                this.ShouldAttachOwnedExtensions(node, symbol) &&
+                this.ownedExtensions.TryGetMethods(symbol, out IReadOnlyList<MethodDeclarationSyntax> ownedExtensionMethods))
+            {
+                membersToTranslate.AddRange(
+                    ownedExtensionMethods
+                        .Where(this.CanLowerOwnedExtension)
+                        .Select(method => (
+                            Member: (MemberDeclarationSyntax)method,
+                            OwnedExtensionTarget: symbol)));
+            }
+
             var instanceMembers = new List<GMember>();
             var sharedMembers = new List<GMember>();
-            foreach (MemberDeclarationSyntax member in mergedMembers)
+            foreach ((MemberDeclarationSyntax member, INamedTypeSymbol ownedExtensionTarget) in membersToTranslate)
             {
                 // Issue #1910: a merged-in member from another partial part lives
-                // in a different `SyntaxTree`; resolve it (and everything nested
-                // inside it) through that tree's own semantic model.
+                // in a different `SyntaxTree`; issue #2821 owned extension methods
+                // can as well. Resolve either through that tree's semantic model.
                 using IDisposable modelScope = this.context.UseSemanticModelFor(member.SyntaxTree);
                 foreach ((GMember translated, bool isStatic) in this.TranslateMember(
                     member,
@@ -1224,7 +1239,8 @@ public sealed partial class CSharpToGSharpTranslator
                     lift,
                     propertyCtorInits,
                     primaryCtorParamNames,
-                    callSiteLoweredStructConstructors))
+                    callSiteLoweredStructConstructors,
+                    ownedExtensionTarget))
                 {
                     // A C# operator overload translates to a receiver-clause
                     // `func (a T) operator <op>(...)`; like every receiver-clause
@@ -1233,17 +1249,6 @@ public sealed partial class CSharpToGSharpTranslator
                     // reference aggregate (ADR-0035, sample Operators.gs; §B.5).
                     if (translated is MethodDeclaration { Receiver: not null } opMethod &&
                         opMethod.Name.StartsWith("operator ", System.StringComparison.Ordinal))
-                    {
-                        this.state.PendingTopLevelDeclarations.Add(translated);
-                        continue;
-                    }
-
-                    // A lifted owned-value-aggregate instance method (it carries a
-                    // receiver clause) cannot live in the struct body; collect it
-                    // as a top-level sibling declaration (issue #938).
-                    if (IsValueAggregate(kind.Value) &&
-                        !isStatic &&
-                        translated is MethodDeclaration { Receiver: not null })
                     {
                         this.state.PendingTopLevelDeclarations.Add(translated);
                         continue;
@@ -1409,6 +1414,19 @@ public sealed partial class CSharpToGSharpTranslator
                 attributes: this.MapAttributes(mergedAttributeLists),
                 isUnsafe: isUnsafe,
                 isPartial: isPartial);
+        }
+
+        private bool ShouldAttachOwnedExtensions(
+            TypeDeclarationSyntax node,
+            INamedTypeSymbol symbol)
+        {
+            if (!this.preservePartialParts ||
+                !this.partialTypeParts.TryGetValue(symbol, out List<TypeDeclarationSyntax> parts))
+            {
+                return true;
+            }
+
+            return parts[0].SyntaxTree == node.SyntaxTree && parts[0].Span == node.Span;
         }
 
         /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -56,22 +56,6 @@ public sealed partial class CSharpToGSharpTranslator
                 return replacement;
             }
 
-            // Inside a lifted owned-struct receiver method (issue #938) a bare
-            // reference to an instance member carries an implicit C# `this`; a
-            // top-level receiver-clause `func` has no implicit receiver, so the
-            // reference must be made explicit through the receiver (`self.X`).
-            if (this.state.CurrentReceiverName != null)
-            {
-                ISymbol symbol = this.context.GetSymbolInfo(identifier).Symbol;
-                if (symbol is { IsStatic: false } &&
-                    symbol.Kind is SymbolKind.Field or SymbolKind.Property or SymbolKind.Method)
-                {
-                    return new MemberAccessExpression(
-                        new IdentifierExpression(this.state.CurrentReceiverName),
-                        SanitizeIdentifier(identifier.Identifier.Text));
-                }
-            }
-
             // A C# bare sibling static field/property reference (`FfAc3ChannelsTab`)
             // carries an implicit type qualifier. A G# top-level `func` (e.g. a
             // lifted extension method whose former `static class` keeps the field

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -345,6 +345,23 @@ public sealed partial class CSharpToGSharpTranslator
             if (this.context.GetSymbolInfo(member).Symbol is IMethodSymbol { IsExtensionMethod: true } memberExtMethod)
             {
                 this.typeMapper.TrackExtensionMethodNamespace(memberExtMethod);
+                if (memberExtMethod.MethodKind == MethodKind.ReducedExtension &&
+                    this.TryGetStaticExtensionHelper(memberExtMethod, out string helperOwner, out string helperName))
+                {
+                    if (member.Parent is ArgumentSyntax nameOfArgument &&
+                        IsNameOfArgument(nameOfArgument))
+                    {
+                        return new MemberAccessExpression(
+                            new IdentifierExpression(helperOwner),
+                            helperName);
+                    }
+
+                    return this.TranslateStaticExtensionHelperMethodGroup(
+                        member,
+                        memberExtMethod,
+                        helperOwner,
+                        helperName);
+                }
             }
 
             // Issue #1879: a C# 14 extension-block member is declared on a

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -426,7 +426,7 @@ public sealed partial class CSharpToGSharpTranslator
                 callTypeArgs);
 
             GExpression guard = new BinaryExpression(
-                this.TranslateExpression(conditionalAccess.Expression),
+                receiver,
                 "!=",
                 new IdentifierExpression("nil"));
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -84,13 +84,12 @@ public sealed partial class CSharpToGSharpTranslator
                 return new InvocationExpression(invokeTarget, invokeArguments, null);
             }
 
-            // A C# extension method whose receiver is an enum is emitted as a
-            // plain static helper (a receiver clause is rejected on enums,
-            // GS0103). Rewrite the call `x.M(args)` to the positional form
-            // `Owner.M(x, args)` so it binds to that helper.
+            // Extensions that must remain static helpers (enum receivers or
+            // owned reduced-signature collisions) use positional calls.
             if (invocation.Expression is MemberAccessExpressionSyntax extMember
                 && this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol extMethod
-                && TryGetEnumExtension(extMethod, out string extOwner, out string extName))
+                && extMethod.MethodKind == MethodKind.ReducedExtension
+                && this.TryGetStaticExtensionHelper(extMethod, out string extOwner, out string extName))
             {
                 var extArgs = new List<GExpression>
                 {
@@ -126,6 +125,7 @@ public sealed partial class CSharpToGSharpTranslator
                 && staticExt.Parameters.Length >= 1
                 && !(staticExt.ReducedFrom ?? staticExt).DeclaringSyntaxReferences.IsDefaultOrEmpty
                 && (staticExt.Parameters[0].Type?.TypeKind ?? TypeKind.Unknown) != TypeKind.Enum
+                && !this.ownedExtensions.IsStaticHelper(staticExt)
                 && this.context.SemanticModel.GetSymbolInfo(staticExtMember.Expression).Symbol is INamedTypeSymbol
                 && TryGetExplicitExtensionReceiverArgument(
                     staticExtOperation,
@@ -167,6 +167,7 @@ public sealed partial class CSharpToGSharpTranslator
                 && bareExt.Parameters.Length >= 1
                 && !(bareExt.ReducedFrom ?? bareExt).DeclaringSyntaxReferences.IsDefaultOrEmpty
                 && (bareExt.Parameters[0].Type?.TypeKind ?? TypeKind.Unknown) != TypeKind.Enum
+                && !this.ownedExtensions.IsStaticHelper(bareExt)
                 && TryGetExplicitExtensionReceiverArgument(
                     bareExtOperation,
                     bareExt,
@@ -381,15 +382,12 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         /// <summary>
-        /// Rewrites a null-conditional call to an enum extension method
-        /// (<c>recv?.M(args)</c> where <c>M</c> is <c>this EnumType</c>) into the
+        /// Rewrites a null-conditional call to a static-helper extension method
+        /// into the
         /// ternary <c>if recv != nil { Owner.M(recv!!, args) } else { nil }</c>.
-        /// An enum extension is emitted as a plain static helper (a G# receiver
-        /// clause is rejected on enums, GS0103), so the <c>?.</c> member-binding
-        /// form cannot bind to it; gsc reports GS0159. The receiver is a pure
-        /// expression in practice, so the duplicated evaluation is safe.
+        /// The <c>?.</c> member-binding form cannot bind to a static helper.
         /// </summary>
-        private bool TryTranslateNullConditionalEnumExtension(
+        private bool TryTranslateNullConditionalStaticExtensionHelper(
             ConditionalAccessExpressionSyntax conditionalAccess,
             out GExpression result)
         {
@@ -402,7 +400,7 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             if (this.context.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method ||
-                !TryGetEnumExtension(method, out string owner, out string name))
+                !this.TryGetStaticExtensionHelper(method, out string owner, out string name))
             {
                 return false;
             }
@@ -501,17 +499,14 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         /// <summary>
-        /// Determines whether <paramref name="method"/> is a C# extension method
-        /// whose receiver (<c>this</c>) parameter is an enum. Such an extension
-        /// cannot carry a G# receiver clause (ADR-0079; gsc reports GS0103), so it
-        /// is emitted as a plain static helper and its call sites are rewritten to
-        /// the positional form <c>Owner.Method(receiver, …)</c>.
+        /// Determines whether <paramref name="method"/> is emitted as a plain
+        /// static helper rather than a receiver-clause method.
         /// </summary>
         /// <param name="method">The bound (possibly reduced) call symbol.</param>
         /// <param name="ownerName">The declaring static class name when matched.</param>
         /// <param name="methodName">The helper method name when matched.</param>
-        /// <returns><see langword="true"/> when the call targets an enum extension.</returns>
-        private static bool TryGetEnumExtension(IMethodSymbol method, out string ownerName, out string methodName)
+        /// <returns><see langword="true"/> when the call targets a static helper.</returns>
+        private bool TryGetStaticExtensionHelper(IMethodSymbol method, out string ownerName, out string methodName)
         {
             ownerName = null;
             methodName = null;
@@ -522,7 +517,8 @@ public sealed partial class CSharpToGSharpTranslator
 
             ITypeSymbol receiverType = method.ReceiverType
                 ?? method.Parameters.FirstOrDefault()?.Type;
-            if (receiverType?.TypeKind != TypeKind.Enum)
+            if (receiverType?.TypeKind != TypeKind.Enum &&
+                !this.ownedExtensions.IsStaticHelper(method))
             {
                 return false;
             }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -386,7 +386,8 @@ public sealed partial class CSharpToGSharpTranslator
         /// <summary>
         /// Rewrites a null-conditional call to a static-helper extension method
         /// into the
-        /// ternary <c>if recv != nil { Owner.M(recv!!, args) } else { nil }</c>.
+        /// ternary
+        /// <c>if recv != nil { R?(Owner.M(recv!!, args)) } else { nil }</c>.
         /// The <c>?.</c> member-binding form cannot bind to a static helper.
         /// </summary>
         private bool TryTranslateNullConditionalStaticExtensionHelper(
@@ -424,6 +425,16 @@ public sealed partial class CSharpToGSharpTranslator
                 new MemberAccessExpression(new IdentifierExpression(owner), name),
                 callArgs,
                 callTypeArgs);
+            if (this.context.GetTypeInfo(conditionalAccess).Type is
+                { SpecialType: not SpecialType.System_Void } conditionalType)
+            {
+                call = new ConversionExpression(
+                    MakeNullable(this.typeMapper.Map(
+                        conditionalType,
+                        this.context,
+                        conditionalAccess.GetLocation())),
+                    call);
+            }
 
             GExpression guard = new BinaryExpression(
                 receiver,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -613,11 +613,11 @@ public sealed partial class CSharpToGSharpTranslator
         private void ReportUnsupportedConditionalStaticHelperChain(
             ConditionalAccessExpressionSyntax conditionalAccess)
         {
-            this.context.ReportUnsupported(
-                conditionalAccess,
+            const string message =
                 "a null-conditional static-helper extension call with a non-member receiver chain " +
                 "cannot be lowered without losing the conditional receiver; the safe extension form " +
-                "is retained instead (issue #2821).");
+                "is retained instead (issue #2821).";
+            this.context.ReportUnsupported(conditionalAccess, message);
         }
 
         // Issue #914 (oblivious sink): a null-conditional delegate/event invoke

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -387,7 +387,7 @@ public sealed partial class CSharpToGSharpTranslator
         /// Rewrites a null-conditional call to a static-helper extension method
         /// into the
         /// ternary
-        /// <c>if recv != nil { R?(Owner.M(recv!!, args)) } else { nil }</c>.
+        /// <c>if recv != nil { Owner.M(recv!!, args) } else { default(R?) }</c>.
         /// The <c>?.</c> member-binding form cannot bind to a static helper.
         /// </summary>
         private bool TryTranslateNullConditionalStaticExtensionHelper(
@@ -396,54 +396,228 @@ public sealed partial class CSharpToGSharpTranslator
         {
             result = null;
 
-            if (conditionalAccess.WhenNotNull is not InvocationExpressionSyntax invocation ||
-                invocation.Expression is not MemberBindingExpressionSyntax binding)
+            if (!this.TryMatchNullConditionalStaticExtensionHelper(
+                    conditionalAccess,
+                    out InvocationExpressionSyntax invocation,
+                    out IMethodSymbol method,
+                    out string owner,
+                    out string name,
+                    out SimpleNameSyntax helperName,
+                    out ExpressionSyntax chainedReceiver) ||
+                method.ReturnsVoid)
             {
                 return false;
             }
 
-            if (this.context.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method ||
-                !this.TryGetStaticExtensionHelper(method, out string owner, out string name))
+            if (chainedReceiver != null &&
+                !IsSupportedConditionalStaticHelperReceiver(chainedReceiver))
+            {
+                this.ReportUnsupportedConditionalStaticHelperChain(conditionalAccess);
+                result = this.PreserveNullConditionalStaticExtensionInvocation(
+                    conditionalAccess,
+                    invocation,
+                    helperName);
+                return true;
+            }
+
+            if (this.context.GetTypeInfo(conditionalAccess).Type is not { } conditionalType)
             {
                 return false;
             }
 
+            this.BuildNullConditionalStaticExtensionHelper(
+                conditionalAccess,
+                invocation,
+                owner,
+                name,
+                helperName,
+                chainedReceiver,
+                out GExpression guard,
+                out GExpression call);
+
+            GTypeReference nullableType = this.typeMapper.Map(
+                conditionalType,
+                this.context,
+                conditionalAccess.GetLocation());
+            if (!nullableType.IsNullable)
+            {
+                nullableType = MakeNullable(nullableType);
+            }
+
+            result = new ParenthesizedExpression(
+                new IfExpression(guard, call, new DefaultValueExpression(nullableType)));
+            return true;
+        }
+
+        private bool TryTranslateNullConditionalStaticExtensionHelperStatement(
+            ConditionalAccessExpressionSyntax conditionalAccess,
+            out GStatement result)
+        {
+            result = null;
+            if (!this.TryMatchNullConditionalStaticExtensionHelper(
+                    conditionalAccess,
+                    out InvocationExpressionSyntax invocation,
+                    out IMethodSymbol method,
+                    out string owner,
+                    out string name,
+                    out SimpleNameSyntax helperName,
+                    out ExpressionSyntax chainedReceiver) ||
+                !method.ReturnsVoid)
+            {
+                return false;
+            }
+
+            if (chainedReceiver != null &&
+                !IsSupportedConditionalStaticHelperReceiver(chainedReceiver))
+            {
+                this.ReportUnsupportedConditionalStaticHelperChain(conditionalAccess);
+                result = new ExpressionStatement(
+                    this.PreserveNullConditionalStaticExtensionInvocation(
+                        conditionalAccess,
+                        invocation,
+                        helperName));
+                return true;
+            }
+
+            this.BuildNullConditionalStaticExtensionHelper(
+                conditionalAccess,
+                invocation,
+                owner,
+                name,
+                helperName,
+                chainedReceiver,
+                out GExpression guard,
+                out GExpression call);
+
+            result = new IfStatement(
+                guard,
+                new BlockStatement(new GStatement[] { new ExpressionStatement(call) }));
+            return true;
+        }
+
+        private bool TryMatchNullConditionalStaticExtensionHelper(
+            ConditionalAccessExpressionSyntax conditionalAccess,
+            out InvocationExpressionSyntax invocation,
+            out IMethodSymbol method,
+            out string owner,
+            out string name,
+            out SimpleNameSyntax helperName,
+            out ExpressionSyntax chainedReceiver)
+        {
+            invocation = conditionalAccess.WhenNotNull as InvocationExpressionSyntax;
+            method = invocation == null
+                ? null
+                : this.context.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
+            owner = null;
+            name = null;
+            helperName = null;
+            chainedReceiver = null;
+            if (invocation == null ||
+                method == null ||
+                !this.TryGetStaticExtensionHelper(method, out owner, out name))
+            {
+                return false;
+            }
+
+            switch (invocation.Expression)
+            {
+                case MemberBindingExpressionSyntax binding:
+                    helperName = binding.Name;
+                    return true;
+
+                case MemberAccessExpressionSyntax member:
+                    helperName = member.Name;
+                    chainedReceiver = member.Expression;
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        private void BuildNullConditionalStaticExtensionHelper(
+            ConditionalAccessExpressionSyntax conditionalAccess,
+            InvocationExpressionSyntax invocation,
+            string owner,
+            string name,
+            SimpleNameSyntax helperName,
+            ExpressionSyntax chainedReceiver,
+            out GExpression guard,
+            out GExpression call)
+        {
             GExpression receiver = this.SpillOperand(
                 this.TranslateExpression(conditionalAccess.Expression),
                 conditionalAccess.Expression);
-
-            var callArgs = new List<GExpression>
+            GExpression helperReceiver = new NonNullAssertionExpression(receiver);
+            if (chainedReceiver != null)
             {
-                new NonNullAssertionExpression(receiver),
-            };
+                helperReceiver = TranslateConditionalStaticHelperReceiver(
+                    chainedReceiver,
+                    helperReceiver);
+            }
+
+            var callArgs = new List<GExpression> { helperReceiver };
             callArgs.AddRange(this.TranslateArguments(invocation.ArgumentList.Arguments));
-            IReadOnlyList<GTypeReference> callTypeArgs = binding.Name is GenericNameSyntax generic
+            IReadOnlyList<GTypeReference> callTypeArgs = helperName is GenericNameSyntax generic
                 ? this.MapTypeArguments(generic)
                 : null;
 
-            GExpression call = new InvocationExpression(
+            call = new InvocationExpression(
                 new MemberAccessExpression(new IdentifierExpression(owner), name),
                 callArgs,
                 callTypeArgs);
-            if (this.context.GetTypeInfo(conditionalAccess).Type is
-                { SpecialType: not SpecialType.System_Void } conditionalType)
+            guard = new BinaryExpression(receiver, "!=", LiteralExpression.Null());
+        }
+
+        private static bool IsSupportedConditionalStaticHelperReceiver(ExpressionSyntax expression) =>
+            expression is MemberBindingExpressionSyntax ||
+            (expression is MemberAccessExpressionSyntax member &&
+             IsSupportedConditionalStaticHelperReceiver(member.Expression));
+
+        private static GExpression TranslateConditionalStaticHelperReceiver(
+            ExpressionSyntax expression,
+            GExpression conditionalReceiver)
+        {
+            return expression switch
             {
-                call = new ConversionExpression(
-                    MakeNullable(this.typeMapper.Map(
-                        conditionalType,
-                        this.context,
-                        conditionalAccess.GetLocation())),
-                    call);
-            }
+                MemberBindingExpressionSyntax binding =>
+                    new MemberAccessExpression(
+                        conditionalReceiver,
+                        SanitizeIdentifier(binding.Name.Identifier.Text)),
+                MemberAccessExpressionSyntax member =>
+                    new MemberAccessExpression(
+                        TranslateConditionalStaticHelperReceiver(
+                            member.Expression,
+                            conditionalReceiver),
+                        SanitizeIdentifier(member.Name.Identifier.Text)),
+                _ => conditionalReceiver,
+            };
+        }
 
-            GExpression guard = new BinaryExpression(
-                receiver,
-                "!=",
-                new IdentifierExpression("nil"));
+        private GExpression PreserveNullConditionalStaticExtensionInvocation(
+            ConditionalAccessExpressionSyntax conditionalAccess,
+            InvocationExpressionSyntax invocation,
+            SimpleNameSyntax helperName)
+        {
+            IReadOnlyList<GTypeReference> typeArguments = helperName is GenericNameSyntax generic
+                ? this.MapTypeArguments(generic)
+                : null;
+            return new ConditionalAccessExpression(
+                this.TranslateExpression(conditionalAccess.Expression),
+                new InvocationExpression(
+                    this.TranslateExpression(invocation.Expression),
+                    this.TranslateCallArguments(invocation, invocation.ArgumentList.Arguments),
+                    typeArguments));
+        }
 
-            result = new ParenthesizedExpression(
-                new IfExpression(guard, call, new IdentifierExpression("nil")));
-            return true;
+        private void ReportUnsupportedConditionalStaticHelperChain(
+            ConditionalAccessExpressionSyntax conditionalAccess)
+        {
+            this.context.ReportUnsupported(
+                conditionalAccess,
+                "a null-conditional static-helper extension call with a non-member receiver chain " +
+                "cannot be lowered without losing the conditional receiver; the safe extension form " +
+                "is retained instead (issue #2821).");
         }
 
         // Issue #914 (oblivious sink): a null-conditional delegate/event invoke

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -93,7 +93,9 @@ public sealed partial class CSharpToGSharpTranslator
             {
                 var extArgs = new List<GExpression>
                 {
-                    this.TranslateExpression(extMember.Expression),
+                    PassStaticExtensionHelperReceiver(
+                        this.TranslateReceiverWithNullForgiveness(extMember.Expression),
+                        extMethod),
                 };
                 extArgs.AddRange(this.TranslateArguments(invocation.ArgumentList.Arguments));
                 IReadOnlyList<GTypeReference> extTypeArgs = extMember.Name is GenericNameSyntax extGeneric
@@ -405,7 +407,9 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
-            GExpression receiver = this.TranslateExpression(conditionalAccess.Expression);
+            GExpression receiver = this.SpillOperand(
+                this.TranslateExpression(conditionalAccess.Expression),
+                conditionalAccess.Expression);
 
             var callArgs = new List<GExpression>
             {
@@ -536,7 +540,7 @@ public sealed partial class CSharpToGSharpTranslator
             string methodName)
         {
             GExpression receiver = this.CaptureMethodGroupReceiver(
-                this.TranslateExpression(member.Expression),
+                this.TranslateReceiverWithNullForgiveness(member.Expression),
                 member.Expression);
 
             IMethodSymbol invoke = (this.context.GetTypeInfo(member).ConvertedType as INamedTypeSymbol)
@@ -546,7 +550,7 @@ public sealed partial class CSharpToGSharpTranslator
             var parameters = new List<Parameter>(sourceParameters.Length);
             var arguments = new List<GExpression>(sourceParameters.Length + 1)
             {
-                receiver,
+                PassStaticExtensionHelperReceiver(receiver, method),
             };
 
             for (int i = 0; i < sourceParameters.Length; i++)
@@ -581,6 +585,16 @@ public sealed partial class CSharpToGSharpTranslator
                 arguments,
                 typeArguments);
             return new LambdaExpression(parameters, expressionBody: call);
+        }
+
+        private static GExpression PassStaticExtensionHelperReceiver(
+            GExpression receiver,
+            IMethodSymbol method)
+        {
+            IMethodSymbol original = method.ReducedFrom ?? method;
+            return original.Parameters[0].RefKind is RefKind.Ref or RefKind.Out
+                ? new UnaryExpression("&", receiver)
+                : receiver;
         }
 
         private GExpression CaptureMethodGroupReceiver(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -403,8 +403,22 @@ public sealed partial class CSharpToGSharpTranslator
                     out string owner,
                     out string name,
                     out SimpleNameSyntax helperName,
-                    out ExpressionSyntax chainedReceiver) ||
-                method.ReturnsVoid)
+                    out ExpressionSyntax chainedReceiver))
+            {
+                return false;
+            }
+
+            if (DependsOnEnclosingConditionalReceiver(conditionalAccess.Expression))
+            {
+                this.ReportUnsupportedNestedConditionalStaticHelperChain(conditionalAccess);
+                result = this.PreserveNullConditionalStaticExtensionInvocation(
+                    conditionalAccess,
+                    invocation,
+                    helperName);
+                return true;
+            }
+
+            if (method.ReturnsVoid)
             {
                 return false;
             }
@@ -465,6 +479,17 @@ public sealed partial class CSharpToGSharpTranslator
                 !method.ReturnsVoid)
             {
                 return false;
+            }
+
+            if (DependsOnEnclosingConditionalReceiver(conditionalAccess.Expression))
+            {
+                this.ReportUnsupportedNestedConditionalStaticHelperChain(conditionalAccess);
+                result = new ExpressionStatement(
+                    this.PreserveNullConditionalStaticExtensionInvocation(
+                        conditionalAccess,
+                        invocation,
+                        helperName));
+                return true;
             }
 
             if (chainedReceiver != null &&
@@ -551,7 +576,7 @@ public sealed partial class CSharpToGSharpTranslator
             GExpression helperReceiver = new NonNullAssertionExpression(receiver);
             if (chainedReceiver != null)
             {
-                helperReceiver = TranslateConditionalStaticHelperReceiver(
+                helperReceiver = this.TranslateConditionalStaticHelperReceiver(
                     chainedReceiver,
                     helperReceiver);
             }
@@ -574,25 +599,26 @@ public sealed partial class CSharpToGSharpTranslator
             (expression is MemberAccessExpressionSyntax member &&
              IsSupportedConditionalStaticHelperReceiver(member.Expression));
 
-        private static GExpression TranslateConditionalStaticHelperReceiver(
+        private GExpression TranslateConditionalStaticHelperReceiver(
             ExpressionSyntax expression,
             GExpression conditionalReceiver)
         {
-            return expression switch
+            GExpression previous = this.state.ConditionalReceiverReplacement;
+            this.state.ConditionalReceiverReplacement = conditionalReceiver;
+            try
             {
-                MemberBindingExpressionSyntax binding =>
-                    new MemberAccessExpression(
-                        conditionalReceiver,
-                        SanitizeIdentifier(binding.Name.Identifier.Text)),
-                MemberAccessExpressionSyntax member =>
-                    new MemberAccessExpression(
-                        TranslateConditionalStaticHelperReceiver(
-                            member.Expression,
-                            conditionalReceiver),
-                        SanitizeIdentifier(member.Name.Identifier.Text)),
-                _ => conditionalReceiver,
-            };
+                return this.TranslateExpression(expression);
+            }
+            finally
+            {
+                this.state.ConditionalReceiverReplacement = previous;
+            }
         }
+
+        private static bool DependsOnEnclosingConditionalReceiver(ExpressionSyntax expression) =>
+            expression.DescendantNodesAndSelf(
+                    descendIntoChildren: node => node is not ConditionalAccessExpressionSyntax)
+                .Any(node => node is MemberBindingExpressionSyntax or ElementBindingExpressionSyntax);
 
         private GExpression PreserveNullConditionalStaticExtensionInvocation(
             ConditionalAccessExpressionSyntax conditionalAccess,
@@ -617,6 +643,16 @@ public sealed partial class CSharpToGSharpTranslator
                 "a null-conditional static-helper extension call with a non-member receiver chain " +
                 "cannot be lowered without losing the conditional receiver; the safe extension form " +
                 "is retained instead (issue #2821).";
+            this.context.ReportUnsupported(conditionalAccess, message);
+        }
+
+        private void ReportUnsupportedNestedConditionalStaticHelperChain(
+            ConditionalAccessExpressionSyntax conditionalAccess)
+        {
+            const string message =
+                "a static-helper extension call nested under another null-conditional receiver " +
+                "cannot be lowered without spilling a bare conditional receiver; the safe extension " +
+                "form is retained instead (issue #2821).";
             this.context.ReportUnsupported(conditionalAccess, message);
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -529,6 +529,87 @@ public sealed partial class CSharpToGSharpTranslator
             return ownerName != null;
         }
 
+        private GExpression TranslateStaticExtensionHelperMethodGroup(
+            MemberAccessExpressionSyntax member,
+            IMethodSymbol method,
+            string ownerName,
+            string methodName)
+        {
+            GExpression receiver = this.CaptureMethodGroupReceiver(
+                this.TranslateExpression(member.Expression),
+                member.Expression);
+
+            IMethodSymbol invoke = (this.context.GetTypeInfo(member).ConvertedType as INamedTypeSymbol)
+                ?.DelegateInvokeMethod;
+            ImmutableArray<IParameterSymbol> sourceParameters =
+                invoke?.Parameters ?? method.Parameters;
+            var parameters = new List<Parameter>(sourceParameters.Length);
+            var arguments = new List<GExpression>(sourceParameters.Length + 1)
+            {
+                receiver,
+            };
+
+            for (int i = 0; i < sourceParameters.Length; i++)
+            {
+                Parameter mapped = this.MapParameter(
+                    sourceParameters[i],
+                    member,
+                    promoteNullability: false);
+                string name = $"__arg{i}";
+                parameters.Add(new Parameter(
+                    name,
+                    mapped.Type,
+                    mapped.IsVariadic,
+                    mapped.RefKind));
+                GExpression argument = new IdentifierExpression(name);
+                if (sourceParameters[i].RefKind is RefKind.Ref or RefKind.Out)
+                {
+                    argument = new UnaryExpression("&", argument);
+                }
+
+                arguments.Add(argument);
+            }
+
+            IMethodSymbol original = method.ReducedFrom ?? method;
+            IReadOnlyList<GTypeReference> typeArguments = original.IsGenericMethod
+                ? method.TypeArguments
+                    .Select(type => this.typeMapper.Map(type, this.context, member.GetLocation()))
+                    .ToList()
+                : null;
+            var call = new InvocationExpression(
+                new MemberAccessExpression(new IdentifierExpression(ownerName), methodName),
+                arguments,
+                typeArguments);
+            return new LambdaExpression(parameters, expressionBody: call);
+        }
+
+        private GExpression CaptureMethodGroupReceiver(
+            GExpression receiver,
+            ExpressionSyntax receiverSyntax)
+        {
+            if (this.state.PendingSpillPrologue != null)
+            {
+                string temp = $"__spill{this.state.SpillCounter++}";
+                this.state.PendingSpillPrologue.Add(
+                    new LocalDeclarationStatement(BindingKind.Let, temp, initializer: receiver));
+                return new IdentifierExpression(temp);
+            }
+
+            if (this.state.PendingHelperCaptures != null)
+            {
+                string name = $"__p{this.state.PendingHelperCaptures.Count}";
+                GTypeReference type = this.ResolveExpressionType(receiverSyntax)
+                    ?? new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
+                this.state.PendingHelperCaptures.Add((name, receiver, type));
+                return new IdentifierExpression(name);
+            }
+
+            this.context.ReportUnsupported(
+                receiverSyntax,
+                "a static-helper extension method group here has no enclosing evaluation seam to capture its receiver once.");
+            return receiver;
+        }
+
         /// <summary>
         /// Translates a single C# call argument, honoring <c>out</c>/<c>ref</c>
         /// argument forms (ADR-0115 §B; sample <c>TryParseOutVar.gs</c>): an

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -1055,10 +1055,10 @@ public sealed partial class CSharpToGSharpTranslator
             // emitted G# round-trips (ADR-0115 §B.6).
             bool isOpen = this.IsMemberEmittedOpen(symbol, isOverride);
 
-            // A method emitted in top-level receiver-clause form has no
-            // `open`/`override`: those modifiers are only valid on in-body
-            // members. Drop them so the emitted G# round-trips.
-            if (receiver != null)
+            // Receiver-clause methods and value-aggregate members have no
+            // `open`/`override`: G# value aggregates expose no open base method
+            // to override. Drop the modifiers so the emitted G# binds.
+            if (receiver != null || IsValueAggregate(ownerKind))
             {
                 isOpen = false;
                 isOverride = false;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -28,7 +28,8 @@ public sealed partial class CSharpToGSharpTranslator
             ConstructorLift lift,
             IReadOnlyList<(string Name, GExpression Value)> propertyCtorInits,
             IReadOnlyCollection<string> primaryCtorParamNames = null,
-            IReadOnlyCollection<ConstructorDeclarationSyntax> callSiteLoweredStructConstructors = null)
+            IReadOnlyCollection<ConstructorDeclarationSyntax> callSiteLoweredStructConstructors = null,
+            INamedTypeSymbol ownedExtensionTarget = null)
         {
             switch (member)
             {
@@ -41,7 +42,15 @@ public sealed partial class CSharpToGSharpTranslator
                     break;
 
                 case MethodDeclarationSyntax method:
-                    (GMember methodMember, bool methodIsStatic) = this.TranslateMethod(method, ownerKind);
+                    if (ownedExtensionTarget is null && this.CanLowerOwnedExtension(method))
+                    {
+                        break;
+                    }
+
+                    (GMember methodMember, bool methodIsStatic) = this.TranslateMethod(
+                        method,
+                        ownerKind,
+                        ownedExtensionTarget: ownedExtensionTarget);
                     if (methodMember != null)
                     {
                         yield return (methodMember, methodIsStatic);
@@ -225,6 +234,26 @@ public sealed partial class CSharpToGSharpTranslator
                         $"member '{member.Kind()}' has no canonical G# mapping yet (ADR-0115 §B.11).");
                     break;
             }
+        }
+
+        private bool CanLowerOwnedExtension(MethodDeclarationSyntax method)
+        {
+            if (!this.ownedExtensions.Contains(method))
+            {
+                return false;
+            }
+
+            using IDisposable modelScope = this.context.UseSemanticModelFor(method.SyntaxTree);
+            if (this.context.GetDeclaredSymbol(method) is not IMethodSymbol symbol ||
+                !symbol.IsExtensionMethod ||
+                symbol.Parameters.Length == 0)
+            {
+                return false;
+            }
+
+            IParameterSymbol receiver = symbol.Parameters[0];
+            return receiver.RefKind == RefKind.None &&
+                !this.ShouldPromoteToNullableReference(receiver);
         }
 
         /// <summary>
@@ -759,7 +788,8 @@ public sealed partial class CSharpToGSharpTranslator
         private (GMember Member, bool IsStatic) TranslateMethod(
             MethodDeclarationSyntax node,
             TypeDeclarationKind ownerKind,
-            Receiver forcedReceiver = null)
+            Receiver forcedReceiver = null,
+            INamedTypeSymbol ownedExtensionTarget = null)
         {
             var symbol = this.context.GetDeclaredSymbol(node) as IMethodSymbol;
             bool isStatic = symbol != null && symbol.IsStatic;
@@ -892,7 +922,7 @@ public sealed partial class CSharpToGSharpTranslator
 
             Receiver receiver = null;
             bool skipFirstParameter = false;
-            bool selfQualifyBody = false;
+            IParameterSymbol ownedExtensionSelf = null;
 
             if (forcedReceiver != null)
             {
@@ -910,15 +940,22 @@ public sealed partial class CSharpToGSharpTranslator
             }
             else if (symbol != null && symbol.IsExtensionMethod)
             {
-                // C# extension methods translate to the receiver-clause form on a
-                // non-owned type (ADR-0115 §B.5). A receiver clause is only valid
-                // on a struct/class (ADR-0079); an extension on an enum receiver
-                // is rejected by gsc (GS0103 "must be a struct or class"), so it
-                // stays a plain static helper and its call sites are rewritten to
-                // the positional form `Owner.Method(receiver, …)`.
                 IParameterSymbol self = symbol.Parameters.FirstOrDefault();
-                if (self != null && self.Type.TypeKind != TypeKind.Enum)
+                if (self != null && ownedExtensionTarget != null)
                 {
+                    // Issue #2821: a same-package source receiver is owned by
+                    // this output package. Emit the extension as an in-body
+                    // member and preserve its former `this` parameter as a local
+                    // copy of the real instance for the translated body.
+                    ownedExtensionSelf = self;
+                    skipFirstParameter = true;
+                    isStatic = false;
+                }
+                else if (self != null && self.Type.TypeKind != TypeKind.Enum)
+                {
+                    // External C# extension methods retain receiver-clause form
+                    // (ADR-0115 §B.5). Enum receivers stay static helpers because
+                    // G# rejects receiver clauses on enums (GS0103).
                     // Issue #1072/#1535: an extension receiver that is null-compared
                     // or null-assigned in the body is really nullable (common in
                     // nullable-oblivious sources, e.g. `this object o => o == null`),
@@ -934,45 +971,28 @@ public sealed partial class CSharpToGSharpTranslator
                     isStatic = false;
                 }
             }
-            else if (!isStatic && IsValueAggregate(ownerKind))
-            {
-                // Owned-struct instance method: the parser rejects an in-body
-                // 'func' inside a struct body (GS0005) and the binder flags the
-                // receiver-clause form with GS0314, so no warning-free spelling
-                // exists today. Emit the only form that parses and record the
-                // known gap (issue #938, ADR-0115 §B.5).
-                receiver = new Receiver(
-                    "self",
-                    new NamedTypeReference(symbol?.ContainingType?.Name ?? node.Identifier.Text));
-                selfQualifyBody = true;
-                this.context.Report(new TranslationDiagnostic(
-                    nameof(SyntaxKind.MethodDeclaration),
-                    $"instance method '{node.Identifier.Text}' on owned struct/data-struct emits the receiver-clause form (the only form that parses); the binder will flag GS0314 — expected, known compiler gap (issue #938, ADR-0115 §B.5).",
-                    node.GetLocation(),
-                    TranslationSeverity.Info));
-            }
 
             List<Parameter> parameters = this.MapParameters(symbol, node.ParameterList, skipFirstParameter);
             GTypeReference returnType = this.MapReturnType(symbol, node);
             List<TypeParameter> typeParameters = this.MapMethodTypeParameters(symbol);
 
             bool hasBody = node.Body != null || node.ExpressionBody != null;
-            string previousReceiver = this.state.CurrentReceiverName;
-            if (selfQualifyBody)
-            {
-                this.state.CurrentReceiverName = receiver.Name;
-            }
-
             BlockStatement body;
-            try
+            body = hasBody
+                ? this.TranslateBody(node, $"method '{node.Identifier.Text}'")
+                : null;
+
+            if (body != null && ownedExtensionSelf != null)
             {
-                body = hasBody
-                    ? this.TranslateBody(node, $"method '{node.Identifier.Text}'")
-                    : null;
-            }
-            finally
-            {
-                this.state.CurrentReceiverName = previousReceiver;
+                var statements = new List<GStatement>(body.Statements.Count + 1)
+                {
+                    new LocalDeclarationStatement(
+                        BindingKind.Var,
+                        SanitizeIdentifier(ownedExtensionSelf.Name),
+                        initializer: new ThisExpression()),
+                };
+                statements.AddRange(body.Statements);
+                body = new BlockStatement(statements);
             }
 
             // ADR-0122 / issue #1014: a C# `unsafe` method body is an unsafe
@@ -1033,11 +1053,9 @@ public sealed partial class CSharpToGSharpTranslator
             // emitted G# round-trips (ADR-0115 §B.6).
             bool isOpen = this.IsMemberEmittedOpen(symbol, isOverride);
 
-            // A method lifted to the top-level receiver-clause form (an owned-value
-            // aggregate method or an extension method) has no `open`/`override`:
-            // those modifiers are only valid on in-body class members, and the
-            // parser rejects `override func (...)` (GS0005). Drop them so the
-            // emitted G# round-trips (ADR-0115 §B.5/§B.14).
+            // A method emitted in top-level receiver-clause form has no
+            // `open`/`override`: those modifiers are only valid on in-body
+            // members. Drop them so the emitted G# round-trips.
             if (receiver != null)
             {
                 isOpen = false;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -951,7 +951,9 @@ public sealed partial class CSharpToGSharpTranslator
                     skipFirstParameter = true;
                     isStatic = false;
                 }
-                else if (self != null && self.Type.TypeKind != TypeKind.Enum)
+                else if (self != null &&
+                    self.Type.TypeKind != TypeKind.Enum &&
+                    !this.ownedExtensions.IsStaticHelper(symbol))
                 {
                     // External C# extension methods retain receiver-clause form
                     // (ADR-0115 §B.5). Enum receivers stay static helpers because

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -240,7 +240,9 @@ public sealed partial class CSharpToGSharpTranslator
                     return this.TranslatePredefinedTypeExpression(predefinedType);
 
                 case ConditionalAccessExpressionSyntax conditionalAccess:
-                    if (this.TryTranslateNullConditionalEnumExtension(conditionalAccess, out GExpression enumExtResult))
+                    if (this.TryTranslateNullConditionalStaticExtensionHelper(
+                            conditionalAccess,
+                            out GExpression enumExtResult))
                     {
                         return enumExtResult;
                     }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -270,17 +270,19 @@ public sealed partial class CSharpToGSharpTranslator
                     {
                         return new InvocationExpression(
                             new MemberAccessExpression(
-                                new ConditionalReceiverExpression(),
+                                this.state.ConditionalReceiverReplacement ??
+                                    new ConditionalReceiverExpression(),
                                 SanitizeIdentifier(memberBinding.Name.Identifier.Text)),
                             new List<GExpression>(),
                             null);
                     }
 
-                    // The `.b` continuation of a null-conditional chain. Its
-                    // receiver is the empty conditional-receiver placeholder, so it
-                    // renders as the bare `.b` that follows the `?`.
+                    // The `.b` continuation normally uses the empty conditional
+                    // receiver; static-helper prefix rebuilding temporarily
+                    // supplies the guarded receiver instead.
                     return new MemberAccessExpression(
-                        new ConditionalReceiverExpression(),
+                        this.state.ConditionalReceiverReplacement ??
+                            new ConditionalReceiverExpression(),
                         SanitizeIdentifier(memberBinding.Name.Identifier.Text));
 
                 case ElementBindingExpressionSyntax elementBinding:

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -1874,10 +1874,8 @@ public sealed partial class CSharpToGSharpTranslator
         //     property/field of the enclosing type. gsc resolves a bare-identifier
         //     assignment receiver as a variable/parameter; an implicit-this property
         //     receiver has no local slot, so the member write fails (GS0158 /
-        //     GS9998). Qualifying it as `this.Prop.Member = v` (or `self.Prop.Member
-        //     = v` inside a lifted receiver-clause func, issue #938 — see
-        //     <paramref name="left"/>'s <see cref="currentReceiverName"/>) routes the
-        //     write through the expression-receiver path, which binds correctly.
+        //     GS9998). Qualifying it as `this.Prop.Member = v` routes the write
+        //     through the expression-receiver path, which binds correctly.
         //     When `Prop` is itself declared-nullable (or promoted, issue #1072),
         //     the same `!!` the read path applies is inserted on the qualified
         //     receiver (`this.Prop!!.Member = v`) — the qualification and the
@@ -1900,11 +1898,8 @@ public sealed partial class CSharpToGSharpTranslator
                     this.context.GetSymbolInfo(receiverId).Symbol is { IsStatic: false } receiverSymbol &&
                     receiverSymbol.Kind is SymbolKind.Property or SymbolKind.Field)
                 {
-                    GExpression qualifier = this.state.CurrentReceiverName != null
-                        ? new IdentifierExpression(this.state.CurrentReceiverName)
-                        : new ThisExpression();
                     GExpression qualifiedReceiver = new MemberAccessExpression(
-                        qualifier, SanitizeIdentifier(receiverId.Identifier.Text));
+                        new ThisExpression(), SanitizeIdentifier(receiverId.Identifier.Text));
 
                     if (this.ReceiverNeedsNullForgiveness(receiverId, isDereferenceReceiver: true) ||
                         this.ReceiverIsNullableReferenceFieldOrProperty(receiverId))

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -1763,6 +1763,14 @@ public sealed partial class CSharpToGSharpTranslator
 
         private GStatement TranslateExpressionStatement(ExpressionSyntax expression)
         {
+            if (expression is ConditionalAccessExpressionSyntax conditionalAccess &&
+                this.TryTranslateNullConditionalStaticExtensionHelperStatement(
+                    conditionalAccess,
+                    out GStatement conditionalHelperStatement))
+            {
+                return conditionalHelperStatement;
+            }
+
             switch (expression)
             {
                 case AssignmentExpressionSyntax assignment when this.IsDelegateMulticastCombine(assignment, out string combineOp):

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -156,6 +156,27 @@ public sealed partial class CSharpToGSharpTranslator
                         isAsync: isAsync);
                 }
 
+                // A void static-helper `?.` call needs a guarded statement, not
+                // an expression-bodied lambda whose body cannot represent void.
+                if (!isAsync &&
+                    lambda.Body is ConditionalAccessExpressionSyntax voidConditional &&
+                    this.TryMatchNullConditionalStaticExtensionHelper(
+                        voidConditional,
+                        out _,
+                        out IMethodSymbol voidHelper,
+                        out _,
+                        out _,
+                        out _,
+                        out _) &&
+                    voidHelper.ReturnsVoid)
+                {
+                    return new LambdaExpression(
+                        parameters,
+                        blockBody: new BlockStatement(this.WithSpillSeam(
+                            () => this.TranslateExpressionStatements((ExpressionSyntax)lambda.Body).ToList()).ToList()),
+                        isAsync: false);
+                }
+
                 if (lambda.Body is AssignmentExpressionSyntax)
                 {
                     // An assignment is statement-only in G#; an assignment-bodied lambda

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -469,12 +469,14 @@ public sealed partial class CSharpToGSharpTranslator
 
                 INamedTypeSymbol receiverDefinition = receiverType.OriginalDefinition;
                 if (receiverDefinition.TypeKind is not (TypeKind.Class or TypeKind.Struct) ||
+                    IsGenericReceiver(receiverType) ||
                     !SymbolEqualityComparer.Default.Equals(
                         receiverDefinition.ContainingAssembly,
                         compilation.Assembly) ||
                     !SymbolEqualityComparer.Default.Equals(
                         receiverDefinition.ContainingNamespace,
-                        method.ContainingNamespace))
+                        method.ContainingNamespace) ||
+                    HasSameNamedInstanceMember(receiverType, method.Name))
                 {
                     continue;
                 }
@@ -484,6 +486,32 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         return result;
+    }
+
+    private static bool IsGenericReceiver(INamedTypeSymbol type)
+    {
+        for (INamedTypeSymbol current = type; current != null; current = current.ContainingType)
+        {
+            if (current.IsGenericType)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasSameNamedInstanceMember(INamedTypeSymbol type, string name)
+    {
+        for (INamedTypeSymbol current = type; current != null; current = current.BaseType)
+        {
+            if (current.GetMembers(name).Any(member => !member.IsStatic))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>> CollectPartialTypeParts(Compilation compilation)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -451,6 +451,7 @@ public sealed partial class CSharpToGSharpTranslator
     private static OwnedExtensionRegistry CollectOwnedExtensions(Compilation compilation)
     {
         var result = new OwnedExtensionRegistry();
+        var candidates = new List<(INamedTypeSymbol Receiver, MethodDeclarationSyntax Syntax, IMethodSymbol Method)>();
         foreach (Microsoft.CodeAnalysis.SyntaxTree tree in compilation.SyntaxTrees)
         {
             SemanticModel model = compilation.GetSemanticModel(tree);
@@ -475,13 +476,31 @@ public sealed partial class CSharpToGSharpTranslator
                         compilation.Assembly) ||
                     !SymbolEqualityComparer.Default.Equals(
                         receiverDefinition.ContainingNamespace,
-                        method.ContainingNamespace) ||
-                    HasSameNamedInstanceMember(receiverType, method.Name))
+                        method.ContainingNamespace))
                 {
                     continue;
                 }
 
-                result.Add(receiverDefinition, methodDeclaration);
+                candidates.Add((receiverDefinition, methodDeclaration, method));
+            }
+        }
+
+        foreach ((INamedTypeSymbol receiver, MethodDeclarationSyntax syntax, IMethodSymbol method) in candidates)
+        {
+            bool duplicateOwnedExtension = candidates.Any(
+                other =>
+                    !ReferenceEquals(other.Syntax, syntax) &&
+                    SymbolEqualityComparer.Default.Equals(other.Receiver, receiver) &&
+                    HaveSameReducedSignature(method, other.Method));
+            if (duplicateOwnedExtension || HasReducedDeclarationCollision(receiver, method))
+            {
+                result.AddStaticHelper(syntax);
+                continue;
+            }
+
+            if (!HasApplicableInstanceMember(compilation, receiver, method))
+            {
+                result.Add(receiver, syntax);
             }
         }
 
@@ -501,18 +520,138 @@ public sealed partial class CSharpToGSharpTranslator
         return false;
     }
 
-    private static bool HasSameNamedInstanceMember(INamedTypeSymbol type, string name)
+    private static bool HasReducedDeclarationCollision(INamedTypeSymbol type, IMethodSymbol extension)
     {
         for (INamedTypeSymbol current = type; current != null; current = current.BaseType)
         {
-            if (current.GetMembers(name).Any(member => !member.IsStatic))
+            foreach (ISymbol member in current.GetMembers(extension.Name))
             {
-                return true;
+                if (member.IsStatic)
+                {
+                    continue;
+                }
+
+                if (member is not IMethodSymbol method ||
+                    HaveSameReducedSignature(
+                        extension,
+                        method,
+                        leftIsExtension: true,
+                        rightIsExtension: false))
+                {
+                    return true;
+                }
             }
         }
 
         return false;
     }
+
+    private static bool HasApplicableInstanceMember(
+        Compilation compilation,
+        INamedTypeSymbol type,
+        IMethodSymbol extension)
+    {
+        for (INamedTypeSymbol current = type; current != null; current = current.BaseType)
+        {
+            foreach (IMethodSymbol method in current.GetMembers(extension.Name).OfType<IMethodSymbol>())
+            {
+                if (!method.IsStatic &&
+                    HasOverlappingApplicability(compilation, method, extension))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasOverlappingApplicability(
+        Compilation compilation,
+        IMethodSymbol instanceMethod,
+        IMethodSymbol extension)
+    {
+        int instanceMinimum = MinimumArgumentCount(instanceMethod.Parameters, 0);
+        int extensionMinimum = MinimumArgumentCount(extension.Parameters, 1);
+        int instanceMaximum = MaximumArgumentCount(instanceMethod.Parameters, 0);
+        int extensionMaximum = MaximumArgumentCount(extension.Parameters, 1);
+        int minimum = Math.Max(instanceMinimum, extensionMinimum);
+        int maximum = Math.Min(instanceMaximum, extensionMaximum);
+        if (minimum > maximum)
+        {
+            return false;
+        }
+
+        if (instanceMethod.TypeParameters.Length > 0 ||
+            extension.TypeParameters.Length > 0 ||
+            instanceMethod.Parameters.Any(parameter => parameter.IsOptional || parameter.IsParams) ||
+            extension.Parameters.Skip(1).Any(parameter => parameter.IsOptional || parameter.IsParams))
+        {
+            return true;
+        }
+
+        if (instanceMethod.Parameters.Length != extension.Parameters.Length - 1)
+        {
+            return false;
+        }
+
+        return instanceMethod.Parameters
+            .Zip(extension.Parameters.Skip(1), (target, source) => (Target: target, Source: source))
+            .All(pair =>
+                pair.Target.RefKind == pair.Source.RefKind &&
+                (pair.Source.RefKind == RefKind.None
+                    ? compilation.ClassifyConversion(pair.Source.Type, pair.Target.Type).IsImplicit
+                    : SignatureType(pair.Source.Type) == SignatureType(pair.Target.Type)));
+    }
+
+    private static int MinimumArgumentCount(ImmutableArray<IParameterSymbol> parameters, int offset) =>
+        parameters.Skip(offset).Count(parameter => !parameter.IsOptional && !parameter.IsParams);
+
+    private static int MaximumArgumentCount(ImmutableArray<IParameterSymbol> parameters, int offset) =>
+        parameters.Length > offset && parameters[parameters.Length - 1].IsParams
+            ? int.MaxValue
+            : parameters.Length - offset;
+
+    private static bool HaveSameReducedSignature(
+        IMethodSymbol left,
+        IMethodSymbol right,
+        bool leftIsExtension = true,
+        bool rightIsExtension = true)
+    {
+        if (left.Name != right.Name ||
+            left.TypeParameters.Length != right.TypeParameters.Length)
+        {
+            return false;
+        }
+
+        int leftOffset = leftIsExtension ? 1 : 0;
+        int rightOffset = rightIsExtension ? 1 : 0;
+        if (left.Parameters.Length - leftOffset != right.Parameters.Length - rightOffset)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < left.Parameters.Length - leftOffset; i++)
+        {
+            IParameterSymbol leftParameter = left.Parameters[leftOffset + i];
+            IParameterSymbol rightParameter = right.Parameters[rightOffset + i];
+            if (leftParameter.RefKind != rightParameter.RefKind ||
+                SignatureType(leftParameter.Type) != SignatureType(rightParameter.Type))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string SignatureType(ITypeSymbol type) =>
+        string.Concat(
+            type.ToDisplayParts(SymbolDisplayFormat.FullyQualifiedFormat)
+                .Select(part => part.Symbol is ITypeParameterSymbol
+                    { TypeParameterKind: TypeParameterKind.Method } parameter
+                        ? "!" + parameter.Ordinal.ToString(CultureInfo.InvariantCulture)
+                        : part.ToString()));
 
     private static Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>> CollectPartialTypeParts(Compilation compilation)
     {
@@ -976,6 +1115,9 @@ public sealed partial class CSharpToGSharpTranslator
         private readonly Dictionary<MethodDeclarationSyntax, INamedTypeSymbol> receiversByMethod =
             new();
 
+        private readonly HashSet<(Microsoft.CodeAnalysis.SyntaxTree Tree, int Start, int Length)> staticHelpers =
+            new();
+
         public void Add(INamedTypeSymbol receiver, MethodDeclarationSyntax method)
         {
             if (!this.methodsByReceiver.TryGetValue(receiver, out List<MethodDeclarationSyntax> methods))
@@ -990,6 +1132,18 @@ public sealed partial class CSharpToGSharpTranslator
 
         public bool Contains(MethodDeclarationSyntax method) =>
             this.receiversByMethod.ContainsKey(method);
+
+        public void AddStaticHelper(MethodDeclarationSyntax method) =>
+            this.staticHelpers.Add((method.SyntaxTree, method.SpanStart, method.Span.Length));
+
+        public bool IsStaticHelper(IMethodSymbol method)
+        {
+            IMethodSymbol original = method?.ReducedFrom ?? method;
+            return original != null &&
+                original.DeclaringSyntaxReferences.Any(
+                    reference => this.staticHelpers.Contains(
+                        (reference.SyntaxTree, reference.Span.Start, reference.Span.Length)));
+        }
 
         public bool TryGetMethods(
             INamedTypeSymbol receiver,
@@ -1029,6 +1183,14 @@ public sealed partial class CSharpToGSharpTranslator
                     {
                         filtered.Add(entry.Key, method);
                     }
+                }
+            }
+
+            foreach ((Microsoft.CodeAnalysis.SyntaxTree tree, int start, int length) in this.staticHelpers)
+            {
+                if (retainedFilePaths.Contains(tree.FilePath))
+                {
+                    filtered.staticHelpers.Add((tree, start, length));
                 }
             }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -450,7 +450,7 @@ public sealed partial class CSharpToGSharpTranslator
 
     private static OwnedExtensionRegistry CollectOwnedExtensions(Compilation compilation)
     {
-        var result = new OwnedExtensionRegistry();
+        var result = new OwnedExtensionRegistry(compilation.Assembly);
         var candidates = new List<(INamedTypeSymbol Receiver, MethodDeclarationSyntax Syntax, IMethodSymbol Method)>();
         foreach (Microsoft.CodeAnalysis.SyntaxTree tree in compilation.SyntaxTrees)
         {
@@ -460,23 +460,7 @@ public sealed partial class CSharpToGSharpTranslator
                 .OfType<MethodDeclarationSyntax>())
             {
                 if (model.GetDeclaredSymbol(methodDeclaration) is not IMethodSymbol method ||
-                    !method.IsExtensionMethod ||
-                    method.Parameters.Length == 0 ||
-                    method.Parameters[0].NullableAnnotation == NullableAnnotation.Annotated ||
-                    method.Parameters[0].Type is not INamedTypeSymbol receiverType)
-                {
-                    continue;
-                }
-
-                INamedTypeSymbol receiverDefinition = receiverType.OriginalDefinition;
-                if (receiverDefinition.TypeKind is not (TypeKind.Class or TypeKind.Struct) ||
-                    IsGenericReceiver(receiverType) ||
-                    !SymbolEqualityComparer.Default.Equals(
-                        receiverDefinition.ContainingAssembly,
-                        compilation.Assembly) ||
-                    !SymbolEqualityComparer.Default.Equals(
-                        receiverDefinition.ContainingNamespace,
-                        method.ContainingNamespace))
+                    !TryGetOwnedExtensionReceiver(method, out INamedTypeSymbol receiverDefinition))
                 {
                     continue;
                 }
@@ -487,15 +471,8 @@ public sealed partial class CSharpToGSharpTranslator
 
         foreach ((INamedTypeSymbol receiver, MethodDeclarationSyntax syntax, IMethodSymbol method) in candidates)
         {
-            bool crossContainerOverload = candidates.Any(
-                other =>
-                    !ReferenceEquals(other.Syntax, syntax) &&
-                    SymbolEqualityComparer.Default.Equals(other.Receiver, receiver) &&
-                    other.Method.Name == method.Name &&
-                    !SymbolEqualityComparer.Default.Equals(
-                        other.Method.ContainingType,
-                        method.ContainingType));
-            if (crossContainerOverload || HasReducedDeclarationCollision(receiver, method))
+            if (HasCrossContainerOwnedExtensionOverload(receiver, method) ||
+                HasReducedDeclarationCollision(receiver, method))
             {
                 result.AddStaticHelper(syntax);
                 continue;
@@ -508,6 +485,59 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         return result;
+    }
+
+    private static bool TryGetOwnedExtensionReceiver(
+        IMethodSymbol method,
+        out INamedTypeSymbol receiverDefinition)
+    {
+        receiverDefinition = null;
+        if (method == null ||
+            !method.IsExtensionMethod ||
+            method.Parameters.Length == 0 ||
+            method.Parameters[0].NullableAnnotation == NullableAnnotation.Annotated ||
+            method.Parameters[0].Type is not INamedTypeSymbol receiverType)
+        {
+            return false;
+        }
+
+        receiverDefinition = receiverType.OriginalDefinition;
+        return receiverDefinition.TypeKind is TypeKind.Class or TypeKind.Struct &&
+            !IsGenericReceiver(receiverType) &&
+            SymbolEqualityComparer.Default.Equals(
+                receiverDefinition.ContainingAssembly,
+                method.ContainingAssembly) &&
+            SymbolEqualityComparer.Default.Equals(
+                receiverDefinition.ContainingNamespace,
+                method.ContainingNamespace);
+    }
+
+    private static bool HasCrossContainerOwnedExtensionOverload(
+        INamedTypeSymbol receiver,
+        IMethodSymbol method)
+    {
+        foreach (INamedTypeSymbol type in receiver.ContainingNamespace.GetTypeMembers())
+        {
+            foreach (IMethodSymbol other in type.GetMembers(method.Name).OfType<IMethodSymbol>())
+            {
+                if (!SymbolEqualityComparer.Default.Equals(other.ContainingType, method.ContainingType) &&
+                    TryGetOwnedExtensionReceiver(other, out INamedTypeSymbol otherReceiver) &&
+                    SymbolEqualityComparer.Default.Equals(otherReceiver, receiver))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsReproducibleStaticHelper(IMethodSymbol method)
+    {
+        IMethodSymbol original = method?.ReducedFrom ?? method;
+        return TryGetOwnedExtensionReceiver(original, out INamedTypeSymbol receiver) &&
+            (HasCrossContainerOwnedExtensionOverload(receiver, original) ||
+                HasReducedDeclarationCollision(receiver, original));
     }
 
     private static bool IsGenericReceiver(INamedTypeSymbol type)
@@ -1052,7 +1082,7 @@ public sealed partial class CSharpToGSharpTranslator
             this.subclassedBases = subclassedBases;
             this.staticUsingTargets = staticUsingTargets ?? new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
             this.partialTypeParts = partialTypeParts ?? new Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>>(SymbolEqualityComparer.Default);
-            this.ownedExtensions = ownedExtensions ?? new OwnedExtensionRegistry();
+            this.ownedExtensions = ownedExtensions ?? new OwnedExtensionRegistry(context.Compilation.Assembly);
             this.preservePartialParts = preservePartialParts;
             this.markMergedTypePartial = markMergedTypePartial;
             this.efEntityTypes = CollectEfEntityTypes(context.Compilation);
@@ -1081,6 +1111,8 @@ public sealed partial class CSharpToGSharpTranslator
 
     private sealed class OwnedExtensionRegistry
     {
+        private readonly IAssemblySymbol assembly;
+
         private readonly Dictionary<INamedTypeSymbol, List<MethodDeclarationSyntax>> methodsByReceiver =
             new(SymbolEqualityComparer.Default);
 
@@ -1089,6 +1121,11 @@ public sealed partial class CSharpToGSharpTranslator
 
         private readonly HashSet<(Microsoft.CodeAnalysis.SyntaxTree Tree, int Start, int Length)> staticHelpers =
             new();
+
+        public OwnedExtensionRegistry(IAssemblySymbol assembly = null)
+        {
+            this.assembly = assembly;
+        }
 
         public void Add(INamedTypeSymbol receiver, MethodDeclarationSyntax method)
         {
@@ -1111,10 +1148,22 @@ public sealed partial class CSharpToGSharpTranslator
         public bool IsStaticHelper(IMethodSymbol method)
         {
             IMethodSymbol original = method?.ReducedFrom ?? method;
-            return original != null &&
-                original.DeclaringSyntaxReferences.Any(
+            if (original == null)
+            {
+                return false;
+            }
+
+            if (original.DeclaringSyntaxReferences.Any(
                     reference => this.staticHelpers.Contains(
-                        (reference.SyntaxTree, reference.Span.Start, reference.Span.Length)));
+                        (reference.SyntaxTree, reference.Span.Start, reference.Span.Length))))
+            {
+                return true;
+            }
+
+            // Referenced projects do not share this compilation's syntax-keyed
+            // registry. Re-run the declaration-only rule on metadata symbols.
+            return !SymbolEqualityComparer.Default.Equals(original.ContainingAssembly, this.assembly) &&
+                IsReproducibleStaticHelper(original);
         }
 
         public bool TryGetMethods(
@@ -1139,7 +1188,7 @@ public sealed partial class CSharpToGSharpTranslator
                 return this;
             }
 
-            var filtered = new OwnedExtensionRegistry();
+            var filtered = new OwnedExtensionRegistry(this.assembly);
             foreach (KeyValuePair<INamedTypeSymbol, List<MethodDeclarationSyntax>> entry in this.methodsByReceiver)
             {
                 bool targetIsRetained = entry.Key.DeclaringSyntaxReferences.Any(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -487,18 +487,21 @@ public sealed partial class CSharpToGSharpTranslator
 
         foreach ((INamedTypeSymbol receiver, MethodDeclarationSyntax syntax, IMethodSymbol method) in candidates)
         {
-            bool duplicateOwnedExtension = candidates.Any(
+            bool crossContainerOverload = candidates.Any(
                 other =>
                     !ReferenceEquals(other.Syntax, syntax) &&
                     SymbolEqualityComparer.Default.Equals(other.Receiver, receiver) &&
-                    HaveSameReducedSignature(method, other.Method));
-            if (duplicateOwnedExtension || HasReducedDeclarationCollision(receiver, method))
+                    other.Method.Name == method.Name &&
+                    !SymbolEqualityComparer.Default.Equals(
+                        other.Method.ContainingType,
+                        method.ContainingType));
+            if (crossContainerOverload || HasReducedDeclarationCollision(receiver, method))
             {
                 result.AddStaticHelper(syntax);
                 continue;
             }
 
-            if (!HasApplicableInstanceMember(compilation, receiver, method))
+            if (!HasApplicableInstanceMember(receiver, method))
             {
                 result.Add(receiver, syntax);
             }
@@ -546,17 +549,14 @@ public sealed partial class CSharpToGSharpTranslator
         return false;
     }
 
-    private static bool HasApplicableInstanceMember(
-        Compilation compilation,
-        INamedTypeSymbol type,
-        IMethodSymbol extension)
+    private static bool HasApplicableInstanceMember(INamedTypeSymbol type, IMethodSymbol extension)
     {
         for (INamedTypeSymbol current = type; current != null; current = current.BaseType)
         {
             foreach (IMethodSymbol method in current.GetMembers(extension.Name).OfType<IMethodSymbol>())
             {
                 if (!method.IsStatic &&
-                    HasOverlappingApplicability(compilation, method, extension))
+                    HasOverlappingApplicability(method, extension))
                 {
                     return true;
                 }
@@ -566,42 +566,14 @@ public sealed partial class CSharpToGSharpTranslator
         return false;
     }
 
-    private static bool HasOverlappingApplicability(
-        Compilation compilation,
-        IMethodSymbol instanceMethod,
-        IMethodSymbol extension)
+    private static bool HasOverlappingApplicability(IMethodSymbol instanceMethod, IMethodSymbol extension)
     {
         int instanceMinimum = MinimumArgumentCount(instanceMethod.Parameters, 0);
         int extensionMinimum = MinimumArgumentCount(extension.Parameters, 1);
         int instanceMaximum = MaximumArgumentCount(instanceMethod.Parameters, 0);
         int extensionMaximum = MaximumArgumentCount(extension.Parameters, 1);
-        int minimum = Math.Max(instanceMinimum, extensionMinimum);
-        int maximum = Math.Min(instanceMaximum, extensionMaximum);
-        if (minimum > maximum)
-        {
-            return false;
-        }
-
-        if (instanceMethod.TypeParameters.Length > 0 ||
-            extension.TypeParameters.Length > 0 ||
-            instanceMethod.Parameters.Any(parameter => parameter.IsOptional || parameter.IsParams) ||
-            extension.Parameters.Skip(1).Any(parameter => parameter.IsOptional || parameter.IsParams))
-        {
-            return true;
-        }
-
-        if (instanceMethod.Parameters.Length != extension.Parameters.Length - 1)
-        {
-            return false;
-        }
-
-        return instanceMethod.Parameters
-            .Zip(extension.Parameters.Skip(1), (target, source) => (Target: target, Source: source))
-            .All(pair =>
-                pair.Target.RefKind == pair.Source.RefKind &&
-                (pair.Source.RefKind == RefKind.None
-                    ? compilation.ClassifyConversion(pair.Source.Type, pair.Target.Type).IsImplicit
-                    : SignatureType(pair.Source.Type) == SignatureType(pair.Target.Type)));
+        return Math.Max(instanceMinimum, extensionMinimum) <=
+            Math.Min(instanceMaximum, extensionMaximum);
     }
 
     private static int MinimumArgumentCount(ImmutableArray<IParameterSymbol> parameters, int offset) =>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -62,6 +62,13 @@ public sealed partial class CSharpToGSharpTranslator
     // every document translated from the same compilation.
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Compilation, Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>>> PartialTypePartsCache = new();
 
+    // Issue #2821: classic C# extension methods whose receiver type is declared
+    // in the same source compilation and namespace belong to that output
+    // package. Collect them once per compilation so the receiver's declaration
+    // can absorb them even when the extension and target live in different
+    // files (including partial target declarations).
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Compilation, OwnedExtensionRegistry> OwnedExtensionsCache = new();
+
     // ADR-0145 (§C/§D): opt-in "preserve partial parts" mode. In the DEFAULT
     // (false) cs2gs-migration mode, all C# `partial` parts of a type are MERGED
     // into ONE non-partial G# type, emitted once (issue #1910). The
@@ -187,6 +194,9 @@ public sealed partial class CSharpToGSharpTranslator
             partialTypeParts = FilterPartialTypeParts(partialTypeParts, this.retainedFilePaths);
         }
 
+        OwnedExtensionRegistry ownedExtensions =
+            GetOrCollectOwnedExtensions(context.Compilation).Filter(this.retainedFilePaths);
+
         string package = this.packageFilter ?? this.ResolvePackage(root, context);
 
         // Issue #1910 (gap 3): a merged-in member from a non-primary partial
@@ -204,6 +214,8 @@ public sealed partial class CSharpToGSharpTranslator
             this.preservePartialParts
                 ? Enumerable.Empty<Microsoft.CodeAnalysis.SyntaxTree>()
                 : CollectExtraUsingTrees(root, partialTypeParts);
+        extraUsingTrees = extraUsingTrees.Concat(
+            CollectOwnedExtensionUsingTrees(root, context, ownedExtensions));
         IReadOnlyList<ImportDirective> imports = this.TranslateImports(root, extraUsingTrees, context);
 
         HashSet<INamedTypeSymbol> openBases = GetOrCollectSubclassedBaseTypes(context.Compilation);
@@ -245,6 +257,7 @@ public sealed partial class CSharpToGSharpTranslator
             staticUsingTargets,
             entryPoint,
             partialTypeParts,
+            ownedExtensions,
             this.preservePartialParts,
             this.markMergedTypePartial);
 
@@ -311,8 +324,8 @@ public sealed partial class CSharpToGSharpTranslator
                 members.Add(translated);
             }
 
-            // Owned-struct receiver methods (issue #938) are emitted as siblings
-            // immediately after their owning type so they read together.
+            // Synthesized top-level receiver funcs/operators are emitted as
+            // siblings immediately after their source aggregate.
             members.AddRange(visitor.DrainPendingTopLevel());
         }
 
@@ -430,6 +443,49 @@ public sealed partial class CSharpToGSharpTranslator
         return PartialTypePartsCache.GetValue(compilation, CollectPartialTypeParts);
     }
 
+    private static OwnedExtensionRegistry GetOrCollectOwnedExtensions(Compilation compilation)
+    {
+        return OwnedExtensionsCache.GetValue(compilation, CollectOwnedExtensions);
+    }
+
+    private static OwnedExtensionRegistry CollectOwnedExtensions(Compilation compilation)
+    {
+        var result = new OwnedExtensionRegistry();
+        foreach (Microsoft.CodeAnalysis.SyntaxTree tree in compilation.SyntaxTrees)
+        {
+            SemanticModel model = compilation.GetSemanticModel(tree);
+            foreach (MethodDeclarationSyntax methodDeclaration in tree.GetRoot()
+                .DescendantNodes()
+                .OfType<MethodDeclarationSyntax>())
+            {
+                if (model.GetDeclaredSymbol(methodDeclaration) is not IMethodSymbol method ||
+                    !method.IsExtensionMethod ||
+                    method.Parameters.Length == 0 ||
+                    method.Parameters[0].NullableAnnotation == NullableAnnotation.Annotated ||
+                    method.Parameters[0].Type is not INamedTypeSymbol receiverType)
+                {
+                    continue;
+                }
+
+                INamedTypeSymbol receiverDefinition = receiverType.OriginalDefinition;
+                if (receiverDefinition.TypeKind is not (TypeKind.Class or TypeKind.Struct) ||
+                    !SymbolEqualityComparer.Default.Equals(
+                        receiverDefinition.ContainingAssembly,
+                        compilation.Assembly) ||
+                    !SymbolEqualityComparer.Default.Equals(
+                        receiverDefinition.ContainingNamespace,
+                        method.ContainingNamespace))
+                {
+                    continue;
+                }
+
+                result.Add(receiverDefinition, methodDeclaration);
+            }
+        }
+
+        return result;
+    }
+
     private static Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>> CollectPartialTypeParts(Compilation compilation)
     {
         var result = new Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>>(SymbolEqualityComparer.Default);
@@ -506,6 +562,32 @@ public sealed partial class CSharpToGSharpTranslator
                 if (part.SyntaxTree != root.SyntaxTree)
                 {
                     trees.Add(part.SyntaxTree);
+                }
+            }
+        }
+
+        return trees;
+    }
+
+    private static HashSet<Microsoft.CodeAnalysis.SyntaxTree> CollectOwnedExtensionUsingTrees(
+        CompilationUnitSyntax root,
+        TranslationContext context,
+        OwnedExtensionRegistry ownedExtensions)
+    {
+        var trees = new HashSet<Microsoft.CodeAnalysis.SyntaxTree>();
+        foreach (TypeDeclarationSyntax declaration in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+        {
+            if (context.GetDeclaredSymbol(declaration) is not INamedTypeSymbol type ||
+                !ownedExtensions.TryGetMethods(type, out IReadOnlyList<MethodDeclarationSyntax> methods))
+            {
+                continue;
+            }
+
+            foreach (MethodDeclarationSyntax method in methods)
+            {
+                if (method.SyntaxTree != root.SyntaxTree)
+                {
+                    trees.Add(method.SyntaxTree);
                 }
             }
         }
@@ -744,6 +826,10 @@ public sealed partial class CSharpToGSharpTranslator
         // declaration; every other part's members are merged into it.
         private readonly Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>> partialTypeParts;
 
+        // Issue #2821: same-package source extension methods are emitted as
+        // members of their owned receiver type, not as top-level receiver funcs.
+        private readonly OwnedExtensionRegistry ownedExtensions;
+
         // ADR-0145 (§C/§D): when true, `partial` parts are NOT merged — every
         // part is emitted as its own standalone G# `partial` declaration (using
         // only its own members), so a generated part augments the user's real G#
@@ -818,6 +904,7 @@ public sealed partial class CSharpToGSharpTranslator
             HashSet<INamedTypeSymbol> staticUsingTargets,
             IMethodSymbol entryPoint,
             Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>> partialTypeParts,
+            OwnedExtensionRegistry ownedExtensions,
             bool preservePartialParts = false,
             bool markMergedTypePartial = false)
         {
@@ -826,6 +913,7 @@ public sealed partial class CSharpToGSharpTranslator
             this.subclassedBases = subclassedBases;
             this.staticUsingTargets = staticUsingTargets ?? new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
             this.partialTypeParts = partialTypeParts ?? new Dictionary<INamedTypeSymbol, List<TypeDeclarationSyntax>>(SymbolEqualityComparer.Default);
+            this.ownedExtensions = ownedExtensions ?? new OwnedExtensionRegistry();
             this.preservePartialParts = preservePartialParts;
             this.markMergedTypePartial = markMergedTypePartial;
             this.efEntityTypes = CollectEfEntityTypes(context.Compilation);
@@ -850,5 +938,73 @@ public sealed partial class CSharpToGSharpTranslator
 
         public override GMember VisitDelegateDeclaration(DelegateDeclarationSyntax node) =>
             this.TranslateDelegateDeclaration(node);
+    }
+
+    private sealed class OwnedExtensionRegistry
+    {
+        private readonly Dictionary<INamedTypeSymbol, List<MethodDeclarationSyntax>> methodsByReceiver =
+            new(SymbolEqualityComparer.Default);
+
+        private readonly Dictionary<MethodDeclarationSyntax, INamedTypeSymbol> receiversByMethod =
+            new();
+
+        public void Add(INamedTypeSymbol receiver, MethodDeclarationSyntax method)
+        {
+            if (!this.methodsByReceiver.TryGetValue(receiver, out List<MethodDeclarationSyntax> methods))
+            {
+                methods = new List<MethodDeclarationSyntax>();
+                this.methodsByReceiver.Add(receiver, methods);
+            }
+
+            methods.Add(method);
+            this.receiversByMethod.Add(method, receiver);
+        }
+
+        public bool Contains(MethodDeclarationSyntax method) =>
+            this.receiversByMethod.ContainsKey(method);
+
+        public bool TryGetMethods(
+            INamedTypeSymbol receiver,
+            out IReadOnlyList<MethodDeclarationSyntax> methods)
+        {
+            if (receiver != null &&
+                this.methodsByReceiver.TryGetValue(receiver.OriginalDefinition, out List<MethodDeclarationSyntax> found))
+            {
+                methods = found;
+                return true;
+            }
+
+            methods = Array.Empty<MethodDeclarationSyntax>();
+            return false;
+        }
+
+        public OwnedExtensionRegistry Filter(HashSet<string> retainedFilePaths)
+        {
+            if (retainedFilePaths is null)
+            {
+                return this;
+            }
+
+            var filtered = new OwnedExtensionRegistry();
+            foreach (KeyValuePair<INamedTypeSymbol, List<MethodDeclarationSyntax>> entry in this.methodsByReceiver)
+            {
+                bool targetIsRetained = entry.Key.DeclaringSyntaxReferences.Any(
+                    r => retainedFilePaths.Contains(r.SyntaxTree.FilePath));
+                if (!targetIsRetained)
+                {
+                    continue;
+                }
+
+                foreach (MethodDeclarationSyntax method in entry.Value)
+                {
+                    if (retainedFilePaths.Contains(method.SyntaxTree.FilePath))
+                    {
+                        filtered.Add(entry.Key, method);
+                    }
+                }
+            }
+
+            return filtered;
+        }
     }
 }

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -179,6 +179,12 @@ internal sealed class DocumentTranslationState
     // Monotonic counter for synthesizing spill temporaries (issue #1731).
     public int SpillCounter { get; set; }
 
+    // While rebuilding a static-helper receiver chained from `?.`, replace the
+    // conditional-receiver placeholder with the already-guarded receiver so the
+    // normal member-access translator still applies tuple/nullable/pointer and
+    // extension-property rewrites to the rest of the chain.
+    public GExpression ConditionalReceiverReplacement { get; set; }
+
     // Issue #1902: numbers the `__qN` tuple parameter synthesized to carry a
     // query's transparent identifier (multiple in-scope range variables)
     // through a lambda that C#'s query-translation spec (§12.19.3) would bind

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -144,11 +144,8 @@ internal sealed class DocumentTranslationState
     public Dictionary<ISymbol, MultiDimArrayInfo> MultiDimArrays { get; } =
         new Dictionary<ISymbol, MultiDimArrayInfo>(SymbolEqualityComparer.Default);
 
-    // Owned struct / data-struct instance methods cannot live in the type
-    // body (the parser rejects an in-body `func`); they are lifted to
-    // top-level receiver-clause `func`s emitted as siblings of the type
-    // (issue #938, ADR-0115 §B.5). Collected here per aggregate and drained
-    // by the document translator.
+    // Top-level declarations synthesized while translating an aggregate
+    // (receiver-clause extensions and operators) are emitted as siblings.
     public List<GMember> PendingTopLevelDeclarations { get; } = new List<GMember>();
 
     // The syntax node whose body is currently being translated. It bounds the
@@ -231,12 +228,6 @@ internal sealed class DocumentTranslationState
     // Monotonic counter for synthesizing null-seam helper method names
     // (issue #1849), reset per aggregate alongside `PendingSynthHelpers`.
     public int SynthHelperCounter { get; set; }
-
-    // When translating the body of a lifted owned-value-aggregate receiver
-    // method (issue #938), the implicit `this.` of a bare instance-member
-    // reference must be made explicit through the receiver name (`self.`),
-    // because a top-level receiver-clause `func` has no implicit receiver.
-    public string CurrentReceiverName { get; set; }
 
     // The exception variable bound by the innermost enclosing `catch` clause,
     // used to translate a C# re-throw (`throw;`) — which has no bare G# form —


### PR DESCRIPTION
## Summary
- keep owned struct and data-struct instance methods inside their declaring type
- move same-compilation, same-namespace extension methods into owned receiver declarations, including split partial types
- retain receiver clauses for external or nullable/ref receivers and propagate extension-file imports
- avoid merging excluded generated extension files

## Validation
- `Issue2821OwnedExtensionMemberTranslationTests`: 4 passed
- extension/partial/Oahu-related suite: 115 passed
- full Oahu migration translated all 15 projects; affected methods now appear inside `Ec3IndependentSubstream`, `SemanticColor`, `LogEntry`, and `Icon`
- no `GS0314` found in generated Oahu output or run artifacts
- Oahu corpus remains 4/15 green due other compile/ILVerify diagnostics

Fixes #2821