### PR TITLE
gsc: model switch and select arms in definite-return CFG

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -51,13 +51,7 @@ public sealed class ControlFlowGraph
     /// <param name="body">The bound block statement.</param>
     /// <returns>The control flow graph.</returns>
     public static ControlFlowGraph Create(BoundBlockStatement body)
-    {
-        var basicBlockBuilder = new BasicBlockBuilder();
-        var blocks = basicBlockBuilder.Build(body);
-
-        var graphBuilder = new GraphBuilder();
-        return graphBuilder.Build(blocks);
-    }
+        => Create(body, treatThrowsAsTerminators: false);
 
     /// <summary>
     /// Reports whether all paths in a bound block statement return or not.
@@ -67,9 +61,9 @@ public sealed class ControlFlowGraph
     public static bool AllPathsReturn(BoundBlockStatement body)
     {
         // This projection is intentionally limited to definite-return. Other
-        // data-flow analyzers call Create(body) and still treat fixed/scope as
-        // opaque, so their escaping-goto behavior is unchanged.
-        var graph = Create(ProjectSequentialRegionsForDefiniteReturn(body));
+        // data-flow analyzers call Create(body) and still treat these compound
+        // statements as opaque, so their region-specific behavior is unchanged.
+        var graph = Create(ProjectRegionsForDefiniteReturn(body), treatThrowsAsTerminators: true);
 
         foreach (var branch in graph.End.Incoming)
         {
@@ -199,9 +193,20 @@ public sealed class ControlFlowGraph
         }
     }
 
-    private static BoundBlockStatement ProjectSequentialRegionsForDefiniteReturn(BoundStatement statement)
+    private static ControlFlowGraph Create(BoundBlockStatement body, bool treatThrowsAsTerminators)
+    {
+        var basicBlockBuilder = new BasicBlockBuilder(treatThrowsAsTerminators);
+        var blocks = basicBlockBuilder.Build(body);
+
+        var graphBuilder = new GraphBuilder();
+        return graphBuilder.Build(blocks);
+    }
+
+    private static BoundBlockStatement ProjectRegionsForDefiniteReturn(BoundStatement statement)
     {
         var builder = System.Collections.Immutable.ImmutableArray.CreateBuilder<BoundStatement>();
+        var labelOrdinal = 0;
+        var choiceOrdinal = 0;
         Add(statement);
         return new BoundBlockStatement(null, builder.ToImmutable());
 
@@ -227,11 +232,245 @@ public sealed class ControlFlowGraph
                     // Its task join and failure rethrow remain emit-time behavior.
                     Add(scopeStatement.Body);
                     break;
+                case BoundPatternSwitchStatement switchStatement:
+                    AddPatternSwitch(switchStatement);
+                    break;
+                case BoundSelectStatement selectStatement:
+                    AddSelect(selectStatement);
+                    break;
                 default:
                     builder.Add(current);
                     break;
             }
         }
+
+        void AddPatternSwitch(BoundPatternSwitchStatement switchStatement)
+        {
+            var endLabel = NewLabel("switchEnd");
+            var arms = new List<(BoundPatternSwitchArm Arm, BoundLabel Label)>();
+            var literalDiscriminant = switchStatement.Discriminant as BoundLiteralExpression;
+            BoundPatternSwitchArm defaultArm = null;
+            BoundLabel defaultLabel = null;
+            var dispatchComplete = false;
+
+            foreach (var arm in switchStatement.Arms)
+            {
+                if (arm.IsDefault)
+                {
+                    defaultArm = arm;
+                    defaultLabel = NewLabel("switchDefault");
+                    continue;
+                }
+
+                if (arm.Guard is BoundLiteralExpression { Value: false })
+                {
+                    continue;
+                }
+
+                if (literalDiscriminant != null
+                    && TryMatchLiteralPattern(arm.Pattern, literalDiscriminant.Value, out var matches))
+                {
+                    if (!matches)
+                    {
+                        continue;
+                    }
+
+                    if (arm.Guard == null || arm.Guard is BoundLiteralExpression { Value: true })
+                    {
+                        var matchingArmLabel = NewLabel("switchArm");
+                        arms.Add((arm, matchingArmLabel));
+                        builder.Add(new BoundGotoStatement(null, matchingArmLabel));
+                        dispatchComplete = true;
+                        break;
+                    }
+                }
+
+                var armLabel = NewLabel("switchArm");
+                arms.Add((arm, armLabel));
+                if (arm.Pattern is BoundDiscardPattern && arm.Guard == null)
+                {
+                    builder.Add(new BoundGotoStatement(null, armLabel));
+                    dispatchComplete = true;
+                    break;
+                }
+
+                builder.Add(new BoundConditionalGotoStatement(null, armLabel, NewChoice()));
+            }
+
+            if (!dispatchComplete)
+            {
+                builder.Add(new BoundGotoStatement(null, defaultArm == null ? endLabel : defaultLabel));
+            }
+
+            foreach (var (arm, armLabel) in arms)
+            {
+                builder.Add(new BoundLabelStatement(null, armLabel));
+                Add(arm.Body);
+                builder.Add(new BoundGotoStatement(null, endLabel));
+            }
+
+            if (defaultArm != null)
+            {
+                builder.Add(new BoundLabelStatement(null, defaultLabel));
+                Add(defaultArm.Body);
+                builder.Add(new BoundGotoStatement(null, endLabel));
+            }
+
+            builder.Add(new BoundLabelStatement(null, endLabel));
+        }
+
+        void AddSelect(BoundSelectStatement selectStatement)
+        {
+            var dispatchLabel = NewLabel("selectDispatch");
+            var endLabel = NewLabel("selectEnd");
+            var cases = new List<(BoundSelectCase Case, BoundLabel Label)>();
+            BoundSelectCase defaultCase = null;
+            BoundLabel defaultLabel = null;
+
+            builder.Add(new BoundLabelStatement(null, dispatchLabel));
+            foreach (var @case in selectStatement.Cases)
+            {
+                if (@case.IsDefault)
+                {
+                    defaultCase = @case;
+                    defaultLabel = NewLabel("selectDefault");
+                    continue;
+                }
+
+                var caseLabel = NewLabel("selectCase");
+                cases.Add((@case, caseLabel));
+                builder.Add(new BoundConditionalGotoStatement(null, caseLabel, NewChoice()));
+            }
+
+            builder.Add(new BoundGotoStatement(null, defaultCase == null ? dispatchLabel : defaultLabel));
+
+            foreach (var (@case, caseLabel) in cases)
+            {
+                builder.Add(new BoundLabelStatement(null, caseLabel));
+                Add(@case.Body);
+                builder.Add(new BoundGotoStatement(null, endLabel));
+            }
+
+            if (defaultCase != null)
+            {
+                builder.Add(new BoundLabelStatement(null, defaultLabel));
+                Add(defaultCase.Body);
+                builder.Add(new BoundGotoStatement(null, endLabel));
+            }
+
+            builder.Add(new BoundLabelStatement(null, endLabel));
+        }
+
+        BoundLabel NewLabel(string name)
+            => new($"<>definiteReturn_{name}_{labelOrdinal++}");
+
+        BoundExpression NewChoice()
+            => new BoundVariableExpression(
+                null,
+                new LocalVariableSymbol($"<>definiteReturnChoice{choiceOrdinal++}", isReadOnly: true, TypeSymbol.Bool));
+
+        static bool TryMatchLiteralPattern(BoundPattern pattern, object value, out bool matches)
+        {
+            switch (pattern)
+            {
+                case BoundConstantPattern { Value: BoundLiteralExpression constant }:
+                    matches = LiteralEquals(value, constant.Value);
+                    return true;
+                case BoundDiscardPattern:
+                    matches = true;
+                    return true;
+                case BoundTypePattern when value == null:
+                    matches = false;
+                    return true;
+                case BoundRelationalPattern { Value: BoundLiteralExpression right } nanRelational
+                    when IsNaN(value) || IsNaN(right.Value):
+                    matches = nanRelational.Op.Kind == BoundBinaryOperatorKind.NotEquals;
+                    return nanRelational.Op.Kind is BoundBinaryOperatorKind.Equals
+                        or BoundBinaryOperatorKind.NotEquals
+                        or BoundBinaryOperatorKind.Less
+                        or BoundBinaryOperatorKind.LessOrEquals
+                        or BoundBinaryOperatorKind.Greater
+                        or BoundBinaryOperatorKind.GreaterOrEquals;
+                case BoundRelationalPattern { Value: BoundLiteralExpression right } relational
+                    when TryCompareLiterals(value, right.Value, out var comparison):
+                    switch (relational.Op.Kind)
+                    {
+                        case BoundBinaryOperatorKind.Equals:
+                            matches = comparison == 0;
+                            return true;
+                        case BoundBinaryOperatorKind.NotEquals:
+                            matches = comparison != 0;
+                            return true;
+                        case BoundBinaryOperatorKind.Less:
+                            matches = comparison < 0;
+                            return true;
+                        case BoundBinaryOperatorKind.LessOrEquals:
+                            matches = comparison <= 0;
+                            return true;
+                        case BoundBinaryOperatorKind.Greater:
+                            matches = comparison > 0;
+                            return true;
+                        case BoundBinaryOperatorKind.GreaterOrEquals:
+                            matches = comparison >= 0;
+                            return true;
+                        default:
+                            matches = false;
+                            return false;
+                    }
+
+                case BoundBinaryPattern binary
+                    when TryMatchLiteralPattern(binary.Left, value, out var left)
+                        && TryMatchLiteralPattern(binary.Right, value, out var right):
+                    matches = binary.IsConjunction ? left && right : left || right;
+                    return true;
+                case BoundNotPattern notPattern
+                    when TryMatchLiteralPattern(notPattern.Pattern, value, out var inner):
+                    matches = !inner;
+                    return true;
+                default:
+                    matches = false;
+                    return false;
+            }
+        }
+
+        static bool TryCompareLiterals(object left, object right, out int comparison)
+        {
+            left = UnwrapEnum(left);
+            right = UnwrapEnum(right);
+            if (left == null || right == null || IsNaN(left) || IsNaN(right))
+            {
+                comparison = 0;
+                return false;
+            }
+
+            if (left.GetType() == right.GetType() && left is IComparable comparable)
+            {
+                comparison = comparable.CompareTo(right);
+                return true;
+            }
+
+            comparison = 0;
+            return false;
+        }
+
+        static bool LiteralEquals(object left, object right)
+        {
+            left = UnwrapEnum(left);
+            right = UnwrapEnum(right);
+            return !IsNaN(left) && !IsNaN(right) && Equals(left, right);
+        }
+
+        static object UnwrapEnum(object value)
+            => value is Enum enumValue
+                ? Convert.ChangeType(
+                    enumValue,
+                    Enum.GetUnderlyingType(enumValue.GetType()),
+                    System.Globalization.CultureInfo.InvariantCulture)
+                : value;
+
+        static bool IsNaN(object value)
+            => (value is float floatValue && float.IsNaN(floatValue))
+                || (value is double doubleValue && double.IsNaN(doubleValue));
     }
 
     /// <summary>
@@ -361,6 +600,19 @@ public sealed class ControlFlowGraph
     {
         private readonly List<BoundStatement> statements = [];
         private readonly List<BasicBlock> blocks = [];
+        private readonly bool treatThrowsAsTerminators;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BasicBlockBuilder"/> class.
+        /// </summary>
+        public BasicBlockBuilder()
+        {
+        }
+
+        internal BasicBlockBuilder(bool treatThrowsAsTerminators)
+        {
+            this.treatThrowsAsTerminators = treatThrowsAsTerminators;
+        }
 
         /// <summary>
         /// Builds a basic block from the provided bound block statement and adds
@@ -399,8 +651,15 @@ public sealed class ControlFlowGraph
                         }
 
                         break;
-                    case BoundNodeKind.TryStatement:
                     case BoundNodeKind.ThrowStatement:
+                        statements.Add(statement);
+                        if (treatThrowsAsTerminators)
+                        {
+                            StartBlock();
+                        }
+
+                        break;
+                    case BoundNodeKind.TryStatement:
                     case BoundNodeKind.GoStatement:
                     case BoundNodeKind.ChannelSendStatement:
                     case BoundNodeKind.SelectStatement:

--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -248,7 +248,6 @@ public sealed class ControlFlowGraph
         {
             var endLabel = NewLabel("switchEnd");
             var arms = new List<(BoundPatternSwitchArm Arm, BoundLabel Label)>();
-            var literalDiscriminant = switchStatement.Discriminant as BoundLiteralExpression;
             BoundPatternSwitchArm defaultArm = null;
             BoundLabel defaultLabel = null;
             var dispatchComplete = false;
@@ -260,29 +259,6 @@ public sealed class ControlFlowGraph
                     defaultArm = arm;
                     defaultLabel = NewLabel("switchDefault");
                     continue;
-                }
-
-                if (arm.Guard is BoundLiteralExpression { Value: false })
-                {
-                    continue;
-                }
-
-                if (literalDiscriminant != null
-                    && TryMatchLiteralPattern(arm.Pattern, literalDiscriminant.Value, out var matches))
-                {
-                    if (!matches)
-                    {
-                        continue;
-                    }
-
-                    if (arm.Guard == null || arm.Guard is BoundLiteralExpression { Value: true })
-                    {
-                        var matchingArmLabel = NewLabel("switchArm");
-                        arms.Add((arm, matchingArmLabel));
-                        builder.Add(new BoundGotoStatement(null, matchingArmLabel));
-                        dispatchComplete = true;
-                        break;
-                    }
                 }
 
                 var armLabel = NewLabel("switchArm");
@@ -313,7 +289,6 @@ public sealed class ControlFlowGraph
             {
                 builder.Add(new BoundLabelStatement(null, defaultLabel));
                 Add(defaultArm.Body);
-                builder.Add(new BoundGotoStatement(null, endLabel));
             }
 
             builder.Add(new BoundLabelStatement(null, endLabel));
@@ -355,7 +330,6 @@ public sealed class ControlFlowGraph
             {
                 builder.Add(new BoundLabelStatement(null, defaultLabel));
                 Add(defaultCase.Body);
-                builder.Add(new BoundGotoStatement(null, endLabel));
             }
 
             builder.Add(new BoundLabelStatement(null, endLabel));
@@ -368,109 +342,6 @@ public sealed class ControlFlowGraph
             => new BoundVariableExpression(
                 null,
                 new LocalVariableSymbol($"<>definiteReturnChoice{choiceOrdinal++}", isReadOnly: true, TypeSymbol.Bool));
-
-        static bool TryMatchLiteralPattern(BoundPattern pattern, object value, out bool matches)
-        {
-            switch (pattern)
-            {
-                case BoundConstantPattern { Value: BoundLiteralExpression constant }:
-                    matches = LiteralEquals(value, constant.Value);
-                    return true;
-                case BoundDiscardPattern:
-                    matches = true;
-                    return true;
-                case BoundTypePattern when value == null:
-                    matches = false;
-                    return true;
-                case BoundRelationalPattern { Value: BoundLiteralExpression right } nanRelational
-                    when IsNaN(value) || IsNaN(right.Value):
-                    matches = nanRelational.Op.Kind == BoundBinaryOperatorKind.NotEquals;
-                    return nanRelational.Op.Kind is BoundBinaryOperatorKind.Equals
-                        or BoundBinaryOperatorKind.NotEquals
-                        or BoundBinaryOperatorKind.Less
-                        or BoundBinaryOperatorKind.LessOrEquals
-                        or BoundBinaryOperatorKind.Greater
-                        or BoundBinaryOperatorKind.GreaterOrEquals;
-                case BoundRelationalPattern { Value: BoundLiteralExpression right } relational
-                    when TryCompareLiterals(value, right.Value, out var comparison):
-                    switch (relational.Op.Kind)
-                    {
-                        case BoundBinaryOperatorKind.Equals:
-                            matches = comparison == 0;
-                            return true;
-                        case BoundBinaryOperatorKind.NotEquals:
-                            matches = comparison != 0;
-                            return true;
-                        case BoundBinaryOperatorKind.Less:
-                            matches = comparison < 0;
-                            return true;
-                        case BoundBinaryOperatorKind.LessOrEquals:
-                            matches = comparison <= 0;
-                            return true;
-                        case BoundBinaryOperatorKind.Greater:
-                            matches = comparison > 0;
-                            return true;
-                        case BoundBinaryOperatorKind.GreaterOrEquals:
-                            matches = comparison >= 0;
-                            return true;
-                        default:
-                            matches = false;
-                            return false;
-                    }
-
-                case BoundBinaryPattern binary
-                    when TryMatchLiteralPattern(binary.Left, value, out var left)
-                        && TryMatchLiteralPattern(binary.Right, value, out var right):
-                    matches = binary.IsConjunction ? left && right : left || right;
-                    return true;
-                case BoundNotPattern notPattern
-                    when TryMatchLiteralPattern(notPattern.Pattern, value, out var inner):
-                    matches = !inner;
-                    return true;
-                default:
-                    matches = false;
-                    return false;
-            }
-        }
-
-        static bool TryCompareLiterals(object left, object right, out int comparison)
-        {
-            left = UnwrapEnum(left);
-            right = UnwrapEnum(right);
-            if (left == null || right == null || IsNaN(left) || IsNaN(right))
-            {
-                comparison = 0;
-                return false;
-            }
-
-            if (left.GetType() == right.GetType() && left is IComparable comparable)
-            {
-                comparison = comparable.CompareTo(right);
-                return true;
-            }
-
-            comparison = 0;
-            return false;
-        }
-
-        static bool LiteralEquals(object left, object right)
-        {
-            left = UnwrapEnum(left);
-            right = UnwrapEnum(right);
-            return !IsNaN(left) && !IsNaN(right) && Equals(left, right);
-        }
-
-        static object UnwrapEnum(object value)
-            => value is Enum enumValue
-                ? Convert.ChangeType(
-                    enumValue,
-                    Enum.GetUnderlyingType(enumValue.GetType()),
-                    System.Globalization.CultureInfo.InvariantCulture)
-                : value;
-
-        static bool IsNaN(object value)
-            => (value is float floatValue && float.IsNaN(floatValue))
-                || (value is double doubleValue && double.IsNaN(doubleValue));
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -338,6 +338,7 @@ public sealed class ControlFlowGraph
         BoundLabel NewLabel(string name)
             => new($"<>definiteReturn_{name}_{labelOrdinal++}");
 
+        // Keep this non-literal so GraphBuilder preserves both synthetic alternatives.
         BoundExpression NewChoice()
             => new BoundVariableExpression(
                 null,

--- a/test/Compiler.Tests/Emit/Issue2890SwitchSelectEscapingBranchEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2890SwitchSelectEscapingBranchEmitTests.cs
@@ -98,6 +98,142 @@ public class Issue2890SwitchSelectEscapingBranchEmitTests
         Assert.Equal(8, GetField(assembly, "result"));
     }
 
+    [Fact]
+    public void SelectWithoutDefaultWhoseEveryArmReturns_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2890.EmitSelectNoDefaultReturns
+            import Gsharp.Extensions.Go
+
+            func F() int32 {
+                let ch = make(chan int32, 1)
+                ch <- 12
+                select {
+                    case ch <- 1 { return 11 }
+                    case let value = <-ch { return value }
+                }
+            }
+
+            public var result = F()
+            """;
+
+        var assembly = CompileAndRun(Source);
+        Assert.Equal(12, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void SelectWhoseEveryArmThrows_VerifiesLoadsAndThrows()
+    {
+        const string Source = """
+            package Issue2890.EmitSelectThrows
+            import System
+            import Gsharp.Extensions.Go
+
+            func F() int32 {
+                let ch = make(chan int32, 1)
+                select {
+                    case ch <- 1 { throw Exception("send") }
+                    case <-ch { throw Exception("receive") }
+                    default { throw Exception("default") }
+                }
+            }
+
+            public var result = F()
+            """;
+
+        var exception = Assert.Throws<TargetInvocationException>(() => CompileAndRun(Source));
+        Assert.IsType<Exception>(exception.InnerException);
+    }
+
+    [Fact]
+    public void SwitchArmContainingReturningSelect_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2890.EmitSwitchSelectReturns
+            import Gsharp.Extensions.Go
+
+            func F(x int32) int32 {
+                let ch = make(chan int32, 1)
+                switch x {
+                    case 1 {
+                        select {
+                            case ch <- 1 { return 1 }
+                            default { return 2 }
+                        }
+                    }
+                    default { return 3 }
+                }
+            }
+
+            public var result = F(1)
+            """;
+
+        var assembly = CompileAndRun(Source);
+        Assert.Equal(1, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void PatternSwitchWhoseEveryArmReturns_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2890.EmitSwitchReturnsGuard
+
+            func F(x int32) int32 {
+                switch x {
+                    case 1 { return 1 }
+                    default { return 2 }
+                }
+            }
+
+            public var result = F(2)
+            """;
+
+        var assembly = CompileAndRun(Source);
+        Assert.Equal(2, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void CompletingSwitchArmFollowedByReturn_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2890.EmitSwitchThenReturnGuard
+
+            func F(x int32) int32 {
+                switch x {
+                    case 1 { }
+                    default { return 1 }
+                }
+
+                return 2
+            }
+
+            public var result = F(1) + F(0)
+            """;
+
+        var assembly = CompileAndRun(Source);
+        Assert.Equal(3, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void TypePatternSwitchWhoseEveryArmReturns_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2890.EmitTypePatternGuard
+
+            func F(value object) int32 {
+                switch value {
+                    case _ is string { return 1 }
+                    default { return 2 }
+                }
+            }
+
+            public var result = F("text") + F(7)
+            """;
+
+        var assembly = CompileAndRun(Source);
+        Assert.Equal(3, GetField(assembly, "result"));
+    }
+
     private static void AssertOnlyGs0100AndNoEmission(string source)
     {
         using var peStream = new MemoryStream();

--- a/test/Compiler.Tests/Emit/Issue2890SwitchSelectEscapingBranchEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2890SwitchSelectEscapingBranchEmitTests.cs
@@ -1,0 +1,156 @@
+// <copyright file="Issue2890SwitchSelectEscapingBranchEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2890: arm-aware definite-return projection must reject escaping
+/// switch/select branches without changing switch/select emission.
+/// </summary>
+public class Issue2890SwitchSelectEscapingBranchEmitTests
+{
+    [Fact]
+    public void BreakOutOfPatternSwitchArm_ReportsGs0100AndEmitsNothing()
+    {
+        const string Source = """
+            package Issue2890.EmitSwitchBreak
+
+            func F(x int32) int32 {
+                for {
+                    switch x {
+                        default { break }
+                    }
+                }
+            }
+            """;
+
+        AssertOnlyGs0100AndNoEmission(Source);
+    }
+
+    [Fact]
+    public void BreakOutOfSelectArm_ReportsGs0100AndEmitsNothing()
+    {
+        const string Source = """
+            package Issue2890.EmitSelectBreak
+            import Gsharp.Extensions.Go
+
+            func F() int32 {
+                for {
+                    select {
+                        default { break }
+                    }
+                }
+            }
+            """;
+
+        AssertOnlyGs0100AndNoEmission(Source);
+    }
+
+    [Fact]
+    public void SelectWhoseEveryArmReturns_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2890.EmitSelectReturns
+            import Gsharp.Extensions.Go
+
+            func F() int32 {
+                let ch = make(chan int32, 1)
+                select {
+                    case ch <- 1 { return 11 }
+                    case <-ch { return 12 }
+                    default { return 13 }
+                }
+            }
+
+            public var result = F()
+            """;
+
+        var assembly = CompileAndRun(Source);
+        Assert.Equal(11, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void TotalDiscardSwitchWhoseArmReturns_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2890.EmitDiscardReturns
+
+            func F(x int32) int32 {
+                switch x {
+                    case _ { return x + 1 }
+                }
+            }
+
+            public var result = F(7)
+            """;
+
+        var assembly = CompileAndRun(Source);
+        Assert.Equal(8, GetField(assembly, "result"));
+    }
+
+    private static void AssertOnlyGs0100AndNoEmission(string source)
+    {
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+        var diagnostic = Assert.Single(result.Diagnostics.Where(candidate => candidate.IsError));
+        var expectedStart = source.IndexOf("F(", StringComparison.Ordinal);
+
+        Assert.False(result.Success);
+        Assert.Equal("GS0100", diagnostic.Id);
+        Assert.Equal(expectedStart, diagnostic.Location.Span.Start);
+        Assert.Equal(1, diagnostic.Location.Span.Length);
+        Assert.Equal("F", diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+        Assert.Equal(0, peStream.Length);
+    }
+
+    private static Assembly CompileAndRun(string source)
+    {
+        using var peStream = new MemoryStream();
+        var result = Compile(source, peStream);
+        Assert.True(
+            result.Success,
+            string.Join(Environment.NewLine, result.Diagnostics.Select(diagnostic => diagnostic.ToString())));
+
+        var assemblyPath = Path.Combine(
+            Directory.GetCurrentDirectory(),
+            $"Issue2890_{Guid.NewGuid():N}.dll");
+        try
+        {
+            File.WriteAllBytes(assemblyPath, peStream.ToArray());
+            IlVerifier.Verify(assemblyPath);
+        }
+        finally
+        {
+            File.Delete(assemblyPath);
+        }
+
+        var assembly = Assembly.Load(peStream.ToArray());
+        var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+        return assembly;
+    }
+
+    private static EmitResult Compile(string source, Stream peStream)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Emit(peStream);
+    }
+
+    private static int GetField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+        return (int)program.GetField(name, BindingFlags.Public | BindingFlags.Static)!.GetValue(null)!;
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2899ThrowDeadCodeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2899ThrowDeadCodeEmitTests.cs
@@ -1,0 +1,109 @@
+// <copyright file="Issue2899ThrowDeadCodeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2899: throw followed by dead code must emit valid IL when
+/// definite-return accepts the enclosing non-void function.
+/// </summary>
+public class Issue2899ThrowDeadCodeEmitTests
+{
+    [Fact]
+    public void ThrowFollowedByDeadCode_VerifiesLoadsAndRuns()
+    {
+        const string Source = """
+            package Issue2899.Emit
+            import System
+
+            func Value() int32 {
+                throw Exception("value")
+                var dead = 1
+            }
+
+            func Assign(out value int32) {
+                throw Exception("assign")
+                value = 1
+            }
+
+            func Conditional(condition bool) int32 {
+                if condition {
+                    return 1
+                }
+                throw Exception("conditional")
+                var dead = 2
+            }
+
+            public var result = 0
+            try {
+                Value()
+            } catch (ex Exception) {
+                result += 1
+            }
+
+            try {
+                var value = 0
+                Assign(out value)
+            } catch (ex Exception) {
+                result += 2
+            }
+
+            result += Conditional(true)
+            try {
+                Conditional(false)
+            } catch (ex Exception) {
+                result += 4
+            }
+            """;
+
+        var assembly = CompileAndRun(Source);
+        Assert.Equal(8, GetField(assembly, "result"));
+    }
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            string.Join(Environment.NewLine, result.Diagnostics.Select(diagnostic => diagnostic.ToString())));
+
+        var assemblyPath = Path.Combine(
+            Directory.GetCurrentDirectory(),
+            $"Issue2899_{Guid.NewGuid():N}.dll");
+        try
+        {
+            File.WriteAllBytes(assemblyPath, peStream.ToArray());
+            IlVerifier.Verify(assemblyPath);
+        }
+        finally
+        {
+            File.Delete(assemblyPath);
+        }
+
+        var assembly = Assembly.Load(peStream.ToArray());
+        var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+        return assembly;
+    }
+
+    private static int GetField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+        return (int)program.GetField(name, BindingFlags.Public | BindingFlags.Static)!.GetValue(null)!;
+    }
+}

--- a/test/Compiler.Tests/IlVerifier.cs
+++ b/test/Compiler.Tests/IlVerifier.cs
@@ -159,6 +159,14 @@ internal static class IlVerifier
                 .ToString();
             throw new XunitException(message);
         }
+
+        var successMarker = $"All Classes and Methods in {assemblyPath} Verified.";
+        if (!stdout.Contains(successMarker, StringComparison.Ordinal))
+        {
+            throw new XunitException(
+                $"ilverify exited successfully without confirming verification of '{assemblyPath}'.{Environment.NewLine}" +
+                stdout.TrimEnd() + Environment.NewLine + stderr.TrimEnd());
+        }
     }
 
     /// <summary>
@@ -408,6 +416,11 @@ internal static class IlVerifier
             if (string.IsNullOrEmpty(path))
             {
                 return;
+            }
+
+            if (!File.Exists(path))
+            {
+                throw new XunitException($"ilverify: reference assembly not found at '{path}'");
             }
 
             // ilverify treats the verified assembly itself as the "primary"

--- a/test/Compiler.Tests/IlVerifierTests.cs
+++ b/test/Compiler.Tests/IlVerifierTests.cs
@@ -64,6 +64,18 @@ public class IlVerifierTests
     }
 
     [Fact]
+    public void Verify_MissingReference_Throws()
+    {
+        var bogus = Path.Combine(
+            Directory.GetCurrentDirectory(),
+            $"does-not-exist-{Guid.NewGuid():N}.dll");
+        var exception = Assert.Throws<XunitException>(
+            () => IlVerifier.Verify(typeof(IlVerifierTests).Assembly.Location, new[] { bogus }));
+
+        Assert.Contains("reference assembly not found", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Verify_RespectsSkipEnvVar()
     {
         var prev = Environment.GetEnvironmentVariable("GSHARP_SKIP_ILVERIFY");

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2890SwitchSelectEscapingBranchFlowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2890SwitchSelectEscapingBranchFlowTests.cs
@@ -205,6 +205,96 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
     }
 
     [Fact]
+    public void LiteralSwitchWithoutDefault_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2890.LiteralNoDefault
+
+            func F() int32 {
+                switch 1 {
+                    case 1 { return 10 }
+                    case 2 { return 20 }
+                }
+            }
+            """;
+
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
+    public void ImpossibleLiteralArmBreak_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2890.ImpossibleLiteralBreak
+
+            func F() int32 {
+                for {
+                    switch 1 {
+                        case 2 { break }
+                    }
+                }
+            }
+            """;
+
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
+    public void FalseGuardArmBreak_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2890.FalseGuardBreak
+
+            func F(x int32) int32 {
+                for {
+                    switch x {
+                        case _ when false { break }
+                        default { return 1 }
+                    }
+                }
+            }
+            """;
+
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
+    public void CompletingSwitchArmDoesNotFallThroughToDefault_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2890.SwitchArmCompletion
+
+            func F(x int32) int32 {
+                switch x {
+                    case 1 { }
+                    default { return 1 }
+                }
+            }
+            """;
+
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
+    public void CompletingSelectArmDoesNotFallThroughToDefault_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2890.SelectArmCompletion
+            import Gsharp.Extensions.Go
+
+            func F() int32 {
+                let ch = make(chan int32, 1)
+                select {
+                    case ch <- 1 { }
+                    default { return 1 }
+                }
+            }
+            """;
+
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
     public void SelectWhoseEveryArmReturns_DoesNotReportGs0100()
     {
         const string Source = """
@@ -305,11 +395,10 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
     }
 
     [Fact]
-    public void LiteralSwitchSkipsImpossibleEscapingArms()
+    public void LiteralSwitchImpossibleEscapingArms_ReportsGs0100()
     {
         const string Source = """
             package Issue2890.LiteralSwitch
-            import Gsharp.Extensions.Go
 
             func F() int32 {
                 for {
@@ -320,9 +409,56 @@ public class Issue2890SwitchSelectEscapingBranchFlowTests
                     }
                 }
             }
+            """;
 
-            func SelectControl() int32 {
-                select {
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
+    public void PatternSwitchWhoseEveryArmReturns_RemainsValid()
+    {
+        const string Source = """
+            package Issue2890.SwitchReturnsGuard
+
+            func F(x int32) int32 {
+                switch x {
+                    case 1 { return 1 }
+                    default { return 2 }
+                }
+            }
+            """;
+
+        AssertNoErrors(Source);
+    }
+
+    [Fact]
+    public void CompletingSwitchArmFollowedByReturn_RemainsValid()
+    {
+        const string Source = """
+            package Issue2890.SwitchThenReturnGuard
+
+            func F(x int32) int32 {
+                switch x {
+                    case 1 { }
+                    default { return 1 }
+                }
+
+                return 2
+            }
+            """;
+
+        AssertNoErrors(Source);
+    }
+
+    [Fact]
+    public void TypePatternSwitchWhoseEveryArmReturns_RemainsValid()
+    {
+        const string Source = """
+            package Issue2890.TypePatternGuard
+
+            func F(value object) int32 {
+                switch value {
+                    case _ is string { return 1 }
                     default { return 2 }
                 }
             }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2890SwitchSelectEscapingBranchFlowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2890SwitchSelectEscapingBranchFlowTests.cs
@@ -1,0 +1,366 @@
+// <copyright file="Issue2890SwitchSelectEscapingBranchFlowTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2890: definite-return CFG must model pattern-switch and select arms
+/// as alternatives while preserving branches that escape those arms.
+/// </summary>
+public class Issue2890SwitchSelectEscapingBranchFlowTests
+{
+    [Fact]
+    public void BreakOutOfPatternSwitchArm_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2890.SwitchBreak
+
+            func F(x int32) int32 {
+                for {
+                    switch x {
+                        default { break }
+                    }
+                }
+            }
+            """;
+
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
+    public void BreakOutOfSelectDefaultArm_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2890.SelectBreak
+            import Gsharp.Extensions.Go
+
+            func F() int32 {
+                for {
+                    select {
+                        default { break }
+                    }
+                }
+            }
+            """;
+
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
+    public void BreakOutOfRealSelectArm_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2890.SelectRealBreak
+            import Gsharp.Extensions.Go
+
+            func F() int32 {
+                let ch = make(chan int32, 1)
+                for {
+                    select {
+                        case ch <- 1 { break }
+                        case <-ch { continue }
+                        default { continue }
+                    }
+                }
+            }
+            """;
+
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
+    public void BreakOutOfNestedPatternSwitchArm_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2890.NestedSwitchBreak
+
+            func F(x int32, y int32) int32 {
+                for {
+                    switch x {
+                        case 1 {
+                            switch y {
+                                default { break }
+                            }
+                        }
+                        default { continue }
+                    }
+                }
+            }
+            """;
+
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
+    public void LabeledBreakOutOfPatternSwitchArm_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2890.LabeledSwitchBreak
+
+            func F(x int32) int32 {
+                outer: for {
+                    for {
+                        switch x {
+                            default { break outer }
+                        }
+                    }
+                }
+            }
+            """;
+
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
+    public void GotoOutOfPatternSwitchArm_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2890.SwitchGoto
+
+            func F(x int32) int32 {
+                switch x {
+                    case 1 { goto done }
+                    default { return 1 }
+                }
+                return 2
+            done:
+                var reached = true
+            }
+            """;
+
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
+    public void GotoOutOfSelectArm_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2890.SelectGoto
+            import Gsharp.Extensions.Go
+
+            func F() int32 {
+                select {
+                    default { goto done }
+                }
+                return 1
+            done:
+                var reached = true
+            }
+            """;
+
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
+    public void PatternSwitchInsideFixedBreak_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2890.SwitchFixedBreak
+
+            func F(x int32, xs []int32) int32 {
+                unsafe {
+                    for {
+                        fixed p *int32 = xs {
+                            switch x {
+                                default { break }
+                            }
+                        }
+                    }
+                }
+            }
+            """;
+
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
+    public void PatternSwitchInsideScopeBreak_ReportsGs0100()
+    {
+        const string Source = """
+            package Issue2890.SwitchScopeBreak
+            import Gsharp.Extensions.Go
+
+            func F(x int32) int32 {
+                for {
+                    scope {
+                        switch x {
+                            default { break }
+                        }
+                    }
+                }
+            }
+            """;
+
+        AssertOnlyGs0100(Source);
+    }
+
+    [Fact]
+    public void SelectWhoseEveryArmReturns_DoesNotReportGs0100()
+    {
+        const string Source = """
+            package Issue2890.SelectReturns
+            import Gsharp.Extensions.Go
+
+            func F() int32 {
+                let ch = make(chan int32, 1)
+                select {
+                    case ch <- 1 { return 1 }
+                    case <-ch { return 2 }
+                    default { return 3 }
+                }
+            }
+            """;
+
+        AssertNoErrors(Source);
+    }
+
+    [Fact]
+    public void SelectWithoutDefaultWhoseEveryArmReturns_DoesNotReportGs0100()
+    {
+        const string Source = """
+            package Issue2890.SelectNoDefaultReturns
+            import Gsharp.Extensions.Go
+
+            func F() int32 {
+                let ch = make(chan int32, 1)
+                select {
+                    case ch <- 1 { return 1 }
+                    case <-ch { return 2 }
+                }
+            }
+            """;
+
+        AssertNoErrors(Source);
+    }
+
+    [Fact]
+    public void SelectWhoseEveryArmThrows_DoesNotReportGs0100()
+    {
+        const string Source = """
+            package Issue2890.SelectThrows
+            import System
+            import Gsharp.Extensions.Go
+
+            func F() int32 {
+                let ch = make(chan int32, 1)
+                select {
+                    case ch <- 1 { throw Exception() }
+                    case <-ch { throw Exception() }
+                    default { throw Exception() }
+                }
+            }
+            """;
+
+        AssertNoErrors(Source);
+    }
+
+    [Fact]
+    public void TotalDiscardSwitchWhoseArmReturns_DoesNotReportGs0100()
+    {
+        const string Source = """
+            package Issue2890.DiscardReturns
+
+            func F(x int32) int32 {
+                switch x {
+                    case _ { return 1 }
+                }
+            }
+            """;
+
+        AssertNoErrors(Source);
+    }
+
+    [Fact]
+    public void SwitchArmContainingReturningSelect_DoesNotReportGs0100()
+    {
+        const string Source = """
+            package Issue2890.SwitchSelectReturns
+            import Gsharp.Extensions.Go
+
+            func F(x int32) int32 {
+                let ch = make(chan int32, 1)
+                switch x {
+                    case 1 {
+                        select {
+                            case ch <- 1 { return 1 }
+                            default { return 2 }
+                        }
+                    }
+                    default { return 3 }
+                }
+            }
+            """;
+
+        AssertNoErrors(Source);
+    }
+
+    [Fact]
+    public void LiteralSwitchSkipsImpossibleEscapingArms()
+    {
+        const string Source = """
+            package Issue2890.LiteralSwitch
+            import Gsharp.Extensions.Go
+
+            func F() int32 {
+                for {
+                    switch 1 {
+                        case 2 { break }
+                        case > 5 { break }
+                        default { return 1 }
+                    }
+                }
+            }
+
+            func SelectControl() int32 {
+                select {
+                    default { return 2 }
+                }
+            }
+            """;
+
+        AssertNoErrors(Source);
+    }
+
+    private static void AssertOnlyGs0100(string source)
+    {
+        var (result, emittedLength) = Compile(source);
+        var diagnostic = Assert.Single(result.Diagnostics.Where(candidate => candidate.IsError));
+        var expectedStart = source.IndexOf("F(", StringComparison.Ordinal);
+
+        Assert.False(result.Success);
+        Assert.Equal("GS0100", diagnostic.Id);
+        Assert.Equal(expectedStart, diagnostic.Location.Span.Start);
+        Assert.Equal(1, diagnostic.Location.Span.Length);
+        Assert.Equal("F", diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+        Assert.Equal(0, emittedLength);
+    }
+
+    private static void AssertNoErrors(string source)
+    {
+        var (result, emittedLength) = Compile(source);
+        Assert.True(
+            result.Success,
+            string.Join(Environment.NewLine, result.Diagnostics.Select(diagnostic => diagnostic.ToString())));
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.True(emittedLength > 0);
+    }
+
+    private static (EmitResult Result, long EmittedLength) Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        return (result, peStream.Length);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2899ThrowDeadCodeFlowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2899ThrowDeadCodeFlowTests.cs
@@ -1,0 +1,74 @@
+// <copyright file="Issue2899ThrowDeadCodeFlowTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2899: definite-return may split at throw, but shared out-parameter
+/// analysis must keep its existing opaque exception-flow behavior.
+/// </summary>
+public class Issue2899ThrowDeadCodeFlowTests
+{
+    [Fact]
+    public void ThrowFollowedByDeadCode_DoesNotReportGs0100OrGs0238()
+    {
+        const string Source = """
+            package Issue2899.ThrowDeadCode
+            import System
+
+            func Value() int32 {
+                throw Exception("boom")
+                var dead = 1
+            }
+
+            func Assign(out value int32) {
+                throw Exception("boom")
+                value = 1
+            }
+            """;
+
+        AssertNoErrors(Source);
+    }
+
+    [Fact]
+    public void ConditionalReturnAndThrowFollowedByDeadCode_DoesNotReportGs0100()
+    {
+        const string Source = """
+            package Issue2899.ConditionalThrowDeadCode
+            import System
+
+            func F(condition bool) int32 {
+                if condition {
+                    return 1
+                }
+                throw Exception("boom")
+                var dead = 2
+            }
+            """;
+
+        AssertNoErrors(Source);
+    }
+
+    private static void AssertNoErrors(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            string.Join(Environment.NewLine, result.Diagnostics.Select(diagnostic => diagnostic.ToString())));
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.True(peStream.Length > 0);
+    }
+}


### PR DESCRIPTION
## Summary

- project pattern-switch and select arms into an arm-aware, definite-return-only CFG view
- expose escaping break/goto edges without changing lowering or emission
- keep shared definite-assignment and ref-struct analyses on their existing opaque CFG
- fix the related definite-return-only throw/dead-code bug from #2899
- keep literal switches conservative until lowering and emission share constant folding

## Root cause and approach

`Lowerer.Flatten` keeps `BoundPatternSwitchStatement` and `BoundSelectStatement` structured while flattening each arm body. The shared `BasicBlockBuilder` therefore saw each whole statement as one opaque fall-through node. Lowered gotos inside arms could not resolve labels outside the structured node, including an enclosing loop's break label, so definite-return missed paths that reached the end of a value-returning function.

The sequential projection added for #2883 cannot be reused for arm bodies: `fixed` and `scope` execute one body once, while switch/select arms are alternatives. Concatenating arms would invent case-to-case execution and make fallthrough unsound.

`AllPathsReturn` now uses the existing private projection plumbing with explicit arm topology:

- pattern switch: independent match alternatives, a default/no-match route, and an end edge from each non-default arm that completes normally
- select with default: every channel case is an alternative; no ready case dispatches to default
- select without default: no ready case loops back to dispatch, representing blocking rather than method fallthrough
- each arm body is recursively projected, so nested switch/select and #2883 fixed/scope regions compose
- an unguarded discard remains a total arm because emission also treats it as total

G# `break` targets loops only. A `break` inside a switch arm exits the nearest loop; outside a loop it remains GS0120. Switch/select arms do not fall through into later arms.

## Review fix: conservative literal dispatch

The first revision folded literal discriminants and literal-false guards only in definite-return analysis. Emission still generated real dispatch and unmatched fallthrough, allowing invalid non-void IL.

This revision adopts variant S:

- removed literal-discriminant capture and matching
- removed literal-false guard pruning
- removed all literal comparison, enum, NaN, relational, binary, and negation folding helpers
- retained only the sound total-discard shortcut
- changed the previous literal acceptance test to require GS0100
- added `b09`, `e05`, `g03`, switch `i01`, and the select arm-completion sibling

A constant switch without a default now reports GS0100. Accepting it requires folding in lowering so analysis and emission share one shape; tracked by #2914.

## Analyzer and emission isolation

The public `ControlFlowGraph.Create(body)` path remains behaviorally unchanged for ref-kind definite assignment and ref-struct async liveness. Only `AllPathsReturn` requests region projection and throw termination.

Arm projection exposes throws followed by synthetic arm-end branches. Definite-return alone therefore splits blocks at throw. Shared CFG callers do not, preserving Roslyn-legal out-parameter behavior and avoiding GS0238/GS0239/GS0219 drift. This also fixes #2899.

Lowering and `MethodBodyEmitter` remain unchanged. Pattern-switch end-label/trailing-ret behavior stays owned by the existing emitter guard.

## Over-fire guards

Added three explicit shapes that compile on both merge-base and HEAD:

- switch where every arm returns
- normally completing switch arm followed by a return
- type-pattern switch where every arm returns

Each has a Compiler.Tests twin that IL-verifies, loads, invokes, and checks its result. Every no-error shape in the Core issue test now has such an emit/runtime twin, including select with/without default, throwing select, total discard, and nested switch/select. Of the nine baseline-preserving tests in the revert proof, six are over-fire guards for valid programs and three are under-fire guards that preserve GS0100 for non-returning programs.

## Under-fire coverage

Verified GS0100, exact function-identifier location, sole-error status, and zero PE bytes for:

- default-only switch/select breaks
- real select send/receive alternatives
- nested and labeled switch-arm breaks
- goto from switch/select arms to a non-returning external label
- switch-arm breaks through fixed and scope projection
- literal unmatched-arm breaks
- literal-false guarded breaks
- non-default switch/select arms that complete normally rather than falling into a later/default arm
- literal switches without an emitted no-match return

Both original CLI repros exit 1 with one GS0100 and emit no DLL.

#2891 remains separate: removing the switch from the try repro leaves the same failure. Try/catch/finally needs exception-region alternatives plus finally-on-every-exit semantics, and `try` is the remaining opaque definite-return region.

#2906 remains unchanged: exhaustive closed-enum switches report GS0100 on merge-base and HEAD because exhaustiveness is not carried into this bound CFG node.

## Mutation audit

Each mutation ran against 25 Core issue tests and 10 Compiler emit tests. Every remaining production behavior hunk reddened at least one test:

| Mutation | Core red | Compiler red |
|---|---:|---:|
| shared `Create` throw isolation disabled | 1 | 0 |
| definite-return throw split disabled | 3 | 1 |
| pattern-switch projection disabled | 11 | 3 |
| select projection disabled | 7 | 5 |
| total-discard shortcut removed | 1 | 1 |
| switch default/no-match route forced to end | 8 | 4 |
| switch per-arm end edge removed | 1 | 0 |
| select default route forced to end | 6 | 5 |
| select case dispatch removed | 2 | 0 |
| select per-case end edge removed | 1 | 0 |

Redundant gotos from the final default switch/select arm to the immediately following end label were deleted rather than retained as untestable hunks.

## Revert proof

With the production CFG file restored to merge-base while all new tests remained:

- Core: 19 failed, 6 passed
- Compiler: 7 failed, 3 passed
- total behavior-change pins: 26/26 failed
- total baseline-preserving guards: 9/9 passed

This corrects the first revision's terminology: tests that fail on revert are pins; guards must pass on both revisions.

## IL verification hardening

`IlVerifier` now:

- rejects every missing `-r` path before invoking the tool
- requires the tool's exact `All Classes and Methods ... Verified.` success marker even when exit code is zero
- has a helper regression test for missing references

## Validation

- targeted Release tests: Core 25 passed; Compiler/IlVerifier 15 passed, including the #2899 ILVerify/load/invoke twin
- full Core.Tests: 6,884 passed, 0 failed, 1 skipped (6,885 total)
- full Compiler.Tests: 3,687 passed, 0 failed
- CI-style Release graph build: 0 warnings, 0 errors
- 148-file corpus: diagnostic status identical for 148/148; 142/142 emitted assemblies byte-identical; 6/6 failures identical; zero diagnostic drift and zero byte drift
- exact switch/select repros: one GS0100 each, no assembly emitted
- no e2e run

Follow-ups filed: #2906 for closed-enum exhaustiveness, #2914 for lowering-time constant-switch folding, #2921 for missing GS0100 enforcement in lambda bodies, and #2922 for pre-existing `fixed` + `switch` invalid IL. No #2890 shape in a named function or accessor remains deferred; lambda bodies are unchecked and tracked by #2921.

Fixes #2890
Fixes #2899
