### PR TITLE
Fix #2839: unify through metadata-provenance nullable annotations

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -4618,6 +4618,22 @@ internal sealed class MemberLookup
             actual = nullableActual.UnderlyingType;
         }
 
+        // Issue #2839: the very same annotation arrives as a
+        // NullabilityAnnotatedTypeSymbol — not a NullableTypeSymbol — when its
+        // provenance is metadata ([NullableAttribute] on an imported member)
+        // rather than a source `?`. It is a pure annotation wrapper carrying the
+        // imported type's nullable-flag bytes, so structurally it must unify
+        // exactly like the source-annotated case above. Without this unwrap an
+        // imported nullable collection navigation property (for example
+        // `ICollection<Child>?` declared in a referenced assembly) matched none
+        // of the structural patterns below, so the element type was never
+        // recovered and EF Core's collection `ThenInclude` overload was
+        // silently dropped in favour of the scalar one.
+        while (actual is NullabilityAnnotatedTypeSymbol annotatedActual)
+        {
+            actual = annotatedActual.BaseType;
+        }
+
         // T[] / []T (open array element).
         if (openClr.IsArray && openClr.GetArrayRank() == 1)
         {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2839MetadataNullableNavigationThenIncludeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2839MetadataNullableNavigationThenIncludeTests.cs
@@ -1,0 +1,193 @@
+// <copyright file="Issue2839MetadataNullableNavigationThenIncludeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding
+{
+    /// <summary>
+    /// Issue #2839: a nullable collection navigation property must bind the
+    /// collection <c>ThenInclude</c> overload regardless of whether its nullable
+    /// annotation came from source or from metadata. Issue #2523 only covered
+    /// the same-compilation form, so the cross-assembly shape regressed.
+    /// </summary>
+    public sealed class Issue2839MetadataNullableNavigationThenIncludeTests
+    {
+        [Fact]
+        public void MetadataNullableCollectionNavigationBindsThenInclude()
+        {
+            AssertBinds(
+                """
+                import System.Linq
+                import Microsoft.EntityFrameworkCore
+                import GSharp.Core.Tests.CodeAnalysis.Binding.Issue2839Fixtures
+
+                func Build2839(source IQueryable[Entity2839]) IQueryable[Entity2839] ->
+                    source
+                        .Include((entity Entity2839) -> entity.NullableChildren)
+                        .ThenInclude((child Child2839) -> child.Leaf)
+                """);
+        }
+
+        [Fact]
+        public void MetadataNonNullableCollectionNavigationBindsThenInclude()
+        {
+            AssertBinds(
+                """
+                import System.Linq
+                import Microsoft.EntityFrameworkCore
+                import GSharp.Core.Tests.CodeAnalysis.Binding.Issue2839Fixtures
+
+                func Build2839NonNull(source IQueryable[Entity2839]) IQueryable[Entity2839] ->
+                    source
+                        .Include((entity Entity2839) -> entity.Children)
+                        .ThenInclude((child Child2839) -> child.Leaf)
+                """);
+        }
+
+        [Fact]
+        public void SameCompilationNullableCollectionNavigationBindsThenInclude()
+        {
+            AssertBinds(
+                """
+                import System.Collections.Generic
+                import System.Linq
+                import Microsoft.EntityFrameworkCore
+
+                class LocalLeaf2839 {
+                }
+
+                class LocalChild2839 {
+                    prop Leaf LocalLeaf2839? { get; init; }
+                }
+
+                class LocalEntity2839 {
+                    prop NullableChildren ICollection[LocalChild2839]? { get; init; }
+                }
+
+                func BuildLocal2839(source IQueryable[LocalEntity2839]) IQueryable[LocalEntity2839] ->
+                    source
+                        .Include((entity LocalEntity2839) -> entity.NullableChildren)
+                        .ThenInclude((child LocalChild2839) -> child.Leaf)
+                """);
+        }
+
+        [Fact]
+        public void ExplicitlyAnnotatedReceiverBindsThenInclude()
+        {
+            AssertBinds(
+                """
+                import System.Collections.Generic
+                import System.Linq
+                import Microsoft.EntityFrameworkCore
+                import Microsoft.EntityFrameworkCore.Query
+                import GSharp.Core.Tests.CodeAnalysis.Binding.Issue2839Fixtures
+
+                func BuildAnnotated2839(source IQueryable[Entity2839]) IQueryable[Entity2839] {
+                    let included IIncludableQueryable[Entity2839, ICollection[Child2839]?] =
+                        source.Include((entity Entity2839) -> entity.NullableChildren)
+                    return included.ThenInclude((child Child2839) -> child.Leaf)
+                }
+                """);
+        }
+
+        [Fact]
+        public void MetadataNullableInterfaceCollectionNavigationRecoversElementForFurtherChaining()
+        {
+            AssertBinds(
+                """
+                import System.Linq
+                import Microsoft.EntityFrameworkCore
+                import GSharp.Core.Tests.CodeAnalysis.Binding.Issue2839Fixtures
+
+                func BuildChained2839(source IQueryable[Entity2839]) IQueryable[Entity2839] ->
+                    source
+                        .Include((entity Entity2839) -> entity.NullableChildren)
+                        .ThenInclude((child Child2839) -> child.Leaf)
+                        .ThenInclude((leaf Leaf2839) -> leaf.Name)
+                        .Include((entity Entity2839) -> entity.NullableList)
+                        .ThenInclude((child Child2839) -> child.Leaf)
+                """);
+        }
+
+        [Fact]
+        public void OahuBookLibraryShapeBindsIncludeIncludeThenInclude()
+        {
+            // Oahu/src/Oahu.Core/BookLibrary.cs:126 verbatim shape: a scalar
+            // Include, then a collection Include over a metadata-annotated
+            // nullable navigation, then ThenInclude off that collection.
+            AssertBinds(
+                """
+                import System.Linq
+                import Microsoft.EntityFrameworkCore
+                import GSharp.Core.Tests.CodeAnalysis.Binding.Issue2839Fixtures
+
+                func BuildBookLibrary2839(source IQueryable[Entity2839]) IQueryable[Entity2839] ->
+                    source
+                        .Include((entity Entity2839) -> entity.Conversion)
+                        .Include((entity Entity2839) -> entity.NullableChildren)
+                        .ThenInclude((child Child2839) -> child.Leaf)
+                """);
+        }
+
+        private static void AssertBinds(string source)
+        {
+            var paths = TrustedPlatformAssemblies().ToList();
+            paths.Add(typeof(Issue2839Fixtures.Entity2839).Assembly.Location);
+            paths.Add(typeof(Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions).Assembly.Location);
+
+            using var resolver = ReferenceResolver.WithReferences(paths);
+            var tree = SyntaxTree.Parse(SourceText.From(source));
+            var global = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), resolver);
+            var program = Binder.BindProgram(global, resolver);
+            var diagnostics = global.Diagnostics.AddRange(program.Diagnostics);
+            Assert.True(
+                diagnostics.All(diagnostic => !diagnostic.IsError),
+                string.Join(Environment.NewLine, diagnostics));
+        }
+
+        private static IEnumerable<string> TrustedPlatformAssemblies()
+        {
+            var value = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+            return string.IsNullOrWhiteSpace(value)
+                ? Array.Empty<string>()
+                : value.Split(Path.PathSeparator).Where(File.Exists);
+        }
+    }
+}
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding.Issue2839Fixtures
+{
+    public sealed class Leaf2839
+    {
+        public string? Name { get; set; }
+    }
+
+    public sealed class Child2839
+    {
+        public Leaf2839? Leaf { get; set; }
+    }
+
+    public sealed class Entity2839
+    {
+        public Leaf2839? Conversion { get; set; }
+
+        public ICollection<Child2839>? NullableChildren { get; } = new List<Child2839>();
+
+        public ICollection<Child2839> Children { get; } = new List<Child2839>();
+
+        public List<Child2839>? NullableList { get; } = new List<Child2839>();
+    }
+}


### PR DESCRIPTION
Closes #2839.

## Problem

`ThenInclude` failed to bind when the preceding `Include` selector returned a nullable collection navigation property **imported from a referenced assembly**. The identical declaration in the *same* compilation bound fine.

```
BookLibrary.gs(84,125): error GS0159: Cannot find function ThenInclude.
BookLibrary.gs(84,140): error GS0155: Cannot convert type
  'System.Collections.Generic.ICollection`1[[Oahu.BooksDatabase.Component, Oahu.Data, ...]]?'
  to 'Oahu.BooksDatabase.Component'.
```

Highest blast radius of Oahu migration cycle 18: 2 source sites blocked 9 of 15 projects.

## Root cause

Reference nullability has **two** symbol representations in gsc:

| Provenance | Symbol |
| --- | --- |
| Source-written `?` | `NullableTypeSymbol` |
| `[NullableAttribute]` read from metadata | `NullabilityAnnotatedTypeSymbol` |

`MemberLookup.UnifyForMethodTypeArgs` stripped **only the former** before structural matching. Unifying the open `IEnumerable<TPreviousProperty>` against an actual `ICollection<Child>?` therefore fell through every structural pattern (A/B/C) and left `TPreviousProperty` unresolved — confirmed by tracing:

```
[SYMTGT] SKIP ... ThenInclude(IIncludableQueryable<TEntity, IEnumerable<TPreviousProperty>>, ...)
         usable=False inferred=[R3.Data.Parent, <null>, <null>]
[SYMTGT] KEEP ... ThenInclude(IIncludableQueryable<TEntity, TPreviousProperty>, ...)
         inferred=[R3.Data.Parent, ICollection`1[Child]?, <null>]
[UNIFY-C] open=IEnumerable`1[TPreviousProperty]
          actual=ICollection`1[[R3.Data.Child, ...]] (NullabilityAnnotatedTypeSymbol) NO projection
```

This silently dropped EF Core's **collection** `ThenInclude` overload from `TryMapDeferredLambdaTargetsSymbolic`. With only the scalar overload surviving, the lambda was hard-bound against `TPreviousProperty = ICollection<Child>?`, and the explicit `(c Child)` parameter then failed the issue #2810 *"an explicit lambda parameter type is a contract, not a hint"* check. The lambda became a `BoundErrorExpression`, which in turn aborted `TryBindImportedExtensionCall` before overload resolution ever ran — hence the confusing pair of diagnostics.

This is exactly why the reported type looked identical in both the working and failing cases: the *nominal* type is the same, only the internal representation differs.

## Fix

One unwrap in `UnifyForMethodTypeArgs`, immediately after the existing `NullableTypeSymbol` strip and after the direct-MVar branch (so nullability evidence is still preserved for a direct type-parameter match, matching the existing contract).

Both overloads now recover a type argument, disagree, and `TryMapDeferredLambdaTargetsSymbolic` returns `false` — deferring to the CLR-driven path **exactly as it already does for the non-nullable metadata case**. The fix restores symmetry rather than adding a new special case.

Unwrapping `NullabilityAnnotatedTypeSymbol` to `.BaseType` for structural purposes is the established convention (`Conversion.cs:117-122`, `ConversionClassifier.cs:2059`, `ExternalClrOverrideResolver.cs:324`, `MemberLookup.cs:2099`).

## Why #2523 did not cover this

#2523 fixed the same symptom only for the **same-compilation** form. Its regression fixture declares the entity in G# source, so the annotation always arrived as a `NullableTypeSymbol` and the metadata path was never exercised.

## Regression coverage

New `test/Core.Tests/CodeAnalysis/Binding/Issue2839MetadataNullableNavigationThenIncludeTests.cs` — deliberately **two-assembly** (C# metadata fixtures compiled into the test assembly + real EF Core), per the issue's suggested coverage:

| Test | Role |
| --- | --- |
| `MetadataNullableCollectionNavigationBindsThenInclude` | the defect |
| `MetadataNullableInterfaceCollectionNavigationRecoversElementForFurtherChaining` | chained `Include`/`ThenInclude`, incl. `List[T]?` |
| `OahuBookLibraryShapeBindsIncludeIncludeThenInclude` | verbatim `Oahu/src/Oahu.Core/BookLibrary.cs:126` shape |
| `MetadataNonNullableCollectionNavigationBindsThenInclude` | control |
| `SameCompilationNullableCollectionNavigationBindsThenInclude` | control (the #2523 row) |
| `ExplicitlyAnnotatedReceiverBindsThenInclude` | control |

**Non-vacuous:** with the fix reverted, exactly the 3 defect tests fail and the 3 controls pass.

## Validation

| Suite | Result |
| --- | --- |
| Core.Tests | 6824 passed / 1 skipped (+6 new) |
| Compiler.Tests | 3573 passed / 0 failed |
| Cs2Gs.Tests | 1837 passed / 0 failed |

Also verified end-to-end on the original cross-assembly `gsc` repro (`oahu-mig-c18/repro4`): `mini.gs`, `probe2.gs`, `direct.gs`, `direct_null.gs` all compile.

Copilot-Session: c4b0096d-f45e-4060-9b99-3948fd470f89
