### PR TITLE
Fix #2823: canonicalize conditional index nullability

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -757,7 +757,15 @@ namespace Demo
 {
     public class Provider
     {
+        public string[]? Items { get; set; }
         public string[]? MaybeItems() => null;
+
+        public string[]? this[int index] => null;
+    }
+
+    public readonly struct ValueProvider
+    {
+        public string[] this[int index] => System.Array.Empty<string>();
     }
 
     public class MetadataItems
@@ -767,12 +775,59 @@ namespace Demo
 
         public string? FirstAuthor => Artist?.Split(';')?[0];
         public string? MaybeFirst => Provider?.MaybeItems()?[0];
+        public string? MaybeMember(Provider? p) => p?.Items?[0];
+        public string? MaybeIndexer(Provider? p) => p?[0]?[0];
+        public string? ValueIndexer(ValueProvider? p) => p?[0]?[0];
+
+        public string? FlowNarrowedMember(Provider p)
+        {
+            if (p.Items is null)
+            {
+                return null;
+            }
+
+            return p?.Items?[0];
+        }
     }
 }");
 
         Assert.Contains("Artist?.Split(';')[0]", printed);
         Assert.DoesNotContain("Artist?.Split(';')?[0]", printed);
         Assert.Contains("Provider?.MaybeItems()?[0]", printed);
+        Assert.Contains("p?.Items?[0]", printed);
+        Assert.Contains("p?[0]?[0]", printed);
+        Assert.Contains("p?[0][0]", printed);
+        Assert.Contains("return p?.Items?[0]", printed);
+        AssertGscCompiles(printed, "GS0300");
+    }
+
+    [Fact]
+    public void NullConditionalIndex_RetainsSafeIndexForPromotedMemberBindings()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Provider
+    {
+        public string[] FieldItems = System.Array.Empty<string>();
+        public string[] PropertyItems { get; set; } = System.Array.Empty<string>();
+
+        public void Clear()
+        {
+            FieldItems = null;
+            PropertyItems = null;
+        }
+    }
+
+    public class C
+    {
+        public string Field(Provider p) => p?.FieldItems?[0];
+        public string Property(Provider p) => p?.PropertyItems?[0];
+    }
+}");
+
+        Assert.Contains("p?.FieldItems?[0]", printed);
+        Assert.Contains("p?.PropertyItems?[0]", printed);
         AssertGscCompiles(printed, "GS0300");
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -796,7 +796,7 @@ namespace Demo
         Assert.Contains("Provider?.MaybeItems()?[0]", printed);
         Assert.Contains("p?.Items?[0]", printed);
         Assert.Contains("p?[0]?[0]", printed);
-        Assert.Contains("p?[0][0]", printed);
+        Assert.Contains("p?[0]!![0]", printed);
         Assert.Contains("return p?.Items?[0]", printed);
         AssertGscCompiles(printed, "GS0300");
     }

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -770,8 +770,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("Artist?.Split(\";\")[0]", printed);
-        Assert.DoesNotContain("Artist?.Split(\";\")?[0]", printed);
+        Assert.Contains("Artist?.Split(';')[0]", printed);
+        Assert.DoesNotContain("Artist?.Split(';')?[0]", printed);
         Assert.Contains("Provider?.MaybeItems()?[0]", printed);
         AssertGscCompiles(printed, "GS0300");
     }

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -770,8 +770,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("Artist?.Split(';')[0]", printed);
-        Assert.DoesNotContain("Artist?.Split(';')?[0]", printed);
+        Assert.Contains("Artist?.Split(\";\")[0]", printed);
+        Assert.DoesNotContain("Artist?.Split(\";\")?[0]", printed);
         Assert.Contains("Provider?.MaybeItems()?[0]", printed);
         AssertGscCompiles(printed, "GS0300");
     }

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -796,6 +796,7 @@ namespace Demo
         Assert.Contains("Provider?.MaybeItems()?[0]", printed);
         Assert.Contains("p?.Items?[0]", printed);
         Assert.Contains("p?[0]?[0]", printed);
+        Assert.Contains("p?[0]!![0]", printed);
         Assert.Contains("return p?.Items?[0]", printed);
         AssertGscCompiles(printed, "GS0300");
     }

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -796,7 +796,6 @@ namespace Demo
         Assert.Contains("Provider?.MaybeItems()?[0]", printed);
         Assert.Contains("p?.Items?[0]", printed);
         Assert.Contains("p?[0]?[0]", printed);
-        Assert.Contains("p?[0]!![0]", printed);
         Assert.Contains("return p?.Items?[0]", printed);
         AssertGscCompiles(printed, "GS0300");
     }

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -765,11 +765,6 @@ namespace Demo
         public string[]? this[int index] => null;
     }
 
-    public class NonNullableProvider
-    {
-        public string[] this[int index] => System.Array.Empty<string>();
-    }
-
     public readonly struct ValueProvider
     {
         public string[] this[int index] => System.Array.Empty<string>();
@@ -784,8 +779,6 @@ namespace Demo
         public string? MaybeFirst => Provider?.MaybeItems()?[0];
         public string? MaybeMember(Provider? p) => p?.Items?[0];
         public string? MaybeIndexer(Provider? p) => p?[0]?[0];
-        public string? ClassIndexer(NonNullableProvider? p) => p?[1]?[2];
-        public string? ValueIndexer(ValueProvider? p) => p?[3]?[4];
         public string[]? NullableValueProperty(Provider? p) => p?.MaybeValue?[5];
         public string[]? NullableValueMethod(Provider? p) => p?.MaybeValueResult()?[6];
 
@@ -806,11 +799,40 @@ namespace Demo
         Assert.Contains("Provider?.MaybeItems()?[0]", printed);
         Assert.Contains("p?.Items?[0]", printed);
         Assert.Contains("p?[0]?[0]", printed);
-        Assert.Contains("p?[1]!![2]", printed);
-        Assert.Contains("p?[3]!![4]", printed);
         Assert.Contains("p?.MaybeValue?[5]", printed);
         Assert.Contains("p?.MaybeValueResult()?[6]", printed);
         Assert.Contains("return p?.Items?[0]", printed);
+        AssertGscCompiles(printed, "GS0300");
+    }
+
+    [Fact]
+    public void NullConditionalIndex_PreservesLiftedReceiverNullPropagation()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class ClassProvider
+    {
+        public string[] Items => System.Array.Empty<string>();
+        public string[] this[int index] => System.Array.Empty<string>();
+    }
+
+    public readonly struct ValueProvider
+    {
+        public string[] this[int index] => System.Array.Empty<string>();
+    }
+
+    public class C
+    {
+        public string? ClassReceiver(ClassProvider? p) => p?[1]?[2];
+        public string? ValueReceiver(ValueProvider? p) => p?[3]?[4];
+    }
+}");
+
+        Assert.Contains("p?[1]?[2]", printed);
+        Assert.Contains("p?[3]?[4]", printed);
+        Assert.DoesNotContain("!!", printed);
         AssertGscCompiles(printed, "GS0300");
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -743,6 +743,40 @@ namespace Demo
     }
 
     /// <summary>
+    /// Oahu.Decrypt's <c>Artist?.Split(';')?[0]</c> uses a second safe index
+    /// even though <c>String.Split</c> returns a non-null array. Keep null
+    /// propagation from <c>Artist</c>, but render the dependent index as ordinary
+    /// <c>[0]</c>; a genuinely nullable chain result must retain <c>?[0]</c>.
+    /// </summary>
+    [Fact]
+    public void NullConditionalIndex_UsesImmediateChainResultNullability()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Provider
+    {
+        public string[]? MaybeItems() => null;
+    }
+
+    public class MetadataItems
+    {
+        public string? Artist { get; set; }
+        public Provider? Provider { get; set; }
+
+        public string? FirstAuthor => Artist?.Split(';')?[0];
+        public string? MaybeFirst => Provider?.MaybeItems()?[0];
+    }
+}");
+
+        Assert.Contains("Artist?.Split(';')[0]", printed);
+        Assert.DoesNotContain("Artist?.Split(';')?[0]", printed);
+        Assert.Contains("Provider?.MaybeItems()?[0]", printed);
+        AssertGscCompiles(printed, "GS0300");
+    }
+
+    /// <summary>
     /// A tuple literal element is a value position: a declared-nullable
     /// (<c>T?</c>) operand flow-proven non-null by a preceding guard must be
     /// emitted with the G# non-null assertion (<c>x!!</c>), because G# does not
@@ -792,7 +826,7 @@ namespace Demo
         return printed;
     }
 
-    private static void AssertGscCompiles(string source)
+    private static void AssertGscCompiles(string source, params string[] forbiddenDiagnostics)
     {
         string compiler =
             GscInvoker.Resolve(null, "Release", AppContext.BaseDirectory) ??
@@ -817,6 +851,10 @@ namespace Demo
                 Array.Empty<string>());
 
             Assert.True(result.Succeeded, result.Output);
+            foreach (string diagnostic in forbiddenDiagnostics)
+            {
+                Assert.DoesNotContain(diagnostic, result.Output);
+            }
         }
         finally
         {

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -759,8 +759,15 @@ namespace Demo
     {
         public string[]? Items { get; set; }
         public string[]? MaybeItems() => null;
+        public ValueProvider? MaybeValue { get; set; }
+        public ValueProvider? MaybeValueResult() => null;
 
         public string[]? this[int index] => null;
+    }
+
+    public class NonNullableProvider
+    {
+        public string[] this[int index] => System.Array.Empty<string>();
     }
 
     public readonly struct ValueProvider
@@ -777,7 +784,10 @@ namespace Demo
         public string? MaybeFirst => Provider?.MaybeItems()?[0];
         public string? MaybeMember(Provider? p) => p?.Items?[0];
         public string? MaybeIndexer(Provider? p) => p?[0]?[0];
-        public string? ValueIndexer(ValueProvider? p) => p?[0]?[0];
+        public string? ClassIndexer(NonNullableProvider? p) => p?[1]?[2];
+        public string? ValueIndexer(ValueProvider? p) => p?[3]?[4];
+        public string[]? NullableValueProperty(Provider? p) => p?.MaybeValue?[5];
+        public string[]? NullableValueMethod(Provider? p) => p?.MaybeValueResult()?[6];
 
         public string? FlowNarrowedMember(Provider p)
         {
@@ -796,7 +806,10 @@ namespace Demo
         Assert.Contains("Provider?.MaybeItems()?[0]", printed);
         Assert.Contains("p?.Items?[0]", printed);
         Assert.Contains("p?[0]?[0]", printed);
-        Assert.Contains("p?[0]!![0]", printed);
+        Assert.Contains("p?[1]!![2]", printed);
+        Assert.Contains("p?[3]!![4]", printed);
+        Assert.Contains("p?.MaybeValue?[5]", printed);
+        Assert.Contains("p?.MaybeValueResult()?[6]", printed);
         Assert.Contains("return p?.Items?[0]", printed);
         AssertGscCompiles(printed, "GS0300");
     }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -252,6 +252,17 @@ public sealed partial class CSharpToGSharpTranslator
                         return delegateInvokeResult;
                     }
 
+                    if (conditionalAccess.Expression is ConditionalAccessExpressionSyntax previousAccess
+                        && FindLeadingElementBinding(conditionalAccess.WhenNotNull)
+                            is ElementBindingExpressionSyntax elementBinding
+                        && !this.ConditionalAccessResultIsNullable(previousAccess))
+                    {
+                        return this.TranslateNonNullableConditionalIndex(
+                            conditionalAccess.WhenNotNull,
+                            elementBinding,
+                            this.TranslateExpression(previousAccess));
+                    }
+
                     return new ConditionalAccessExpression(
                         this.TranslateExpression(conditionalAccess.Expression),
                         this.TranslateExpression(conditionalAccess.WhenNotNull));
@@ -290,7 +301,14 @@ public sealed partial class CSharpToGSharpTranslator
                         ? this.TranslateIndexArgumentWithNullForgiveness(
                             elementBinding.ArgumentList.Arguments[0])
                         : new IdentifierExpression("nil");
-                    return new IndexExpression(new ConditionalReceiverExpression(), bindingIndex);
+                    GExpression bindingReceiver =
+                        this.state.ConditionalElementReceivers.TryGetValue(
+                            elementBinding,
+                            out GExpression elementReceiver)
+                                ? elementReceiver
+                                : this.state.ConditionalReceiverReplacement ??
+                                    new ConditionalReceiverExpression();
+                    return new IndexExpression(bindingReceiver, bindingIndex);
 
                 case TypeOfExpressionSyntax typeOf:
                     return new TypeOfExpression(this.MapTypeOfOperand(typeOf.Type));
@@ -426,6 +444,46 @@ public sealed partial class CSharpToGSharpTranslator
                         $"expression '{expression.Kind()}' has no canonical G# form yet; emitted an identifier placeholder (ADR-0115 §B).");
                     return new IdentifierExpression("nil");
             }
+        }
+
+        private static ElementBindingExpressionSyntax FindLeadingElementBinding(
+            ExpressionSyntax expression) =>
+            expression switch
+            {
+                ElementBindingExpressionSyntax elementBinding => elementBinding,
+                ParenthesizedExpressionSyntax parenthesized =>
+                    FindLeadingElementBinding(parenthesized.Expression),
+                InvocationExpressionSyntax invocation =>
+                    FindLeadingElementBinding(invocation.Expression),
+                MemberAccessExpressionSyntax memberAccess =>
+                    FindLeadingElementBinding(memberAccess.Expression),
+                ElementAccessExpressionSyntax elementAccess =>
+                    FindLeadingElementBinding(elementAccess.Expression),
+                _ => null,
+            };
+
+        private GExpression TranslateNonNullableConditionalIndex(
+            ExpressionSyntax continuation,
+            ElementBindingExpressionSyntax elementBinding,
+            GExpression receiver)
+        {
+            this.state.ConditionalElementReceivers.Add(elementBinding, receiver);
+            try
+            {
+                return this.TranslateExpression(continuation);
+            }
+            finally
+            {
+                this.state.ConditionalElementReceivers.Remove(elementBinding);
+            }
+        }
+
+        private bool ConditionalAccessResultIsNullable(
+            ConditionalAccessExpressionSyntax conditionalAccess)
+        {
+            ExpressionSyntax result = conditionalAccess.WhenNotNull;
+            return this.NullableReferenceValueMayBeNull(result)
+                || this.ReceiverValueIsPromotedNullable(result);
         }
 
         // A constant pattern whose expression is actually a bare/qualified TYPE

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -252,15 +252,15 @@ public sealed partial class CSharpToGSharpTranslator
                         return delegateInvokeResult;
                     }
 
-                    if (conditionalAccess.Expression is ConditionalAccessExpressionSyntax previousAccess
+                    if (DependsOnEnclosingConditionalReceiver(conditionalAccess.Expression)
                         && FindLeadingElementBinding(conditionalAccess.WhenNotNull)
                             is ElementBindingExpressionSyntax conditionalIndexBinding
-                        && !this.ConditionalAccessResultIsNullable(previousAccess))
+                        && !this.ConditionalIndexReceiverIsNullable(conditionalAccess.Expression))
                     {
                         return this.TranslateNonNullableConditionalIndex(
                             conditionalAccess.WhenNotNull,
                             conditionalIndexBinding,
-                            this.TranslateExpression(previousAccess));
+                            this.TranslateExpression(conditionalAccess.Expression));
                     }
 
                     return new ConditionalAccessExpression(
@@ -478,13 +478,9 @@ public sealed partial class CSharpToGSharpTranslator
             }
         }
 
-        private bool ConditionalAccessResultIsNullable(
-            ConditionalAccessExpressionSyntax conditionalAccess)
-        {
-            ExpressionSyntax result = conditionalAccess.WhenNotNull;
-            return this.NullableReferenceValueMayBeNull(result)
-                || this.ReceiverValueIsPromotedNullable(result);
-        }
+        private bool ConditionalIndexReceiverIsNullable(ExpressionSyntax receiver) =>
+            this.NullableReferenceValueMayBeNull(receiver)
+                || this.ReceiverValueIsPromotedNullable(receiver);
 
         // A constant pattern whose expression is actually a bare/qualified TYPE
         // reference (Roslyn parses `is T`/`not T` after a pattern combinator as a

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -254,12 +254,12 @@ public sealed partial class CSharpToGSharpTranslator
 
                     if (conditionalAccess.Expression is ConditionalAccessExpressionSyntax previousAccess
                         && FindLeadingElementBinding(conditionalAccess.WhenNotNull)
-                            is ElementBindingExpressionSyntax elementBinding
+                            is ElementBindingExpressionSyntax conditionalIndexBinding
                         && !this.ConditionalAccessResultIsNullable(previousAccess))
                     {
                         return this.TranslateNonNullableConditionalIndex(
                             conditionalAccess.WhenNotNull,
-                            elementBinding,
+                            conditionalIndexBinding,
                             this.TranslateExpression(previousAccess));
                     }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -490,9 +490,7 @@ public sealed partial class CSharpToGSharpTranslator
         {
             GExpression translated = this.TranslateExpression(receiver);
             return this.context.GetTypeInfo(receiver).Type is INamedTypeSymbol
-                {
-                    OriginalDefinition.SpecialType: SpecialType.System_Nullable_T,
-                }
+                { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T }
                     ? new NonNullAssertionExpression(translated)
                     : translated;
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -489,8 +489,14 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression TranslateConditionalIndexReceiver(ExpressionSyntax receiver)
         {
             GExpression translated = this.TranslateExpression(receiver);
-            return this.context.GetTypeInfo(receiver).Type is INamedTypeSymbol
-                { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T }
+            while (receiver is ParenthesizedExpressionSyntax parenthesized)
+            {
+                receiver = parenthesized.Expression;
+            }
+
+            return receiver is ConditionalAccessExpressionSyntax conditionalAccess
+                && this.context.GetTypeInfo(conditionalAccess.Expression).Type is INamedTypeSymbol
+                    { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T }
                     ? new NonNullAssertionExpression(translated)
                     : translated;
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -260,7 +260,7 @@ public sealed partial class CSharpToGSharpTranslator
                         return this.TranslateNonNullableConditionalIndex(
                             conditionalAccess.WhenNotNull,
                             conditionalIndexBinding,
-                            this.TranslateConditionalIndexReceiver(conditionalAccess.Expression));
+                            this.TranslateExpression(conditionalAccess.Expression));
                     }
 
                     return new ConditionalAccessExpression(
@@ -483,19 +483,12 @@ public sealed partial class CSharpToGSharpTranslator
             ExpressionSyntax result = FindConditionalAccessResult(receiver);
             TypeInfo resultTypeInfo = this.context.GetTypeInfo(result);
             ITypeSymbol resultType = resultTypeInfo.Type ?? resultTypeInfo.ConvertedType;
-            return resultType is INamedTypeSymbol
+            return FindLeadingElementBinding(receiver) != null
+                || resultType is INamedTypeSymbol
                     { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T }
                 || this.NullableReferenceValueMayBeNull(result)
                 || this.ReceiverValueIsPromotedNullable(result)
                 || this.ReceiverIsNullableReferenceFieldOrProperty(result);
-        }
-
-        private GExpression TranslateConditionalIndexReceiver(ExpressionSyntax receiver)
-        {
-            GExpression translated = this.TranslateExpression(receiver);
-            return FindLeadingElementBinding(receiver) != null
-                    ? new NonNullAssertionExpression(translated)
-                    : translated;
         }
 
         private static ExpressionSyntax FindConditionalAccessResult(ExpressionSyntax expression) =>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -260,7 +260,7 @@ public sealed partial class CSharpToGSharpTranslator
                         return this.TranslateNonNullableConditionalIndex(
                             conditionalAccess.WhenNotNull,
                             conditionalIndexBinding,
-                            this.TranslateReceiverWithNullForgiveness(conditionalAccess.Expression));
+                            this.TranslateConditionalIndexReceiver(conditionalAccess.Expression));
                     }
 
                     return new ConditionalAccessExpression(
@@ -484,6 +484,17 @@ public sealed partial class CSharpToGSharpTranslator
             return this.NullableReferenceValueMayBeNull(result)
                 || this.ReceiverValueIsPromotedNullable(result)
                 || this.ReceiverIsNullableReferenceFieldOrProperty(result);
+        }
+
+        private GExpression TranslateConditionalIndexReceiver(ExpressionSyntax receiver)
+        {
+            GExpression translated = this.TranslateExpression(receiver);
+            return this.context.GetTypeInfo(receiver).Type is INamedTypeSymbol
+                {
+                    OriginalDefinition.SpecialType: SpecialType.System_Nullable_T,
+                }
+                    ? new NonNullAssertionExpression(translated)
+                    : translated;
         }
 
         private static ExpressionSyntax FindConditionalAccessResult(ExpressionSyntax expression) =>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -260,7 +260,7 @@ public sealed partial class CSharpToGSharpTranslator
                         return this.TranslateNonNullableConditionalIndex(
                             conditionalAccess.WhenNotNull,
                             conditionalIndexBinding,
-                            this.TranslateExpression(conditionalAccess.Expression));
+                            this.TranslateReceiverWithNullForgiveness(conditionalAccess.Expression));
                     }
 
                     return new ConditionalAccessExpression(
@@ -478,9 +478,23 @@ public sealed partial class CSharpToGSharpTranslator
             }
         }
 
-        private bool ConditionalIndexReceiverIsNullable(ExpressionSyntax receiver) =>
-            this.NullableReferenceValueMayBeNull(receiver)
-                || this.ReceiverValueIsPromotedNullable(receiver);
+        private bool ConditionalIndexReceiverIsNullable(ExpressionSyntax receiver)
+        {
+            ExpressionSyntax result = FindConditionalAccessResult(receiver);
+            return this.NullableReferenceValueMayBeNull(result)
+                || this.ReceiverValueIsPromotedNullable(result)
+                || this.ReceiverIsNullableReferenceFieldOrProperty(result);
+        }
+
+        private static ExpressionSyntax FindConditionalAccessResult(ExpressionSyntax expression) =>
+            expression switch
+            {
+                ParenthesizedExpressionSyntax parenthesized =>
+                    FindConditionalAccessResult(parenthesized.Expression),
+                ConditionalAccessExpressionSyntax conditionalAccess =>
+                    FindConditionalAccessResult(conditionalAccess.WhenNotNull),
+                _ => expression,
+            };
 
         // A constant pattern whose expression is actually a bare/qualified TYPE
         // reference (Roslyn parses `is T`/`not T` after a pattern combinator as a

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -494,8 +494,11 @@ public sealed partial class CSharpToGSharpTranslator
                 receiver = parenthesized.Expression;
             }
 
-            return receiver is ConditionalAccessExpressionSyntax conditionalAccess
-                && this.context.GetTypeInfo(conditionalAccess.Expression).Type is INamedTypeSymbol
+            ConditionalAccessExpressionSyntax enclosingAccess = receiver.Ancestors()
+                .OfType<ConditionalAccessExpressionSyntax>()
+                .FirstOrDefault(access => access.WhenNotNull.DescendantNodesAndSelf().Contains(receiver));
+            return enclosingAccess != null
+                && this.context.GetTypeInfo(enclosingAccess.Expression).Type is INamedTypeSymbol
                     { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T }
                     ? new NonNullAssertionExpression(translated)
                     : translated;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -481,7 +481,11 @@ public sealed partial class CSharpToGSharpTranslator
         private bool ConditionalIndexReceiverIsNullable(ExpressionSyntax receiver)
         {
             ExpressionSyntax result = FindConditionalAccessResult(receiver);
-            return this.NullableReferenceValueMayBeNull(result)
+            TypeInfo resultTypeInfo = this.context.GetTypeInfo(result);
+            ITypeSymbol resultType = resultTypeInfo.Type ?? resultTypeInfo.ConvertedType;
+            return resultType is INamedTypeSymbol
+                    { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T }
+                || this.NullableReferenceValueMayBeNull(result)
                 || this.ReceiverValueIsPromotedNullable(result)
                 || this.ReceiverIsNullableReferenceFieldOrProperty(result);
         }
@@ -489,17 +493,7 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression TranslateConditionalIndexReceiver(ExpressionSyntax receiver)
         {
             GExpression translated = this.TranslateExpression(receiver);
-            while (receiver is ParenthesizedExpressionSyntax parenthesized)
-            {
-                receiver = parenthesized.Expression;
-            }
-
-            ConditionalAccessExpressionSyntax enclosingAccess = receiver.Ancestors()
-                .OfType<ConditionalAccessExpressionSyntax>()
-                .FirstOrDefault(access => access.WhenNotNull.DescendantNodesAndSelf().Contains(receiver));
-            return enclosingAccess != null
-                && this.context.GetTypeInfo(enclosingAccess.Expression).Type is INamedTypeSymbol
-                    { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T }
+            return FindLeadingElementBinding(receiver) != null
                     ? new NonNullAssertionExpression(translated)
                     : translated;
         }

--- a/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/DocumentTranslationState.cs
@@ -185,6 +185,13 @@ internal sealed class DocumentTranslationState
     // extension-property rewrites to the rest of the chain.
     public GExpression ConditionalReceiverReplacement { get; set; }
 
+    // Issue #2823: a redundant `?[i]` after an earlier conditional-access
+    // segment whose own result is non-nullable becomes an ordinary dependent
+    // `[i]`. Keying the replacement by the exact element binding prevents a
+    // nested conditional access in the continuation from borrowing its receiver.
+    public Dictionary<ElementBindingExpressionSyntax, GExpression> ConditionalElementReceivers { get; } =
+        new Dictionary<ElementBindingExpressionSyntax, GExpression>();
+
     // Issue #1902: numbers the `__qN` tuple parameter synthesized to carry a
     // query's transparent identifier (multiple in-scope range variables)
     // through a lambda that C#'s query-translation spec (§12.19.3) would bind


### PR DESCRIPTION
## Summary
- trace nullability from each preceding conditional-access result
- lower redundant dependent `?[...]` to ordinary `[...]` without changing earlier null propagation
- preserve safe indexing when chain result is genuinely nullable
- add Oahu.Decrypt regression and GS0300 validation

## Validation
- `git diff --check`
- direct `gsc` validation: `Artist?.Split(';')[0]` compiles clean; redundant `?[0]` reproduces GS0300
- local .NET test execution skipped per request; PR CI validates test suite

Closes #2823
