### PR TITLE
gsc: model branches escaping fixed bodies in definite-return CFG

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -66,10 +66,10 @@ public sealed class ControlFlowGraph
     /// <returns>Whether all its paths return or not.</returns>
     public static bool AllPathsReturn(BoundBlockStatement body)
     {
-        // Keep fixed/scope structured for emit and data-flow consumers, but
-        // expose their sequential bodies to this graph so escaping gotos can
-        // resolve labels in the enclosing function.
-        var graph = Create(ExpandSequentialRegions(body));
+        // This projection is intentionally limited to definite-return. Other
+        // data-flow analyzers call Create(body) and still treat fixed/scope as
+        // opaque, so their escaping-goto behavior is unchanged.
+        var graph = Create(ProjectSequentialRegionsForDefiniteReturn(body));
 
         foreach (var branch in graph.End.Incoming)
         {
@@ -199,7 +199,7 @@ public sealed class ControlFlowGraph
         }
     }
 
-    private static BoundBlockStatement ExpandSequentialRegions(BoundStatement statement)
+    private static BoundBlockStatement ProjectSequentialRegionsForDefiniteReturn(BoundStatement statement)
     {
         var builder = System.Collections.Immutable.ImmutableArray.CreateBuilder<BoundStatement>();
         Add(statement);
@@ -217,9 +217,14 @@ public sealed class ControlFlowGraph
 
                     break;
                 case BoundFixedStatement fixedStatement:
+                    // Fixed executes its body once; pin setup and normal-exit
+                    // release remain emit concerns. Escaping exits currently
+                    // skip that release epilogue (#2900).
                     Add(fixedStatement.Body);
                     break;
                 case BoundScopeStatement scopeStatement:
+                    // Scope also executes its body once in normal control flow.
+                    // Its task join and failure rethrow remain emit-time behavior.
                     Add(scopeStatement.Body);
                     break;
                 default:
@@ -376,7 +381,6 @@ public sealed class ControlFlowGraph
                     case BoundNodeKind.GotoStatement:
                     case BoundNodeKind.ConditionalGotoStatement:
                     case BoundNodeKind.ReturnStatement:
-                    case BoundNodeKind.ThrowStatement:
                         statements.Add(statement);
                         StartBlock();
                         break;
@@ -396,6 +400,7 @@ public sealed class ControlFlowGraph
 
                         break;
                     case BoundNodeKind.TryStatement:
+                    case BoundNodeKind.ThrowStatement:
                     case BoundNodeKind.GoStatement:
                     case BoundNodeKind.ChannelSendStatement:
                     case BoundNodeKind.SelectStatement:

--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -66,7 +66,10 @@ public sealed class ControlFlowGraph
     /// <returns>Whether all its paths return or not.</returns>
     public static bool AllPathsReturn(BoundBlockStatement body)
     {
-        var graph = Create(body);
+        // Keep fixed/scope structured for emit and data-flow consumers, but
+        // expose their sequential bodies to this graph so escaping gotos can
+        // resolve labels in the enclosing function.
+        var graph = Create(ExpandSequentialRegions(body));
 
         foreach (var branch in graph.End.Incoming)
         {
@@ -193,6 +196,36 @@ public sealed class ControlFlowGraph
             default:
                 return statement.Kind == BoundNodeKind.ReturnStatement
                     || statement.Kind == BoundNodeKind.ThrowStatement;
+        }
+    }
+
+    private static BoundBlockStatement ExpandSequentialRegions(BoundStatement statement)
+    {
+        var builder = System.Collections.Immutable.ImmutableArray.CreateBuilder<BoundStatement>();
+        Add(statement);
+        return new BoundBlockStatement(null, builder.ToImmutable());
+
+        void Add(BoundStatement current)
+        {
+            switch (current)
+            {
+                case BoundBlockStatement block:
+                    foreach (var nested in block.Statements)
+                    {
+                        Add(nested);
+                    }
+
+                    break;
+                case BoundFixedStatement fixedStatement:
+                    Add(fixedStatement.Body);
+                    break;
+                case BoundScopeStatement scopeStatement:
+                    Add(scopeStatement.Body);
+                    break;
+                default:
+                    builder.Add(current);
+                    break;
+            }
         }
     }
 
@@ -343,6 +376,7 @@ public sealed class ControlFlowGraph
                     case BoundNodeKind.GotoStatement:
                     case BoundNodeKind.ConditionalGotoStatement:
                     case BoundNodeKind.ReturnStatement:
+                    case BoundNodeKind.ThrowStatement:
                         statements.Add(statement);
                         StartBlock();
                         break;
@@ -362,7 +396,6 @@ public sealed class ControlFlowGraph
 
                         break;
                     case BoundNodeKind.TryStatement:
-                    case BoundNodeKind.ThrowStatement:
                     case BoundNodeKind.GoStatement:
                     case BoundNodeKind.ChannelSendStatement:
                     case BoundNodeKind.SelectStatement:

--- a/test/Compiler.Tests/Emit/Issue2883FixedEscapingBranchEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2883FixedEscapingBranchEmitTests.cs
@@ -1,0 +1,198 @@
+// <copyright file="Issue2883FixedEscapingBranchEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2883: escaping branches inside <c>fixed</c> bodies must remain
+/// visible to definite-return analysis without changing fixed emission.
+/// </summary>
+public class Issue2883FixedEscapingBranchEmitTests
+{
+    private static readonly string[] FixedIlVerifyIgnored =
+    {
+        "Unverifiable",
+        "UnmanagedPointer",
+        "StackUnexpected",
+        "StackByRef",
+        "ExpectedPtr",
+        "StackUnexpectedArrayType",
+        "ExpectedNumericType",
+    };
+
+    [Fact]
+    public void BreakOutOfFixed_WithReturnAfterLoop_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2883.BreakReturn
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    for {
+                        fixed p *int32 = xs {
+                            break
+                        }
+                    }
+                }
+                return 7
+            }
+
+            public var result = F([]int32{1})
+            """;
+
+        var assembly = CompileAndRun(Source);
+
+        Assert.Equal(7, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void BreakOutOfNestedFixed_WithReturnAfterLoop_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2883.NestedBreakReturn
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    for {
+                        fixed p *int32 = xs {
+                            fixed q *int32 = xs {
+                                break
+                            }
+                        }
+                    }
+                }
+                return 8
+            }
+
+            public var result = F([]int32{1})
+            """;
+
+        var assembly = CompileAndRun(Source);
+
+        Assert.Equal(8, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void ContinueOutOfFixed_SkipsFollowingReturnAndRuns()
+    {
+        const string Source = """
+            package Issue2883.ContinueReturn
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    for var i = 0; i < 2; i++ {
+                        fixed p *int32 = xs {
+                            continue
+                        }
+                        return -1
+                    }
+                }
+                return 9
+            }
+
+            public var result = F([]int32{1})
+            """;
+
+        var assembly = CompileAndRun(Source);
+
+        Assert.Equal(9, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void GotoOutOfFixed_ToReturningLabel_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2883.GotoReturn
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    fixed p *int32 = xs {
+                        goto done
+                    }
+                }
+                return -1
+            done:
+                return 10
+            }
+
+            public var result = F([]int32{1})
+            """;
+
+        var assembly = CompileAndRun(Source);
+
+        Assert.Equal(10, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void BreakOutOfScope_WithReturnAfterLoop_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2883.ScopeBreakReturn
+
+            func F() int32 {
+                for {
+                    scope {
+                        break
+                    }
+                }
+                return 11
+            }
+
+            public var result = F()
+            """;
+
+        var assembly = CompileAndRun(Source, fixedBody: false);
+
+        Assert.Equal(11, GetField(assembly, "result"));
+    }
+
+    private static Assembly CompileAndRun(string source, bool fixedBody = true)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            string.Join(Environment.NewLine, result.Diagnostics.Select(diagnostic => diagnostic.ToString())));
+
+        var assemblyPath = Path.Combine(
+            Directory.GetCurrentDirectory(),
+            $"Issue2883_{Guid.NewGuid():N}.dll");
+        try
+        {
+            File.WriteAllBytes(assemblyPath, peStream.ToArray());
+            IlVerifier.Verify(
+                assemblyPath,
+                additionalReferences: null,
+                ignoredErrorCodes: fixedBody ? FixedIlVerifyIgnored : null);
+        }
+        finally
+        {
+            File.Delete(assemblyPath);
+        }
+
+        var assembly = Assembly.Load(peStream.ToArray());
+        var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+        return assembly;
+    }
+
+    private static int GetField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+        return (int)program.GetField(name, BindingFlags.Public | BindingFlags.Static)!.GetValue(null)!;
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2883FixedEscapingBranchEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2883FixedEscapingBranchEmitTests.cs
@@ -15,7 +15,9 @@ namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>
 /// Issue #2883: escaping branches inside <c>fixed</c> bodies must remain
-/// visible to definite-return analysis without changing fixed emission.
+/// visible to definite-return analysis without changing fixed emission. The
+/// negative test is the load-bearing regression; runtime tests guard against
+/// projection over-fire and emission changes.
 /// </summary>
 public class Issue2883FixedEscapingBranchEmitTests
 {
@@ -29,6 +31,32 @@ public class Issue2883FixedEscapingBranchEmitTests
         "StackUnexpectedArrayType",
         "ExpectedNumericType",
     };
+
+    [Fact]
+    public void BreakOutOfFixed_WithoutReturn_ReportsGs0100AndEmitsNothing()
+    {
+        const string Source = """
+            package Issue2883.Break
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    for {
+                        fixed p *int32 = xs {
+                            break
+                        }
+                    }
+                }
+            }
+            """;
+
+        using var peStream = new MemoryStream();
+        var result = Compile(Source, peStream);
+        var diagnostic = Assert.Single(result.Diagnostics);
+
+        Assert.False(result.Success);
+        Assert.Equal("GS0100", diagnostic.Id);
+        Assert.Equal(0, peStream.Length);
+    }
 
     [Fact]
     public void BreakOutOfFixed_WithReturnAfterLoop_VerifiesAndRuns()
@@ -159,9 +187,7 @@ public class Issue2883FixedEscapingBranchEmitTests
     private static Assembly CompileAndRun(string source, bool fixedBody = true)
     {
         using var peStream = new MemoryStream();
-        var tree = SyntaxTree.Parse(SourceText.From(source));
-        var compilation = new Compilation(tree);
-        var result = compilation.Emit(peStream);
+        var result = Compile(source, peStream);
 
         Assert.True(
             result.Success,
@@ -188,6 +214,13 @@ public class Issue2883FixedEscapingBranchEmitTests
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
         entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
         return assembly;
+    }
+
+    private static EmitResult Compile(string source, Stream peStream)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Emit(peStream);
     }
 
     private static int GetField(Assembly assembly, string name)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2883FixedEscapingBranchFlowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2883FixedEscapingBranchFlowTests.cs
@@ -1,0 +1,205 @@
+// <copyright file="Issue2883FixedEscapingBranchFlowTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2883: definite-return analysis must see branches that escape a
+/// structured <c>fixed</c> or <c>scope</c> body.
+/// </summary>
+public class Issue2883FixedEscapingBranchFlowTests
+{
+    [Fact]
+    public void BreakOutOfFixed_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2883.Break
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    for {
+                        fixed p *int32 = xs {
+                            break
+                        }
+                    }
+                }
+            }
+            """;
+
+        AssertGs0100(Source);
+    }
+
+    [Fact]
+    public void BreakOutOfNestedFixed_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2883.NestedBreak
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    for {
+                        fixed p *int32 = xs {
+                            fixed q *int32 = xs {
+                                break
+                            }
+                        }
+                    }
+                }
+            }
+            """;
+
+        AssertGs0100(Source);
+    }
+
+    [Fact]
+    public void LabeledBreakOutOfFixed_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2883.LabeledBreak
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    outer: for {
+                        for {
+                            fixed p *int32 = xs {
+                                break outer
+                            }
+                        }
+                    }
+                }
+            }
+            """;
+
+        AssertGs0100(Source);
+    }
+
+    [Fact]
+    public void GotoOutOfFixed_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2883.Goto
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    fixed p *int32 = xs {
+                        goto done
+                    }
+                }
+                return 1
+            done:
+                var reached = true
+            }
+            """;
+
+        AssertGs0100(Source);
+    }
+
+    [Fact]
+    public void ContinueOutOfFixed_PreservesInfiniteLoop()
+    {
+        const string Source = """
+            package Issue2883.Continue
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    for {
+                        fixed p *int32 = xs {
+                            continue
+                        }
+                        break
+                    }
+                }
+            }
+            """;
+
+        AssertNoGs0100(Source);
+    }
+
+    [Fact]
+    public void LabeledContinueOutOfFixed_PreservesInfiniteLoop()
+    {
+        const string Source = """
+            package Issue2883.LabeledContinue
+
+            func F(xs []int32) int32 {
+                unsafe {
+                    outer: for {
+                        for {
+                            fixed p *int32 = xs {
+                                continue outer
+                            }
+                            break outer
+                        }
+                    }
+                }
+            }
+            """;
+
+        AssertNoGs0100(Source);
+    }
+
+    [Fact]
+    public void BreakOutOfScope_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2883.ScopeBreak
+
+            func F() int32 {
+                for {
+                    scope {
+                        break
+                    }
+                }
+            }
+            """;
+
+        AssertGs0100(Source);
+    }
+
+    [Fact]
+    public void GotoOutOfScope_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2883.ScopeGoto
+
+            func F() int32 {
+                scope {
+                    goto done
+                }
+                return 1
+            done:
+                var reached = true
+            }
+            """;
+
+        AssertGs0100(Source);
+    }
+
+    private static void AssertGs0100(string source)
+    {
+        var diagnostics = Compile(source);
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0100");
+    }
+
+    private static void AssertNoGs0100(string source)
+    {
+        var diagnostics = Compile(source);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == "GS0100");
+    }
+
+    private static System.Collections.Immutable.ImmutableArray<Diagnostic> Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        return compilation.Emit(peStream).Diagnostics;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2883FixedEscapingBranchFlowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2883FixedEscapingBranchFlowTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.IO;
+using System.Linq;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
@@ -186,13 +187,15 @@ public class Issue2883FixedEscapingBranchFlowTests
     private static void AssertGs0100(string source)
     {
         var diagnostics = Compile(source);
-        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0100");
+        var diagnostic = Assert.Single(diagnostics.Where(candidate => candidate.IsError));
+        Assert.Equal("GS0100", diagnostic.Id);
+        Assert.Equal("F", diagnostic.Location.Text.ToString(diagnostic.Location.Span));
     }
 
     private static void AssertNoGs0100(string source)
     {
         var diagnostics = Compile(source);
-        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == "GS0100");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
     }
 
     private static System.Collections.Immutable.ImmutableArray<Diagnostic> Compile(string source)


### PR DESCRIPTION
## Summary

- project `fixed` and `scope` bodies into a definite-return-only CFG view so escaping branches can resolve enclosing labels
- leave the lowered structured nodes unchanged for emission and other data-flow consumers
- cover break, nested/labeled break, continue, labeled continue, goto, scope siblings, diagnostic-only emission, IL verification, and runtime behavior

## Root cause and approach

`Lowerer.Flatten` deliberately keeps each `BoundFixedStatement` as a structured node while flattening only its body. `MethodBodyEmitter.EmitFixedStatement` needs that node to emit the pin prologue, body, and normal-fallthrough release epilogue. Flattening the fixed statement itself would discard that structure.

The enclosing definite-return `ControlFlowGraph`, however, treated the structured node as opaque. Gotos lowered inside its nested body therefore could not see labels outside the fixed region, including an enclosing loop's break/continue labels. This made definite-return analysis miss valid loop-exit edges and also misclassify continue-only infinite loops.

The fix leaves lowering and emission unchanged. `AllPathsReturn` builds a private sequential projection that expands only `fixed` and `scope` bodies, which each execute once in normal control flow. The public/shared `Create(body)` path remains unchanged, so `RefKindDefiniteAssignmentAnalyzer`, `RefStructAsyncLivenessAnalyzer`, and other CFG consumers still receive the original opaque structured nodes.

`scope` still performs its task join and failure rethrow during emission; those runtime mechanics do not add a normal fallthrough alternative. `fixed` still releases its pin on normal fallthrough. Escaping branches currently skip that release epilogue; that pre-existing over-pinning defect is tracked separately in #2900 and is not claimed as fixed here.

## Review correction

The first revision also split basic blocks at every `throw`. That hunk was unrelated to #2883 and was removed after review: the shared CFG then peeled statements after a throw, causing `RefKindDefiniteAssignmentAnalyzer` to report GS0238 for previously legal out-parameter code. The useful throw-plus-dead-code GS0100 improvement and its required data-flow work are tracked in #2899.

## Sibling investigation

- `continue` and labeled `continue` inside `fixed` had the inverse symptom: genuine infinite loops incorrectly reported GS0100. Covered here.
- `goto`, labeled break, nested fixed, and the same escaping branches through `scope` share the sequential-region cause. Covered here.
- Pattern `switch` and `select` arms are alternatives, so sequential projection would be unsound. Filed #2890.
- `try`/`catch`/`finally` needs exception-region-aware CFG modeling. Filed #2891.
- Fixed escape paths skip their pin-release epilogue. Filed #2900.
- Throw plus dead code needs a definite-return fix coordinated with out-parameter analysis. Filed #2899.
- `go`, channel-send, await-for-range, and yield do not expose a synchronously executed nested statement body in the post-lowering definite-return graph.

## Coverage

Load-bearing Core regressions assert:

- break from fixed without a following return reports GS0100
- nested and labeled break preserve the loop-exit edge
- goto outside fixed reports GS0100 when its target falls through
- continue and labeled continue preserve genuine infinite-loop definite return
- break/goto through scope receive the same treatment
- GS0100 is the sole error and is anchored at the function identifier

Load-bearing Compiler regression asserts the original no-return repro reports GS0100 and writes zero PE bytes.

Five additional Compiler tests are over-fire/codegen guards, not root-fix detectors. They assert valid break, nested break, continue, goto, and scope forms still compile, ILVerify, and run correctly.

Existing #2843 terminal-fixed and #2283 trailing-ret tests remain green.

## Validation

- Targeted Core: `dotnet test test/Core.Tests/Core.Tests.csproj -c Debug --no-restore --nologo --filter 'FullyQualifiedName~Issue2883FixedEscapingBranchFlowTests'` — 8 passed, 0 failed
- Targeted Compiler plus #2843/#2283 guards: `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Debug --no-restore --nologo --filter 'FullyQualifiedName~Issue2883FixedEscapingBranchEmitTests|FullyQualifiedName~Issue2843FixedDefiniteReturnEmitTests|FullyQualifiedName~Issue2283SwitchAllTerminalArmsEmitTests'` — 19 passed, 0 failed
- Full Compiler.Tests: `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Debug --no-restore --nologo --blame-hang-timeout 5m --blame-hang-dump-type none` — 3,657 passed, 0 failed
- Full Core.Tests: `dotnet test test/Core.Tests/Core.Tests.csproj -c Debug --no-restore --nologo` — 6,850 passed, 0 failed, 1 skipped
- Load-bearing check with only the projection disabled: all 8 Core regressions failed; the new Compiler no-return test failed while all 5 over-fire/codegen guards passed; all passed again after restoration
- GS0238 blocker probe after removing the throw hunk: gsc exits 0 and emits the library
- Byte comparison: 148/148 assemblies byte-identical between the projection-disabled compiler and the final compiler (139 sample compilations plus 9 dedicated fixed/scope shapes)
- Original CLI repro after fix: gsc exits 1 with GS0100 and emits no assembly
- Valid return-after-loop CLI control: gsc exits 0, ILVerify exits 0, runtime prints `7` and exits 0

Fixes #2883
