### PR TITLE
Fix for..in over a class-typed source (#2859)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -797,12 +797,33 @@ internal sealed class MemberLookup
     /// <returns><see langword="true"/> when the type is enumerable.</returns>
     public static bool TryGetClrEnumerableElementType(Type clrType, out Type elementType)
     {
-        foreach (var iface in EnumerateSelfAndInterfaces(clrType))
+        // Issue #2859: walk the interface closure transitively. `GetInterfaces()`
+        // on a type projected through a MetadataLoadContext does not always
+        // expand an interface's own base interfaces, so a class that declares
+        // only `IReadOnlyCollection[T]` (as every cs2gs-translated collection
+        // does) would otherwise never surface the `IEnumerable[T]` it derives.
+        var seen = new HashSet<Type>();
+        var pending = new Queue<Type>(EnumerateSelfAndInterfaces(clrType));
+        while (pending.Count > 0)
         {
+            Type iface = pending.Dequeue();
+            if (iface == null || !seen.Add(iface))
+            {
+                continue;
+            }
+
             if (iface.IsGenericType && iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IEnumerable`1")
             {
                 elementType = iface.GetGenericArguments()[0];
                 return true;
+            }
+
+            if (!ReferenceEquals(iface, clrType))
+            {
+                foreach (Type nested in iface.GetInterfaces())
+                {
+                    pending.Enqueue(nested);
+                }
             }
         }
 
@@ -836,12 +857,12 @@ internal sealed class MemberLookup
         }
 
         var enumeratorType = getEnumerator.ReturnType;
-        var moveNext = enumeratorType.GetMethod(
-            "MoveNext",
-            BindingFlags.Instance | BindingFlags.Public,
-            binder: null,
-            types: Type.EmptyTypes,
-            modifiers: null);
+
+        // Issue #2859: `MoveNext`/`Current` live on the base `IEnumerator`
+        // interface when the enumerator is an `IEnumerator[T]`, and
+        // `Type.GetMethod` does not search an interface's base interfaces.
+        var moveNext = SafeGetMethodIncludingSelfAndInterfaces(
+            enumeratorType, "MoveNext", Type.EmptyTypes);
         if (moveNext?.ReturnType.IsSameAs(typeof(bool)) != true)
         {
             elementType = null;
@@ -877,6 +898,17 @@ internal sealed class MemberLookup
         if (currentField != null)
         {
             elementType = currentField.FieldType;
+            return true;
+        }
+
+        // Issue #2859: an `IEnumerator[T]` declares `Current` on itself but a
+        // non-generic `IEnumerator` receiver (or an interface whose `Current`
+        // is inherited) needs the base-interface walk that `Type.GetProperty`
+        // skips for interface types.
+        var inheritedCurrent = SafeGetPropertyIncludingSelfAndInterfaces(enumeratorType, "Current");
+        if (inheritedCurrent != null)
+        {
+            elementType = inheritedCurrent.PropertyType;
             return true;
         }
 
@@ -2021,25 +2053,47 @@ internal sealed class MemberLookup
     /// Probes a user-defined <see cref="StructSymbol"/> for the
     /// duck-typed enumerable shape (<c>GetEnumerator() → MoveNext() / Current</c>).
     /// </summary>
+    /// <remarks>
+    /// Issue #2859: the enumerator returned by <c>GetEnumerator()</c> does not
+    /// have to be a user-declared type. The overwhelmingly common shape — the
+    /// one cs2gs emits for every C# class that implements
+    /// <c>IEnumerable&lt;T&gt;</c> — returns an imported
+    /// <c>IEnumerator[T]</c> (or a BCL struct enumerator such as
+    /// <c>List[T].Enumerator</c>). Those enumerators expose <c>Current</c> as a
+    /// property rather than a field, so the user-declared probe below cannot
+    /// see them; before this fix `for x in userList` fell through to the
+    /// indexer probe and reported <c>GS0116</c>. The lowerer's
+    /// <c>TryBuildMoveNextAndCurrent</c> already handles CLR enumerators, so
+    /// accepting them here is all that was missing.
+    /// </remarks>
     /// <param name="type">The user struct symbol to probe.</param>
     /// <param name="elementType">The element <see cref="TypeSymbol"/>, on success.</param>
     /// <returns><see langword="true"/> when the duck-typed shape matches.</returns>
     public static bool TryGetUserPatternEnumerableElementType(StructSymbol type, out TypeSymbol elementType)
     {
-        if (TypeMemberModel.TryGetMethodIncludingInherited(type, "GetEnumerator", out var getEnumerator) &&
-            getEnumerator.Parameters.Length == 0 &&
-            getEnumerator.Type is StructSymbol enumeratorType &&
-            TypeMemberModel.TryGetMethodIncludingInherited(enumeratorType, "MoveNext", out var moveNext) &&
-            moveNext.Parameters.Length == 0 &&
-            moveNext.Type == TypeSymbol.Bool &&
-            enumeratorType.TryGetField("Current", out var currentField))
+        elementType = null;
+        if (!TypeMemberModel.TryGetMethodIncludingInherited(type, "GetEnumerator", out var getEnumerator) ||
+            getEnumerator.Parameters.Length != 0 ||
+            getEnumerator.Type is null)
         {
-            elementType = currentField.Type;
-            return true;
+            return false;
         }
 
-        elementType = null;
-        return false;
+        if (getEnumerator.Type is StructSymbol enumeratorType)
+        {
+            if (TypeMemberModel.TryGetMethodIncludingInherited(enumeratorType, "MoveNext", out var moveNext) &&
+                moveNext.Parameters.Length == 0 &&
+                moveNext.Type == TypeSymbol.Bool &&
+                enumeratorType.TryGetField("Current", out var currentField))
+            {
+                elementType = currentField.Type;
+                return true;
+            }
+
+            return false;
+        }
+
+        return TryGetClrEnumeratorElementType(getEnumerator.Type, out elementType);
     }
 
     /// <summary>
@@ -3826,6 +3880,57 @@ internal sealed class MemberLookup
             projectedType = null;
             return false;
         }
+    }
+
+    /// <summary>
+    /// Issue #2859: resolves the element type of an imported (CLR) enumerator
+    /// such as <c>IEnumerator[T]</c> or <c>List[T].Enumerator</c>. Prefers the
+    /// symbolic type argument over the reflected <c>Current</c> property
+    /// because a constructed generic closed over a same-compilation type is
+    /// deliberately erased to the <c>&lt;object&gt;</c> shape on
+    /// <see cref="TypeSymbol.ClrType"/> (#313/#939).
+    /// </summary>
+    /// <param name="enumeratorType">The enumerator type returned by <c>GetEnumerator()</c>.</param>
+    /// <param name="elementType">The element <see cref="TypeSymbol"/>, on success.</param>
+    /// <returns><see langword="true"/> when the enumerator shape matches.</returns>
+    private static bool TryGetClrEnumeratorElementType(TypeSymbol enumeratorType, out TypeSymbol elementType)
+    {
+        elementType = null;
+        Type enumeratorClr = enumeratorType.ClrType;
+        if (enumeratorClr == null)
+        {
+            return false;
+        }
+
+        MethodInfo moveNext = SafeGetMethodIncludingSelfAndInterfaces(
+            enumeratorClr, "MoveNext", Type.EmptyTypes);
+        PropertyInfo current = SafeGetPropertyIncludingSelfAndInterfaces(enumeratorClr, "Current");
+        if (moveNext == null || current == null)
+        {
+            return false;
+        }
+
+        if (enumeratorType is ImportedTypeSymbol imported &&
+            imported.HasSubstitutableTypeArgument &&
+            imported.OpenDefinition != null &&
+            !imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            PropertyInfo openCurrent = SafeGetPropertyIncludingSelfAndInterfaces(
+                imported.OpenDefinition, "Current");
+            if (openCurrent != null)
+            {
+                TypeSymbol mapped = MapOpenClrTypeToSymbolic(
+                    openCurrent.PropertyType, imported.OpenDefinition, imported.TypeArguments);
+                if (mapped != null && mapped != TypeSymbol.Error)
+                {
+                    elementType = mapped;
+                    return true;
+                }
+            }
+        }
+
+        elementType = TypeSymbol.FromClrType(current.PropertyType);
+        return elementType != null && elementType != TypeSymbol.Error;
     }
 
     private static PropertyInfo[] CollectVisibleClrIndexers(TypeSymbol targetType, Type clrTarget)

--- a/test/Compiler.Tests/Emit/Issue2859ClassTypedForInEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2859ClassTypedForInEmitTests.cs
@@ -1,0 +1,344 @@
+// <copyright file="Issue2859ClassTypedForInEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2859 — <c>for x in source</c> reported
+/// <c>GS0116: Type 'X' is not indexable</c> whenever the source's static type
+/// was a user <c>class</c> rather than an interface.
+/// <para>
+/// Root cause: the binder's user-type arm only accepted a
+/// <c>GetEnumerator()</c> whose return type was ANOTHER user-declared type
+/// exposing <c>Current</c> as a FIELD. Every real collection — and everything
+/// cs2gs emits for a C# <c>IEnumerable&lt;T&gt;</c> implementer — returns an
+/// imported <c>IEnumerator[T]</c> whose <c>Current</c> is a property, so the
+/// probe failed and the loop fell through to the indexer path.
+/// </para>
+/// <para>
+/// Two further gaps only surfaced across an assembly boundary, where the
+/// collection is an <c>ImportedTypeSymbol</c>: the <c>IEnumerable[T]</c> probe
+/// did not expand an interface's OWN base interfaces (so a class declaring only
+/// <c>IReadOnlyCollection[T]</c> never surfaced <c>IEnumerable[T]</c>), and the
+/// duck-typed probe looked for <c>MoveNext</c> with <c>Type.GetMethod</c>,
+/// which does not search an interface's base interfaces.
+/// </para>
+/// Real-world site: <c>tools/Oahu.Diagnostics/Checks/DeepStructureCheck.gs</c>
+/// iterating <c>Oahu.Decrypt.Mpeg4.Chunks.ChunkEntryList</c>.
+/// Each fact uses a UNIQUE package name because the in-process type caches are
+/// name-keyed.
+/// </summary>
+public class Issue2859ClassTypedForInEmitTests
+{
+    [Fact]
+    public void EndToEnd_ForIn_SameAssemblyClassImplementingIEnumerable_Runs()
+    {
+        // The reported defect: iterating a class-typed source whose
+        // GetEnumerator() returns an imported IEnumerator[T].
+        const string source = """
+            package i2859same
+            import System
+            import System.Collections
+            import System.Collections.Generic
+
+            class Bag : IEnumerable[int32] {
+                private let items List[int32]
+
+                init() {
+                    items = List[int32]()
+                    items.Add(1)
+                    items.Add(2)
+                    items.Add(3)
+                }
+
+                func GetEnumerator() IEnumerator[int32] -> items.GetEnumerator()
+                private func (IEnumerable) GetEnumerator() IEnumerator -> GetEnumerator()
+            }
+
+            func Main() {
+                var total = 0
+                let bag = Bag()
+                for x in bag {
+                    total += x
+                }
+
+                Console.WriteLine(total)
+            }
+            """;
+
+        Assert.Equal("6\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_ForIn_SameAssemblyClassWithSourceDeclaredElement_KeepsElementType()
+    {
+        // The element type is a same-compilation class, so the constructed
+        // IEnumerator[Item] is erased to IEnumerator<object> on its ClrType.
+        // The loop variable must still recover the symbolic `Item` (otherwise
+        // `it.Value` cannot bind).
+        const string source = """
+            package i2859elem
+            import System
+            import System.Collections.Generic
+
+            class Item {
+                prop Value int32 { get; init; }
+            }
+
+            class ItemBag {
+                private let items List[Item]
+
+                init() {
+                    items = List[Item]()
+                    items.Add(Item{Value: 7})
+                    items.Add(Item{Value: 9})
+                }
+
+                func GetEnumerator() IEnumerator[Item] -> items.GetEnumerator()
+            }
+
+            func Main() {
+                var total = 0
+                for it in ItemBag() {
+                    total += it.Value
+                }
+
+                Console.WriteLine(total)
+            }
+            """;
+
+        Assert.Equal("16\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_ForIn_ImportedClassDeclaringOnlyIReadOnlyCollection_Runs()
+    {
+        // The Oahu shape: `ChunkEntryList : IReadOnlyCollection[ChunkEntry]`
+        // consumed from another assembly. IEnumerable[T] is only reachable by
+        // expanding IReadOnlyCollection[T]'s own base interfaces.
+        const string library = """
+            package i2859lib
+            import System
+            import System.Collections
+            import System.Collections.Generic
+
+            class Entry {
+                prop N int32 { get; init; }
+            }
+
+            class EntryList : IReadOnlyCollection[Entry] {
+                private let items List[Entry]
+
+                init() {
+                    items = List[Entry]()
+                    items.Add(Entry{N: 4})
+                    items.Add(Entry{N: 5})
+                }
+
+                prop Count int32 { get -> items.Count }
+
+                func GetEnumerator() IEnumerator[Entry] -> items.GetEnumerator()
+                private func (IEnumerable) GetEnumerator() IEnumerator -> GetEnumerator()
+            }
+            """;
+
+        const string source = """
+            package i2859xasm
+            import System
+            import i2859lib
+
+            func Main() {
+                var total = 0
+                let list = EntryList()
+                for e in list {
+                    total += e.N
+                }
+
+                Console.WriteLine(total)
+            }
+            """;
+
+        Assert.Equal("9\n", CompileAndRun(source, library, "i2859lib"));
+    }
+
+    [Fact]
+    public void EndToEnd_ForIn_ImportedDuckTypedClassWithNoInterface_Runs()
+    {
+        // No interface at all — only a public GetEnumerator() returning an
+        // imported IEnumerator[T]. MoveNext lives on the BASE IEnumerator
+        // interface, which Type.GetMethod does not search.
+        const string library = """
+            package i2859ducklib
+            import System.Collections.Generic
+
+            class DuckBag {
+                private let items List[int32]
+
+                init() {
+                    items = List[int32]()
+                    items.Add(10)
+                    items.Add(20)
+                }
+
+                func GetEnumerator() IEnumerator[int32] -> items.GetEnumerator()
+            }
+            """;
+
+        const string source = """
+            package i2859duck
+            import System
+            import i2859ducklib
+
+            func Main() {
+                var total = 0
+                for v in DuckBag() {
+                    total += v
+                }
+
+                Console.WriteLine(total)
+            }
+            """;
+
+        Assert.Equal("30\n", CompileAndRun(source, library, "i2859ducklib"));
+    }
+
+    [Fact]
+    public void EndToEnd_ForIn_InterfaceTypedSource_StillRuns()
+    {
+        // Control: the interface-typed source always worked and must keep
+        // working — this fact fails if the widening broke the existing path.
+        const string source = """
+            package i2859ctrl
+            import System
+            import System.Collections.Generic
+
+            func Main() {
+                var total = 0
+                let items IEnumerable[int32] = List[int32]{ 1, 2, 3, 4 }
+                for x in items {
+                    total += x
+                }
+
+                Console.WriteLine(total)
+            }
+            """;
+
+        Assert.Equal("10\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source, string library = null, string libraryAssemblyName = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2859_exe_").FullName;
+        try
+        {
+            string libDll = null;
+            if (library != null)
+            {
+                // ilverify resolves `-r` references by FILE NAME, so the
+                // library must be written out under its assembly identity.
+                var libSrc = Path.Combine(tempDir, libraryAssemblyName + ".gs");
+                libDll = Path.Combine(tempDir, libraryAssemblyName + ".dll");
+                File.WriteAllText(libSrc, library);
+                Compile(new[]
+                {
+                    "/out:" + libDll,
+                    "/target:library",
+                    "/targetframework:net10.0",
+                    libSrc,
+                });
+                IlVerifier.Verify(libDll);
+            }
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+            if (libDll != null)
+            {
+                args.Add("/r:" + libDll);
+            }
+
+            args.Add(srcPath);
+            Compile(args.ToArray());
+            IlVerifier.Verify(dllPath, libDll != null ? new[] { libDll } : null);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void Compile(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2859ClassTypedForInBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2859ClassTypedForInBinderTests.cs
@@ -1,0 +1,133 @@
+// <copyright file="Issue2859ClassTypedForInBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2859: binder-level facts for <c>for x in source</c> over a
+/// class-typed source. The duck-typed enumerable probe used to demand that
+/// <c>GetEnumerator()</c> return ANOTHER user-declared type exposing
+/// <c>Current</c> as a FIELD, so the ubiquitous
+/// <c>GetEnumerator() IEnumerator[T]</c> shape reported
+/// <c>GS0116: Type 'X' is not indexable</c>. The negative control pins the
+/// widening: a class that is genuinely not enumerable must STILL report
+/// GS0116, otherwise the fix would have degraded a real diagnostic into
+/// silently broken lowering.
+/// </summary>
+public class Issue2859ClassTypedForInBinderTests
+{
+    [Fact]
+    public void ForIn_ClassWithImportedEnumerator_Binds()
+    {
+        const string source = @"
+package p
+import System.Collections
+import System.Collections.Generic
+class Bag : IEnumerable[int32] {
+    private let items List[int32]
+    init() { items = List[int32]() }
+    func GetEnumerator() IEnumerator[int32] -> items.GetEnumerator()
+    private func (IEnumerable) GetEnumerator() IEnumerator -> GetEnumerator()
+}
+class C {
+    func Sum(b Bag) int32 {
+        var total = 0
+        for x in b { total += x }
+        return total
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ForIn_ClassWithGetEnumeratorOnly_Binds()
+    {
+        // No interface at all — the pure duck-typed shape.
+        const string source = @"
+package p
+import System.Collections.Generic
+class Duck {
+    private let items List[int32]
+    init() { items = List[int32]() }
+    func GetEnumerator() IEnumerator[int32] -> items.GetEnumerator()
+}
+class C {
+    func Sum(d Duck) int32 {
+        var total = 0
+        for x in d { total += x }
+        return total
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ForIn_ClassWithUserDeclaredEnumerator_StillBinds()
+    {
+        // Control: the pre-existing user-declared-enumerator shape
+        // (MoveNext() + a Current FIELD) must keep binding.
+        const string source = @"
+package p
+class E {
+    public var Current int32 = 0
+    func MoveNext() bool -> false
+}
+class Coll {
+    func GetEnumerator() E -> E()
+}
+class C {
+    func Sum(c Coll) int32 {
+        var total = 0
+        for x in c { total += x }
+        return total
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ForIn_NonEnumerableClass_StillReportsNotIndexable()
+    {
+        // Negative control (non-vacuity): the widening must not swallow the
+        // real diagnostic for a class that exposes no enumerable shape.
+        const string source = @"
+package p
+class Plain {
+    prop N int32 { get; init; }
+}
+class C {
+    func Sum(x Plain) int32 {
+        var total = 0
+        for v in x { total += 1 }
+        return total
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0116");
+    }
+
+    private static ImmutableArray<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+    }
+}


### PR DESCRIPTION
Fixes #2859.

## Problem

`for x in collection` over a **class-typed** source reported `GS0116` ("type is not indexable") whenever the class exposed a CLR enumerator — the shape `cs2gs` emits for every C# `IEnumerable<T>` implementer.

## Root cause

Three separate binder gaps:

1. `MemberLookup.TryGetUserPatternEnumerableElementType` demanded that `GetEnumerator` return a `StructSymbol` whose `Current` is a **field**. Real collections return an imported `IEnumerator[T]` whose `Current` is a **property**, so the `case StructSymbol userType when …` arm of the `for..in` strategy switch never fired and the loop fell through to `default:` → `GS0116`.
2. `TryGetClrEnumerableElementType` walked `Type.GetInterfaces()` non-transitively, so a class declaring only `IReadOnlyCollection[T]` never surfaced `IEnumerable[T]`. (gsc emits `InterfaceImpl` rows only for *directly declared* interfaces, so this bites across an assembly boundary.)
3. `TryGetClrPatternEnumerableElementType` resolved `MoveNext` with `Type.GetMethod`, which does not search an interface's base interfaces — `IEnumerator[T]` (whose `MoveNext` lives on `IEnumerator`) therefore failed duck-typed detection.

## Fix

- `TryGetUserPatternEnumerableElementType` keeps the original user-declared-enumerator arm and otherwise delegates to a new private `TryGetClrEnumeratorElementType`, which resolves `MoveNext`/`Current` through the interface closure and prefers the **symbolic** element type (via `MapOpenClrTypeToSymbolic`) when the enumerator is a substituted generic.
- `TryGetClrEnumerableElementType` now does a transitive BFS over the interface closure.
- `TryGetClrPatternEnumerableElementType` and `TryGetClrCurrentMemberType` now use the interface-walking lookups.

The lowerer needed **no** changes — `Lowerer.TryBuildGetEnumeratorCall` already handles a `StructSymbol` collection and `TryBuildMoveNextAndCurrent` already handles a CLR enumerator. Only the binder gate was missing.

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue2859ClassTypedForInBinderTests.cs` — 4 binder facts: imported enumerator, `GetEnumerator`-only, user-declared-enumerator control, and the `GS0116` negative control.
- `test/Compiler.Tests/Emit/Issue2859ClassTypedForInEmitTests.cs` — 5 end-to-end facts: same-assembly `IEnumerable[int32]`, same-assembly source-declared element type, cross-assembly `IReadOnlyCollection[Entry]`, cross-assembly duck-typed, and an interface-typed control.

Non-vacuity verified by reverting `MemberLookup.cs`: exactly the 2 binder defect facts and 4 emit defect facts fail; both controls stay green.

## Validation

- `Core.Tests`: **6828 passed / 0 failed** (baseline 6824).
- `Compiler.Tests`: **3602 passed / 0 failed** (baseline 3597).
- Scratch repros for all four shapes run with correct output and pass `ilverify` clean.
