### PR TITLE
Fix structural function to nominal delegate conversion for nullable sources (#2840)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -1492,7 +1492,17 @@ public sealed class Conversion
         // (issue #1121) never ran for a `D?` target, and every delegate
         // conversion path downstream tested the still-wrapped
         // `NullableTypeSymbol`, so a lambda bound fine against `D` but not `D?`.
-        if (type is DelegateTypeSymbol)
+        //
+        // Issue #2840: a structural function type `(P…) -> R` is likewise always
+        // a reference type — it materialises as a delegate instance. Its
+        // `ClrType` is only available when EVERY type in its signature is
+        // CLR-backed, so a single source-declared class anywhere in the
+        // parameter or return list (e.g. `(Src) -> void`) leaves it null and the
+        // fallback below reported it as non-reference. That silently disabled
+        // the `T? -> U?` reference arm, so `((Src) -> void)?` would not convert
+        // to `Action[Src]?` even though the bare, non-nullable conversion was
+        // fine.
+        if (type is DelegateTypeSymbol or FunctionTypeSymbol)
         {
             return true;
         }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -299,6 +299,23 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #2840: the source function type has no `ClrType` whenever ANY
+        // type in its signature is declared in the compilation being emitted
+        // (e.g. `(Src) -> void` for a source class `Src`), because
+        // MapToReferenceClrType has no MetadataLoadContext Type for it. The
+        // value is still a delegate at runtime, so take its `Invoke` MemberRef
+        // from the reified `Func<Src>`/`Action<Src>` TypeSpec instead —
+        // precisely what the CLR-delegate sibling
+        // (EmitFunctionToDelegateConversion) already does for this shape.
+        if (sourceFn != null && this.outer.userTokens.FunctionTypeNeedsSymbolicDelegate(sourceFn))
+        {
+            this.EmitNullGuardedDelegateToDelegateAdaptation(
+                source,
+                this.outer.memberRefs.GetFunctionDelegateInvokeRef(sourceFn),
+                ctorHandle);
+            return;
+        }
+
         throw new NotSupportedException(
             $"Cannot convert function value of type '{sourceFn?.Name}' to named delegate '{targetDelegate.Name}'.");
     }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -48,6 +48,19 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #2840 / #2841: a nullable wrapper over a REFERENCE type is a
+        // binder-level annotation only — it erases to the underlying type's CLR
+        // representation — so the delegate-materialisation arms below classify
+        // on the unwrapped views. Both a structural function type and a named
+        // delegate are unconditionally reference types (each materialises as a
+        // delegate instance), so `((P…) -> R)?` and `D?` share the identical
+        // representation with their bare forms. Genuine `Nullable<T>` value
+        // shapes are left wrapped and fall through to the value-type arms
+        // further down. The null-guarded adaptation helpers already tolerate a
+        // null source, so a possibly-null function value stays correct.
+        var delegateSourceType = UnwrapReferenceNullableForDelegateShape(conv.Expression.Type);
+        var delegateTargetType = UnwrapReferenceNullableForDelegateShape(conv.Type);
+
         // Issue #1330: a function literal converted to a delegate type closed
         // over an in-scope generic type parameter (e.g. `Comparison[TResult]`,
         // the parameter of `Comparer[TResult].Create(...)`). The target has no
@@ -56,8 +69,8 @@ internal sealed partial class MethodBodyEmitter
         // Materialise the delegate with a `.ctor` MemberRef parented at the
         // constructed `Comparison<!TResult>` TypeSpec so the runtime instance
         // matches the callee's reified parameter.
-        if (conv.Expression.Type is FunctionTypeSymbol constructedDelegateSource
-            && conv.Type is ImportedTypeSymbol constructedDelegateTarget
+        if (delegateSourceType is FunctionTypeSymbol constructedDelegateSource
+            && delegateTargetType is ImportedTypeSymbol constructedDelegateTarget
             && constructedDelegateTarget.OpenDefinition != null
             && constructedDelegateTarget.HasSubstitutableTypeArgument
             && ClrTypeUtilities.IsDelegateType(constructedDelegateTarget.ClrType))
@@ -84,10 +97,8 @@ internal sealed partial class MethodBodyEmitter
         // a reference type (a sealed class deriving from
         // `System.MulticastDelegate`), so the materialisation is byte-identical
         // to the bare-`D` case.
-        var namedTargetDelegate = conv.Type as DelegateTypeSymbol
-            ?? (conv.Type as NullableTypeSymbol)?.UnderlyingType as DelegateTypeSymbol;
-        if (conv.Expression.Type is FunctionTypeSymbol namedSourceFn
-            && namedTargetDelegate != null)
+        if (delegateSourceType is FunctionTypeSymbol namedSourceFn
+            && delegateTargetType is DelegateTypeSymbol namedTargetDelegate)
         {
             this.EmitFunctionToNamedDelegateConversion(conv.Expression, namedSourceFn, namedTargetDelegate);
             return;
@@ -97,8 +108,8 @@ internal sealed partial class MethodBodyEmitter
         // delegate while its original body expects the equivalent structural
         // function. Rebuild the value over the named delegate's Invoke target
         // so the adapter body and its outer delegate constructor both verify.
-        if (conv.Type is FunctionTypeSymbol delegateTargetFn
-            && conv.Expression.Type is ImportedTypeSymbol { ClrType: Type importedDelegateSource }
+        if (delegateTargetType is FunctionTypeSymbol delegateTargetFn
+            && delegateSourceType is ImportedTypeSymbol { ClrType: Type importedDelegateSource }
             && ClrTypeUtilities.IsDelegateType(importedDelegateSource))
         {
             var invoke = importedDelegateSource.GetMethod("Invoke")
@@ -120,11 +131,11 @@ internal sealed partial class MethodBodyEmitter
         // argument position; routing it through EmitConversion makes
         // assignment, return, and cast positions emit the same delegate
         // instantiation IL.
-        if (conv.Expression.Type is FunctionTypeSymbol sourceFn
-            && conv.Type?.ClrType != null
-            && ClrTypeUtilities.IsDelegateType(conv.Type.ClrType))
+        if (delegateSourceType is FunctionTypeSymbol sourceFn
+            && delegateTargetType?.ClrType != null
+            && ClrTypeUtilities.IsDelegateType(delegateTargetType.ClrType))
         {
-            this.EmitFunctionToDelegateConversion(conv.Expression, sourceFn, conv.Type.ClrType);
+            this.EmitFunctionToDelegateConversion(conv.Expression, sourceFn, delegateTargetType.ClrType);
             return;
         }
 
@@ -139,8 +150,8 @@ internal sealed partial class MethodBodyEmitter
         // return type built over a bare type parameter `T`, whose ClrType is
         // null during binding so the concrete CLR-delegate path above cannot
         // fire.
-        if (conv.Expression.Type is FunctionTypeSymbol fnNoOpFrom
-            && conv.Type is FunctionTypeSymbol fnNoOpTo
+        if (delegateSourceType is FunctionTypeSymbol fnNoOpFrom
+            && delegateTargetType is FunctionTypeSymbol fnNoOpTo
             && IsRepresentationPreservingFunctionConversion(fnNoOpFrom, fnNoOpTo))
         {
             this.EmitExpression(conv.Expression);
@@ -587,6 +598,30 @@ internal sealed partial class MethodBodyEmitter
 
         throw new NotSupportedException(
             $"Conversion from '{from.Name}' to '{to.Name}' is not yet supported by the emitter.");
+    }
+
+    /// <summary>
+    /// Issue #2840 / #2841: strips reference-nullable wrappers so the
+    /// delegate-materialisation arms of <see cref="EmitConversion"/> see the
+    /// bare function / delegate shape. A <see cref="NullableTypeSymbol"/> over a
+    /// reference type is a binder-level annotation that erases to the underlying
+    /// type's CLR representation, so a <c>D?</c> or <c>((P…) -&gt; R)?</c> slot
+    /// materialises byte-identically to its bare form. Genuine
+    /// <c>Nullable&lt;T&gt;</c> value shapes are left wrapped so they keep
+    /// reaching the value-type arms.
+    /// </summary>
+    /// <param name="type">The declared source or target type of the conversion.</param>
+    /// <returns>The unwrapped type, or <paramref name="type"/> when no reference-nullable wrapper applies.</returns>
+    private static TypeSymbol UnwrapReferenceNullableForDelegateShape(TypeSymbol type)
+    {
+        while (type is NullableTypeSymbol nullable
+            && !ReflectionMetadataEmitter.IsValueTypeNullable(nullable)
+            && nullable.UnderlyingType != null)
+        {
+            type = nullable.UnderlyingType;
+        }
+
+        return type;
     }
 
     // Issues #1356/#2542/#2618: reference nullability erases from parameter and

--- a/test/Compiler.Tests/Emit/Issue2840NullableFunctionToDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2840NullableFunctionToDelegateEmitTests.cs
@@ -1,0 +1,417 @@
+// <copyright file="Issue2840NullableFunctionToDelegateEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2840 — a structural function type failed to convert to a nominal
+/// delegate whenever the SOURCE was nullable.
+/// <para>
+/// The issue reported the trigger as "type-parameter substitution from the
+/// enclosing generic class", but the minimal repro needs neither generics nor
+/// a second assembly: <c>((Src) -&gt; void)?</c> would not convert to
+/// <c>System.Action[Src]?</c> for a source-declared class <c>Src</c>, while the
+/// bare non-nullable conversion was fine.
+/// </para>
+/// <para>
+/// Root cause: <c>Conversion.IsReferenceLikeTarget</c> did not recognise
+/// <c>FunctionTypeSymbol</c>. A structural function type only has a
+/// <c>ClrType</c> when EVERY type in its signature is CLR-backed, so a single
+/// source-declared class anywhere in its parameter or return list leaves it
+/// null and the trailing <c>ClrType</c> fallback reported it as
+/// non-reference-like. That gated off the <c>T? -&gt; U?</c> reference arm.
+/// Emit needed the matching wrapper strip, plus the symbolic-<c>Invoke</c>
+/// fallback its CLR-delegate sibling already had.
+/// </para>
+/// Each fact uses a UNIQUE package name because the in-process type caches are
+/// name-keyed.
+/// </summary>
+public class Issue2840NullableFunctionToDelegateEmitTests
+{
+    [Fact]
+    public void EndToEnd_NullableStructuralFunctionToNullableImportedDelegate_SourceClassInSignature_Runs()
+    {
+        // The true minimal repro: no generics, no named delegate, no second
+        // assembly. `Src` being declared in this compilation is what nulls the
+        // function type's ClrType.
+        const string source = """
+            package i2840minimal
+            import System
+
+            class Src {
+                prop N int32 -> 5
+            }
+
+            func Main() {
+                var f ((Src) -> void)? = nil
+                f = (s Src) -> System.Console.WriteLine(s.N)
+                var d System.Action[Src]? = f
+                if d != nil {
+                    // Invoked through a non-nullable local: directly invoking a
+                    // NARROWED nullable imported generic delegate whose type
+                    // argument is source-declared emits an `Invoke` MemberRef
+                    // parented at the erased `Action<object>`. That is a
+                    // separate, pre-existing defect (it reproduces with no
+                    // conversion at all) and is tracked on its own issue.
+                    let invoke System.Action[Src] = d
+                    invoke(Src())
+                }
+            }
+            """;
+
+        Assert.Equal("5\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_NullableStructuralFunctionToNullableNamedDelegate_SourceClassInSignature_Runs()
+    {
+        const string source = """
+            package i2840named
+            import System
+
+            class Src {
+                prop N int32 -> 6
+            }
+
+            type PD = delegate func(s Src) void
+
+            func Main() {
+                var f ((Src) -> void)? = nil
+                f = (s Src) -> System.Console.WriteLine(s.N)
+                var d PD? = f
+                if d != nil {
+                    d(Src())
+                }
+            }
+            """;
+
+        Assert.Equal("6\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_NullableStructuralFunctionToNullableNamedDelegate_BclOnlySignature_Runs()
+    {
+        // Same shape but with a fully CLR-backed signature, so the source
+        // function type DOES have a ClrType. This one is gated purely by the
+        // named delegate target lacking one.
+        const string source = """
+            package i2840namedbcl
+            import System
+
+            type PD = delegate func(x int32) void
+
+            func Main() {
+                var f ((int32) -> void)? = nil
+                f = (x int32) -> System.Console.WriteLine(x * 3)
+                var d PD? = f
+                if d != nil {
+                    d(9)
+                }
+            }
+            """;
+
+        Assert.Equal("27\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_FunctionVariableToNamedDelegate_SourceClassInSignature_Runs()
+    {
+        // The adjacent emit gap this fix also had to close: a function VALUE
+        // (not a literal or method group) flowing into a named delegate needs
+        // the symbolic `Invoke` MemberRef, because the source function type has
+        // no ClrType. Non-nullable on both sides — reachable independently of
+        // the nullable arm, and reachable through it once the binder accepts
+        // the nullable form.
+        const string source = """
+            package i2840fnvar
+            import System
+
+            class Src {
+                prop N int32 -> 8
+            }
+
+            type PD = delegate func(s Src) void
+
+            func Main() {
+                let f ((Src) -> void) = (s Src) -> System.Console.WriteLine(s.N)
+                var d PD = f
+                d(Src())
+            }
+            """;
+
+        Assert.Equal("8\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_SameCompilation_EnclosingGenericClass_NullableDelegateParameter_Runs()
+    {
+        // The issue's "same-compilation" FAIL row.
+        const string source = """
+            package i2840samecomp
+            import System
+
+            interface ICanc {
+                prop IsCancelled bool { get }
+            }
+
+            type Conv[T ICanc] = delegate func(book int32, ctx T, cb (string) -> void) void
+
+            class Jobb[T ICanc] {
+                func Do(ctx T, convertAction Conv[T]?) {
+                    if convertAction != nil {
+                        convertAction(7, ctx, (s string) -> System.Console.WriteLine(s))
+                    }
+                }
+            }
+
+            class Cancel : ICanc {
+                prop IsCancelled bool -> false
+            }
+
+            func Main() {
+                let job = Jobb[Cancel]()
+                var convertAction ((int32, Cancel, (string) -> void) -> void)? = nil
+                convertAction = (book int32, ctx Cancel, onState (string) -> void) -> {
+                    onState("same" + System.Convert.ToString(book))
+                }
+                job.Do(Cancel(), convertAction)
+                job.Do(Cancel(), nil)
+                System.Console.WriteLine("done")
+            }
+            """;
+
+        Assert.Equal("same7\ndone\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_CrossAssembly_EnclosingGenericClass_NullableDelegateParameter_Runs()
+    {
+        // The issue's headline cross-assembly FAIL row and the originating Oahu
+        // shape (`MainWindow.axaml.gs:345`).
+        const string library = """
+            package i2840lib
+            import System
+
+            interface ICanc {
+                prop IsCancelled bool { get }
+            }
+
+            type Conv[T ICanc] = delegate func(book int32, ctx T, cb (string) -> void) void
+
+            class Jobb[T ICanc] {
+                func Do(ctx T, convertAction Conv[T]?) {
+                    if convertAction != nil {
+                        convertAction(7, ctx, (s string) -> System.Console.WriteLine(s))
+                    }
+                }
+            }
+            """;
+
+        const string consumer = """
+            package i2840use
+            import System
+            import i2840lib
+
+            class Cancel : ICanc {
+                prop IsCancelled bool -> false
+            }
+
+            func Main() {
+                let job = Jobb[Cancel]()
+                var convertAction ((int32, Cancel, (string) -> void) -> void)? = nil
+                convertAction = (book int32, ctx Cancel, onState (string) -> void) -> {
+                    onState("cross" + System.Convert.ToString(book))
+                }
+                job.Do(Cancel(), convertAction)
+                job.Do(Cancel(), nil)
+                System.Console.WriteLine("done")
+            }
+            """;
+
+        Assert.Equal("cross7\ndone\n", CompileAndRun(consumer, library, "i2840lib"));
+    }
+
+    [Fact]
+    public void EndToEnd_GenericMethodOnNonGenericClass_NullableDelegateParameter_Runs()
+    {
+        // Control: the issue's PASS row for a generic METHOD. A fix for the
+        // enclosing-class form must not regress it.
+        const string source = """
+            package i2840genmethod
+            import System
+
+            interface ICanc {
+                prop IsCancelled bool { get }
+            }
+
+            type Conv[T ICanc] = delegate func(book int32, ctx T, cb (string) -> void) void
+
+            class Jobb {
+                func Do[T ICanc](ctx T, convertAction Conv[T]?) {
+                    if convertAction != nil {
+                        convertAction(3, ctx, (s string) -> System.Console.WriteLine(s))
+                    }
+                }
+            }
+
+            class Cancel : ICanc {
+                prop IsCancelled bool -> false
+            }
+
+            func Main() {
+                let job = Jobb()
+                var convertAction ((int32, Cancel, (string) -> void) -> void)? = nil
+                convertAction = (book int32, ctx Cancel, onState (string) -> void) -> {
+                    onState("gm" + System.Convert.ToString(book))
+                }
+                job.Do(Cancel(), convertAction)
+                System.Console.WriteLine("done")
+            }
+            """;
+
+        Assert.Equal("gm3\ndone\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_NonNullableStructuralFunctionToDelegate_StillRuns()
+    {
+        // Control: the non-nullable direction that always worked.
+        const string source = """
+            package i2840control
+            import System
+
+            class Src {
+                prop N int32 -> 2
+            }
+
+            func Main() {
+                let f ((Src) -> void) = (s Src) -> System.Console.WriteLine(s.N)
+                var d System.Action[Src] = f
+                d(Src())
+                var n System.Action[Src]? = f
+                if n != nil {
+                    let invoke System.Action[Src] = n
+                    invoke(Src())
+                }
+            }
+            """;
+
+        Assert.Equal("2\n2\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source, string library = null, string libraryAssemblyName = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2840_exe_").FullName;
+        try
+        {
+            string libDll = null;
+            if (library != null)
+            {
+                // ilverify resolves `-r` references by FILE NAME, so the
+                // library must be written out under its assembly identity.
+                var libSrc = Path.Combine(tempDir, libraryAssemblyName + ".gs");
+                libDll = Path.Combine(tempDir, libraryAssemblyName + ".dll");
+                File.WriteAllText(libSrc, library);
+                Compile(new[]
+                {
+                    "/out:" + libDll,
+                    "/target:library",
+                    "/targetframework:net10.0",
+                    libSrc,
+                });
+                IlVerifier.Verify(libDll);
+            }
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+            if (libDll != null)
+            {
+                args.Add("/r:" + libDll);
+            }
+
+            args.Add(srcPath);
+            Compile(args.ToArray());
+            IlVerifier.Verify(dllPath, libDll != null ? new[] { libDll } : null);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void Compile(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+}


### PR DESCRIPTION
Fixes #2840.

## Problem

A structural G# function type failed to convert to a nominal delegate whenever the **source** was nullable:

```gs
class Src { prop N int32 -> 1 }

var f ((Src) -> void)? = nil
var d System.Action[Src]? = f
//  error GS0155: Cannot convert type '((Src) -> void)?' to 'System.Action`1[Src]?'.
```

This gates `Oahu.App` (`MainWindow.axaml.gs:345`).

**The issue's stated trigger — "type-parameter substitution from the enclosing generic class" — is not the cause.** The minimal repro above needs no generics, no named delegate, and no second assembly. The *non-nullable* form works fine even in the reported enclosing-generic-class shape. See the [diagnosis correction](https://github.com/DavidObando/gsharp/issues/2840#issuecomment-5113303578) on the issue.

## Root cause

**1. Binder — `Conversion.IsReferenceLikeTarget` did not recognise `FunctionTypeSymbol`.**

That predicate gates the `T? -> U?` reference arm (issue #1121). A structural function type only has a `ClrType` when **every** type in its signature is CLR-backed, so a single source-declared class anywhere in the parameter or return list leaves it null and the trailing `ClrType` fallback classified it as *non*-reference-like.

`Cancel` in the issue's repro is exactly such a class — that, not the enclosing generic class, is what made the original case fail. A structural function type is of course always a reference type: it materialises as a delegate instance.

**2. Emitter — the delegate arms of `EmitConversion` tested `conv.Type` / `conv.Expression.Type` directly**, so a `NullableTypeSymbol` wrapper made all five of them miss and emit raised `GS9998: NotSupportedException`.

**3. Emitter — `EmitFunctionToNamedDelegateConversion` had no symbolic-`Invoke` fallback.** Its delegate-to-delegate adaptation branch required `sourceFn.ClrType != null`, which is exactly what a source-declared type in the signature nulls out. Its CLR-delegate sibling `EmitFunctionToDelegateConversion` already handled this via `FunctionTypeNeedsSymbolicDelegate`. Without this, fix (1) would have converted a clean `GS0155` into a `GS9998`.

## Fix

- **`Conversion.cs`** — `IsReferenceLikeTarget` now treats `FunctionTypeSymbol` as unconditionally reference-like, alongside the `DelegateTypeSymbol` arm added for #2841.
- **`MethodBodyEmitter.Conversions.cs`** — new `UnwrapReferenceNullableForDelegateShape` helper; the five delegate arms classify on the unwrapped views. Genuine `Nullable<T>` value shapes stay wrapped and keep reaching the value-type arms. The null-guarded adaptation helpers already tolerate a null source.
- **`MethodBodyEmitter.Closures.cs`** — named-delegate conversion falls back to `GetFunctionDelegateInvokeRef` when the source function type has no `ClrType`, mirroring its CLR-delegate sibling.

## Tests

New `test/Compiler.Tests/Emit/Issue2840NullableFunctionToDelegateEmitTests.cs` — 8 end-to-end facts that compile, `ilverify`, run, and assert stdout. One uses a **two-assembly** harness for the issue's cross-assembly row.

| Fact | Role |
| --- | --- |
| `NullableStructuralFunctionToNullableImportedDelegate_SourceClassInSignature` | defect — the true minimal repro |
| `NullableStructuralFunctionToNullableNamedDelegate_SourceClassInSignature` | defect |
| `FunctionVariableToNamedDelegate_SourceClassInSignature` | defect — the symbolic-`Invoke` gap |
| `SameCompilation_EnclosingGenericClass_NullableDelegateParameter` | defect — issue's same-compilation row |
| `CrossAssembly_EnclosingGenericClass_NullableDelegateParameter` | defect — issue's headline row / Oahu shape |
| `GenericMethodOnNonGenericClass_NullableDelegateParameter` | defect — issue listed this as PASS, but it fails without the fix |
| `NullableStructuralFunctionToNullableNamedDelegate_BclOnlySignature` | control (covered by #2841) |
| `NonNullableStructuralFunctionToDelegate_StillRuns` | control — non-nullable direction |

Non-vacuity verified by reverting all three source changes: exactly the 6 defect facts fail and the 2 controls stay green. Every repro from the issue now compiles **and** passes `ilverify`.

## Adjacent defects found — filed separately, not fixed here

- **#2850** — the issue's "static generic function **PASS**" row only ever passed *compilation*. It emits **no argument conversion at all** and fails `ilverify`, both before and after this change. That row is deliberately omitted from the test file until #2850 lands.
- **#2849** — invoking a *narrowed* nullable imported generic delegate with a source-declared type argument emits an `Invoke` MemberRef parented at the erased `Action<object>`. Pre-existing and reachable with no conversion at all. Two tests here invoke through a non-nullable local (with a comment) to route around it.
- **#2851** — the issue's "Diagnostic-quality defect" section is much broader than delegates: constructed generic **classes** drop their type arguments too (`Box[int32]` renders as `Box`). Split out rather than fixed here, since it touches diagnostic rendering for every G#-declared generic type.

## Validation

- `Core.Tests` — 6824 passed, 0 failed, 1 skipped
- `Compiler.Tests` — all passed (includes the 8 new facts)
- `Cs2Gs.Tests` — all passed
