### PR TITLE
Fix structural function arguments to generic delegates

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
@@ -1553,10 +1553,19 @@ internal sealed partial class OverloadResolver
             // method call-argument path, the one that reproduces the issue's
             // exact repro (`Apply((n int32) -> ...)` against a `func
             // Apply(h TickHandler)` parameter).
-            if (expectedType is DelegateTypeSymbol namedDelegateCallTarget
-                && argument.Type is FunctionTypeSymbol
-                && !(substitution != null && TypeSymbol.ContainsTypeParameter(parameter.Type))
-                && !ReferenceEquals(argument.Type, namedDelegateCallTarget))
+            // Issue #2850: strip reference nullability on both sides and use
+            // the substituted target, whether it is closed at this call site
+            // or remains open during generic forwarding. A direct generic
+            // free-function call must materialize the structural value as the
+            // nominal delegate just like the instance/static method paths do.
+            var nominalDelegateCallTarget = expectedType is NullableTypeSymbol nullableDelegateTarget
+                ? nullableDelegateTarget.UnderlyingType
+                : expectedType;
+            var structuralArgumentType = argument.Type is NullableTypeSymbol nullableFunctionArgument
+                ? nullableFunctionArgument.UnderlyingType
+                : argument.Type;
+            if (nominalDelegateCallTarget is DelegateTypeSymbol
+                && structuralArgumentType is FunctionTypeSymbol)
             {
                 var namedDelegateLoc = i < parameterSyntax.Length ? parameterSyntax[i].Location : syntax.Identifier.Location;
                 boundArguments[i] = conversions.BindConversion(namedDelegateLoc, argument, expectedType);

--- a/test/Compiler.Tests/Emit/Issue2840NullableFunctionToDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2840NullableFunctionToDelegateEmitTests.cs
@@ -274,6 +274,42 @@ public class Issue2840NullableFunctionToDelegateEmitTests
     }
 
     [Fact]
+    public void EndToEnd_StaticGenericFunction_NullableDelegateParameter_Runs()
+    {
+        const string source = """
+            package i2840staticgeneric
+            import System
+
+            interface ICanc {
+                prop IsCancelled bool { get }
+            }
+
+            type Conv[T ICanc] = delegate func(book int32, ctx T, cb (string) -> void) void
+
+            class Cancel : ICanc {
+                prop IsCancelled bool -> false
+            }
+
+            func Do[T ICanc](ctx T, convertAction Conv[T]?) {
+                if convertAction != nil {
+                    convertAction(4, ctx, (s string) -> System.Console.WriteLine(s))
+                }
+            }
+
+            func Main() {
+                var ca ((int32, Cancel, (string) -> void) -> void)? = nil
+                ca = (book int32, ctx Cancel, onState (string) -> void) -> {
+                    onState("sg")
+                }
+                Do(Cancel(), ca)
+                System.Console.WriteLine("done")
+            }
+            """;
+
+        Assert.Equal("sg\ndone\n", CompileAndRun(source));
+    }
+
+    [Fact]
     public void EndToEnd_NonNullableStructuralFunctionToDelegate_StillRuns()
     {
         // Control: the non-nullable direction that always worked.

--- a/test/Compiler.Tests/Emit/Issue2850StructuralFunctionToGenericDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2850StructuralFunctionToGenericDelegateEmitTests.cs
@@ -1,0 +1,279 @@
+// <copyright file="Issue2850StructuralFunctionToGenericDelegateEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2850 — direct calls to generic free functions skipped the conversion
+/// from a structural function value to a substituted nominal delegate parameter.
+/// </summary>
+public class Issue2850StructuralFunctionToGenericDelegateEmitTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StructuralFunctionArgument_AllGenericDeclaringForms_VerifyAndRun(bool nullable)
+    {
+        var suffix = nullable ? "nullable" : "nonnullable";
+        var parameterType = nullable ? "Conv[T]?" : "Conv[T]";
+        var nilCalls = nullable
+            ? """
+                genericJob.Do(Cancel(), nil)
+                methodJob.Do(Cancel(), nil)
+                DoStatic(Cancel(), nil)
+                """
+            : string.Empty;
+
+        var source = $$"""
+            package i2850{{suffix}}
+            import System
+
+            interface ICanc { prop IsCancelled bool { get } }
+
+            type Conv[T ICanc] = delegate func(book int32, ctx T, cb (string) -> void) void
+
+            class Cancel : ICanc { prop IsCancelled bool -> false }
+
+            class GenericJob[T ICanc] {
+                func Do(ctx T, convertAction {{parameterType}}) {
+                    if convertAction != nil {
+                        convertAction(4, ctx, (s string) -> System.Console.WriteLine("generic-class:" + s))
+                    }
+                }
+            }
+
+            class MethodJob {
+                func Do[T ICanc](ctx T, convertAction {{parameterType}}) {
+                    if convertAction != nil {
+                        convertAction(4, ctx, (s string) -> System.Console.WriteLine("generic-method:" + s))
+                    }
+                }
+            }
+
+            func DoStatic[T ICanc](ctx T, convertAction {{parameterType}}) {
+                if convertAction != nil {
+                    convertAction(4, ctx, (s string) -> System.Console.WriteLine("static-function:" + s))
+                }
+            }
+
+            func Main() {
+                let genericJob = GenericJob[Cancel]()
+                let methodJob = MethodJob()
+                let ca ((int32, Cancel, (string) -> void) -> void) =
+                    (book int32, ctx Cancel, onState (string) -> void) -> {
+                        onState("{{suffix}}")
+                    }
+                genericJob.Do(Cancel(), ca)
+                methodJob.Do(Cancel(), ca)
+                DoStatic(Cancel(), ca)
+                {{nilCalls}}
+                System.Console.WriteLine("done")
+            }
+            """;
+
+        Assert.Equal(
+            "generic-class:" + suffix + "\n"
+            + "generic-method:" + suffix + "\n"
+            + "static-function:" + suffix + "\n"
+            + "done\n",
+            CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GenericFreeFunction_ForwardsOpenStructuralFunctionToOpenNamedDelegate_VerifiesAndRuns()
+    {
+        const string source = """
+            package i2850forward
+            import System
+
+            interface ICanc { prop IsCancelled bool { get } }
+
+            type Conv[T ICanc] = delegate func(book int32, ctx T, cb (string) -> void) void
+
+            class Cancel : ICanc { prop IsCancelled bool -> false }
+
+            func Inner[T ICanc](ctx T, convertAction Conv[T]?) {
+                if convertAction != nil {
+                    convertAction(4, ctx, (s string) -> System.Console.WriteLine("inner:" + s))
+                }
+            }
+
+            func Outer[T ICanc](ctx T, f ((int32, T, (string) -> void) -> void)) {
+                Inner(ctx, f)
+            }
+
+            func Main() {
+                let f ((int32, Cancel, (string) -> void) -> void) =
+                    (book int32, ctx Cancel, onState (string) -> void) -> {
+                        onState("fwd")
+                    }
+                Outer(Cancel(), f)
+                System.Console.WriteLine("done")
+            }
+            """;
+
+        Assert.Equal("inner:fwd\ndone\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableStructuralFunction_ToNonNullableGenericNamedDelegate_ReportsGS0155()
+    {
+        const string source = """
+            package i2850nullabletononnullable
+            import System
+
+            interface ICanc { prop IsCancelled bool { get } }
+
+            type Conv[T ICanc] = delegate func(book int32, ctx T, cb (string) -> void) void
+
+            class Cancel : ICanc { prop IsCancelled bool -> false }
+
+            func Do[T ICanc](ctx T, convertAction Conv[T]) {
+            }
+
+            func Main() {
+                var ca ((int32, Cancel, (string) -> void) -> void)? = nil
+                Do(Cancel(), ca)
+            }
+            """;
+
+        var diagnostics = CompileExpectingFailure(source);
+        Assert.Contains("GS0155", diagnostics, StringComparison.Ordinal);
+        Assert.DoesNotContain("GS9998", diagnostics, StringComparison.Ordinal);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2850_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            Compile(new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void Compile(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static string CompileExpectingFailure(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2850_error_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + dllPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            var diagnostics = stdoutWriter.ToString() + stderrWriter.ToString();
+            Assert.True(
+                compileExit != 0,
+                $"expected gsc to reject nullable structural function to non-nullable delegate:\n{diagnostics}");
+            return diagnostics;
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2850.

## Root cause

The direct generic free-function call path guarded named-delegate argument materialization using the unsubstituted parameter type. Because `Conv<T>` contained a type parameter, that path skipped `BindConversion` even after inference produced the effective call-site target. It also missed nullable structural sources and nullable nominal targets. Instance and static method paths already convert these arguments.

The same asymmetry applied when one generic free function forwarded an open structural function value to another generic free function: the substituted target remained `Conv<T>`, so a closed-target guard still skipped conversion and emitted the same invalid stack type.

## Fix

Keep the fix in call argument binding: unwrap reference nullability on the structural source and nominal target, recognize the nominal delegate target after substitution, and route the structural value through `BindConversion`. This inserts the required `BoundConversionExpression`; emitter behavior remains unchanged.

The final form deliberately has no `ContainsTypeParameter(expectedType)` guard. Open `Conv<T>` forwarding needs the same conversion as closed `Conv<Cancel>` calls, and removing that conjunct is both smaller and complete. Full tests, 11 focused probes from review, and the sample corpus found no over-firing.

## Source compatibility

This also makes nullable structural function values passed to non-nullable generic named-delegate parameters report `GS0155`. Main previously accepted that source but emitted invalid IL; the equivalent generic-class and generic-method forms already rejected it. A negative regression test now pins this intentional source-breaking correction.

## Coverage

- All three declaring forms: instance method on a generic class, generic method on a non-generic class, and generic free function.
- Both `Conv<T>` and `Conv<T>?` parameters, with IL verification and runtime output assertions.
- Open generic free-function-to-free-function forwarding (`Conv<T>` remains open).
- Nullable structural source to non-nullable nominal target reports `GS0155` and not `GS9998`.
- Restored the static-generic-function row in the issue #2840 suite, including a nullable structural source.

## Verification

- Rebased onto current main `309a1ad8`.
- Targeted delegate tests: 18/18 passed.
- Revert sanity: all 5 added regression cases failed with the production change reverted (`5 failed, 8 pre-existing passed, 13 total`).
- `Compiler.Tests`: 3,676 passed, 0 failed.
- `Core.Tests`: 6,859 passed, 1 skipped, 0 failed.
- Sample corpus: 119/119 assemblies byte-identical to current main.
- Open forwarding verifies and prints `inner:fwd` then `done`.

Nothing deferred. No follow-up issues required.