### PR TITLE
Fix constructed generic type display in diagnostics

### DIFF
--- a/src/Core/CodeAnalysis/DiagnosticBag.Reports.Declarations.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.Reports.Declarations.cs
@@ -1012,7 +1012,7 @@ public sealed partial class DiagnosticBag
     /// <param name="sourceType">The conversion source type.</param>
     /// <param name="targetType">The conversion target type.</param>
     public void ReportDuplicateConversionOperator(TextLocation location, TypeSymbol sourceType, TypeSymbol targetType)
-    => Report(location, DiagnosticDescriptors.DuplicateConversionOperator, sourceType?.Name, targetType?.Name);
+    => Report(location, DiagnosticDescriptors.DuplicateConversionOperator, sourceType, targetType);
 
     /// <summary>
     /// ADR-0149: GS0492 — an explicit-interface qualifier clause

--- a/src/Core/CodeAnalysis/DiagnosticBag.Reports.Expressions.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.Reports.Expressions.cs
@@ -78,7 +78,7 @@ public sealed partial class DiagnosticBag
     /// <param name="location">The text location.</param>
     /// <param name="type">The actual type.</param>
     public void ReportTypeNotIndexable(TextLocation location, TypeSymbol type)
-    => Report(location, DiagnosticDescriptors.TypeNotIndexable, type.Name);
+    => Report(location, DiagnosticDescriptors.TypeNotIndexable, type);
 
     /// <summary>
     /// Reports that a built-in intrinsic was applied to an unsupported argument type.
@@ -87,7 +87,7 @@ public sealed partial class DiagnosticBag
     /// <param name="name">The intrinsic name.</param>
     /// <param name="type">The actual argument type.</param>
     public void ReportIntrinsicArgumentType(TextLocation location, string name, TypeSymbol type)
-    => Report(location, DiagnosticDescriptors.IntrinsicArgumentType, name, type.Name);
+    => Report(location, DiagnosticDescriptors.IntrinsicArgumentType, name, type);
 
     /// <summary>
     /// Reports that an expression must have a value.
@@ -404,7 +404,7 @@ public sealed partial class DiagnosticBag
     /// <param name="location">The text location of the range expression.</param>
     /// <param name="type">The non-sliceable target type.</param>
     public void ReportTypeNotSliceable(TextLocation location, TypeSymbol type)
-    => Report(location, DiagnosticDescriptors.TypeNotSliceable, type.Name);
+    => Report(location, DiagnosticDescriptors.TypeNotSliceable, type);
 
     /// <summary>GS9002: Argument must be passed by reference.</summary>
     /// <param name="location">The text location of the argument.</param>

--- a/src/Core/CodeAnalysis/DiagnosticBag.Reports.Statements.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.Reports.Statements.cs
@@ -34,7 +34,7 @@ public sealed partial class DiagnosticBag
     /// <param name="location">The text location of the using keyword.</param>
     /// <param name="type">The non-disposable type.</param>
     public void ReportTypeNotDisposable(TextLocation location, TypeSymbol type)
-    => Report(location, DiagnosticDescriptors.TypeNotDisposable, type.Name);
+    => Report(location, DiagnosticDescriptors.TypeNotDisposable, type);
 
     /// <summary>
     /// Reports that the keyworkd can only be used inside of loops.
@@ -106,7 +106,7 @@ public sealed partial class DiagnosticBag
     /// <param name="type">The malformed imported type.</param>
     /// <param name="memberName">The ambiguous member name.</param>
     public void ReportAmbiguousImportedMember(TextLocation location, TypeSymbol type, string memberName)
-    => Report(location, DiagnosticDescriptors.AmbiguousImportedMember, type.Name, memberName);
+    => Report(location, DiagnosticDescriptors.AmbiguousImportedMember, type, memberName);
 
     /// <summary>
     /// Issue #946: reports that an <c>init</c>-only property was assigned
@@ -182,7 +182,7 @@ public sealed partial class DiagnosticBag
     /// <param name="location">The text location of the operand.</param>
     /// <param name="type">The offending operand type.</param>
     public void ReportLockTargetMustBeReferenceType(TextLocation location, TypeSymbol type)
-    => Report(location, DiagnosticDescriptors.LockTargetMustBeReferenceType, type.Name);
+    => Report(location, DiagnosticDescriptors.LockTargetMustBeReferenceType, type);
 
     /// <summary>
     /// Reports that a generic local-function declaration (<c>let Name[T, ...] = func (...) ... { ... }</c>,
@@ -404,7 +404,7 @@ public sealed partial class DiagnosticBag
     /// <param name="location">The text location of the offending assignment.</param>
     /// <param name="type">The read-only span type being written through.</param>
     public void ReportCannotAssignReadOnlySpanElement(TextLocation location, TypeSymbol type)
-    => Report(location, DiagnosticDescriptors.CannotAssignReadOnlySpanElement, type.Name);
+    => Report(location, DiagnosticDescriptors.CannotAssignReadOnlySpanElement, type);
 
     /// <summary>
     /// ADR-0060 §5: reports an assignment to an <c>in</c> parameter inside the function body.
@@ -538,7 +538,7 @@ public sealed partial class DiagnosticBag
     /// <param name="location">The collection expression location.</param>
     /// <param name="type">The collection type.</param>
     public void ReportTypeNotIterable(TextLocation location, TypeSymbol type)
-    => Report(location, DiagnosticDescriptors.TypeNotIterable, type.Name);
+    => Report(location, DiagnosticDescriptors.TypeNotIterable, type);
 
     /// <summary>
     /// Reports that <c>await using let</c> appears outside an <c>async</c> function.
@@ -553,7 +553,7 @@ public sealed partial class DiagnosticBag
     /// <param name="location">The text location of the await using keyword.</param>
     /// <param name="type">The non-async-disposable type.</param>
     public void ReportTypeNotAsyncDisposable(TextLocation location, TypeSymbol type)
-    => Report(location, DiagnosticDescriptors.TypeNotAsyncDisposable, type.Name);
+    => Report(location, DiagnosticDescriptors.TypeNotAsyncDisposable, type);
 
     /// <summary>
     /// ADR-0070 / issue #707: GS0293 — a labeled <c>break</c> or <c>continue</c>

--- a/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
+++ b/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
@@ -670,10 +670,17 @@ public static class SymbolDisplay
                 // parenthesizing here also fixes nested occurrences (slice
                 // element, generic arg, tuple element). Non-function nullable
                 // types are rendered unchanged.
+                if (nullable.UnderlyingType is SliceTypeSymbol nullableSlice)
+                {
+                    return $"[]?{FormatType(nullableSlice.ElementType)}";
+                }
+
                 var underlying = FormatType(nullable.UnderlyingType);
                 return nullable.UnderlyingType is FunctionTypeSymbol
                     ? $"({underlying})?"
                     : $"{underlying}?";
+            case NullabilityAnnotatedTypeSymbol annotated:
+                return FormatType(annotated.BaseType);
             case FunctionTypeSymbol function:
                 return FormatFunctionType(function);
             case SliceTypeSymbol slice:
@@ -684,6 +691,10 @@ public static class SymbolDisplay
                 return $"sequence[{FormatType(sequence.ElementType)}]";
             case MapTypeSymbol map:
                 return $"map[{FormatType(map.KeyType)},{FormatType(map.ValueType)}]";
+            case PointerTypeSymbol pointer:
+                return $"*{FormatType(pointer.PointeeType)}";
+            case ByRefTypeSymbol byRef:
+                return $"*{FormatType(byRef.PointeeType)}";
             case TupleTypeSymbol tuple:
                 return $"({string.Join(", ", tuple.ElementTypes.Select(FormatType))})";
             case StructSymbol aggregate when IsAnonymousClassType(aggregate):
@@ -695,6 +706,24 @@ public static class SymbolDisplay
                 // follow-up: members are get-only auto-properties, not plain
                 // fields (see AnonymousTypeCache), so render Properties here.
                 return $"{{ {string.Join(", ", aggregate.Properties.Select(p => $"{p.Name}: {FormatType(p.Type)}"))} }}";
+            case StructSymbol aggregate:
+                return FormatSourceType(
+                    aggregate.Definition?.Name ?? aggregate.Name,
+                    aggregate.ContainingType,
+                    aggregate.EnclosingTypeArguments,
+                    GetDisplayTypeArguments(aggregate.TypeArguments, aggregate.TypeParameters));
+            case InterfaceSymbol @interface:
+                return FormatSourceType(
+                    @interface.Definition?.Name ?? @interface.Name,
+                    @interface.ContainingType,
+                    ImmutableArray<TypeSymbol>.Empty,
+                    GetDisplayTypeArguments(@interface.TypeArguments, @interface.TypeParameters));
+            case DelegateTypeSymbol delegateType:
+                return FormatSourceType(
+                    delegateType.Definition?.Name ?? delegateType.Name,
+                    containingType: null,
+                    ImmutableArray<TypeSymbol>.Empty,
+                    GetDisplayTypeArguments(delegateType.TypeArguments, delegateType.TypeParameters));
             case ImportedTypeSymbol imported:
                 return FormatImportedType(imported);
             default:
@@ -716,6 +745,57 @@ public static class SymbolDisplay
     /// <returns><see langword="true"/> if <paramref name="type"/> is a synthesized anonymous-class type.</returns>
     private static bool IsAnonymousClassType(StructSymbol type)
         => type.Declaration == null && type.Name.StartsWith("<>AnonymousType", StringComparison.Ordinal);
+
+    private static string FormatSourceType(
+        string name,
+        TypeSymbol containingType,
+        ImmutableArray<TypeSymbol> enclosingTypeArguments,
+        ImmutableArray<TypeSymbol> typeArguments)
+    {
+        var prefix = string.Empty;
+        if (containingType != null)
+        {
+            prefix = enclosingTypeArguments.IsDefaultOrEmpty
+                ? $"{FormatType(containingType)}."
+                : $"{FormatContainingSourceType(containingType, enclosingTypeArguments)}.";
+        }
+
+        return prefix + name + FormatTypeArguments(typeArguments);
+    }
+
+    private static string FormatContainingSourceType(
+        TypeSymbol containingType,
+        ImmutableArray<TypeSymbol> enclosingTypeArguments)
+    {
+        if (containingType is StructSymbol aggregate)
+        {
+            var ownArgumentCount = Math.Min(aggregate.TypeParameters.Length, enclosingTypeArguments.Length);
+            var outerArgumentCount = enclosingTypeArguments.Length - ownArgumentCount;
+            return FormatSourceType(
+                aggregate.Name,
+                aggregate.ContainingType,
+                enclosingTypeArguments.Take(outerArgumentCount).ToImmutableArray(),
+                enclosingTypeArguments.Skip(outerArgumentCount).ToImmutableArray());
+        }
+
+        return FormatType(containingType);
+    }
+
+    private static string FormatTypeArguments(ImmutableArray<TypeSymbol> typeArguments)
+    {
+        return typeArguments.IsDefaultOrEmpty
+            ? string.Empty
+            : $"[{string.Join(", ", typeArguments.Select(FormatType))}]";
+    }
+
+    private static ImmutableArray<TypeSymbol> GetDisplayTypeArguments(
+        ImmutableArray<TypeSymbol> typeArguments,
+        ImmutableArray<TypeParameterSymbol> typeParameters)
+    {
+        return !typeArguments.IsDefaultOrEmpty
+            ? typeArguments
+            : typeParameters.Cast<TypeSymbol>().ToImmutableArray();
+    }
 
     /// <summary>
     /// Renders a <see cref="FunctionTypeSymbol"/> in its canonical arrow shape
@@ -768,9 +848,9 @@ public static class SymbolDisplay
         if (!imported.TypeArguments.IsDefaultOrEmpty)
         {
             var definition = imported.OpenDefinition;
-            var baseName = StripGenericArity(definition?.FullName ?? definition?.Name) ?? imported.Name;
-            var args = string.Join(", ", imported.TypeArguments.Select(a => a == null ? "?" : FormatType(a)));
-            return $"{baseName}[{args}]";
+            return definition == null
+                ? $"{StripGenericArity(imported.Name)}[{string.Join(", ", imported.TypeArguments.Select(FormatGenericTypeArgument))}]"
+                : FormatImportedGenericTypeName(definition, imported.TypeArguments);
         }
 
         return FormatClrTypeName(imported.ClrType, qualifyNames: true);
@@ -787,10 +867,15 @@ public static class SymbolDisplay
             return name;
         }
 
-        var tickIndex = name.IndexOf('`');
-        if (tickIndex >= 0)
+        for (var tickIndex = name.IndexOf('`'); tickIndex >= 0; tickIndex = name.IndexOf('`', tickIndex))
         {
-            name = name.Substring(0, tickIndex);
+            var endIndex = tickIndex + 1;
+            while (endIndex < name.Length && char.IsDigit(name[endIndex]))
+            {
+                endIndex++;
+            }
+
+            name = name.Remove(tickIndex, endIndex - tickIndex);
         }
 
         return name.Replace('+', '.');
@@ -846,17 +931,59 @@ public static class SymbolDisplay
             return qualifyNames ? (clrType.FullName ?? clrType.Name).Replace('+', '.') : clrType.Name;
         }
 
-        var typeName = clrType.IsNested ? clrType.Name : (qualifyNames ? clrType.FullName ?? clrType.Name : clrType.Name);
-        var tickIndex = typeName.IndexOf('`');
-        if (tickIndex >= 0)
+        return FormatClrGenericTypeName(
+            clrType.GetGenericTypeDefinition(),
+            clrType.GetGenericArguments(),
+            qualifyNames);
+    }
+
+    private static string FormatClrGenericTypeName(Type definition, Type[] typeArguments, bool qualifyNames)
+    {
+        var declaringArgumentCount = definition.DeclaringType?.GetGenericArguments().Length ?? 0;
+        var ownArguments = typeArguments.Skip(declaringArgumentCount).ToArray();
+        var name = StripGenericArity(definition.Name);
+
+        if (definition.IsNested)
         {
-            typeName = typeName.Substring(0, tickIndex);
+            var declaringArguments = typeArguments.Take(declaringArgumentCount).ToArray();
+            name = $"{FormatClrGenericTypeName(definition.DeclaringType, declaringArguments, qualifyNames)}.{name}";
+        }
+        else if (qualifyNames && !string.IsNullOrEmpty(definition.Namespace))
+        {
+            name = $"{definition.Namespace}.{name}";
         }
 
-        typeName = typeName.Replace('+', '.');
-        var args = clrType.GetGenericArguments();
-        return $"{typeName}[{string.Join(", ", args.Select(a => FormatClrTypeName(a, qualifyNames)))}]";
+        return ownArguments.Length == 0
+            ? name
+            : $"{name}[{string.Join(", ", ownArguments.Select(a => FormatClrTypeName(a, qualifyNames)))}]";
     }
+
+    private static string FormatImportedGenericTypeName(
+        Type definition,
+        ImmutableArray<TypeSymbol> typeArguments)
+    {
+        var declaringArgumentCount = definition.DeclaringType?.GetGenericArguments().Length ?? 0;
+        var ownArguments = typeArguments.Skip(declaringArgumentCount).ToImmutableArray();
+        var name = StripGenericArity(definition.Name);
+
+        if (definition.IsNested)
+        {
+            name = $"{FormatImportedGenericTypeName(
+                definition.DeclaringType,
+                typeArguments.Take(declaringArgumentCount).ToImmutableArray())}.{name}";
+        }
+        else if (!string.IsNullOrEmpty(definition.Namespace))
+        {
+            name = $"{definition.Namespace}.{name}";
+        }
+
+        return ownArguments.IsDefaultOrEmpty
+            ? name
+            : $"{name}[{string.Join(", ", ownArguments.Select(FormatGenericTypeArgument))}]";
+    }
+
+    private static string FormatGenericTypeArgument(TypeSymbol type)
+        => type == null ? "?" : FormatType(type);
 
     private static bool TryGetGSharpPrimitiveName(Type clrType, out string name)
     {

--- a/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
+++ b/src/Core/CodeAnalysis/Symbols/Display/SymbolDisplay.cs
@@ -675,6 +675,11 @@ public static class SymbolDisplay
                     return $"[]?{FormatType(nullableSlice.ElementType)}";
                 }
 
+                if (nullable.UnderlyingType is ArrayTypeSymbol nullableArray)
+                {
+                    return $"[{nullableArray.Length}]?{FormatType(nullableArray.ElementType)}";
+                }
+
                 var underlying = FormatType(nullable.UnderlyingType);
                 return nullable.UnderlyingType is FunctionTypeSymbol
                     ? $"({underlying})?"
@@ -683,6 +688,10 @@ public static class SymbolDisplay
                 return FormatType(annotated.BaseType);
             case FunctionTypeSymbol function:
                 return FormatFunctionType(function);
+            case FunctionPointerTypeSymbol functionPointer:
+                return FormatFunctionPointerType(functionPointer);
+            case ArrayTypeSymbol array:
+                return $"[{array.Length}]{FormatType(array.ElementType)}";
             case SliceTypeSymbol slice:
                 return $"[]{FormatType(slice.ElementType)}";
             case AsyncSequenceTypeSymbol asyncSequence:
@@ -691,10 +700,14 @@ public static class SymbolDisplay
                 return $"sequence[{FormatType(sequence.ElementType)}]";
             case MapTypeSymbol map:
                 return $"map[{FormatType(map.KeyType)},{FormatType(map.ValueType)}]";
+            case ChannelTypeSymbol channel:
+                return $"chan {FormatType(channel.ElementType)}";
             case PointerTypeSymbol pointer:
                 return $"*{FormatType(pointer.PointeeType)}";
             case ByRefTypeSymbol byRef:
                 return $"*{FormatType(byRef.PointeeType)}";
+            case PinnedTypeSymbol pinned:
+                return $"pinned {FormatType(pinned.UnderlyingType)}";
             case TupleTypeSymbol tuple:
                 return $"({string.Join(", ", tuple.ElementTypes.Select(FormatType))})";
             case StructSymbol aggregate when IsAnonymousClassType(aggregate):
@@ -833,6 +846,20 @@ public static class SymbolDisplay
         sb.Append(") -> ");
         sb.Append(FormatType(function.ReturnType));
         return sb.ToString();
+    }
+
+    private static string FormatFunctionPointerType(FunctionPointerTypeSymbol functionPointer)
+    {
+        var parameters = string.Join(", ", functionPointer.ParameterTypes.Select(FormatGenericTypeArgument));
+        var returnType = FormatGenericTypeArgument(functionPointer.ReturnType);
+        if (!functionPointer.IsManaged)
+        {
+            return $"unmanaged[{functionPointer.CallingConvention}] ({parameters}) -> {returnType}";
+        }
+
+        return functionPointer.ReturnType == TypeSymbol.Void
+            ? $"*func({parameters})"
+            : $"*func({parameters}) {returnType}";
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/SymbolPrinter.cs
+++ b/src/Core/CodeAnalysis/Symbols/SymbolPrinter.cs
@@ -2,9 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System;
-using System.Collections.Immutable;
 using System.IO;
+using GSharp.Core.CodeAnalysis.Symbols.Display;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.IO;
 
@@ -75,7 +74,7 @@ public static class SymbolPrinter
         if (symbol.Type != null)
         {
             writer.WriteSpace();
-            writer.WriteIdentifier(symbol.Type.Name);
+            symbol.Type.WriteTo(writer);
         }
     }
 
@@ -116,105 +115,7 @@ public static class SymbolPrinter
 
     private static void WriteTypeTo(TypeSymbol symbol, TextWriter writer)
     {
-        if (symbol is NullableTypeSymbol nullable
-            && TryWriteConstructedTypeTo(nullable.UnderlyingType, writer))
-        {
-            writer.Write('?');
-            return;
-        }
-
-        if (!TryWriteConstructedTypeTo(symbol, writer))
-        {
-            writer.WriteIdentifier(symbol.Name);
-        }
-    }
-
-    private static bool TryWriteConstructedTypeTo(TypeSymbol symbol, TextWriter writer)
-    {
-        switch (symbol)
-        {
-            case StructSymbol { TypeArguments.IsDefaultOrEmpty: false } aggregate:
-                WriteConstructedTypeTo(aggregate.Definition.Name, aggregate.TypeArguments, writer);
-                return true;
-            case InterfaceSymbol { TypeArguments.IsDefaultOrEmpty: false } @interface:
-                WriteConstructedTypeTo(@interface.Definition.Name, @interface.TypeArguments, writer);
-                return true;
-            case DelegateTypeSymbol { TypeArguments.IsDefaultOrEmpty: false } @delegate:
-                WriteConstructedTypeTo(@delegate.Definition.Name, @delegate.TypeArguments, writer);
-                return true;
-            case ImportedTypeSymbol imported:
-                return TryWriteImportedConstructedTypeTo(imported, writer);
-            default:
-                return false;
-        }
-    }
-
-    private static void WriteConstructedTypeTo(
-        string name,
-        ImmutableArray<TypeSymbol> typeArguments,
-        TextWriter writer)
-    {
-        writer.WriteIdentifier(RemoveGenericArity(name));
-        writer.Write('[');
-        for (var i = 0; i < typeArguments.Length; i++)
-        {
-            if (i > 0)
-            {
-                writer.Write(", ");
-            }
-
-            WriteTypeTo(typeArguments[i], writer);
-        }
-
-        writer.Write(']');
-    }
-
-    private static bool TryWriteImportedConstructedTypeTo(ImportedTypeSymbol imported, TextWriter writer)
-    {
-        if (imported.OpenDefinition != null && !imported.TypeArguments.IsDefaultOrEmpty)
-        {
-            WriteConstructedTypeTo(
-                imported.OpenDefinition.FullName ?? imported.OpenDefinition.Name,
-                imported.TypeArguments,
-                writer);
-            return true;
-        }
-
-        var clrType = imported.ClrType;
-        if (clrType == null || !clrType.IsGenericType || clrType.IsGenericTypeDefinition)
-        {
-            return false;
-        }
-
-        var definition = clrType.GetGenericTypeDefinition();
-        var clrArguments = clrType.GetGenericArguments();
-        var typeArguments = ImmutableArray.CreateBuilder<TypeSymbol>(clrArguments.Length);
-        foreach (var argument in clrArguments)
-        {
-            typeArguments.Add(TypeSymbol.FromClrType(argument));
-        }
-
-        WriteConstructedTypeTo(
-            definition.FullName ?? definition.Name,
-            typeArguments.MoveToImmutable(),
-            writer);
-        return true;
-    }
-
-    private static string RemoveGenericArity(string name)
-    {
-        for (var tick = name.IndexOf('`'); tick >= 0; tick = name.IndexOf('`', tick))
-        {
-            var end = tick + 1;
-            while (end < name.Length && char.IsDigit(name[end]))
-            {
-                end++;
-            }
-
-            name = name.Remove(tick, end - tick);
-        }
-
-        return name;
+        writer.WriteIdentifier(SymbolDisplay.ToTypeDisplayString(symbol));
     }
 
     private static void WriteEnumMemberTo(EnumMemberSymbol symbol, TextWriter writer)

--- a/src/Core/CodeAnalysis/Symbols/SymbolPrinter.cs
+++ b/src/Core/CodeAnalysis/Symbols/SymbolPrinter.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.IO;
@@ -115,7 +116,105 @@ public static class SymbolPrinter
 
     private static void WriteTypeTo(TypeSymbol symbol, TextWriter writer)
     {
-        writer.WriteIdentifier(symbol.Name);
+        if (symbol is NullableTypeSymbol nullable
+            && TryWriteConstructedTypeTo(nullable.UnderlyingType, writer))
+        {
+            writer.Write('?');
+            return;
+        }
+
+        if (!TryWriteConstructedTypeTo(symbol, writer))
+        {
+            writer.WriteIdentifier(symbol.Name);
+        }
+    }
+
+    private static bool TryWriteConstructedTypeTo(TypeSymbol symbol, TextWriter writer)
+    {
+        switch (symbol)
+        {
+            case StructSymbol { TypeArguments.IsDefaultOrEmpty: false } aggregate:
+                WriteConstructedTypeTo(aggregate.Definition.Name, aggregate.TypeArguments, writer);
+                return true;
+            case InterfaceSymbol { TypeArguments.IsDefaultOrEmpty: false } @interface:
+                WriteConstructedTypeTo(@interface.Definition.Name, @interface.TypeArguments, writer);
+                return true;
+            case DelegateTypeSymbol { TypeArguments.IsDefaultOrEmpty: false } @delegate:
+                WriteConstructedTypeTo(@delegate.Definition.Name, @delegate.TypeArguments, writer);
+                return true;
+            case ImportedTypeSymbol imported:
+                return TryWriteImportedConstructedTypeTo(imported, writer);
+            default:
+                return false;
+        }
+    }
+
+    private static void WriteConstructedTypeTo(
+        string name,
+        ImmutableArray<TypeSymbol> typeArguments,
+        TextWriter writer)
+    {
+        writer.WriteIdentifier(RemoveGenericArity(name));
+        writer.Write('[');
+        for (var i = 0; i < typeArguments.Length; i++)
+        {
+            if (i > 0)
+            {
+                writer.Write(", ");
+            }
+
+            WriteTypeTo(typeArguments[i], writer);
+        }
+
+        writer.Write(']');
+    }
+
+    private static bool TryWriteImportedConstructedTypeTo(ImportedTypeSymbol imported, TextWriter writer)
+    {
+        if (imported.OpenDefinition != null && !imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            WriteConstructedTypeTo(
+                imported.OpenDefinition.FullName ?? imported.OpenDefinition.Name,
+                imported.TypeArguments,
+                writer);
+            return true;
+        }
+
+        var clrType = imported.ClrType;
+        if (clrType == null || !clrType.IsGenericType || clrType.IsGenericTypeDefinition)
+        {
+            return false;
+        }
+
+        var definition = clrType.GetGenericTypeDefinition();
+        var clrArguments = clrType.GetGenericArguments();
+        var typeArguments = ImmutableArray.CreateBuilder<TypeSymbol>(clrArguments.Length);
+        foreach (var argument in clrArguments)
+        {
+            typeArguments.Add(TypeSymbol.FromClrType(argument));
+        }
+
+        WriteConstructedTypeTo(
+            definition.FullName ?? definition.Name,
+            typeArguments.MoveToImmutable(),
+            writer);
+        return true;
+    }
+
+    private static string RemoveGenericArity(string name)
+    {
+        for (var tick = name.IndexOf('`'); tick >= 0; tick = name.IndexOf('`', tick))
+        {
+            var end = tick + 1;
+            while (end < name.Length && char.IsDigit(name[end]))
+            {
+                end++;
+            }
+
+            name = name.Remove(tick, end - tick);
+        }
+
+        return name;
     }
 
     private static void WriteEnumMemberTo(EnumMemberSymbol symbol, TextWriter writer)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2851GenericDiagnosticDisplayTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2851GenericDiagnosticDisplayTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.InteropServices;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -79,12 +80,17 @@ public class Issue2851GenericDiagnosticDisplayTests
         var box = StructSymbol.Construct(definition, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
         var cases = new (TypeSymbol Type, string Display)[]
         {
+            (ArrayTypeSymbol.Get(box, 3), "[3]Box[int32]"),
             (SliceTypeSymbol.Get(box), "[]Box[int32]"),
             (SequenceTypeSymbol.Get(box), "sequence[Box[int32]]"),
             (MapTypeSymbol.Get(TypeSymbol.String, box), "map[string,Box[int32]]"),
+            (ChannelTypeSymbol.Get(box), "chan Box[int32]"),
             (TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(box, TypeSymbol.Int32)), "(Box[int32], int32)"),
             (FunctionTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(box), TypeSymbol.Void), "(Box[int32]) -> void"),
+            (FunctionPointerTypeSymbol.GetManaged(ImmutableArray.Create<TypeSymbol>(box), box), "*func(Box[int32]) Box[int32]"),
+            (FunctionPointerTypeSymbol.Get(CallingConvention.Cdecl, ImmutableArray.Create<TypeSymbol>(box), box), "unmanaged[Cdecl] (Box[int32]) -> Box[int32]"),
             (PointerTypeSymbol.Get(box), "*Box[int32]"),
+            (new PinnedTypeSymbol(box), "pinned Box[int32]"),
         };
 
         foreach (var (type, display) in cases)
@@ -95,6 +101,21 @@ public class Issue2851GenericDiagnosticDisplayTests
             var diagnostic = Assert.Single(bag);
             Assert.Equal($"Cannot convert type '{display}' to 'string'.", diagnostic.Message);
         }
+    }
+
+    [Fact]
+    public void FixedArrayDisplay_DistinguishesNullableArrayFromNullableElements()
+    {
+        var nullableArray = NullableTypeSymbol.Get(ArrayTypeSymbol.Get(TypeSymbol.Int32, 3));
+        var nullableElements = ArrayTypeSymbol.Get(NullableTypeSymbol.Get(TypeSymbol.Int32), 3);
+        var nullableArrayAndElements = NullableTypeSymbol.Get(nullableElements);
+
+        Assert.Equal("[3]?int32", SymbolDisplay.ToTypeDisplayString(nullableArray));
+        Assert.Equal("[3]int32?", SymbolDisplay.ToTypeDisplayString(nullableElements));
+        Assert.Equal("[3]?int32?", SymbolDisplay.ToTypeDisplayString(nullableArrayAndElements));
+        Assert.NotEqual(
+            SymbolDisplay.ToTypeDisplayString(nullableArray),
+            SymbolDisplay.ToTypeDisplayString(nullableElements));
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2851GenericDiagnosticDisplayTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2851GenericDiagnosticDisplayTests.cs
@@ -1,0 +1,140 @@
+// <copyright file="Issue2851GenericDiagnosticDisplayTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2851: diagnostic type display preserves constructed generic arguments
+/// without changing metadata-facing symbol names.
+/// </summary>
+public class Issue2851GenericDiagnosticDisplayTests
+{
+    [Fact]
+    public void Gs0155_DisplaysConstructedSourceTypesAndNullableForms()
+    {
+        const string source = """
+            package P
+
+            class Box[T] {}
+            struct Cell[T] { var Value T }
+            type Conv[T] = delegate func(v T) void
+
+            func Test() {
+                var box Box[int32] = Box[int32]()
+                var classText string = box
+
+                var nullableBox Box[int32]? = nil
+                var nullableClassText string = nullableBox
+
+                var nested Box[Box[int32]] = Box[Box[int32]]()
+                var nestedText string = nested
+
+                var nullableConv Conv[int32]? = nil
+                nullableConv = (s string) -> {}
+
+                var conv Conv[int32] = (v int32) -> {}
+                var delegateText string = conv
+                var nullableDelegateText string = nullableConv
+
+                var cell Cell[int32] = Cell[int32]{Value: 1}
+                var structText string = cell
+
+                var nullableCell Cell[int32]? = nil
+                var nullableStructText string = nullableCell
+            }
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.Equal(8, diagnostics.Length);
+        AssertDiagnostic(diagnostics, "GS0155", "Cannot convert type 'Box[int32]' to 'string'.");
+        AssertDiagnostic(diagnostics, "GS0155", "Cannot convert type 'Box[int32]?' to 'string'.");
+        AssertDiagnostic(diagnostics, "GS0155", "Cannot convert type 'Box[Box[int32]]' to 'string'.");
+        AssertDiagnostic(diagnostics, "GS0155", "Cannot convert type '(string) -> void' to 'Conv[int32]?'.");
+        AssertDiagnostic(diagnostics, "GS0155", "Cannot convert type 'Conv[int32]' to 'string'.");
+        AssertDiagnostic(diagnostics, "GS0155", "Cannot convert type 'Conv[int32]?' to 'string'.");
+        AssertDiagnostic(diagnostics, "GS0155", "Cannot convert type 'Cell[int32]' to 'string'.");
+        AssertDiagnostic(diagnostics, "GS0155", "Cannot convert type 'Cell[int32]?' to 'string'.");
+    }
+
+    [Fact]
+    public void Gs0156_UsesSameConstructedTypeDisplayWithoutChangingName()
+    {
+        var compilation = CreateCompilation("""
+            package P
+            class Box[T] {}
+            type Conv[T] = delegate func(v T) void
+            """);
+        var boxDefinition = compilation.GlobalScope.Structs.Single(s => s.Name == "Box");
+        var delegateDefinition = compilation.GlobalScope.Delegates.Single(d => d.Name == "Conv");
+        var box = StructSymbol.Construct(boxDefinition, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+        var conv = DelegateTypeSymbol.Construct(delegateDefinition, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+        var nullableBox = NullableTypeSymbol.Get(box);
+        var nullableConv = NullableTypeSymbol.Get(conv);
+        var bag = new DiagnosticBag();
+        var location = MakeLocation();
+
+        bag.ReportCannotConvertImplicitly(location, box, nullableBox);
+        bag.ReportCannotConvertImplicitly(location, nullableConv, conv);
+
+        Assert.Equal("Box", box.Name);
+        Assert.Equal("Conv", conv.Name);
+        Assert.Collection(
+            bag,
+            diagnostic => Assert.Equal(
+                "Cannot convert type 'Box[int32]' to 'Box[int32]?'. An explicit conversion exists (are you missing a cast?)",
+                diagnostic.Message),
+            diagnostic => Assert.Equal(
+                "Cannot convert type 'Conv[int32]?' to 'Conv[int32]'. An explicit conversion exists (are you missing a cast?)",
+                diagnostic.Message));
+    }
+
+    [Fact]
+    public void ImportedConstructedGeneric_UsesGSharpSyntaxWithoutClrArity()
+    {
+        var bag = new DiagnosticBag();
+
+        bag.ReportCannotConvertImplicitly(
+            MakeLocation(),
+            ImportedTypeSymbol.Get(typeof(System.Collections.Generic.List<int>)),
+            TypeSymbol.String);
+
+        var diagnostic = Assert.Single(bag);
+        Assert.Equal(
+            "Cannot convert type 'System.Collections.Generic.List[int32]' to 'string'. An explicit conversion exists (are you missing a cast?)",
+            diagnostic.Message);
+    }
+
+    private static ImmutableArray<Diagnostic> GetDiagnostics(string source)
+    {
+        var compilation = CreateCompilation(source);
+        return compilation.SyntaxTrees.SelectMany(tree => tree.Diagnostics)
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .Where(diagnostic => diagnostic.IsError)
+            .ToImmutableArray();
+    }
+
+    private static Compilation CreateCompilation(string source)
+        => new(SyntaxTree.Parse(SourceText.From(source)));
+
+    private static void AssertDiagnostic(
+        ImmutableArray<Diagnostic> diagnostics,
+        string id,
+        string message)
+        => Assert.Contains(diagnostics, diagnostic => diagnostic.Id == id && diagnostic.Message == message);
+
+    private static TextLocation MakeLocation()
+        => new(SourceText.From("x"), new TextSpan(0, 1));
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2851GenericDiagnosticDisplayTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2851GenericDiagnosticDisplayTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Symbols.Display;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
@@ -57,7 +58,6 @@ public class Issue2851GenericDiagnosticDisplayTests
 
         var diagnostics = GetDiagnostics(source);
 
-        Assert.Equal(8, diagnostics.Length);
         AssertDiagnostic(diagnostics, "GS0155", "Cannot convert type 'Box[int32]' to 'string'.");
         AssertDiagnostic(diagnostics, "GS0155", "Cannot convert type 'Box[int32]?' to 'string'.");
         AssertDiagnostic(diagnostics, "GS0155", "Cannot convert type 'Box[Box[int32]]' to 'string'.");
@@ -69,15 +69,111 @@ public class Issue2851GenericDiagnosticDisplayTests
     }
 
     [Fact]
+    public void DiagnosticDisplay_RecursesThroughConstructedTypeWrappers()
+    {
+        var compilation = CreateCompilation("""
+            package P
+            class Box[T] {}
+            """);
+        var definition = compilation.GlobalScope.Structs.Single(s => s.Name == "Box");
+        var box = StructSymbol.Construct(definition, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+        var cases = new (TypeSymbol Type, string Display)[]
+        {
+            (SliceTypeSymbol.Get(box), "[]Box[int32]"),
+            (SequenceTypeSymbol.Get(box), "sequence[Box[int32]]"),
+            (MapTypeSymbol.Get(TypeSymbol.String, box), "map[string,Box[int32]]"),
+            (TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(box, TypeSymbol.Int32)), "(Box[int32], int32)"),
+            (FunctionTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(box), TypeSymbol.Void), "(Box[int32]) -> void"),
+            (PointerTypeSymbol.Get(box), "*Box[int32]"),
+        };
+
+        foreach (var (type, display) in cases)
+        {
+            var bag = new DiagnosticBag();
+            bag.ReportCannotConvert(MakeLocation(), type, TypeSymbol.String);
+
+            var diagnostic = Assert.Single(bag);
+            Assert.Equal($"Cannot convert type '{display}' to 'string'.", diagnostic.Message);
+        }
+    }
+
+    [Fact]
+    public void SymbolDisplay_CoversInterfacesMultipleArgumentsDefinitionsAndNestedTypes()
+    {
+        var compilation = CreateCompilation("""
+            package P
+
+            interface Contract[T] {}
+            class Pair[T, U] {}
+            struct Outer[T] {
+                struct Tag {}
+                struct Inner[U] {}
+            }
+
+            func Use(tag Outer[int32].Tag, inner Outer[int32].Inner[string]) {}
+            """);
+
+        var contractDefinition = compilation.GlobalScope.Interfaces.Single(i => i.Name == "Contract");
+        var pairDefinition = compilation.GlobalScope.Structs.Single(s => s.Name == "Pair");
+        var contract = InterfaceSymbol.Construct(
+            contractDefinition,
+            ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+        var pair = StructSymbol.Construct(
+            pairDefinition,
+            ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32, TypeSymbol.String));
+        var use = compilation.GlobalScope.Functions.Single(f => f.Name == "Use");
+
+        Assert.Equal("Contract[T]", SymbolDisplay.ToTypeDisplayString(contractDefinition));
+        Assert.Equal("Contract[int32]", SymbolDisplay.ToTypeDisplayString(contract));
+        Assert.Equal("Pair[T, U]", SymbolDisplay.ToTypeDisplayString(pairDefinition));
+        Assert.Equal("Pair[int32, string]", SymbolDisplay.ToTypeDisplayString(pair));
+        Assert.Equal("Outer[int32].Tag", SymbolDisplay.ToTypeDisplayString(use.Parameters[0].Type));
+        Assert.Equal("Outer[int32].Inner[string]", SymbolDisplay.ToTypeDisplayString(use.Parameters[1].Type));
+    }
+
+    [Fact]
+    public void ImportedTypes_DisplayAnnotatedNestedAndOpenGenericForms()
+    {
+        var annotated = new NullabilityAnnotatedTypeSymbol(
+            ImportedTypeSymbol.Get(typeof(System.Collections.Generic.List<int>)),
+            ImmutableArray.Create<byte>(1, 1));
+
+        Assert.Equal(
+            "System.Collections.Generic.List[int32]",
+            SymbolDisplay.ToTypeDisplayString(annotated));
+        Assert.Equal(
+            "System.Collections.Generic.Dictionary[int32, string].Enumerator",
+            SymbolDisplay.ToTypeDisplayString(
+                ImportedTypeSymbol.Get(typeof(System.Collections.Generic.Dictionary<int, string>.Enumerator))));
+        Assert.Equal(
+            "GSharp.Core.Tests.CodeAnalysis.Binding.Issue2851ImportedOuter[int32].Inner[string]",
+            SymbolDisplay.ToTypeDisplayString(
+                ImportedTypeSymbol.Get(typeof(Issue2851ImportedOuter<int>.Inner<string>))));
+        Assert.Equal(
+            "GSharp.Core.Tests.CodeAnalysis.Binding.Issue2851ImportedOuter[int32].Inner[string]",
+            SymbolDisplay.ToTypeDisplayString(
+                ImportedTypeSymbol.GetConstructed(
+                    typeof(Issue2851ImportedOuter<int>.Inner<string>),
+                    typeof(Issue2851ImportedOuter<>.Inner<>),
+                    ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32, TypeSymbol.String))));
+        Assert.Equal(
+            "System.Collections.Generic.List[T]",
+            SymbolDisplay.ToTypeDisplayString(
+                ImportedTypeSymbol.Get(typeof(System.Collections.Generic.List<>))));
+    }
+
+    [Fact]
     public void Gs0156_UsesSameConstructedTypeDisplayWithoutChangingName()
     {
         var compilation = CreateCompilation("""
             package P
             class Box[T] {}
             type Conv[T] = delegate func(v T) void
+            func Make() Box[int32] { return Box[int32]() }
             """);
         var boxDefinition = compilation.GlobalScope.Structs.Single(s => s.Name == "Box");
         var delegateDefinition = compilation.GlobalScope.Delegates.Single(d => d.Name == "Conv");
+        var make = compilation.GlobalScope.Functions.Single(f => f.Name == "Make");
         var box = StructSymbol.Construct(boxDefinition, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
         var conv = DelegateTypeSymbol.Construct(delegateDefinition, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
         var nullableBox = NullableTypeSymbol.Get(box);
@@ -90,6 +186,9 @@ public class Issue2851GenericDiagnosticDisplayTests
 
         Assert.Equal("Box", box.Name);
         Assert.Equal("Conv", conv.Name);
+        Assert.Equal("Box[T]", SymbolDisplay.ToTypeDisplayString(boxDefinition));
+        Assert.Equal("Conv[T]", SymbolDisplay.ToTypeDisplayString(delegateDefinition));
+        Assert.Contains("Box[int32]", make.ToString(), StringComparison.Ordinal);
         Assert.Collection(
             bag,
             diagnostic => Assert.Equal(
@@ -137,4 +236,11 @@ public class Issue2851GenericDiagnosticDisplayTests
 
     private static TextLocation MakeLocation()
         => new(SourceText.From("x"), new TextSpan(0, 1));
+}
+
+internal class Issue2851ImportedOuter<T>
+{
+    internal class Inner<TValue>
+    {
+    }
 }

--- a/test/Interpreter.Tests/GSharpReplTests.cs
+++ b/test/Interpreter.Tests/GSharpReplTests.cs
@@ -10,6 +10,18 @@ namespace GSharp.Interpreter.Tests;
 public class GSharpReplTests
 {
     [Fact]
+    public void Snapshot_DisplaysConstructedSourceGenericType()
+    {
+        var engine = new SessionEngine();
+
+        Assert.False(engine.Evaluate("class Box[T] {}").HasError);
+        Assert.False(engine.Evaluate("let box = Box[int32]()").HasError);
+
+        var variable = Assert.Single(engine.Snapshot().Variables);
+        Assert.Contains("Box[int32]", variable.Display);
+    }
+
+    [Fact]
     public void Evaluate_SimpleExpression_ReturnsValue()
     {
         var cell = new SessionEngine().Evaluate("1 + 2");

--- a/test/LanguageServer.Tests/HoverHandlerTests.cs
+++ b/test/LanguageServer.Tests/HoverHandlerTests.cs
@@ -14,6 +14,18 @@ namespace GSharp.LanguageServer.Tests;
 public class HoverHandlerTests
 {
     [Fact]
+    public void ComputeHover_DisplaysConstructedSourceGenericType()
+    {
+        const string source = "class Box[T] {}\nfunc main() {\n    let box = Box[int32]()\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var hover = HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "box"));
+
+        Assert.NotNull(hover);
+        Assert.Contains("Box[int32]", hover.Contents.ToString(), System.StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ComputeHover_HonorsCancellation()
     {
         // Issue #1662: ComputeHover accepted a CancellationToken but never observed it. On a

--- a/test/LanguageServer.Tests/InlayHintHandlerTests.cs
+++ b/test/LanguageServer.Tests/InlayHintHandlerTests.cs
@@ -11,6 +11,21 @@ namespace GSharp.LanguageServer.Tests;
 public class InlayHintHandlerTests
 {
     [Fact]
+    public void ComputeHints_DisplaysConstructedSourceGenericType()
+    {
+        const string source = "class Box[T] {}\nlet box = Box[int32]()\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var hint = Assert.Single(
+            InlayHintComputer.ComputeHints(
+                content,
+                includeParameterNames: false,
+                includeTypes: true));
+
+        Assert.Equal(": Box[int32]", hint.Label.String);
+    }
+
+    [Fact]
     public void ComputeHints_ShowsParameterNames()
     {
         const string source = "func add(a int32, b int32) int32 { return a + b }\nvar x = add(1, 2)\n";


### PR DESCRIPTION
## Summary

- Extend the existing `SymbolDisplay` type formatter for constructed source classes, structs, interfaces, and named delegates, including wrappers, nested types, nullable annotations, and generic definitions.
- Make `SymbolPrinter` delegate type rendering to `SymbolDisplay`, so diagnostics, hover, inlay hints, and the REPL use one recursive formatter. Function return types now use the same path.
- Keep `TypeSymbol.Name` unchanged; metadata emission still applies CLR arity mangling separately through `TypeDefEmitter.MangleGenericName`.

## Root cause and consolidation

Constructed source symbols intentionally retain their definition's bare `Name`, but `SymbolPrinter` previously rendered diagnostics from that value. The first revision taught `SymbolPrinter` to reconstruct generic types; review identified that `SymbolDisplay.FormatType` already provided the canonical recursive formatter used by hover, inlay hints, and the REPL.

This revision takes the full-consolidation route: `SymbolDisplay` now handles the missing constructed source cases, and `SymbolPrinter.WriteTypeTo` delegates to it. The duplicate formatter and arity helper were removed. Full Core and Compiler runs required zero pre-existing expectation changes. Consolidation exposed one existing formatter bug for nullable slices (`[]int32?` instead of `[]?int32`); the shared formatter now preserves the canonical spelling.

The earlier diagnostic-helper changes remain limited to `DiagnosticBag.Reports.*` call sites that passed `TypeSymbol.Name` instead of a symbol. This PR does not claim that every binder report with a string parameter has been converted.

## Display behavior

- Source constructions render as G# syntax: `Box[int32]`, `Pair[int32, string]`, and `Conv[int32]?`.
- Wrapper types recurse: fixed arrays, slices, sequences, maps, channels, tuples, function types, function pointers, pointers, pinned types, and nullable forms preserve inner generic arguments. Nullable fixed arrays retain the canonical `[N]?T` spelling, distinct from `[N]T?`.
- `[NullableAttribute]` wrappers unwrap through their base type for display.
- Source nested types preserve enclosing arguments: `Outer[int32].Tag` and `Outer[int32].Inner[string]`.
- Imported generics normalize assembly-qualified CLR names to readable G# syntax, including primitives and nested argument ownership, for example `System.Collections.Generic.List[int32]` and `Dictionary[int32, string].Enumerator`.
- Open/source generic definitions render their parameters consistently, such as `Box[T]`; this caused no test churn, so no follow-up issue was needed.

No pre-existing diagnostic-text expectation depended on CLR arity-mangled output. Pre-existing expectations updated: 0.

## Coverage

Regression coverage includes:

- GS0155 and GS0156 for generic classes, structs, named delegates, nullable forms, and `Box[Box[int32]]`
- interfaces and multi-parameter constructions
- fixed-array nullable-position collision coverage plus array, slice, sequence, map, channel, tuple, function, function-pointer, pointer, and pinned wrappers
- `NullabilityAnnotatedTypeSymbol`
- source and imported nested generics, plus open imported definitions
- unchanged metadata-facing `Name` values
- function return display
- hover, inlay-hint, and REPL snapshot display

Revert sanity removed the relevant source formatter changes while retaining tests. Pass 2: Core issue tests failed 4/6, hover/inlay failed 2/2, and REPL failed 1/1. Pass 3: the `[3]?int32` versus `[3]int32?` test failed with both forms rendered as `[3]int32?`, and the wrapper diagnostic test failed at `[3]Box[int32]` rendering as `[3]Box`. After restoration, all 7 Core issue tests passed.

## Validation

- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --nologo --verbosity minimal --filter FullyQualifiedName~Issue2851GenericDiagnosticDisplayTests` — 7 passed
- `dotnet test test/LanguageServer.Tests/LanguageServer.Tests.csproj --no-restore --nologo --verbosity minimal --filter 'FullyQualifiedName~ComputeHover_DisplaysConstructedSourceGenericType|FullyQualifiedName~ComputeHints_DisplaysConstructedSourceGenericType'` — 2 passed
- `dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj --no-restore --nologo --verbosity minimal --filter FullyQualifiedName~Snapshot_DisplaysConstructedSourceGenericType` — 1 passed
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore --nologo --verbosity minimal` — 6,849 passed, 1 skipped
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --no-restore --nologo --verbosity minimal` — 3,644 passed
- `dotnet test test/LanguageServer.Tests/LanguageServer.Tests.csproj --no-restore --nologo --verbosity minimal` — 452 passed
- `dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj --no-restore --nologo --verbosity minimal` — 444 passed
- `dotnet test test/Extensions.Tests/Extensions.Tests.csproj --no-restore --nologo --verbosity minimal` — 104 passed
- `dotnet test test/InternalAnalyzers.Tests/InternalAnalyzers.Tests.csproj --no-restore --nologo --verbosity minimal` — 7 passed
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-restore --nologo --verbosity minimal --configuration Release` — 1,860 passed
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-restore --nologo --verbosity minimal` — 1,860 passed on final rerun

The first Debug Cs2Gs run had one setup-order failure because its package smoke test requires packages in `out/bin/Release/nupkgs`; the Release run produced them and passed, then the exact Debug command passed in full.

Follow-up issue filed: #2898 tracks pre-existing hover declaration headers and nested enums losing constructed enclosing-type context (`Outer[int32].Color` versus `Outer[string].Color`). A display-only enum branch would render both as `Outer[T].Color`; the complete fix requires binder/symbol/emitter support. Reflection hardening was not added: `ClrTypeUtilities` has no safe generic-argument accessor, so a local fallback would add non-trivial duplicate policy; the guarded diagnostic pipeline already degrades reflection failures to GS9998. Deferred work for #2851: none.

Fixes #2851



