### PR TITLE
Recognize imported overrides and stop cloning abstract data classes (#2863, #2864)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
+++ b/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
@@ -670,6 +670,32 @@ internal sealed class DataStructSynthesizer
 
     private void EmitDataClassClone(StructSymbol structSym, MethodDefinitionHandle copyConstructor)
     {
+        // Issue #2864: a data class is abstract when its effective member set
+        // still contains a no-body `open` member (StructSymbol.IsAbstract,
+        // #987). Emitting the ordinary copy-construct body there produced
+        // `newobj` of the abstract type itself, which ilverify rejects with
+        // NewobjAbstractClass.
+        //
+        // C# solves this by declaring `<Clone>$` abstract on the base and
+        // having each derived record override it with a COVARIANT return type
+        // (`Derived <Clone>$()` overriding `Base <Clone>$()`), which requires
+        // an explicit MethodImpl plus `PreserveBaseOverridesAttribute`. This
+        // emitter has no covariant-return support: every `<Clone>$` returns its
+        // own declaring type, so the signatures never match and the derived
+        // method silently lands in a fresh slot. Declaring the base one
+        // abstract would therefore leave it permanently unimplemented and the
+        // runtime would reject the derived type with a TypeLoadException.
+        //
+        // `<Clone>$` has no consumer inside gsc — it exists purely for C#
+        // record shape compatibility — so the correct narrow fix is to omit it
+        // on an abstract data class, exactly as an abstract type omits any
+        // other member it cannot implement. Concrete data classes are
+        // unaffected.
+        if (structSym.IsAbstract)
+        {
+            return;
+        }
+
         int bodyOffset = -1;
         if (!this.emitCtx.MetadataOnly)
         {

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1871,11 +1871,17 @@ internal sealed class ReflectionMetadataEmitter
             // skipping the synthesized ToString body in that case. The two
             // skips are independent and compose (a zero-field data class
             // with a user ToString override reserves five rows).
+            // Issue #2864: an ABSTRACT data class skips `<Clone>$` (one fewer
+            // row) — see DataStructSynthesizer.EmitDataClassClone's matching
+            // early return, which exists because `newobj` of the abstract type
+            // itself is unverifiable and this emitter has no covariant-return
+            // support to declare the member abstract instead.
             if (c.IsData)
             {
                 methodRow += 10
                     - (DataStructSynthesizer.HasZeroDeconstructionMembers(c) ? 1 : 0)
-                    - (DataStructSynthesizer.HasUserToStringOverride(c) ? 1 : 0);
+                    - (DataStructSynthesizer.HasUserToStringOverride(c) ? 1 : 0)
+                    - (c.IsAbstract ? 1 : 0);
             }
 
             if (!c.Methods.IsDefaultOrEmpty)

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -815,7 +815,19 @@ public static class ClrTypeUtilities
         }
         catch (Exception ex) when (IsMetadataLoadFailure(ex))
         {
-            return false;
+            // Issue #2863: MetadataLoadContext does not implement
+            // GetBaseDefinition() at all — it throws NotSupportedException for
+            // EVERY method, which IsMetadataLoadFailure classifies as a load
+            // failure. Returning the conservative "not an override" here made
+            // every imported member look like a fresh declaration, which in
+            // turn made every virtual imported property look abstract
+            // (PropertySymbol.IsAbstract) and every imported type that had one
+            // report GS0386 at its concrete use sites. Read the override bit
+            // straight out of the metadata instead: a method that introduces a
+            // new virtual slot carries `newslot`, while one that overrides an
+            // inherited slot does not. Interface implementations are emitted
+            // `virtual final newslot`, so they correctly stay non-overrides.
+            return IsOverrideFromMetadataAttributes(accessor);
         }
     }
 
@@ -1012,6 +1024,30 @@ public static class ClrTypeUtilities
         MemberCache<FieldInfo>.Cache.Clear();
         MemberCache<EventInfo>.Cache.Clear();
         MemberCache<ConstructorInfo>.Cache.Clear();
+    }
+
+    /// <summary>
+    /// Issue #2863: decides whether <paramref name="accessor"/> overrides an
+    /// inherited virtual slot using only <see cref="MethodBase.Attributes"/>,
+    /// which every metadata backend — including
+    /// <c>MetadataLoadContext</c> — supports. A method that introduces a new
+    /// virtual slot is emitted <c>virtual newslot</c>; a method that overrides
+    /// an inherited one is emitted <c>virtual</c> without <c>newslot</c>.
+    /// </summary>
+    /// <param name="accessor">The method to classify.</param>
+    /// <returns><c>true</c> when the method reuses an inherited virtual slot.</returns>
+    private static bool IsOverrideFromMetadataAttributes(MethodInfo accessor)
+    {
+        try
+        {
+            var attributes = accessor.Attributes;
+            return (attributes & MethodAttributes.Virtual) != 0
+                && (attributes & MethodAttributes.NewSlot) == 0;
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex))
+        {
+            return false;
+        }
     }
 
     private static bool GenericArgumentsAreAssignable(Type target, Type source)

--- a/test/Compiler.Tests/Emit/Issue2863ImportedOverrideEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2863ImportedOverrideEmitTests.cs
@@ -1,0 +1,431 @@
+// <copyright file="Issue2863ImportedOverrideEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2863 — <c>ClrTypeUtilities.SafeIsOverride</c> probed
+/// <c>MethodInfo.GetBaseDefinition()</c>, which <c>MetadataLoadContext</c> does
+/// not implement: it throws <c>NotSupportedException</c> for EVERY method, and
+/// <c>IsMetadataLoadFailure</c> classifies that as a load failure, so the
+/// conservative "not an override" default was returned for every imported
+/// member.
+/// <para>
+/// <c>PropertySymbol.IsAbstract</c> is
+/// <c>IsVirtual &amp;&amp; !IsOverride &amp;&amp; !IsAutoProperty &amp;&amp; …</c>
+/// and imported properties never carry body syntax, so an imported property
+/// that OVERRIDES a base declaration looked abstract. That made
+/// <c>StructSymbol.IsAbstract</c> mark the whole imported type abstract, and
+/// every cross-assembly use site reported
+/// <c>GS0386: Cannot create an instance of the abstract type</c>.
+/// </para>
+/// <para>
+/// The override bit is now read straight out of metadata: a method that
+/// introduces a new virtual slot is emitted <c>virtual newslot</c>, one that
+/// overrides an inherited slot is not.
+/// </para>
+/// </summary>
+public class Issue2863ImportedOverrideEmitTests
+{
+    [Fact]
+    public void ImportedDataClassOverridingAbstractShapedBaseProperty_Runs()
+    {
+        // The exact Oahu shape: `public abstract record` translates to an
+        // `open data class` with a no-body `open prop`, and the concrete
+        // derived record overrides it.
+        const string library = """
+            package i2863lib
+
+            open data class Base {
+                open prop Kind string {
+                    get;
+                }
+            }
+
+            open data class Derived(Value int32) : Base {
+                open override prop Kind string -> "derived"
+            }
+            """;
+
+        const string source = """
+            package i2863a
+            import i2863lib
+
+            func Main() {
+                let d = Derived(7)
+                System.Console.WriteLine(d.Kind + ":" + d.Value.ToString())
+            }
+            """;
+
+        Assert.Equal("derived:7\n", CompileAndRun(source, library, "i2863lib"));
+    }
+
+    [Fact]
+    public void ImportedDataClassWithSeveralOverriddenProperties_Runs()
+    {
+        // Only the semantic-aggregate path (records / data classes) feeds
+        // SafeIsOverride, so every load-bearing fact here uses a data class.
+        const string library = """
+            package i2863lib2
+
+            open data class Shape {
+                open prop Name string {
+                    get;
+                }
+
+                open prop Sides int32 {
+                    get;
+                }
+            }
+
+            open data class Square : Shape {
+                open override prop Name string -> "square"
+
+                open override prop Sides int32 -> 4
+            }
+            """;
+
+        const string source = """
+            package i2863b
+            import i2863lib2
+
+            func Main() {
+                let s = Square()
+                System.Console.WriteLine(s.Name + ":" + s.Sides.ToString())
+            }
+            """;
+
+        Assert.Equal("square:4\n", CompileAndRun(source, library, "i2863lib2"));
+    }
+
+    [Fact]
+    public void ImportedDataClassDerivedAssignedToBaseTypedLocal_DispatchesVirtually()
+    {
+        // The overriding property must still be virtual, so a base-typed
+        // reference dispatches to the derived implementation.
+        const string library = """
+            package i2863lib3
+
+            open data class Shape {
+                open prop Name string {
+                    get;
+                }
+            }
+
+            open data class Square : Shape {
+                open override prop Name string -> "square"
+            }
+
+            open data class Circle : Shape {
+                open override prop Name string -> "circle"
+            }
+            """;
+
+        const string source = """
+            package i2863c
+            import i2863lib3
+
+            func Main() {
+                let a Shape = Square()
+                let b Shape = Circle()
+                System.Console.WriteLine(a.Name + "," + b.Name)
+            }
+            """;
+
+        Assert.Equal("square,circle\n", CompileAndRun(source, library, "i2863lib3"));
+    }
+
+    [Fact]
+    public void ImportedDataClassTwoLevelOverrideChain_UsesMostDerivedImplementation()
+    {
+        // A middle type that both overrides and is overridden exercises the
+        // `virtual, no newslot` classification on BOTH ends of the chain.
+        const string library = """
+            package i2863lib4
+
+            open data class Level0 {
+                open prop Tag string {
+                    get;
+                }
+            }
+
+            open data class Level1 : Level0 {
+                open override prop Tag string -> "one"
+            }
+
+            open data class Level2 : Level1 {
+                open override prop Tag string -> "two"
+            }
+            """;
+
+        const string source = """
+            package i2863d
+            import i2863lib4
+
+            func Main() {
+                let a Level0 = Level1()
+                let b Level0 = Level2()
+                System.Console.WriteLine(a.Tag + "," + b.Tag)
+            }
+            """;
+
+        Assert.Equal("one,two\n", CompileAndRun(source, library, "i2863lib4"));
+    }
+
+    [Fact]
+    public void ImportedAbstractShapedDataClassBase_IsStillNotConstructible()
+    {
+        // Non-vacuity guard in the other direction: reading the override bit
+        // from metadata must NOT make genuinely abstract imported types look
+        // concrete.
+        const string library = """
+            package i2863lib5
+
+            open data class Shape {
+                open prop Name string {
+                    get;
+                }
+            }
+
+            open data class Square : Shape {
+                open override prop Name string -> "square"
+            }
+            """;
+
+        const string source = """
+            package i2863e
+            import i2863lib5
+
+            func Main() {
+                let s = Shape()
+                System.Console.WriteLine(s.Name)
+            }
+            """;
+
+        var diagnostics = CompileExpectingFailure(source, library, "i2863lib5");
+        Assert.Contains("GS0386", diagnostics);
+    }
+
+    [Fact]
+    public void ImportedNonVirtualProperty_IsUnaffected()
+    {
+        // Control: an ordinary sealed-shaped imported property is neither
+        // virtual nor an override, and keeps working.
+        const string library = """
+            package i2863lib6
+
+            class Holder(Value int32) {
+                prop Doubled int32 -> Value * 2
+            }
+            """;
+
+        const string source = """
+            package i2863f
+            import i2863lib6
+
+            func Main() {
+                let h = Holder(21)
+                System.Console.WriteLine(h.Doubled.ToString())
+            }
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source, library, "i2863lib6"));
+    }
+
+    private static string CompileAndRun(string source, string library = null, string libraryAssemblyName = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2863_exe_").FullName;
+        try
+        {
+            var dllPath = BuildExecutable(tempDir, source, library, libraryAssemblyName, out var libDll);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            IlVerifier.Verify(dllPath, libDll != null ? new[] { libDll } : null);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private static string CompileExpectingFailure(string source, string library, string libraryAssemblyName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2863_err_").FullName;
+        try
+        {
+            var libSrc = Path.Combine(tempDir, libraryAssemblyName + ".gs");
+            var libDll = Path.Combine(tempDir, libraryAssemblyName + ".dll");
+            File.WriteAllText(libSrc, library);
+            Compile(new[]
+            {
+                "/out:" + libDll,
+                "/target:library",
+                "/targetframework:net10.0",
+                libSrc,
+            });
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            File.WriteAllText(srcPath, source);
+
+            return CompileCapturingOutput(new[]
+            {
+                "/out:" + Path.Combine(tempDir, "test.dll"),
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/r:" + libDll,
+                srcPath,
+            });
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private static string BuildExecutable(
+        string tempDir,
+        string source,
+        string library,
+        string libraryAssemblyName,
+        out string libDll)
+    {
+        libDll = null;
+        if (library != null)
+        {
+            // ilverify resolves `-r` references by FILE NAME, so the library
+            // must be written out under its assembly identity.
+            var libSrc = Path.Combine(tempDir, libraryAssemblyName + ".gs");
+            libDll = Path.Combine(tempDir, libraryAssemblyName + ".dll");
+            File.WriteAllText(libSrc, library);
+            Compile(new[]
+            {
+                "/out:" + libDll,
+                "/target:library",
+                "/targetframework:net10.0",
+                libSrc,
+            });
+            IlVerifier.Verify(libDll);
+        }
+
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var dllPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + dllPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+        };
+        if (libDll != null)
+        {
+            args.Add("/r:" + libDll);
+        }
+
+        args.Add(srcPath);
+        Compile(args.ToArray());
+        return dllPath;
+    }
+
+    private static void Compile(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static string CompileCapturingOutput(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(compileExit != 0, "expected gsc to fail but it succeeded");
+        return stdoutWriter + stderrWriter.ToString();
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2864AbstractDataClassCloneEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2864AbstractDataClassCloneEmitTests.cs
@@ -1,0 +1,241 @@
+// <copyright file="Issue2864AbstractDataClassCloneEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2864 — <c>DataStructSynthesizer.EmitDataClassClone</c> gave every
+/// data class a <c>&lt;Clone&gt;$</c> whose body is
+/// <c>ldarg.0; newobj &lt;copy ctor&gt;; ret</c>. A data class is ABSTRACT when
+/// its effective member set still contains a no-body <c>open</c> member
+/// (<c>StructSymbol.IsAbstract</c>, #987), and <c>newobj</c> of an abstract
+/// type is rejected by ilverify with <c>NewobjAbstractClass</c>.
+/// <para>
+/// <c>&lt;Clone&gt;$</c> exists purely for C# record shape compatibility and
+/// has no consumer inside gsc (G# has no <c>with</c> expression), so it is now
+/// omitted on an abstract data class. The matching MethodDef row reservation in
+/// <c>ReflectionMetadataEmitter.PlanClassMethods</c> must skip the same row —
+/// these facts pin that alignment, since a stale reservation silently shifts
+/// every later method token in the type.
+/// </para>
+/// </summary>
+public class Issue2864AbstractDataClassCloneEmitTests
+{
+    [Fact]
+    public void AbstractDataClassWithConcreteDerived_VerifiesAndRuns()
+    {
+        const string source = """
+            package i2864a
+
+            open data class Base {
+                open prop Kind string {
+                    get;
+                }
+            }
+
+            open data class Derived(Value int32) : Base {
+                open override prop Kind string -> "derived"
+            }
+
+            func Main() {
+                let d = Derived(7)
+                System.Console.WriteLine(d.Kind + ":" + d.Value.ToString())
+            }
+            """;
+
+        Assert.Equal("derived:7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void AbstractDataClassWithUserMethods_KeepsMethodTokensAligned()
+    {
+        // The reservation fix is the risky half: omitting the `<Clone>$` row
+        // without shrinking PlanClassMethods' reservation shifts every later
+        // MethodDef token in the type, which corrupts unrelated call sites
+        // rather than failing loudly.
+        const string source = """
+            package i2864b
+
+            open data class Shape {
+                open prop Name string {
+                    get;
+                }
+
+                func Describe() string -> "shape:" + this.Name
+
+                func Twice() string -> this.Describe() + "/" + this.Describe()
+            }
+
+            open data class Square(Side int32) : Shape {
+                open override prop Name string -> "square"
+
+                func Area() int32 -> this.Side * this.Side
+            }
+
+            func Main() {
+                let s = Square(4)
+                System.Console.WriteLine(s.Twice() + "|" + s.Area().ToString())
+            }
+            """;
+
+        Assert.Equal("shape:square/shape:square|16\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void AbstractDataClassWithUserToStringOverride_ComposesWithExistingSkips()
+    {
+        // Issue #2361 already removes one reserved row for a hand-written
+        // ToString; the new abstract skip must compose with it rather than
+        // replace it.
+        const string source = """
+            package i2864c
+
+            open data class Base {
+                open prop Kind string {
+                    get;
+                }
+
+                func Describe() string -> "kind=" + this.Kind
+
+                open override func ToString() string -> "base<" + this.Kind + ">"
+
+                func Shout() string -> this.Describe() + "!"
+            }
+
+            open data class Leaf(Id int32) : Base {
+                open override prop Kind string -> "leaf"
+            }
+
+            func Main() {
+                let l = Leaf(3)
+                System.Console.WriteLine(l.Shout() + "|" + l.ToString() + "|" + l.Id.ToString())
+            }
+            """;
+
+        // `Leaf` synthesizes its OWN ToString, which overrides the base's
+        // hand-written one — that is ordinary data-class behaviour. What
+        // matters here is that `Base` reserves 10 - 1 (ToString) - 1 (Clone)
+        // rows, so `Describe` and `Shout` still resolve to the right tokens.
+        Assert.Equal("kind=leaf!|Leaf(Id=3)|3\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ConcreteDataClass_StillEmitsWorkingSynthesizedMembers()
+    {
+        // Control: a data class that is NOT abstract keeps every synthesized
+        // member, including `<Clone>$`, and its rows stay aligned.
+        const string source = """
+            package i2864d
+
+            open data class Point(X int32, Y int32) {
+                func Sum() int32 -> this.X + this.Y
+            }
+
+            func Main() {
+                let p = Point(2, 5)
+                System.Console.WriteLine(p.Sum().ToString() + "|" + p.ToString())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.StartsWith("7|", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2864_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            Compile(new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private static void Compile(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+}


### PR DESCRIPTION
Fixes #2863. Fixes #2864.

## #2863 — imported members were never recognized as overrides

`ClrTypeUtilities.SafeIsOverride` probed `MethodInfo.GetBaseDefinition()`:

```csharp
try
{
    return accessor.GetBaseDefinition() != accessor;
}
catch (Exception ex) when (IsMetadataLoadFailure(ex))
{
    return false;
}
```

`MetadataLoadContext` does not implement that API — it throws `NotSupportedException` for **every** method — and `IsMetadataLoadFailure` counts `NotSupportedException` as a load failure. The conservative "not an override" default was therefore returned for every imported member, silently.

`PropertySymbol.IsAbstract` is `IsVirtual && !IsOverride && !IsAutoProperty && ((HasGetter && GetterBodySyntax == null) || …)`, and imported properties never carry body syntax. So an imported property that *overrides* a base declaration looked abstract, `StructSymbol.IsAbstract` marked the whole imported type abstract, and every cross-assembly use site reported:

```
error GS0386: Cannot create an instance of the abstract type 'Derived' (issue #987)
```

The override bit is now read straight out of metadata, which every backend supports: a method that introduces a new virtual slot is emitted `virtual newslot`; one that overrides an inherited slot is not. Interface implementations are emitted `virtual final newslot`, so they correctly remain non-overrides.

## #2864 — `<Clone>$` on an abstract data class

Fixing #2863 exposed this. `DataStructSynthesizer.EmitDataClassClone` gave every data class a `<Clone>$` whose body is `ldarg.0; newobj <copy ctor>; ret`. A data class is abstract when its effective member set still contains a no-body `open` member (`StructSymbol.IsAbstract`, #987), and `newobj` of an abstract type is rejected:

```
[IL]: Error [NewobjAbstractClass]: [lib.dll : lib.Base::<Clone>$()][offset 0x00000001]
      Cannot construct an instance of abstract class.
```

C# declares `<Clone>$` abstract on an abstract record and overrides it with a **covariant return type**, which requires an explicit `MethodImpl` plus `PreserveBaseOverridesAttribute`. This emitter has no covariant-return support — every `<Clone>$` returns its own declaring type, so signatures never match and the derived method silently lands in a fresh slot. Declaring the base one abstract was tried first and leaves it permanently unimplemented (`TypeLoadException: Method '<Clone>$' … does not have an implementation`).

`<Clone>$` has no consumer inside gsc — G# has no `with` expression; it exists purely for C# record shape compatibility — so it is now **omitted** on an abstract data class. The matching MethodDef row reservation in `ReflectionMetadataEmitter.PlanClassMethods` is shrunk by one to keep every later method token aligned, composing with the existing #2363 and #2361 skips.

## Tests

Ten new end-to-end emit facts.

`test/Compiler.Tests/Emit/Issue2863ImportedOverrideEmitTests.cs`:

| fact | covers |
| --- | --- |
| `ImportedDataClassOverridingAbstractShapedBaseProperty_Runs` | the exact Oahu shape |
| `ImportedDataClassWithSeveralOverriddenProperties_Runs` | multiple overridden properties |
| `ImportedDataClassDerivedAssignedToBaseTypedLocal_DispatchesVirtually` | overrides stay virtual |
| `ImportedDataClassTwoLevelOverrideChain_UsesMostDerivedImplementation` | a type that both overrides and is overridden |
| `ImportedAbstractShapedDataClassBase_IsStillNotConstructible` | **control** — a genuinely abstract imported type must still report GS0386 |
| `ImportedNonVirtualProperty_IsUnaffected` | **control** — ordinary imported property |

`test/Compiler.Tests/Emit/Issue2864AbstractDataClassCloneEmitTests.cs`:

| fact | covers |
| --- | --- |
| `AbstractDataClassWithConcreteDerived_VerifiesAndRuns` | ilverify + runtime |
| `AbstractDataClassWithUserMethods_KeepsMethodTokensAligned` | the row-reservation fix |
| `AbstractDataClassWithUserToStringOverride_ComposesWithExistingSkips` | composition with the #2361 skip |
| `ConcreteDataClass_StillEmitsWorkingSynthesizedMembers` | **control** — concrete data classes unchanged |

Seven of the ten fail without these changes; all three controls pass, confirming non-vacuity in both directions.

Note that only the semantic-aggregate path (records / data classes) feeds `SafeIsOverride`, so every load-bearing fact uses a data class — an equivalent plain `open class` version was verified to be vacuous and was replaced.

## Validation

- `Core.Tests`: 6824 passed, 1 skipped, **0 failed**
- `Compiler.Tests`: full suite green
- The cross-assembly repro is **`ilverify` clean** and runs correctly

## Impact

Unblocks `tests/Oahu.Cli.Tests` in the cs2gs Oahu migration — all 12 of its errors were GS0386 on concrete `data class`es (`CaptchaChallenge`, `ExternalLoginChallenge`, `ProfileKeyEx`) plus GS0159/GS0158/GS0133 cascades — and clears the only `ilverify` failure in the migration that is not also present in the C# baseline assemblies (`src/Oahu.Cli.App`).
