### PR TITLE
Add cross-project oblivious nullability controls

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2842CrossProjectObliviousLocalPromotionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2842CrossProjectObliviousLocalPromotionTranslationTests.cs
@@ -54,7 +54,7 @@ namespace Core
 }";
 
     [Fact]
-    public void ObliviousDataTaintedInProject_ToObliviousCore_ForgivesPromotedMemberRead()
+    public void ObliviousDataTaintedInProject_ToObliviousCore_PreservesTaintThroughLocalReturn()
     {
         LoadedCSharpProject data = LoadOblivious(DataWithInProjectTaint, "Data");
         LoadedCSharpProject core = LoadOblivious(
@@ -64,11 +64,13 @@ namespace Core
 
         string printed = TranslateProject(core, new[] { core.Compilation, data.Compilation });
 
-        Assert.Contains("let reason = conversion.FailureReason!!", Compact(printed));
+        string compact = Compact(printed);
+        Assert.Contains("let reason = conversion.FailureReason!!", compact);
+        Assert.Contains("return reason!!", compact);
     }
 
     [Fact]
-    public void ObliviousDataTaintedInProject_ToNullableEnabledCore_ForgivesPromotedMemberRead()
+    public void ObliviousDataTaintedInProject_ToNullableEnabledCore_KeepsLocalNonNullable()
     {
         LoadedCSharpProject data = LoadOblivious(DataWithInProjectTaint, "Data");
         LoadedCSharpProject core = LoadEnabled(
@@ -78,11 +80,13 @@ namespace Core
 
         string printed = TranslateProject(core, new[] { core.Compilation, data.Compilation });
 
-        Assert.Contains("let reason = conversion.FailureReason!!", Compact(printed));
+        string compact = Compact(printed);
+        Assert.Contains("let reason = conversion.FailureReason!!", compact);
+        Assert.DoesNotContain("return reason!!", compact);
     }
 
     [Fact]
-    public void ObliviousData_ToObliviousMidTaint_ToNullableEnabledApp_ForgivesReceiverAndMemberRead()
+    public void ObliviousData_ToObliviousMidTaint_ToNullableEnabledApp_PreservesDistinctContracts()
     {
         const string dataSource = @"
 namespace Data
@@ -140,11 +144,16 @@ namespace App
                 mid.Compilation.ToMetadataReference(),
             });
 
-        string printed = TranslateProject(
-            app,
-            new[] { app.Compilation, mid.Compilation, data.Compilation });
+        var compilations = new[] { app.Compilation, mid.Compilation, data.Compilation };
+        string printedData = TranslateProject(data, compilations);
+        string printedApp = TranslateProject(app, compilations);
 
-        Assert.Contains("let reason = conversion!!.FailureReason!!", Compact(printed));
+        Assert.Contains("prop FailureReason string?", Compact(printedData));
+
+        string compactApp = Compact(printedApp);
+        Assert.Contains("func Read(conversion Conversion?)", compactApp);
+        Assert.Contains("let reason = conversion!!.FailureReason!!", compactApp);
+        Assert.DoesNotContain("return reason!!", compactApp);
     }
 
     private static LoadedCSharpProject LoadOblivious(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2842CrossProjectObliviousLocalPromotionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2842CrossProjectObliviousLocalPromotionTranslationTests.cs
@@ -1,0 +1,240 @@
+// <copyright file="Issue2842CrossProjectObliviousLocalPromotionTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Positive controls for issue #2842. PR #2860 fixed the actual defect by
+/// reporting C# binding errors from <c>TranslateStage</c>; these fixtures pin
+/// the already-correct local-declaration forgiveness path when the member binds
+/// across nullable-oblivious and nullable-enabled project boundaries.
+/// </summary>
+public class Issue2842CrossProjectObliviousLocalPromotionTranslationTests
+{
+    private const string DataWithInProjectTaint = @"
+namespace Data
+{
+    public class Conversion
+    {
+        public string FailureReason { get; set; }
+
+        public void ClearFailure()
+        {
+            FailureReason = null;
+        }
+    }
+}";
+
+    private const string ConsumerSource = @"
+using Data;
+
+namespace Core
+{
+    public class Consumer
+    {
+        public string Read(Conversion conversion)
+        {
+            string reason = conversion.FailureReason;
+            return reason;
+        }
+    }
+}";
+
+    [Fact]
+    public void ObliviousDataTaintedInProject_ToObliviousCore_ForgivesPromotedMemberRead()
+    {
+        LoadedCSharpProject data = LoadOblivious(DataWithInProjectTaint, "Data");
+        LoadedCSharpProject core = LoadOblivious(
+            ConsumerSource,
+            "Core",
+            new MetadataReference[] { data.Compilation.ToMetadataReference() });
+
+        string printed = TranslateProject(core, new[] { core.Compilation, data.Compilation });
+
+        Assert.Contains("let reason = conversion.FailureReason!!", Compact(printed));
+    }
+
+    [Fact]
+    public void ObliviousDataTaintedInProject_ToNullableEnabledCore_ForgivesPromotedMemberRead()
+    {
+        LoadedCSharpProject data = LoadOblivious(DataWithInProjectTaint, "Data");
+        LoadedCSharpProject core = LoadEnabled(
+            ConsumerSource,
+            "Core",
+            new MetadataReference[] { data.Compilation.ToMetadataReference() });
+
+        string printed = TranslateProject(core, new[] { core.Compilation, data.Compilation });
+
+        Assert.Contains("let reason = conversion.FailureReason!!", Compact(printed));
+    }
+
+    [Fact]
+    public void ObliviousData_ToObliviousMidTaint_ToNullableEnabledApp_ForgivesReceiverAndMemberRead()
+    {
+        const string dataSource = @"
+namespace Data
+{
+    public class Conversion
+    {
+        public string FailureReason { get; set; }
+    }
+}";
+        LoadedCSharpProject data = LoadOblivious(dataSource, "Data");
+
+        const string midSource = @"
+using Data;
+
+namespace Mid
+{
+    public static class ConversionTainter
+    {
+        public static void ClearFailure(Conversion conversion)
+        {
+            conversion.FailureReason = null;
+        }
+    }
+}";
+        LoadedCSharpProject mid = LoadOblivious(
+            midSource,
+            "Mid",
+            new MetadataReference[] { data.Compilation.ToMetadataReference() });
+
+        const string appSource = @"
+using Data;
+
+namespace App
+{
+    public class Consumer
+    {
+        public string Read(Conversion conversion)
+        {
+            if (conversion is null)
+            {
+                return """";
+            }
+
+            string reason = conversion.FailureReason;
+            return reason;
+        }
+    }
+}";
+        LoadedCSharpProject app = LoadEnabled(
+            appSource,
+            "App",
+            new MetadataReference[]
+            {
+                data.Compilation.ToMetadataReference(),
+                mid.Compilation.ToMetadataReference(),
+            });
+
+        string printed = TranslateProject(
+            app,
+            new[] { app.Compilation, mid.Compilation, data.Compilation });
+
+        Assert.Contains("let reason = conversion!!.FailureReason!!", Compact(printed));
+    }
+
+    private static LoadedCSharpProject LoadOblivious(
+        string source,
+        string assemblyName,
+        IReadOnlyList<MetadataReference> extraReferences = null)
+    {
+        LoadedCSharpProject project = LoadWithReferences(source, assemblyName, extraReferences);
+        Assert.Equal(NullableContextOptions.Disable, project.Compilation.Options.NullableContextOptions);
+        return project;
+    }
+
+    private static LoadedCSharpProject LoadEnabled(
+        string source,
+        string assemblyName,
+        IReadOnlyList<MetadataReference> extraReferences = null)
+    {
+        IReadOnlyList<MetadataReference> references = extraReferences is null
+            ? CSharpProjectLoader.RuntimeReferences()
+            : CSharpProjectLoader.RuntimeReferences().Concat(extraReferences).ToList();
+
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest),
+            path: assemblyName + ".cs");
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { tree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+
+        List<Diagnostic> diagnostics = compilation.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToList();
+        Assert.True(
+            diagnostics.Count == 0,
+            $"{assemblyName} should bind with no C# errors: " +
+                string.Join(Environment.NewLine, diagnostics));
+
+        var document = new LoadedDocument(
+            assemblyName + ".cs",
+            tree,
+            compilation.GetSemanticModel(tree));
+        return new LoadedCSharpProject(compilation, new[] { document }, Array.Empty<Diagnostic>());
+    }
+
+    private static LoadedCSharpProject LoadWithReferences(
+        string source,
+        string assemblyName,
+        IReadOnlyList<MetadataReference> extraReferences)
+    {
+        IReadOnlyList<MetadataReference> references = extraReferences is null
+            ? CSharpProjectLoader.RuntimeReferences()
+            : CSharpProjectLoader.RuntimeReferences().Concat(extraReferences).ToList();
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { (assemblyName + ".cs", source) },
+            references,
+            assemblyName);
+        Assert.True(
+            project.BoundWithoutErrors,
+            $"{assemblyName} should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        return project;
+    }
+
+    private static string TranslateProject(
+        LoadedCSharpProject project,
+        IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath,
+            siblingCompilations,
+            repositoryCompilations: siblingCompilations);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    private static string Compact(string printed) =>
+        string.Join(" ", printed.Split(
+            new[] { ' ', '\t', '\r', '\n' },
+            StringSplitOptions.RemoveEmptyEntries));
+}


### PR DESCRIPTION
## Summary

- add three cross-project positive controls for issue #2842
- cover oblivious Data to oblivious Core, oblivious Data to nullable-enabled Core, and the three-project oblivious Data/Mid to nullable-enabled App topology
- assert the exact emitted G# forgiveness shapes documented during the investigation
- pin cross-project taint propagation through the oblivious local return and prove the Mid project promotes Data's emitted property contract while the enabled App keeps its local non-nullable

PR #2860 already delivered the source-side fix by reporting C# binding errors from the translate stage. This PR supplies the remaining regression coverage requested in the issue comment.

## Validation

- `MSBUILDDISABLENODEREUSE=1 dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` — 1860 passed, 0 failed, 0 skipped
- mutation: deleting Data's `ClearFailure()` fails the new `return reason!!` assertion
- mutation: removing Data from the sibling/repository compilation set fails the same `return reason!!` assertion
- mutation: deleting Mid fails the new `prop FailureReason string?` assertion

Fixes #2842
