### PR TITLE
Restore covariant record clones for abstract data classes

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -32,7 +32,7 @@ internal sealed partial class DeclarationBinder
                 continue;
             }
 
-            var dataCloneAncestor = structSymbol.DataCloneAncestor;
+            var dataCloneAncestor = structSymbol.GetDataCloneAncestor();
             if (!structSymbol.IsData && dataCloneAncestor?.IsAbstract == true)
             {
                 // Synthesized record clones are not FunctionSymbols, so the

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -32,7 +32,7 @@ internal sealed partial class DeclarationBinder
                 continue;
             }
 
-            var dataCloneAncestor = structSymbol.GetDataCloneAncestor();
+            var dataCloneAncestor = structSymbol.DataCloneAncestor;
             if (!structSymbol.IsData && dataCloneAncestor?.IsAbstract == true)
             {
                 // Synthesized record clones are not FunctionSymbols, so the

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -32,28 +32,16 @@ internal sealed partial class DeclarationBinder
                 continue;
             }
 
-            if (!structSymbol.IsData)
+            var dataCloneAncestor = structSymbol.GetDataCloneAncestor();
+            if (!structSymbol.IsData && dataCloneAncestor?.IsAbstract == true)
             {
-                for (var baseClass = structSymbol.BaseClass; baseClass != null; baseClass = baseClass.BaseClass)
-                {
-                    if (!baseClass.IsData)
-                    {
-                        continue;
-                    }
-
-                    // Synthesized record clones are not FunctionSymbols, so
-                    // the ordinary abstract-member walk cannot see this slot.
-                    if (baseClass.IsAbstract)
-                    {
-                        Diagnostics.ReportAbstractMemberNotImplemented(
-                            syntax.Identifier.Location,
-                            structSymbol.Name,
-                            baseClass.Name,
-                            "<Clone>$");
-                    }
-
-                    break;
-                }
+                // Synthesized record clones are not FunctionSymbols, so the
+                // ordinary abstract-member walk cannot see this slot.
+                Diagnostics.ReportAbstractMemberNotImplemented(
+                    syntax.Identifier.Location,
+                    structSymbol.Name,
+                    dataCloneAncestor.Name,
+                    "<Clone>$");
             }
 
             foreach (var abstractMethod in structSymbol.GetUnimplementedAbstractMethods())

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -32,6 +32,30 @@ internal sealed partial class DeclarationBinder
                 continue;
             }
 
+            if (!structSymbol.IsData)
+            {
+                for (var baseClass = structSymbol.BaseClass; baseClass != null; baseClass = baseClass.BaseClass)
+                {
+                    if (!baseClass.IsData)
+                    {
+                        continue;
+                    }
+
+                    // Synthesized record clones are not FunctionSymbols, so
+                    // the ordinary abstract-member walk cannot see this slot.
+                    if (baseClass.IsAbstract)
+                    {
+                        Diagnostics.ReportAbstractMemberNotImplemented(
+                            syntax.Identifier.Location,
+                            structSymbol.Name,
+                            baseClass.Name,
+                            "<Clone>$");
+                    }
+
+                    break;
+                }
+            }
+
             foreach (var abstractMethod in structSymbol.GetUnimplementedAbstractMethods())
             {
                 // Skip abstract methods declared directly on this class — those

--- a/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
+++ b/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
@@ -102,7 +102,6 @@ internal sealed class DataStructSynthesizer
     private readonly Func<StructSymbol, EntityHandle, string, BlobBuilder, EntityHandle> resolveUserMethodRef;
     private readonly Func<MethodInfo, TypeSymbol, EntityHandle> resolveImportedMethodRef;
 
-    private readonly Dictionary<StructSymbol, MethodDefinitionHandle> dataClassCopyConstructors = new();
     private readonly Dictionary<StructSymbol, MethodDefinitionHandle> dataClassEqualsTypedMethods = new();
     private readonly Dictionary<StructSymbol, MethodDefinitionHandle> equalityContractGetters = new();
 
@@ -500,7 +499,6 @@ internal sealed class DataStructSynthesizer
             var equalityContractGetter = this.EmitDataClassEqualityContractGetter(structSym);
             this.equalityContractGetters[structSym] = equalityContractGetter;
             var copyConstructor = this.EmitDataClassCopyConstructor(structSym);
-            this.dataClassCopyConstructors[structSym] = copyConstructor;
             this.EmitDataClassClone(structSym, copyConstructor);
         }
 
@@ -623,7 +621,13 @@ internal sealed class DataStructSynthesizer
             this.nextParameterHandle());
     }
 
-    private MethodDefinitionHandle EmitDataClassCopyConstructor(StructSymbol structSym)
+    /// <summary>
+    /// Emits the copy constructor shared by data classes and non-data
+    /// intermediary classes in a data-class inheritance chain.
+    /// </summary>
+    /// <param name="structSym">The class whose fields are copied.</param>
+    /// <returns>The emitted copy-constructor MethodDef.</returns>
+    public MethodDefinitionHandle EmitDataClassCopyConstructor(StructSymbol structSym)
     {
         int bodyOffset = -1;
         if (!this.emitCtx.MetadataOnly)
@@ -661,13 +665,22 @@ internal sealed class DataStructSynthesizer
         new BlobEncoder(signature).MethodSignature(isInstanceMethod: true)
             .Parameters(1, r => r.Void(), ps => this.encodeTypeSymbol(ps.AddParameter().Type(), structSym));
         var visibility = IsDataObjectOverrideFinal(structSym) ? MethodAttributes.Private : MethodAttributes.Family;
-        return this.emitCtx.Metadata.AddMethodDefinition(
+        var copyConstructor = this.emitCtx.Metadata.AddMethodDefinition(
             visibility | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
             MethodImplAttributes.IL | MethodImplAttributes.Managed,
             this.emitCtx.Metadata.GetOrAddString(".ctor"),
             this.emitCtx.Metadata.GetOrAddBlob(signature),
             bodyOffset,
             this.nextParameterHandle());
+
+        if (this.cache.DataClassCopyConstructorHandles.TryGetValue(structSym, out var plannedCopyConstructor)
+            && copyConstructor != plannedCopyConstructor)
+        {
+            throw new InvalidOperationException(
+                $"Class '{structSym.Name}' copy-constructor MethodDef row {MetadataTokens.GetRowNumber(copyConstructor)} did not match the planned row {MetadataTokens.GetRowNumber(plannedCopyConstructor)}.");
+        }
+
+        return copyConstructor;
     }
 
     private void EmitDataClassClone(StructSymbol structSym, MethodDefinitionHandle copyConstructor)
@@ -786,15 +799,16 @@ internal sealed class DataStructSynthesizer
     {
         copyConstructorToken = default;
         var baseClass = structSym.BaseClass;
-        if (baseClass?.IsData != true)
+        if (baseClass == null)
         {
             return false;
         }
 
         var baseDefinition = baseClass.Definition ?? baseClass;
-        if (!this.dataClassCopyConstructors.TryGetValue(baseDefinition, out var baseCopyConstructor))
+        if (!this.cache.DataClassCopyConstructorHandles.TryGetValue(baseDefinition, out var baseCopyConstructor))
         {
-            return false;
+            throw new InvalidOperationException(
+                $"Class '{structSym.Name}' has no planned copy constructor for direct base '{baseClass.Name}'.");
         }
 
         if (!ReflectionMetadataEmitter.IsUserGenericTypeReference(baseClass))

--- a/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
+++ b/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
@@ -630,8 +630,7 @@ internal sealed class DataStructSynthesizer
         {
             var il = new InstructionEncoder(new BlobBuilder());
             il.LoadArgument(0);
-            if (structSym.BaseClass?.IsData == true
-                && this.dataClassCopyConstructors.TryGetValue(structSym.BaseClass, out var baseCopyConstructor))
+            if (this.TryResolveBaseCopyConstructorToken(structSym, out var baseCopyConstructor))
             {
                 il.LoadArgument(1);
                 il.OpCode(ILOpCode.Call);
@@ -738,8 +737,8 @@ internal sealed class DataStructSynthesizer
     private bool TryResolveBaseCloneToken(StructSymbol structSym, out EntityHandle cloneToken)
     {
         cloneToken = default;
-        var baseClass = structSym.BaseClass;
-        if (baseClass?.IsData != true)
+        var baseClass = structSym.GetDataCloneAncestor();
+        if (baseClass == null)
         {
             return false;
         }
@@ -780,6 +779,34 @@ internal sealed class DataStructSynthesizer
         new BlobEncoder(signature).MethodSignature(isInstanceMethod: true)
             .Parameters(0, r => this.encodeTypeSymbol(r.Type(), baseClass.Definition), _ => { });
         cloneToken = this.resolveUserMethodRef(baseClass, baseClone, "<Clone>$", signature);
+        return true;
+    }
+
+    private bool TryResolveBaseCopyConstructorToken(StructSymbol structSym, out EntityHandle copyConstructorToken)
+    {
+        copyConstructorToken = default;
+        var baseClass = structSym.BaseClass;
+        if (baseClass?.IsData != true)
+        {
+            return false;
+        }
+
+        var baseDefinition = baseClass.Definition ?? baseClass;
+        if (!this.dataClassCopyConstructors.TryGetValue(baseDefinition, out var baseCopyConstructor))
+        {
+            return false;
+        }
+
+        if (!ReflectionMetadataEmitter.IsUserGenericTypeReference(baseClass))
+        {
+            copyConstructorToken = baseCopyConstructor;
+            return true;
+        }
+
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature).MethodSignature(isInstanceMethod: true)
+            .Parameters(1, r => r.Void(), ps => this.encodeTypeSymbol(ps.AddParameter().Type(), baseDefinition));
+        copyConstructorToken = this.resolveUserMethodRef(baseClass, baseCopyConstructor, ".ctor", signature);
         return true;
     }
 

--- a/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
+++ b/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
@@ -737,7 +737,7 @@ internal sealed class DataStructSynthesizer
     private bool TryResolveBaseCloneToken(StructSymbol structSym, out EntityHandle cloneToken)
     {
         cloneToken = default;
-        var baseClass = structSym.DataCloneAncestor;
+        var baseClass = structSym.GetDataCloneAncestor();
         if (baseClass == null)
         {
             return false;

--- a/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
+++ b/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
@@ -737,7 +737,7 @@ internal sealed class DataStructSynthesizer
     private bool TryResolveBaseCloneToken(StructSymbol structSym, out EntityHandle cloneToken)
     {
         cloneToken = default;
-        var baseClass = structSym.GetDataCloneAncestor();
+        var baseClass = structSym.DataCloneAncestor;
         if (baseClass == null)
         {
             return false;

--- a/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
+++ b/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
@@ -100,6 +100,7 @@ internal sealed class DataStructSynthesizer
     private readonly Func<StructSymbol, EntityHandle> resolveUserTypeToken;
     private readonly Func<StructSymbol, FieldSymbol, EntityHandle> resolveUserFieldToken;
     private readonly Func<StructSymbol, EntityHandle, string, BlobBuilder, EntityHandle> resolveUserMethodRef;
+    private readonly Func<MethodInfo, TypeSymbol, EntityHandle> resolveImportedMethodRef;
 
     private readonly Dictionary<StructSymbol, MethodDefinitionHandle> dataClassCopyConstructors = new();
     private readonly Dictionary<StructSymbol, MethodDefinitionHandle> dataClassEqualsTypedMethods = new();
@@ -122,7 +123,8 @@ internal sealed class DataStructSynthesizer
         Func<ParameterHandle> nextParameterHandle,
         Func<StructSymbol, EntityHandle> resolveUserTypeToken,
         Func<StructSymbol, FieldSymbol, EntityHandle> resolveUserFieldToken,
-        Func<StructSymbol, EntityHandle, string, BlobBuilder, EntityHandle> resolveUserMethodRef)
+        Func<StructSymbol, EntityHandle, string, BlobBuilder, EntityHandle> resolveUserMethodRef,
+        Func<MethodInfo, TypeSymbol, EntityHandle> resolveImportedMethodRef)
     {
         this.emitCtx = emitCtx ?? throw new ArgumentNullException(nameof(emitCtx));
         this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
@@ -135,6 +137,7 @@ internal sealed class DataStructSynthesizer
         this.resolveUserTypeToken = resolveUserTypeToken ?? throw new ArgumentNullException(nameof(resolveUserTypeToken));
         this.resolveUserFieldToken = resolveUserFieldToken ?? throw new ArgumentNullException(nameof(resolveUserFieldToken));
         this.resolveUserMethodRef = resolveUserMethodRef ?? throw new ArgumentNullException(nameof(resolveUserMethodRef));
+        this.resolveImportedMethodRef = resolveImportedMethodRef ?? throw new ArgumentNullException(nameof(resolveImportedMethodRef));
     }
 
     /// <summary>
@@ -670,34 +673,10 @@ internal sealed class DataStructSynthesizer
 
     private void EmitDataClassClone(StructSymbol structSym, MethodDefinitionHandle copyConstructor)
     {
-        // Issue #2864: a data class is abstract when its effective member set
-        // still contains a no-body `open` member (StructSymbol.IsAbstract,
-        // #987). Emitting the ordinary copy-construct body there produced
-        // `newobj` of the abstract type itself, which ilverify rejects with
-        // NewobjAbstractClass.
-        //
-        // C# solves this by declaring `<Clone>$` abstract on the base and
-        // having each derived record override it with a COVARIANT return type
-        // (`Derived <Clone>$()` overriding `Base <Clone>$()`), which requires
-        // an explicit MethodImpl plus `PreserveBaseOverridesAttribute`. This
-        // emitter has no covariant-return support: every `<Clone>$` returns its
-        // own declaring type, so the signatures never match and the derived
-        // method silently lands in a fresh slot. Declaring the base one
-        // abstract would therefore leave it permanently unimplemented and the
-        // runtime would reject the derived type with a TypeLoadException.
-        //
-        // `<Clone>$` has no consumer inside gsc — it exists purely for C#
-        // record shape compatibility — so the correct narrow fix is to omit it
-        // on an abstract data class, exactly as an abstract type omits any
-        // other member it cannot implement. Concrete data classes are
-        // unaffected.
-        if (structSym.IsAbstract)
-        {
-            return;
-        }
+        var hasBaseClone = this.TryResolveBaseCloneToken(structSym, out var baseClone);
 
         int bodyOffset = -1;
-        if (!this.emitCtx.MetadataOnly)
+        if (!structSym.IsAbstract && !this.emitCtx.MetadataOnly)
         {
             var il = new InstructionEncoder(new BlobBuilder());
             il.LoadArgument(0);
@@ -711,22 +690,97 @@ internal sealed class DataStructSynthesizer
         new BlobEncoder(signature).MethodSignature(isInstanceMethod: true)
             .Parameters(0, r => this.encodeTypeSymbol(r.Type(), structSym), _ => { });
         var attributes = MethodAttributes.Public | MethodAttributes.HideBySig;
-        if (!IsDataObjectOverrideFinal(structSym))
+        if (structSym.IsAbstract || hasBaseClone || !IsDataObjectOverrideFinal(structSym))
         {
-            attributes |= MethodAttributes.Virtual;
-            if (structSym.BaseClass?.IsData != true)
-            {
-                attributes |= MethodAttributes.NewSlot;
-            }
+            // Covariant returns differ at the CLR-signature level. Match
+            // Roslyn: emit a new virtual slot, then bind it explicitly to the
+            // base clone with a MethodImpl row.
+            attributes |= MethodAttributes.Virtual | MethodAttributes.NewSlot;
         }
 
-        this.emitCtx.Metadata.AddMethodDefinition(
+        if (structSym.IsAbstract)
+        {
+            attributes |= MethodAttributes.Abstract;
+        }
+
+        var cloneMethod = this.emitCtx.Metadata.AddMethodDefinition(
             attributes,
             MethodImplAttributes.IL | MethodImplAttributes.Managed,
             this.emitCtx.Metadata.GetOrAddString("<Clone>$"),
             this.emitCtx.Metadata.GetOrAddBlob(signature),
             bodyOffset,
             this.nextParameterHandle());
+
+        if (this.cache.DataClassCloneHandles.TryGetValue(structSym, out var plannedClone)
+            && cloneMethod != plannedClone)
+        {
+            throw new InvalidOperationException(
+                $"Data class '{structSym.Name}' <Clone>$ MethodDef row {MetadataTokens.GetRowNumber(cloneMethod)} did not match the planned row {MetadataTokens.GetRowNumber(plannedClone)}.");
+        }
+
+        if (hasBaseClone)
+        {
+            this.emitCtx.Metadata.AddMethodImplementation(
+                this.cache.StructTypeDefs[structSym],
+                cloneMethod,
+                baseClone);
+
+            var valueBlob = new BlobBuilder();
+            valueBlob.WriteUInt16(0x0001);
+            valueBlob.WriteUInt16(0);
+            this.emitCtx.Metadata.AddCustomAttribute(
+                cloneMethod,
+                this.wellKnown.GetPreserveBaseOverridesAttributeCtorRef(),
+                this.emitCtx.Metadata.GetOrAddBlob(valueBlob));
+        }
+    }
+
+    private bool TryResolveBaseCloneToken(StructSymbol structSym, out EntityHandle cloneToken)
+    {
+        cloneToken = default;
+        var baseClass = structSym.BaseClass;
+        if (baseClass?.IsData != true)
+        {
+            return false;
+        }
+
+        if (baseClass.ClrType is { } importedBase)
+        {
+            var candidates = ClrTypeUtilities.SafeGetMethods(
+                    importedBase,
+                    BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(method =>
+                    method.Name == "<Clone>$"
+                    && !method.IsGenericMethod
+                    && method.GetParameters().Length == 0
+                    && method.IsVirtual
+                    && ClrTypeUtilities.AreSame(method.ReturnType, importedBase))
+                .ToArray();
+            if (candidates.Length != 1)
+            {
+                return false;
+            }
+
+            cloneToken = this.resolveImportedMethodRef(candidates[0], baseClass);
+            return true;
+        }
+
+        if (!this.cache.DataClassCloneHandles.TryGetValue(baseClass.Definition, out var baseClone))
+        {
+            return false;
+        }
+
+        if (!ReflectionMetadataEmitter.IsUserGenericTypeReference(baseClass))
+        {
+            cloneToken = baseClone;
+            return true;
+        }
+
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => this.encodeTypeSymbol(r.Type(), baseClass), _ => { });
+        cloneToken = this.resolveUserMethodRef(baseClass, baseClone, "<Clone>$", signature);
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
+++ b/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
@@ -101,7 +101,6 @@ internal sealed class DataStructSynthesizer
     private readonly Func<StructSymbol, FieldSymbol, EntityHandle> resolveUserFieldToken;
     private readonly Func<StructSymbol, EntityHandle, string, BlobBuilder, EntityHandle> resolveUserMethodRef;
     private readonly Func<MethodInfo, TypeSymbol, EntityHandle> resolveImportedMethodRef;
-    private readonly Func<ConstructorInfo, TypeSymbol, EntityHandle> resolveImportedCtorRef;
 
     private readonly Dictionary<StructSymbol, MethodDefinitionHandle> dataClassEqualsTypedMethods = new();
     private readonly Dictionary<StructSymbol, MethodDefinitionHandle> equalityContractGetters = new();
@@ -124,8 +123,7 @@ internal sealed class DataStructSynthesizer
         Func<StructSymbol, EntityHandle> resolveUserTypeToken,
         Func<StructSymbol, FieldSymbol, EntityHandle> resolveUserFieldToken,
         Func<StructSymbol, EntityHandle, string, BlobBuilder, EntityHandle> resolveUserMethodRef,
-        Func<MethodInfo, TypeSymbol, EntityHandle> resolveImportedMethodRef,
-        Func<ConstructorInfo, TypeSymbol, EntityHandle> resolveImportedCtorRef)
+        Func<MethodInfo, TypeSymbol, EntityHandle> resolveImportedMethodRef)
     {
         this.emitCtx = emitCtx ?? throw new ArgumentNullException(nameof(emitCtx));
         this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
@@ -139,7 +137,6 @@ internal sealed class DataStructSynthesizer
         this.resolveUserFieldToken = resolveUserFieldToken ?? throw new ArgumentNullException(nameof(resolveUserFieldToken));
         this.resolveUserMethodRef = resolveUserMethodRef ?? throw new ArgumentNullException(nameof(resolveUserMethodRef));
         this.resolveImportedMethodRef = resolveImportedMethodRef ?? throw new ArgumentNullException(nameof(resolveImportedMethodRef));
-        this.resolveImportedCtorRef = resolveImportedCtorRef ?? throw new ArgumentNullException(nameof(resolveImportedCtorRef));
     }
 
     /// <summary>
@@ -805,26 +802,6 @@ internal sealed class DataStructSynthesizer
         if (baseClass == null)
         {
             return false;
-        }
-
-        if (baseClass.ClrType is { } importedBase)
-        {
-            var candidates = ClrTypeUtilities.SafeGetConstructors(
-                    importedBase,
-                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                .Where(constructor =>
-                    (constructor.IsPublic || constructor.IsFamily || constructor.IsFamilyOrAssembly)
-                    && constructor.GetParameters() is [{ } parameter]
-                    && ClrTypeUtilities.AreSame(parameter.ParameterType, importedBase))
-                .ToArray();
-            if (candidates.Length != 1)
-            {
-                throw new InvalidOperationException(
-                    $"Imported base class '{baseClass.Name}' has no unique accessible copy constructor.");
-            }
-
-            copyConstructorToken = this.resolveImportedCtorRef(candidates[0], baseClass);
-            return true;
         }
 
         var baseDefinition = baseClass.Definition ?? baseClass;

--- a/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
+++ b/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
@@ -778,7 +778,7 @@ internal sealed class DataStructSynthesizer
 
         var signature = new BlobBuilder();
         new BlobEncoder(signature).MethodSignature(isInstanceMethod: true)
-            .Parameters(0, r => this.encodeTypeSymbol(r.Type(), baseClass), _ => { });
+            .Parameters(0, r => this.encodeTypeSymbol(r.Type(), baseClass.Definition), _ => { });
         cloneToken = this.resolveUserMethodRef(baseClass, baseClone, "<Clone>$", signature);
         return true;
     }

--- a/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
+++ b/src/Core/CodeAnalysis/Emit/DataStructSynthesizer.cs
@@ -101,6 +101,7 @@ internal sealed class DataStructSynthesizer
     private readonly Func<StructSymbol, FieldSymbol, EntityHandle> resolveUserFieldToken;
     private readonly Func<StructSymbol, EntityHandle, string, BlobBuilder, EntityHandle> resolveUserMethodRef;
     private readonly Func<MethodInfo, TypeSymbol, EntityHandle> resolveImportedMethodRef;
+    private readonly Func<ConstructorInfo, TypeSymbol, EntityHandle> resolveImportedCtorRef;
 
     private readonly Dictionary<StructSymbol, MethodDefinitionHandle> dataClassEqualsTypedMethods = new();
     private readonly Dictionary<StructSymbol, MethodDefinitionHandle> equalityContractGetters = new();
@@ -123,7 +124,8 @@ internal sealed class DataStructSynthesizer
         Func<StructSymbol, EntityHandle> resolveUserTypeToken,
         Func<StructSymbol, FieldSymbol, EntityHandle> resolveUserFieldToken,
         Func<StructSymbol, EntityHandle, string, BlobBuilder, EntityHandle> resolveUserMethodRef,
-        Func<MethodInfo, TypeSymbol, EntityHandle> resolveImportedMethodRef)
+        Func<MethodInfo, TypeSymbol, EntityHandle> resolveImportedMethodRef,
+        Func<ConstructorInfo, TypeSymbol, EntityHandle> resolveImportedCtorRef)
     {
         this.emitCtx = emitCtx ?? throw new ArgumentNullException(nameof(emitCtx));
         this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
@@ -137,6 +139,7 @@ internal sealed class DataStructSynthesizer
         this.resolveUserFieldToken = resolveUserFieldToken ?? throw new ArgumentNullException(nameof(resolveUserFieldToken));
         this.resolveUserMethodRef = resolveUserMethodRef ?? throw new ArgumentNullException(nameof(resolveUserMethodRef));
         this.resolveImportedMethodRef = resolveImportedMethodRef ?? throw new ArgumentNullException(nameof(resolveImportedMethodRef));
+        this.resolveImportedCtorRef = resolveImportedCtorRef ?? throw new ArgumentNullException(nameof(resolveImportedCtorRef));
     }
 
     /// <summary>
@@ -802,6 +805,26 @@ internal sealed class DataStructSynthesizer
         if (baseClass == null)
         {
             return false;
+        }
+
+        if (baseClass.ClrType is { } importedBase)
+        {
+            var candidates = ClrTypeUtilities.SafeGetConstructors(
+                    importedBase,
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(constructor =>
+                    (constructor.IsPublic || constructor.IsFamily || constructor.IsFamilyOrAssembly)
+                    && constructor.GetParameters() is [{ } parameter]
+                    && ClrTypeUtilities.AreSame(parameter.ParameterType, importedBase))
+                .ToArray();
+            if (candidates.Length != 1)
+            {
+                throw new InvalidOperationException(
+                    $"Imported base class '{baseClass.Name}' has no unique accessible copy constructor.");
+            }
+
+            copyConstructorToken = this.resolveImportedCtorRef(candidates[0], baseClass);
+            return true;
         }
 
         var baseDefinition = baseClass.Definition ?? baseClass;

--- a/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
+++ b/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
@@ -383,6 +383,14 @@ internal sealed class MetadataTokenCache
         = new Dictionary<StructSymbol, MethodDefinitionHandle>();
 
     /// <summary>
+    /// Gets the planned <c>&lt;Clone&gt;$</c> MethodDef for each data class.
+    /// Planned handles let covariant clone MethodImpl rows target a base clone
+    /// even when the base method body has not been emitted yet.
+    /// </summary>
+    public Dictionary<StructSymbol, MethodDefinitionHandle> DataClassCloneHandles { get; }
+        = new Dictionary<StructSymbol, MethodDefinitionHandle>();
+
+    /// <summary>
     /// Issue #420 (P3-7): structural cache key for MethodSpec rows whose
     /// generic arguments include user-defined type symbols. Uses reference
     /// equality on the contained <see cref="TypeSymbol"/> entries (declared

--- a/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
+++ b/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
@@ -383,6 +383,15 @@ internal sealed class MetadataTokenCache
         = new Dictionary<StructSymbol, MethodDefinitionHandle>();
 
     /// <summary>
+    /// Gets the planned copy-constructor MethodDef for each data class and
+    /// non-data class in a data-class inheritance chain. Planned handles let
+    /// derived copy constructors call their direct base copy constructor
+    /// regardless of declaration or body-emission order.
+    /// </summary>
+    public Dictionary<StructSymbol, MethodDefinitionHandle> DataClassCopyConstructorHandles { get; }
+        = new Dictionary<StructSymbol, MethodDefinitionHandle>();
+
+    /// <summary>
     /// Gets the planned <c>&lt;Clone&gt;$</c> MethodDef for each data class.
     /// Planned handles let covariant clone MethodImpl rows target a base clone
     /// even when the base method body has not been emitted yet.

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1055,7 +1055,8 @@ internal sealed class ReflectionMetadataEmitter
             this.customAttrEncoder.NextParameterHandle,
             this.userTokens.ResolveUserTypeToken,
             this.userTokens.ResolveFieldToken,
-            this.userTokens.GetUserStructMethodRef);
+            this.userTokens.GetUserStructMethodRef,
+            (method, containingType) => this.memberRefs.GetMethodEntityHandle(method, containingType));
 
         // PR-E-7: MemberDefEmitter wires up after DataStructSynthesizer.
         // It depends on the same EmitContext/MetadataTokenCache/WellKnownReferences
@@ -1871,17 +1872,18 @@ internal sealed class ReflectionMetadataEmitter
             // skipping the synthesized ToString body in that case. The two
             // skips are independent and compose (a zero-field data class
             // with a user ToString override reserves five rows).
-            // Issue #2864: an ABSTRACT data class skips `<Clone>$` (one fewer
-            // row) — see DataStructSynthesizer.EmitDataClassClone's matching
-            // early return, which exists because `newobj` of the abstract type
-            // itself is unverifiable and this emitter has no covariant-return
-            // support to declare the member abstract instead.
             if (c.IsData)
             {
+                // Issue #2871: `<Clone>$` is the third synthesized data-class
+                // row (after EqualityContract.get and the copy constructor).
+                // Record it during planning so derived covariant clones can
+                // emit a MethodImpl against the base slot regardless of body
+                // emission order. Abstract data classes still reserve and emit
+                // this row; their clone is abstract and has no body.
+                this.cache.DataClassCloneHandles[c] = MetadataTokens.MethodDefinitionHandle(methodRow + 2);
                 methodRow += 10
                     - (DataStructSynthesizer.HasZeroDeconstructionMembers(c) ? 1 : 0)
-                    - (DataStructSynthesizer.HasUserToStringOverride(c) ? 1 : 0)
-                    - (c.IsAbstract ? 1 : 0);
+                    - (DataStructSynthesizer.HasUserToStringOverride(c) ? 1 : 0);
             }
 
             if (!c.Methods.IsDefaultOrEmpty)

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1056,7 +1056,8 @@ internal sealed class ReflectionMetadataEmitter
             this.userTokens.ResolveUserTypeToken,
             this.userTokens.ResolveFieldToken,
             this.userTokens.GetUserStructMethodRef,
-            (method, containingType) => this.memberRefs.GetMethodEntityHandle(method, containingType));
+            (method, containingType) => this.memberRefs.GetMethodEntityHandle(method, containingType),
+            (constructor, containingType) => this.memberRefs.GetCtorReference(constructor, containingType));
 
         // PR-E-7: MemberDefEmitter wires up after DataStructSynthesizer.
         // It depends on the same EmitContext/MetadataTokenCache/WellKnownReferences

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1056,8 +1056,7 @@ internal sealed class ReflectionMetadataEmitter
             this.userTokens.ResolveUserTypeToken,
             this.userTokens.ResolveFieldToken,
             this.userTokens.GetUserStructMethodRef,
-            (method, containingType) => this.memberRefs.GetMethodEntityHandle(method, containingType),
-            (constructor, containingType) => this.memberRefs.GetCtorReference(constructor, containingType));
+            (method, containingType) => this.memberRefs.GetMethodEntityHandle(method, containingType));
 
         // PR-E-7: MemberDefEmitter wires up after DataStructSynthesizer.
         // It depends on the same EmitContext/MetadataTokenCache/WellKnownReferences

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1831,6 +1831,21 @@ internal sealed class ReflectionMetadataEmitter
         var classCtorRows = new Dictionary<StructSymbol, int>();
         var classPrimaryCtorRows = new Dictionary<StructSymbol, int>();
         var aggregateMethodHandles = new Dictionary<FunctionSymbol, MethodDefinitionHandle>();
+        var dataCopyConstructorClasses = new HashSet<StructSymbol>();
+
+        // Clone MethodImpl rows may skip non-data intermediaries, but instance
+        // constructors must call the direct base. Give every user class in a
+        // data-class ancestry chain a planned copy constructor.
+        foreach (var dataClass in topClasses
+            .Concat(nestedOrdered.OfType<StructSymbol>().Where(type => type.IsClass))
+            .Where(type => type.IsData))
+        {
+            for (var current = dataClass; current != null; current = current.BaseClass)
+            {
+                dataCopyConstructorClasses.Add(current.Definition ?? current);
+            }
+        }
+
         void PlanClassMethods(StructSymbol c)
         {
             classCtorRows[c] = methodRow++;
@@ -1853,6 +1868,11 @@ internal sealed class ReflectionMetadataEmitter
             if (c.HasPrimaryConstructor && c.BaseConstructorInitializer == null && c.ExplicitConstructor == null)
             {
                 classPrimaryCtorRows[c] = methodRow++;
+            }
+
+            if (!c.IsData && dataCopyConstructorClasses.Contains(c))
+            {
+                this.cache.DataClassCopyConstructorHandles[c] = MetadataTokens.MethodDefinitionHandle(methodRow++);
             }
 
             // Issue #2228: a `data class` synthesizes the same seven
@@ -1880,6 +1900,7 @@ internal sealed class ReflectionMetadataEmitter
                 // emit a MethodImpl against the base slot regardless of body
                 // emission order. Abstract data classes still reserve and emit
                 // this row; their clone is abstract and has no body.
+                this.cache.DataClassCopyConstructorHandles[c] = MetadataTokens.MethodDefinitionHandle(methodRow + 1);
                 this.cache.DataClassCloneHandles[c] = MetadataTokens.MethodDefinitionHandle(methodRow + 2);
                 methodRow += 10
                     - (DataStructSynthesizer.HasZeroDeconstructionMembers(c) ? 1 : 0)
@@ -3310,6 +3331,11 @@ internal sealed class ReflectionMetadataEmitter
                     var primaryHandle = this.typeDefEmitter.EmitClassPrimaryConstructor(c);
                     this.cache.ClassPrimaryCtorHandles[c] = primaryHandle;
                 }
+            }
+
+            if (!c.IsData && this.cache.DataClassCopyConstructorHandles.ContainsKey(c))
+            {
+                this.dataStructSynth.EmitDataClassCopyConstructor(c);
             }
 
             // Issue #2228: emit the seven synthesized members for a `data

--- a/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
+++ b/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
@@ -488,6 +488,7 @@ internal sealed class WellKnownReferences
     /// Covariant class overrides emitted through MethodImpl rows require this
     /// marker so further-derived overrides preserve the full base slot chain.
     /// </summary>
+    /// <returns>The cached constructor reference.</returns>
     public MemberReferenceHandle GetPreserveBaseOverridesAttributeCtorRef()
     {
         if (this.preserveBaseOverridesAttributeCtorRef.HasValue)

--- a/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
+++ b/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
@@ -92,6 +92,7 @@ internal sealed class WellKnownReferences
     // as plain static helpers on `<Program>`.
     private MemberReferenceHandle? extensionAttributeCtorRef;
     private MemberReferenceHandle? compilerGeneratedAttributeCtorRef;
+    private MemberReferenceHandle? preserveBaseOverridesAttributeCtorRef;
     private MemberReferenceHandle? unsafeValueTypeAttributeCtorRef;
     private MemberReferenceHandle? fixedBufferAttributeCtorRef;
 
@@ -479,6 +480,35 @@ internal sealed class WellKnownReferences
             this.emitCtx.Metadata.GetOrAddString(".ctor"),
             this.emitCtx.Metadata.GetOrAddBlob(ctorSig));
         return this.compilerGeneratedAttributeCtorRef.Value;
+    }
+
+    /// <summary>
+    /// Returns the cached parameterless constructor for
+    /// <c>System.Runtime.CompilerServices.PreserveBaseOverridesAttribute</c>.
+    /// Covariant class overrides emitted through MethodImpl rows require this
+    /// marker so further-derived overrides preserve the full base slot chain.
+    /// </summary>
+    public MemberReferenceHandle GetPreserveBaseOverridesAttributeCtorRef()
+    {
+        if (this.preserveBaseOverridesAttributeCtorRef.HasValue)
+        {
+            return this.preserveBaseOverridesAttributeCtorRef.Value;
+        }
+
+        var attrType = this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.PreserveBaseOverridesAttribute", requireExternalVisibility: false, out var resolved)
+            ? resolved
+            : typeof(System.Runtime.CompilerServices.PreserveBaseOverridesAttribute);
+        var attrTypeRef = this.getTypeReference(attrType);
+
+        var ctorSig = new BlobBuilder();
+        new BlobEncoder(ctorSig).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, r => r.Void(), _ => { });
+
+        this.preserveBaseOverridesAttributeCtorRef = this.emitCtx.Metadata.AddMemberReference(
+            attrTypeRef,
+            this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            this.emitCtx.Metadata.GetOrAddBlob(ctorSig));
+        return this.preserveBaseOverridesAttributeCtorRef.Value;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -355,7 +355,7 @@ public sealed class StructSymbol : TypeSymbol
                 return effectiveProperties.Values.Any(property => property.IsAbstract);
             }
 
-            return (!IsData && GetDataCloneAncestor()?.IsAbstract == true)
+            return (!IsData && DataCloneAncestor?.IsAbstract == true)
                 || !GetUnimplementedAbstractMethods().IsDefaultOrEmpty
                 || HasUnimplementedAbstractProperties();
         }
@@ -379,17 +379,20 @@ public sealed class StructSymbol : TypeSymbol
     /// Gets the nearest base class that declares the synthesized data-class
     /// clone slot, skipping non-data intermediary classes.
     /// </summary>
-    internal StructSymbol GetDataCloneAncestor()
+    internal StructSymbol DataCloneAncestor
     {
-        for (var ancestor = BaseClass; ancestor != null; ancestor = ancestor.BaseClass)
+        get
         {
-            if (ancestor.IsData)
+            for (var ancestor = BaseClass; ancestor != null; ancestor = ancestor.BaseClass)
             {
-                return ancestor;
+                if (ancestor.IsData)
+                {
+                    return ancestor;
+                }
             }
-        }
 
-        return null;
+            return null;
+        }
     }
 
     /// <summary>Gets the interfaces this type implements (Phase 3.B.4). Populated by the binder after the symbol is constructed; defaults to empty.</summary>

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -320,8 +320,10 @@ public sealed class StructSymbol : TypeSymbol
     /// Gets a value indicating whether this class is abstract — issue #987. A
     /// class is abstract when its effective member set (own + inherited, after
     /// override resolution) contains at least one abstract method (a no-body
-    /// <c>open func</c>). Such a type cannot be instantiated and is emitted with
-    /// <c>TypeAttributes.Abstract</c>. Always <c>false</c> for value-type structs.
+    /// <c>open func</c>), or when a non-data class inherits an abstract
+    /// synthesized record clone. Such a type cannot be instantiated and is
+    /// emitted with <c>TypeAttributes.Abstract</c>. Always <c>false</c> for
+    /// value-type structs.
     /// </summary>
     public bool IsAbstract
     {
@@ -353,7 +355,9 @@ public sealed class StructSymbol : TypeSymbol
                 return effectiveProperties.Values.Any(property => property.IsAbstract);
             }
 
-            return !GetUnimplementedAbstractMethods().IsDefaultOrEmpty || HasUnimplementedAbstractProperties();
+            return (!IsData && GetDataCloneAncestor()?.IsAbstract == true)
+                || !GetUnimplementedAbstractMethods().IsDefaultOrEmpty
+                || HasUnimplementedAbstractProperties();
         }
     }
 
@@ -369,6 +373,23 @@ public sealed class StructSymbol : TypeSymbol
 
             return GetSubstitutedBaseClass();
         }
+    }
+
+    /// <summary>
+    /// Gets the nearest base class that declares the synthesized data-class
+    /// clone slot, skipping non-data intermediary classes.
+    /// </summary>
+    internal StructSymbol GetDataCloneAncestor()
+    {
+        for (var ancestor = BaseClass; ancestor != null; ancestor = ancestor.BaseClass)
+        {
+            if (ancestor.IsData)
+            {
+                return ancestor;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>Gets the interfaces this type implements (Phase 3.B.4). Populated by the binder after the symbol is constructed; defaults to empty.</summary>

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -355,7 +355,7 @@ public sealed class StructSymbol : TypeSymbol
                 return effectiveProperties.Values.Any(property => property.IsAbstract);
             }
 
-            return (!IsData && DataCloneAncestor?.IsAbstract == true)
+            return (!IsData && GetDataCloneAncestor()?.IsAbstract == true)
                 || !GetUnimplementedAbstractMethods().IsDefaultOrEmpty
                 || HasUnimplementedAbstractProperties();
         }
@@ -372,26 +372,6 @@ public sealed class StructSymbol : TypeSymbol
             }
 
             return GetSubstitutedBaseClass();
-        }
-    }
-
-    /// <summary>
-    /// Gets the nearest base class that declares the synthesized data-class
-    /// clone slot, skipping non-data intermediary classes.
-    /// </summary>
-    internal StructSymbol DataCloneAncestor
-    {
-        get
-        {
-            for (var ancestor = BaseClass; ancestor != null; ancestor = ancestor.BaseClass)
-            {
-                if (ancestor.IsData)
-                {
-                    return ancestor;
-                }
-            }
-
-            return null;
         }
     }
 
@@ -1624,6 +1604,24 @@ public sealed class StructSymbol : TypeSymbol
         }
 
         return builder.MoveToImmutable();
+    }
+
+    /// <summary>
+    /// Gets the nearest base class that declares the synthesized data-class
+    /// clone slot, skipping non-data intermediary classes.
+    /// </summary>
+    /// <returns>The nearest data-class ancestor, or null when none exists.</returns>
+    internal StructSymbol GetDataCloneAncestor()
+    {
+        for (var ancestor = BaseClass; ancestor != null; ancestor = ancestor.BaseClass)
+        {
+            if (ancestor.IsData)
+            {
+                return ancestor;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue2864AbstractDataClassCloneEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2864AbstractDataClassCloneEmitTests.cs
@@ -18,12 +18,11 @@ namespace GSharp.Compiler.Tests.Emit;
 /// (<c>StructSymbol.IsAbstract</c>, #987), and <c>newobj</c> of an abstract
 /// type is rejected by ilverify with <c>NewobjAbstractClass</c>.
 /// <para>
-/// <c>&lt;Clone&gt;$</c> exists purely for C# record shape compatibility and
-/// has no consumer inside gsc (G# has no <c>with</c> expression), so it is now
-/// omitted on an abstract data class. The matching MethodDef row reservation in
-/// <c>ReflectionMetadataEmitter.PlanClassMethods</c> must skip the same row —
-/// these facts pin that alignment, since a stale reservation silently shifts
-/// every later method token in the type.
+/// Issue #2871 restores the C# record shape: abstract data classes emit an
+/// abstract <c>&lt;Clone&gt;$</c>, and derived data classes bind their
+/// covariant-return clone to the base slot with MethodImpl metadata. The
+/// MethodDef planner must reserve that row so every later method token remains
+/// aligned.
 /// </para>
 /// </summary>
 public class Issue2864AbstractDataClassCloneEmitTests
@@ -56,10 +55,9 @@ public class Issue2864AbstractDataClassCloneEmitTests
     [Fact]
     public void AbstractDataClassWithUserMethods_KeepsMethodTokensAligned()
     {
-        // The reservation fix is the risky half: omitting the `<Clone>$` row
-        // without shrinking PlanClassMethods' reservation shifts every later
-        // MethodDef token in the type, which corrupts unrelated call sites
-        // rather than failing loudly.
+        // The planner and emitter must both include the abstract `<Clone>$`
+        // row. Any disagreement shifts every later MethodDef token in the type
+        // and corrupts unrelated call sites rather than failing locally.
         const string source = """
             package i2864b
 
@@ -121,8 +119,9 @@ public class Issue2864AbstractDataClassCloneEmitTests
 
         // `Leaf` synthesizes its OWN ToString, which overrides the base's
         // hand-written one — that is ordinary data-class behaviour. What
-        // matters here is that `Base` reserves 10 - 1 (ToString) - 1 (Clone)
-        // rows, so `Describe` and `Shout` still resolve to the right tokens.
+        // matters here is that `Base` reserves 10 - 1 (ToString) rows,
+        // including its abstract Clone row, so `Describe` and `Shout` still
+        // resolve to the right tokens.
         Assert.Equal("kind=leaf!|Leaf(Id=3)|3\n", CompileAndRun(source));
     }
 

--- a/test/Compiler.Tests/Emit/Issue2871CovariantRecordCloneEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2871CovariantRecordCloneEmitTests.cs
@@ -11,9 +11,12 @@ using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.Loader;
 using GSharp.Compiler;
+using GSharp.Core.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
 
 namespace GSharp.Compiler.Tests.Emit;
 
@@ -136,6 +139,77 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
             CompileCSharpConsumerAndRun(gsharp, csharp));
     }
 
+    [Fact]
+    public void ConcreteNonDataSubclass_OfAbstractDataClass_ReportsCloneDiagnostic()
+    {
+        var syntax = GsSyntaxTree.Parse(SourceText.From(
+            """
+            package i2871nondataderived
+
+            open data class Base {
+                open prop Kind string {
+                    get;
+                }
+            }
+
+            class Leaf : Base {
+                override prop Kind string -> "leaf"
+            }
+            """));
+        var compilation = new GsCompilation(syntax);
+
+        using var output = new MemoryStream();
+        var result = compilation.Emit(
+            output,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: "Issue2871.NonDataDerived");
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            diagnostic =>
+                diagnostic.Id == "GS0387"
+                && diagnostic.Message.Contains("<Clone>$", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CSharpWithExpression_ThroughConstructedGenericAbstractBase_Runs()
+    {
+        const string gsharp = """
+            package i2871genericruntime
+
+            open data class Base[T] {
+                prop Value T { get; init; }
+
+                open prop Kind string {
+                    get;
+                }
+            }
+
+            data class Leaf(Extra int32) : Base[int32] {
+                override prop Kind string -> "leaf"
+            }
+            """;
+        const string csharp = """
+            using i2871genericruntime;
+
+            public static class Probe
+            {
+                public static string Run()
+                {
+                    Base<int> original = new Leaf(7) { Value = 3 };
+                    var clone = original with { Value = 5 };
+                    return $"{clone.GetType().Name}:{((Leaf)clone).Extra}:{clone.Value}";
+                }
+            }
+            """;
+
+        Assert.Equal(
+            "Leaf:7:5",
+            CompileCSharpConsumerAndRun(gsharp, csharp));
+    }
+
     private static void AssertAbstractClone(MethodDefinition clone)
     {
         Assert.True((clone.Attributes & MethodAttributes.Abstract) != 0);
@@ -232,7 +306,8 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
             var loadContext = new AssemblyLoadContext("Issue2871-" + Guid.NewGuid(), isCollectible: true);
             try
             {
-                _ = loadContext.LoadFromAssemblyPath(libraryPath);
+                var libraryAssembly = loadContext.LoadFromAssemblyPath(libraryPath);
+                _ = libraryAssembly.GetTypes();
                 var consumerAssembly = loadContext.LoadFromAssemblyPath(consumerPath);
                 return (string)consumerAssembly.GetType("Probe", throwOnError: true)!
                     .GetMethod("Run", BindingFlags.Public | BindingFlags.Static)!

--- a/test/Compiler.Tests/Emit/Issue2871CovariantRecordCloneEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2871CovariantRecordCloneEmitTests.cs
@@ -174,9 +174,9 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
     }
 
     [Fact]
-    public void CSharpWithExpression_ThroughConstructedGenericAbstractBase_Runs()
+    public void ConstructedGenericAbstractBaseClone_MemberRefMatchesDefinitionAndTypeLoads()
     {
-        const string gsharp = """
+        const string source = """
             package i2871genericruntime
 
             open data class Base[T] {
@@ -191,23 +191,47 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
                 override prop Kind string -> "leaf"
             }
             """;
-        const string csharp = """
-            using i2871genericruntime;
 
-            public static class Probe
+        var directory = CreateArtifactsDirectory();
+        try
+        {
+            var libraryPath = CompileGSharpLibrary(directory, "Records", source);
+            using (var stream = File.OpenRead(libraryPath))
+            using (var peReader = new PEReader(stream))
             {
-                public static string Run()
-                {
-                    Base<int> original = new Leaf(7) { Value = 3 };
-                    var clone = original with { Value = 5 };
-                    return $"{clone.GetType().Name}:{((Leaf)clone).Extra}:{clone.Value}";
-                }
-            }
-            """;
+                var reader = peReader.GetMetadataReader();
+                var baseType = FindType(reader, "Base`1");
+                var leafType = FindType(reader, "Leaf");
+                var baseClone = FindMethod(reader, baseType, "<Clone>$");
+                var leafClone = FindMethod(reader, leafType, "<Clone>$");
+                var leafCloneToken = MetadataTokens.GetToken(leafClone);
+                var methodImpl = reader.GetTypeDefinition(leafType)
+                    .GetMethodImplementations()
+                    .Select(reader.GetMethodImplementation)
+                    .Single(row => MetadataTokens.GetToken(row.MethodBody) == leafCloneToken);
 
-        Assert.Equal(
-            "Leaf:7:5",
-            CompileCSharpConsumerAndRun(gsharp, csharp));
+                Assert.Equal(HandleKind.MemberReference, methodImpl.MethodDeclaration.Kind);
+                var baseCloneReference = reader.GetMemberReference((MemberReferenceHandle)methodImpl.MethodDeclaration);
+                Assert.Equal(
+                    reader.GetBlobBytes(reader.GetMethodDefinition(baseClone).Signature),
+                    reader.GetBlobBytes(baseCloneReference.Signature));
+            }
+
+            var loadContext = new AssemblyLoadContext("Issue2871-generic-" + Guid.NewGuid(), isCollectible: true);
+            try
+            {
+                var assembly = loadContext.LoadFromAssemblyPath(libraryPath);
+                Assert.Contains(assembly.GetTypes(), type => type.Name == "Leaf");
+            }
+            finally
+            {
+                loadContext.Unload();
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
     }
 
     private static void AssertAbstractClone(MethodDefinition clone)

--- a/test/Compiler.Tests/Emit/Issue2871CovariantRecordCloneEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2871CovariantRecordCloneEmitTests.cs
@@ -313,6 +313,148 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
         }
     }
 
+    [Fact]
+    public void CopyConstructor_DerivedDeclaredBeforeBase_UsesPlannedBaseRowAndPreservesFields()
+    {
+        const string source = """
+            package i2871reversed
+
+            data class Leaf(Extra int32) : Base {
+                override prop Kind string -> "leaf"
+            }
+
+            open data class Base {
+                prop Id int32 { get; init; }
+
+                open prop Kind string {
+                    get;
+                }
+            }
+            """;
+        const string csharp = """
+            using i2871reversed;
+
+            public static class Probe
+            {
+                public static string Run()
+                {
+                    Base original = new Leaf(7) { Id = 3 };
+                    var clone = original with { };
+                    return $"{clone.GetType().Name}:{((Leaf)clone).Extra}:{clone.Id}";
+                }
+            }
+            """;
+
+        var directory = CreateArtifactsDirectory();
+        try
+        {
+            var libraryPath = CompileGSharpLibrary(directory, "Records", source);
+            IlVerifier.Verify(libraryPath);
+
+            using (var stream = File.OpenRead(libraryPath))
+            using (var peReader = new PEReader(stream))
+            {
+                var reader = peReader.GetMetadataReader();
+                var baseCopyConstructor = FindCopyConstructor(reader, FindType(reader, "Base"));
+                var leafCopyConstructor = FindCopyConstructor(reader, FindType(reader, "Leaf"));
+                Assert.True(MethodContainsCallTo(
+                    peReader,
+                    reader,
+                    leafCopyConstructor,
+                    baseCopyConstructor));
+            }
+
+            Assert.Equal(
+                "Leaf:7:3",
+                CompileCSharpConsumerAndRun(directory, libraryPath, csharp));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CopyConstructor_ThroughNonDataIntermediary_UsesDirectCtorChainAndPreservesFields()
+    {
+        const string source = """
+            package i2871copyintermediary
+
+            data class Leaf(LeafValue int32) : Middle {
+            }
+
+            open class Middle : Base {
+                prop MiddleValue int32 { get; init; }
+
+                override prop Kind string -> "middle"
+            }
+
+            open data class Base {
+                prop BaseValue int32 { get; init; }
+
+                open prop Kind string {
+                    get;
+                }
+            }
+            """;
+        const string csharp = """
+            using i2871copyintermediary;
+
+            public static class Probe
+            {
+                public static string Run()
+                {
+                    Base original = new Leaf(7) { BaseValue = 3, MiddleValue = 5 };
+                    var clone = (Leaf)(original with { });
+                    return $"{clone.GetType().Name}:{clone.LeafValue}:{clone.MiddleValue}:{clone.BaseValue}";
+                }
+            }
+            """;
+
+        var directory = CreateArtifactsDirectory();
+        try
+        {
+            var libraryPath = CompileGSharpLibrary(directory, "Records", source);
+            IlVerifier.Verify(libraryPath);
+
+            using (var stream = File.OpenRead(libraryPath))
+            using (var peReader = new PEReader(stream))
+            {
+                var reader = peReader.GetMetadataReader();
+                var baseType = FindType(reader, "Base");
+                var middleType = FindType(reader, "Middle");
+                var leafType = FindType(reader, "Leaf");
+                var baseCopyConstructor = FindCopyConstructor(reader, baseType);
+                var middleCopyConstructor = FindCopyConstructor(reader, middleType);
+                var leafCopyConstructor = FindCopyConstructor(reader, leafType);
+
+                Assert.True(MethodContainsCallTo(
+                    peReader,
+                    reader,
+                    middleCopyConstructor,
+                    baseCopyConstructor));
+                Assert.True(MethodContainsCallTo(
+                    peReader,
+                    reader,
+                    leafCopyConstructor,
+                    middleCopyConstructor));
+                AssertCloneMethodImpl(
+                    reader,
+                    leafType,
+                    FindMethod(reader, leafType, "<Clone>$"),
+                    FindMethod(reader, baseType, "<Clone>$"));
+            }
+
+            Assert.Equal(
+                "Leaf:7:5:3",
+                CompileCSharpConsumerAndRun(directory, libraryPath, csharp));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
     private static void AssertAbstractClone(MethodDefinition clone)
     {
         Assert.True((clone.Attributes & MethodAttributes.Abstract) != 0);
@@ -389,7 +531,13 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
             .Where(handle => reader.GetString(reader.GetMethodDefinition(handle).Name) == ".ctor")
             .Single(handle =>
             {
-                var signature = reader.GetBlobReader(reader.GetMethodDefinition(handle).Signature);
+                var definition = reader.GetMethodDefinition(handle);
+                if ((definition.Attributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Public)
+                {
+                    return false;
+                }
+
+                var signature = reader.GetBlobReader(definition.Signature);
                 var header = signature.ReadSignatureHeader();
                 if (header.IsGeneric)
                 {
@@ -406,23 +554,37 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
         TypeDefinitionHandle typeHandle,
         MemberReferenceHandle target)
     {
-        var targetToken = MetadataTokens.GetToken(target);
         foreach (var methodHandle in reader.GetTypeDefinition(typeHandle).GetMethods())
         {
-            var method = reader.GetMethodDefinition(methodHandle);
-            if (method.RelativeVirtualAddress == 0)
+            if (MethodContainsCallTo(peReader, reader, methodHandle, target))
             {
-                continue;
+                return true;
             }
+        }
 
-            var il = peReader.GetMethodBody(method.RelativeVirtualAddress).GetILBytes();
-            for (var i = 0; il != null && i + 4 < il.Length; i++)
+        return false;
+    }
+
+    private static bool MethodContainsCallTo(
+        PEReader peReader,
+        MetadataReader reader,
+        MethodDefinitionHandle methodHandle,
+        EntityHandle target)
+    {
+        var method = reader.GetMethodDefinition(methodHandle);
+        if (method.RelativeVirtualAddress == 0)
+        {
+            return false;
+        }
+
+        var targetToken = MetadataTokens.GetToken(target);
+        var il = peReader.GetMethodBody(method.RelativeVirtualAddress).GetILBytes();
+        for (var i = 0; il != null && i + 4 < il.Length; i++)
+        {
+            if (il[i] == 0x28
+                && BinaryPrimitives.ReadInt32LittleEndian(il.AsSpan(i + 1, 4)) == targetToken)
             {
-                if (il[i] == 0x28
-                    && BinaryPrimitives.ReadInt32LittleEndian(il.AsSpan(i + 1, 4)) == targetToken)
-                {
-                    return true;
-                }
+                return true;
             }
         }
 

--- a/test/Compiler.Tests/Emit/Issue2871CovariantRecordCloneEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2871CovariantRecordCloneEmitTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -140,6 +141,58 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
     }
 
     [Fact]
+    public void OpenNonDataIntermediary_InheritsAbstractClone_EmitsAbstractAndTypeLoads()
+    {
+        const string source = """
+            package i2871intermediary
+
+            open data class Base {
+                open prop Kind string {
+                    get;
+                }
+            }
+
+            open class Middle : Base {
+                override prop Kind string -> "middle"
+            }
+            """;
+
+        var directory = CreateArtifactsDirectory();
+        try
+        {
+            var libraryPath = CompileGSharpLibrary(directory, "Records", source);
+            IlVerifier.Verify(libraryPath);
+
+            using (var stream = File.OpenRead(libraryPath))
+            using (var peReader = new PEReader(stream))
+            {
+                var reader = peReader.GetMetadataReader();
+                var middleType = FindType(reader, "Middle");
+                var middleDefinition = reader.GetTypeDefinition(middleType);
+                Assert.True((middleDefinition.Attributes & TypeAttributes.Abstract) != 0);
+                Assert.DoesNotContain(
+                    middleDefinition.GetMethods(),
+                    handle => reader.GetString(reader.GetMethodDefinition(handle).Name) == "<Clone>$");
+            }
+
+            var loadContext = new AssemblyLoadContext("Issue2871-intermediary-" + Guid.NewGuid(), isCollectible: true);
+            try
+            {
+                var assembly = loadContext.LoadFromAssemblyPath(libraryPath);
+                Assert.True(assembly.GetType("i2871intermediary.Middle", throwOnError: true)!.IsAbstract);
+            }
+            finally
+            {
+                loadContext.Unload();
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ConcreteNonDataSubclass_OfAbstractDataClass_ReportsCloneDiagnostic()
     {
         var syntax = GsSyntaxTree.Parse(SourceText.From(
@@ -152,8 +205,11 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
                 }
             }
 
-            class Leaf : Base {
+            open class Middle : Base {
                 override prop Kind string -> "leaf"
+            }
+
+            class Leaf : Middle {
             }
             """));
         var compilation = new GsCompilation(syntax);
@@ -174,7 +230,7 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
     }
 
     [Fact]
-    public void ConstructedGenericAbstractBaseClone_MemberRefMatchesDefinitionAndTypeLoads()
+    public void CSharpWithExpression_ThroughConstructedGenericAbstractBase_RunsAndPreservesBaseFields()
     {
         const string source = """
             package i2871genericruntime
@@ -191,11 +247,25 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
                 override prop Kind string -> "leaf"
             }
             """;
+        const string csharp = """
+            using i2871genericruntime;
+
+            public static class Probe
+            {
+                public static string Run()
+                {
+                    Base<int> original = new Leaf(7) { Value = 3 };
+                    var clone = original with { };
+                    return $"{clone.GetType().Name}:{((Leaf)clone).Extra}:{original.Value}:{clone.Value}";
+                }
+            }
+            """;
 
         var directory = CreateArtifactsDirectory();
         try
         {
             var libraryPath = CompileGSharpLibrary(directory, "Records", source);
+            IlVerifier.Verify(libraryPath);
             using (var stream = File.OpenRead(libraryPath))
             using (var peReader = new PEReader(stream))
             {
@@ -212,21 +282,30 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
 
                 Assert.Equal(HandleKind.MemberReference, methodImpl.MethodDeclaration.Kind);
                 var baseCloneReference = reader.GetMemberReference((MemberReferenceHandle)methodImpl.MethodDeclaration);
+                Assert.Equal(reader.GetTypeDefinition(leafType).BaseType, baseCloneReference.Parent);
                 Assert.Equal(
                     reader.GetBlobBytes(reader.GetMethodDefinition(baseClone).Signature),
                     reader.GetBlobBytes(baseCloneReference.Signature));
+
+                var baseCopyConstructor = FindCopyConstructor(reader, baseType);
+                var baseCopyConstructorSignature = reader.GetBlobBytes(
+                    reader.GetMethodDefinition(baseCopyConstructor).Signature);
+                var baseCopyConstructorReference = reader.MemberReferences.Single(handle =>
+                {
+                    var reference = reader.GetMemberReference(handle);
+                    return reader.GetString(reference.Name) == ".ctor"
+                        && reference.Parent == reader.GetTypeDefinition(leafType).BaseType
+                        && reader.GetBlobBytes(reference.Signature).SequenceEqual(baseCopyConstructorSignature);
+                });
+                Assert.Equal(
+                    HandleKind.TypeSpecification,
+                    reader.GetMemberReference(baseCopyConstructorReference).Parent.Kind);
+                Assert.True(TypeContainsCallTo(peReader, reader, leafType, baseCopyConstructorReference));
             }
 
-            var loadContext = new AssemblyLoadContext("Issue2871-generic-" + Guid.NewGuid(), isCollectible: true);
-            try
-            {
-                var assembly = loadContext.LoadFromAssemblyPath(libraryPath);
-                Assert.Contains(assembly.GetTypes(), type => type.Name == "Leaf");
-            }
-            finally
-            {
-                loadContext.Unload();
-            }
+            Assert.Equal(
+                "Leaf:7:3:3",
+                CompileCSharpConsumerAndRun(directory, libraryPath, csharp));
         }
         finally
         {
@@ -301,6 +380,55 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
             .Single(handle => reader.GetString(reader.GetMethodDefinition(handle).Name) == name);
     }
 
+    private static MethodDefinitionHandle FindCopyConstructor(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle)
+    {
+        return reader.GetTypeDefinition(typeHandle)
+            .GetMethods()
+            .Where(handle => reader.GetString(reader.GetMethodDefinition(handle).Name) == ".ctor")
+            .Single(handle =>
+            {
+                var signature = reader.GetBlobReader(reader.GetMethodDefinition(handle).Signature);
+                var header = signature.ReadSignatureHeader();
+                if (header.IsGeneric)
+                {
+                    _ = signature.ReadCompressedInteger();
+                }
+
+                return signature.ReadCompressedInteger() == 1;
+            });
+    }
+
+    private static bool TypeContainsCallTo(
+        PEReader peReader,
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        MemberReferenceHandle target)
+    {
+        var targetToken = MetadataTokens.GetToken(target);
+        foreach (var methodHandle in reader.GetTypeDefinition(typeHandle).GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (method.RelativeVirtualAddress == 0)
+            {
+                continue;
+            }
+
+            var il = peReader.GetMethodBody(method.RelativeVirtualAddress).GetILBytes();
+            for (var i = 0; il != null && i + 4 < il.Length; i++)
+            {
+                if (il[i] == 0x28
+                    && BinaryPrimitives.ReadInt32LittleEndian(il.AsSpan(i + 1, 4)) == targetToken)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     private static string CompileCSharpConsumerAndRun(string gsharp, string csharp)
     {
         var directory = CreateArtifactsDirectory();
@@ -308,43 +436,47 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
         {
             var libraryPath = CompileGSharpLibrary(directory, "Records", gsharp);
             IlVerifier.Verify(libraryPath);
-
-            var consumerPath = Path.Combine(directory, "Consumer.dll");
-            var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
-                    ?.Split(Path.PathSeparator)
-                    ?? Array.Empty<string>())
-                .Where(File.Exists)
-                .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
-                .Append(MetadataReference.CreateFromFile(libraryPath));
-            var consumer = CSharpCompilation.Create(
-                "Consumer",
-                new[] { CSharpSyntaxTree.ParseText(csharp, new CSharpParseOptions(LanguageVersion.Latest)) },
-                references,
-                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-            using (var output = File.Create(consumerPath))
-            {
-                var result = consumer.Emit(output);
-                Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
-            }
-
-            var loadContext = new AssemblyLoadContext("Issue2871-" + Guid.NewGuid(), isCollectible: true);
-            try
-            {
-                var libraryAssembly = loadContext.LoadFromAssemblyPath(libraryPath);
-                _ = libraryAssembly.GetTypes();
-                var consumerAssembly = loadContext.LoadFromAssemblyPath(consumerPath);
-                return (string)consumerAssembly.GetType("Probe", throwOnError: true)!
-                    .GetMethod("Run", BindingFlags.Public | BindingFlags.Static)!
-                    .Invoke(null, null)!;
-            }
-            finally
-            {
-                loadContext.Unload();
-            }
+            return CompileCSharpConsumerAndRun(directory, libraryPath, csharp);
         }
         finally
         {
             Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string CompileCSharpConsumerAndRun(string directory, string libraryPath, string csharp)
+    {
+        var consumerPath = Path.Combine(directory, "Consumer.dll");
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .Append(MetadataReference.CreateFromFile(libraryPath));
+        var consumer = CSharpCompilation.Create(
+            "Consumer",
+            new[] { CSharpSyntaxTree.ParseText(csharp, new CSharpParseOptions(LanguageVersion.Latest)) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using (var output = File.Create(consumerPath))
+        {
+            var result = consumer.Emit(output);
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        }
+
+        var loadContext = new AssemblyLoadContext("Issue2871-" + Guid.NewGuid(), isCollectible: true);
+        try
+        {
+            var libraryAssembly = loadContext.LoadFromAssemblyPath(libraryPath);
+            _ = libraryAssembly.GetTypes();
+            var consumerAssembly = loadContext.LoadFromAssemblyPath(consumerPath);
+            return (string)consumerAssembly.GetType("Probe", throwOnError: true)!
+                .GetMethod("Run", BindingFlags.Public | BindingFlags.Static)!
+                .Invoke(null, null)!;
+        }
+        finally
+        {
+            loadContext.Unload();
         }
     }
 

--- a/test/Compiler.Tests/Emit/Issue2871CovariantRecordCloneEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2871CovariantRecordCloneEmitTests.cs
@@ -455,6 +455,90 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
         }
     }
 
+    [Fact]
+    public void CopyConstructor_FromImportedDataBase_UsesMemberRefAndPreservesFields()
+    {
+        const string baseSource = """
+            package i2871importedbase
+
+            open data class Base {
+                prop BaseValue int32 { get; init; }
+
+                open prop Kind string {
+                    get;
+                }
+            }
+            """;
+        const string derivedSource = """
+            package i2871importedderived
+
+            import i2871importedbase
+
+            data class Leaf(LeafValue int32) : Base {
+                override prop Kind string -> "leaf"
+            }
+            """;
+        const string csharp = """
+            using i2871importedbase;
+            using i2871importedderived;
+
+            public static class Probe
+            {
+                public static string Run()
+                {
+                    Base original = new Leaf(7) { BaseValue = 3 };
+                    var clone = original with { };
+                    return $"{clone.GetType().Name}:{((Leaf)clone).LeafValue}:{clone.BaseValue}";
+                }
+            }
+            """;
+
+        var directory = CreateArtifactsDirectory();
+        try
+        {
+            var basePath = CompileGSharpLibrary(directory, "BaseRecords", baseSource);
+            var derivedPath = CompileGSharpLibrary(directory, "DerivedRecords", derivedSource, basePath);
+            IlVerifier.Verify(basePath);
+            IlVerifier.Verify(derivedPath, new[] { basePath });
+
+            using (var stream = File.OpenRead(derivedPath))
+            using (var peReader = new PEReader(stream))
+            {
+                var reader = peReader.GetMetadataReader();
+                var leafType = FindType(reader, "Leaf");
+                var leafCopyConstructor = FindCopyConstructor(reader, leafType);
+                var importedBaseCopyConstructor = reader.MemberReferences.Single(handle =>
+                {
+                    var reference = reader.GetMemberReference(handle);
+                    if (reader.GetString(reference.Name) != ".ctor"
+                        || reference.Parent.Kind != HandleKind.TypeReference
+                        || GetParameterCount(reader, reference.Signature) != 1)
+                    {
+                        return false;
+                    }
+
+                    var parent = reader.GetTypeReference((TypeReferenceHandle)reference.Parent);
+                    return reader.GetString(parent.Namespace) == "i2871importedbase"
+                        && reader.GetString(parent.Name) == "Base";
+                });
+
+                Assert.True(MethodContainsCallTo(
+                    peReader,
+                    reader,
+                    leafCopyConstructor,
+                    importedBaseCopyConstructor));
+            }
+
+            Assert.Equal(
+                "Leaf:7:3",
+                CompileCSharpConsumerAndRun(directory, new[] { basePath, derivedPath }, csharp));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
     private static void AssertAbstractClone(MethodDefinition clone)
     {
         Assert.True((clone.Attributes & MethodAttributes.Abstract) != 0);
@@ -548,6 +632,18 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
             });
     }
 
+    private static int GetParameterCount(MetadataReader reader, BlobHandle signatureHandle)
+    {
+        var signature = reader.GetBlobReader(signatureHandle);
+        var header = signature.ReadSignatureHeader();
+        if (header.IsGeneric)
+        {
+            _ = signature.ReadCompressedInteger();
+        }
+
+        return signature.ReadCompressedInteger();
+    }
+
     private static bool TypeContainsCallTo(
         PEReader peReader,
         MetadataReader reader,
@@ -607,6 +703,9 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
     }
 
     private static string CompileCSharpConsumerAndRun(string directory, string libraryPath, string csharp)
+        => CompileCSharpConsumerAndRun(directory, new[] { libraryPath }, csharp);
+
+    private static string CompileCSharpConsumerAndRun(string directory, string[] libraryPaths, string csharp)
     {
         var consumerPath = Path.Combine(directory, "Consumer.dll");
         var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
@@ -614,7 +713,7 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
                 ?? Array.Empty<string>())
             .Where(File.Exists)
             .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
-            .Append(MetadataReference.CreateFromFile(libraryPath));
+            .Concat(libraryPaths.Select(path => MetadataReference.CreateFromFile(path)));
         var consumer = CSharpCompilation.Create(
             "Consumer",
             new[] { CSharpSyntaxTree.ParseText(csharp, new CSharpParseOptions(LanguageVersion.Latest)) },
@@ -629,8 +728,11 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
         var loadContext = new AssemblyLoadContext("Issue2871-" + Guid.NewGuid(), isCollectible: true);
         try
         {
-            var libraryAssembly = loadContext.LoadFromAssemblyPath(libraryPath);
-            _ = libraryAssembly.GetTypes();
+            foreach (var libraryPath in libraryPaths)
+            {
+                _ = loadContext.LoadFromAssemblyPath(libraryPath).GetTypes();
+            }
+
             var consumerAssembly = loadContext.LoadFromAssemblyPath(consumerPath);
             return (string)consumerAssembly.GetType("Probe", throwOnError: true)!
                 .GetMethod("Run", BindingFlags.Public | BindingFlags.Static)!
@@ -642,7 +744,11 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
         }
     }
 
-    private static string CompileGSharpLibrary(string directory, string assemblyName, string source)
+    private static string CompileGSharpLibrary(
+        string directory,
+        string assemblyName,
+        string source,
+        params string[] references)
     {
         var sourcePath = Path.Combine(directory, assemblyName + ".gs");
         var libraryPath = Path.Combine(directory, assemblyName + ".dll");
@@ -657,13 +763,16 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
         int exitCode;
         try
         {
-            exitCode = Program.Main(new[]
-            {
-                "/out:" + libraryPath,
-                "/target:library",
-                "/targetframework:net10.0",
-                sourcePath,
-            });
+            var arguments = new[]
+                {
+                    "/out:" + libraryPath,
+                    "/target:library",
+                    "/targetframework:net10.0",
+                }
+                .Concat(references.Select(reference => "/r:" + reference))
+                .Append(sourcePath)
+                .ToArray();
+            exitCode = Program.Main(arguments);
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2871CovariantRecordCloneEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2871CovariantRecordCloneEmitTests.cs
@@ -455,90 +455,6 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
         }
     }
 
-    [Fact]
-    public void CopyConstructor_FromImportedDataBase_UsesMemberRefAndPreservesFields()
-    {
-        const string baseSource = """
-            package i2871importedbase
-
-            open data class Base {
-                prop BaseValue int32 { get; init; }
-
-                open prop Kind string {
-                    get;
-                }
-            }
-            """;
-        const string derivedSource = """
-            package i2871importedderived
-
-            import i2871importedbase
-
-            data class Leaf(LeafValue int32) : Base {
-                override prop Kind string -> "leaf"
-            }
-            """;
-        const string csharp = """
-            using i2871importedbase;
-            using i2871importedderived;
-
-            public static class Probe
-            {
-                public static string Run()
-                {
-                    Base original = new Leaf(7) { BaseValue = 3 };
-                    var clone = original with { };
-                    return $"{clone.GetType().Name}:{((Leaf)clone).LeafValue}:{clone.BaseValue}";
-                }
-            }
-            """;
-
-        var directory = CreateArtifactsDirectory();
-        try
-        {
-            var basePath = CompileGSharpLibrary(directory, "BaseRecords", baseSource);
-            var derivedPath = CompileGSharpLibrary(directory, "DerivedRecords", derivedSource, basePath);
-            IlVerifier.Verify(basePath);
-            IlVerifier.Verify(derivedPath, new[] { basePath });
-
-            using (var stream = File.OpenRead(derivedPath))
-            using (var peReader = new PEReader(stream))
-            {
-                var reader = peReader.GetMetadataReader();
-                var leafType = FindType(reader, "Leaf");
-                var leafCopyConstructor = FindCopyConstructor(reader, leafType);
-                var importedBaseCopyConstructor = reader.MemberReferences.Single(handle =>
-                {
-                    var reference = reader.GetMemberReference(handle);
-                    if (reader.GetString(reference.Name) != ".ctor"
-                        || reference.Parent.Kind != HandleKind.TypeReference
-                        || GetParameterCount(reader, reference.Signature) != 1)
-                    {
-                        return false;
-                    }
-
-                    var parent = reader.GetTypeReference((TypeReferenceHandle)reference.Parent);
-                    return reader.GetString(parent.Namespace) == "i2871importedbase"
-                        && reader.GetString(parent.Name) == "Base";
-                });
-
-                Assert.True(MethodContainsCallTo(
-                    peReader,
-                    reader,
-                    leafCopyConstructor,
-                    importedBaseCopyConstructor));
-            }
-
-            Assert.Equal(
-                "Leaf:7:3",
-                CompileCSharpConsumerAndRun(directory, new[] { basePath, derivedPath }, csharp));
-        }
-        finally
-        {
-            Directory.Delete(directory, recursive: true);
-        }
-    }
-
     private static void AssertAbstractClone(MethodDefinition clone)
     {
         Assert.True((clone.Attributes & MethodAttributes.Abstract) != 0);
@@ -632,18 +548,6 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
             });
     }
 
-    private static int GetParameterCount(MetadataReader reader, BlobHandle signatureHandle)
-    {
-        var signature = reader.GetBlobReader(signatureHandle);
-        var header = signature.ReadSignatureHeader();
-        if (header.IsGeneric)
-        {
-            _ = signature.ReadCompressedInteger();
-        }
-
-        return signature.ReadCompressedInteger();
-    }
-
     private static bool TypeContainsCallTo(
         PEReader peReader,
         MetadataReader reader,
@@ -703,9 +607,6 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
     }
 
     private static string CompileCSharpConsumerAndRun(string directory, string libraryPath, string csharp)
-        => CompileCSharpConsumerAndRun(directory, new[] { libraryPath }, csharp);
-
-    private static string CompileCSharpConsumerAndRun(string directory, string[] libraryPaths, string csharp)
     {
         var consumerPath = Path.Combine(directory, "Consumer.dll");
         var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
@@ -713,7 +614,7 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
                 ?? Array.Empty<string>())
             .Where(File.Exists)
             .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
-            .Concat(libraryPaths.Select(path => MetadataReference.CreateFromFile(path)));
+            .Append(MetadataReference.CreateFromFile(libraryPath));
         var consumer = CSharpCompilation.Create(
             "Consumer",
             new[] { CSharpSyntaxTree.ParseText(csharp, new CSharpParseOptions(LanguageVersion.Latest)) },
@@ -728,11 +629,8 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
         var loadContext = new AssemblyLoadContext("Issue2871-" + Guid.NewGuid(), isCollectible: true);
         try
         {
-            foreach (var libraryPath in libraryPaths)
-            {
-                _ = loadContext.LoadFromAssemblyPath(libraryPath).GetTypes();
-            }
-
+            var libraryAssembly = loadContext.LoadFromAssemblyPath(libraryPath);
+            _ = libraryAssembly.GetTypes();
             var consumerAssembly = loadContext.LoadFromAssemblyPath(consumerPath);
             return (string)consumerAssembly.GetType("Probe", throwOnError: true)!
                 .GetMethod("Run", BindingFlags.Public | BindingFlags.Static)!
@@ -744,11 +642,7 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
         }
     }
 
-    private static string CompileGSharpLibrary(
-        string directory,
-        string assemblyName,
-        string source,
-        params string[] references)
+    private static string CompileGSharpLibrary(string directory, string assemblyName, string source)
     {
         var sourcePath = Path.Combine(directory, assemblyName + ".gs");
         var libraryPath = Path.Combine(directory, assemblyName + ".dll");
@@ -763,16 +657,13 @@ public sealed class Issue2871CovariantRecordCloneEmitTests
         int exitCode;
         try
         {
-            var arguments = new[]
-                {
-                    "/out:" + libraryPath,
-                    "/target:library",
-                    "/targetframework:net10.0",
-                }
-                .Concat(references.Select(reference => "/r:" + reference))
-                .Append(sourcePath)
-                .ToArray();
-            exitCode = Program.Main(arguments);
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + libraryPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2871CovariantRecordCloneEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2871CovariantRecordCloneEmitTests.cs
@@ -1,0 +1,296 @@
+// <copyright file="Issue2871CovariantRecordCloneEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Runtime.Loader;
+using GSharp.Compiler;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2871: abstract data classes retain the C# record clone contract.
+/// Abstract clones have no body; derived covariant clones use MethodImpl rows
+/// and PreserveBaseOverridesAttribute so every base-typed with-expression
+/// dispatches to the most-derived copy constructor without TypeLoadException.
+/// </summary>
+public sealed class Issue2871CovariantRecordCloneEmitTests
+{
+    [Fact]
+    public void AbstractCloneChain_HasPlannedRowsMethodImplsAndPreserveAttributes()
+    {
+        const string source = """
+            package i2871metadata
+
+            open data class Base {
+                prop Id int32 { get; init; }
+
+                open prop Kind string {
+                    get;
+                }
+
+                func Describe() string -> this.Kind + ":" + this.Id.ToString()
+            }
+
+            open data class Middle : Base {
+            }
+
+            data class Leaf(Value int32) : Middle {
+                override prop Kind string -> "leaf"
+            }
+            """;
+
+        var directory = CreateArtifactsDirectory();
+        try
+        {
+            var libraryPath = CompileGSharpLibrary(directory, "Records", source);
+            IlVerifier.Verify(libraryPath);
+
+            using var stream = File.OpenRead(libraryPath);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+
+            var baseType = FindType(reader, "Base");
+            var middleType = FindType(reader, "Middle");
+            var leafType = FindType(reader, "Leaf");
+            var baseClone = FindMethod(reader, baseType, "<Clone>$");
+            var middleClone = FindMethod(reader, middleType, "<Clone>$");
+            var leafClone = FindMethod(reader, leafType, "<Clone>$");
+
+            AssertAbstractClone(reader.GetMethodDefinition(baseClone));
+            AssertAbstractClone(reader.GetMethodDefinition(middleClone));
+
+            var leafCloneDefinition = reader.GetMethodDefinition(leafClone);
+            Assert.True((leafCloneDefinition.Attributes & MethodAttributes.Virtual) != 0);
+            Assert.True((leafCloneDefinition.Attributes & MethodAttributes.NewSlot) != 0);
+            Assert.True((leafCloneDefinition.Attributes & MethodAttributes.Abstract) == 0);
+            Assert.NotEqual(0, leafCloneDefinition.RelativeVirtualAddress);
+
+            AssertCloneMethodImpl(reader, middleType, middleClone, baseClone);
+            AssertCloneMethodImpl(reader, leafType, leafClone, middleClone);
+            Assert.False(HasPreserveBaseOverridesAttribute(reader, baseClone));
+            Assert.True(HasPreserveBaseOverridesAttribute(reader, middleClone));
+            Assert.True(HasPreserveBaseOverridesAttribute(reader, leafClone));
+
+            var describe = FindMethod(reader, baseType, "Describe");
+            Assert.Equal(
+                8,
+                MetadataTokens.GetRowNumber(describe) - MetadataTokens.GetRowNumber(baseClone));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CSharpWithExpression_ThroughAbstractCloneChain_Runs()
+    {
+        const string gsharp = """
+            package i2871runtime
+
+            open data class Base {
+                prop Id int32 { get; init; }
+
+                open prop Kind string {
+                    get;
+                }
+            }
+
+            open data class Middle : Base {
+            }
+
+            data class Leaf(Value int32) : Middle {
+                override prop Kind string -> "leaf"
+            }
+            """;
+        const string csharp = """
+            using i2871runtime;
+
+            public static class Probe
+            {
+                public static string Run()
+                {
+                    Base original = new Leaf(7) { Id = 3 };
+                    Middle middle = (Middle)original;
+                    Leaf leaf = (Leaf)original;
+                    var fromBase = original with { };
+                    var fromMiddle = middle with { };
+                    var fromLeaf = leaf with { Value = 8 };
+                    return $"{fromBase.GetType().Name}:{((Leaf)fromBase).Value}:{fromBase.Id}|{fromMiddle.GetType().Name}:{((Leaf)fromMiddle).Value}:{fromMiddle.Id}|{fromLeaf.Value}";
+                }
+            }
+            """;
+
+        Assert.Equal(
+            "Leaf:7:3|Leaf:7:3|8",
+            CompileCSharpConsumerAndRun(gsharp, csharp));
+    }
+
+    private static void AssertAbstractClone(MethodDefinition clone)
+    {
+        Assert.True((clone.Attributes & MethodAttributes.Abstract) != 0);
+        Assert.True((clone.Attributes & MethodAttributes.Virtual) != 0);
+        Assert.True((clone.Attributes & MethodAttributes.NewSlot) != 0);
+        Assert.Equal(0, clone.RelativeVirtualAddress);
+    }
+
+    private static void AssertCloneMethodImpl(
+        MetadataReader reader,
+        TypeDefinitionHandle implementingType,
+        MethodDefinitionHandle body,
+        MethodDefinitionHandle declaration)
+    {
+        var bodyToken = MetadataTokens.GetToken(body);
+        var methodImpl = reader.GetTypeDefinition(implementingType)
+            .GetMethodImplementations()
+            .Select(reader.GetMethodImplementation)
+            .Single(row => MetadataTokens.GetToken(row.MethodBody) == bodyToken);
+        Assert.Equal(MetadataTokens.GetToken(declaration), MetadataTokens.GetToken(methodImpl.MethodDeclaration));
+    }
+
+    private static bool HasPreserveBaseOverridesAttribute(
+        MetadataReader reader,
+        MethodDefinitionHandle methodHandle)
+    {
+        foreach (var attributeHandle in reader.GetMethodDefinition(methodHandle).GetCustomAttributes())
+        {
+            var attribute = reader.GetCustomAttribute(attributeHandle);
+            if (attribute.Constructor.Kind != HandleKind.MemberReference)
+            {
+                continue;
+            }
+
+            var constructor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+            if (constructor.Parent.Kind != HandleKind.TypeReference)
+            {
+                continue;
+            }
+
+            var attributeType = reader.GetTypeReference((TypeReferenceHandle)constructor.Parent);
+            if (reader.GetString(attributeType.Namespace) == "System.Runtime.CompilerServices"
+                && reader.GetString(attributeType.Name) == "PreserveBaseOverridesAttribute")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static TypeDefinitionHandle FindType(MetadataReader reader, string name)
+    {
+        return reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name) == name);
+    }
+
+    private static MethodDefinitionHandle FindMethod(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        string name)
+    {
+        return reader.GetTypeDefinition(typeHandle)
+            .GetMethods()
+            .Single(handle => reader.GetString(reader.GetMethodDefinition(handle).Name) == name);
+    }
+
+    private static string CompileCSharpConsumerAndRun(string gsharp, string csharp)
+    {
+        var directory = CreateArtifactsDirectory();
+        try
+        {
+            var libraryPath = CompileGSharpLibrary(directory, "Records", gsharp);
+            IlVerifier.Verify(libraryPath);
+
+            var consumerPath = Path.Combine(directory, "Consumer.dll");
+            var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                    ?.Split(Path.PathSeparator)
+                    ?? Array.Empty<string>())
+                .Where(File.Exists)
+                .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+                .Append(MetadataReference.CreateFromFile(libraryPath));
+            var consumer = CSharpCompilation.Create(
+                "Consumer",
+                new[] { CSharpSyntaxTree.ParseText(csharp, new CSharpParseOptions(LanguageVersion.Latest)) },
+                references,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            using (var output = File.Create(consumerPath))
+            {
+                var result = consumer.Emit(output);
+                Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+            }
+
+            var loadContext = new AssemblyLoadContext("Issue2871-" + Guid.NewGuid(), isCollectible: true);
+            try
+            {
+                _ = loadContext.LoadFromAssemblyPath(libraryPath);
+                var consumerAssembly = loadContext.LoadFromAssemblyPath(consumerPath);
+                return (string)consumerAssembly.GetType("Probe", throwOnError: true)!
+                    .GetMethod("Run", BindingFlags.Public | BindingFlags.Static)!
+                    .Invoke(null, null)!;
+            }
+            finally
+            {
+                loadContext.Unload();
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string CompileGSharpLibrary(string directory, string assemblyName, string source)
+    {
+        var sourcePath = Path.Combine(directory, assemblyName + ".gs");
+        var libraryPath = Path.Combine(directory, assemblyName + ".dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + libraryPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(
+            exitCode == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+        return libraryPath;
+    }
+
+    private static string CreateArtifactsDirectory()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2871-artifacts",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+}


### PR DESCRIPTION
Fixes #2871

## Summary
- emit abstract `<Clone>$` methods instead of omitting record clone shape
- bind derived covariant clones with `MethodImpl` and `PreserveBaseOverridesAttribute`
- reserve/cache clone MethodDef tokens and add metadata plus C# `with` runtime coverage

## Testing
- GitHub Actions: build/full tests, cs2gs, e2e, VS/VS Code extension jobs all passed
- no local `dotnet` invocation per request