### PR TITLE
Fix #2838: unmanaged generic pointer stride and Span[T] pin erasure

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -458,6 +458,10 @@ internal sealed partial class ExpressionBinder
 
     private static int StaticPointeeSize(TypeSymbol pointee)
     {
+        // Issue #2838: an open type parameter has no compile-time size, so
+        // IsStructPointee must route it to the runtime `sizeof` opcode instead.
+        System.Diagnostics.Debug.Assert(pointee is not TypeParameterSymbol, "open type-parameter pointee reached StaticPointeeSize");
+
         if (pointee == TypeSymbol.Int8 || pointee == TypeSymbol.UInt8 || pointee == TypeSymbol.Bool)
         {
             return 1;
@@ -485,12 +489,24 @@ internal sealed partial class ExpressionBinder
 
     /// <summary>
     /// ADR-0122 §4 / issue #1034. Returns whether <paramref name="pointee"/> is a
-    /// user/value struct pointee whose unmanaged size is not a known compile-time
-    /// constant — so pointer arithmetic must scale by the emitted CIL
-    /// <c>sizeof</c> opcode rather than a literal.
+    /// pointee whose unmanaged size is not a known compile-time constant — so
+    /// pointer arithmetic must scale by the emitted CIL <c>sizeof</c> opcode
+    /// rather than a literal.
+    /// <para>
+    /// Issue #2838: an open type parameter (<c>*T</c> under
+    /// <c>where T : unmanaged</c>) belongs in this bucket. A
+    /// <c>TypeParameterSymbol</c> carries no <see cref="TypeSymbol.ClrType"/>
+    /// at all, so it matched neither the struct case nor the value-type case
+    /// and fell through to <see cref="StaticPointeeSize"/>, silently scaling by
+    /// <c>nint.Size</c> (8) for EVERY instantiation. That produced no
+    /// diagnostic and no exception, just wrong answers for any <c>T</c> whose
+    /// size is not 8. The size is only known per-instantiation at runtime, so
+    /// it must always come from <c>sizeof !!T</c>.
+    /// </para>
     /// </summary>
     private static bool IsStructPointee(TypeSymbol pointee) =>
-        pointee is StructSymbol { IsClass: false }
+        pointee is TypeParameterSymbol
+        || pointee is StructSymbol { IsClass: false }
         || (pointee is not StructSymbol and not PointerTypeSymbol
             && pointee?.ClrType is { IsValueType: true }
             && !TypeSymbol.IsLegalPointeeType(pointee));

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1415,6 +1415,23 @@ internal sealed partial class ExpressionBinder
             return GetEffectiveArgumentClrTypeForOverloadResolution(byRef.PointeeType)?.MakeByRefType();
         }
 
+        // Issue #2838: a pointer whose pointee has no CLR identity — canonically
+        // `*T` under `T : unmanaged`, produced by `fixed p *T = span` — likewise
+        // rides through its pointee's erasure. Without this the pointer argument
+        // yielded no effective CLR type at all, so overload resolution never ran
+        // and an imported generic call over it (e.g. `Vector256.Load(p)`) dead-
+        // ended with GS0159. The inferred `object` erasure is re-projected back
+        // to the symbolic type argument by the same recovery step that handles
+        // every other erased inference.
+        if (typeSymbol is PointerTypeSymbol pointer)
+        {
+            var pointeeClr = GetEffectiveArgumentClrTypeForOverloadResolution(pointer.PointeeType);
+            if (pointeeClr != null && !pointeeClr.IsByRef)
+            {
+                return pointeeClr.MakePointerType();
+            }
+        }
+
         // Issue #2182: a G# slice `[]T` whose element type has no CLR backing
         // (a generic type parameter, or another same-compilation user type)
         // has a null `ClrType`, so `GetEffectiveArgumentClrType` returned null

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1776,6 +1776,25 @@ internal sealed class MemberLookup
                 }
 
                 return false;
+            case PointerTypeSymbol pointer:
+                // Issue #2838: `*T` under `T : unmanaged` — canonically the
+                // pointer bound by `fixed p *T = span` — has a null ClrType
+                // because its pointee is an open type parameter. Without this
+                // case the argument produced no erased CLR type at all, so
+                // `TryLookupFunction` bailed out before overload resolution ran
+                // and an imported generic call over the pointer (e.g.
+                // `Vector256.Load(p)`) dead-ended with GS0159. Erase the pointee
+                // and re-form the pointer so the candidate's `!!0*` parameter can
+                // unify; symbolic recovery downstream re-derives the real type
+                // argument for the MethodSpec.
+                if (TryProjectErasedClrType(pointer.PointeeType, out var pointeeErased)
+                    && !pointeeErased.IsByRef)
+                {
+                    erased = pointeeErased.MakePointerType();
+                    return true;
+                }
+
+                return false;
             case SequenceTypeSymbol seq:
                 // Issue #1320: `sequence[T]` (an iterator return, alias for
                 // `IEnumerable<T>`) over a same-compilation user element type has
@@ -4643,6 +4662,25 @@ internal sealed class MemberLookup
                 UnifyForMethodTypeArgs(openPointee, actual, openMethod, result);
             }
 
+            return;
+        }
+
+        if (openClr.IsPointer)
+        {
+            // Issue #2838: `Vector256.Load[T](*T source)` called with a `*T`
+            // argument. Without this case an open pointer parameter matched
+            // none of the structural forms above, so `T` was never recovered
+            // and the MethodSpec fell back to the erased `object` — emitting
+            // `Vector256::Load<System.Object>`, which is not even a
+            // constructible instantiation. Mirrors the by-ref case: unify
+            // through the pointee, tolerating an actual that is already the
+            // pointee rather than a pointer.
+            var openPointerPointee = openClr.GetElementType();
+            UnifyForMethodTypeArgs(
+                openPointerPointee,
+                actual is PointerTypeSymbol actualPointer ? actualPointer.PointeeType : actual,
+                openMethod,
+                result);
             return;
         }
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
@@ -836,7 +836,7 @@ internal sealed partial class StatementBinder
                 // (a `modreq(InAttribute)` ref-return); the method-reference
                 // encoder reproduces that modreq (see EncodeReturnClr).
                 pinKind = FixedPinKind.PinnableReference;
-                elementType = TypeSymbol.FromClrType(pinnableElementClr);
+                elementType = ResolvePinnableElementType(source.Type, pinnableElementClr);
                 pinnedUnderlying = ByRefTypeSymbol.Get(elementType);
             }
             else
@@ -948,6 +948,52 @@ internal sealed partial class StatementBinder
         method = found;
         elementClrType = found.ReturnType.GetElementType();
         return elementClrType != null;
+    }
+
+    // Issue #2838: recover the SYMBOLIC element type of a span-like pin source.
+    // `TryGetPinnableReference` resolves through `sourceType.ClrType`, which for
+    // a `Span[T]` inside a generic method is the type-erased `Span<object>` — so
+    // its ref-return element is `System.Object`, not `T`. Binding the pointer as
+    // `*object` produced a `pinned object&` local and, because an erased pointee
+    // is not recognized as a value type, an 8-byte pointer-arithmetic stride for
+    // every instantiation. Re-resolve the method on the OPEN definition (whose
+    // ref-return is `!0`) and map that back through the receiver's real type
+    // arguments. Falls back to the CLR element type for non-generic and fully
+    // closed sources, preserving existing behavior.
+    private static TypeSymbol ResolvePinnableElementType(TypeSymbol sourceType, System.Type pinnableElementClr)
+    {
+        if (sourceType is ImportedTypeSymbol { OpenDefinition: not null } imported
+            && !imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            System.Reflection.MethodInfo openMethod = null;
+            try
+            {
+                openMethod = imported.OpenDefinition.GetMethod(
+                    "GetPinnableReference",
+                    System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
+                    binder: null,
+                    types: System.Type.EmptyTypes,
+                    modifiers: null);
+            }
+            catch (System.Reflection.AmbiguousMatchException)
+            {
+                openMethod = null;
+            }
+
+            var openElement = openMethod?.ReturnType.IsByRef == true
+                ? openMethod.ReturnType.GetElementType()
+                : null;
+            if (openElement != null)
+            {
+                var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openElement, imported);
+                if (mapped != null)
+                {
+                    return mapped;
+                }
+            }
+        }
+
+        return TypeSymbol.FromClrType(pinnableElementClr);
     }
 
     private BoundStatement BindAwaitForRangeStatement(AwaitForRangeStatementSyntax syntax)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
@@ -178,7 +178,17 @@ internal sealed partial class MethodBodyEmitter
         this.il.StoreLocal(sourceSlot);
         this.il.LoadLocalAddress(sourceSlot);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(getPinnableReference)); // -> T&
+
+        // Issue #2838: encode the parent through the SYMBOLIC source type, not
+        // the `MethodInfo` alone. For `fixed p *T = span` inside a generic
+        // method, `sourceClr` is the erased `Span<object>` (an open type
+        // argument has no reference-context CLR type), so the plain MemberRef
+        // path emitted `Span<object>::GetPinnableReference()` against a
+        // `Span<!!T>` receiver — verifier-rejected `StackUnexpected`.
+        // `GetMethodEntityHandle` re-encodes the parent TypeSpec from the
+        // symbol's real type arguments, and falls through to the plain
+        // MemberRef when the container is non-generic or fully closed.
+        this.il.Token(this.outer.memberRefs.GetMethodEntityHandle(getPinnableReference, node.PinnedSource.Type)); // -> T&
         this.il.StoreLocal(pinnedSlot);          // T& pinned = ref
         this.il.LoadLocal(pinnedSlot);
         this.il.OpCode(ILOpCode.Conv_u);

--- a/test/Compiler.Tests/Emit/Issue2838GenericPointerStrideEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2838GenericPointerStrideEmitTests.cs
@@ -1,0 +1,443 @@
+// <copyright file="Issue2838GenericPointerStrideEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2838: pointer arithmetic over a pointer to an <c>unmanaged</c>-constrained
+/// generic type parameter silently used a hard-coded 8-byte stride.
+/// <para>
+/// An open <c>TypeParameterSymbol</c> has no
+/// reference-context CLR type (its <c>ClrType</c> is <c>null</c>), so the
+/// pointee-size classifier did not see a value type and fell back to the
+/// <c>nint.Size</c> literal. Every instantiation — <c>*uint8</c>, <c>*uint16</c>,
+/// <c>*int32</c> — therefore scaled by 8. That is a WRONG-ANSWER bug, not merely a
+/// verification failure, so these tests execute the emitted code and assert the
+/// computed strides rather than only inspecting metadata.
+/// </para>
+/// <para>
+/// A secondary defect in the same report: <c>fixed p *T = span</c> emitted the
+/// <c>GetPinnableReference()</c> MemberRef parented at the erased
+/// <c>Span`1&lt;object&gt;</c> while the receiver on the stack was
+/// <c>Span`1&lt;!!T&gt;</c>. The parent must be a TypeSpec naming the type
+/// parameter.
+/// </para>
+/// </summary>
+public class Issue2838GenericPointerStrideEmitTests
+{
+    // Raw-pointer code is unverifiable by design. This is the established
+    // tolerated set for the `fixed` pinnable-reference form (see
+    // Issue1043FixedPinnableEmitTests): `conv.u` on the pinned `T&` is exactly
+    // what C# emits and is inherently unverifiable. Listing only these codes
+    // keeps unrelated verification regressions failing the test.
+    private static readonly string[] UnsafeIlVerifyIgnored =
+    {
+        "Unverifiable",
+        "UnmanagedPointer",
+        "StackUnexpected",
+        "StackByRef",
+        "ExpectedPtr",
+        "StackUnexpectedArrayType",
+        "ExpectedNumericType",
+    };
+
+    /// <summary>
+    /// The headline regression: <c>(p + 1) - p</c> over <c>*T</c> must advance by
+    /// <c>sizeof(T)</c>. Before the fix every instantiation printed <c>8</c>.
+    /// </summary>
+    [Fact]
+    public void PointerDifference_OverGenericUnmanaged_UsesRuntimeStride()
+    {
+        var source = """
+            package Probe
+
+            import System
+
+            class Stride {
+                shared {
+                    func PointerStride[T unmanaged](xs Span[T]) int64 {
+                        unsafe {
+                            var d int64 = 0
+                            fixed p *T = xs {
+                                d = int64((p + 1)) - int64(p)
+                            }
+                            return d
+                        }
+                    }
+                }
+            }
+
+            func run() {
+                Console.WriteLine(Stride.PointerStride[uint8]([8]uint8))
+                Console.WriteLine(Stride.PointerStride[uint16]([8]uint16))
+                Console.WriteLine(Stride.PointerStride[int32]([8]int32))
+                Console.WriteLine(Stride.PointerStride[int64]([8]int64))
+            }
+
+            run()
+            """;
+
+        var output = CompileAndRun(source, UnsafeIlVerifyIgnored);
+        Assert.Equal("1\n2\n4\n8\n", output);
+    }
+
+    /// <summary>
+    /// Covers the other consumer of the pointee-size helper: scaling a
+    /// non-constant offset (<c>p + n</c>) rather than a literal <c>+ 1</c>.
+    /// </summary>
+    [Fact]
+    public void PointerOffset_OverGenericUnmanaged_ScalesByElementSize()
+    {
+        var source = """
+            package Probe
+
+            import System
+
+            class Stride {
+                shared {
+                    func OffsetDelta[T unmanaged](xs Span[T], n int32) int64 {
+                        unsafe {
+                            var d int64 = 0
+                            fixed p *T = xs {
+                                d = int64((p + n)) - int64(p)
+                            }
+                            return d
+                        }
+                    }
+                }
+            }
+
+            func run() {
+                Console.WriteLine(Stride.OffsetDelta[uint8]([8]uint8, 3))
+                Console.WriteLine(Stride.OffsetDelta[uint16]([8]uint16, 3))
+                Console.WriteLine(Stride.OffsetDelta[int32]([8]int32, 3))
+                Console.WriteLine(Stride.OffsetDelta[int64]([8]int64, 3))
+            }
+
+            run()
+            """;
+
+        var output = CompileAndRun(source, UnsafeIlVerifyIgnored);
+        Assert.Equal("3\n6\n12\n24\n", output);
+    }
+
+    /// <summary>
+    /// Metadata-level guard for both defects, so a future regression is diagnosed
+    /// at the IL shape rather than only as a wrong printed number:
+    /// the stride must be the <c>sizeof</c> opcode (never a baked-in
+    /// <c>ldc.i4.8</c>), and the <c>GetPinnableReference</c> MemberRef must be
+    /// parented at a TypeSpec that names the method type parameter.
+    /// </summary>
+    [Fact]
+    public void GenericPointerWalk_EmitsSizeOfOpcodeAndSymbolicPinnableParent()
+    {
+        var source = """
+            package Probe
+
+            import System
+
+            class Stride {
+                shared {
+                    func PointerStride[T unmanaged](xs Span[T]) int64 {
+                        unsafe {
+                            var d int64 = 0
+                            fixed p *T = xs {
+                                d = int64((p + 1)) - int64(p)
+                            }
+                            return d
+                        }
+                    }
+                }
+            }
+
+            func run() {
+                Console.WriteLine(Stride.PointerStride[int32]([8]int32))
+            }
+
+            run()
+            """;
+
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2838_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+            CompileOrThrow(srcPath, outPath);
+
+            using var pe = new PEReader(File.OpenRead(outPath));
+            var md = pe.GetMetadataReader();
+
+            var il = GetMethodIl(pe, md, "PointerStride");
+
+            // ECMA-335 III.1.2.1: `sizeof` is the two-byte prefixed opcode
+            // 0xFE 0x1C. Its presence proves the stride is computed from the
+            // runtime type token rather than a compile-time constant.
+            Assert.True(
+                ContainsSequence(il, 0xFE, 0x1C),
+                "PointerStride must scale by the `sizeof` opcode over the generic type token.");
+
+            // `ldc.i4.8; conv.i` (0x1E 0xD3) was the exact erased-stride
+            // emission. Matching the pair rather than the bare constant avoids
+            // false positives from 0x1E appearing inside a metadata token.
+            Assert.False(
+                ContainsSequence(il, 0x1E, 0xD3),
+                "PointerStride must not bake in an 8-byte stride.");
+
+            AssertPinnableReferenceParentNamesTypeParameter(md);
+        }
+        finally
+        {
+            TryDeleteDir(tempDir);
+        }
+    }
+
+    private static void AssertPinnableReferenceParentNamesTypeParameter(MetadataReader md)
+    {
+        var found = false;
+        foreach (var mrh in md.MemberReferences)
+        {
+            var mr = md.GetMemberReference(mrh);
+            if (md.GetString(mr.Name) != "GetPinnableReference")
+            {
+                continue;
+            }
+
+            found = true;
+
+            // The receiver is `Span[T]`, so the parent must be a TypeSpec — a
+            // plain TypeRef parent would be the erased `Span<object>`.
+            Assert.True(
+                mr.Parent.Kind == HandleKind.TypeSpecification,
+                $"GetPinnableReference parent must be a TypeSpecification, was {mr.Parent.Kind}.");
+
+            var spec = md.GetTypeSpecification((TypeSpecificationHandle)mr.Parent);
+            var blob = md.GetBlobBytes(spec.Signature);
+
+            // ECMA-335 II.23.1.16: ELEMENT_TYPE_MVAR (0x1E) — the method-level
+            // generic parameter `!!T`. Its absence means the argument erased.
+            Assert.Contains((byte)0x1E, blob);
+        }
+
+        Assert.True(found, "no GetPinnableReference MemberRef found in emitted metadata");
+    }
+
+    private static byte[] GetMethodIl(PEReader pe, MetadataReader md, string methodName)
+    {
+        foreach (var mh in md.MethodDefinitions)
+        {
+            var mdef = md.GetMethodDefinition(mh);
+            if (md.GetString(mdef.Name) != methodName || mdef.RelativeVirtualAddress == 0)
+            {
+                continue;
+            }
+
+            return pe.GetMethodBody(mdef.RelativeVirtualAddress).GetILBytes()
+                ?? throw new InvalidOperationException($"method '{methodName}' has no IL body");
+        }
+
+        throw new InvalidOperationException($"method '{methodName}' not found in emitted metadata");
+    }
+
+    private static bool ContainsSequence(byte[] haystack, params byte[] needle)
+    {
+        for (var i = 0; i + needle.Length <= haystack.Length; i++)
+        {
+            var match = true;
+            for (var j = 0; j < needle.Length; j++)
+            {
+                if (haystack[i + j] != needle[j])
+                {
+                    match = false;
+                    break;
+                }
+            }
+
+            if (match)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #2838 symptom 2: passing a `*T` to an imported generic method
+    /// (`Vector256.Load[T](*T)`) must infer <c>T</c>, not the erased
+    /// <c>object</c>. Before the fix the open pointer parameter matched none of
+    /// the unifier's structural forms, so the MethodSpec closed over
+    /// <c>System.Object</c> — emitting <c>Vector256::Load&lt;System.Object&gt;</c>,
+    /// which is not a constructible instantiation and failed verification with
+    /// <c>StackUnexpected</c>. This mirrors the real
+    /// <c>Oahu.Decrypt.Mpeg4.Util.HelperExtensions</c> shape.
+    /// </summary>
+    [Fact]
+    public void GenericPointerArgument_ToImportedGenericMethod_InfersTypeParameter()
+    {
+        var source = """
+            package Probe
+
+            import System
+            import System.Runtime.Intrinsics
+
+            class V {
+                shared {
+                    func AllLessOrEqual[T unmanaged](ints Span[T], comparand Vector256[T]) bool {
+                        unsafe {
+                            var ok = true
+                            fixed p *T = ints {
+                                let v = Vector256.Load(p)
+                                ok = Vector256.LessThanOrEqualAll(v, comparand)
+                            }
+                            return ok
+                        }
+                    }
+                }
+            }
+            """;
+
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2838_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+            CompileOrThrow(srcPath, outPath, "library");
+
+            using var pe = new PEReader(File.OpenRead(outPath));
+            var md = pe.GetMetadataReader();
+
+            var specCount = md.GetTableRowCount(TableIndex.MethodSpec);
+            Assert.True(specCount > 0, "expected at least one MethodSpec for the generic Vector256 calls");
+
+            var sawLoad = false;
+            for (var i = 1; i <= specCount; i++)
+            {
+                var spec = md.GetMethodSpecification(MetadataTokens.MethodSpecificationHandle(i));
+                if (spec.Method.Kind != HandleKind.MemberReference)
+                {
+                    continue;
+                }
+
+                var name = md.GetString(md.GetMemberReference((MemberReferenceHandle)spec.Method).Name);
+                var blob = md.GetBlobBytes(spec.Signature);
+
+                // ECMA-335 II.23.2.15: GENERICINST (0x0A), argument count, then
+                // each argument. `1E 00` is MVAR(0) — the method type parameter.
+                // `1C` is ELEMENT_TYPE_OBJECT, the erasure this test guards.
+                Assert.False(
+                    Array.IndexOf(blob, (byte)0x1C) >= 0,
+                    $"MethodSpec for '{name}' closed over the erased System.Object: {BitConverter.ToString(blob)}");
+
+                if (name == "Load")
+                {
+                    sawLoad = true;
+                    Assert.True(
+                        ContainsSequence(blob, 0x1E, 0x00),
+                        $"Vector256.Load must close over the method type parameter, was {BitConverter.ToString(blob)}");
+                }
+            }
+
+            Assert.True(sawLoad, "no MethodSpec found for Vector256.Load");
+        }
+        finally
+        {
+            TryDeleteDir(tempDir);
+        }
+    }
+
+    private static void CompileOrThrow(string srcPath, string outPath, string target = "exe")
+    {
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+    }
+
+    private static string CompileAndRun(string source, string[] ignoredIlVerifyCodes)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2838_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            CompileOrThrow(srcPath, outPath);
+            IlVerifier.Verify(outPath, null, ignoredIlVerifyCodes);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            TryDeleteDir(tempDir);
+        }
+    }
+
+    private static void TryDeleteDir(string dir)
+    {
+        try
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2838.

## The bug

`fixed p *T = span` inside a generic method over `T : unmanaged` silently miscompiled. Every instantiation scaled pointer arithmetic by **8 bytes**, so `(long)(p + 1) - (long)p` returned `8` for `byte`, `ushort` and `int` alike. No diagnostic, no exception — just wrong answers.

In Oahu this affects `Oahu.Decrypt.Mpeg4.Util.HelperExtensions.AllLessThanOrEqual_256/_512`, corrupting MP4 chunk-size analysis on any machine where `Vector256.IsHardwareAccelerated` is true. Oahu's own tests do not catch it because that guard is false on arm64, so only the scalar fallback runs.

## Root cause

All four defects trace to the same fact: a `TypeParameterSymbol` carries **no `ClrType`**, and several pointer/pin paths silently degraded instead of handling that.

| # | Location | Defect |
|---|---|---|
| 1 | `StatementBinder.Blocks` | `TryGetPinnableReference` resolves through `sourceType.ClrType`, which for `Span[T]` is the erased `Span<object>` — so the pin element bound as `object`, producing `pinned object&` and `*object` locals. |
| 2 | `ExpressionBinder.Operators` | `IsStructPointee` matched neither the struct case nor the value-type case for a type parameter, so it fell through to `StaticPointeeSize`'s `nint.Size` fallback. |
| 3 | `MethodBodyEmitter.Statements` | The `GetPinnableReference` MemberRef was parented at the erased `Span<object>` while the receiver on the stack was `Span<!!T>` → verifier `StackUnexpected`. |
| 4 | `MemberLookup` | Neither `TryProjectErasedClrType` nor `UnifyForMethodTypeArgs` handled pointers, so a `*T` argument to an imported generic method produced no erased CLR type at all, and once resolvable never recovered `T` — emitting the unconstructible `Vector256::Load<System.Object>`. |

Fixes 1 and 2 are each independently necessary: 1 makes the pointee a real `TypeParameterSymbol` instead of erased `object`, and 2 is what routes that type parameter to the runtime `sizeof` opcode.

Defect 4 was surfaced *by* fix 1 — once the pointer became `*!!T`, the missing pointer cases turned the silent miscompile into a hard `GS0159`. Both `MemberLookup` fixes mirror the existing by-ref cases directly above them.

## Verification

`Oahu.Decrypt.Mpeg4.Util.HelperExtensions` now compiles, and its ilverify output **matches csc exactly**:

- Both `StackUnexpected` errors are gone.
- The sole remaining `ExpectedNumericType` (`conv.u` on the pinned `T&`) is emitted **identically by csc** for the same source — confirmed by building the equivalent C# and running ilverify on both.
- All `MethodSpec` rows now close over `!!T`; no `System.Object` remains.

## Tests

`Issue2838GenericPointerStrideEmitTests` (4 tests). The runtime tests **execute** the emitted code and assert strides `1/2/4/8` and offsets `3/6/12/24` — a metadata-only assertion would not have caught a wrong-answer bug. Both `PointeeSizeAsNint` consumers (`p + n` and `p - q`) are covered, plus an IL-shape guard (`sizeof` present, no baked-in 8-byte stride, `GetPinnableReference` parent is a TypeSpec naming `MVAR`) and a MethodSpec-inference guard.

| Suite | Result |
|---|---|
| Core.Tests | 6818 passed, 1 skipped |
| Compiler.Tests | 3577 passed, 0 failed |
| Cs2Gs.Tests | 1814 passed, 0 failed |

## Noted, not fixed (out of scope)

`stackalloc [4]T` under `T : unmanaged` is rejected by `GS0399` ("must be a blittable/unmanaged type"). That is a clean diagnostic rather than a miscompile, lives in the blittable-detection path, and is not exercised by Oahu — worth a separate issue.