### PR TITLE
Fix lambda conversion to a nullable named delegate target (#2841)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -1483,6 +1483,20 @@ public sealed class Conversion
             return true;
         }
 
+        // Issue #2841: a user-declared named delegate (ADR-0059 / issue #255) is
+        // emitted as a sealed class deriving from `System.MulticastDelegate`, so
+        // it is unconditionally a reference type. Like `StructSymbol`/
+        // `InterfaceSymbol` above it carries NO `ClrType` at bind time (its
+        // TypeDef only exists after emit), so the CLR-backing fallback below
+        // cannot recognise it. Without this arm the `T -> U?` reference-wrap arm
+        // (issue #1121) never ran for a `D?` target, and every delegate
+        // conversion path downstream tested the still-wrapped
+        // `NullableTypeSymbol`, so a lambda bound fine against `D` but not `D?`.
+        if (type is DelegateTypeSymbol)
+        {
+            return true;
+        }
+
         // Issue #2188: a reference-constrained type parameter (`[T class …]`,
         // i.e. `HasReferenceTypeConstraint`, or a class-base constraint such as
         // `[T Box]`) is PROVABLY a reference type. It therefore participates in

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -77,8 +77,17 @@ internal sealed partial class MethodBodyEmitter
         // `ldnull/ldftn/newobj` (or closure `dup/ldftn/newobj`) sequence
         // but referencing the delegate's emitted ctor MethodDef handle
         // instead of a CLR ConstructorInfo.
+        //
+        // Issue #2841: a `D?` target reaches here too. A nullable wrapper over
+        // a REFERENCE type is a binder-level annotation that erases to the
+        // underlying type's CLR representation, and a named delegate is always
+        // a reference type (a sealed class deriving from
+        // `System.MulticastDelegate`), so the materialisation is byte-identical
+        // to the bare-`D` case.
+        var namedTargetDelegate = conv.Type as DelegateTypeSymbol
+            ?? (conv.Type as NullableTypeSymbol)?.UnderlyingType as DelegateTypeSymbol;
         if (conv.Expression.Type is FunctionTypeSymbol namedSourceFn
-            && conv.Type is DelegateTypeSymbol namedTargetDelegate)
+            && namedTargetDelegate != null)
         {
             this.EmitFunctionToNamedDelegateConversion(conv.Expression, namedSourceFn, namedTargetDelegate);
             return;

--- a/test/Compiler.Tests/Emit/Issue2841NullableNamedDelegateTargetEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2841NullableNamedDelegateTargetEmitTests.cs
@@ -1,0 +1,382 @@
+// <copyright file="Issue2841NullableNamedDelegateTargetEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2841 — a lambda converted to a named delegate <c>D</c> but not to
+/// <c>D?</c>.
+/// <para>
+/// Root cause: <c>Conversion.IsReferenceLikeTarget</c> had no
+/// <see cref="GSharp.Core.CodeAnalysis.Symbols.DelegateTypeSymbol"/> case, and a
+/// source-declared named delegate carries no <c>ClrType</c> at bind time, so the
+/// trailing <c>ClrType</c> fallback could not recognise it either. The
+/// <c>T -&gt; U?</c> arm of nullable classification (issue #1121) is gated on
+/// that predicate, so it never ran and every delegate-conversion arm below it
+/// tested the still-wrapped <c>NullableTypeSymbol</c> target and failed.
+/// </para>
+/// Each fact uses a UNIQUE package name because the in-process type caches are
+/// name-keyed.
+/// </summary>
+public class Issue2841NullableNamedDelegateTargetEmitTests
+{
+    [Fact]
+    public void EndToEnd_LambdaAssignedToNullableNamedDelegateLocal_Runs()
+    {
+        // The exact issue #2841 shape: `var h D? = nil` then `h = lambda`.
+        const string source = """
+            package i2841assign
+            import System
+
+            type PlainDel = delegate func(x int32, cb (string) -> void) void
+
+            func Main() {
+                var h PlainDel? = nil
+                h = (x int32, cb (string) -> void) -> { cb("a" + System.Convert.ToString(x)) }
+                if h != nil {
+                    h(1, (s string) -> System.Console.WriteLine(s))
+                }
+            }
+            """;
+
+        Assert.Equal("a1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_LambdaInitializesNullableNamedDelegateLocal_Runs()
+    {
+        // The second failing row of the issue's truth table: `let h D? = lambda`.
+        const string source = """
+            package i2841init
+            import System
+
+            type PlainDel = delegate func(x int32, cb (string) -> void) void
+
+            func Main() {
+                let h PlainDel? = (x int32, cb (string) -> void) -> { cb("b" + System.Convert.ToString(x)) }
+                if h != nil {
+                    h(2, (s string) -> System.Console.WriteLine(s))
+                }
+            }
+            """;
+
+        Assert.Equal("b2\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_LambdaPassedToNullableNamedDelegateParameter_Runs()
+    {
+        // Argument position — the shape Oahu actually hits (`job.Do(ctx, action)`
+        // where the parameter is declared `Conv?`).
+        const string source = """
+            package i2841param
+            import System
+
+            type PlainDel = delegate func(x int32) void
+
+            func Apply(h PlainDel?) {
+                if h != nil {
+                    h(5)
+                }
+            }
+
+            func Main() {
+                Apply((x int32) -> System.Console.WriteLine(x * 10))
+                Apply(nil)
+                System.Console.WriteLine("done")
+            }
+            """;
+
+        Assert.Equal("50\ndone\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_LambdaAssignedToNullableNamedDelegateProperty_Runs()
+    {
+        const string source = """
+            package i2841prop
+            import System
+
+            type PlainDel = delegate func(x int32) void
+
+            class C {
+                prop H PlainDel? { get; set; }
+            }
+
+            func Main() {
+                var c = C()
+                c.H = (x int32) -> System.Console.WriteLine(x + 1)
+                let h = c.H
+                if h != nil {
+                    h(41)
+                }
+            }
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_LambdaReturnedAsNullableNamedDelegate_Runs()
+    {
+        const string source = """
+            package i2841ret
+            import System
+
+            type PlainDel = delegate func(x int32) void
+
+            func Make(enabled bool) PlainDel? {
+                if !enabled {
+                    return nil
+                }
+
+                return (x int32) -> System.Console.WriteLine(x - 1)
+            }
+
+            func Main() {
+                let h = Make(true)
+                if h != nil {
+                    h(8)
+                }
+
+                System.Console.WriteLine(Make(false) == nil)
+            }
+            """;
+
+        Assert.Equal("7\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_MethodGroupAssignedToNullableNamedDelegate_Runs()
+    {
+        // Issue #2841 asks for method-group coverage alongside lambda literals:
+        // the method-group path must reach the same nullable-stripped target.
+        const string source = """
+            package i2841mg
+            import System
+
+            type PlainDel = delegate func(x int32) void
+
+            func Show(x int32) {
+                System.Console.WriteLine(x * 4)
+            }
+
+            func Main() {
+                var h PlainDel? = nil
+                h = Show
+                if h != nil {
+                    h(6)
+                }
+
+                let g PlainDel? = Show
+                if g != nil {
+                    g(7)
+                }
+            }
+            """;
+
+        Assert.Equal("24\n28\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_NonNullableNamedDelegateValueFlowsIntoNullableSlot_Runs()
+    {
+        // The symmetric direction the issue calls out: a `D` value assigned into
+        // a `D?` slot. A fix must not regress this widening.
+        const string source = """
+            package i2841widen
+            import System
+
+            type PlainDel = delegate func(x int32) void
+
+            func Apply(h PlainDel?) {
+                if h != nil {
+                    h(9)
+                }
+            }
+
+            func Main() {
+                let d PlainDel = (x int32) -> System.Console.WriteLine(x + 100)
+                var slot PlainDel? = d
+                Apply(d)
+                if slot != nil {
+                    slot(11)
+                }
+            }
+            """;
+
+        Assert.Equal("109\n111\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_LambdaAndNilAgainstNullableImportedDelegate_Runs()
+    {
+        // Control for an IMPORTED BCL delegate target: `System.Action[int32]?`
+        // already resolves through the ClrType arm, so it must stay green.
+        const string source = """
+            package i2841imported
+            import System
+
+            func Apply(h System.Action[int32]?) {
+                if h != nil {
+                    h(12)
+                }
+            }
+
+            func Main() {
+                var h System.Action[int32]? = nil
+                h = (x int32) -> System.Console.WriteLine(x * 2)
+                Apply(h)
+                Apply(nil)
+                System.Console.WriteLine("ok")
+            }
+            """;
+
+        Assert.Equal("24\nok\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_NonNullableNamedDelegateTargetStillRuns()
+    {
+        // Control: the passing rows of the issue's truth table must stay green.
+        const string source = """
+            package i2841control
+            import System
+
+            type PlainDel = delegate func(x int32) void
+
+            func Apply(h PlainDel) {
+                h(3)
+            }
+
+            func Main() {
+                let a PlainDel = (x int32) -> System.Console.WriteLine(x)
+                a(1)
+                var b PlainDel = (x int32) -> System.Console.WriteLine(x)
+                b = (x int32) -> System.Console.WriteLine(x * 2)
+                b(2)
+                Apply((x int32) -> System.Console.WriteLine(x * 3))
+            }
+            """;
+
+        Assert.Equal("1\n4\n9\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_LambdaAssignedToNullableGenericNamedDelegate_Runs()
+    {
+        // A generic named delegate closed over a concrete argument, still in a
+        // nullable slot — the shape closest to Oahu's `Conv[T]?` parameter.
+        const string source = """
+            package i2841generic
+            import System
+
+            type Conv[T] = delegate func(value T, cb (string) -> void) void
+
+            func Run(c Conv[int32]?, v int32) {
+                if c != nil {
+                    c(v, (s string) -> System.Console.WriteLine(s))
+                }
+            }
+
+            func Main() {
+                var c Conv[int32]? = nil
+                c = (value int32, cb (string) -> void) -> { cb("g" + System.Convert.ToString(value)) }
+                Run(c, 4)
+                Run(nil, 0)
+                System.Console.WriteLine("end")
+            }
+            """;
+
+        Assert.Equal("g4\nend\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2841_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2841.

## Problem

A lambda (or method group) converted to a named delegate `D`, but not to `D?`:

```gs
type PlainDel = delegate func(x int32, cb (string) -> void)

var h PlainDel? = nil
h = (x int32, cb (string) -> void) -> { cb("a") }
//  error GS0155: Cannot convert type '(int32, (string) -> void) -> void' to 'PlainDel?'.
```

The only difference between the passing and failing rows of the issue's truth table is the `?`. A nullable target should widen the set of legal values, never narrow it.

This gates `Oahu.App`, and it is especially common in translated C# because cs2gs's oblivious-nullability promotion turns many delegate-typed locals, fields, and parameters into `D?` — so the promotion itself made previously-legal assignments unassignable.

## Root cause

Two independent gaps, both of which had to be fixed; each one alone still leaves the shape broken.

**1. Binder — `Conversion.IsReferenceLikeTarget` had no `DelegateTypeSymbol` case.**

The `T -> U?` reference-wrap arm (issue #1121) is gated on `IsReferenceLikeTarget(toNullable.UnderlyingType)`. That predicate special-cases `InterfaceSymbol`, `StructSymbol { IsClass: true }`, slices/arrays and reference-constrained type parameters, then falls back to inspecting `ClrType`.

A user-declared named delegate (ADR-0059 / issue #255) matched none of them: it is emitted as a sealed class deriving from `System.MulticastDelegate`, but — exactly like `StructSymbol`/`InterfaceSymbol` — it carries **no `ClrType` at bind time**, because its TypeDef only comes into being once the emitter has produced it. So the `ClrType` fallback could not recognise it either.

With the arm skipped, classification fell through to the delegate-conversion paths further down, all of which test the target directly and therefore saw the still-wrapped `NullableTypeSymbol` rather than the `DelegateTypeSymbol` — hence GS0155.

**2. Emitter — `MethodBodyEmitter.EmitConversion`'s named-delegate arm tested `conv.Type` directly.**

Once the binder accepted the conversion, emit failed instead:

```
error GS9998: NotSupportedException: Conversion from '(int32) -> void' to 'PlainDel?' is not yet supported by the emitter.
```

The ADR-0059 arm matched `conv.Type is DelegateTypeSymbol`, which a `NullableTypeSymbol` wrapper does not satisfy.

## Fix

**`src/Core/CodeAnalysis/Binding/Conversion.cs`** — teach `IsReferenceLikeTarget` that a `DelegateTypeSymbol` is unconditionally a reference type, mirroring the existing `StructSymbol { IsClass: true }` / `InterfaceSymbol` / `IsReferenceConstrainedTypeParameter` arms that exist for precisely the same "no `ClrType` during binding" reason.

**`src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs`** — strip a nullable wrapper over a named delegate before the ADR-0059 arm. A nullable wrapper over a *reference* type is a binder-level annotation that erases to the underlying type's CLR representation, and a named delegate is always a reference type, so the emitted `ldnull`/`ldftn`/`newobj` (or closure `dup`/`ldftn`/`newobj`) sequence is byte-identical to the bare-`D` case.

## Tests

New `test/Compiler.Tests/Emit/Issue2841NullableNamedDelegateTargetEmitTests.cs` — 10 end-to-end facts that compile, `ilverify`, run, and assert stdout.

Covering the issue's requested matrix:

| Fact | Role |
| --- | --- |
| `LambdaAssignedToNullableNamedDelegateLocal` | defect (`var h D? = nil; h = lambda`) |
| `LambdaInitializesNullableNamedDelegateLocal` | defect (`let h D? = lambda`) |
| `LambdaPassedToNullableNamedDelegateParameter` | defect (argument position — the Oahu shape) |
| `LambdaAssignedToNullableNamedDelegateProperty` | defect (property setter) |
| `LambdaReturnedAsNullableNamedDelegate` | defect (return position, plus `return nil`) |
| `LambdaAssignedToNullableGenericNamedDelegate` | defect (`Conv[int32]?`) |
| `MethodGroupAssignedToNullableNamedDelegate` | defect (method group, as the issue requested) |
| `NonNullableNamedDelegateTargetStillRuns` | control — the passing rows of the truth table |
| `NonNullableNamedDelegateValueFlowsIntoNullableSlot` | control — the symmetric `D` → `D?` direction the issue asked to protect |
| `LambdaAndNilAgainstNullableImportedDelegate` | control — imported BCL `System.Action[int32]?` |

Non-vacuity verified by reverting both source changes: exactly the 7 defect facts fail (GS0155 in the binder, then GS9998 in the emitter once only the binder half is restored) and the 3 controls stay green. Each half was also reverted individually to confirm both are load-bearing.

The original hand-written repro from the issue (`oahu-mig-c18/repro4/dlam.gs`) now compiles.

## Validation

- `Core.Tests` — 6818 passed, 0 failed, 1 skipped
- `Compiler.Tests` — all passed (includes the 10 new facts)
- `Cs2Gs.Tests` — all passed
