### PR TITLE
Fix generic unmanaged stackalloc

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BlittableDetector.cs
+++ b/src/Core/CodeAnalysis/Binding/BlittableDetector.cs
@@ -161,6 +161,11 @@ internal sealed class BlittableDetector
 
         if (type is StructSymbol structSym)
         {
+            if (structSym.IsGenericDefinition)
+            {
+                return false;
+            }
+
             return IsBlittableStruct(structSym, visiting, unmanaged);
         }
 
@@ -168,6 +173,11 @@ internal sealed class BlittableDetector
         // Marshal.SizeOf can accept structs that still contain GC references.
         // Blittability keeps the existing runtime marshalling classification.
         var clr = type.ClrType;
+        if (clr?.IsGenericParameter == true || clr?.ContainsGenericParameters == true)
+        {
+            return false;
+        }
+
         if (clr != null && clr.IsValueType)
         {
             if (clr.IsEnum)
@@ -204,7 +214,9 @@ internal sealed class BlittableDetector
     {
         if (type == null
             || type.IsByRef
-            || type.IsByRefLike)
+            || type.IsByRefLike
+            || type.IsGenericParameter
+            || type.ContainsGenericParameters)
         {
             return false;
         }
@@ -215,6 +227,14 @@ internal sealed class BlittableDetector
         }
 
         if (!type.IsValueType)
+        {
+            return false;
+        }
+
+        // C# excludes Nullable<T> from the unmanaged-type set. That applies
+        // recursively too: a struct containing an int? field is not unmanaged.
+        if (type.IsGenericType
+            && type.GetGenericTypeDefinition().FullName == "System.Nullable`1")
         {
             return false;
         }

--- a/src/Core/CodeAnalysis/Binding/BlittableDetector.cs
+++ b/src/Core/CodeAnalysis/Binding/BlittableDetector.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Symbols;
 
@@ -25,11 +26,10 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// a class instance by-reference across the P/Invoke boundary.
 /// </para>
 /// <para>
-/// Imported CLR struct types defer to the runtime's classification —
-/// <see cref="System.Runtime.InteropServices.Marshal.SizeOf(System.Type)"/>
-/// only succeeds for blittable types, so a successful call confirms the
-/// classification. The result is cached per type to keep the recursion
-/// cheap when a top-level signature visits the same field type twice.
+/// Imported CLR struct types use runtime marshalling classification for
+/// blittability. Unmanaged classification instead walks every instance field
+/// recursively because <see cref="System.Runtime.InteropServices.Marshal.SizeOf(System.Type)"/>
+/// can succeed for structs that contain managed references.
 /// </para>
 /// </remarks>
 internal sealed class BlittableDetector
@@ -164,15 +164,20 @@ internal sealed class BlittableDetector
             return IsBlittableStruct(structSym, visiting, unmanaged);
         }
 
-        // Imported CLR types: defer to the runtime's classification by
-        // attempting Marshal.SizeOf. A non-blittable type raises
-        // ArgumentException; blittable types return the size in bytes.
+        // Imported CLR types: unmanaged classification must inspect fields;
+        // Marshal.SizeOf can accept structs that still contain GC references.
+        // Blittability keeps the existing runtime marshalling classification.
         var clr = type.ClrType;
         if (clr != null && clr.IsValueType)
         {
             if (clr.IsEnum)
             {
                 return true;
+            }
+
+            if (unmanaged)
+            {
+                return IsImportedUnmanagedType(clr, new HashSet<Type>());
             }
 
             try
@@ -187,6 +192,55 @@ internal sealed class BlittableDetector
         }
 
         return false;
+    }
+
+    private static bool IsImportedUnmanagedType(Type type, HashSet<Type> visiting)
+    {
+        if (type == null
+            || type.IsByRef
+            || type.IsByRefLike
+            || !type.IsValueType
+            || (type.IsGenericType
+                && type.GetGenericTypeDefinition().FullName == "System.Nullable`1"))
+        {
+            return false;
+        }
+
+        if (type.IsPointer || type.IsFunctionPointer || type.IsEnum || type.IsPrimitive)
+        {
+            return true;
+        }
+
+        if (!visiting.Add(type))
+        {
+            return true;
+        }
+
+        try
+        {
+            var fields = type.GetFields(
+                System.Reflection.BindingFlags.Instance
+                    | System.Reflection.BindingFlags.Public
+                    | System.Reflection.BindingFlags.NonPublic);
+
+            foreach (var field in fields)
+            {
+                if (!IsImportedUnmanagedType(field.FieldType, visiting))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+        finally
+        {
+            visiting.Remove(type);
+        }
     }
 
     private static bool IsUnmanagedOnlyPrimitive(TypeSymbol type)

--- a/src/Core/CodeAnalysis/Binding/BlittableDetector.cs
+++ b/src/Core/CodeAnalysis/Binding/BlittableDetector.cs
@@ -177,6 +177,12 @@ internal sealed class BlittableDetector
 
             if (unmanaged)
             {
+                if (clr.IsGenericType
+                    && clr.GetGenericTypeDefinition().FullName == "System.Nullable`1")
+                {
+                    return false;
+                }
+
                 return IsImportedUnmanagedType(clr, new HashSet<Type>());
             }
 
@@ -198,10 +204,7 @@ internal sealed class BlittableDetector
     {
         if (type == null
             || type.IsByRef
-            || type.IsByRefLike
-            || !type.IsValueType
-            || (type.IsGenericType
-                && type.GetGenericTypeDefinition().FullName == "System.Nullable`1"))
+            || type.IsByRefLike)
         {
             return false;
         }
@@ -209,6 +212,11 @@ internal sealed class BlittableDetector
         if (type.IsPointer || type.IsFunctionPointer || type.IsEnum || type.IsPrimitive)
         {
             return true;
+        }
+
+        if (!type.IsValueType)
+        {
+            return false;
         }
 
         if (!visiting.Add(type))

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -2234,17 +2234,18 @@ internal sealed partial class ExpressionBinder
             return new BoundStackAllocExpression(syntax, pointerType, elementType, count, isPointerForm: true, initializerElements);
         }
 
-        // Safe form: yield a Span<T> over the allocated memory. Open type
-        // parameters and same-compilation value types have no CLR Type during
-        // binding, so retain T symbolically over an object-erased reflection
-        // shape; signature/member-reference emit restores the real argument.
-        var spanOpen = typeof(System.Span<>);
-        var spanType = elementType.ClrType != null
-            ? (TypeSymbol)TypeSymbol.FromClrType(spanOpen.MakeGenericType(elementType.ClrType))
-            : ImportedTypeSymbol.GetConstructed(
-                spanOpen.MakeGenericType(typeof(object)),
-                spanOpen,
-                ImmutableArray.Create(elementType));
+        // Safe form: yield a Span<T> over the allocated memory. Keep the open
+        // type and concrete reflection argument in the resolver's load context;
+        // retain the bound element symbol so open/same-compilation arguments
+        // remain symbolic for emit.
+        var spanOpen = this.binderCtx.References.MapClrTypeToReferences(typeof(System.Span<>));
+        var elementClr = elementType.ClrType != null
+            ? this.binderCtx.References.MapClrTypeToReferences(elementType.ClrType)
+            : this.binderCtx.References.GetCoreType("System.Object");
+        var spanType = ImportedTypeSymbol.GetConstructed(
+            spanOpen.MakeGenericType(elementClr),
+            spanOpen,
+            ImmutableArray.Create(elementType));
         return new BoundStackAllocExpression(syntax, spanType, elementType, count, isPointerForm: false, initializerElements);
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -2168,10 +2168,12 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        // The element type must be unmanaged/blittable: the buffer is raw,
-        // contiguous, GC-untracked stack memory, so a managed reference (or a
-        // type structurally containing one) cannot live in it.
-        if (!TypeSymbol.IsLegalPointeeType(elementType) || elementType.ClrType == null)
+        // The element type must be unmanaged: the buffer is raw, contiguous,
+        // GC-untracked stack memory, so a managed reference (or a type
+        // structurally containing one) cannot live in it. Reuse the generic
+        // constraint classifier so `T unmanaged` is accepted while `T struct`
+        // and unconstrained `T` remain rejected.
+        if (!Binder.IsUnmanagedTypeForConstraint(elementType))
         {
             Diagnostics.ReportStackAllocElementTypeNotBlittable(syntax.ElementTypeIdentifier.Location, elementType.Name);
             return new BoundErrorExpression(null);
@@ -2232,8 +2234,17 @@ internal sealed partial class ExpressionBinder
             return new BoundStackAllocExpression(syntax, pointerType, elementType, count, isPointerForm: true, initializerElements);
         }
 
-        // Safe form: yield a Span<T> over the allocated memory.
-        var spanType = TypeSymbol.FromClrType(typeof(System.Span<>).MakeGenericType(elementType.ClrType));
+        // Safe form: yield a Span<T> over the allocated memory. Open type
+        // parameters and same-compilation value types have no CLR Type during
+        // binding, so retain T symbolically over an object-erased reflection
+        // shape; signature/member-reference emit restores the real argument.
+        var spanOpen = typeof(System.Span<>);
+        var spanType = elementType.ClrType != null
+            ? (TypeSymbol)TypeSymbol.FromClrType(spanOpen.MakeGenericType(elementType.ClrType))
+            : ImportedTypeSymbol.GetConstructed(
+                spanOpen.MakeGenericType(typeof(object)),
+                spanOpen,
+                ImmutableArray.Create(elementType));
         return new BoundStackAllocExpression(syntax, spanType, elementType, count, isPointerForm: false, initializerElements);
     }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -892,7 +892,8 @@ internal sealed partial class MethodBodyEmitter
         var spanClr = node.ResultType.ClrType
             ?? throw new InvalidOperationException(
                 $"stackalloc result type '{node.ResultType.Name}' has no CLR reflection shape.");
-        var spanCtor = spanClr.GetConstructor(new[] { typeof(void).MakePointerType(), typeof(int) })
+        var voidPointer = this.outer.emitCtx.References.MapClrTypeToReferences(typeof(void).MakePointerType());
+        var spanCtor = spanClr.GetConstructor(new[] { voidPointer, this.outer.emitCtx.CoreInt32Type })
             ?? throw new InvalidOperationException(
                 $"'{node.ResultType.Name}' has no (void*, int) constructor.");
         this.il.OpCode(ILOpCode.Newobj);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -841,9 +841,7 @@ internal sealed partial class MethodBodyEmitter
                 "stackalloc count scratch slot was not pre-allocated by the method-body planner.");
         }
 
-        var elementClr = node.ElementType.ClrType
-            ?? throw new InvalidOperationException(
-                $"stackalloc element type '{node.ElementType.Name}' has no CLR type.");
+        var elementToken = this.outer.memberRefs.GetElementTypeToken(node.ElementType);
 
         // count -> scratch slot (single evaluation).
         this.EmitExpression(node.Count);
@@ -852,7 +850,7 @@ internal sealed partial class MethodBodyEmitter
         // bytes = count * sizeof(T); localloc -> void* (native int).
         this.il.LoadLocal(countSlot);
         this.il.OpCode(ILOpCode.Sizeof);
-        this.il.Token(this.outer.memberRefs.GetTypeReference(elementClr));
+        this.il.Token(elementToken);
         this.il.OpCode(ILOpCode.Mul);
         this.il.OpCode(ILOpCode.Conv_u);
         this.il.OpCode(ILOpCode.Localloc);
@@ -872,7 +870,7 @@ internal sealed partial class MethodBodyEmitter
                     // addr = base + i * sizeof(T).
                     this.il.LoadConstantI4(i);
                     this.il.OpCode(ILOpCode.Sizeof);
-                    this.il.Token(this.outer.memberRefs.GetTypeReference(elementClr));
+                    this.il.Token(elementToken);
                     this.il.OpCode(ILOpCode.Mul);
                     this.il.OpCode(ILOpCode.Conv_i);
                     this.il.OpCode(ILOpCode.Add);
@@ -891,12 +889,14 @@ internal sealed partial class MethodBodyEmitter
 
         // Safe form: construct a Span<T> over [ptr, count].
         this.il.LoadLocal(countSlot);
-        var spanClr = typeof(System.Span<>).MakeGenericType(elementClr);
+        var spanClr = node.ResultType.ClrType
+            ?? throw new InvalidOperationException(
+                $"stackalloc result type '{node.ResultType.Name}' has no CLR reflection shape.");
         var spanCtor = spanClr.GetConstructor(new[] { typeof(void).MakePointerType(), typeof(int) })
             ?? throw new InvalidOperationException(
-                $"System.Span<{elementClr.Name}> has no (void*, int) constructor.");
+                $"'{node.ResultType.Name}' has no (void*, int) constructor.");
         this.il.OpCode(ILOpCode.Newobj);
-        this.il.Token(this.outer.memberRefs.GetCtorReference(spanCtor));
+        this.il.Token(this.outer.memberRefs.GetCtorReference(spanCtor, node.ResultType));
     }
 
     private void EmitLen(BoundLenExpression len)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -1853,7 +1853,7 @@ internal sealed partial class MethodBodyEmitter
             // Issue #1613: same fix for byte/bool — ldind.u1 zero-extends.
             this.il.OpCode(ILOpCode.Ldind_u1);
         }
-        else if (pointeeType is StructSymbol { IsClass: false } || (clrType != null && clrType.IsValueType))
+        else if (ReflectionMetadataEmitter.IsValueTypeSymbol(pointeeType))
         {
             this.il.OpCode(ILOpCode.Ldobj);
             this.il.Token(this.outer.memberRefs.GetElementTypeToken(pointeeType));
@@ -1892,7 +1892,7 @@ internal sealed partial class MethodBodyEmitter
         {
             this.il.OpCode(ILOpCode.Stind_i1);
         }
-        else if (pointeeType is StructSymbol { IsClass: false } || (clrType != null && clrType.IsValueType))
+        else if (ReflectionMetadataEmitter.IsValueTypeSymbol(pointeeType))
         {
             this.il.OpCode(ILOpCode.Stobj);
             this.il.Token(this.outer.memberRefs.GetElementTypeToken(pointeeType));

--- a/test/Compiler.Tests/Emit/Issue2852GenericUnmanagedStackAllocEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2852GenericUnmanagedStackAllocEmitTests.cs
@@ -6,10 +6,13 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.Loader;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -83,6 +86,53 @@ public class Issue2852GenericUnmanagedStackAllocEmitTests
         }
     }
 
+    [Fact]
+    public void ImportedEnumStackAlloc_UnderReference_CompilesWithoutGS9998()
+    {
+        var fixtureDirectory = CreateArtifactDirectory(nameof(ImportedEnumStackAlloc_UnderReference_CompilesWithoutGS9998));
+        var fixturePath = Path.Combine(fixtureDirectory, "ImportedTypes.dll");
+        string outputPath = null;
+
+        try
+        {
+            EmitFixture(fixturePath);
+            outputPath = CompileLibrary(
+                ImportedEnumSource,
+                nameof(ImportedEnumStackAlloc_UnderReference_CompilesWithoutGS9998),
+                fixturePath);
+            IlVerifier.Verify(outputPath, new[] { fixturePath }, StackAllocIlVerifyIgnored);
+
+            using var loadContext = new AssemblyLoadContext(
+                nameof(ImportedEnumStackAlloc_UnderReference_CompilesWithoutGS9998),
+                isCollectible: true);
+            try
+            {
+                var fixture = loadContext.LoadFromAssemblyPath(fixturePath);
+                var assembly = loadContext.LoadFromAssemblyPath(outputPath);
+                var probe = assembly.GetType("Probe.ImportedEnumProbe")
+                    ?? throw new InvalidOperationException("ImportedEnumProbe type not found.");
+                var enumType = fixture.GetType("ImportedTypes.ImportedEnum")
+                    ?? throw new InvalidOperationException("ImportedEnum type not found.");
+                var value = Enum.ToObject(enumType, 1);
+
+                Assert.Equal(value, probe.GetMethod("RoundTrip")!.Invoke(null, new[] { value }));
+            }
+            finally
+            {
+                loadContext.Unload();
+            }
+        }
+        finally
+        {
+            if (outputPath != null)
+            {
+                TryDeleteDirectory(Path.GetDirectoryName(outputPath)!);
+            }
+
+            TryDeleteDirectory(fixtureDirectory);
+        }
+    }
+
     private const string Source = """
         package Probe
 
@@ -101,20 +151,46 @@ public class Issue2852GenericUnmanagedStackAllocEmitTests
         }
         """;
 
-    private static string CompileLibrary(string source, string testName)
+    private const string ImportedEnumSource = """
+        package Probe
+        import ImportedTypes
+
+        public class ImportedEnumProbe {
+            shared {
+                public func RoundTrip(value ImportedEnum) ImportedEnum {
+                    var values = stackalloc [2]ImportedEnum
+                    values[1] = value
+                    return values[1]
+                }
+            }
+        }
+        """;
+
+    private const string ImportedEnumFixtureSource = """
+        namespace ImportedTypes;
+
+        public enum ImportedEnum : short
+        {
+            Zero,
+            One,
+        }
+        """;
+
+    private static string CompileLibrary(string source, string testName, params string[] references)
     {
-        var directory = Directory.CreateTempSubdirectory("gs_issue2852_").FullName;
+        var directory = CreateArtifactDirectory(testName);
         var sourcePath = Path.Combine(directory, "test.gs");
         var outputPath = Path.Combine(directory, "test.dll");
         File.WriteAllText(sourcePath, source);
 
-        var args = new[]
+        var args = new List<string>
         {
             "/out:" + outputPath,
             "/target:library",
             "/targetframework:net10.0",
-            sourcePath,
         };
+        args.AddRange(references.Select(reference => "/r:" + reference));
+        args.Add(sourcePath);
 
         using var compileOut = new StringWriter();
         using var compileErr = new StringWriter();
@@ -125,7 +201,7 @@ public class Issue2852GenericUnmanagedStackAllocEmitTests
         int exitCode;
         try
         {
-            exitCode = Program.Main(args);
+            exitCode = Program.Main(args.ToArray());
         }
         finally
         {
@@ -133,10 +209,37 @@ public class Issue2852GenericUnmanagedStackAllocEmitTests
             Console.SetError(previousErr);
         }
 
+        var diagnostics = compileOut.ToString() + compileErr.ToString();
+        Assert.DoesNotContain("GS9998", diagnostics, StringComparison.Ordinal);
         Assert.True(
             exitCode == 0,
-            $"{testName}: gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            $"{testName}: gsc failed:\n{diagnostics}");
         return outputPath;
+    }
+
+    private static string CreateArtifactDirectory(string testName)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2852-artifacts",
+            testName,
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void EmitFixture(string path)
+    {
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(reference => MetadataReference.CreateFromFile(reference));
+        var compilation = CSharpCompilation.Create(
+            "ImportedTypes",
+            new[] { CSharpSyntaxTree.ParseText(ImportedEnumFixtureSource) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var result = compilation.Emit(path);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
     }
 
     private static byte[] GetMethodIl(PEReader pe, MetadataReader metadata, string methodName)

--- a/test/Compiler.Tests/Emit/Issue2852GenericUnmanagedStackAllocEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2852GenericUnmanagedStackAllocEmitTests.cs
@@ -102,7 +102,7 @@ public class Issue2852GenericUnmanagedStackAllocEmitTests
                 fixturePath);
             IlVerifier.Verify(outputPath, new[] { fixturePath }, StackAllocIlVerifyIgnored);
 
-            using var loadContext = new AssemblyLoadContext(
+            var loadContext = new AssemblyLoadContext(
                 nameof(ImportedEnumStackAlloc_UnderReference_CompilesWithoutGS9998),
                 isCollectible: true);
             try

--- a/test/Compiler.Tests/Emit/Issue2852GenericUnmanagedStackAllocEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2852GenericUnmanagedStackAllocEmitTests.cs
@@ -1,0 +1,231 @@
+// <copyright file="Issue2852GenericUnmanagedStackAllocEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Runtime.Loader;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2852: runtime and metadata coverage for
+/// <c>stackalloc [n]T</c> under <c>T unmanaged</c>.
+/// </summary>
+public class Issue2852GenericUnmanagedStackAllocEmitTests
+{
+    private static readonly string[] StackAllocIlVerifyIgnored =
+    {
+        "Unverifiable",
+    };
+
+    [Fact]
+    public void GenericUnmanagedStackAlloc_WritesAndReadsUsingRuntimeElementSize()
+    {
+        var outputPath = CompileLibrary(Source, nameof(GenericUnmanagedStackAlloc_WritesAndReadsUsingRuntimeElementSize));
+        IlVerifier.Verify(outputPath, null, StackAllocIlVerifyIgnored);
+
+        var loadContext = new AssemblyLoadContext(
+            nameof(GenericUnmanagedStackAlloc_WritesAndReadsUsingRuntimeElementSize),
+            isCollectible: true);
+        try
+        {
+            var assembly = loadContext.LoadFromAssemblyPath(outputPath);
+            var probe = assembly.GetType("Probe.StackAllocProbe")
+                ?? throw new InvalidOperationException("StackAllocProbe type not found.");
+
+            Assert.Equal(7, probe.GetMethod("Byte")!.Invoke(null, null));
+            Assert.Equal(123456, probe.GetMethod("Int32")!.Invoke(null, null));
+            Assert.Equal(9876543210L, probe.GetMethod("Int64")!.Invoke(null, null));
+        }
+        finally
+        {
+            loadContext.Unload();
+            TryDeleteDirectory(Path.GetDirectoryName(outputPath)!);
+        }
+    }
+
+    [Fact]
+    public void GenericUnmanagedStackAlloc_EmitsSymbolicSizeAndSpanConstructor()
+    {
+        var outputPath = CompileLibrary(Source, nameof(GenericUnmanagedStackAlloc_EmitsSymbolicSizeAndSpanConstructor));
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(outputPath));
+            var metadata = pe.GetMetadataReader();
+            var il = GetMethodIl(pe, metadata, "RoundTrip");
+            var sizeOfOperands = GetSizeOfOperands(il);
+
+            Assert.NotEmpty(sizeOfOperands);
+            foreach (var operand in sizeOfOperands)
+            {
+                Assert.Equal(HandleKind.TypeSpecification, operand.Kind);
+                var signature = metadata.GetBlobBytes(
+                    metadata.GetTypeSpecification((TypeSpecificationHandle)operand).Signature);
+                Assert.True(
+                    ContainsSequence(signature, 0x1E, 0x00),
+                    $"sizeof operand must name method type parameter !!0: {BitConverter.ToString(signature)}");
+            }
+
+            Assert.True(
+                HasSymbolicSpanConstructor(metadata),
+                "Span constructor parent must be a TypeSpec closed over method type parameter !!0.");
+        }
+        finally
+        {
+            TryDeleteDirectory(Path.GetDirectoryName(outputPath)!);
+        }
+    }
+
+    private const string Source = """
+        package Probe
+
+        public class StackAllocProbe {
+            shared {
+                public func RoundTrip[T unmanaged](value T) T {
+                    var values = stackalloc [4]T
+                    values[3] = value
+                    return values[3]
+                }
+
+                public func Byte() int32 -> int32(RoundTrip[uint8](uint8(7)))
+                public func Int32() int32 -> RoundTrip[int32](123456)
+                public func Int64() int64 -> RoundTrip[int64](9876543210)
+            }
+        }
+        """;
+
+    private static string CompileLibrary(string source, string testName)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue2852_").FullName;
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        var args = new[]
+        {
+            "/out:" + outputPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            sourcePath,
+        };
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousErr);
+        }
+
+        Assert.True(
+            exitCode == 0,
+            $"{testName}: gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        return outputPath;
+    }
+
+    private static byte[] GetMethodIl(PEReader pe, MetadataReader metadata, string methodName)
+    {
+        foreach (var handle in metadata.MethodDefinitions)
+        {
+            var method = metadata.GetMethodDefinition(handle);
+            if (metadata.GetString(method.Name) == methodName && method.RelativeVirtualAddress != 0)
+            {
+                return pe.GetMethodBody(method.RelativeVirtualAddress).GetILBytes()
+                    ?? throw new InvalidOperationException($"Method '{methodName}' has no IL body.");
+            }
+        }
+
+        throw new InvalidOperationException($"Method '{methodName}' not found.");
+    }
+
+    private static List<EntityHandle> GetSizeOfOperands(byte[] il)
+    {
+        var operands = new List<EntityHandle>();
+        for (var i = 0; i + 5 < il.Length; i++)
+        {
+            if (il[i] != 0xFE || il[i + 1] != 0x1C)
+            {
+                continue;
+            }
+
+            var token = BinaryPrimitives.ReadInt32LittleEndian(il.AsSpan(i + 2, 4));
+            operands.Add(MetadataTokens.EntityHandle(token));
+            i += 5;
+        }
+
+        return operands;
+    }
+
+    private static bool HasSymbolicSpanConstructor(MetadataReader metadata)
+    {
+        foreach (var handle in metadata.MemberReferences)
+        {
+            var member = metadata.GetMemberReference(handle);
+            if (metadata.GetString(member.Name) != ".ctor"
+                || member.Parent.Kind != HandleKind.TypeSpecification)
+            {
+                continue;
+            }
+
+            var signature = metadata.GetBlobBytes(
+                metadata.GetTypeSpecification((TypeSpecificationHandle)member.Parent).Signature);
+            if (ContainsSequence(signature, 0x1E, 0x00))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsSequence(byte[] bytes, params byte[] sequence)
+    {
+        for (var i = 0; i + sequence.Length <= bytes.Length; i++)
+        {
+            var match = true;
+            for (var j = 0; j < sequence.Length; j++)
+            {
+                if (bytes[i + j] != sequence[j])
+                {
+                    match = false;
+                    break;
+                }
+            }
+
+            if (match)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void TryDeleteDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2852GenericUnmanagedStackAllocEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2852GenericUnmanagedStackAllocEmitTests.cs
@@ -87,9 +87,9 @@ public class Issue2852GenericUnmanagedStackAllocEmitTests
     }
 
     [Fact]
-    public void ImportedEnumStackAlloc_UnderReference_CompilesWithoutGS9998()
+    public void ImportedEnumStackAlloc_UnderReference_CompilesCleanly()
     {
-        var fixtureDirectory = CreateArtifactDirectory(nameof(ImportedEnumStackAlloc_UnderReference_CompilesWithoutGS9998));
+        var fixtureDirectory = CreateArtifactDirectory(nameof(ImportedEnumStackAlloc_UnderReference_CompilesCleanly));
         var fixturePath = Path.Combine(fixtureDirectory, "ImportedTypes.dll");
         string outputPath = null;
 
@@ -98,12 +98,12 @@ public class Issue2852GenericUnmanagedStackAllocEmitTests
             EmitFixture(fixturePath);
             outputPath = CompileLibrary(
                 ImportedEnumSource,
-                nameof(ImportedEnumStackAlloc_UnderReference_CompilesWithoutGS9998),
+                nameof(ImportedEnumStackAlloc_UnderReference_CompilesCleanly),
                 fixturePath);
             IlVerifier.Verify(outputPath, new[] { fixturePath }, StackAllocIlVerifyIgnored);
 
             var loadContext = new AssemblyLoadContext(
-                nameof(ImportedEnumStackAlloc_UnderReference_CompilesWithoutGS9998),
+                nameof(ImportedEnumStackAlloc_UnderReference_CompilesCleanly),
                 isCollectible: true);
             try
             {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2852GenericUnmanagedStackAllocTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2852GenericUnmanagedStackAllocTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
@@ -154,7 +155,7 @@ public class Issue2852GenericUnmanagedStackAllocTests
     }
 
     [Fact]
-    public void StackAlloc_ImportedStructContainingNullableField_Binds()
+    public void StackAlloc_ImportedStructContainingNullableField_ReportsGS0399()
     {
         const string source = """
             package p
@@ -164,21 +165,53 @@ public class Issue2852GenericUnmanagedStackAllocTests
             }
             """;
 
-        Assert.Empty(GetDiagnostics(source));
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0399");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9998");
     }
 
     [Fact]
-    public void StackAlloc_TopLevelNullable_ReportsGS0399()
+    public void StackAlloc_ImportedOpenGenericDefinition_ReportsGS0399()
     {
         const string source = """
+            package definitions
+            struct Empty[T] {}
+
             package p
-            import System
+            import definitions
             func F() {
-                var values = stackalloc [4]Nullable[int32]
+                var values = stackalloc [4]Empty
             }
             """;
 
-        Assert.Contains(GetDiagnostics(source), d => d.Id == "GS0399");
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0399");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9998");
+    }
+
+    [Fact]
+    public void Classifier_ImportedGenericParameter_IsNotUnmanaged()
+    {
+        var genericParameter = typeof(Issue2852ImportedUnmanagedGenericHost<>).GetGenericArguments()[0];
+        var type = TypeSymbol.FromClrType(genericParameter);
+
+        Assert.False(new BlittableDetector().IsUnmanaged(type));
+    }
+
+    [Fact]
+    public void Classifier_ImportedOpenGenericDefinition_IsNotUnmanaged()
+    {
+        var type = TypeSymbol.FromClrType(typeof(Issue2852ImportedEmptyGenericStruct<>));
+
+        Assert.False(new BlittableDetector().IsUnmanaged(type));
+    }
+
+    [Fact]
+    public void Classifier_ClosedImportedGenericStruct_RemainsUnmanaged()
+    {
+        var type = TypeSymbol.FromClrType(typeof(Issue2852ImportedEmptyGenericStruct<int>));
+
+        Assert.True(new BlittableDetector().IsUnmanaged(type));
     }
 
     private static ImmutableArray<Diagnostic> GetDiagnostics(string source)
@@ -228,4 +261,13 @@ public unsafe struct Issue2852ImportedPointerFields
 public struct Issue2852ImportedNullableFieldStruct
 {
     public int? Value { get; set; }
+}
+
+public struct Issue2852ImportedEmptyGenericStruct<T>
+{
+}
+
+public struct Issue2852ImportedUnmanagedGenericHost<T>
+    where T : unmanaged
+{
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2852GenericUnmanagedStackAllocTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2852GenericUnmanagedStackAllocTests.cs
@@ -1,0 +1,89 @@
+// <copyright file="Issue2852GenericUnmanagedStackAllocTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2852: <c>stackalloc [n]T</c> accepts an
+/// <c>unmanaged</c>-constrained type parameter without admitting type
+/// parameters or structs that may contain managed references.
+/// </summary>
+public class Issue2852GenericUnmanagedStackAllocTests
+{
+    [Fact]
+    public void StackAlloc_UnmanagedTypeParameter_Binds()
+    {
+        const string source = """
+            package p
+            func F[T unmanaged](value T) T {
+                var values = stackalloc [4]T
+                values[3] = value
+                return values[3]
+            }
+            """;
+
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void StackAlloc_StructConstrainedTypeParameter_ReportsGS0399()
+    {
+        const string source = """
+            package p
+            func F[T struct]() {
+                var values = stackalloc [4]T
+            }
+            """;
+
+        Assert.Contains(GetDiagnostics(source), d => d.Id == "GS0399");
+    }
+
+    [Fact]
+    public void StackAlloc_UnconstrainedTypeParameter_ReportsGS0399()
+    {
+        const string source = """
+            package p
+            func F[T any]() {
+                var values = stackalloc [4]T
+            }
+            """;
+
+        Assert.Contains(GetDiagnostics(source), d => d.Id == "GS0399");
+    }
+
+    [Fact]
+    public void StackAlloc_StructContainingReference_ReportsGS0399()
+    {
+        const string source = """
+            package p
+            struct Bad {
+                var Text string
+            }
+            func F() {
+                var values = stackalloc [4]Bad
+            }
+            """;
+
+        Assert.Contains(GetDiagnostics(source), d => d.Id == "GS0399");
+    }
+
+    private static ImmutableArray<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2852GenericUnmanagedStackAllocTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2852GenericUnmanagedStackAllocTests.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using GSharp.Core.CodeAnalysis;
@@ -76,6 +77,68 @@ public class Issue2852GenericUnmanagedStackAllocTests
         Assert.Contains(GetDiagnostics(source), d => d.Id == "GS0399");
     }
 
+    [Fact]
+    public void StackAlloc_ImportedStructContainingReference_ReportsGS0399()
+    {
+        const string source = """
+            package p
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+            func F() {
+                var values = stackalloc [4]Issue2852ImportedManagedStruct
+            }
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0399");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9998");
+    }
+
+    [Fact]
+    public void StackAlloc_ImportedNestedStructContainingReference_ReportsGS0399()
+    {
+        const string source = """
+            package p
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+            func F() {
+                var values = stackalloc [4]Issue2852ImportedNestedManagedStruct
+            }
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0399");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9998");
+    }
+
+    [Fact]
+    public void StackAlloc_ImportedRefStruct_ReportsGS0399()
+    {
+        const string source = """
+            package p
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+            func F() {
+                var values = stackalloc [4]Issue2852ImportedRefStruct
+            }
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0399");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9998");
+    }
+
+    [Fact]
+    public void StackAlloc_ImportedNestedUnmanagedStruct_Binds()
+    {
+        const string source = """
+            package p
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+            func F() {
+                var values = stackalloc [4]Issue2852ImportedUnmanagedOuter
+            }
+            """;
+
+        Assert.Empty(GetDiagnostics(source));
+    }
+
     private static ImmutableArray<Diagnostic> GetDiagnostics(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));
@@ -86,4 +149,29 @@ public class Issue2852GenericUnmanagedStackAllocTests
             .Where(d => d.IsError)
             .ToImmutableArray();
     }
+}
+
+public struct Issue2852ImportedManagedStruct
+{
+    public string Text { get; set; }
+}
+
+public struct Issue2852ImportedNestedManagedStruct
+{
+    public Issue2852ImportedManagedStruct Inner { get; set; }
+}
+
+public ref struct Issue2852ImportedRefStruct
+{
+    public Span<int> Values { get; set; }
+}
+
+public struct Issue2852ImportedUnmanagedInner
+{
+    public int Value { get; set; }
+}
+
+public struct Issue2852ImportedUnmanagedOuter
+{
+    public Issue2852ImportedUnmanagedInner Inner { get; set; }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2852GenericUnmanagedStackAllocTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2852GenericUnmanagedStackAllocTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2852GenericUnmanagedStackAllocTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2852GenericUnmanagedStackAllocTests.cs
@@ -139,6 +139,48 @@ public class Issue2852GenericUnmanagedStackAllocTests
         Assert.Empty(GetDiagnostics(source));
     }
 
+    [Fact]
+    public void StackAlloc_ImportedStructContainingPointerAndFunctionPointerFields_Binds()
+    {
+        const string source = """
+            package p
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+            func F() {
+                var values = stackalloc [4]Issue2852ImportedPointerFields
+            }
+            """;
+
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void StackAlloc_ImportedStructContainingNullableField_Binds()
+    {
+        const string source = """
+            package p
+            import GSharp.Core.Tests.CodeAnalysis.Binding
+            func F() {
+                var values = stackalloc [4]Issue2852ImportedNullableFieldStruct
+            }
+            """;
+
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void StackAlloc_TopLevelNullable_ReportsGS0399()
+    {
+        const string source = """
+            package p
+            import System
+            func F() {
+                var values = stackalloc [4]Nullable[int32]
+            }
+            """;
+
+        Assert.Contains(GetDiagnostics(source), d => d.Id == "GS0399");
+    }
+
     private static ImmutableArray<Diagnostic> GetDiagnostics(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));
@@ -174,4 +216,16 @@ public struct Issue2852ImportedUnmanagedInner
 public struct Issue2852ImportedUnmanagedOuter
 {
     public Issue2852ImportedUnmanagedInner Inner { get; set; }
+}
+
+public unsafe struct Issue2852ImportedPointerFields
+{
+    public int* Pointer { get; set; }
+
+    public delegate* unmanaged<int, int> FunctionPointer { get; set; }
+}
+
+public struct Issue2852ImportedNullableFieldStruct
+{
+    public int? Value { get; set; }
 }

--- a/test/Core.Tests/Core.Tests.csproj
+++ b/test/Core.Tests/Core.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(NetCoreAppTargetFramework)</TargetFramework>
     <RootNamespace>GSharp.Core.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #2852.

## Summary
- classify `stackalloc` elements with existing unmanaged-constraint logic so `T unmanaged` binds while `T struct`, unconstrained `T`, and ref-containing structs remain rejected
- preserve open element types symbolically in `Span<T>` and emit `sizeof !!T`, `Span<!!T>..ctor`, `ldobj !!T`, and `stobj !!T`
- add binder negatives plus runtime and metadata regressions across byte, int32, and int64 instantiations

## Validation
- `git diff --check`
- targeted Core.Tests and Compiler.Tests coverage added; GitHub Actions validates build and execution