### PR TITLE
Fix inline bare return parsing

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.Statements.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Statements.cs
@@ -1265,11 +1265,12 @@ public partial class Parser
         var keyword = MatchToken(SyntaxKind.ReturnKeyword);
         var keywordLine = syntaxTree.Text.GetLineIndex(keyword.Span.Start);
         var currentLine = syntaxTree.Text.GetLineIndex(Current.Span.Start);
-        var isEof = Current.Kind == SyntaxKind.EndOfFileToken;
-        var sameLine = !isEof && keywordLine == currentLine;
+        var hasExpression = Current.Kind != SyntaxKind.EndOfFileToken
+            && Current.Kind != SyntaxKind.CloseBraceToken
+            && keywordLine == currentLine;
         SyntaxToken refKeyword = null;
         ExpressionSyntax expression = null;
-        if (sameLine)
+        if (hasExpression)
         {
             // Issue #490 (ADR-0060 follow-up): optional `ref` contextual modifier directly
             // following `return` marks this as a ref-return: `return ref <lvalue>`. The

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue2855InlineBareReturnParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue2855InlineBareReturnParserTests.cs
@@ -1,0 +1,53 @@
+// <copyright file="Issue2855InlineBareReturnParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #2855: a closing brace on the same line terminates a bare
+/// <c>return</c>; it must not be parsed as the return expression.
+/// </summary>
+public class Issue2855InlineBareReturnParserTests
+{
+    private const string Source = """
+        package P
+
+        func Stop(value bool) {
+            if value { return }
+        }
+
+        Stop(true)
+        """;
+
+    [Fact]
+    public void SameLineCloseBrace_LeavesBareReturnExpressionNull()
+    {
+        var tree = SyntaxTree.Parse(Source);
+
+        Assert.Empty(tree.Diagnostics);
+        var function = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var ifStatement = Assert.IsType<IfStatementSyntax>(Assert.Single(function.Body.Statements));
+        var ifBody = Assert.IsType<BlockStatementSyntax>(ifStatement.ThenStatement);
+        var returnStatement = Assert.IsType<ReturnStatementSyntax>(Assert.Single(ifBody.Statements));
+        Assert.Null(returnStatement.Expression);
+    }
+
+    [Fact]
+    public void SameLineCloseBrace_DoesNotProduceReturnBindingDiagnostics()
+    {
+        var tree = SyntaxTree.Parse(Source);
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        var program = Binder.BindProgram(globalScope);
+
+        Assert.Empty(tree.Diagnostics);
+        Assert.Empty(globalScope.Diagnostics);
+        Assert.Empty(program.Diagnostics);
+    }
+}


### PR DESCRIPTION
## Summary
- treat a same-line closing brace as the terminator of a valueless `return`
- preserve the nullable return-expression shape through binding
- add parser and binder regressions for the reported one-line block

## Root cause
The lexer removes whitespace/newline tokens, so `ParseReturnStatement` uses source line positions to decide whether an expression follows `return`. It treated every non-EOF token on the same line as an expression start, including `}`. Expression recovery then synthesized a missing identifier (GS0005), and the binder saw that synthetic expression in a void function (GS0122).

## Validation
- `git show --check`
- LSP parsed both changed C# files and resolved their symbols
- local .NET build/tests not run, per issue-owner instruction

Fixes #2855