### PR TITLE
Fix GS9998 when a nested lambda captures an erased adapter parameter (#2861)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -958,6 +958,15 @@ internal sealed class LambdaBinder
         var adapterParameters = ImmutableArray.CreateBuilder<ParameterSymbol>(literal.Function.Parameters.Length);
         var replacementMap = new Dictionary<VariableSymbol, BoundExpression>();
         var adapterPrefix = ImmutableArray.CreateBuilder<BoundStatement>();
+
+        // Issue #2861: a nested literal inside the body captures the ORIGINAL
+        // parameter symbol, which does not exist in the adapter method. Such a
+        // capture needs a real variable to bind against, so the inline
+        // `BoundConversionExpression` replacement below is not usable for it —
+        // collect the nested captures up front and force the converted-local
+        // path for every parameter one of them captures.
+        var nestedCaptures = CollectNestedCapturedVariables(literal.Body);
+        var nestedSubstitution = new Dictionary<VariableSymbol, VariableSymbol>();
         for (var i = 0; i < literal.Function.Parameters.Length; i++)
         {
             var original = literal.Function.Parameters[i];
@@ -983,7 +992,8 @@ internal sealed class LambdaBinder
                     && !TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(
                         adapterParameterType,
                         original.Type))
-                || conversions.HasUserDefinedImplicitConversion(adapterParameterType, original.Type);
+                || conversions.HasUserDefinedImplicitConversion(adapterParameterType, original.Type)
+                || (original.RefKind == RefKind.None && nestedCaptures.Contains(original));
             if (bindConvertedLocal)
             {
                 var converted = conversions.BindConversion(
@@ -1000,6 +1010,10 @@ internal sealed class LambdaBinder
                     convertedLocal,
                     converted));
                 replacementMap[original] = new BoundVariableExpression(null, convertedLocal);
+                if (original.RefKind == RefKind.None && nestedCaptures.Contains(original))
+                {
+                    nestedSubstitution[original] = convertedLocal;
+                }
             }
             else
             {
@@ -1064,7 +1078,7 @@ internal sealed class LambdaBinder
         // unverifiable FieldAccess/MethodAccess IL site.
         adapterFunction.LexicalEnclosingType = literal.Function.LexicalEnclosingType;
 
-        var body = (BoundBlockStatement)new ErasedFunctionLiteralAdapterRewriter(replacementMap, adapterResultType)
+        var body = (BoundBlockStatement)new ErasedFunctionLiteralAdapterRewriter(replacementMap, nestedSubstitution, adapterResultType)
             .RewriteStatement(literal.Body);
         if (adapterPrefix.Count > 0)
         {
@@ -1945,6 +1959,26 @@ internal sealed class LambdaBinder
     }
 
     /// <summary>
+    /// Issue #2861: gathers every variable captured by a function literal (or
+    /// local function) nested inside <paramref name="body"/>, transitively.
+    /// The erased-adapter rewriter must know these up front because a captured
+    /// variable can only be replaced by another <em>variable</em>, never by the
+    /// inline conversion expression the adapter otherwise substitutes.
+    /// </summary>
+    /// <param name="body">The literal body to scan.</param>
+    /// <returns>The set of variables captured by nested literals.</returns>
+    private static HashSet<VariableSymbol> CollectNestedCapturedVariables(BoundStatement body)
+    {
+        var sink = new HashSet<VariableSymbol>();
+        if (body != null)
+        {
+            new NestedCaptureCollector(sink).RewriteStatement(body);
+        }
+
+        return sink;
+    }
+
+    /// <summary>
     /// Issue #1940: scans a generic local function's parameter types, return type, and body for any
     /// reference to a <paramref name="enclosingTypeParameters"/> member — a type parameter owned by an
     /// enclosing generic method or class rather than the local function's own <c>[T, U, …]</c> list.
@@ -2103,16 +2137,182 @@ internal sealed class LambdaBinder
         }
     }
 
+    /// <summary>
+    /// Issue #2861: collects the variables captured by function literals nested
+    /// inside a body. <see cref="BoundTreeRewriter"/> treats a literal as a leaf,
+    /// so this walker descends explicitly to reach literals-in-literals.
+    /// </summary>
+    private sealed class NestedCaptureCollector : BoundTreeRewriter
+    {
+        private readonly HashSet<VariableSymbol> sink;
+
+        public NestedCaptureCollector(HashSet<VariableSymbol> sink)
+        {
+            this.sink = sink;
+        }
+
+        /// <inheritdoc/>
+        protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+        {
+            foreach (var captured in node.CapturedVariables)
+            {
+                this.sink.Add(captured);
+            }
+
+            this.RewriteStatement(node.Body);
+            return node;
+        }
+
+        /// <inheritdoc/>
+        protected override BoundStatement RewriteLocalFunctionDeclaration(BoundLocalFunctionDeclaration node)
+        {
+            this.RewriteFunctionLiteralExpression(node.Literal);
+            return node;
+        }
+    }
+
+    /// <summary>
+    /// Issue #2861: replaces variable references inside a nested function
+    /// literal — body reads/writes and the literal's own
+    /// <see cref="BoundFunctionLiteralExpression.CapturedVariables"/> list —
+    /// when the erased adapter re-homed the captured parameter onto a
+    /// converted local declared in the adapter's prologue.
+    /// </summary>
+    private sealed class NestedCaptureSubstitutionRewriter : BoundTreeRewriter
+    {
+        private readonly Dictionary<VariableSymbol, VariableSymbol> substitution;
+
+        private NestedCaptureSubstitutionRewriter(Dictionary<VariableSymbol, VariableSymbol> substitution)
+        {
+            this.substitution = substitution;
+        }
+
+        public static BoundFunctionLiteralExpression Rewrite(
+            BoundFunctionLiteralExpression literal,
+            Dictionary<VariableSymbol, VariableSymbol> substitution)
+        {
+            return (BoundFunctionLiteralExpression)new NestedCaptureSubstitutionRewriter(substitution)
+                .RewriteFunctionLiteralExpression(literal);
+        }
+
+        /// <inheritdoc/>
+        protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+        {
+            var body = (BoundBlockStatement)this.RewriteStatement(node.Body);
+            var captured = node.CapturedVariables;
+            ImmutableArray<VariableSymbol>.Builder builder = null;
+            for (var i = 0; i < captured.Length; i++)
+            {
+                if (!this.substitution.TryGetValue(captured[i], out var replacement))
+                {
+                    builder?.Add(captured[i]);
+                    continue;
+                }
+
+                if (builder == null)
+                {
+                    builder = ImmutableArray.CreateBuilder<VariableSymbol>(captured.Length);
+                    for (var j = 0; j < i; j++)
+                    {
+                        builder.Add(captured[j]);
+                    }
+                }
+
+                builder.Add(replacement);
+            }
+
+            if (builder == null && ReferenceEquals(body, node.Body))
+            {
+                return node;
+            }
+
+            return new BoundFunctionLiteralExpression(
+                node.Syntax,
+                node.Function,
+                node.FunctionType,
+                body,
+                builder?.ToImmutable() ?? captured);
+        }
+
+        /// <inheritdoc/>
+        protected override BoundStatement RewriteLocalFunctionDeclaration(BoundLocalFunctionDeclaration node)
+        {
+            var rewritten = (BoundFunctionLiteralExpression)this.RewriteFunctionLiteralExpression(node.Literal);
+            return ReferenceEquals(rewritten, node.Literal)
+                ? node
+                : new BoundLocalFunctionDeclaration(node.Syntax, rewritten);
+        }
+
+        /// <inheritdoc/>
+        protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
+        {
+            return this.substitution.TryGetValue(node.Variable, out var replacement)
+                ? new BoundVariableExpression(node.Syntax, replacement)
+                : node;
+        }
+
+        /// <inheritdoc/>
+        protected override BoundExpression RewriteAssignmentExpression(BoundAssignmentExpression node)
+        {
+            var rewritten = (BoundAssignmentExpression)base.RewriteAssignmentExpression(node);
+            return this.substitution.TryGetValue(rewritten.Variable, out var replacement)
+                ? new BoundAssignmentExpression(rewritten.Syntax, replacement, rewritten.Expression)
+                : rewritten;
+        }
+
+        /// <inheritdoc/>
+        protected override BoundExpression RewriteFieldAssignmentExpression(BoundFieldAssignmentExpression node)
+        {
+            var rewritten = base.RewriteFieldAssignmentExpression(node);
+            if (rewritten is not BoundFieldAssignmentExpression fieldAssignment
+                || fieldAssignment.Receiver == null
+                || !this.substitution.TryGetValue(fieldAssignment.Receiver, out var replacement))
+            {
+                return rewritten;
+            }
+
+            return new BoundFieldAssignmentExpression(
+                fieldAssignment.Syntax,
+                replacement,
+                fieldAssignment.StructType,
+                fieldAssignment.Field,
+                fieldAssignment.Value,
+                fieldAssignment.ResultType);
+        }
+
+        /// <inheritdoc/>
+        protected override BoundExpression RewriteIndexAssignmentExpression(BoundIndexAssignmentExpression node)
+        {
+            var rewritten = base.RewriteIndexAssignmentExpression(node);
+            if (rewritten is not BoundIndexAssignmentExpression indexAssignment
+                || indexAssignment.Target == null
+                || !this.substitution.TryGetValue(indexAssignment.Target, out var replacement))
+            {
+                return rewritten;
+            }
+
+            return new BoundIndexAssignmentExpression(
+                indexAssignment.Syntax,
+                replacement,
+                indexAssignment.Index,
+                indexAssignment.Value,
+                indexAssignment.Type);
+        }
+    }
+
     private sealed class ErasedFunctionLiteralAdapterRewriter : BoundTreeRewriter
     {
         private readonly Dictionary<VariableSymbol, BoundExpression> replacementMap;
+        private readonly Dictionary<VariableSymbol, VariableSymbol> nestedSubstitution;
         private readonly TypeSymbol adapterReturnType;
 
         public ErasedFunctionLiteralAdapterRewriter(
             Dictionary<VariableSymbol, BoundExpression> replacementMap,
+            Dictionary<VariableSymbol, VariableSymbol> nestedSubstitution,
             TypeSymbol adapterReturnType)
         {
             this.replacementMap = replacementMap;
+            this.nestedSubstitution = nestedSubstitution;
             this.adapterReturnType = adapterReturnType;
         }
 
@@ -2121,6 +2321,34 @@ internal sealed class LambdaBinder
             return this.replacementMap.TryGetValue(node.Variable, out var replacement)
                 ? replacement
                 : node;
+        }
+
+        // Issue #2861: BoundTreeRewriter treats a function literal as a leaf,
+        // so a nested lambda keeps reading — and keeps listing in its
+        // CapturedVariables — the ORIGINAL parameter symbol that the adapter
+        // replaced. The adapter method has no slot for that symbol, so emit
+        // fails with GS9998 "has no local slot or parameter index in the
+        // current method". Rewrite the nested literal against the converted
+        // locals the adapter prologue declares for exactly these captures.
+        protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+        {
+            return this.nestedSubstitution.Count == 0
+                ? node
+                : NestedCaptureSubstitutionRewriter.Rewrite(node, this.nestedSubstitution);
+        }
+
+        /// <inheritdoc/>
+        protected override BoundStatement RewriteLocalFunctionDeclaration(BoundLocalFunctionDeclaration node)
+        {
+            if (this.nestedSubstitution.Count == 0)
+            {
+                return node;
+            }
+
+            var rewritten = NestedCaptureSubstitutionRewriter.Rewrite(node.Literal, this.nestedSubstitution);
+            return ReferenceEquals(rewritten, node.Literal)
+                ? node
+                : new BoundLocalFunctionDeclaration(node.Syntax, rewritten);
         }
 
         protected override BoundStatement RewriteReturnStatement(BoundReturnStatement node)

--- a/test/Compiler.Tests/Emit/Issue2861AdapterNestedCaptureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2861AdapterNestedCaptureEmitTests.cs
@@ -1,0 +1,340 @@
+// <copyright file="Issue2861AdapterNestedCaptureEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2861 — a lambda with an EXPLICIT parameter type that is converted to
+/// a delegate whose slot type differs makes the binder synthesize an erased
+/// parameter adapter (<c>LambdaBinder.CreateErasedFunctionLiteralAdapter</c>),
+/// which rebinds every parameter onto a fresh <c>ParameterSymbol</c>.
+/// <para>
+/// <c>BoundTreeRewriter</c> treats a nested function literal as a leaf, so a
+/// nested lambda kept reading — and kept listing in its
+/// <c>CapturedVariables</c> — the ORIGINAL parameter symbol, which has no slot
+/// in the adapter method. Emit then crashed with
+/// <c>GS9998: Variable '…' has no local slot or parameter index in the current
+/// method</c>.
+/// </para>
+/// <para>
+/// These facts pin the runtime behaviour end to end: the nested closure must
+/// observe the adapter's converted parameter value on every invocation.
+/// </para>
+/// </summary>
+public class Issue2861AdapterNestedCaptureEmitTests
+{
+    [Fact]
+    public void NestedLambdaCapturingWidenedAdapterParameter_Runs()
+    {
+        // Defect: `Action[string]` supplies a `string` slot while the literal
+        // writes `object`, so an erased adapter is synthesized; the nested
+        // lambda then captures the pre-adapter parameter symbol.
+        const string source = """
+            package i2861a
+            import System
+
+            func Main() {
+                var log = ""
+                let a Action[string] = (msg object) -> {
+                    let g = () -> { log = "got:" + msg.ToString() }
+                    g()
+                }
+
+                a("hello")
+                Console.WriteLine(log)
+            }
+            """;
+
+        Assert.Equal("got:hello\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NestedLambdaCapturingAdapterParameter_ObservesEachInvocation()
+    {
+        // The converted local must be re-initialized per call, not hoisted
+        // once: two invocations must accumulate two distinct values.
+        const string source = """
+            package i2861b
+            import System
+            import System.Collections.Generic
+
+            func Main() {
+                let seen = List[string]()
+                let a Action[string] = (msg object) -> {
+                    let g = () -> { seen.Add(msg.ToString()) }
+                    g()
+                }
+
+                a("first")
+                a("second")
+                Console.WriteLine(string.Join(",", seen))
+            }
+            """;
+
+        Assert.Equal("first,second\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DoublyNestedLambdaCapturingAdapterParameter_Runs()
+    {
+        // The substitution must reach transitively through TWO levels of
+        // nesting, including the intermediate literal's capture list.
+        const string source = """
+            package i2861c
+            import System
+
+            func Main() {
+                var log = ""
+                let a Action[string] = (msg object) -> {
+                    let outer = () -> {
+                        let inner = () -> { log = "deep:" + msg.ToString() }
+                        inner()
+                    }
+
+                    outer()
+                }
+
+                a("nested")
+                Console.WriteLine(log)
+            }
+            """;
+
+        Assert.Equal("deep:nested\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NestedLambdaCapturingImportedDataClassParameter_Runs()
+    {
+        // The shape that blocked the Oahu migration: an imported `data class`
+        // is materialized as a semantic-aggregate StructSymbol while the
+        // delegate slot resolves to an ImportedTypeSymbol for the same CLR
+        // type, so the binder believes a conversion is needed and synthesizes
+        // an adapter for what is really an identity conversion.
+        const string library = """
+            package i2861lib
+
+            data class Msg(IncItem int32?) {
+            }
+            """;
+
+        const string source = """
+            package i2861d
+            import System
+            import i2861lib
+
+            func Main() {
+                var total = 0
+                let report Action[Msg] = (msg Msg) -> {
+                    let apply = () -> {
+                        if msg.IncItem != nil {
+                            total += msg.IncItem!!
+                        }
+                    }
+
+                    apply()
+                }
+
+                report(Msg(7))
+                report(Msg(5))
+                Console.WriteLine(total)
+            }
+            """;
+
+        Assert.Equal("12\n", CompileAndRun(source, library, "i2861lib"));
+    }
+
+    [Fact]
+    public void NestedLambdaCapturingAdapterParameterAndEnclosingLocal_Runs()
+    {
+        // Mixed captures: the nested literal captures BOTH the re-homed
+        // adapter parameter and a local from the enclosing method, so the
+        // substitution must rewrite one entry of the capture list and leave
+        // the other untouched.
+        const string source = """
+            package i2861e
+            import System
+
+            func Main() {
+                let prefix = "p:"
+                var log = ""
+                let a Action[string] = (msg object) -> {
+                    let g = () -> { log = prefix + msg.ToString() }
+                    g()
+                }
+
+                a("value")
+                Console.WriteLine(log)
+            }
+            """;
+
+        Assert.Equal("p:value\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NestedLambdaInLoopCapturingAdapterParameter_Runs()
+    {
+        // A nested literal created inside a loop in the adapter body: each
+        // iteration's closure must still bind to the adapter's converted
+        // local rather than the erased pre-adapter parameter.
+        const string source = """
+            package i2861f
+            import System
+            import System.Collections.Generic
+
+            func Main() {
+                let seen = List[string]()
+                let a Action[string] = (msg object) -> {
+                    let indexes = List[int32]{ 0, 1 }
+                    for i in indexes {
+                        let g = () -> { seen.Add(msg.ToString() + i.ToString()) }
+                        g()
+                    }
+                }
+
+                a("x")
+                Console.WriteLine(string.Join(",", seen))
+            }
+            """;
+
+        Assert.Equal("x0,x1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LambdaWithoutNesting_StillRunsThroughAdapter()
+    {
+        // Control: the non-nested adapter path must keep working unchanged.
+        const string source = """
+            package i2861ctrl
+            import System
+
+            func Main() {
+                var log = ""
+                let a Action[string] = (msg object) -> {
+                    log = "flat:" + msg.ToString()
+                }
+
+                a("value")
+                Console.WriteLine(log)
+            }
+            """;
+
+        Assert.Equal("flat:value\n", CompileAndRun(source));
+    }
+
+
+    private static string CompileAndRun(string source, string library = null, string libraryAssemblyName = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2861_exe_").FullName;
+        try
+        {
+            string libDll = null;
+            if (library != null)
+            {
+                // ilverify resolves `-r` references by FILE NAME, so the
+                // library must be written out under its assembly identity.
+                var libSrc = Path.Combine(tempDir, libraryAssemblyName + ".gs");
+                libDll = Path.Combine(tempDir, libraryAssemblyName + ".dll");
+                File.WriteAllText(libSrc, library);
+                Compile(new[]
+                {
+                    "/out:" + libDll,
+                    "/target:library",
+                    "/targetframework:net10.0",
+                    libSrc,
+                });
+                IlVerifier.Verify(libDll);
+            }
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+            if (libDll != null)
+            {
+                args.Add("/r:" + libDll);
+            }
+
+            args.Add(srcPath);
+            Compile(args.ToArray());
+            IlVerifier.Verify(dllPath, libDll != null ? new[] { libDll } : null);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void Compile(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+}


### PR DESCRIPTION
Fixes #2861.

## Problem

When an explicitly typed lambda parameter is not runtime-equivalent to the target delegate's slot type, `LambdaBinder` synthesizes an **erased parameter adapter**: every parameter is rebound to a fresh `ParameterSymbol` and the body is rewritten by `ErasedFunctionLiteralAdapterRewriter`.

`BoundTreeRewriter.RewriteFunctionLiteralExpression` and `RewriteLocalFunctionDeclaration` deliberately return nested literals unchanged, so a nested lambda kept reading -- and kept listing in its `CapturedVariables` -- the *original* parameter symbol that the adapter method no longer declares. Emit then failed with:

```
GS9998: Variable 'msg' has no local slot or parameter index in the current method
```

Minimal repro:

```gs
let a Action[string] = (msg object) -> {
    let g = () -> { let x = msg }
    g()
}
```

Removing the explicit parameter type, or removing the nesting, made it compile -- both of which suppress the adapter.

## Fix

Because a capture requires a *variable*, the inline `BoundConversionExpression` replacement cannot be used for these parameters. `CreateErasedFunctionLiteralAdapter` now:

1. Collects, via the new `NestedCaptureCollector`, every variable captured by any nested lambda or local function in the body.
2. Forces those parameters onto the **converted-local** path (a real local slot), recording `original -> convertedLocal`.
3. Substitutes throughout every nested literal via the new `NestedCaptureSubstitutionRewriter`, which rewrites variable reads, all four assignment forms, and -- importantly -- each nested literal's rebuilt `CapturedVariables` set.

## Tests

Seven new end-to-end emit facts in `test/Compiler.Tests/Emit/Issue2861AdapterNestedCaptureEmitTests.cs`:

| fact | covers |
| --- | --- |
| `NestedLambdaCapturingWidenedAdapterParameter_Runs` | the base repro |
| `NestedLambdaCapturingAdapterParameter_ObservesEachInvocation` | value is re-read per invocation, not captured once |
| `DoublyNestedLambdaCapturingAdapterParameter_Runs` | two levels of nesting |
| `NestedLambdaCapturingImportedDataClassParameter_Runs` | cross-assembly `data class` parameter (the original Oahu shape) |
| `NestedLambdaCapturingAdapterParameterAndEnclosingLocal_Runs` | mixed parameter + enclosing-local capture |
| `NestedLambdaInLoopCapturingAdapterParameter_Runs` | nesting inside a loop |
| `LambdaWithoutNesting_StillRunsThroughAdapter` | control: non-nested adapter path unchanged |

Six of the seven fail on `main`; the control passes, confirming non-vacuity.

## Validation

- `Core.Tests`: 6824 passed, 1 skipped, **0 failed**
- `Compiler.Tests`: **3604 passed, 0 failed** (baseline 3597 + 7 new)
- A hand-built assembly exercising the repro runs correctly and is **`ilverify` clean**

## Impact

Unblocks `src/Oahu.App` in the cs2gs Oahu migration, which failed to emit with this exact GS9998.

## Follow-up (not fixed here)

The adapter should not have been synthesized at all for the imported-`data class` case: an imported `data class` is materialized as a semantic-aggregate `StructSymbol` while the delegate slot resolves to an `ImportedTypeSymbol` for the same CLR type, and `TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability` has no arm for that mixed pair, so it falls through to `left.GetType() != right.GetType()`. Adding a mixed arm that compares `ClrType` would avoid the needless adapter. This is documented in #2861; the fix here is the correct one regardless, since the general case (`(msg object)` against `Action[string]`) legitimately needs an adapter.
