### PR TITLE
Fix imported data-class abstractness and delegate-target selection (#2874, #2876)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -4851,9 +4851,22 @@ internal sealed class ReflectionMetadataEmitter
     // maintained predicate.
     internal static bool ArgIsSymbolicUserDefined(TypeSymbol arg)
     {
+        // Issue #2876: an IMPORTED data type's semantic aggregate is also a
+        // StructSymbol (see ImportedTypeSymbol.BuildSemanticAggregate, which
+        // passes `clrType: type`), yet it is fully reflection-resolvable and
+        // therefore NOT symbolic. Symbolic encoding exists precisely because a
+        // same-compilation user type has no CLR backing yet, which is exactly
+        // the `ClrType == null` case — the identical guard already used by
+        // TypeSymbol.IsSameCompilationUserTypeTopLevel for these same four
+        // symbol kinds. Without it, a lambda over an imported data class made
+        // its whole function type look symbolic, so
+        // EmitFunctionToDelegateConversion discarded the real target delegate
+        // and materialised the natural `Func`/`Action` shape instead — pushing
+        // a `Func<T,bool>` where a `Predicate<T>` was expected (unverifiable
+        // IL, ilverify StackUnexpected).
         if (arg is StructSymbol or InterfaceSymbol or EnumSymbol or DelegateTypeSymbol)
         {
-            return true;
+            return arg.ClrType == null;
         }
 
         // Issue #833: an in-scope generic type parameter (MVar/Var) carried

--- a/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
@@ -377,7 +377,8 @@ public sealed class ImportedTypeSymbol : TypeSymbol
                 isVirtual: (getter ?? setter)?.IsVirtual == true,
                 isOverride: ClrTypeUtilities.SafeIsOverride(getter ?? setter),
                 isStatic: (getter ?? setter)?.IsStatic == true,
-                isInitOnly: setter != null && IsInitOnlySetter(setter)));
+                isInitOnly: setter != null && IsInitOnlySetter(setter),
+                metadataIsAbstract: (getter ?? setter)?.IsAbstract == true));
         }
 
         var primaryConstructorParameters = BuildPrimaryConstructorParameters(

--- a/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
@@ -29,6 +29,11 @@ public sealed class PropertySymbol : Symbol
     /// <param name="isInitOnly">Whether the property's setter is an <c>init</c>-only accessor (issue #946).</param>
     /// <param name="getterAccessibility">The getter accessibility, or the property accessibility when omitted.</param>
     /// <param name="setterAccessibility">The setter accessibility, or the property accessibility when omitted.</param>
+    /// <param name="metadataIsAbstract">
+    /// The abstractness read straight out of metadata for an imported property, or
+    /// <see langword="null"/> for a source-declared property whose abstractness is inferred
+    /// from its declaration shape (issue #2874).
+    /// </param>
     public PropertySymbol(
         string name,
         TypeSymbol type,
@@ -43,7 +48,8 @@ public sealed class PropertySymbol : Symbol
         PropertyDeclarationSyntax declaration = null,
         bool isInitOnly = false,
         Accessibility? getterAccessibility = null,
-        Accessibility? setterAccessibility = null)
+        Accessibility? setterAccessibility = null,
+        bool? metadataIsAbstract = null)
         : base(name)
     {
         Type = type;
@@ -59,6 +65,7 @@ public sealed class PropertySymbol : Symbol
         IsInitOnly = isInitOnly;
         GetterAccessibility = getterAccessibility ?? accessibility;
         SetterAccessibility = setterAccessibility ?? accessibility;
+        MetadataIsAbstract = metadataIsAbstract;
     }
 
     /// <inheritdoc/>
@@ -102,12 +109,27 @@ public sealed class PropertySymbol : Symbol
     /// <summary>Gets a value indicating whether this property overrides a base property.</summary>
     public bool IsOverride { get; }
 
+    /// <summary>
+    /// Gets the abstractness read straight out of metadata for an imported property, or
+    /// <see langword="null"/> when this property was declared in source (issue #2874).
+    /// </summary>
+    /// <remarks>
+    /// An imported property carries no body syntax, so the source-shape inference below
+    /// classified every virtual, non-overriding imported property (for example one that
+    /// implements an interface member, which is emitted <c>virtual newslot</c>) as abstract.
+    /// That propagated to <see cref="StructSymbol.IsAbstract"/> and made the whole imported
+    /// type unconstructible with <c>GS0386</c>. Metadata already records the answer exactly,
+    /// so imported properties bypass the inference entirely.
+    /// </remarks>
+    public bool? MetadataIsAbstract { get; }
+
     /// <summary>Gets a value indicating whether this property declares an abstract accessor slot.</summary>
     public bool IsAbstract =>
-        IsVirtual
-        && !IsOverride
-        && !IsAutoProperty
-        && ((HasGetter && GetterBodySyntax == null) || (HasSetter && SetterBodySyntax == null));
+        MetadataIsAbstract
+        ?? (IsVirtual
+            && !IsOverride
+            && !IsAutoProperty
+            && ((HasGetter && GetterBodySyntax == null) || (HasSetter && SetterBodySyntax == null)));
 
     /// <summary>Gets the setter parameter name (defaults to "value").</summary>
     public string SetterParameterName { get; }

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -2218,7 +2218,8 @@ public sealed class StructSymbol : TypeSymbol
                 p.Declaration,
                 p.IsInitOnly,
                 p.GetterAccessibility,
-                p.SetterAccessibility)
+                p.SetterAccessibility,
+                p.MetadataIsAbstract)
             {
                 IsIndexer = p.IsIndexer,
                 Parameters = newParams,

--- a/test/Compiler.Tests/Emit/Issue2874ImportedVirtualPropertyAbstractnessTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2874ImportedVirtualPropertyAbstractnessTests.cs
@@ -1,0 +1,445 @@
+// <copyright file="Issue2874ImportedVirtualPropertyAbstractnessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2874 — an imported <c>data class</c> carrying a property that is
+/// virtual but NOT an override was classified as abstract, so any
+/// cross-assembly construction reported
+/// <c>GS0386: Cannot create an instance of the abstract type</c>.
+/// <para>
+/// <c>PropertySymbol.IsAbstract</c> inferred abstractness from declaration
+/// shape (<c>IsVirtual &amp;&amp; !IsOverride &amp;&amp; !IsAutoProperty</c>
+/// and no accessor body syntax). An imported property never carries body
+/// syntax and is built with <c>isAutoProperty: false</c>, so every
+/// <c>virtual newslot</c> imported property — which is what an <c>open prop</c>
+/// with a body and what an interface implementation both emit — satisfied the
+/// whole conjunction.
+/// </para>
+/// <para>
+/// Issue #2870 had already fixed the <c>open override prop</c> half of this by
+/// keeping overrides out of a new slot; this covers the remaining
+/// non-override half. Abstractness for an imported property is now read
+/// straight out of metadata instead of being inferred.
+/// </para>
+/// </summary>
+public class Issue2874ImportedVirtualPropertyAbstractnessTests
+{
+    [Fact]
+    public void ImportedDataClassWithOpenComputedProperty_IsConstructible()
+    {
+        const string library = """
+            package i2874lib1
+
+            open data class KEx(Id int32, Name string) {
+                open prop Other string {
+                    get -> "x"
+                }
+            }
+            """;
+
+        const string source = """
+            package i2874a
+            import i2874lib1
+
+            func Main() {
+                let k = KEx(1, "n")
+                System.Console.WriteLine(k.Name + "," + k.Other)
+            }
+            """;
+
+        Assert.Equal("n,x\n", CompileAndRun(source, library, "i2874lib1"));
+    }
+
+    [Fact]
+    public void ImportedDataClassImplementingAnInterfaceProperty_IsConstructible()
+    {
+        // The actual Oahu shape: `ProfileKeyEx` implements `IProfileKeyEx`, so
+        // its accessors are emitted `virtual newslot` even though nothing in
+        // the source says `open`.
+        const string library = """
+            package i2874lib2
+
+            interface IKey {
+                prop AccountName string {
+                    get;
+                }
+            }
+
+            data class ProfileKeyEx(AccountName string) : IKey
+            """;
+
+        const string source = """
+            package i2874b
+            import i2874lib2
+
+            func Main() {
+                let k = ProfileKeyEx("acct")
+                System.Console.WriteLine(k.AccountName)
+            }
+            """;
+
+        Assert.Equal("acct\n", CompileAndRun(source, library, "i2874lib2"));
+    }
+
+    [Fact]
+    public void ImportedDataClassWithSettableAndVirtualProperty_IsConstructible()
+    {
+        // Mixes a settable auto-property (which is emitted with an explicit
+        // MethodImpl, not a new virtual slot) with an `open` computed property
+        // (which IS `virtual newslot`), so both accessor shapes coexist on one
+        // imported type.
+        //
+        // A settable interface property must be declared explicitly rather
+        // than positionally; a positional member emits no setter at all
+        // (issue #2875), which is a separate defect.
+        const string library = """
+            package i2874lib3
+
+            interface IBox {
+                prop Value int32 {
+                    get;
+                    set;
+                }
+            }
+
+            open data class Box : IBox {
+                prop Value int32 {
+                    get;
+                    set;
+                }
+
+                open prop Doubled int32 -> Value * 2
+            }
+            """;
+
+        const string source = """
+            package i2874c
+            import i2874lib3
+
+            func Main() {
+                let b = Box()
+                b.Value = 7
+                System.Console.WriteLine(b.Value.ToString() + "," + b.Doubled.ToString())
+            }
+            """;
+
+        Assert.Equal("7,14\n", CompileAndRun(source, library, "i2874lib3"));
+    }
+
+    [Fact]
+    public void ImportedDataClassBuiltFromAReferenceAssembly_IsConstructible()
+    {
+        // MSBuild hands downstream compilations the `/refout` reference
+        // assembly, not the implementation, so the import path must agree on
+        // both. This is the shape that actually broke the Oahu build.
+        const string library = """
+            package i2874lib4
+
+            open data class Challenge(Id int32) {
+                open prop Kind string {
+                    get -> "captcha"
+                }
+            }
+            """;
+
+        const string source = """
+            package i2874d
+            import i2874lib4
+
+            func Main() {
+                let c = Challenge(3)
+                System.Console.WriteLine(c.Kind)
+            }
+            """;
+
+        Assert.Equal("captcha\n", CompileAndRunAgainstReferenceAssembly(source, library, "i2874lib4"));
+    }
+
+    [Fact]
+    public void ImportedGenuinelyAbstractDataClass_IsStillNotConstructible()
+    {
+        // Control: reading abstractness from metadata must not make a truly
+        // abstract imported type look concrete. A no-body `open prop` on an
+        // `open data class` emits an abstract accessor.
+        const string library = """
+            package i2874lib5
+
+            open data class Shape {
+                open prop Name string {
+                    get;
+                }
+            }
+
+            data class Square : Shape {
+                override prop Name string -> "square"
+            }
+            """;
+
+        const string source = """
+            package i2874e
+            import i2874lib5
+
+            func Main() {
+                let s = Shape()
+                System.Console.WriteLine(s.Name)
+            }
+            """;
+
+        var diagnostics = CompileExpectingFailure(source, library, "i2874lib5");
+        Assert.Contains("GS0386", diagnostics);
+    }
+
+    [Fact]
+    public void LocallyDeclaredAbstractShapedDataClass_IsStillNotConstructible()
+    {
+        // Control: the source-shape inference is still the authority for a
+        // property declared in the current compilation.
+        const string source = """
+            package i2874f
+
+            open data class Local {
+                open prop Tag string {
+                    get;
+                }
+            }
+
+            func Main() {
+                let l = Local()
+                System.Console.WriteLine(l.Tag)
+            }
+            """;
+
+        var diagnostics = CompileExpectingFailure(source, library: null, libraryAssemblyName: null);
+        Assert.Contains("GS0386", diagnostics);
+    }
+
+    private static string CompileAndRun(string source, string library = null, string libraryAssemblyName = null)
+    {
+        return RunBuilt(source, library, libraryAssemblyName, useReferenceAssembly: false);
+    }
+
+    private static string CompileAndRunAgainstReferenceAssembly(string source, string library, string libraryAssemblyName)
+    {
+        return RunBuilt(source, library, libraryAssemblyName, useReferenceAssembly: true);
+    }
+
+    private static string RunBuilt(string source, string library, string libraryAssemblyName, bool useReferenceAssembly)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2874_").FullName;
+        try
+        {
+            var dllPath = BuildExecutable(tempDir, source, library, libraryAssemblyName, useReferenceAssembly, out var libDll);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            IlVerifier.Verify(dllPath, libDll != null ? new[] { libDll } : null);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private static string CompileExpectingFailure(string source, string library, string libraryAssemblyName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2874_err_").FullName;
+        try
+        {
+            var args = new List<string>
+            {
+                "/out:" + Path.Combine(tempDir, "test.dll"),
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+
+            if (library != null)
+            {
+                var libSrc = Path.Combine(tempDir, libraryAssemblyName + ".gs");
+                var libDll = Path.Combine(tempDir, libraryAssemblyName + ".dll");
+                File.WriteAllText(libSrc, library);
+                Compile(new[]
+                {
+                    "/out:" + libDll,
+                    "/target:library",
+                    "/targetframework:net10.0",
+                    libSrc,
+                });
+                args.Add("/r:" + libDll);
+            }
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            File.WriteAllText(srcPath, source);
+            args.Add(srcPath);
+
+            return CompileCapturingOutput(args.ToArray());
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private static string BuildExecutable(
+        string tempDir,
+        string source,
+        string library,
+        string libraryAssemblyName,
+        bool useReferenceAssembly,
+        out string libDll)
+    {
+        libDll = null;
+        string referencePath = null;
+        if (library != null)
+        {
+            // ilverify resolves `-r` references by FILE NAME, so the library
+            // must be written out under its assembly identity.
+            var libSrc = Path.Combine(tempDir, libraryAssemblyName + ".gs");
+            libDll = Path.Combine(tempDir, libraryAssemblyName + ".dll");
+            File.WriteAllText(libSrc, library);
+
+            var libArgs = new List<string>
+            {
+                "/out:" + libDll,
+                "/target:library",
+                "/targetframework:net10.0",
+            };
+
+            if (useReferenceAssembly)
+            {
+                // The reference assembly must live in its own directory: it
+                // shares the library's assembly identity, and the runtime must
+                // still load the IMPLEMENTATION next to the executable.
+                var refDir = Path.Combine(tempDir, "ref");
+                Directory.CreateDirectory(refDir);
+                referencePath = Path.Combine(refDir, libraryAssemblyName + ".dll");
+                libArgs.Add("/refout:" + referencePath);
+            }
+
+            libArgs.Add(libSrc);
+            Compile(libArgs.ToArray());
+            IlVerifier.Verify(libDll);
+        }
+
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var dllPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + dllPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+        };
+        if (libDll != null)
+        {
+            args.Add("/r:" + (referencePath ?? libDll));
+        }
+
+        args.Add(srcPath);
+        Compile(args.ToArray());
+        return dllPath;
+    }
+
+    private static void Compile(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static string CompileCapturingOutput(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(compileExit != 0, "expected gsc to fail but it succeeded");
+        return stdoutWriter + stderrWriter.ToString();
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2876ImportedDataClassDelegateTargetEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2876ImportedDataClassDelegateTargetEmitTests.cs
@@ -1,0 +1,346 @@
+// <copyright file="Issue2876ImportedDataClassDelegateTargetEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2876 — a lambda flowing into a non-<c>Func</c>/<c>Action</c> delegate
+/// parameter (<c>Predicate[T]</c>, <c>Comparison[T]</c>) of a GENERIC method
+/// closed over an IMPORTED <c>data class</c> materialised the natural
+/// <c>Func</c>/<c>Action</c> shape instead of the requested delegate, producing
+/// unverifiable IL (<c>ilverify StackUnexpected: [found ref System.Func`2&lt;T,bool&gt;]
+/// [expected ref System.Predicate`1&lt;T&gt;]</c>) with no diagnostic.
+/// <para>
+/// <c>ReflectionMetadataEmitter.ArgIsSymbolicUserDefined</c> answered
+/// <see langword="true"/> for ANY <c>StructSymbol</c>. An imported data type's
+/// semantic aggregate is also a <c>StructSymbol</c> (see
+/// <c>ImportedTypeSymbol.BuildSemanticAggregate</c>, which passes
+/// <c>clrType: type</c>), so the lambda's whole function type looked symbolic
+/// and <c>EmitFunctionToDelegateConversion</c> discarded the real target
+/// delegate in favour of the natural <c>Func</c>/<c>Action</c> shape.
+/// Symbolic encoding is only needed when there is no CLR type to reflect over,
+/// i.e. <c>ClrType == null</c> — the same guard
+/// <c>TypeSymbol.IsSameCompilationUserTypeTopLevel</c> already applies to these
+/// four symbol kinds.
+/// </para>
+/// <para>
+/// Every fact here runs <c>ilverify</c> over the produced assembly (see
+/// <c>RunBuilt</c>), which is what actually catches the regression.
+/// </para>
+/// </summary>
+public class Issue2876ImportedDataClassDelegateTargetEmitTests
+{
+    /// <summary>
+    /// The generic helpers reused by most facts. <c>Predicate[T]</c> and
+    /// <c>Comparison[T]</c> are the broken shapes; <c>Func[T, bool]</c> is the
+    /// natural shape that always worked.
+    /// </summary>
+    private const string HelpersLibrary = """
+        package i2876lib
+
+        import System
+        import System.Collections.Generic
+
+        public data class Item(Asin string, Title string)
+
+        public class PlainItem {
+            public var Asin string
+
+            init(asin string) {
+                this.Asin = asin
+            }
+        }
+
+        public class Filters {
+            shared {
+                func CountMatching[T](items IEnumerable[T], p Predicate[T]) int32 {
+                    var n = 0
+                    for item in items {
+                        if p.Invoke(item) {
+                            n = n + 1
+                        }
+                    }
+
+                    return n
+                }
+
+                func Order[T](a T, b T, c Comparison[T]) int32 {
+                    return c.Invoke(a, b)
+                }
+
+                func CountFunc[T](items IEnumerable[T], p Func[T, bool]) int32 {
+                    var n = 0
+                    for item in items {
+                        if p.Invoke(item) {
+                            n = n + 1
+                        }
+                    }
+
+                    return n
+                }
+            }
+        }
+        """;
+
+    [Fact]
+    public void LambdaToGenericPredicateParameter_OverImportedDataClass_Verifies()
+    {
+        const string source = """
+            package i2876a
+
+            import System
+            import System.Collections.Generic
+            import i2876lib
+
+            func Main() {
+                let items = List[Item]()
+                items.Add(Item("A1", "One"))
+                items.Add(Item("A2", "Two"))
+                Console.WriteLine(Filters.CountMatching(items, (i Item) -> i.Asin == "A1"))
+            }
+            """;
+
+        Assert.Equal("1\n", CompileAndRun(source, HelpersLibrary, "i2876lib"));
+    }
+
+    [Fact]
+    public void LambdaToGenericComparisonParameter_OverImportedDataClass_Verifies()
+    {
+        const string source = """
+            package i2876b
+
+            import System
+            import i2876lib
+
+            func Main() {
+                Console.WriteLine(Filters.Order(Item("A1", "One"), Item("A2", "Two"), (x Item, y Item) -> String.Compare(x.Asin, y.Asin)))
+            }
+            """;
+
+        Assert.Equal("-1\n", CompileAndRun(source, HelpersLibrary, "i2876lib"));
+    }
+
+    [Fact]
+    public void LambdaToGenericFuncParameter_OverImportedDataClass_StillVerifies()
+    {
+        // Control: `Func`/`Action` are the natural structural delegate shapes,
+        // so this arm was never affected.
+        const string source = """
+            package i2876c
+
+            import System
+            import System.Collections.Generic
+            import i2876lib
+
+            func Main() {
+                let items = List[Item]()
+                items.Add(Item("A1", "One"))
+                items.Add(Item("A2", "Two"))
+                Console.WriteLine(Filters.CountFunc(items, (i Item) -> i.Asin == "A2"))
+            }
+            """;
+
+        Assert.Equal("1\n", CompileAndRun(source, HelpersLibrary, "i2876lib"));
+    }
+
+    [Fact]
+    public void LambdaToGenericPredicateParameter_OverImportedPlainClass_StillVerifies()
+    {
+        // Control: a plain imported class is an ImportedTypeSymbol, never a
+        // StructSymbol, so it never tripped the symbolic gate.
+        const string source = """
+            package i2876d
+
+            import System
+            import System.Collections.Generic
+            import i2876lib
+
+            func Main() {
+                let items = List[PlainItem]()
+                items.Add(PlainItem("P1"))
+                items.Add(PlainItem("P2"))
+                Console.WriteLine(Filters.CountMatching(items, (p PlainItem) -> p.Asin == "P1"))
+            }
+            """;
+
+        Assert.Equal("1\n", CompileAndRun(source, HelpersLibrary, "i2876lib"));
+    }
+
+    [Fact]
+    public void LambdaToGenericPredicateParameter_OverLocalDataClass_StillVerifies()
+    {
+        // Control: a SAME-COMPILATION data class genuinely has no CLR type, so
+        // it must keep taking the symbolic path.
+        const string source = """
+            package i2876e
+
+            import System
+            import System.Collections.Generic
+            import i2876lib
+
+            data class Local(Key string)
+
+            func Main() {
+                let items = List[Local]()
+                items.Add(Local("L1"))
+                items.Add(Local("L2"))
+                Console.WriteLine(Filters.CountMatching(items, (l Local) -> l.Key == "L2"))
+            }
+            """;
+
+        Assert.Equal("1\n", CompileAndRun(source, HelpersLibrary, "i2876lib"));
+    }
+
+    [Fact]
+    public void MethodGroupToGenericPredicateParameter_OverImportedDataClass_Verifies()
+    {
+        // A method group materialises through the same
+        // EmitFunctionToDelegateConversion entry point as a lambda.
+        const string source = """
+            package i2876f
+
+            import System
+            import System.Collections.Generic
+            import i2876lib
+
+            func IsFirst(i Item) bool {
+                return i.Asin == "A1"
+            }
+
+            func Main() {
+                let items = List[Item]()
+                items.Add(Item("A1", "One"))
+                items.Add(Item("A2", "Two"))
+                Console.WriteLine(Filters.CountMatching(items, IsFirst))
+            }
+            """;
+
+        Assert.Equal("1\n", CompileAndRun(source, HelpersLibrary, "i2876lib"));
+    }
+
+    private static string CompileAndRun(string source, string library, string libraryAssemblyName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2876_").FullName;
+        try
+        {
+            var dllPath = BuildExecutable(tempDir, source, library, libraryAssemblyName, out var libDll);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            IlVerifier.Verify(dllPath, libDll != null ? new[] { libDll } : null);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private static string BuildExecutable(
+        string tempDir,
+        string source,
+        string library,
+        string libraryAssemblyName,
+        out string libDll)
+    {
+        // ilverify resolves `-r` references by FILE NAME, so the library must
+        // be written out under its assembly identity.
+        var libSrc = Path.Combine(tempDir, libraryAssemblyName + ".gs");
+        libDll = Path.Combine(tempDir, libraryAssemblyName + ".dll");
+        File.WriteAllText(libSrc, library);
+
+        Compile(new[]
+        {
+            "/out:" + libDll,
+            "/target:library",
+            "/targetframework:net10.0",
+            libSrc,
+        });
+        IlVerifier.Verify(libDll);
+
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var dllPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        Compile(new[]
+        {
+            "/out:" + dllPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            "/r:" + libDll,
+            srcPath,
+        });
+
+        return dllPath;
+    }
+
+    private static void Compile(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+}


### PR DESCRIPTION
Fixes #2874. Fixes #2876.

Two cross-assembly defects, both rooted in the same modelling fact: an imported `data` type's semantic aggregate is a `StructSymbol` that nonetheless carries a real backing CLR type. Code that treats "is a `StructSymbol`" as a synonym for "is same-compilation" gets it wrong for exactly this shape.

Both were found migrating Oahu; together they are what kept `tests/Oahu.Cli.Tests` from going green.

## #2874 — imported virtual, non-override property wrongly abstract

`PropertySymbol.IsAbstract` inferred abstractness from declaration shape:

```
IsVirtual && !IsOverride && !IsAutoProperty
  && ((HasGetter && GetterBodySyntax == null) || (HasSetter && SetterBodySyntax == null))
```

An imported property never carries body syntax, and `ImportedTypeSymbol.BuildSemanticAggregate` builds it with `isAutoProperty: false`, so **every** `virtual newslot` imported property satisfied the whole conjunction. Both an `open prop` with a body and an interface-implementing property emit that shape, so the containing data class looked abstract and every cross-assembly construction reported `GS0386: cannot create an instance of an abstract type`.

#2870 had already fixed the `open override prop` half by keeping overrides out of a new slot; this is the remaining non-override half.

Abstractness is now read straight out of metadata rather than inferred. `PropertySymbol` gains an optional `MetadataIsAbstract`, populated from the accessor's `MethodInfo.IsAbstract` in `BuildSemanticAggregate` and forwarded through `StructSymbol`'s substituted-property clone. `IsAbstract` prefers it and falls back to the syntactic inference only for same-compilation properties. (`MethodInfo.IsAbstract` is supported by `MetadataLoadContext`, unlike `GetBaseDefinition()`.)

## #2876 — lambda materialised the wrong delegate type

A lambda flowing into a `Predicate[T]` or `Comparison[T]` parameter of a **generic** method closed over an **imported** `data class` was materialised as the natural `Func`/`Action` shape instead of the requested delegate — silently, with no diagnostic, producing unverifiable IL:

```
[IL]: Error [StackUnexpected]: ... [found ref 'System.Func`2<Item,bool>']
                                   [expected ref 'System.Predicate`1<Item>']
```

`ReflectionMetadataEmitter.ArgIsSymbolicUserDefined` answered `true` for **any** `StructSymbol`, so a lambda over an imported data class made its whole function type look symbolic; `EmitFunctionToDelegateConversion` then discarded the real target delegate in favour of the natural shape (issue #1502's behaviour, which is only correct when the target *is* `Func`/`Action`).

Symbolic encoding exists precisely because a same-compilation user type has no CLR backing yet — the `ClrType == null` case. That is the identical guard `TypeSymbol.IsSameCompilationUserTypeTopLevel` already applies to these same four symbol kinds; `ArgIsSymbolicUserDefined` was simply missing it.

The bisection that isolated it (all verified):

| Case | Before |
| --- | --- |
| imported `data class`, `Predicate[T]` | **StackUnexpected** |
| imported `data class`, `Comparison[T]` | **StackUnexpected** |
| imported `data class`, `Func[T,bool]` / `Action[T]` | clean |
| imported plain `class`, `Predicate[T]` | clean |
| local `data class`, `Predicate[T]` | clean |
| non-generic `Predicate[Item]` parameter | clean |

The binder was never at fault — it produced an identical `BoundConversionExpression` typed `System.Predicate\`1[Item]` in both the working and broken cases. The divergence was entirely in emit.

## Testing

- `Issue2874ImportedVirtualPropertyAbstractnessTests` — 6 facts: open computed property, interface-implementing property, reference-assembly variants, plus same-compilation controls. **3 fail without the fix.**
- `Issue2876ImportedDataClassDelegateTargetEmitTests` — 6 facts: `Predicate` and `Comparison` over an imported data class, method group, with `Func` / plain-class / local-data-class controls. Every fact runs `ilverify` over the produced assembly, which is what catches the regression. **3 fail without the fix.**
- Full `Compiler.Tests` and `Core.Tests` green.
