### PR TITLE
Fix numeric ellipsis loop variable capture

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BinderContext.cs
+++ b/src/Core/CodeAnalysis/Binding/BinderContext.cs
@@ -127,13 +127,20 @@ internal sealed class BinderContext
     /// the binder's root scope is created.</param>
     public BinderContext(BoundScope parent)
     {
-        RootScope = new BoundScope(parent);
+        InitialScope = new BoundScope(parent);
+        RootScope = InitialScope;
     }
 
     /// <summary>
     /// Gets the diagnostics bag for the binder this context backs.
     /// </summary>
     public DiagnosticBag Diagnostics { get; } = new DiagnosticBag();
+
+    /// <summary>
+    /// Gets the binder's initial scope. Unlike <see cref="RootScope"/>, this
+    /// remains stable while nested statement binding pushes child scopes.
+    /// </summary>
+    public BoundScope InitialScope { get; }
 
     /// <summary>
     /// Gets the reference resolver associated with the binder's scope chain.

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -2496,12 +2496,11 @@ internal sealed partial class DeclarationBinder
         var name = identifier.Text ?? "?";
         var declare = !identifier.IsMissing;
 
-        // ADR-0066 D1: variables declared inside top-level statements live on
-        // `BoundGlobalScope.Variables` as `GlobalVariableSymbol`s even though
-        // the enclosing synthesized `<Main>$` is a non-null function (so that
-        // `return` / `await` validation works). Treat the synthesized entry
-        // point as a top-level context for variable-creation purposes only.
-        var inTopLevelContext = function == null || function.IsTopLevelEntryPoint;
+        // Direct top-level declarations become global fields. Variables in a
+        // nested TLS scope (loops, catches, blocks, etc.) remain method locals;
+        // they are not republished into BoundGlobalScope.Variables.
+        var inTopLevelContext = function == null
+            || (function.IsTopLevelEntryPoint && ReferenceEquals(scope, binderCtx.InitialScope));
         var variable = inTopLevelContext
                             ? (VariableSymbol)new GlobalVariableSymbol(name, isReadOnly, type, accessibility, declaringSyntax: identifier)
                             : new LocalVariableSymbol(name, isReadOnly, type, declaringSyntax: identifier);

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -311,6 +311,11 @@ public class Compilation
             return new EvaluationResult(allWarnings.Concat(allErrors).ToImmutableArray(), null);
         }
 
+        // Keep interpreted closure cells aligned with emitted closure cells.
+        program = Lowering.CaptureBoxingRewriter.Lower(
+            program,
+            (References ?? Symbols.ReferenceResolver.Default()).MapClrTypeToReferences);
+
         var evaluator = new Evaluator(program, variables);
         try
         {

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -312,6 +312,8 @@ public class Compilation
         }
 
         // Keep interpreted closure cells aligned with emitted closure cells.
+        // Evaluation consumes expression receivers directly and exactly once,
+        // so it does not need the emit-only side-effect spiller first.
         program = Lowering.CaptureBoxingRewriter.Lower(
             program,
             (References ?? Symbols.ReferenceResolver.Default()).MapClrTypeToReferences);
@@ -404,9 +406,9 @@ public class Compilation
 
         // Issue #523: hoist captured locals/parameters into per-variable
         // box classes so function literals see writes to the variable cell
-        // (Go/C# closure semantics). Must run after side-effect spilling
-        // and before the async / iterator state-machine lowerers so they
-        // see the boxed captures rather than the snapshot-by-value pattern.
+        // (Go/C# closure semantics). On the emit path, this must run after
+        // side-effect spilling and before the async / iterator state-machine
+        // lowerers so they see boxed captures rather than snapshots.
         // Issue #2037: thread the MLC cross-reflection-context projector so
         // box classes hoisting an imported constructed generic over an
         // enclosing type parameter don't erase it under cs2gs.

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -86,49 +86,43 @@ public sealed partial class Evaluator
                 }
             }
 
+            var statement = program.Functions[node.Function];
+            var isIterator = IsIteratorFunction(node.Function, statement);
+            object result;
             using (PushFrame(locals))
             {
-                var statement = program.Functions[node.Function];
-
-                if (IsIteratorFunction(node.Function, statement))
+                if (isIterator)
                 {
-                    return EvaluateIteratorFunction(node.Function, statement);
+                    result = EvaluateIteratorFunction(node.Function, statement);
                 }
-
-                var result = EvaluateFunctionBody(statement);
-
-                // ADR-0060 item #7: write the final parameter slot value back to
-                // the caller's lvalue for every 'ref'/'out' parameter.
-                if (userRefSlots != null)
+                else
                 {
-                    foreach (var (parameter, operand) in userRefSlots)
-                    {
-                        var finalValue = locals.TryGetValue(parameter, out var v) ? v : null;
-                        switch (operand)
-                        {
-                            case BoundVariableExpression bve:
-                                Assign(bve.Variable, finalValue);
-                                break;
-                            case BoundFieldAccessExpression fa:
-                                WriteBackField(fa, finalValue);
-                                break;
-                            case BoundPropertyAccessExpression pa:
-                                WriteBackProperty(pa, finalValue);
-                                break;
-                            case BoundIndexExpression idx:
-                                WriteBackIndex(idx, finalValue);
-                                break;
-                        }
-                    }
+                    result = EvaluateFunctionBody(statement);
                 }
+            }
 
-                if (node.Function.IsAsync)
+            // ADR-0060 item #7: write the final parameter slot value back to
+            // the caller's lvalue after restoring the caller's frame.
+            if (userRefSlots != null)
+            {
+                foreach (var (parameter, operand) in userRefSlots)
                 {
-                    return WrapAsyncResult(node.Function.Type, result);
+                    var finalValue = locals.TryGetValue(parameter, out var v) ? v : null;
+                    WriteBackToOperand(operand, finalValue);
                 }
+            }
 
+            if (isIterator)
+            {
                 return result;
             }
+
+            if (node.Function.IsAsync)
+            {
+                return WrapAsyncResult(node.Function.Type, result);
+            }
+
+            return result;
         }
     }
 

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -505,12 +505,15 @@ public sealed partial class Evaluator
 
     private object EvaluateIndexAssignmentExpression(BoundIndexAssignmentExpression node)
     {
-        var targetValue = node.Target.Kind == Symbols.SymbolKind.GlobalVariable
-            ? GetGlobal(node.Target)
-            : Locals.Peek()[node.Target];
+        var targetValue = node.TargetExpression != null
+            ? EvaluateExpression(node.TargetExpression)
+            : node.Target.Kind == Symbols.SymbolKind.GlobalVariable
+                ? GetGlobal(node.Target)
+                : Locals.Peek()[node.Target];
+        var targetType = node.TargetExpression?.Type ?? node.Target.Type;
 
         // Phase 3.A.4: map indexed assignment `m[k] = v`.
-        if (node.Target.Type is MapTypeSymbol && targetValue is System.Collections.IDictionary dict)
+        if (targetType is MapTypeSymbol && targetValue is System.Collections.IDictionary dict)
         {
             var key = EvaluateExpression(node.Index);
             var value = EvaluateExpression(node.Value);
@@ -1505,9 +1508,11 @@ public sealed partial class Evaluator
 
     private object EvaluateClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
     {
-        var target = node.Target.Kind == Symbols.SymbolKind.GlobalVariable
-            ? GetGlobal(node.Target)
-            : Locals.Peek()[node.Target];
+        var target = node.TargetExpression != null
+            ? EvaluateExpression(node.TargetExpression)
+            : node.Target.Kind == Symbols.SymbolKind.GlobalVariable
+                ? GetGlobal(node.Target)
+                : Locals.Peek()[node.Target];
 
         var args = new object[node.Arguments.Length];
         for (var i = 0; i < node.Arguments.Length; i++)
@@ -1567,7 +1572,7 @@ public sealed partial class Evaluator
     {
         // ADR-0053: static field assignment — receiver is null; store in the
         // static-field storage keyed by (StructType, Field).
-        if (node.Receiver == null)
+        if (node.Receiver == null && node.ReceiverExpression == null)
         {
             var value = EvaluateExpression(node.Value);
 
@@ -1583,9 +1588,11 @@ public sealed partial class Evaluator
             return value;
         }
 
-        var current = node.Receiver.Kind == Symbols.SymbolKind.GlobalVariable
-            ? GetGlobal(node.Receiver)
-            : Locals.Peek()[node.Receiver];
+        var current = node.ReceiverExpression != null
+            ? EvaluateExpression(node.ReceiverExpression)
+            : node.Receiver.Kind == Symbols.SymbolKind.GlobalVariable
+                ? GetGlobal(node.Receiver)
+                : Locals.Peek()[node.Receiver];
 
         var sv = current as StructValue ?? new StructValue(node.StructType);
 
@@ -1608,7 +1615,15 @@ public sealed partial class Evaluator
             var copy = sv.Copy();
             var value = EvaluateExpression(node.Value);
             copy.Fields[node.Field.Name] = value;
-            Assign(node.Receiver, copy);
+            if (node.ReceiverExpression != null)
+            {
+                WriteBackToOperand(node.ReceiverExpression, copy);
+            }
+            else
+            {
+                Assign(node.Receiver, copy);
+            }
+
             return value;
         }
     }

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -505,11 +505,7 @@ public sealed partial class Evaluator
 
     private object EvaluateIndexAssignmentExpression(BoundIndexAssignmentExpression node)
     {
-        var targetValue = node.TargetExpression != null
-            ? EvaluateExpression(node.TargetExpression)
-            : node.Target.Kind == Symbols.SymbolKind.GlobalVariable
-                ? GetGlobal(node.Target)
-                : Locals.Peek()[node.Target];
+        var targetValue = ResolveReceiverValue(node.TargetExpression, node.Target);
         var targetType = node.TargetExpression?.Type ?? node.Target.Type;
 
         // Phase 3.A.4: map indexed assignment `m[k] = v`.
@@ -1508,11 +1504,7 @@ public sealed partial class Evaluator
 
     private object EvaluateClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
     {
-        var target = node.TargetExpression != null
-            ? EvaluateExpression(node.TargetExpression)
-            : node.Target.Kind == Symbols.SymbolKind.GlobalVariable
-                ? GetGlobal(node.Target)
-                : Locals.Peek()[node.Target];
+        var target = ResolveReceiverValue(node.TargetExpression, node.Target);
 
         var args = new object[node.Arguments.Length];
         for (var i = 0; i < node.Arguments.Length; i++)
@@ -1588,11 +1580,7 @@ public sealed partial class Evaluator
             return value;
         }
 
-        var current = node.ReceiverExpression != null
-            ? EvaluateExpression(node.ReceiverExpression)
-            : node.Receiver.Kind == Symbols.SymbolKind.GlobalVariable
-                ? GetGlobal(node.Receiver)
-                : Locals.Peek()[node.Receiver];
+        var current = ResolveReceiverValue(node.ReceiverExpression, node.Receiver);
 
         var sv = current as StructValue ?? new StructValue(node.StructType);
 
@@ -1601,13 +1589,13 @@ public sealed partial class Evaluator
         // Go-style value semantics by writing to a copy.
         if (node.StructType.IsClass)
         {
-            var value = EvaluateExpression(node.Value);
-            sv.Fields[node.Field.Name] = value;
-            if (!ReferenceEquals(sv, current))
+            if (current == null)
             {
-                Assign(node.Receiver, sv);
+                throw new NullReferenceException();
             }
 
+            var value = EvaluateExpression(node.Value);
+            sv.Fields[node.Field.Name] = value;
             return value;
         }
         else
@@ -1626,6 +1614,18 @@ public sealed partial class Evaluator
 
             return value;
         }
+    }
+
+    private object ResolveReceiverValue(BoundExpression expression, VariableSymbol receiver)
+    {
+        if (expression != null)
+        {
+            return EvaluateExpression(expression);
+        }
+
+        return receiver.Kind == Symbols.SymbolKind.GlobalVariable
+            ? GetGlobal(receiver)
+            : Locals.Peek()[receiver];
     }
 
     private object EvaluatePropertyAccessExpression(BoundPropertyAccessExpression node)

--- a/src/Core/CodeAnalysis/Evaluator.Statements.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Statements.cs
@@ -63,6 +63,10 @@ public sealed partial class Evaluator
 
             switch (s.Kind)
             {
+                case BoundNodeKind.BlockStatement:
+                    EvaluateStatement((BoundBlockStatement)s);
+                    index++;
+                    break;
                 case BoundNodeKind.VariableDeclaration:
                     EvaluateVariableDeclaration((BoundVariableDeclaration)s);
                     index++;

--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -134,6 +134,14 @@ internal static class CaptureBoxingRewriter
             return program;
         }
 
+        var statement = program.Statement;
+        if (program.EntryPoint != null
+            && program.Functions.TryGetValue(program.EntryPoint, out var entryPointBody)
+            && ReferenceEquals(statement, entryPointBody))
+        {
+            statement = newFunctions[program.EntryPoint];
+        }
+
         var combinedStructs = program.Structs.AddRange(newStructs);
 
         var result = new BoundProgram(
@@ -142,7 +150,7 @@ internal static class CaptureBoxingRewriter
             program.Diagnostics,
             newFunctions.ToImmutable(),
             program.EntryPoint,
-            program.Statement,
+            statement,
             combinedStructs,
             program.Interfaces,
             program.Enums,

--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -158,6 +158,13 @@ internal static class CaptureBoxingRewriter
         return result;
     }
 
+    internal static bool IsCaptured(BoundStatement body, VariableSymbol variable)
+    {
+        var captured = new HashSet<VariableSymbol>();
+        CaptureWalker.Collect(body, captured);
+        return captured.Contains(variable);
+    }
+
     private static (BoundBlockStatement Body, Dictionary<FunctionSymbol, BoundBlockStatement> LambdaUpdates)
         RewriteFunctionBody(
         FunctionSymbol function,

--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -135,6 +135,9 @@ internal static class CaptureBoxingRewriter
         }
 
         var statement = program.Statement;
+
+        // Binder registers synthesized top-level statements as the same block
+        // instance in Statement and Functions[EntryPoint].
         if (program.EntryPoint != null
             && program.Functions.TryGetValue(program.EntryPoint, out var entryPointBody)
             && ReferenceEquals(statement, entryPointBody))

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -299,7 +299,11 @@ public sealed class Lowerer : BoundTreeRewriter
         //     gotoTrue ((step > 0 && lower < upper) || (step < 0 && lower > upper)) body
         //     break:
         // }
-        var variableDeclaration = new BoundVariableDeclaration(null, node.Variable, node.LowerBound);
+        var isCaptured = CaptureBoxingRewriter.IsCaptured(node.Body, node.Variable);
+        var controlVariable = isCaptured
+            ? new LocalVariableSymbol("$ellipsis", isReadOnly: false, type: TypeSymbol.Int32)
+            : node.Variable;
+        var variableDeclaration = new BoundVariableDeclaration(null, controlVariable, node.LowerBound);
         var upperBoundSymbol = new LocalVariableSymbol("upperBound", isReadOnly: true, type: TypeSymbol.Int32);
         var upperBoundDeclaration = new BoundVariableDeclaration(null, upperBoundSymbol, node.UpperBound);
         var stepBoundSymbol = new LocalVariableSymbol("step", isReadOnly: false, type: TypeSymbol.Int32);
@@ -307,7 +311,7 @@ public sealed class Lowerer : BoundTreeRewriter
             null,
             variable: stepBoundSymbol,
             initializer: new BoundLiteralExpression(null, 1));
-        var variableExpression = new BoundVariableExpression(null, node.Variable);
+        var variableExpression = new BoundVariableExpression(null, controlVariable);
         var upperBoundExpression = new BoundVariableExpression(null, upperBoundSymbol);
         var stepBoundExpression = new BoundVariableExpression(null, stepBoundSymbol);
         var ifLowerIsGreaterThanUpperExpression = new BoundBinaryExpression(
@@ -331,11 +335,22 @@ public sealed class Lowerer : BoundTreeRewriter
         var bodyLabel = GenerateLabel();
         var bodyLabelStatement = new BoundLabelStatement(null, bodyLabel);
         var continueLabelStatement = new BoundLabelStatement(null, node.ContinueLabel);
+        var iterationVariableDeclaration = isCaptured
+            ? new BoundVariableDeclaration(null, node.Variable, variableExpression)
+            : null;
+        var copyIterationVariableBack = isCaptured
+            ? new BoundExpressionStatement(
+                null,
+                new BoundAssignmentExpression(
+                    null,
+                    controlVariable,
+                    new BoundVariableExpression(null, node.Variable)))
+            : null;
         var increment = new BoundExpressionStatement(
             null,
             expression: new BoundAssignmentExpression(
                 null,
-                variable: node.Variable,
+                variable: controlVariable,
                 expression: new BoundBinaryExpression(
                     null,
                     left: variableExpression,
@@ -381,21 +396,31 @@ public sealed class Lowerer : BoundTreeRewriter
         var gotoTrue = new BoundConditionalGotoStatement(null, bodyLabel, condition, jumpIfTrue: true);
         var breakLabelStatement = new BoundLabelStatement(null, node.BreakLabel);
 
-        var result = new BoundBlockStatement(
-            null,
-            ImmutableArray.Create<BoundStatement>(
-            variableDeclaration,
-            upperBoundDeclaration,
-            stepBoundDeclaration,
-            ifLowerIsGreaterThanUpperIfStatement,
-            gotoStart,
-            bodyLabelStatement,
-            node.Body,
-            continueLabelStatement,
-            increment,
-            startLabelStatement,
-            gotoTrue,
-            breakLabelStatement));
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        statements.Add(variableDeclaration);
+        statements.Add(upperBoundDeclaration);
+        statements.Add(stepBoundDeclaration);
+        statements.Add(ifLowerIsGreaterThanUpperIfStatement);
+        statements.Add(gotoStart);
+        statements.Add(bodyLabelStatement);
+        if (iterationVariableDeclaration != null)
+        {
+            statements.Add(iterationVariableDeclaration);
+        }
+
+        statements.Add(node.Body);
+        statements.Add(continueLabelStatement);
+        if (copyIterationVariableBack != null)
+        {
+            statements.Add(copyIterationVariableBack);
+        }
+
+        statements.Add(increment);
+        statements.Add(startLabelStatement);
+        statements.Add(gotoTrue);
+        statements.Add(breakLabelStatement);
+
+        var result = new BoundBlockStatement(null, statements.ToImmutable());
         return RewriteStatement(result);
     }
 

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -301,7 +301,7 @@ public sealed class Lowerer : BoundTreeRewriter
         // }
         var isCaptured = CaptureBoxingRewriter.IsCaptured(node.Body, node.Variable);
         var controlVariable = isCaptured
-            ? new LocalVariableSymbol("$ellipsis", isReadOnly: false, type: TypeSymbol.Int32)
+            ? new LocalVariableSymbol("ellipsis", isReadOnly: false, type: TypeSymbol.Int32)
             : node.Variable;
         var variableDeclaration = new BoundVariableDeclaration(null, controlVariable, node.LowerBound);
         var upperBoundSymbol = new LocalVariableSymbol("upperBound", isReadOnly: true, type: TypeSymbol.Int32);

--- a/test/Compiler.Tests/Emit/Issue2329CatchCaptureBoxingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2329CatchCaptureBoxingEmitTests.cs
@@ -43,16 +43,12 @@ namespace GSharp.Compiler.Tests.Emit;
 /// ordinary slot via specialized emit dispatch, exactly like a catch clause.
 /// </para>
 /// <para>
-/// A <c>for i in a...b</c> loop variable was also audited: it is boxed
-/// correctly already, because the general <c>Lowerer</c> desugars it into an
-/// ordinary <c>var i = a</c> declaration (feeding the C-style counting loop)
-/// during binding, *before* <c>CaptureBoxingRewriter</c> runs — so the
-/// existing <c>RewriteVariableDeclaration</c> box path already covers it (and,
-/// matching C#'s <c>for</c> loop semantics, all closures over it correctly
-/// share one variable cell for the whole loop, not a fresh cell per
-/// iteration — a `for x in collection` foreach loop remains intentionally
-/// un-boxed, since its per-iteration-fresh variable already matches C#
-/// foreach semantics). An unsafe <c>fixed</c> pointer/pinned local capture was
+/// A <c>for i in a...b</c> loop variable is also declaration-backed before
+/// capture boxing. When captured, ellipsis lowering now separates the hidden
+/// counting variable from a fresh per-iteration <c>i</c> declaration, so the
+/// existing <c>RewriteVariableDeclaration</c> box path allocates one cell per
+/// iteration, matching G# collection <c>for-in</c> semantics. An unsafe
+/// <c>fixed</c> pointer/pinned local capture was
 /// also audited: rather than box a raw unmanaged pointer past the lifetime of
 /// its pin (unsafe — the pin is released when the enclosing <c>fixed</c>
 /// block exits), the fix rejects the escape at binding time with a dedicated

--- a/test/Compiler.Tests/Emit/Issue2853EllipsisLoopCaptureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2853EllipsisLoopCaptureTests.cs
@@ -3,9 +3,13 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using GSharp.Compiler;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -22,23 +26,85 @@ public class Issue2853EllipsisLoopCaptureTests
             package Issue2853
             import System
 
-            func Main() {
+            func capture() int32 {
                 var callback = () -> { return -1 }
 
                 for i in 0 ... 3 {
                     if i == 0 { callback = () -> { return i } }
                 }
 
-                Console.WriteLine(callback())
+                return callback()
             }
+
+            let result = capture()
+            Console.WriteLine(result)
+            result
             """;
 
-        Assert.Equal("0\n", CompileAndRun(Source));
+        AssertEnginesAgree(Source, expected: 0, nameof(ClosureCapturesValueFromCreatingIteration));
     }
 
-    private static string CompileAndRun(string source)
+    [Fact]
+    public void CapturedWriteAdvancesLoopControlVariable()
     {
-        var directory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2853EllipsisLoopCaptureTests));
+        const string Source = """
+            package Issue2853Write
+            import System
+
+            func countIterations() int32 {
+                var iterations = 0
+                for i in 0 ... 5 {
+                    var bump = () -> { i = i + 1 }
+                    bump()
+                    iterations = iterations + 1
+                }
+
+                return iterations
+            }
+
+            let result = countIterations()
+            Console.WriteLine(result)
+            result
+            """;
+
+        AssertEnginesAgree(Source, expected: 3, nameof(CapturedWriteAdvancesLoopControlVariable));
+    }
+
+    [Fact]
+    public void CapturedFunctionLocalWritesSharedCell()
+    {
+        const string Source = """
+            package Issue2853Write
+            import System
+
+            func mutate() int32 {
+                var value = 20
+                var bump = () -> { value = value + 1 }
+                bump()
+                return value
+            }
+
+            let result = mutate()
+            Console.WriteLine(result)
+            result
+            """;
+
+        AssertEnginesAgree(Source, expected: 21, nameof(CapturedFunctionLocalWritesSharedCell));
+    }
+
+    private static void AssertEnginesAgree(string source, int expected, string testName)
+    {
+        var evaluation = new Compilation(SyntaxTree.Parse(source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(evaluation.Diagnostics);
+        Assert.Equal(expected, evaluation.Value);
+        Assert.Equal($"{expected}\n", CompileAndRun(source, testName));
+    }
+
+    private static string CompileAndRun(string source, string testName)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2853EllipsisLoopCaptureTests), testName);
         Directory.CreateDirectory(directory);
         var sourcePath = Path.Combine(directory, "test.gs");
         var assemblyPath = Path.Combine(directory, "test.dll");

--- a/test/Compiler.Tests/Emit/Issue2853EllipsisLoopCaptureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2853EllipsisLoopCaptureTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 using GSharp.Compiler;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -195,8 +196,10 @@ public class Issue2853EllipsisLoopCaptureTests
 
     private static void AssertEnginesAgree(string source, int expected, string testName)
     {
-        var evaluation = new Compilation(SyntaxTree.Parse(source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var evaluationTask = Task.Run(() => new Compilation(SyntaxTree.Parse(source))
+            .Evaluate(new Dictionary<VariableSymbol, object>()));
+        Assert.True(evaluationTask.Wait(TimeSpan.FromSeconds(30)), "interpreter evaluation timed out");
+        var evaluation = evaluationTask.GetAwaiter().GetResult();
 
         Assert.Empty(evaluation.Diagnostics);
         Assert.Equal(expected, evaluation.Value);

--- a/test/Compiler.Tests/Emit/Issue2853EllipsisLoopCaptureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2853EllipsisLoopCaptureTests.cs
@@ -92,6 +92,107 @@ public class Issue2853EllipsisLoopCaptureTests
         AssertEnginesAgree(Source, expected: 21, nameof(CapturedFunctionLocalWritesSharedCell));
     }
 
+    [Fact]
+    public void CapturedIndexWritesUseExpressionTargets()
+    {
+        const string Source = """
+            package Issue2853CapturedIndexWrites
+            import System
+            import System.Collections.Generic
+
+            func mutate() int32 {
+                var slice = []int32{1}
+                var values = map[string,int32]{"x": 2}
+                var list = List[int32]()
+                list.Add(3)
+                var read = () -> { return slice[0] + values["x"] + list[0] }
+
+                slice[0] = 40
+                values["x"] = 50
+                list[0] = 60
+                return slice[0] + values["x"] + list[0] + read()
+            }
+
+            let result = mutate()
+            Console.WriteLine(result)
+            result
+            """;
+
+        AssertEnginesAgree(Source, expected: 300, nameof(CapturedIndexWritesUseExpressionTargets));
+    }
+
+    [Fact]
+    public void CapturedInstanceFieldWritesUseExpressionReceivers()
+    {
+        const string Source = """
+            package Issue2853CapturedFieldWrite
+            import System
+
+            class Counter {
+                var Value int32
+            }
+
+            struct Pair {
+                var Value int32
+            }
+
+            func mutate() int32 {
+                var counter = Counter()
+                counter.Value = 5
+                var readCounter = () -> { return counter.Value }
+
+                var pair = Pair{Value: 1}
+                var readPair = () -> { return pair.Value }
+                pair.Value = 6
+
+                return counter.Value + readCounter() + pair.Value + readPair()
+            }
+
+            let result = mutate()
+            Console.WriteLine(result)
+            result
+            """;
+
+        AssertEnginesAgree(Source, expected: 22, nameof(CapturedInstanceFieldWritesUseExpressionReceivers));
+    }
+
+    [Fact]
+    public void CapturedRefOutAndAliasWritesUseCallerCell()
+    {
+        const string Source = """
+            package Issue2853CapturedRefWrites
+            import System
+
+            func addOne(ref value int32) {
+                value = value + 1
+            }
+
+            func setSeven(out value int32) {
+                value = 7
+            }
+
+            func mutate() int32 {
+                var n = 1
+                var readN = () -> { return n }
+                let ref alias = n
+                alias = alias + 1
+                addOne(ref n)
+
+                var m = 0
+                var readM = () -> { return m }
+                setSeven(out m)
+
+                return n * 1000 + readN() * 100 + m * 10 + readM()
+            }
+
+            let result = mutate()
+            Console.WriteLine(result)
+            result
+            """;
+
+        AssertEnginesAgree(Source, expected: 3377, nameof(CapturedRefOutAndAliasWritesUseCallerCell));
+    }
+
     private static void AssertEnginesAgree(string source, int expected, string testName)
     {
         var evaluation = new Compilation(SyntaxTree.Parse(source))
@@ -149,9 +250,18 @@ public class Issue2853EllipsisLoopCaptureTests
             RedirectStandardError = true,
             UseShellExecute = false,
         });
-        var output = process.StandardOutput.ReadToEnd();
-        var error = process.StandardError.ReadToEnd();
-        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        var exited = process.WaitForExit(30_000);
+        if (!exited)
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+        }
+
+        Assert.True(exited, "dotnet exec timed out");
+        var output = outputTask.GetAwaiter().GetResult();
+        var error = errorTask.GetAwaiter().GetResult();
         Assert.True(process.ExitCode == 0, error);
         return output.Replace("\r\n", "\n");
     }

--- a/test/Compiler.Tests/Emit/Issue2853EllipsisLoopCaptureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2853EllipsisLoopCaptureTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="Issue2853EllipsisLoopCaptureTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2853: numeric ellipsis loop captures use a fresh variable cell per iteration.
+/// </summary>
+public class Issue2853EllipsisLoopCaptureTests
+{
+    [Fact]
+    public void ClosureCapturesValueFromCreatingIteration()
+    {
+        const string Source = """
+            package Issue2853
+            import System
+
+            func Main() {
+                var callback = () -> { return -1 }
+
+                for i in 0 ... 3 {
+                    if i == 0 { callback = () -> { return i } }
+                }
+
+                Console.WriteLine(callback())
+            }
+            """;
+
+        Assert.Equal("0\n", CompileAndRun(Source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2853EllipsisLoopCaptureTests));
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var assemblyPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousErr = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            Assert.True(exitCode == 0, $"gsc failed:\n{stdout}\n{stderr}");
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousErr);
+        }
+
+        IlVerifier.Verify(assemblyPath);
+
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                assemblyPath,
+            },
+            WorkingDirectory = directory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(process.ExitCode == 0, error);
+        return output.Replace("\r\n", "\n");
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2854TopLevelEllipsisLoopCaptureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2854TopLevelEllipsisLoopCaptureTests.cs
@@ -1,0 +1,91 @@
+// <copyright file="Issue2854TopLevelEllipsisLoopCaptureTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2854: top-level numeric ellipsis loop captures compile and run.
+/// </summary>
+public class Issue2854TopLevelEllipsisLoopCaptureTests
+{
+    [Fact]
+    public void TopLevelClosureCapturesIterationVariable()
+    {
+        const string Source = """
+            package Issue2854
+            import System
+
+            var callback = () -> { return -1 }
+
+            for i in 0 ... 1 {
+                callback = () -> { return i }
+            }
+
+            let result = callback()
+            Console.WriteLine(result)
+            """;
+
+        Assert.Equal("0\n", CompileAndRun(Source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2854TopLevelEllipsisLoopCaptureTests));
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var assemblyPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousErr = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            Assert.True(exitCode == 0, $"gsc failed:\n{stdout}\n{stderr}");
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousErr);
+        }
+
+        IlVerifier.Verify(assemblyPath);
+
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                assemblyPath,
+            },
+            WorkingDirectory = directory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(process.ExitCode == 0, error);
+        return output.Replace("\r\n", "\n");
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2854TopLevelEllipsisLoopCaptureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2854TopLevelEllipsisLoopCaptureTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 using GSharp.Compiler;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -65,8 +66,10 @@ public class Issue2854TopLevelEllipsisLoopCaptureTests
 
     private static void AssertEnginesAgree(string source, int expected, string testName)
     {
-        var evaluation = new Compilation(SyntaxTree.Parse(source))
-            .Evaluate(new Dictionary<VariableSymbol, object>());
+        var evaluationTask = Task.Run(() => new Compilation(SyntaxTree.Parse(source))
+            .Evaluate(new Dictionary<VariableSymbol, object>()));
+        Assert.True(evaluationTask.Wait(TimeSpan.FromSeconds(30)), "interpreter evaluation timed out");
+        var evaluation = evaluationTask.GetAwaiter().GetResult();
 
         Assert.Empty(evaluation.Diagnostics);
         Assert.Equal(expected, evaluation.Value);

--- a/test/Compiler.Tests/Emit/Issue2854TopLevelEllipsisLoopCaptureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2854TopLevelEllipsisLoopCaptureTests.cs
@@ -3,9 +3,13 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using GSharp.Compiler;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -30,14 +34,48 @@ public class Issue2854TopLevelEllipsisLoopCaptureTests
 
             let result = callback()
             Console.WriteLine(result)
+            result
             """;
 
-        Assert.Equal("0\n", CompileAndRun(Source));
+        AssertEnginesAgree(Source, expected: 0, nameof(TopLevelClosureCapturesIterationVariable));
     }
 
-    private static string CompileAndRun(string source)
+    [Fact]
+    public void TopLevelForInCapturedWriteUsesSharedCell()
     {
-        var directory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2854TopLevelEllipsisLoopCaptureTests));
+        const string Source = """
+            package Issue2854ForIn
+            import System
+
+            var source = []int32{7, 8}
+            var total = 0
+            for value in source {
+                var bump = () -> { value = value + 100 }
+                bump()
+                total = total + value
+            }
+
+            let result = total
+            Console.WriteLine(result)
+            result
+            """;
+
+        AssertEnginesAgree(Source, expected: 215, nameof(TopLevelForInCapturedWriteUsesSharedCell));
+    }
+
+    private static void AssertEnginesAgree(string source, int expected, string testName)
+    {
+        var evaluation = new Compilation(SyntaxTree.Parse(source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(evaluation.Diagnostics);
+        Assert.Equal(expected, evaluation.Value);
+        Assert.Equal($"{expected}\n", CompileAndRun(source, testName));
+    }
+
+    private static string CompileAndRun(string source, string testName)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2854TopLevelEllipsisLoopCaptureTests), testName);
         Directory.CreateDirectory(directory);
         var sourcePath = Path.Combine(directory, "test.gs");
         var assemblyPath = Path.Combine(directory, "test.dll");

--- a/test/Compiler.Tests/Emit/Issue2854TopLevelEllipsisLoopCaptureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2854TopLevelEllipsisLoopCaptureTests.cs
@@ -120,9 +120,18 @@ public class Issue2854TopLevelEllipsisLoopCaptureTests
             RedirectStandardError = true,
             UseShellExecute = false,
         });
-        var output = process.StandardOutput.ReadToEnd();
-        var error = process.StandardError.ReadToEnd();
-        Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        var exited = process.WaitForExit(30_000);
+        if (!exited)
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+        }
+
+        Assert.True(exited, "dotnet exec timed out");
+        var output = outputTask.GetAwaiter().GetResult();
+        var error = errorTask.GetAwaiter().GetResult();
         Assert.True(process.ExitCode == 0, error);
         return output.Replace("\r\n", "\n");
     }

--- a/test/Core.Tests/CodeAnalysis/Binding/LambdaTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/LambdaTests.cs
@@ -14,7 +14,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>
 /// Phase 4.7 — first-class function types (<c>func(T) R</c>), function literals,
-/// indirect calls, and by-value closure capture (interpreter-only).
+/// indirect calls, and closure capture.
 /// </summary>
 public class LambdaTests
 {
@@ -53,11 +53,8 @@ f()
     }
 
     [Fact]
-    public void Closure_ValueCaptureSnapshotsAtLiteralEvaluation()
+    public void Closure_CapturedLocalSharesVariableCell()
     {
-        // Captured *locals* are snapshotted at literal-evaluation time. Globals
-        // are intentionally not captured (read live at call time). Use a helper
-        // function to exercise local-capture semantics.
         var result = Evaluate(@"
 func makeReader() () -> int32 {
     var n = 1
@@ -69,7 +66,7 @@ let r = makeReader()
 r()
 ");
         Assert.Empty(result.Diagnostics);
-        Assert.Equal(1, result.Value);
+        Assert.Equal(99, result.Value);
     }
 
     [Fact]

--- a/test/Interpreter.Tests/Issue2853EllipsisLoopCaptureInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2853EllipsisLoopCaptureInterpreterTests.cs
@@ -1,0 +1,40 @@
+// <copyright file="Issue2853EllipsisLoopCaptureInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2853 interpreter guard for numeric ellipsis loop capture semantics.
+/// </summary>
+public class Issue2853EllipsisLoopCaptureInterpreterTests
+{
+    [Fact]
+    public void ClosureCapturesValueFromCreatingIteration()
+    {
+        var tree = SyntaxTree.Parse(
+            """
+            func capture() int32 {
+                var callback = () -> { return -1 }
+
+                for i in 0 ... 3 {
+                    if i == 0 { callback = () -> { return i } }
+                }
+
+                return callback()
+            }
+
+            capture()
+            """);
+        var result = new Compilation(tree).Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+}

--- a/test/Interpreter.Tests/Issue2853EllipsisLoopCaptureInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2853EllipsisLoopCaptureInterpreterTests.cs
@@ -18,7 +18,7 @@ public class Issue2853EllipsisLoopCaptureInterpreterTests
     [Fact]
     public void ClosureCapturesValueFromCreatingIteration()
     {
-        var tree = SyntaxTree.Parse(
+        AssertEvaluates(
             """
             func capture() int32 {
                 var callback = () -> { return -1 }
@@ -31,10 +31,54 @@ public class Issue2853EllipsisLoopCaptureInterpreterTests
             }
 
             capture()
-            """);
-        var result = new Compilation(tree).Evaluate(new Dictionary<VariableSymbol, object>());
+            """,
+            expected: 0);
+    }
+
+    [Fact]
+    public void CapturedWriteAdvancesLoopControlVariable()
+    {
+        AssertEvaluates(
+            """
+            func countIterations() int32 {
+                var iterations = 0
+                for i in 0 ... 5 {
+                    var bump = () -> { i = i + 1 }
+                    bump()
+                    iterations = iterations + 1
+                }
+
+                return iterations
+            }
+
+            countIterations()
+            """,
+            expected: 3);
+    }
+
+    [Fact]
+    public void CapturedFunctionLocalWritesSharedCell()
+    {
+        AssertEvaluates(
+            """
+            func mutate() int32 {
+                var value = 20
+                var bump = () -> { value = value + 1 }
+                bump()
+                return value
+            }
+
+            mutate()
+            """,
+            expected: 21);
+    }
+
+    private static void AssertEvaluates(string source, int expected)
+    {
+        var result = new Compilation(SyntaxTree.Parse(source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
 
         Assert.Empty(result.Diagnostics);
-        Assert.Equal(0, result.Value);
+        Assert.Equal(expected, result.Value);
     }
 }

--- a/test/Interpreter.Tests/Issue2853EllipsisLoopCaptureInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2853EllipsisLoopCaptureInterpreterTests.cs
@@ -73,6 +73,118 @@ public class Issue2853EllipsisLoopCaptureInterpreterTests
             expected: 21);
     }
 
+    [Fact]
+    public void CapturedIndexWritesUseExpressionTargets()
+    {
+        AssertEvaluates(
+            """
+            import System.Collections.Generic
+
+            func mutate() int32 {
+                var slice = []int32{1}
+                var values = map[string,int32]{"x": 2}
+                var list = List[int32]()
+                list.Add(3)
+                var read = () -> { return slice[0] + values["x"] + list[0] }
+
+                slice[0] = 40
+                values["x"] = 50
+                list[0] = 60
+                return slice[0] + values["x"] + list[0] + read()
+            }
+
+            mutate()
+            """,
+            expected: 300);
+    }
+
+    [Fact]
+    public void CapturedInstanceFieldWritesUseExpressionReceivers()
+    {
+        AssertEvaluates(
+            """
+            class Counter {
+                var Value int32
+            }
+
+            struct Pair {
+                var Value int32
+            }
+
+            func mutate() int32 {
+                var counter = Counter()
+                counter.Value = 5
+                var readCounter = () -> { return counter.Value }
+
+                var pair = Pair{Value: 1}
+                var readPair = () -> { return pair.Value }
+                pair.Value = 6
+
+                return counter.Value + readCounter() + pair.Value + readPair()
+            }
+
+            mutate()
+            """,
+            expected: 22);
+    }
+
+    [Fact]
+    public void CapturedRefOutAndAliasWritesUseCallerCell()
+    {
+        AssertEvaluates(
+            """
+            func addOne(ref value int32) {
+                value = value + 1
+            }
+
+            func setSeven(out value int32) {
+                value = 7
+            }
+
+            func mutate() int32 {
+                var n = 1
+                var readN = () -> { return n }
+                let ref alias = n
+                alias = alias + 1
+                addOne(ref n)
+
+                var m = 0
+                var readM = () -> { return m }
+                setSeven(out m)
+
+                return n * 1000 + readN() * 100 + m * 10 + readM()
+            }
+
+            mutate()
+            """,
+            expected: 3377);
+    }
+
+    [Fact]
+    public void CapturedNilClassFieldWriteReportsDiagnostic()
+    {
+        const string Source = """
+            class Counter {
+                var Value int32
+            }
+
+            func mutate() int32 {
+                var counter = Counter()
+                var read = () -> { return counter.Value }
+                counter = nil
+                counter.Value = 5
+                return read()
+            }
+
+            mutate()
+            """;
+
+        var result = new Compilation(SyntaxTree.Parse(Source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS9999");
+    }
+
     private static void AssertEvaluates(string source, int expected)
     {
         var result = new Compilation(SyntaxTree.Parse(source))

--- a/test/Interpreter.Tests/Issue2854TopLevelEllipsisLoopCaptureInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2854TopLevelEllipsisLoopCaptureInterpreterTests.cs
@@ -1,0 +1,37 @@
+// <copyright file="Issue2854TopLevelEllipsisLoopCaptureInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2854 interpreter guard for top-level numeric ellipsis loop captures.
+/// </summary>
+public class Issue2854TopLevelEllipsisLoopCaptureInterpreterTests
+{
+    [Fact]
+    public void TopLevelClosureCapturesIterationVariable()
+    {
+        var tree = SyntaxTree.Parse(
+            """
+            var callback = () -> { return -1 }
+
+            for i in 0 ... 1 {
+                callback = () -> { return i }
+            }
+
+            let result = callback()
+            result
+            """);
+        var result = new Compilation(tree).Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+}

--- a/test/Interpreter.Tests/Issue2854TopLevelEllipsisLoopCaptureInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2854TopLevelEllipsisLoopCaptureInterpreterTests.cs
@@ -18,7 +18,7 @@ public class Issue2854TopLevelEllipsisLoopCaptureInterpreterTests
     [Fact]
     public void TopLevelClosureCapturesIterationVariable()
     {
-        var tree = SyntaxTree.Parse(
+        AssertEvaluates(
             """
             var callback = () -> { return -1 }
 
@@ -28,10 +28,34 @@ public class Issue2854TopLevelEllipsisLoopCaptureInterpreterTests
 
             let result = callback()
             result
-            """);
-        var result = new Compilation(tree).Evaluate(new Dictionary<VariableSymbol, object>());
+            """,
+            expected: 0);
+    }
+
+    [Fact]
+    public void TopLevelForInCapturedWriteUsesSharedCell()
+    {
+        AssertEvaluates(
+            """
+            var source = []int32{7, 8}
+            var total = 0
+            for value in source {
+                var bump = () -> { value = value + 100 }
+                bump()
+                total = total + value
+            }
+
+            total
+            """,
+            expected: 215);
+    }
+
+    private static void AssertEvaluates(string source, int expected)
+    {
+        var result = new Compilation(SyntaxTree.Parse(source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
 
         Assert.Empty(result.Diagnostics);
-        Assert.Equal(0, result.Value);
+        Assert.Equal(expected, result.Value);
     }
 }

--- a/website/docs/guide/expressions-and-statements.md
+++ b/website/docs/guide/expressions-and-statements.md
@@ -106,6 +106,10 @@ for i in 0...10 {
 }
 ```
 
+Captured variables introduced by collection `for-in` and numeric ellipsis
+loops are fresh for each iteration. A variable declared in a three-part loop
+(`for var i = 0; i < n; i++`) is shared by every closure created by that loop.
+
 ## Goto and labels
 
 A label can prefix any statement, and `goto name` jumps to a label in the same function. Labels can be forward-referenced; duplicates and missing labels are diagnosed. Use this mostly for translated C# or low-level control flow — structured `if`, `switch`, and loops remain clearer for hand-written code.

--- a/website/docs/guide/expressions-and-statements.md
+++ b/website/docs/guide/expressions-and-statements.md
@@ -34,6 +34,10 @@ let trimmed = numbers[1..^1]
 
 Lambda literals use the arrow form. The canonical form infers parameter and return types from the target delegate: `(x) -> expr`, `(a, b) -> expr`, or the paren-dropped single-parameter `x -> expr`; block bodies use `(params) -> { ... }`. A block body is a statement block with an optional trailing value expression: an `if`-without-`else` and other void control-flow run as statements, `return` works anywhere, and a trailing expression (or `return`) supplies the value — full parity with `func` literals (void when neither yields a value). Types may also be written explicitly (`(x int32) -> expr`), and async lambdas use `async (params) -> ...`. A trailing lambda may follow a call as the final argument.
 
+Closures capture local and parameter variable cells, not value snapshots.
+Writes through the enclosing scope or another closure are visible to every
+closure that captures the same variable.
+
 Members can also use `->` for a single-expression body: `func Square(x int32) int32 -> x * x`, `prop Count int32 -> items.Length`, `get -> field`, and `set -> field = value`. The C# fat arrow `=>` is not G# syntax.
 
 ## Interpolation
@@ -109,6 +113,8 @@ for i in 0...10 {
 Captured variables introduced by collection `for-in` and numeric ellipsis
 loops are fresh for each iteration. A variable declared in a three-part loop
 (`for var i = 0; i < n; i++`) is shared by every closure created by that loop.
+A captured local declared inside any loop body is fresh each time its
+declaration executes, regardless of loop form.
 
 ## Goto and labels
 


### PR DESCRIPTION
## Summary

- Give captured numeric ellipsis variables a fresh cell per iteration.
- Keep nested top-level variables as method locals so emitted captures have slots.
- Apply existing capture boxing to evaluation and teach the evaluator every boxed receiver/target write shape.
- Add gsc/evaluator parity, ILVerify, mutation, timeout, and documentation coverage.

Closes #2853
Closes #2854

## Semantics

ADR-0069 already defines the language rule: capture boxing hoists every captured local or parameter into a shared heap cell so closures observe each other's writes. The interpreter previously did not consistently honor that rule.

G# itself supplies the loop precedent. On the branch base, interpreted numeric ellipsis read-capture was already per-iteration while emitted code returned the final shared-slot value; the compiler was the outlier. Collection `for-in` was also already per-iteration. The guide now records:

- collection `for-in`: fresh captured loop variable per iteration;
- numeric ellipsis `for i in lo ... hi`: fresh captured loop variable per iteration;
- three-part `for var i = ...; ...; ...`: one shared loop variable;
- a captured local declared in any loop body is fresh whenever its declaration executes;
- all closures capturing the same local/parameter share its variable cell.

This mirrors C# `foreach` versus three-part `for`, while following the issue's stated G# ellipsis expectation.

## Root cause and fix

Ellipsis lowering declared the user loop variable once before the loop. Existing capture boxing therefore allocated one box, so emitted closures saw its terminal value. Lowering now uses the existing `CaptureWalker` predicate: captured loops get a hidden control local, a fresh user-variable declaration per iteration, and a copy-back before increment so closure writes still advance control flow. Uncaptured loops retain the old lowering.

Top-level binding also classified every variable under the synthesized entry point as global. Nested loop/block symbols were not emitted as global fields and had no local slot, causing #2854. A stable initial binder scope now distinguishes direct top-level declarations from nested locals.

Running `CaptureBoxingRewriter` during evaluation fixed shared-cell semantics but made its expression-receiver forms live in the interpreter. The evaluator now:

- evaluates `TargetExpression` for slice/array/map and CLR index writes;
- evaluates `ReceiverExpression` for instance-field writes;
- writes copied value structs back through the expression receiver;
- performs user `ref`/`out` writeback after restoring the caller frame, reusing `WriteBackToOperand` for captured boxes and ref aliases;
- preserves direct iterator results after the call-frame refactor.

The top-level rewritten-body identity invariant is documented. Emitted-process output is drained asynchronously, so the 30-second timeout now actually fires and kills a stuck process tree.

## Cross-engine regression coverage

Eight compiler tests feed one source to both `Compilation.Evaluate` and gsc, compare both to the same expected value, run the emitted assembly, and ILVerify it. They cover:

1. #2853 per-iteration ellipsis capture (`0`);
2. captured loop-variable writes advancing the loop (`3` iterations);
3. ordinary function-local shared-cell writes (`21`);
4. captured slice, map, and `List<T>` index writes (`300`);
5. captured class and value-struct field writes (`22`);
6. ref alias, `ref`, and `out` writes to captured cells (`3377`);
7. #2854 top-level ellipsis capture (`0`);
8. top-level collection-loop captured writes (`215`).

### B2 repro A: index writes

| Probe | Base gsi | Branch gsi | Base gsc | Branch gsc |
| --- | --- | --- | --- | --- |
| slice | `a[0]=42 f()=42` | same | same | same |
| map | `m[x]=42 f()=42` | same | same | same |
| `List<T>` | `list[0]=42 f()=42` | same | same | same |

### B2 repro B: instance field write

| Probe | Base gsi | Branch gsi | Base gsc | Branch gsc |
| --- | --- | --- | --- | --- |
| class field | `c.V=5 f()=5` | same | same | same |

### B2 repro C: captured ref/out

| Probe | Base gsi | Branch gsi | Base gsc | Branch gsc |
| --- | --- | --- | --- | --- |
| ref + out | `n=2 f=1 m=0 g=0` | `n=3 f=3 m=7 g=7` | `n=3 f=3 m=7 g=7` | same |

The base-gsi ref/out result is a pre-existing interpreter bug; the branch now agrees with both compiled engines.

## Round 3 hardening

Parity evaluation now runs on a task with a 30-second bound before the emitted-process leg. The H7 mutation that increments the per-iteration variable instead of the hidden control variable now finishes the eight-test filter in 63 seconds: 3 failed, 5 passed, with both non-terminating interpreter cases reporting `interpreter evaluation timed out`. The same mutation previously exceeded an external 400-second cap.

The three duplicated expression-or-symbol reads now share `ResolveReceiverValue`. Index/map, CLR index, and field assignment still each choose their expression receiver when present; the map target-type fallback remains separate and pinned. Captured nil class field assignment now throws a modeled null-reference diagnostic rather than reaching `Assign(null, ...)`.

The interpreter intentionally runs capture boxing without `SideEffectSpiller`. Emit needs spilling because emitted compound assignment shapes could re-emit side effects; evaluation directly consumes each expression receiver once. Comments at both pipeline positions now state that distinction.

`Interpreter.Tests` now directly covers captured slice/map/`List<T>` writes, class/value-struct field writes, ref alias + `ref` + `out`, and nil class field assignment.

## Post-refactor mutation audit

Every semantic mutation produced red. B2 mutations now fail both parity and interpreter-native coverage where applicable:

| Mutated behavior | Compiler parity | Interpreter-native/Core |
| --- | ---: | ---: |
| stable binder initial scope | 2 / 8 | — |
| nested top-level local classification | 2 / 8 | — |
| interpreter boxing pipeline | 5 / 8 | 4 / 7 |
| ref/out writeback in callee frame | 1 / 8 | 1 / 7 |
| iterator direct-result return removed | — | 3 / 7 |
| shared receiver helper ignores expression | 2 / 8 | 2 / 7 |
| array/map expression target ignored | 1 / 8 | 1 / 7 |
| map target-type fallback removed | 1 / 8 | 1 / 7 |
| CLR index expression target ignored | 1 / 8 | 1 / 7 |
| expression field mistaken for static field | 1 / 8 | 2 / 7 |
| field expression receiver ignored | 1 / 8 | 1 / 7 |
| nil class receiver guard removed | — | 1 / 7 |
| value-struct expression writeback removed | 1 / 8 | 1 / 7 |
| synthetic box blocks rejected | 8 / 8 | 6 / 7 |
| rewritten top-level statement not synchronized | 1 / 8 | — |
| ellipsis capture detection disabled | 2 / 8 | — |
| hidden control-variable read removed | 3 / 8 | — |
| hidden control-variable increment removed (H7) | 3 / 8 | two 30-second timeout failures |
| fresh iteration declaration removed | 3 / 8 | — |
| loop-variable copy-back removed | 1 / 8 | — |
| capture predicate forced true | — | 3 Core failures |

## Verification

- `Compiler.Tests`: 3,679 passed, 0 failed, 0 skipped.
- `Core.Tests`: 6,859 passed, 0 failed, 1 skipped (6,860 total).
- `Interpreter.Tests`: 453 passed, 0 failed, 0 skipped.
- CI-style Release solution build: 0 warnings, 0 errors.
- #2853 compiled and ran with `0`.
- #2854 compiled and ran with `0`.
- Sample corpus: 122 sources; base and branch both compiled 119, and all 119 assemblies were byte-identical. The same three extension-dependent samples failed on both. Differences: 0; status mismatches: 0.
- gsi sample sweep: SAME=122, DIFF=0.
- Capture-free ellipsis loops are byte-identical to the branch base. Captured-loop IL changes only where the fresh display-class instance is required.

## Scope

Iterator-function closure capture still fails with the same GS9998 on the branch base and this branch across loop forms. It is pre-existing and tracked in #2907.

Files changed: 8 under `src/`, 6 tests, and 1 guide file. No work within #2853/#2854 or the review findings was deferred.
