### PR TITLE
gsc: recognize returning fixed blocks in definite-return analysis

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -86,9 +86,7 @@ public sealed class ControlFlowGraph
             // falls off its end either, so it is likewise a valid terminator
             // (issue #1596). Non-exhaustive switches (no `default`) still fall
             // through and are rejected below.
-            if (lastStatement.Kind != BoundNodeKind.ReturnStatement
-                && lastStatement.Kind != BoundNodeKind.ThrowStatement
-                && !(lastStatement is BoundPatternSwitchStatement sw && SwitchAlwaysReturns(sw)))
+            if (!StatementDefinitelyReturns(lastStatement))
             {
                 return false;
             }
@@ -179,7 +177,7 @@ public sealed class ControlFlowGraph
     /// </summary>
     /// <param name="statement">The bound statement.</param>
     /// <returns>Whether the statement definitely returns or throws.</returns>
-    private static bool StatementDefinitelyReturns(BoundStatement statement)
+    internal static bool StatementDefinitelyReturns(BoundStatement statement)
     {
         switch (statement)
         {
@@ -190,6 +188,8 @@ public sealed class ControlFlowGraph
                 return last != null && StatementDefinitelyReturns(last);
             case BoundPatternSwitchStatement nestedSwitch:
                 return SwitchAlwaysReturns(nestedSwitch);
+            case BoundFixedStatement fixedStatement:
+                return StatementDefinitelyReturns(fixedStatement.Body);
             default:
                 return statement.Kind == BoundNodeKind.ReturnStatement
                     || statement.Kind == BoundNodeKind.ThrowStatement;
@@ -363,20 +363,27 @@ public sealed class ControlFlowGraph
                         }
 
                         break;
+                    case BoundNodeKind.FixedStatement:
+                        statements.Add(statement);
+
+                        if (StatementDefinitelyReturns(statement))
+                        {
+                            StartBlock();
+                        }
+
+                        break;
                     case BoundNodeKind.TryStatement:
                     case BoundNodeKind.ThrowStatement:
                     case BoundNodeKind.GoStatement:
                     case BoundNodeKind.ChannelSendStatement:
                     case BoundNodeKind.SelectStatement:
                     case BoundNodeKind.ScopeStatement:
-                    case BoundNodeKind.FixedStatement:
                     case BoundNodeKind.AwaitForRangeStatement:
                     case BoundNodeKind.YieldStatement:
                         // Treat exception-flow constructs as opaque statements; precise
                         // CFG modeling of catch/finally edges is deferred to a later phase.
                         // GoStatement and ChannelSendStatement fall through to the next
-                        // statement at the CFG level. A FixedStatement carries a pinned
-                        // body that likewise falls through to the following statement.
+                        // statement at the CFG level.
                         statements.Add(statement);
                         break;
                     default:
@@ -485,6 +492,17 @@ public sealed class ControlFlowGraph
                             }
 
                             break;
+                        case BoundNodeKind.FixedStatement:
+                            if (StatementDefinitelyReturns(statement))
+                            {
+                                Connect(current, end);
+                            }
+                            else if (isLastStatementInBlock)
+                            {
+                                Connect(current, next);
+                            }
+
+                            break;
                         case BoundNodeKind.VariableDeclaration:
                         case BoundNodeKind.LocalFunctionDeclaration:
                         case BoundNodeKind.LabelStatement:
@@ -494,7 +512,6 @@ public sealed class ControlFlowGraph
                         case BoundNodeKind.ChannelSendStatement:
                         case BoundNodeKind.SelectStatement:
                         case BoundNodeKind.ScopeStatement:
-                        case BoundNodeKind.FixedStatement:
                         case BoundNodeKind.AwaitForRangeStatement:
                         case BoundNodeKind.YieldStatement:
                             // Issue #798: `yield` (ADR-0040) participates in the

--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -352,17 +352,6 @@ public sealed class ControlFlowGraph
                         statements.Add(statement);
                         break;
                     case BoundNodeKind.PatternSwitchStatement:
-                        statements.Add(statement);
-
-                        // An exhaustive switch (default present and every arm
-                        // returns/throws) terminates the block like a return;
-                        // otherwise it falls through to the next statement.
-                        if (SwitchAlwaysReturns((BoundPatternSwitchStatement)statement))
-                        {
-                            StartBlock();
-                        }
-
-                        break;
                     case BoundNodeKind.FixedStatement:
                         statements.Add(statement);
 
@@ -478,20 +467,6 @@ public sealed class ControlFlowGraph
                             Connect(current, end);
                             break;
                         case BoundNodeKind.PatternSwitchStatement:
-                            // An exhaustive switch (default present and every arm
-                            // returns/throws) terminates control like a return and
-                            // connects to the end block. A non-exhaustive switch may
-                            // fall through to the next statement (issue #1596).
-                            if (SwitchAlwaysReturns((BoundPatternSwitchStatement)statement))
-                            {
-                                Connect(current, end);
-                            }
-                            else if (isLastStatementInBlock)
-                            {
-                                Connect(current, next);
-                            }
-
-                            break;
                         case BoundNodeKind.FixedStatement:
                             if (StatementDefinitelyReturns(statement))
                             {

--- a/src/Core/CodeAnalysis/Emit/FunctionEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/FunctionEmitter.cs
@@ -170,6 +170,8 @@ internal sealed class FunctionEmitter
 
             try
             {
+                // MoveNextBodyRewriter owns this synthesized epilogue and
+                // guarantees that the body already ends in ret.
                 emitter.EmitBlock(body);
             }
             catch (Exception ex) when (ex is not EmitDiagnosticException and not OutOfMemoryException and not StackOverflowException)

--- a/src/Core/CodeAnalysis/Emit/FunctionEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/FunctionEmitter.cs
@@ -362,18 +362,12 @@ internal sealed class FunctionEmitter
                 // at the last-visited BoundNode (or the function's syntax).
                 try
                 {
-                    emitter.EmitBlock(body);
+                    emitter.EmitMethodBody(body, alwaysAppendRet: function.Type == TypeSymbol.Void);
                 }
                 catch (Exception ex) when (ex is not EmitDiagnosticException and not OutOfMemoryException and not StackOverflowException)
                 {
                     var anchor = emitter.CurrentAnchor ?? function.Declaration ?? body.Syntax;
                     EmitDiagnosticException.Wrap(anchor, ex);
-                }
-
-                // Always cap with a trailing ret. Lowering does not guarantee one for void.
-                if (function.Type == TypeSymbol.Void)
-                {
-                    il.OpCode(ILOpCode.Ret);
                 }
 
                 bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il, maxStack: MaxStackTracker.ComputeMaxStack(il), localVariablesSignature: localsSignature);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
@@ -56,6 +56,9 @@ internal sealed partial class MethodBodyEmitter
         this.EmitExpression(node.Discriminant);
         this.il.StoreLocal(discriminantSlot);
 
+        // Issue #2283: all-terminal switches still emit their uniform dead
+        // branches/end label. EmitMethodBody must append a real ret at that
+        // label so no branch targets the exact end of the method body.
         var endLabel = this.il.DefineLabel();
         BoundPatternSwitchArm defaultArm = null;
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
@@ -56,16 +56,7 @@ internal sealed partial class MethodBodyEmitter
         this.EmitExpression(node.Discriminant);
         this.il.StoreLocal(discriminantSlot);
 
-        // If the switch is exhaustive (has a `default` arm) and every arm
-        // definitely returns/throws, no path ever falls through to an "end"
-        // of the switch — emitting a trailing `Br endLabel`/`MarkLabel(endLabel)`
-        // in that case produces a label reachable only via dead branches,
-        // which crashes ilverify's predecessor bookkeeping (issue #2283).
-        // Reuse the same reachability analysis the binder already uses for
-        // definite-return checking (ControlFlowGraph.SwitchAlwaysReturns) so
-        // this stays in sync with that logic.
-        var alwaysReturns = ControlFlowGraph.SwitchAlwaysReturns(node);
-        var endLabel = alwaysReturns ? default : this.il.DefineLabel();
+        var endLabel = this.il.DefineLabel();
         BoundPatternSwitchArm defaultArm = null;
 
         foreach (var arm in node.Arms)
@@ -89,10 +80,7 @@ internal sealed partial class MethodBodyEmitter
             }
 
             this.EmitStatement(arm.Body);
-            if (!alwaysReturns)
-            {
-                this.il.Branch(ILOpCode.Br, endLabel);
-            }
+            this.il.Branch(ILOpCode.Br, endLabel);
 
             this.il.MarkLabel(nextArm);
         }
@@ -102,10 +90,7 @@ internal sealed partial class MethodBodyEmitter
             this.EmitStatement(defaultArm.Body);
         }
 
-        if (!alwaysReturns)
-        {
-            this.il.MarkLabel(endLabel);
-        }
+        this.il.MarkLabel(endLabel);
     }
 
     // Phase C: switch-expression emit. Mirrors the pattern-switch

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
@@ -65,6 +65,11 @@ internal sealed partial class MethodBodyEmitter
         // Body executes with the pin held.
         this.EmitStatement(node.Body);
 
+        if (ControlFlowGraph.StatementDefinitelyReturns(node.Body))
+        {
+            return;
+        }
+
         // Release the pin on normal exit so the GC stops tracking the buffer.
         if (node.PinKind == FixedPinKind.PinnableReference)
         {

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
@@ -65,11 +65,6 @@ internal sealed partial class MethodBodyEmitter
         // Body executes with the pin held.
         this.EmitStatement(node.Body);
 
-        if (ControlFlowGraph.StatementDefinitelyReturns(node.Body))
-        {
-            return;
-        }
-
         // Release the pin on normal exit so the GC stops tracking the buffer.
         if (node.PinKind == FixedPinKind.PinnableReference)
         {

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -382,9 +382,7 @@ internal sealed partial class MethodBodyEmitter
         else if (statement is not BoundBlockStatement && this.il.Offset != startOffset)
         {
             this.currentPositionEndsInTerminator =
-                statement is BoundReturnStatement or BoundThrowStatement or BoundGotoStatement
-                || statement is BoundExpressionStatement { Expression: BoundThrowExpression }
-                || statement is BoundVariableDeclaration { Initializer: BoundThrowExpression };
+                statement is BoundReturnStatement or BoundThrowStatement or BoundGotoStatement;
         }
     }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -134,6 +134,10 @@ internal sealed partial class MethodBodyEmitter
     private readonly List<SequencePoint> sequencePoints = new List<SequencePoint>();
     private int lastSequencePointIlOffset = -1;
 
+    // Tracks whether the current linear IL position is closed by ret, throw,
+    // or an unconditional branch. A label or ordinary instruction reopens it.
+    private bool currentPositionEndsInTerminator;
+
     public MethodBodyEmitter(
         ReflectionMetadataEmitter outer,
         InstructionEncoder il,
@@ -226,6 +230,18 @@ internal sealed partial class MethodBodyEmitter
         }
     }
 
+    public void EmitMethodBody(BoundBlockStatement body, bool alwaysAppendRet)
+    {
+        this.EmitBlock(body);
+
+        // Preserve the legacy trailing ret on void bodies. For value bodies,
+        // cap only an emitted dead-code tail that follows the real terminator.
+        if (alwaysAppendRet || !this.currentPositionEndsInTerminator)
+        {
+            this.il.OpCode(ILOpCode.Ret);
+        }
+    }
+
     private void EmitBlockExpression(BoundBlockExpression blockExpression)
     {
         // Labels introduced inside an expression-position block (e.g. the
@@ -256,6 +272,8 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitStatement(BoundStatement statement)
     {
+        var startOffset = this.il.Offset;
+
         if (statement.Syntax != null)
         {
             this.currentNode = statement;
@@ -355,6 +373,18 @@ internal sealed partial class MethodBodyEmitter
                     statement.Syntax,
                     $"Bound statement kind '{statement.Kind}' is not yet supported by the emitter.");
                 break;
+        }
+
+        if (statement is BoundLabelStatement)
+        {
+            this.currentPositionEndsInTerminator = false;
+        }
+        else if (statement is not BoundBlockStatement && this.il.Offset != startOffset)
+        {
+            this.currentPositionEndsInTerminator =
+                statement is BoundReturnStatement or BoundThrowStatement or BoundGotoStatement
+                || statement is BoundExpressionStatement { Expression: BoundThrowExpression }
+                || statement is BoundVariableDeclaration { Initializer: BoundThrowExpression };
         }
     }
 

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -1385,6 +1385,8 @@ public sealed class Lowerer : BoundTreeRewriter
             case BoundThrowStatement:
             case BoundGotoStatement:
                 return true;
+            case BoundFixedStatement fixedStatement:
+                return EndsInUnconditionalTransfer(fixedStatement.Body);
             case BoundBlockStatement block:
                 // A trailing label is a reachable continuation for branches
                 // inside the block, so the block can fall through even when

--- a/test/Compiler.Tests/Emit/Issue2283SwitchAllTerminalArmsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2283SwitchAllTerminalArmsEmitTests.cs
@@ -30,14 +30,13 @@ namespace GSharp.Compiler.Tests.Emit;
 /// bookkeeping can't index.
 /// </para>
 /// <para>
-/// The fix reuses <c>ControlFlowGraph.SwitchAlwaysReturns</c> — the exact
-/// reachability check the binder already uses for definite-return analysis
-/// (issue #1596) — to detect this case and skip emitting the trailing
-/// <c>Br endLabel</c> / <c>MarkLabel(endLabel)</c> entirely when the switch
-/// is exhaustive (has a <c>default</c>) and every arm definitely
-/// returns/throws. All other shapes (non-exhaustive switches, switches with a
-/// non-terminal arm, switches followed by more code, and switches using
-/// <c>break</c>) keep emitting the end label exactly as before.
+/// The emitter now keeps one uniform switch shape, including the trailing
+/// <c>Br endLabel</c> / <c>MarkLabel(endLabel)</c>. The method-body epilogue
+/// guard in <c>MethodBodyEmitter.EmitMethodBody</c> recognizes that this label
+/// leaves the current IL position open and appends a real <c>ret</c>. Dead
+/// branches therefore target a valid instruction instead of the exact end of
+/// the method body, preserving the fix for every exhaustive and
+/// non-exhaustive switch shape.
 /// </para>
 /// </summary>
 public class Issue2283SwitchAllTerminalArmsEmitTests

--- a/test/Compiler.Tests/Emit/Issue2843FixedDefiniteReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2843FixedDefiniteReturnEmitTests.cs
@@ -47,7 +47,7 @@ public class Issue2843FixedDefiniteReturnEmitTests
             public var result = F([]int32{1, 2, 3})
             """;
 
-        var assembly = CompileAndRun(Source);
+        var assembly = CompileAndRun(Source, verifyIl: true);
 
         Assert.Equal(3, GetField(assembly, "result"));
     }
@@ -71,7 +71,7 @@ public class Issue2843FixedDefiniteReturnEmitTests
             public var result = F([]int32{1, 2})
             """;
 
-        var assembly = CompileAndRun(Source);
+        var assembly = CompileAndRun(Source, verifyIl: true);
 
         Assert.Equal(2, GetField(assembly, "result"));
     }
@@ -104,6 +104,81 @@ public class Issue2843FixedDefiniteReturnEmitTests
 
         Assert.Equal(1, GetField(assembly, "whenTrue"));
         Assert.Equal(2, GetField(assembly, "whenFalse"));
+    }
+
+    [Fact]
+    public void ThrowAsSoleExitInsideFixed_EmitsAndRuns()
+    {
+        const string Source = """
+            package Issue2843.Throw
+            import System
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    fixed p *int32 = xs {
+                        throw InvalidOperationException("boom")
+                    }
+                }
+            }
+
+            public var result = 0
+            try {
+                F([]int32{1})
+            } catch (ex InvalidOperationException) {
+                result = 1
+            }
+            """;
+
+        var assembly = CompileAndRun(Source, verifyIl: true);
+
+        Assert.Equal(1, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void DeadCodeAfterReturningFixed_EmitsAndRuns()
+    {
+        const string Source = """
+            package Issue2843.FixedDeadCode
+
+            func F(xs []int32, condition bool) int32 {
+                unsafe {
+                    fixed p *int32 = xs {
+                        if condition {
+                            return 1
+                        }
+                        return 2
+                    }
+                }
+                var unreachable = 3
+            }
+
+            public var whenTrue = F([]int32{1}, true)
+            public var whenFalse = F([]int32{1}, false)
+            """;
+
+        var assembly = CompileAndRun(Source, verifyIl: true);
+
+        Assert.Equal(1, GetField(assembly, "whenTrue"));
+        Assert.Equal(2, GetField(assembly, "whenFalse"));
+    }
+
+    [Fact]
+    public void DeadCodeAfterReturn_EmitsAndRuns()
+    {
+        const string Source = """
+            package Issue2843.PlainDeadCode
+
+            func F() int32 {
+                return 1
+                var unreachable = 3
+            }
+
+            public var result = F()
+            """;
+
+        var assembly = CompileAndRun(Source, verifyIl: true);
+
+        Assert.Equal(1, GetField(assembly, "result"));
     }
 
     [Fact]

--- a/test/Compiler.Tests/Emit/Issue2843FixedDefiniteReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2843FixedDefiniteReturnEmitTests.cs
@@ -1,0 +1,175 @@
+// <copyright file="Issue2843FixedDefiniteReturnEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2843: a <c>fixed</c> body that returns on every path terminates the
+/// enclosing control-flow path for GS0100 definite-return analysis.
+/// </summary>
+public class Issue2843FixedDefiniteReturnEmitTests
+{
+    private static readonly string[] FixedIlVerifyIgnored =
+    {
+        "Unverifiable",
+        "UnmanagedPointer",
+        "StackUnexpected",
+        "StackByRef",
+        "ExpectedPtr",
+        "StackUnexpectedArrayType",
+        "ExpectedNumericType",
+    };
+
+    [Fact]
+    public void ReturnAsSoleExitInsideFixed_EmitsAndRuns()
+    {
+        const string Source = """
+            package Issue2843.SoleExit
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    fixed p *int32 = xs {
+                        return xs.Length
+                    }
+                }
+            }
+
+            public var result = F([]int32{1, 2, 3})
+            """;
+
+        var assembly = CompileAndRun(Source);
+
+        Assert.Equal(3, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void ReturnInsideNestedFixed_EmitsAndRuns()
+    {
+        const string Source = """
+            package Issue2843.Nested
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    fixed p *int32 = xs {
+                        fixed q *int32 = xs {
+                            return xs.Length
+                        }
+                    }
+                }
+            }
+
+            public var result = F([]int32{1, 2})
+            """;
+
+        var assembly = CompileAndRun(Source);
+
+        Assert.Equal(2, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void FixedInsideReturningIfElse_EmitsVerifiableControlFlowAndRuns()
+    {
+        const string Source = """
+            package Issue2843.IfElse
+
+            func F(xs []int32, condition bool) int32 {
+                unsafe {
+                    if condition {
+                        fixed p *int32 = xs {
+                            return 1
+                        }
+                    } else {
+                        fixed p *int32 = xs {
+                            return 2
+                        }
+                    }
+                }
+            }
+
+            public var whenTrue = F([]int32{1}, true)
+            public var whenFalse = F([]int32{1}, false)
+            """;
+
+        var assembly = CompileAndRun(Source, verifyIl: true);
+
+        Assert.Equal(1, GetField(assembly, "whenTrue"));
+        Assert.Equal(2, GetField(assembly, "whenFalse"));
+    }
+
+    [Fact]
+    public void FixedBodyWithFallthroughPath_StillReportsGs0100()
+    {
+        const string Source = """
+            package Issue2843.Negative
+
+            func F(xs []int32, condition bool) int32 {
+                unsafe {
+                    fixed p *int32 = xs {
+                        if condition {
+                            return xs.Length
+                        }
+                    }
+                }
+            }
+            """;
+
+        var result = Compile(Source);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0100");
+    }
+
+    private static EmitResult Compile(string source, MemoryStream peStream = null)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Emit(peStream ?? new MemoryStream());
+    }
+
+    private static Assembly CompileAndRun(string source, bool verifyIl = false)
+    {
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+
+        Assert.True(
+            result.Success,
+            string.Join(Environment.NewLine, result.Diagnostics.Select(diagnostic => diagnostic.ToString())));
+
+        if (verifyIl)
+        {
+            var assemblyPath = Path.Combine(
+                Directory.GetCurrentDirectory(),
+                $"Issue2843_{Guid.NewGuid():N}.dll");
+            try
+            {
+                File.WriteAllBytes(assemblyPath, peStream.ToArray());
+                IlVerifier.Verify(assemblyPath, null, FixedIlVerifyIgnored);
+            }
+            finally
+            {
+                File.Delete(assemblyPath);
+            }
+        }
+
+        var assembly = Assembly.Load(peStream.ToArray());
+        var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+        return assembly;
+    }
+
+    private static int GetField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+        return (int)program.GetField(name, BindingFlags.Public | BindingFlags.Static)!.GetValue(null)!;
+    }
+}


### PR DESCRIPTION
## Summary

- model a `fixed` statement as terminal when its body definitely returns or throws
- propagate that result through CFG block construction and edge creation
- add a method-body epilogue guard that appends `ret` when emitted dead code leaves a value-returning body unterminated
- retire the fixed-specific pin-release skip and the older all-terminal-switch emission skip; the general guard now makes both continuation shapes valid
- merge the identical pattern-switch/fixed CFG cases
- cover sole-return, nested fixed, returning if/else, terminal throw, negative fallthrough, and dead code after both fixed and plain returns with runtime and IL verification

## Root cause

`ControlFlowGraph` treated every `BoundFixedStatement` as an opaque fallthrough statement, even when its pinned body could not complete normally. Once that analysis gap was closed, a pre-existing emitter hole became reachable: dead statements emitted after a real return could leave the physical method body without a terminating instruction.

`MethodBodyEmitter` now tracks whether the current linear IL position ends in `ret`, `throw`, or an unconditional branch. Value-returning methods receive a final safety `ret` only when later emitted code reopens that position; void methods retain their existing trailing-ret behavior. This central guard replaces per-statement emission exceptions for fixed blocks and exhaustive switches.

Deliberate code-size trade-off: a returning `fixed` keeps the unreachable cleanup tail (`ret; ldnull; stloc; ret`), adding four dead IL bytes versus Roslyn's shorter shape. That small cost avoids restoring a fixed-specific emission skip and keeps one general method-body safety net.

## Follow-up

- #2883 tracks the distinct, pre-existing CFG defect where `break` exits a loop from inside a nested `fixed` body. It reproduces on `main` and is not caused by this PR.

## Validation

- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter 'FullyQualifiedName~Issue2843FixedDefiniteReturnEmitTests|FullyQualifiedName~Issue2283SwitchAllTerminalArmsEmitTests' --no-restore`
  - Passed: 13, Failed: 0, Skipped: 0
- full-source revert sanity check against the branch base with the Issue2843 filter
  - Expected failure confirmed: Passed: 1, Failed: 6, Skipped: 0; source patch restored afterward
- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-restore`
  - Passed: 3648, Failed: 0, Skipped: 0
- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Core.Tests/Core.Tests.csproj -c Release --no-restore`
  - Passed: 6828, Failed: 0, Skipped: 1

Fixes #2843
