### PR TITLE
Mirror the repo layout in migrated build output and stop mislabelling test failures (#2868, #2867)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
@@ -713,10 +713,11 @@ public sealed class SdkCompileRunner
         }
     }
 
-    private static IReadOnlyList<(string Path, byte[] Original)> PrepareTemporaryBuildProps(
+    internal static IReadOnlyList<(string Path, byte[] Original)> PrepareTemporaryBuildProps(
         IEnumerable<string> generatedProjectPaths)
     {
         var prepared = new List<(string Path, byte[] Original)>();
+        string mirrorRoot = ResolveMirrorRoot(generatedProjectPaths);
         try
         {
             foreach (string projectDirectory in generatedProjectPaths
@@ -748,17 +749,31 @@ public sealed class SdkCompileRunner
                 }
 
                 System.Xml.Linq.XNamespace ns = document.Root.Name.Namespace;
+
+                // Issue #2868: mirror each project's repo-relative directory
+                // under `$(Cs2GsArtifactRoot)/bin`, which then acts as the
+                // migrated repo root. A flat `bin/$(MSBuildProjectName)/`
+                // layout collapses the repo structure, so any test that
+                // locates a sibling project's output by walking up from its own
+                // assembly directory (the standard E2E pattern —
+                // `../../../../../src/App/bin/$(Config)/$(TFM)/app.dll`) can
+                // never resolve it, no matter how correct the translation is.
+                // Keeping everything under `bin/` also preserves the existing
+                // "search `<artifactDir>/bin` recursively" contract.
+                string mirroredDirectory = MirroredProjectDirectory(projectDirectory, mirrorRoot);
+
                 document.Root.Add(new System.Xml.Linq.XElement(
                     ns + "PropertyGroup",
                     new System.Xml.Linq.XElement(
                         ns + "BaseOutputPath",
-                        "$(Cs2GsArtifactRoot)/bin/$(MSBuildProjectName)/"),
+                        "$(Cs2GsArtifactRoot)/bin/" + mirroredDirectory + "/bin/"),
                     new System.Xml.Linq.XElement(
                         ns + "BaseIntermediateOutputPath",
-                        "$(Cs2GsArtifactRoot)/obj/$(MSBuildProjectName)/"),
+                        "$(Cs2GsArtifactRoot)/obj/" + mirroredDirectory + "/obj/"),
                     new System.Xml.Linq.XElement(
                         ns + "MSBuildProjectExtensionsPath",
-                        "$(Cs2GsArtifactRoot)/obj/$(MSBuildProjectName)/")));
+                        "$(Cs2GsArtifactRoot)/obj/" + mirroredDirectory + "/obj/")));
+
                 document.Save(propsPath, System.Xml.Linq.SaveOptions.DisableFormatting);
                 prepared.Add((propsPath, original));
             }
@@ -770,6 +785,92 @@ public sealed class SdkCompileRunner
         }
 
         return prepared;
+    }
+
+    /// <summary>
+    /// Issue #2868: resolves the migrated repo root shared by every mirrored
+    /// project — the longest common directory prefix of the complete
+    /// source-to-generated project map, which by construction is the root the
+    /// mirror was written under. Each project's path relative to it is the
+    /// repo-relative directory reproduced inside the artifact tree. With a
+    /// single project there is no sibling to resolve, so its own parent
+    /// directory serves as the root.
+    /// </summary>
+    /// <param name="generatedProjectPaths">The complete generated project path set.</param>
+    /// <returns>The mirrored repo root, or <see langword="null"/> when it cannot be determined.</returns>
+    internal static string ResolveMirrorRoot(IEnumerable<string> generatedProjectPaths)
+    {
+        List<string> directories = (generatedProjectPaths ?? Enumerable.Empty<string>())
+            .Where(path => !string.IsNullOrEmpty(path))
+            .Select(path => Path.GetDirectoryName(Path.GetFullPath(path)))
+            .Where(directory => !string.IsNullOrEmpty(directory))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (directories.Count == 0)
+        {
+            return null;
+        }
+
+        if (directories.Count == 1)
+        {
+            return Path.GetDirectoryName(directories[0]);
+        }
+
+        string[] candidate = directories[0].Split(Path.DirectorySeparatorChar);
+        int shared = candidate.Length;
+        foreach (string directory in directories.Skip(1))
+        {
+            string[] parts = directory.Split(Path.DirectorySeparatorChar);
+            int index = 0;
+            while (index < shared
+                && index < parts.Length
+                && string.Equals(candidate[index], parts[index], StringComparison.OrdinalIgnoreCase))
+            {
+                index++;
+            }
+
+            shared = index;
+        }
+
+        return shared == 0
+            ? null
+            : string.Join(Path.DirectorySeparatorChar.ToString(), candidate.Take(shared));
+    }
+
+    /// <summary>
+    /// Issue #2868: the repo-relative directory that <paramref name="projectDirectory"/>
+    /// is reproduced at inside the artifact tree, expressed with forward
+    /// slashes for MSBuild.
+    /// </summary>
+    /// <param name="projectDirectory">The mirrored project's directory.</param>
+    /// <param name="mirrorRoot">The mirrored repo root, or <see langword="null"/>.</param>
+    /// <returns>The repo-relative directory, never empty.</returns>
+    internal static string MirroredProjectDirectory(string projectDirectory, string mirrorRoot)
+    {
+        string relative = string.IsNullOrEmpty(mirrorRoot)
+            ? Path.GetFileName(projectDirectory)
+            : Path.GetRelativePath(mirrorRoot, projectDirectory);
+        relative = (relative ?? string.Empty).Replace('\\', '/').Trim('/');
+        return relative.Length == 0 || relative == "."
+            ? Path.GetFileName(projectDirectory)
+            : relative;
+    }
+
+    internal static void RestoreTemporaryBuildProps(
+        IEnumerable<(string Path, byte[] Original)> temporaryBuildProps)
+    {
+        foreach ((string Path, byte[] Original) temporary in temporaryBuildProps.Reverse())
+        {
+            if (temporary.Original is null)
+            {
+                File.Delete(temporary.Path);
+            }
+            else
+            {
+                File.WriteAllBytes(temporary.Path, temporary.Original);
+            }
+        }
     }
 
     private static string FindInheritedBuildProps(string projectDirectory)
@@ -787,22 +888,6 @@ public sealed class SdkCompileRunner
         }
 
         return null;
-    }
-
-    private static void RestoreTemporaryBuildProps(
-        IEnumerable<(string Path, byte[] Original)> temporaryBuildProps)
-    {
-        foreach ((string Path, byte[] Original) temporary in temporaryBuildProps.Reverse())
-        {
-            if (temporary.Original is null)
-            {
-                File.Delete(temporary.Path);
-            }
-            else
-            {
-                File.WriteAllBytes(temporary.Path, temporary.Original);
-            }
-        }
     }
 
     private static string ResolveTargetPath(

--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -96,6 +97,21 @@ public sealed class TestParityStage : IMigrationStage
         return StageOutcome.Passed();
     }
 
+    /// <summary>
+    /// Issue #2867: detects the VSTest run summary that only ever appears once
+    /// the test project has built and its tests have actually executed.
+    /// </summary>
+    /// <param name="output">The captured <c>dotnet test</c> output.</param>
+    /// <returns><see langword="true"/> when a test run completed.</returns>
+    internal static bool CompletedTestRun(string output)
+    {
+        return !string.IsNullOrEmpty(output)
+            && Regex.IsMatch(
+                output,
+                @"^\s*(Passed|Failed)!\s+-\s+Failed:",
+                RegexOptions.Multiline | RegexOptions.CultureInvariant);
+    }
+
     private static bool IsStdoutEligible(StageExecutionContext context) =>
         context.App.TargetKind == TargetKind.Exe &&
         !string.IsNullOrEmpty(context.App.StdoutGolden) &&
@@ -119,14 +135,23 @@ public sealed class TestParityStage : IMigrationStage
             context.Options.Config,
             context.Options.GeneratedProjectPaths);
         this.Note(context, result.Output ?? string.Empty);
-        return result.ExitCode == 0
-            ? StageOutcome.Passed()
-            : StageOutcome.Failed(new[]
-            {
-                context.Triage.TestParityLibraryBuildFailure(
-                    result.Output ?? "dotnet test failed without output.",
-                    EmittedGsRelative(context)),
-            });
+        if (result.ExitCode == 0)
+        {
+            return StageOutcome.Passed();
+        }
+
+        // Issue #2867: a non-zero `dotnet test` exit means EITHER the project
+        // failed to build OR it built, ran, and the tests failed. Only the
+        // former is a translator/SDK regression; conflating them sends triage
+        // after the emitter when the real signal is a runtime failure, and
+        // discards the per-test outcomes.
+        string output = result.Output ?? "dotnet test failed without output.";
+        return StageOutcome.Failed(new[]
+        {
+            CompletedTestRun(output)
+                ? context.Triage.TestParityLibraryTestFailure(output, EmittedGsRelative(context))
+                : context.Triage.TestParityLibraryBuildFailure(output, EmittedGsRelative(context)),
+        });
     }
 
     private static bool IsTestProject(string projectPath)

--- a/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
@@ -492,6 +492,53 @@ public sealed class TriageBuilder
     }
 
     /// <summary>
+    /// Issue #2867: builds a triage artifact for a mirrored test project that
+    /// BUILT and RAN but whose tests failed. Reporting this as
+    /// <c>LIBRARY-BUILD-FAILED</c> points investigation at the
+    /// translator/emitter ("a real regression, not translation pending") when
+    /// the actual signal is a runtime test failure, and is the same class of
+    /// misleading degradation as #2842. The diagnostic id is
+    /// <c>LIBRARY-TESTS-FAILED</c>.
+    /// </summary>
+    /// <param name="output">The captured <c>dotnet test</c> output.</param>
+    /// <param name="gsFile">The emitted G# library file (relative path), or null.</param>
+    /// <returns>The populated triage artifact.</returns>
+    public TriageArtifact TestParityLibraryTestFailure(string output, string gsFile = null)
+    {
+        string message = string.IsNullOrWhiteSpace(output) ? "(no test output captured)" : output.Trim();
+
+        var artifact = this.NewArtifact(MigrationStageKind.TestParity, TriageCategory.TestParityFailure);
+        artifact.Diagnostic = new TriageDiagnostic
+        {
+            Id = "LIBRARY-TESTS-FAILED",
+            Message = message,
+            Severity = "error",
+        };
+        artifact.SourceLocation = new TriageSourceLocation
+        {
+            GsFile = gsFile,
+            GsLine = null,
+            GsColumn = null,
+            CsFile = null,
+            CsLine = null,
+            CsColumn = null,
+        };
+        artifact.OffendingCSharpConstruct = new TriageOffendingConstruct
+        {
+            Kind = "LibraryTestRun",
+            Snippet = Truncate(message),
+        };
+        artifact.Fingerprint = Fingerprint.Compute(
+            artifact.Category,
+            artifact.Stage,
+            artifact.Diagnostic.Id,
+            artifact.OffendingCSharpConstruct.Kind,
+            message);
+        artifact.SuggestedIssue = this.TestParityIssue(artifact);
+        return artifact;
+    }
+
+    /// <summary>
     /// Builds a triage artifact for an unhandled exception thrown by a stage
     /// itself, rather than a diagnostic the stage reported normally (issue
     /// #1750). The offending construct <c>kind</c> is the exception's runtime

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2867TestRunClassificationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2867TestRunClassificationTests.cs
@@ -1,0 +1,68 @@
+// <copyright file="Issue2867TestRunClassificationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2867 — a mirrored test project that BUILT, RAN, and whose tests
+/// simply failed was reported as <c>LIBRARY-BUILD-FAILED</c>, because
+/// <c>RunMirroredTestProject</c> classified purely on the <c>dotnet test</c>
+/// exit code. That is the same class of misleading degradation as #2842: the
+/// triage artifact points investigation at the translator/emitter ("a real
+/// regression, not translation pending") when the actual signal is a runtime
+/// test failure.
+/// </summary>
+public class Issue2867TestRunClassificationTests
+{
+    [Theory]
+    [InlineData("Failed!  - Failed:     5, Passed:     0, Skipped:     0, Total:     5, Duration: 5 ms")]
+    [InlineData("Passed!  - Failed:     0, Passed:     7, Skipped:     0, Total:     7, Duration: 2 s")]
+    public void ACompletedTestRunIsRecognised(string summary)
+    {
+        string output = "Test run for /tmp/x/Some.Tests.dll (.NETCoreApp,Version=v10.0)\n"
+            + "A total of 1 test files matched the specified pattern.\n"
+            + summary;
+
+        Assert.True(TestParityStage.CompletedTestRun(output));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("/tmp/x/Some.gs(3,5): error GS0113: Type '' doesn't exist\n\nBuild FAILED.")]
+    [InlineData("MSBUILD : error MSB1009: Project file does not exist.")]
+    public void AGenuineBuildFailureIsNotMistakenForATestRun(string output)
+    {
+        Assert.False(TestParityStage.CompletedTestRun(output));
+    }
+
+    [Fact]
+    public void TheTwoOutcomesCarryDistinctDiagnosticIds()
+    {
+        var triage = new TriageBuilder("run-1", "2026-01-01T00:00:00Z", "0.0.0", "app/App.csproj");
+
+        Assert.Equal(
+            "LIBRARY-TESTS-FAILED",
+            triage.TestParityLibraryTestFailure("Failed!  - Failed: 5, Passed: 0").Diagnostic.Id);
+        Assert.Equal(
+            "LIBRARY-BUILD-FAILED",
+            triage.TestParityLibraryBuildFailure("Build FAILED.").Diagnostic.Id);
+    }
+
+    [Fact]
+    public void ATestRunFailureIsNotAttributedToTheLibraryBuild()
+    {
+        var triage = new TriageBuilder("run-1", "2026-01-01T00:00:00Z", "0.0.0", "app/App.csproj");
+
+        TriageArtifact artifact = triage.TestParityLibraryTestFailure("Failed!  - Failed: 5, Passed: 0");
+
+        Assert.Equal("LibraryTestRun", artifact.OffendingCSharpConstruct.Kind);
+        Assert.NotEqual(
+            triage.TestParityLibraryBuildFailure("Failed!  - Failed: 5, Passed: 0").Fingerprint,
+            artifact.Fingerprint);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2868MirroredArtifactLayoutTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2868MirroredArtifactLayoutTests.cs
@@ -1,0 +1,171 @@
+// <copyright file="Issue2868MirroredArtifactLayoutTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2868 — the mirrored-project build redirected every project's output
+/// to a FLAT <c>$(Cs2GsArtifactRoot)/bin/$(MSBuildProjectName)/</c>, collapsing
+/// the repo structure. Any test that locates a sibling project's output by
+/// walking up from its own assembly directory — the standard end-to-end
+/// pattern, e.g. <c>../../../../../src/App/bin/$(Config)/$(TFM)/app.dll</c> —
+/// could therefore never resolve it, no matter how correct the translation
+/// was, so such suites were permanently red.
+/// <para>
+/// The layout now reproduces each project's repo-relative directory under
+/// <c>$(Cs2GsArtifactRoot)/bin</c>, which acts as the migrated repo root.
+/// Everything still lives under <c>bin/</c>, preserving the existing
+/// "search <c>&lt;artifactDir&gt;/bin</c> recursively" contract.
+/// </para>
+/// </summary>
+public class Issue2868MirroredArtifactLayoutTests
+{
+    [Fact]
+    public void ResolveMirrorRoot_IsTheCommonAncestorOfEveryGeneratedProject()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "mig-out");
+        var projects = new[]
+        {
+            Path.Combine(root, "src", "App", "App.gsproj"),
+            Path.Combine(root, "tests", "App.Tests", "App.Tests.gsproj"),
+            Path.Combine(root, "tools", "Diag", "Diag.gsproj"),
+        };
+
+        Assert.Equal(
+            Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar),
+            SdkCompileRunner.ResolveMirrorRoot(projects));
+    }
+
+    [Fact]
+    public void ResolveMirrorRoot_ForASingleProject_IsItsParent()
+    {
+        // A lone project has no sibling to resolve, so its own parent is the
+        // root and its relative directory stays its own folder name.
+        string root = Path.Combine(Path.GetTempPath(), "mig-single");
+        string project = Path.Combine(root, "App", "App.gsproj");
+
+        string mirrorRoot = SdkCompileRunner.ResolveMirrorRoot(new[] { project });
+
+        Assert.Equal(Path.GetFullPath(Path.Combine(root, "App")), Path.Combine(mirrorRoot, "App"));
+        Assert.Equal(
+            "App",
+            SdkCompileRunner.MirroredProjectDirectory(Path.Combine(root, "App"), mirrorRoot));
+    }
+
+    [Fact]
+    public void MirroredProjectDirectory_PreservesTheRepoRelativePath()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "mig-rel");
+
+        Assert.Equal(
+            "tests/App.E2E.Tests",
+            SdkCompileRunner.MirroredProjectDirectory(
+                Path.Combine(root, "tests", "App.E2E.Tests"),
+                root));
+        Assert.Equal(
+            "src/App",
+            SdkCompileRunner.MirroredProjectDirectory(Path.Combine(root, "src", "App"), root));
+    }
+
+    [Fact]
+    public void MirroredProjectDirectory_WithoutAMirrorRoot_FallsBackToTheFolderName()
+    {
+        Assert.Equal(
+            "App",
+            SdkCompileRunner.MirroredProjectDirectory(
+                Path.Combine(Path.GetTempPath(), "anywhere", "App"),
+                mirrorRoot: null));
+    }
+
+    [Fact]
+    public void PreparedBuildProps_MirrorTheRepoLayoutSoSiblingOutputsResolve()
+    {
+        string root = Directory.CreateTempSubdirectory("gs_2868_").FullName;
+        try
+        {
+            string appDir = Path.Combine(root, "src", "App");
+            string testsDir = Path.Combine(root, "tests", "App.E2E.Tests");
+            Directory.CreateDirectory(appDir);
+            Directory.CreateDirectory(testsDir);
+            var projects = new[]
+            {
+                Path.Combine(appDir, "App.gsproj"),
+                Path.Combine(testsDir, "App.E2E.Tests.gsproj"),
+            };
+
+            IReadOnlyList<(string Path, byte[] Original)> prepared =
+                SdkCompileRunner.PrepareTemporaryBuildProps(projects);
+            try
+            {
+                Assert.Equal(
+                    "$(Cs2GsArtifactRoot)/bin/src/App/bin/",
+                    ReadProperty(Path.Combine(appDir, "Directory.Build.props"), "BaseOutputPath"));
+                Assert.Equal(
+                    "$(Cs2GsArtifactRoot)/bin/tests/App.E2E.Tests/bin/",
+                    ReadProperty(
+                        Path.Combine(testsDir, "Directory.Build.props"),
+                        "BaseOutputPath"));
+
+                // The whole point: from
+                // `<root>/bin/tests/App.E2E.Tests/bin/<Config>/<TFM>` the
+                // standard five-level walk up lands on `<root>/bin`, where
+                // `src/App/bin/<Config>/<TFM>` is exactly where the sibling's
+                // output was written.
+                string testsOutput = Path.Combine(
+                    root, "bin", "tests", "App.E2E.Tests", "bin", "Debug", "net10.0");
+                string walkedUp = Path.GetFullPath(
+                    Path.Combine(testsOutput, "..", "..", "..", "..", ".."));
+                Assert.Equal(Path.Combine(root, "bin"), walkedUp);
+                Assert.Equal(
+                    Path.Combine(walkedUp, "src", "App", "bin", "Debug", "net10.0"),
+                    Path.Combine(root, "bin", "src", "App", "bin", "Debug", "net10.0"));
+
+                // Intermediate output is mirrored the same way so two projects
+                // sharing a name in different folders cannot collide.
+                Assert.Equal(
+                    "$(Cs2GsArtifactRoot)/obj/src/App/obj/",
+                    ReadProperty(
+                        Path.Combine(appDir, "Directory.Build.props"),
+                        "BaseIntermediateOutputPath"));
+            }
+            finally
+            {
+                SdkCompileRunner.RestoreTemporaryBuildProps(prepared);
+            }
+
+            // The props files are temporary: restoring removes the ones that
+            // did not exist beforehand.
+            Assert.False(File.Exists(Path.Combine(appDir, "Directory.Build.props")));
+            Assert.False(File.Exists(Path.Combine(testsDir, "Directory.Build.props")));
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(root, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    private static string ReadProperty(string propsPath, string name)
+    {
+        Assert.True(File.Exists(propsPath), $"expected {propsPath} to exist");
+        return XDocument.Load(propsPath)
+            .Descendants()
+            .Where(element => element.Name.LocalName == name)
+            .Select(element => element.Value)
+            .Single();
+    }
+}


### PR DESCRIPTION
#2868 - mirrored artifact layout

The mirrored-project build redirected every project's output to a FLAT
`$(Cs2GsArtifactRoot)/bin/$(MSBuildProjectName)/`, collapsing the repo
structure. Any test that locates a sibling project's output by walking up
from its own assembly directory - the standard end-to-end pattern, e.g.
`../../../../../src/App/bin/$(Config)/$(TFM)/app.dll` - could therefore
never resolve it, no matter how correct the translation was, so such
suites were permanently red and masked whether the app migrated at all.

Each project's repo-relative directory is now reproduced under
`$(Cs2GsArtifactRoot)/bin`, which acts as the migrated repo root. The root
is the longest common directory prefix of the complete source-to-generated
project map, which by construction is the root the mirror was written
under; a lone project has no sibling to resolve, so its own parent serves.
Intermediate output is mirrored the same way, so two projects sharing a
name in different folders can no longer collide. Everything still lives
under `bin/`, preserving the existing "search <artifactDir>/bin
recursively" contract that the pipeline tests rely on.

In the Oahu migration this takes tests/Oahu.Cli.E2E.Tests from
permanently failing to fully green: the suite now spawns the migrated G#
CLI as a subprocess and reproduces the C# baseline exactly.

#2867 - test failures mislabelled as build failures

RunMirroredTestProject classified purely on the `dotnet test` exit code
and reported every non-zero exit as LIBRARY-BUILD-FAILED, including runs
where the project built, the tests were discovered and executed, and they
simply failed. That is the same class of misleading degradation as #2842:
the triage artifact points investigation at the translator/emitter ("a
real regression, not translation pending") when the actual signal is a
runtime failure.

The two outcomes are now discriminated by the VSTest run summary, which
only ever appears once the project has built and its tests have run, and
a completed-but-failing run gets its own LIBRARY-TESTS-FAILED diagnostic
and LibraryTestRun construct kind.

Tests

- Issue2868MirroredArtifactLayoutTests (5 facts): mirror-root resolution
  for multi- and single-project mirrors, repo-relative mapping, the
  fallback, and an end-to-end assertion that the emitted
  Directory.Build.props place a sibling's output exactly where the
  standard five-level walk-up looks for it. The layout fact fails without
  the fix.
- Issue2867TestRunClassificationTests (8 facts): summary recognition for
  passing and failing runs, genuine build failures and empty output, and
  the distinct diagnostic ids and fingerprints.
- Full Cs2Gs.Tests green.

Fixes #2868
Fixes #2867
