### PR TITLE
Fix reference-assembly override slots and imported data-type equality (#2870, #2866)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
@@ -336,13 +336,24 @@ internal sealed class MemberDefEmitter
                 ? MethodAttributes.Private
                 : AccessibilityMap.ToMethodVisibility(prop.GetterAccessibility))
             | MethodAttributes.SpecialName | MethodAttributes.HideBySig;
-        if (prop.IsVirtual)
-        {
-            methodAttrs |= MethodAttributes.Virtual | MethodAttributes.NewSlot;
-        }
-        else if (prop.IsOverride)
+
+        // Issue #2870: `IsVirtual` (declared `open`) and `IsOverride` are
+        // INDEPENDENT — an `open override prop` is both — so the override test
+        // has to come first. An override reuses the base virtual slot and must
+        // NOT carry NewSlot, whether or not it is itself further overridable.
+        // The implementation assembly happens to route computed-body accessors
+        // through FunctionEmitter and got this right; this fallback path is
+        // what a metadata-only (reference assembly) emit uses for every
+        // property, so the two assemblies disagreed on the vtable layout and
+        // consumers of the reference assembly saw the override as a fresh
+        // virtual — which made the declaring type look abstract (GS0386).
+        if (prop.IsOverride)
         {
             methodAttrs |= MethodAttributes.Virtual;
+        }
+        else if (prop.IsVirtual)
+        {
+            methodAttrs |= MethodAttributes.Virtual | MethodAttributes.NewSlot;
         }
         else if (this.PropertyImplicitlyImplementsInterface(structSym, prop))
         {
@@ -447,13 +458,17 @@ internal sealed class MemberDefEmitter
                 ? MethodAttributes.Private
                 : AccessibilityMap.ToMethodVisibility(prop.SetterAccessibility))
             | MethodAttributes.SpecialName | MethodAttributes.HideBySig;
-        if (prop.IsVirtual)
-        {
-            methodAttrs |= MethodAttributes.Virtual | MethodAttributes.NewSlot;
-        }
-        else if (prop.IsOverride)
+
+        // Issue #2870: see the matching comment in EmitPropertyGetter — the
+        // override test must precede the virtual test, since an
+        // `open override prop` is both.
+        if (prop.IsOverride)
         {
             methodAttrs |= MethodAttributes.Virtual;
+        }
+        else if (prop.IsVirtual)
+        {
+            methodAttrs |= MethodAttributes.Virtual | MethodAttributes.NewSlot;
         }
         else if (this.PropertyImplicitlyImplementsInterface(structSym, prop))
         {

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -790,19 +790,24 @@ internal sealed partial class MethodBodyEmitter
         if (b.Left.Type is StructSymbol ds && ds.IsData && b.Right.Type == ds &&
             (b.Op.Kind == BoundBinaryOperatorKind.Equals || b.Op.Kind == BoundBinaryOperatorKind.NotEquals))
         {
-            var structTypeDef = this.outer.cache.StructTypeDefs[ds];
+            // Issue #2866: an imported data class/struct has no row in
+            // StructTypeDefs (it is only a semantic aggregate projected off
+            // an ImportedTypeSymbol), so the indexer threw KeyNotFound. Route
+            // through GetElementTypeToken, which resolves a locally declared
+            // struct to its TypeDef and an imported one to a TypeRef/TypeSpec,
+            // and only compute it when a `box` is actually emitted.
             this.EmitExpression(b.Left);
             if (!ds.IsClass)
             {
                 this.il.OpCode(ILOpCode.Box);
-                this.il.Token(structTypeDef);
+                this.il.Token(this.outer.memberRefs.GetElementTypeToken(ds));
             }
 
             this.EmitExpression(b.Right);
             if (!ds.IsClass)
             {
                 this.il.OpCode(ILOpCode.Box);
-                this.il.Token(structTypeDef);
+                this.il.Token(this.outer.memberRefs.GetElementTypeToken(ds));
             }
 
             this.il.Call(this.outer.wellKnown.GetObjectStaticEqualsReference());

--- a/test/Compiler.Tests/Emit/Issue2866ImportedDataEqualityEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2866ImportedDataEqualityEmitTests.cs
@@ -1,0 +1,282 @@
+// <copyright file="Issue2866ImportedDataEqualityEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2866 — structural <c>==</c> / <c>!=</c> over a data class or data
+/// struct that lives in a REFERENCED assembly crashed the emitter with
+/// <c>GS9998: KeyNotFoundException</c>.
+/// <para>
+/// The structural-equality arm of <c>MethodBodyEmitter.EmitBinaryExpression</c>
+/// eagerly read <c>cache.StructTypeDefs[ds]</c>. That dictionary only holds
+/// TypeDef rows for types declared in the CURRENT compilation; an imported data
+/// type is a semantic aggregate projected off an <c>ImportedTypeSymbol</c> and
+/// has no row there, so the indexer threw. The token is now resolved through
+/// <c>GetElementTypeToken</c> (TypeDef for local, TypeRef/TypeSpec for
+/// imported) and is only computed when a <c>box</c> is actually emitted, which
+/// is never the case for a data CLASS.
+/// </para>
+/// </summary>
+public class Issue2866ImportedDataEqualityEmitTests
+{
+    [Fact]
+    public void EqualityOnImportedDataClass_CompilesAndComparesStructurally()
+    {
+        const string library = """
+            package i2866lib1
+
+            data class Point(X int32, Y int32)
+            """;
+
+        const string source = """
+            package i2866a
+            import i2866lib1
+
+            func Main() {
+                let a = Point(1, 2)
+                let b = Point(1, 2)
+                let c = Point(3, 4)
+                System.Console.WriteLine((a == b).ToString() + "," + (a == c).ToString())
+            }
+            """;
+
+        Assert.Equal("True,False\n", CompileAndRun(source, library, "i2866lib1"));
+    }
+
+    [Fact]
+    public void InequalityOnImportedDataClass_CompilesAndComparesStructurally()
+    {
+        const string library = """
+            package i2866lib2
+
+            data class Pair(Left string, Right string)
+            """;
+
+        const string source = """
+            package i2866b
+            import i2866lib2
+
+            func Main() {
+                let a = Pair("l", "r")
+                let b = Pair("l", "r")
+                let c = Pair("l", "x")
+                System.Console.WriteLine((a != b).ToString() + "," + (a != c).ToString())
+            }
+            """;
+
+        Assert.Equal("False,True\n", CompileAndRun(source, library, "i2866lib2"));
+    }
+
+    [Fact]
+    public void EqualityOnImportedDataStruct_BoxesThroughAnImportedTypeToken()
+    {
+        // A data STRUCT is the branch that actually needs the element token:
+        // both operands are boxed before the static Object.Equals call, and
+        // for an imported type that token must be a TypeRef, not a TypeDef.
+        const string library = """
+            package i2866lib3
+
+            data struct Vec(X int32, Y int32)
+            """;
+
+        const string source = """
+            package i2866c
+            import i2866lib3
+
+            func Main() {
+                let a = Vec(1, 2)
+                let b = Vec(1, 2)
+                let c = Vec(9, 9)
+                System.Console.WriteLine((a == b).ToString() + "," + (a == c).ToString())
+            }
+            """;
+
+        Assert.Equal("True,False\n", CompileAndRun(source, library, "i2866lib3"));
+    }
+
+    [Fact]
+    public void EqualityOnImportedOpenDataClassHierarchy_UsesRuntimeType()
+    {
+        // Structural equality routes through Object.Equals, so a derived data
+        // class must not compare equal to its base even with equal fields.
+        const string library = """
+            package i2866lib4
+
+            open data class Node(Id int32)
+
+            data class Leaf(Id int32) : Node(Id)
+            """;
+
+        const string source = """
+            package i2866d
+            import i2866lib4
+
+            func Main() {
+                let a Node = Node(1)
+                let b Node = Leaf(1)
+                System.Console.WriteLine((a == b).ToString())
+            }
+            """;
+
+        Assert.Equal("False\n", CompileAndRun(source, library, "i2866lib4"));
+    }
+
+    [Fact]
+    public void EqualityOnLocallyDeclaredDataClass_StillWorks()
+    {
+        // Control: the same-compilation path must keep resolving to the local
+        // TypeDef row and behave exactly as before.
+        const string source = """
+            package i2866e
+
+            data class Local(A int32)
+
+            data struct LocalVal(A int32)
+
+            func Main() {
+                let x = Local(5)
+                let y = Local(5)
+                let p = LocalVal(7)
+                let q = LocalVal(8)
+                System.Console.WriteLine((x == y).ToString() + "," + (p == q).ToString())
+            }
+            """;
+
+        Assert.Equal("True,False\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source, string library = null, string libraryAssemblyName = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2866_").FullName;
+        try
+        {
+            var dllPath = BuildExecutable(tempDir, source, library, libraryAssemblyName, out var libDll);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            IlVerifier.Verify(dllPath, libDll != null ? new[] { libDll } : null);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private static string BuildExecutable(
+        string tempDir,
+        string source,
+        string library,
+        string libraryAssemblyName,
+        out string libDll)
+    {
+        libDll = null;
+        if (library != null)
+        {
+            // ilverify resolves `-r` references by FILE NAME, so the library
+            // must be written out under its assembly identity.
+            var libSrc = Path.Combine(tempDir, libraryAssemblyName + ".gs");
+            libDll = Path.Combine(tempDir, libraryAssemblyName + ".dll");
+            File.WriteAllText(libSrc, library);
+            Compile(new[]
+            {
+                "/out:" + libDll,
+                "/target:library",
+                "/targetframework:net10.0",
+                libSrc,
+            });
+            IlVerifier.Verify(libDll);
+        }
+
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var dllPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + dllPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+        };
+        if (libDll != null)
+        {
+            args.Add("/r:" + libDll);
+        }
+
+        args.Add(srcPath);
+        Compile(args.ToArray());
+        return dllPath;
+    }
+
+    private static void Compile(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2870ReferenceAssemblyOverrideSlotEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2870ReferenceAssemblyOverrideSlotEmitTests.cs
@@ -1,0 +1,299 @@
+// <copyright file="Issue2870ReferenceAssemblyOverrideSlotEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2870 — <c>MemberDefEmitter.EmitPropertyGetter</c>/<c>EmitPropertySetter</c>
+/// tested <c>IsVirtual</c> before <c>IsOverride</c>. The two flags are
+/// independent (<c>IsVirtual</c> means "declared <c>open</c>",
+/// <c>IsOverride</c> means "overrides a base property"), so an
+/// <c>open override prop</c> set both, took the virtual branch, and wrongly
+/// acquired <c>NewSlot</c>.
+/// <para>
+/// The implementation assembly routes computed-body accessors through
+/// <c>FunctionEmitter</c> and got this right, so the defect only surfaced on
+/// the path that emits every property here: the metadata-only
+/// (<c>/refout</c>) emit. MSBuild passes the REFERENCE assembly to downstream
+/// compilations, so a consumer saw the override as a fresh virtual, which made
+/// <c>PropertySymbol.IsAbstract</c> true, marked the declaring type abstract,
+/// and produced <c>GS0386</c> at every construction site.
+/// </para>
+/// </summary>
+public class Issue2870ReferenceAssemblyOverrideSlotEmitTests
+{
+    [Fact]
+    public void OverridingDataClassProperty_HasNoNewSlotInEitherAssembly()
+    {
+        const string source = """
+            package i2870a
+
+            open data class CallbackChallenge {
+                open prop Kind string {
+                    get;
+                }
+            }
+
+            open data class CaptchaChallenge(ImageBytes []uint8) : CallbackChallenge {
+                open override prop Kind string -> "captcha"
+            }
+            """;
+
+        var (implementation, reference) = CompileWithReference(source, "i2870a.dll");
+
+        AssertNoNewSlot(implementation, "CaptchaChallenge", "get_Kind");
+        AssertNoNewSlot(reference, "CaptchaChallenge", "get_Kind");
+        AssertNewSlot(implementation, "CallbackChallenge", "get_Kind");
+        AssertNewSlot(reference, "CallbackChallenge", "get_Kind");
+    }
+
+    [Fact]
+    public void OverridingClassProperty_HasNoNewSlotInEitherAssembly()
+    {
+        const string source = """
+            package i2870b
+
+            open class Shape {
+                open prop Name string {
+                    get;
+                }
+            }
+
+            open class Square : Shape {
+                open override prop Name string -> "square"
+            }
+            """;
+
+        var (implementation, reference) = CompileWithReference(source, "i2870b.dll");
+
+        AssertNoNewSlot(implementation, "Square", "get_Name");
+        AssertNoNewSlot(reference, "Square", "get_Name");
+    }
+
+    [Fact]
+    public void OverridingSettableProperty_HasNoNewSlotInEitherAssembly()
+    {
+        // The setter emitter carries the same ordering bug as the getter.
+        const string source = """
+            package i2870c
+
+            open class Holder {
+                open prop Value string {
+                    get;
+                    set;
+                }
+            }
+
+            open class Derived : Holder {
+                private var backing string = ""
+
+                open override prop Value string {
+                    get -> this.backing
+                    set { this.backing = value }
+                }
+            }
+            """;
+
+        var (implementation, reference) = CompileWithReference(source, "i2870c.dll");
+
+        AssertNoNewSlot(implementation, "Derived", "get_Value");
+        AssertNoNewSlot(implementation, "Derived", "set_Value");
+        AssertNoNewSlot(reference, "Derived", "get_Value");
+        AssertNoNewSlot(reference, "Derived", "set_Value");
+    }
+
+    [Fact]
+    public void ConsumerCompilingAgainstReferenceAssembly_CanConstructTheOverridingType()
+    {
+        // End-to-end guard: this is exactly what MSBuild does for a
+        // ProjectReference, and what produced GS0386 in the Oahu migration.
+        const string library = """
+            package i2870lib
+
+            open data class CallbackChallenge {
+                open prop Kind string {
+                    get;
+                }
+            }
+
+            open data class CaptchaChallenge(ImageBytes []uint8) : CallbackChallenge {
+                open override prop Kind string -> "captcha"
+            }
+            """;
+
+        const string consumer = """
+            package i2870d
+            import i2870lib
+
+            func Main() {
+                let c = CaptchaChallenge([]uint8{1, 2})
+                System.Console.WriteLine(c.Kind)
+            }
+            """;
+
+        var tempDir = Directory.CreateTempSubdirectory("gs_2870_consumer_").FullName;
+        try
+        {
+            var libSrc = Path.Combine(tempDir, "i2870lib.gs");
+            var libDll = Path.Combine(tempDir, "impl", "i2870lib.dll");
+            var libRef = Path.Combine(tempDir, "ref", "i2870lib.dll");
+            Directory.CreateDirectory(Path.GetDirectoryName(libDll));
+            Directory.CreateDirectory(Path.GetDirectoryName(libRef));
+            File.WriteAllText(libSrc, library);
+            Compile(new[]
+            {
+                "/out:" + libDll,
+                "/refout:" + libRef,
+                "/target:library",
+                "/targetframework:net10.0",
+                libSrc,
+            });
+
+            var consumerSrc = Path.Combine(tempDir, "consumer.gs");
+            File.WriteAllText(consumerSrc, consumer);
+
+            // Compiling against the REFERENCE assembly is the case that broke.
+            Compile(new[]
+            {
+                "/out:" + Path.Combine(tempDir, "consumer.dll"),
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/r:" + libRef,
+                consumerSrc,
+            });
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    [Fact]
+    public void NonOverridingVirtualProperty_KeepsNewSlot()
+    {
+        // Control: a property that genuinely introduces a virtual slot must
+        // still carry NewSlot in both assemblies.
+        const string source = """
+            package i2870e
+
+            open class Root {
+                open prop Tag string -> "root"
+            }
+            """;
+
+        var (implementation, reference) = CompileWithReference(source, "i2870e.dll");
+
+        AssertNewSlot(implementation, "Root", "get_Tag");
+        AssertNewSlot(reference, "Root", "get_Tag");
+    }
+
+    private static void AssertNoNewSlot(string assemblyPath, string typeName, string methodName)
+    {
+        var attributes = ReadMethodAttributes(assemblyPath, typeName, methodName);
+        Assert.True(
+            (attributes & MethodAttributes.Virtual) != 0,
+            $"{typeName}::{methodName} in '{Path.GetFileName(assemblyPath)}' should be virtual but is {attributes}.");
+        Assert.True(
+            (attributes & MethodAttributes.NewSlot) == 0,
+            $"{typeName}::{methodName} in '{Path.GetFileName(assemblyPath)}' overrides a base slot " +
+            $"and must not carry NewSlot, but is {attributes}.");
+    }
+
+    private static void AssertNewSlot(string assemblyPath, string typeName, string methodName)
+    {
+        var attributes = ReadMethodAttributes(assemblyPath, typeName, methodName);
+        Assert.True(
+            (attributes & MethodAttributes.NewSlot) != 0,
+            $"{typeName}::{methodName} in '{Path.GetFileName(assemblyPath)}' introduces a virtual slot " +
+            $"and must carry NewSlot, but is {attributes}.");
+    }
+
+    private static MethodAttributes ReadMethodAttributes(string assemblyPath, string typeName, string methodName)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            if (!string.Equals(reader.GetString(type.Name), typeName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (string.Equals(reader.GetString(method.Name), methodName, StringComparison.Ordinal))
+                {
+                    return method.Attributes;
+                }
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"'{typeName}::{methodName}' not found in '{assemblyPath}'.");
+    }
+
+    private static (string Implementation, string Reference) CompileWithReference(string source, string outputName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2870_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, outputName);
+        var refPath = Path.Combine(
+            tempDir,
+            Path.GetFileNameWithoutExtension(outputName) + ".ref" + Path.GetExtension(outputName));
+        File.WriteAllText(srcPath, source);
+
+        Compile(new[]
+        {
+            "/out:" + outPath,
+            "/refout:" + refPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        });
+
+        return (outPath, refPath);
+    }
+
+    private static void Compile(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+}


### PR DESCRIPTION
Fixes #2870.
Fixes #2866.

## #2870 — reference assembly emits an override accessor with `newslot`

This is the defect that was blocking the Oahu migration's `tests/Oahu.Cli.Tests`.

`PropertySymbol.IsVirtual` means *"declared `open`"*; `PropertySymbol.IsOverride`
means *"overrides a base property"*. They are independent bits, and
`open override prop` sets **both**.

`MemberDefEmitter.EmitPropertyGetter` and `EmitPropertySetter` tested
`IsVirtual` **before** `IsOverride`, so an overriding accessor took the
new-slot branch and was emitted `virtual newslot specialname`.

The implementation assembly routes computed-body (`-> expr`) accessors through
`FunctionEmitter`, which gets this right — so the bug only surfaced on the
metadata-only `/refout` path, which emits *every* property through
`MemberDefEmitter`. Because MSBuild passes `obj/.../ref/Foo.dll` (the reference
assembly) to downstream compilations, consumers saw a fresh virtual slot,
concluded `PropertySymbol.IsAbstract`, propagated that to
`StructSymbol.IsAbstract`, and reported
`GS0386: Cannot create an instance of the abstract type`.

That is also why every standalone `gsc /r:impl.dll` repro passed: the
implementation assembly was always correct.

Observed on the real Oahu `CallbackBroker.gs`:

| assembly | `CaptchaChallenge::get_Kind` attributes |
| --- | --- |
| implementation | `Public, Virtual, HideBySig` |
| reference (before) | `Public, Virtual, HideBySig, NewSlot, SpecialName` |
| reference (after) | `Public, Virtual, HideBySig, SpecialName` |

The fix orders `IsOverride` before `IsVirtual` in both accessor emitters.

## #2866 — `==` on an imported data class ICEs with GS9998

Structural `==` / `!=` over a data class or data struct declared in a
**referenced** assembly crashed the emitter:

```
error GS9998: KeyNotFoundException: The given key 'Point' was not present in the dictionary.
```

The structural-equality arm of `MethodBodyEmitter.EmitBinaryExpression` eagerly
read `cache.StructTypeDefs[ds]`. That dictionary only holds TypeDef rows for
types declared in the **current** compilation; an imported data type is a
semantic aggregate projected off an `ImportedTypeSymbol` and has no row there,
so the indexer threw.

The token now resolves through `GetElementTypeToken`, which returns a TypeDef
for a locally declared struct and a TypeRef/TypeSpec for an imported one, and
it is only computed when a `box` is actually emitted — which never happens for
a data **class** (a reference type needs no boxing).

## Validation

- `Core.Tests` — 6828 passed, 1 skipped, 0 failed.
- `Compiler.Tests` — **3629 passed, 0 failed** (3619 on `main` + 5 for #2870 + 5 for #2866).
- Non-vacuity, #2870: with `src/` reverted, 4 of 5 facts fail and the
  `NonOverridingVirtualProperty_KeepsNewSlot` control still passes.
- Non-vacuity, #2866: with `src/` reverted, 4 of 5 facts fail and the
  `EqualityOnLocallyDeclaredDataClass_StillWorks` control still passes.
- Both new suites assert against real emitted metadata read back with
  `System.Reflection.Metadata`, and every executable fact runs `ilverify` plus
  `dotnet exec` on the produced assembly.
