### PR TITLE
Report C# binding errors from the translate stage (#2842)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -27,6 +27,14 @@ namespace Cs2Gs.Pipeline;
 /// </summary>
 public sealed class TranslateStage : IMigrationStage
 {
+    /// <summary>
+    /// The maximum number of individual C# binding errors written to
+    /// <c>translate.log</c> by <see cref="NoteCSharpBindingErrors"/>; a project
+    /// bound against a stale reference assembly can report hundreds of
+    /// cascading errors and the log is a diagnostic aid, not a build log.
+    /// </summary>
+    private const int CSharpBindingErrorNoteLimit = 25;
+
     /// <inheritdoc/>
     public MigrationStageKind Kind => MigrationStageKind.Translate;
 
@@ -114,6 +122,7 @@ public sealed class TranslateStage : IMigrationStage
         // best-effort append-only text log TestParityStage's Note already
         // uses for non-fatal, informational events (test-parity.log).
         NoteNuGetAuditAdvisories(context, project);
+        NoteCSharpBindingErrors(context, project);
 
         var usedOutputPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (context.Options.OutputLayout == MigrationOutputLayout.DiagnosticRun)
@@ -542,6 +551,86 @@ public sealed class TranslateStage : IMigrationStage
             Note(context, "NuGet audit advisory (CS2GS0003, non-fatal): " + advisory.GetMessage());
         }
     }
+
+    /// <summary>
+    /// Issue #2842: records every ordinary C# compiler error the loaded project
+    /// reported into the per-app <c>translate.log</c> and onto stderr.
+    /// <para>
+    /// The <see cref="LoadedCSharpProject.WorkspaceLoadFailed"/> gate above is
+    /// deliberately narrow — it stops only when MSBuild could not open the
+    /// project at all — because some corpus fixtures carry a deliberate C#
+    /// error to exercise a later stage (<c>CompileGap-Library</c>'s
+    /// <c>Residual.Probe</c>). The cost of that narrowness was that a project
+    /// whose C# genuinely does NOT bind was translated anyway, silently and
+    /// with no signal: <c>CSharpProjectLoader.SignificantDiagnostics</c>
+    /// already collected the errors into
+    /// <see cref="LoadedCSharpProject.LoadDiagnostics"/>, but nothing past the
+    /// workspace gate ever looked at them.
+    /// </para>
+    /// <para>
+    /// That is not a cosmetic gap. cs2gs resolves a <c>ProjectReference</c> to
+    /// the sibling's on-disk reference assembly
+    /// (<c>obj/&lt;Config&gt;/ref/X.dll</c>), so a STALE build artifact makes a
+    /// member vanish while its containing type still resolves. Roslyn then
+    /// hands the translator an error type with a null symbol, every
+    /// nullability predicate keyed on that symbol answers "no", and the
+    /// migration emits G# that is subtly wrong in a way whose only visible
+    /// symptom is an inexplicable <c>gsc</c> diagnostic in an unrelated place.
+    /// That is exactly how issue #2842 presented: a stale <c>Oahu.Data</c>
+    /// reference assembly turned <c>conversion.FailureReason</c> into an
+    /// unbound expression, which suppressed the <c>!!</c> forgiveness and
+    /// produced <c>GS0156</c> hundreds of lines downstream.
+    /// </para>
+    /// <para>
+    /// Reporting is non-fatal so the deliberate-error fixtures keep exercising
+    /// the stages after this one, and no triage artifact is produced so run
+    /// fingerprints and the gap ledger are unchanged.
+    /// </para>
+    /// </summary>
+    private static void NoteCSharpBindingErrors(StageExecutionContext context, LoadedCSharpProject project)
+    {
+        List<Diagnostic> errors = project.LoadDiagnostics
+            .Where(IsCSharpCompilerError)
+            .ToList();
+        if (errors.Count == 0)
+        {
+            return;
+        }
+
+        string header =
+            $"C# binding errors ({errors.Count}, non-fatal): the loaded C# project does not bind cleanly, so the " +
+            "emitted G# is translated from partially-unbound syntax and may be silently wrong. A common cause " +
+            "is a STALE build artifact — cs2gs binds each ProjectReference against the sibling's on-disk " +
+            "reference assembly (obj/<Config>/ref/*.dll), so rebuild the C# solution in the same configuration " +
+            "and re-run.";
+        Note(context, header);
+        foreach (Diagnostic error in errors.Take(CSharpBindingErrorNoteLimit))
+        {
+            Note(context, $"  {error.Id} {error.Location.GetLineSpan()}: {error.GetMessage()}");
+        }
+
+        if (errors.Count > CSharpBindingErrorNoteLimit)
+        {
+            Note(context, $"  ... and {errors.Count - CSharpBindingErrorNoteLimit} more.");
+        }
+
+        string warning =
+            $"cs2gs: warning: {context.App.Id}: {errors.Count} C# binding error(s) in the source project; " +
+            $"translated G# may be wrong (first: {errors[0].Id} {errors[0].GetMessage()}). " +
+            "See translate.log; rebuild the C# solution if its build artifacts are stale.";
+        Console.Error.WriteLine(warning);
+    }
+
+    /// <summary>
+    /// True for an ordinary C# compiler error (<c>CS####</c>). cs2gs's own
+    /// loader diagnostics share the <c>CS</c> prefix (<c>CS2GS0001</c>
+    /// workspace-load failure, <c>CS2GS0003</c> NuGet audit advisory) and are
+    /// already handled by their own gates, so they are excluded here.
+    /// </summary>
+    private static bool IsCSharpCompilerError(Diagnostic diagnostic) =>
+        diagnostic.Severity == DiagnosticSeverity.Error
+        && diagnostic.Id.StartsWith("CS", StringComparison.Ordinal)
+        && !diagnostic.Id.StartsWith("CS2GS", StringComparison.Ordinal);
 
     /// <summary>
     /// A best-effort, append-only per-app text log — the Translate-stage

--- a/tools/cs2gs/Cs2Gs.Tests/TranslateStageCSharpBindingErrorTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TranslateStageCSharpBindingErrorTests.cs
@@ -1,0 +1,218 @@
+// <copyright file="TranslateStageCSharpBindingErrorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2842: <see cref="TranslateStage"/>'s only load gate is
+/// <c>LoadedCSharpProject.WorkspaceLoadFailed</c> (CS2GS0001), which fires
+/// solely when MSBuild could not open the project at all. Ordinary C#
+/// compiler errors were collected by
+/// <c>CSharpProjectLoader.SignificantDiagnostics</c> into
+/// <c>LoadedCSharpProject.LoadDiagnostics</c> and then never inspected again,
+/// so a project whose C# does NOT bind was translated anyway — silently, with
+/// no signal anywhere in the run.
+/// <para>
+/// That silence is what made #2842 so hard to diagnose. cs2gs binds each
+/// <c>ProjectReference</c> against the sibling's on-disk reference assembly
+/// (<c>obj/&lt;Config&gt;/ref/*.dll</c>), so a STALE artifact makes a single
+/// member disappear while its containing type still resolves. Roslyn hands the
+/// translator an error type with a null symbol, every nullability predicate
+/// keyed on that symbol answers "no", and the emitted G# loses a <c>!!</c> it
+/// needed — surfacing only as an inexplicable <c>gsc</c> GS0156 far from the
+/// real cause.
+/// </para>
+/// <para>
+/// The stage must therefore REPORT C# binding errors while still PASSING, so
+/// the corpus fixtures that carry a deliberate C# error to exercise later
+/// stages (<c>CompileGap-Library</c>) keep working and no triage artifact,
+/// fingerprint, or gap-ledger entry changes.
+/// </para>
+/// </summary>
+public class TranslateStageCSharpBindingErrorTests
+{
+    /// <summary>
+    /// A project whose C# does not bind must still PASS the Translate stage
+    /// (non-fatal by design) and must leave the offending diagnostic in
+    /// <c>&lt;AppRunDir&gt;/translate.log</c>, together with the stale-artifact
+    /// hint that explains the most common cause.
+    /// </summary>
+    [Fact]
+    public async Task TranslateStage_CSharpBindingError_PassesAndIsNotedInTranslateLog()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        string projectDir = NewScratchDir("translate-csharp-binding-error");
+        string projectPath = WriteProject(
+            projectDir,
+            "Unbound.csproj",
+            "public class Probe { public int Run(int value) { return UndefinedHelper(value); } }");
+
+        string logContent = await RunTranslateAndReadLogAsync(compiler, projectDir, projectPath, "test/UnboundMember");
+
+        // The C# error itself, verbatim enough to identify the offending symbol.
+        Assert.Contains("CS0103", logContent);
+        Assert.Contains("UndefinedHelper", logContent);
+
+        // The header naming the count and the stale-reference-assembly hint —
+        // the whole point of the report is that a reader can act on it.
+        Assert.Contains("C# binding errors", logContent);
+        Assert.Contains("non-fatal", logContent);
+        Assert.Contains("reference assembly", logContent);
+    }
+
+    /// <summary>
+    /// The exact #2842 shape: the containing type resolves but a MEMBER does
+    /// not (CS1061), which is what a stale reference assembly produces. This
+    /// pins the case that previously degraded translation silently rather than
+    /// only the blunt "identifier does not exist" form above.
+    /// </summary>
+    [Fact]
+    public async Task TranslateStage_MissingMemberBindingError_IsNotedInTranslateLog()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        string projectDir = NewScratchDir("translate-csharp-missing-member");
+        string projectPath = WriteProject(
+            projectDir,
+            "MissingMember.csproj",
+            @"public class Entity { public string Present { get; set; } }
+public class Consumer { public string Read(Entity e) { string reason = e.FailureReason; return reason; } }");
+
+        string logContent = await RunTranslateAndReadLogAsync(compiler, projectDir, projectPath, "test/MissingMember");
+
+        Assert.Contains("CS1061", logContent);
+        Assert.Contains("FailureReason", logContent);
+        Assert.Contains("C# binding errors", logContent);
+    }
+
+    /// <summary>
+    /// Non-vacuity control: a project that binds cleanly must produce NO
+    /// binding-error report, so the assertions above cannot pass merely
+    /// because the header is always written.
+    /// </summary>
+    [Fact]
+    public async Task TranslateStage_CleanProject_WritesNoBindingErrorNote()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        string projectDir = NewScratchDir("translate-csharp-clean");
+        string projectPath = WriteProject(
+            projectDir,
+            "Clean.csproj",
+            "public class Probe { public int Run(int value) { return value + 1; } }");
+
+        string outRoot = NewOutputRoot("translate-csharp-clean");
+        var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
+        var pipeline = new MigrationPipeline(options, new IMigrationStage[] { new TranslateStage() });
+        var app = new CorpusApp("test/CleanBinding", projectPath, TargetKind.Exe);
+
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+        Assert.True(appResult.Succeeded, "A cleanly binding project must pass the Translate stage.");
+
+        string[] translateLogs = Directory.GetFiles(outRoot, "translate.log", SearchOption.AllDirectories);
+        string logContent = translateLogs.Length == 0 ? string.Empty : File.ReadAllText(translateLogs[0]);
+        Assert.DoesNotContain("C# binding errors", logContent);
+    }
+
+    private static async Task<string> RunTranslateAndReadLogAsync(
+        string compiler, string projectDir, string projectPath, string appId)
+    {
+        string outRoot = NewOutputRoot(Path.GetFileName(projectDir));
+        var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
+        var pipeline = new MigrationPipeline(options, new IMigrationStage[] { new TranslateStage() });
+        var app = new CorpusApp(appId, projectPath, TargetKind.Exe);
+
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+
+        // Non-fatal by design: the deliberate-C#-error corpus fixtures
+        // (CompileGap-Library) rely on the Translate stage passing so the
+        // Compile stage can produce their triage artifact.
+        Assert.True(
+            appResult.Succeeded,
+            "A C# binding error must be REPORTED, not made fatal — corpus fixtures carry deliberate C# errors.");
+
+        string[] translateLogs = Directory.GetFiles(outRoot, "translate.log", SearchOption.AllDirectories);
+        string translateLog = Assert.Single(translateLogs);
+        return File.ReadAllText(translateLog);
+    }
+
+    /// <summary>
+    /// Writes a minimal buildable console project plus one source file. The
+    /// empty <c>Directory.Build.props</c> override stops MSBuild's directory
+    /// search from climbing to this repo's own root props (which sets
+    /// <c>TreatWarningsAsErrors</c>), matching the convention already used in
+    /// <c>CSharpProjectLoaderDiagnosticsTests</c> and
+    /// <c>TranslateStageNuGetAuditAdvisoryTests</c>.
+    /// </summary>
+    private static string WriteProject(string projectDir, string projectFileName, string source)
+    {
+        File.WriteAllText(Path.Combine(projectDir, "Directory.Build.props"), "<Project></Project>");
+        string projectPath = Path.Combine(projectDir, projectFileName);
+        File.WriteAllText(projectPath, @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+");
+        File.WriteAllText(Path.Combine(projectDir, "Program.cs"), "public class Program { public static void Main() { } }");
+        File.WriteAllText(Path.Combine(projectDir, "Probe.cs"), source);
+        return projectPath;
+    }
+
+    private static string NewOutputRoot(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "pipeline-tests", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string NewScratchDir(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "loader-tests", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION

The GS0156 reported in #2842 was not a translation-logic defect. The issue
body hypothesised a cross-assembly oblivious fixture like #2839; two- and
three-project oblivious fixtures reproducing Oahu's exact topology
(oblivious declaring project -> oblivious tainting project -> nullable-enabled
consuming project) all emit the correct `!!` forgiveness.

Instrumenting `TranslateLocalDeclaration` against the real migration showed
the initializer's type was Roslyn's ERROR type and its symbol was null:
`conversion.FailureReason` did not bind at all. cs2gs resolves a
ProjectReference against the sibling's on-disk reference assembly
(obj/<Config>/ref/*.dll), and Oahu's Debug artifacts predated the commit that
added `FailureReason`. The containing type still resolved, so only the new
member vanished. Every nullability predicate keyed on that null symbol
answered "no", the `!!` was dropped, and the declared/natural type mismatch
forced an explicit `string` clause -- surfacing as GS0156 hundreds of lines
away. Refreshing the reference assembly makes the same migration at the same
commit emit `let reason = conversion!!.FailureReason!!` and compile clean.

The real defect is that this degraded silently. `TranslateStage` gates only on
`LoadedCSharpProject.WorkspaceLoadFailed` (CS2GS0001, "MSBuild could not open
the project"), deliberately ignoring ordinary C# semantic errors so corpus
fixtures carrying a deliberate error (CompileGap-Library) can exercise later
stages. `CSharpProjectLoader.SignificantDiagnostics` already collected those
errors into `LoadDiagnostics`; nothing past the workspace gate ever read them.
Any stale or broken C# input therefore produced subtly wrong G# with no signal
anywhere in the run, and every consumer of the output -- including the nightly
corpus gate -- trusted it.

`NoteCSharpBindingErrors` now writes the offending diagnostics to the per-app
translate.log (mirroring the existing `NoteNuGetAuditAdvisories` pattern) plus
a stderr warning naming the app, the error count, the first diagnostic, and the
stale-artifact hint. Reporting is non-fatal and produces no triage artifact, so
the deliberate-error fixtures keep working and no run fingerprint or gap-ledger
entry changes.

Regression coverage (tools/cs2gs/Cs2Gs.Tests/TranslateStageCSharpBindingErrorTests.cs):
- CS0103 (undefined identifier) is reported and the stage still passes.
- CS1061 (missing MEMBER on a type that does resolve) -- the exact stale
  reference-assembly shape from #2842 -- is reported.
- Non-vacuity control: a cleanly binding project writes no report.

Reverting the source change fails exactly the two defect facts; the control
stays green.

Validation: Cs2Gs.Tests 1841 passed / 0 failed.

Copilot-Session: c4b0096d-f45e-4060-9b99-3948fd470f89
