### PR TITLE
Fix narrowed nullable delegate invocation emission

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -512,22 +512,7 @@ internal sealed partial class ExpressionBinder
             }
         }
 
-        FunctionTypeSymbol functionType;
-        if (callableType is FunctionTypeSymbol fts)
-        {
-            functionType = fts;
-        }
-        else if (callableType is DelegateTypeSymbol nds)
-        {
-            functionType = nds.EquivalentFunctionType;
-        }
-        else if (callableType.ClrType is System.Type memberClrType
-            && ClrTypeUtilities.IsDelegateType(memberClrType)
-            && MemberLookup.TryGetDelegateFunctionType(memberClrType, out var clrFn))
-        {
-            functionType = clrFn;
-        }
-        else
+        if (!MemberLookup.TryGetDelegateFunctionTypeFromSymbol(callableType, out var functionType))
         {
             return false;
         }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -484,10 +484,24 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
+        // Issue #2849: derive both argument conversions and Invoke shape from
+        // the narrowed stable member read, not the nullable declaration.
+        BoundExpression memberLoad = matchedField != null
+            ? isStatic
+                ? new BoundFieldAccessExpression(null, receiver, declaringType, matchedField, memberType)
+                : new BoundFieldAccessExpression(null, receiver, declaringType, matchedField)
+            : new BoundPropertyAccessExpression(null, receiver, declaringType, matchedProperty);
+        memberLoad = ApplyMemberNarrowing(memberLoad);
+        var effectiveMemberType = memberLoad switch
+        {
+            BoundFieldAccessExpression { NarrowedType: TypeSymbol narrowedField } => narrowedField,
+            BoundPropertyAccessExpression { NarrowedType: TypeSymbol narrowedProperty } => narrowedProperty,
+            _ => memberType,
+        };
         var callableType = ce.NullableQuestionToken != null
-            && memberType is NullableTypeSymbol nullableMember
+            && effectiveMemberType is NullableTypeSymbol nullableMember
             ? nullableMember.UnderlyingType
-            : memberType;
+            : effectiveMemberType;
 
         if (isStatic)
         {
@@ -532,14 +546,9 @@ internal sealed partial class ExpressionBinder
                 return true;
             }
 
-            BoundExpression namedMemberLoad = matchedField != null
-                ? isStatic
-                    ? new BoundFieldAccessExpression(null, receiver, declaringType, matchedField, memberType)
-                    : new BoundFieldAccessExpression(null, receiver, declaringType, matchedField)
-                : new BoundPropertyAccessExpression(null, receiver, declaringType, matchedProperty);
             result = BuildDelegateMemberInvocation(
                 ce,
-                namedMemberLoad,
+                memberLoad,
                 callableType,
                 functionType,
                 namedArguments,
@@ -610,11 +619,6 @@ internal sealed partial class ExpressionBinder
             convertedArgs.Add(conversions.BindConversion(argLoc, argument, functionType.ParameterTypes[i]));
         }
 
-        BoundExpression memberLoad = matchedField != null
-            ? isStatic
-                ? new BoundFieldAccessExpression(null, receiver, declaringType, matchedField, memberType)
-                : new BoundFieldAccessExpression(null, receiver, declaringType, matchedField)
-            : new BoundPropertyAccessExpression(null, receiver, declaringType, matchedProperty);
         result = BuildDelegateMemberInvocation(
             ce,
             memberLoad,

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
@@ -983,18 +983,25 @@ internal sealed partial class OverloadResolver
             // resolves each such symbol to the correct field/property access
             // (the same helper the structural `FunctionTypeSymbol` path uses),
             // leaving locals/parameters to the bare-variable fallback.
+            // Issue #2849: preserve the narrowed receiver type on every load
+            // shape so emit can parent Invoke at the reified generic TypeSpec
+            // instead of the nullable declaration's erased ClrType.
             BoundExpression receiver;
             if (delegateVar is ImplicitFieldVariableSymbol clrImplicitField)
             {
-                receiver = BuildImplicitFieldLoad(clrImplicitField);
+                receiver = BuildImplicitFieldLoad(clrImplicitField, narrowedCallTargetType);
             }
-            else if (TryBuildImplicitMemberLoad(delegateVar, syntax.Identifier.Location, out var clrMemberLoad))
+            else if (TryBuildImplicitMemberLoad(
+                delegateVar,
+                syntax.Identifier.Location,
+                out var clrMemberLoad,
+                narrowedCallTargetType))
             {
                 receiver = clrMemberLoad;
             }
             else
             {
-                receiver = new BoundVariableExpression(null, delegateVar);
+                receiver = new BoundVariableExpression(null, delegateVar, narrowedCallTargetType);
             }
 
             // Issue #2796 / #2798: a null-conditional raise `Evt?(args)` of a

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
@@ -534,9 +534,21 @@ internal sealed partial class OverloadResolver
         switch (variable)
         {
             case ImplicitStaticFieldVariableSymbol staticField:
-                load = staticField.InterfaceType != null
-                    ? new BoundFieldAccessExpression(null, staticField.Field, staticField.InterfaceType)
-                    : new BoundFieldAccessExpression(null, receiver: null, staticField.StructType, staticField.Field);
+                if (staticField.InterfaceType != null)
+                {
+                    // Interface static fields are not smart-cast-stable.
+                    load = new BoundFieldAccessExpression(null, staticField.Field, staticField.InterfaceType);
+                }
+                else
+                {
+                    load = new BoundFieldAccessExpression(
+                        null,
+                        receiver: null,
+                        staticField.StructType,
+                        staticField.Field,
+                        narrowedType);
+                }
+
                 return true;
             case ImplicitFieldVariableSymbol instanceField:
                 load = new BoundFieldAccessExpression(
@@ -573,7 +585,8 @@ internal sealed partial class OverloadResolver
                     null,
                     receiver: null,
                     staticProp.StructType,
-                    staticProp.Property);
+                    staticProp.Property,
+                    narrowedType);
                 return true;
             default:
                 return false;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
@@ -68,10 +68,10 @@ internal sealed partial class OverloadResolver
         TypeSymbol receiverType;
         if (variable is ImplicitFieldVariableSymbol implicitField)
         {
-            receiverLoad = BuildImplicitFieldLoad(implicitField);
-            receiverType = implicitField.Field.Type;
+            receiverLoad = BuildImplicitFieldLoad(implicitField, narrowedTargetType);
+            receiverType = receiverLoad.Type;
         }
-        else if (TryBuildImplicitMemberLoad(variable, syntax.Identifier.Location, out var memberLoad))
+        else if (TryBuildImplicitMemberLoad(variable, syntax.Identifier.Location, out var memberLoad, narrowedTargetType))
         {
             receiverLoad = memberLoad;
             receiverType = memberLoad.Type ?? narrowedTargetType ?? variable.Type;
@@ -161,12 +161,15 @@ internal sealed partial class OverloadResolver
     /// symbol may be a base class, producing the correct base field token when
     /// the access originates from a derived method.
     /// </summary>
-    private static BoundExpression BuildImplicitFieldLoad(ImplicitFieldVariableSymbol implicitField) =>
+    private static BoundExpression BuildImplicitFieldLoad(
+        ImplicitFieldVariableSymbol implicitField,
+        TypeSymbol narrowedType = null) =>
         new BoundFieldAccessExpression(
             null,
             new BoundVariableExpression(null, implicitField.Receiver),
             implicitField.StructType,
-            implicitField.Field);
+            implicitField.Field,
+            narrowedType);
 
     private bool TryBindNullableDelegateInvocation(
         VariableSymbol variable,
@@ -521,7 +524,11 @@ internal sealed partial class OverloadResolver
         return true;
     }
 
-    private bool TryBuildImplicitMemberLoad(VariableSymbol variable, TextLocation location, out BoundExpression load)
+    private bool TryBuildImplicitMemberLoad(
+        VariableSymbol variable,
+        TextLocation location,
+        out BoundExpression load,
+        TypeSymbol narrowedType = null)
     {
         load = null;
         switch (variable)
@@ -536,7 +543,8 @@ internal sealed partial class OverloadResolver
                     null,
                     new BoundVariableExpression(null, instanceField.Receiver),
                     instanceField.StructType,
-                    instanceField.Field);
+                    instanceField.Field,
+                    narrowedType);
                 return true;
             case ImplicitPropertyVariableSymbol prop:
                 if (!prop.Property.HasGetter)
@@ -550,7 +558,8 @@ internal sealed partial class OverloadResolver
                     null,
                     new BoundVariableExpression(null, prop.Receiver),
                     prop.StructType,
-                    prop.Property);
+                    prop.Property,
+                    narrowedType);
                 return true;
             case ImplicitStaticPropertyVariableSymbol staticProp:
                 if (!staticProp.Property.HasGetter)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -403,6 +403,15 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #2849: the target carries the authoritative narrowed delegate
+        // type; an earlier function projection may still reflect an erased CLR
+        // placeholder.
+        var functionType = MemberLookup.TryGetDelegateFunctionTypeFromSymbol(
+            call.Target.Type,
+            out var targetFunctionType)
+            ? targetFunctionType
+            : call.FunctionType;
+
         // ADR-0087 §3 R6: a delegate whose parameter or return types carry
         // symbolic types (e.g. `func(T) U` or `async () -> T`) is
         // encoded as a reified `GENERICINST<Func`N><…>` shape. Dispatch
@@ -410,20 +419,20 @@ internal sealed partial class MethodBodyEmitter
         // delegate (e.g. `Func<int, int>`) resolves the MemberRef to
         // its concrete `Invoke` slot, so no `Delegate.DynamicInvoke`
         // marshalling is needed.
-        if (this.outer.userTokens.FunctionTypeNeedsSymbolicDelegate(call.FunctionType))
+        if (this.outer.userTokens.FunctionTypeNeedsSymbolicDelegate(functionType))
         {
             this.EmitExpression(call.Target);
             this.EmitImportedCallArguments(call.Arguments, call.ArgumentRefKinds);
 
             this.il.OpCode(ILOpCode.Callvirt);
-            this.il.Token(this.outer.memberRefs.GetFunctionDelegateInvokeRef(call.FunctionType));
+            this.il.Token(this.outer.memberRefs.GetFunctionDelegateInvokeRef(functionType));
             return;
         }
 
         this.EmitExpression(call.Target);
         this.EmitImportedCallArguments(call.Arguments, call.ArgumentRefKinds);
 
-        var delegateType = this.outer.signatures.ResolveDelegateClrType(call.FunctionType);
+        var delegateType = this.outer.signatures.ResolveDelegateClrType(functionType);
 
         var invoke = delegateType.GetMethod("Invoke")
             ?? throw new InvalidOperationException(

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -403,15 +403,6 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
-        // Issue #2849: the target carries the authoritative narrowed delegate
-        // type; an earlier function projection may still reflect an erased CLR
-        // placeholder.
-        var functionType = MemberLookup.TryGetDelegateFunctionTypeFromSymbol(
-            call.Target.Type,
-            out var targetFunctionType)
-            ? targetFunctionType
-            : call.FunctionType;
-
         // ADR-0087 §3 R6: a delegate whose parameter or return types carry
         // symbolic types (e.g. `func(T) U` or `async () -> T`) is
         // encoded as a reified `GENERICINST<Func`N><…>` shape. Dispatch
@@ -419,20 +410,20 @@ internal sealed partial class MethodBodyEmitter
         // delegate (e.g. `Func<int, int>`) resolves the MemberRef to
         // its concrete `Invoke` slot, so no `Delegate.DynamicInvoke`
         // marshalling is needed.
-        if (this.outer.userTokens.FunctionTypeNeedsSymbolicDelegate(functionType))
+        if (this.outer.userTokens.FunctionTypeNeedsSymbolicDelegate(call.FunctionType))
         {
             this.EmitExpression(call.Target);
             this.EmitImportedCallArguments(call.Arguments, call.ArgumentRefKinds);
 
             this.il.OpCode(ILOpCode.Callvirt);
-            this.il.Token(this.outer.memberRefs.GetFunctionDelegateInvokeRef(functionType));
+            this.il.Token(this.outer.memberRefs.GetFunctionDelegateInvokeRef(call.FunctionType));
             return;
         }
 
         this.EmitExpression(call.Target);
         this.EmitImportedCallArguments(call.Arguments, call.ArgumentRefKinds);
 
-        var delegateType = this.outer.signatures.ResolveDelegateClrType(functionType);
+        var delegateType = this.outer.signatures.ResolveDelegateClrType(call.FunctionType);
 
         var invoke = delegateType.GetMethod("Invoke")
             ?? throw new InvalidOperationException(

--- a/test/Compiler.Tests/Emit/Issue2840NullableFunctionToDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2840NullableFunctionToDelegateEmitTests.cs
@@ -55,14 +55,7 @@ public class Issue2840NullableFunctionToDelegateEmitTests
                 f = (s Src) -> System.Console.WriteLine(s.N)
                 var d System.Action[Src]? = f
                 if d != nil {
-                    // Invoked through a non-nullable local: directly invoking a
-                    // NARROWED nullable imported generic delegate whose type
-                    // argument is source-declared emits an `Invoke` MemberRef
-                    // parented at the erased `Action<object>`. That is a
-                    // separate, pre-existing defect (it reproduces with no
-                    // conversion at all) and is tracked on its own issue.
-                    let invoke System.Action[Src] = d
-                    invoke(Src())
+                    d(Src())
                 }
             }
             """;
@@ -298,8 +291,7 @@ public class Issue2840NullableFunctionToDelegateEmitTests
                 d(Src())
                 var n System.Action[Src]? = f
                 if n != nil {
-                    let invoke System.Action[Src] = n
-                    invoke(Src())
+                    n(Src())
                 }
             }
             """;

--- a/test/Compiler.Tests/Emit/Issue2849NarrowedNullableDelegateInvokeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2849NarrowedNullableDelegateInvokeEmitTests.cs
@@ -1,0 +1,282 @@
+// <copyright file="Issue2849NarrowedNullableDelegateInvokeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2849 — a narrowed nullable imported generic delegate lost its
+/// symbolic receiver type before emit, so <c>Invoke</c> was parented at the
+/// erased <c>Action&lt;object&gt;</c> instead of the reified
+/// <c>Action&lt;Src&gt;</c>.
+/// </summary>
+public class Issue2849NarrowedNullableDelegateInvokeEmitTests
+{
+    [Fact]
+    public void EndToEnd_ImportedDelegateTruthTable_VerifiesAndRuns()
+    {
+        const string source = """
+            package i2849truth
+            import System
+
+            class Src { prop N int32 -> 2 }
+
+            func Main() {
+                let f System.Action[Src] = (s Src) -> System.Console.WriteLine(s.N)
+
+                var d System.Action[Src] = f
+                d(Src())
+
+                var n System.Action[Src]? = f
+                if n != nil {
+                    n(Src())
+                }
+
+                var workaround System.Action[Src]? = f
+                if workaround != nil {
+                    let invoke System.Action[Src] = workaround
+                    invoke(Src())
+                }
+
+                var bcl System.Action[int32]? = (x int32) -> System.Console.WriteLine(x)
+                if bcl != nil {
+                    bcl(1)
+                }
+            }
+            """;
+
+        Assert.Equal("2\n2\n2\n1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_SameCompilationNamedDelegate_VerifiesAndRuns()
+    {
+        const string source = """
+            package i2849namedsame
+            import System
+
+            class Src { prop N int32 -> 21 }
+            type Handler[T] = delegate func(value T) void
+
+            func Main() {
+                let write Handler[Src] = (s Src) -> System.Console.WriteLine(s.N)
+                var handler Handler[Src]? = write
+                if handler != nil {
+                    handler(Src())
+                }
+            }
+            """;
+
+        Assert.Equal("21\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_NarrowedImportedDelegateReceiverShapes_VerifyAndRun()
+    {
+        const string source = """
+            package i2849shapes
+            import System
+
+            class Src { prop N int32 -> 22 }
+
+            class Holder {
+                let Field System.Action[Src]?
+                prop Property System.Action[Src]? { get; init; }
+
+                init(value System.Action[Src]?) {
+                    Field = value
+                    Property = value
+                }
+
+                func Run() {
+                    if Field != nil {
+                        Field(Src())
+                    }
+                    if Property != nil {
+                        Property(Src())
+                    }
+                }
+            }
+
+            func InvokeParameter(handler System.Action[Src]?) {
+                if handler != nil {
+                    handler(Src())
+                }
+            }
+
+            func Main() {
+                let write System.Action[Src] = (s Src) -> System.Console.WriteLine(s.N)
+
+                InvokeParameter(write)
+                Holder(write).Run()
+
+                var optional System.Action[Src]? = write
+                if let narrowed = optional {
+                    narrowed(Src())
+                }
+
+                (optional ?? write)(Src())
+            }
+            """;
+
+        Assert.Equal("22\n22\n22\n22\n22\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_CrossAssemblyImportedAndNamedDelegates_VerifyAndRun()
+    {
+        const string library = """
+            package i2849matrixlib
+            import System
+
+            type Handler[T] = delegate func(value T) void
+
+            class ImportedRelay[T] {
+                func Run(handler System.Action[T]?, value T) {
+                    if handler != nil {
+                        handler(value)
+                    }
+                }
+            }
+
+            class NamedRelay[T] {
+                func Run(handler Handler[T]?, value T) {
+                    if handler != nil {
+                        handler(value)
+                    }
+                }
+            }
+            """;
+
+        const string consumer = """
+            package i2849matrixuse
+            import System
+            import i2849matrixlib
+
+            class Src { prop N int32 -> 23 }
+
+            func Main() {
+                let imported System.Action[Src] = (s Src) -> System.Console.WriteLine(s.N)
+                ImportedRelay[Src]().Run(imported, Src())
+
+                let named Handler[Src] = (s Src) -> System.Console.WriteLine(s.N + 1)
+                NamedRelay[Src]().Run(named, Src())
+            }
+            """;
+
+        Assert.Equal("23\n24\n", CompileAndRun(consumer, library, "i2849matrixlib"));
+    }
+
+    private static string CompileAndRun(string source, string library = null, string libraryAssemblyName = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2849_exe_").FullName;
+        try
+        {
+            string libDll = null;
+            if (library != null)
+            {
+                var libSrc = Path.Combine(tempDir, libraryAssemblyName + ".gs");
+                libDll = Path.Combine(tempDir, libraryAssemblyName + ".dll");
+                File.WriteAllText(libSrc, library);
+                Compile(new[]
+                {
+                    "/out:" + libDll,
+                    "/target:library",
+                    "/targetframework:net10.0",
+                    libSrc,
+                });
+                IlVerifier.Verify(libDll);
+            }
+
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+            if (libDll != null)
+            {
+                args.Add("/r:" + libDll);
+            }
+
+            args.Add(srcPath);
+            Compile(args.ToArray());
+            IlVerifier.Verify(dllPath, libDll != null ? new[] { libDll } : null);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void Compile(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2849NarrowedNullableDelegateInvokeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2849NarrowedNullableDelegateInvokeEmitTests.cs
@@ -27,6 +27,7 @@ public class Issue2849NarrowedNullableDelegateInvokeEmitTests
             import System
 
             class Src { prop N int32 -> 2 }
+            struct Pt { var X int32 }
 
             func Main() {
                 let f System.Action[Src] = (s Src) -> System.Console.WriteLine(s.N)
@@ -49,10 +50,26 @@ public class Issue2849NarrowedNullableDelegateInvokeEmitTests
                 if bcl != nil {
                     bcl(1)
                 }
+
+                let writePt System.Action[Pt] = (p Pt) -> System.Console.WriteLine(p.X)
+                var ptAction System.Action[Pt]? = writePt
+                if ptAction != nil {
+                    var q Pt
+                    q.X = 5
+                    ptAction(q)
+                }
+
+                let readPt System.Func[Pt,int32] = (p Pt) -> p.X + 1
+                var ptFunc System.Func[Pt,int32]? = readPt
+                if ptFunc != nil {
+                    var q Pt
+                    q.X = 6
+                    System.Console.WriteLine(ptFunc(q))
+                }
             }
             """;
 
-        Assert.Equal("2\n2\n2\n1\n", CompileAndRun(source));
+        Assert.Equal("2\n2\n2\n1\n5\n7\n", CompileAndRun(source));
     }
 
     [Fact]
@@ -130,6 +147,61 @@ public class Issue2849NarrowedNullableDelegateInvokeEmitTests
     }
 
     [Fact]
+    public void EndToEnd_IsNarrowedImportedDelegate_VerifiesAndRuns()
+    {
+        const string source = """
+            package i2849isnarrowed
+            import System
+
+            class Src { prop N int32 -> 8 }
+
+            func Run(value object) {
+                if value is System.Action[Src] {
+                    value(Src())
+                }
+            }
+
+            func Main() {
+                let write System.Action[Src] = (s Src) -> System.Console.WriteLine(s.N)
+                Run(write)
+            }
+            """;
+
+        Assert.Equal("8\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_QualifiedStableMemberPath_VerifiesAndRuns()
+    {
+        const string source = """
+            package i2849qualified
+            import System
+
+            class Src { prop N int32 -> 7 }
+
+            class Inner {
+                let H System.Action[Src]?
+                init(h System.Action[Src]?) { H = h }
+            }
+
+            class Outer {
+                let B Inner
+                init(b Inner) { B = b }
+            }
+
+            func Main() {
+                let write System.Action[Src] = (s Src) -> System.Console.WriteLine(s.N)
+                let outer = Outer(Inner(write))
+                if outer.B.H != nil {
+                    outer.B.H(Src())
+                }
+            }
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
     public void EndToEnd_CrossAssemblyImportedAndNamedDelegates_VerifyAndRun()
     {
         const string library = """
@@ -172,6 +244,34 @@ public class Issue2849NarrowedNullableDelegateInvokeEmitTests
             """;
 
         Assert.Equal("23\n24\n", CompileAndRun(consumer, library, "i2849matrixlib"));
+    }
+
+    [Fact]
+    public void EndToEnd_CrossAssemblyNamedDelegateWithConsumerSourceType_VerifiesAndRuns()
+    {
+        const string library = """
+            package i2849lib2
+
+            type Handler[T] = delegate func(value T) void
+            """;
+
+        const string consumer = """
+            package i2849use2
+            import System
+            import i2849lib2
+
+            class Src { prop N int32 -> 9 }
+
+            func Main() {
+                let handler Handler[Src] = (s Src) -> System.Console.WriteLine(s.N)
+                var optional Handler[Src]? = handler
+                if optional != nil {
+                    optional(Src())
+                }
+            }
+            """;
+
+        Assert.Equal("9\n", CompileAndRun(consumer, library, "i2849lib2"));
     }
 
     private static string CompileAndRun(string source, string library = null, string libraryAssemblyName = null)


### PR DESCRIPTION
## Summary

- preserve smart-cast narrowed delegate types on bare local, parameter, field, and property receiver loads
- preserve narrowing for qualified stable member paths before deriving their callable signature
- resolve delegate function shapes during binding through the shared symbolic helper instead of reflecting over erased `ClrType`
- let existing symbolic TypeSpec emission target reified delegates
- remove the now-obsolete non-nullable-local workaround from the #2840 tests

## Root cause

Two receiver builders lost the narrowed delegate type:

1. The bare imported CLR-delegate branch found `narrowedCallTargetType`, but rebuilt the invocation receiver using the variable or member's declared nullable type.
2. The qualified member-call branch built `a.B.H` without applying its stable-path narrowing before deriving argument conversions.

The qualified branch also duplicated delegate-shape projection with a three-branch cascade. Its imported-delegate fallback reflected over `callableType.ClrType`, which is deliberately erased to `Action<object>` when a generic argument is declared in the compilation being emitted. This left the bound indirect call's `FunctionType` erased.

The fix carries narrowing through both receiver-load builders, then uses `MemberLookup.TryGetDelegateFunctionTypeFromSymbol`. That shared helper handles imported `OpenDefinition` plus symbolic `TypeArguments`, so the bound node itself contains the correct reified function shape. `EmitIndirectCall` continues to consume `call.FunctionType` directly; no emit-layer compensation or second source of truth remains.

## Qualified stable-path outcome

Fixed in this PR; `Fixes #2849` remains correct.

Reviewer repro: local root plus two immutable fields, `if a.B.H != nil { a.B.H(Src()) }`.

- before follow-up fix: gsc succeeded; ilverify failed with one `StackUnexpected` (`Action<Src>` vs `Action<object>`); runtime printed `7`
- after follow-up fix: gsc succeeded; ilverify clean; runtime printed `7`

## Coverage

Emit tests assert both `ilverify` cleanliness and runtime output for:

- all four original truth-table rows
- source class and source struct arguments
- `Action[Pt]` and value-returning `Func[Pt,int32]`
- nullable stripping and `is` narrowing with a real emitted `castclass`
- bare locals, parameters, immutable fields, stable properties, `if let`, and qualified stable member chains
- named and imported delegates in same-compilation and cross-assembly scenarios
- an imported named generic delegate closed over a type declared in the consuming compilation
- null-coalescing as the adjacent already-correct control

Load-bearing check: restoring the three #2849 source files to `origin/main` while retaining the tests made 6 tests fail and 1 pass. Restoring the source fixes returned the combined #2849/#2840/#2375 target to 19/19 passing.

## Validation

- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~Issue2849|FullyQualifiedName~Issue2840|FullyQualifiedName~Issue2375"` — 19 passed
- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release` — 3,651 passed
- `MSBUILDDISABLENODEREUSE=1 dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 6,842 passed, 1 skipped

## Separate findings

- #2885 tracks nullable CLR-delegate receivers invoked without valid narrowing: mutable fields, custom-getter properties, `shared var`, `shared let`, and invalidated locals.
- #2889 tracks nested symbolic generic arguments erased in lambda thunk signatures. Its non-nullable `Action[List[Src]]` row already fails, so it is neither a narrowing problem nor part of #2849.

Both reproduce independently on `main` and are not regressions from this PR.

Fixes #2849
