### PR TITLE
Preserve nested source types in lambda thunk signatures

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3850,22 +3850,17 @@ public sealed class Binder
                 return null;
             }
 
-            // #313: in-scope type parameters project onto System.Object under
-            // the type-erased generic model so the closed CLR shape is well
-            // formed while the symbolic argument is preserved alongside.
-            if (TypeSymbol.ContainsTypeParameter(ta))
+            // #313 / #671: keep any symbolic projection alongside the erased
+            // closed CLR shape, including nested generic/array/nullable forms.
+            if (TypeSymbol.RequiresSymbolicProjection(ta) || ta.ClrType == null)
             {
                 hasSymbolicArg = true;
-                clrArgs[i] = scope.References.MapClrTypeToReferences(typeof(object));
-                continue;
-            }
-
-            // Issue #671: user-defined types without a ClrType project onto
-            // System.Object (same as type parameters above).
-            if (ta.ClrType == null)
-            {
-                hasSymbolicArg = true;
-                clrArgs[i] = scope.References.MapClrTypeToReferences(typeof(object));
+                clrArgs[i] = TypeSymbol.ContainsTypeParameter(ta)
+                    || TypeSymbol.ContainsSameCompilationUserType(ta)
+                    || ta.ClrType == null
+                        ? scope.References.MapClrTypeToReferences(typeof(object))
+                        : ResolveClrTypeForGenericArg(ta)
+                            ?? scope.References.MapClrTypeToReferences(ta.ClrType);
                 continue;
             }
 

--- a/test/Compiler.Tests/Emit/Issue2889LambdaThunkNestedGenericTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2889LambdaThunkNestedGenericTests.cs
@@ -1,0 +1,535 @@
+// <copyright file="Issue2889LambdaThunkNestedGenericTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2889 — qualified imported generic types discarded symbolic nested
+/// arguments before lambda target typing, so synthesized thunk signatures used
+/// erased <c>List&lt;object&gt;</c> instead of <c>List&lt;Src&gt;</c>.
+/// </summary>
+public class Issue2889LambdaThunkNestedGenericTests
+{
+    [Fact]
+    public void ImportedClrDelegates_PreserveNestedSourceShapes_VerifyAndRun()
+    {
+        const string source = """
+            package i2889imported
+            import System
+            import System.Collections.Generic
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            struct Pt { var X int32 }
+
+            class MyBox[T any] {
+                let Value T
+                init(value T) { Value = value }
+            }
+
+            class Holder {
+                let Field System.Action[List[Src]]
+                prop Property System.Action[List[Src]] { get; init; }
+
+                init() {
+                    Field = (items List[Src]) -> Console.WriteLine(items[0].N)
+                    Property = (items) -> Console.WriteLine(items[0].N + 1)
+                }
+
+                func Run(items List[Src]) {
+                    Field(items)
+                    Property(items)
+                }
+            }
+
+            func PrintMethod(items List[Src]) {
+                Console.WriteLine(items[0].N)
+            }
+
+            func Main() {
+                let classItems = List[Src]{ Src(10) }
+                let classAction System.Action[List[Src]] =
+                    (items List[Src]) -> Console.WriteLine(items[0].N)
+                classAction(classItems)
+
+                var optional System.Action[List[Src]]? = classAction
+                if optional != nil {
+                    optional(classItems)
+                }
+
+                var point Pt
+                point.X = 12
+                let pointAction System.Action[List[Pt]] =
+                    (items List[Pt]) -> Console.WriteLine(items[0].X)
+                pointAction(List[Pt]{ point })
+
+                let make System.Func[List[Src]] = () -> List[Src]{ Src(13) }
+                Console.WriteLine(make()[0].N)
+
+                let pair System.Action[List[Src], Dictionary[string, Src]] =
+                    (items List[Src], byName Dictionary[string, Src]) ->
+                        Console.WriteLine(items[0].N + byName["x"].N)
+                let byName = Dictionary[string, Src]()
+                byName.Add("x", Src(7))
+                pair(List[Src]{ Src(7) }, byName)
+
+                let deep System.Action[List[List[Src]]] =
+                    (items List[List[Src]]) -> Console.WriteLine(items[0][0].N)
+                deep(List[List[Src]]{ List[Src]{ Src(15) } })
+
+                let generic System.Action[List[MyBox[int32]]] =
+                    (items List[MyBox[int32]]) -> Console.WriteLine(items[0].Value)
+                generic(List[MyBox[int32]]{ MyBox[int32](16) })
+
+                let arrayAction System.Action[[]Src] =
+                    (items []Src) -> Console.WriteLine(items[0].N)
+                arrayAction([]Src{ Src(17) })
+
+                let nullableAction System.Action[List[Src?]] =
+                    (items List[Src?]) -> Console.WriteLine(items[1]!!.N)
+                nullableAction(List[Src?]{ nil, Src(18) })
+
+                let methodGroup System.Action[List[Src]] = PrintMethod
+                methodGroup(List[Src]{ Src(19) })
+
+                let inferred System.Action[List[Src]] =
+                    (items) -> Console.WriteLine(items[0].N)
+                inferred(List[Src]{ Src(20) })
+
+                Holder().Run(List[Src]{ Src(21) })
+            }
+            """;
+
+        Assert.Equal(
+            "10\n10\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n",
+            CompileAndRun(source, expectedSourceTypeName: "i2889imported.Src"));
+    }
+
+    [Fact]
+    public void ImportedNamedDelegates_PreserveNestedSourceShapes_VerifyAndRun()
+    {
+        const string library = """
+            package i2889contracts
+
+            type ImportedSink[T any] = delegate func(value T) void
+            type ImportedPair[T any, U any] = delegate func(first T, second U) void
+            type ImportedFactory[T any] = delegate func() T
+            """;
+
+        const string consumer = """
+            package i2889nameduse
+            import System
+            import System.Collections.Generic
+            import i2889contracts
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            struct Pt { var X int32 }
+
+            class MyBox[T any] {
+                let Value T
+                init(value T) { Value = value }
+            }
+
+            func Print(items List[Src]) { Console.WriteLine(items[0].N) }
+
+            func Main() {
+                let classSink i2889contracts.ImportedSink[List[Src]] =
+                    (items List[Src]) -> Console.WriteLine(items[0].N)
+                classSink(List[Src]{ Src(70) })
+
+                var point Pt
+                point.X = 71
+                let structSink i2889contracts.ImportedSink[List[Pt]] =
+                    (items List[Pt]) -> Console.WriteLine(items[0].X)
+                structSink(List[Pt]{ point })
+
+                let factory i2889contracts.ImportedFactory[List[Src]] =
+                    () -> List[Src]{ Src(72) }
+                Console.WriteLine(factory()[0].N)
+
+                let pair i2889contracts.ImportedPair[List[Src], Dictionary[string, Src]] =
+                    (items List[Src], byName Dictionary[string, Src]) ->
+                        Console.WriteLine(items[0].N + byName["x"].N)
+                let byName = Dictionary[string, Src]()
+                byName.Add("x", Src(36))
+                pair(List[Src]{ Src(37) }, byName)
+
+                let deep i2889contracts.ImportedSink[List[List[Src]]] =
+                    (items List[List[Src]]) -> Console.WriteLine(items[0][0].N)
+                deep(List[List[Src]]{ List[Src]{ Src(74) } })
+
+                let generic i2889contracts.ImportedSink[List[MyBox[int32]]] =
+                    (items List[MyBox[int32]]) -> Console.WriteLine(items[0].Value)
+                generic(List[MyBox[int32]]{ MyBox[int32](75) })
+
+                let arraySink i2889contracts.ImportedSink[[]Src] =
+                    (items []Src) -> Console.WriteLine(items[0].N)
+                arraySink([]Src{ Src(76) })
+
+                let nullableSink i2889contracts.ImportedSink[List[Src?]] =
+                    (items List[Src?]) -> Console.WriteLine(items[1]!!.N)
+                nullableSink(List[Src?]{ nil, Src(77) })
+
+                let group i2889contracts.ImportedSink[List[Src]] = Print
+                group(List[Src]{ Src(78) })
+
+                let inferred i2889contracts.ImportedSink[List[Src]] =
+                    (items) -> Console.WriteLine(items[0].N)
+                inferred(List[Src]{ Src(79) })
+            }
+            """;
+
+        Assert.Equal(
+            "70\n71\n72\n73\n74\n75\n76\n77\n78\n79\n",
+            CompileAndRun(
+                consumer,
+                expectedSourceTypeName: "i2889nameduse.Src",
+                library: library,
+                libraryAssemblyName: "i2889contracts"));
+    }
+
+    [Fact]
+    public void SourceNamedAndFunctionTypeControls_PreserveNestedSourceShapes_VerifyAndRun()
+    {
+        const string source = """
+            package i2889controls
+            import System
+            import System.Collections.Generic
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            struct Pt { var X int32 }
+
+            class MyBox[T any] {
+                let Value T
+                init(value T) { Value = value }
+            }
+
+            type Sink[T any] = delegate func(value T) void
+            type PairSink[T any, U any] = delegate func(first T, second U) void
+            type Factory[T any] = delegate func() T
+
+            func PrintNamed(items List[Src]) { Console.WriteLine(items[0].N) }
+            func PrintBare(items List[Src]) { Console.WriteLine(items[0].N) }
+
+            class NamedHolder {
+                let Field Sink[List[Src]]
+                prop Property Sink[List[Src]] { get; init; }
+
+                init() {
+                    Field = (items List[Src]) -> Console.WriteLine(items[0].N)
+                    Property = (items) -> Console.WriteLine(items[0].N + 1)
+                }
+
+                func Run(items List[Src]) {
+                    Field(items)
+                    Property(items)
+                }
+            }
+
+            class BareHolder {
+                let Field (List[Src]) -> void
+                prop Property (List[Src]) -> void { get; init; }
+
+                init() {
+                    Field = (items List[Src]) -> Console.WriteLine(items[0].N)
+                    Property = (items) -> Console.WriteLine(items[0].N + 1)
+                }
+
+                func Run(items List[Src]) {
+                    Field(items)
+                    Property(items)
+                }
+            }
+
+            func Main() {
+                let named Sink[List[Src]] =
+                    (items List[Src]) -> Console.WriteLine(items[0].N)
+                named(List[Src]{ Src(30) })
+
+                var namedPoint Pt
+                namedPoint.X = 32
+                let namedStruct Sink[List[Pt]] =
+                    (items List[Pt]) -> Console.WriteLine(items[0].X)
+                namedStruct(List[Pt]{ namedPoint })
+
+                let namedFactory Factory[List[Src]] = () -> List[Src]{ Src(33) }
+                Console.WriteLine(namedFactory()[0].N)
+
+                let namedPair PairSink[List[Src], Dictionary[string, Src]] =
+                    (items List[Src], byName Dictionary[string, Src]) ->
+                        Console.WriteLine(items[0].N + byName["x"].N)
+                let namedByName = Dictionary[string, Src]()
+                namedByName.Add("x", Src(17))
+                namedPair(List[Src]{ Src(17) }, namedByName)
+
+                let namedDeep Sink[List[List[Src]]] =
+                    (items List[List[Src]]) -> Console.WriteLine(items[0][0].N)
+                namedDeep(List[List[Src]]{ List[Src]{ Src(35) } })
+
+                let namedGeneric Sink[List[MyBox[int32]]] =
+                    (items List[MyBox[int32]]) -> Console.WriteLine(items[0].Value)
+                namedGeneric(List[MyBox[int32]]{ MyBox[int32](36) })
+
+                let namedArray Sink[[]Src] =
+                    (items []Src) -> Console.WriteLine(items[0].N)
+                namedArray([]Src{ Src(37) })
+
+                let namedNullable Sink[List[Src?]] =
+                    (items List[Src?]) -> Console.WriteLine(items[1]!!.N)
+                namedNullable(List[Src?]{ nil, Src(38) })
+
+                let namedGroup Sink[List[Src]] = PrintNamed
+                namedGroup(List[Src]{ Src(39) })
+                let namedInferred Sink[List[Src]] =
+                    (items) -> Console.WriteLine(items[0].N)
+                namedInferred(List[Src]{ Src(40) })
+                NamedHolder().Run(List[Src]{ Src(41) })
+
+                let bare (List[Src]) -> void =
+                    (items List[Src]) -> Console.WriteLine(items[0].N)
+                bare(List[Src]{ Src(50) })
+
+                var barePoint Pt
+                barePoint.X = 52
+                let bareStruct (List[Pt]) -> void =
+                    (items List[Pt]) -> Console.WriteLine(items[0].X)
+                bareStruct(List[Pt]{ barePoint })
+
+                let bareFactory () -> List[Src] = () -> List[Src]{ Src(53) }
+                Console.WriteLine(bareFactory()[0].N)
+
+                let barePair (List[Src], Dictionary[string, Src]) -> void =
+                    (items List[Src], byName Dictionary[string, Src]) ->
+                        Console.WriteLine(items[0].N + byName["x"].N)
+                let bareByName = Dictionary[string, Src]()
+                bareByName.Add("x", Src(27))
+                barePair(List[Src]{ Src(27) }, bareByName)
+
+                let bareDeep (List[List[Src]]) -> void =
+                    (items List[List[Src]]) -> Console.WriteLine(items[0][0].N)
+                bareDeep(List[List[Src]]{ List[Src]{ Src(55) } })
+
+                let bareGeneric (List[MyBox[int32]]) -> void =
+                    (items List[MyBox[int32]]) -> Console.WriteLine(items[0].Value)
+                bareGeneric(List[MyBox[int32]]{ MyBox[int32](56) })
+
+                let bareArray ([]Src) -> void =
+                    (items []Src) -> Console.WriteLine(items[0].N)
+                bareArray([]Src{ Src(57) })
+
+                let bareNullable (List[Src?]) -> void =
+                    (items List[Src?]) -> Console.WriteLine(items[1]!!.N)
+                bareNullable(List[Src?]{ nil, Src(58) })
+
+                let bareGroup (List[Src]) -> void = PrintBare
+                bareGroup(List[Src]{ Src(59) })
+                let bareInferred (List[Src]) -> void =
+                    (items) -> Console.WriteLine(items[0].N)
+                bareInferred(List[Src]{ Src(60) })
+                BareHolder().Run(List[Src]{ Src(61) })
+
+                let importedPin System.Action[List[Src]] =
+                    (items List[Src]) -> Console.WriteLine(items[0].N)
+                importedPin(List[Src]{ Src(63) })
+            }
+            """;
+
+        Assert.Equal(
+            "30\n32\n33\n34\n35\n36\n37\n38\n39\n40\n41\n42\n"
+            + "50\n52\n53\n54\n55\n56\n57\n58\n59\n60\n61\n62\n63\n",
+            CompileAndRun(source, expectedSourceTypeName: "i2889controls.Src"));
+    }
+
+    private static string CompileAndRun(
+        string source,
+        string expectedSourceTypeName,
+        string library = null,
+        string libraryAssemblyName = null)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "Issue2889_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string libraryPath = null;
+            if (library != null)
+            {
+                var librarySourcePath = Path.Combine(directory, libraryAssemblyName + ".gs");
+                libraryPath = Path.Combine(directory, libraryAssemblyName + ".dll");
+                File.WriteAllText(librarySourcePath, library);
+                Compile(
+                [
+                    "/out:" + libraryPath,
+                    "/target:library",
+                    "/targetframework:net10.0",
+                    librarySourcePath,
+                ]);
+                IlVerifier.Verify(libraryPath);
+            }
+
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var assemblyPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+            var args = new List<string>
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+            if (libraryPath != null)
+            {
+                args.Add("/nowarn:GS9100");
+                args.Add("/r:" + libraryPath);
+            }
+
+            args.Add(sourcePath);
+            Compile(args.ToArray());
+            IlVerifier.Verify(
+                assemblyPath,
+                libraryPath != null ? new[] { libraryPath } : null);
+            AssertLambdaSignatures(assemblyPath, expectedSourceTypeName, libraryPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(assemblyPath, ".runtimeconfig.json");
+            if (!File.Exists(runtimeConfigPath))
+            {
+                File.WriteAllText(runtimeConfigPath, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(runtimeConfigPath);
+            startInfo.ArgumentList.Add(assemblyPath);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out.");
+            Assert.True(
+                process.ExitCode == 0,
+                $"dotnet exec exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static void AssertLambdaSignatures(
+        string assemblyPath,
+        string expectedSourceTypeName,
+        string libraryPath)
+    {
+        var loadContext = new AssemblyLoadContext(
+            "Issue2889_" + Guid.NewGuid().ToString("N"),
+            isCollectible: true);
+        if (libraryPath != null)
+        {
+            loadContext.Resolving += (_, name) =>
+                string.Equals(name.Name, Path.GetFileNameWithoutExtension(libraryPath), StringComparison.Ordinal)
+                    ? loadContext.LoadFromAssemblyPath(libraryPath)
+                    : null;
+        }
+
+        try
+        {
+            var assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+            var signatures = assembly
+                .GetTypes()
+                .SelectMany(type => type.GetMethods(
+                    BindingFlags.Public
+                    | BindingFlags.NonPublic
+                    | BindingFlags.Static
+                    | BindingFlags.Instance))
+                .Where(method => method.Name.Contains("<lambda", StringComparison.Ordinal))
+                .Select(method =>
+                    method.ReturnType + "("
+                    + string.Join(",", method.GetParameters().Select(parameter => parameter.ParameterType))
+                    + ")")
+                .ToArray();
+
+            Assert.NotEmpty(signatures);
+            var rendered = string.Join("\n", signatures);
+            Assert.Contains(
+                "System.Collections.Generic.List`1[" + expectedSourceTypeName + "]",
+                rendered,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "System.Collections.Generic.List`1[System.Object]",
+                rendered,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static void Compile(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(
+            exitCode == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2889LambdaThunkNestedGenericTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2889LambdaThunkNestedGenericTests.cs
@@ -10,6 +10,8 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
 using GSharp.Compiler;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -28,6 +30,7 @@ public class Issue2889LambdaThunkNestedGenericTests
             package i2889imported
             import System
             import System.Collections.Generic
+            import System.Threading.Tasks
 
             class Src {
                 let N int32
@@ -35,6 +38,18 @@ public class Issue2889LambdaThunkNestedGenericTests
             }
 
             struct Pt { var X int32 }
+
+            enum Mode { First, Second }
+
+            interface IValue {
+                func Value() int32;
+            }
+
+            class SourceValue : IValue {
+                let N int32
+                init(n int32) { N = n }
+                func Value() int32 -> N
+            }
 
             class MyBox[T any] {
                 let Value T
@@ -58,6 +73,16 @@ public class Issue2889LambdaThunkNestedGenericTests
 
             func PrintMethod(items List[Src]) {
                 Console.WriteLine(items[0].N)
+            }
+
+            func MakePrinter() System.Action[List[Src]] {
+                return (items List[Src]) -> Console.WriteLine(items[0].N)
+            }
+
+            func InvokePrinter(
+                printer System.Action[List[Src]],
+                items List[Src]) {
+                printer(items)
             }
 
             func Main() {
@@ -111,12 +136,58 @@ public class Issue2889LambdaThunkNestedGenericTests
                 inferred(List[Src]{ Src(20) })
 
                 Holder().Run(List[Src]{ Src(21) })
+
+                let identity System.Func[List[Src], List[Src]] =
+                    (items List[Src]) -> items
+                Console.WriteLine(identity(List[Src]{ Src(23) })[0].N)
+
+                let offset = 1
+                let captured System.Action[List[Src]] =
+                    (items List[Src]) -> Console.WriteLine(items[0].N + offset)
+                captured(List[Src]{ Src(23) })
+
+                MakePrinter()(List[Src]{ Src(25) })
+
+                InvokePrinter(
+                    (items List[Src]) -> Console.WriteLine(items[0].N),
+                    List[Src]{ Src(26) })
+
+                let enumAction System.Action[List[Mode]] =
+                    (items List[Mode]) -> Console.WriteLine(items.Count + 26)
+                enumAction(List[Mode]{ Mode.Second })
+
+                let interfaceAction System.Action[List[IValue]] =
+                    (items List[IValue]) -> Console.WriteLine(items[0].Value())
+                interfaceAction(List[IValue]{ SourceValue(28) })
+
+                let dictionaryAction System.Action[Dictionary[Src, List[Src]]] =
+                    (items Dictionary[Src, List[Src]]) ->
+                        Console.WriteLine(items.Count + 28)
+                let bySource = Dictionary[Src, List[Src]]()
+                bySource.Add(Src(1), List[Src]{ Src(1) })
+                dictionaryAction(bySource)
+
+                let listArrayAction System.Action[[]List[Src]] =
+                    (items []List[Src]) -> Console.WriteLine(items[0][0].N)
+                listArrayAction([]List[Src]{ List[Src]{ Src(30) } })
+
+                let taskFactory System.Func[Task[List[Src]]] =
+                    () -> Task.FromResult[List[Src]](List[Src]{ Src(31) })
+                Console.WriteLine(taskFactory().Result[0].N)
+
+                let taskAction System.Action[Task[List[Src]]] =
+                    (items Task[List[Src]]) -> Console.WriteLine(items.Result[0].N)
+                taskAction(Task.FromResult[List[Src]](List[Src]{ Src(32) }))
             }
             """;
 
         Assert.Equal(
-            "10\n10\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n",
-            CompileAndRun(source, expectedSourceTypeName: "i2889imported.Src"));
+            "10\n10\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n"
+            + "23\n24\n25\n26\n27\n28\n29\n30\n31\n32\n",
+            CompileAndRun(
+                source,
+                expectedSourceTypeName: "i2889imported.Src",
+                expectClosure: true));
     }
 
     [Fact]
@@ -362,11 +433,142 @@ public class Issue2889LambdaThunkNestedGenericTests
             CompileAndRun(source, expectedSourceTypeName: "i2889controls.Src"));
     }
 
+    [Fact]
+    public void InlineLambdaThroughNestedErasedReceiver_ReportsCurrentDiagnostics()
+    {
+        var diagnostics = CompileExpectingFailure("""
+            package i2889inline
+            import System
+            import System.Collections.Generic
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let callbacks = List[System.Action[List[Src]]]()
+                callbacks.Add((items List[Src]) -> Console.WriteLine(items[0].N))
+            }
+            """);
+
+        Assert.Contains("error GS0159: Cannot find function Add.", diagnostics, StringComparison.Ordinal);
+        Assert.Contains(
+            "error GS0155: Cannot convert type 'object' to 'System.Collections.Generic.List[Src]'.",
+            diagnostics,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PublicLibraryDelegateSignature_RoundTripsThroughCSharp()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "Issue2889_PublicApi_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var librarySourcePath = Path.Combine(directory, "library.gs");
+            var libraryPath = Path.Combine(directory, "i2889publicapi.dll");
+            File.WriteAllText(librarySourcePath, """
+                package i2889publicapi
+                import System
+                import System.Collections.Generic
+
+                class Src {}
+
+                class Api {
+                    shared {
+                        func Register(callback System.Action[List[Src]]) {
+                            callback(List[Src]{ Src() })
+                        }
+                    }
+                }
+                """);
+            Compile(
+            [
+                "/out:" + libraryPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                librarySourcePath,
+            ]);
+            IlVerifier.Verify(libraryPath);
+
+            var syntaxTree = CSharpSyntaxTree.ParseText("""
+                using System.Collections.Generic;
+                using i2889publicapi;
+
+                namespace Consumer;
+
+                public static class Runner
+                {
+                    public static int Run()
+                    {
+                        var count = 0;
+                        Api.Register((List<Src> items) => count = items.Count);
+                        return count;
+                    }
+                }
+                """);
+            var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                    ?.Split(Path.PathSeparator)
+                    ?? Array.Empty<string>())
+                .Where(File.Exists)
+                .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+                .Append(MetadataReference.CreateFromFile(libraryPath));
+            var consumerPath = Path.Combine(directory, "consumer.dll");
+            var consumer = CSharpCompilation.Create(
+                "Issue2889CSharpConsumer",
+                new[] { syntaxTree },
+                references,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            using (var peStream = File.Create(consumerPath))
+            {
+                var result = consumer.Emit(peStream);
+                Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+            }
+
+            IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
+
+            var loadContext = new AssemblyLoadContext(
+                "Issue2889_PublicApi_" + Guid.NewGuid().ToString("N"),
+                isCollectible: true);
+            try
+            {
+                var libraryAssembly = loadContext.LoadFromAssemblyPath(libraryPath);
+                loadContext.Resolving += (_, name) =>
+                    name.Name == libraryAssembly.GetName().Name ? libraryAssembly : null;
+
+                var api = libraryAssembly.GetTypes().Single(type => type.Name == "Api");
+                var parameterType = api.GetMethod("Register")!.GetParameters().Single().ParameterType;
+                Assert.Equal(typeof(Action<>), parameterType.GetGenericTypeDefinition());
+                var listType = parameterType.GetGenericArguments().Single();
+                Assert.Equal(typeof(List<>), listType.GetGenericTypeDefinition());
+                var sourceType = listType.GetGenericArguments().Single();
+                Assert.Equal("i2889publicapi.Src", sourceType.FullName);
+                Assert.NotEqual(typeof(object), sourceType);
+
+                var consumerAssembly = loadContext.LoadFromAssemblyPath(consumerPath);
+                var run = consumerAssembly.GetType("Consumer.Runner")!.GetMethod("Run")!;
+                Assert.Equal(1, run.Invoke(null, null));
+            }
+            finally
+            {
+                loadContext.Unload();
+            }
+        }
+        finally
+        {
+            TryDeleteDirectory(directory);
+        }
+    }
+
     private static string CompileAndRun(
         string source,
         string expectedSourceTypeName,
         string library = null,
-        string libraryAssemblyName = null)
+        string libraryAssemblyName = null,
+        bool expectClosure = false)
     {
         var directory = Path.Combine(
             AppContext.BaseDirectory,
@@ -410,7 +612,11 @@ public class Issue2889LambdaThunkNestedGenericTests
             IlVerifier.Verify(
                 assemblyPath,
                 libraryPath != null ? new[] { libraryPath } : null);
-            AssertLambdaSignatures(assemblyPath, expectedSourceTypeName, libraryPath);
+            AssertLambdaSignatures(
+                assemblyPath,
+                expectedSourceTypeName,
+                libraryPath,
+                expectClosure);
 
             var runtimeConfigPath = Path.ChangeExtension(assemblyPath, ".runtimeconfig.json");
             if (!File.Exists(runtimeConfigPath))
@@ -449,20 +655,15 @@ public class Issue2889LambdaThunkNestedGenericTests
         }
         finally
         {
-            try
-            {
-                Directory.Delete(directory, recursive: true);
-            }
-            catch
-            {
-            }
+            TryDeleteDirectory(directory);
         }
     }
 
     private static void AssertLambdaSignatures(
         string assemblyPath,
         string expectedSourceTypeName,
-        string libraryPath)
+        string libraryPath,
+        bool expectClosure)
     {
         var loadContext = new AssemblyLoadContext(
             "Issue2889_" + Guid.NewGuid().ToString("N"),
@@ -478,30 +679,43 @@ public class Issue2889LambdaThunkNestedGenericTests
         try
         {
             var assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
-            var signatures = assembly
+            var lambdaMethods = assembly
                 .GetTypes()
                 .SelectMany(type => type.GetMethods(
                     BindingFlags.Public
                     | BindingFlags.NonPublic
                     | BindingFlags.Static
-                    | BindingFlags.Instance))
-                .Where(method => method.Name.Contains("<lambda", StringComparison.Ordinal))
-                .Select(method =>
-                    method.ReturnType + "("
-                    + string.Join(",", method.GetParameters().Select(parameter => parameter.ParameterType))
-                    + ")")
+                    | BindingFlags.Instance)
+                    .Where(method =>
+                        method.Name.Contains("<lambda", StringComparison.Ordinal)
+                        || (type.FullName?.Contains("<closure", StringComparison.Ordinal) == true
+                            && method.Name == "Invoke"))
+                    .Select(method => (Type: type, Method: method)))
                 .ToArray();
 
-            Assert.NotEmpty(signatures);
-            var rendered = string.Join("\n", signatures);
+            Assert.NotEmpty(lambdaMethods);
+            if (expectClosure)
+            {
+                Assert.Contains(
+                    lambdaMethods,
+                    candidate =>
+                        candidate.Type.FullName?.Contains("<closure", StringComparison.Ordinal) == true
+                        && candidate.Method.Name == "Invoke");
+            }
+
+            var rendered = string.Join(
+                "\n",
+                lambdaMethods.Select(candidate =>
+                    candidate.Method.ReturnType + "("
+                    + string.Join(
+                        ",",
+                        candidate.Method.GetParameters().Select(parameter => parameter.ParameterType))
+                    + ")"));
             Assert.Contains(
                 "System.Collections.Generic.List`1[" + expectedSourceTypeName + "]",
                 rendered,
                 StringComparison.Ordinal);
-            Assert.DoesNotContain(
-                "System.Collections.Generic.List`1[System.Object]",
-                rendered,
-                StringComparison.Ordinal);
+            Assert.DoesNotMatch(@"(?:\[|,)System\.Object(?=[\],\[])", rendered);
         }
         finally
         {
@@ -509,7 +723,40 @@ public class Issue2889LambdaThunkNestedGenericTests
         }
     }
 
+    private static string CompileExpectingFailure(string source)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "Issue2889_Failure_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var assemblyPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+            var result = RunCompiler(
+            [
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            ]);
+            Assert.NotEqual(0, result.ExitCode);
+            return result.Diagnostics;
+        }
+        finally
+        {
+            TryDeleteDirectory(directory);
+        }
+    }
+
     private static void Compile(string[] args)
+    {
+        var result = RunCompiler(args);
+        Assert.True(result.ExitCode == 0, $"gsc failed:\n{result.Diagnostics}");
+    }
+
+    private static (int ExitCode, string Diagnostics) RunCompiler(string[] args)
     {
         using var stdoutWriter = new StringWriter();
         using var stderrWriter = new StringWriter();
@@ -528,8 +775,19 @@ public class Issue2889LambdaThunkNestedGenericTests
             Console.SetError(previousError);
         }
 
-        Assert.True(
-            exitCode == 0,
-            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+        return (
+            exitCode,
+            $"stdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static void TryDeleteDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch
+        {
+        }
     }
 }


### PR DESCRIPTION
Closes #2889.

## Root cause

Erasure happened in binding, before lambda binding or emit. Instrumentation showed qualified `System.Action[List[Src]]` had already become `System.Action[List<object]]`, while the written lambda parameter still carried symbolic `List[Src]`.

Three imported-generic type-clause construction sites exist in `Binder.cs`: `:3027`, `:3855`, and `:4098`. The first and third already used the established recursive `TypeSymbol.RequiresSymbolicProjection` helper; `ConstructIfGeneric` at `:3855` was the last divergent copy. It preserved only direct type parameters or arguments whose `ClrType` was null. Nested `List[Src]` has a non-null erased CLR projection (`List<object>`), so the outer qualified generic discarded its symbolic `TypeArguments` and forced lambda conversion to synthesize an erased thunk.

Emit was ruled out: `SignatureEncoder` already recursively encodes `ImportedTypeSymbol.TypeArguments`, and `FunctionTypeNeedsSymbolicDelegate` already detects nested symbolic user types. Once binding preserves the outer symbolic argument, unchanged emit produces reified signatures. Call binding, overload resolution, and nullable narrowing were not changed.

## Fix

Make `ConstructIfGeneric` use the same pre-existing `RequiresSymbolicProjection` predicate and CLR erasure decision as its sibling type-clause construction paths. This closes the last divergent caller at the first erasure point; no emit compensation or new helper was added.

## Interop evidence

The bug affected public ABI, not only private lambda thunks:

- G# → C#: `main` emitted a G# library API `Register(Action<List<Src>>)` as `Register(Action<List<object>>)`. HEAD emits `List<Src>`; a real Roslyn consumer compiles, loads, invokes it, and receives the expected value.
- C# → G#: imported generic C# delegates closed over `List<Src>` failed conversion on `main`; HEAD preserves the source type and works.

The regression suite now pins the G# library metadata signature, rejects `object`, compiles a Roslyn consumer, IL-verifies both assemblies, loads them, and invokes the consumer.

## Coverage

Five test methods contain more than 50 end-to-end shape rows across imported CLR delegates, imported named delegates, source named delegates, and bare function types. Covered shapes include:

- source class, struct, enum, interface, and generic arguments
- parameter-only, return-only, and `Func<List<Src>, List<Src>>` parameter+return
- multiple generic parameters and two-deep nesting
- `Dictionary<Src, List<Src>>`, `List<Src>[]`, `Task<List<Src>>` parameter and return
- source arrays and nullable source elements
- method groups and inferred lambda parameters
- field/property and constructor storage
- nullable narrowed invocation
- delegate as function parameter
- lambda returned from function
- capturing lambda through closure class
- cross-assembly public G# API consumed by Roslyn

Successful rows emit, run `ilverify`, perform collectible `AssemblyLoadContext` + `GetTypes()`, inspect ordinary and closure lambda signatures, execute, and assert exact output. Signature guards reject symbolic erasure to `System.Object` in any nested generic shape.

## Known diagnostic trade

Correct preservation exposes a pre-existing limitation for inline lambdas passed through erased imported-generic receivers. `List<Action<List<Src>>>.Add((xs List<Src>) -> ...)` compiled on `main` but emitted invalid IL; HEAD rejects it with misleading `GS0159`/`GS0155`. Hoisting the lambda to a typed local works. This current diagnostic is pinned so it cannot silently change, and the underlying general limitation is tracked in #2918 using the `List<Action<Src>>` repro that fails on both main and HEAD.

The three duplicated projection blocks and their latent enum-surrogate divergence are tracked separately in #2919; refactoring them here would widen this correctness PR.

## Verification

- Issue regression: **5 passed, 0 failed**
- Core: **6,888 passed, 1 skipped, 0 failed** (6,889 total)
- Compiler: **3,688 passed, 0 failed**
- warnings-as-errors Release solution build: **0 warnings, 0 errors**
- Corpus (`samples/` + `e2etests/` sources): **148 files**
  - main: **139 LOAD OK / 9 REJECTED**
  - branch: **139 LOAD OK / 9 REJECTED**
  - ordinary corpus drift: **0 diagnostics, 0 exit status, 0 emit presence, 0 bytes, 0 loadability**
  - the disclosed inline-lambda probe is outside this historically delegate-light corpus

## Sub-term mutation audit

| Mutation | Change | Result |
|---|---|---|
| M1 | whole hunk → main | **5/5 red** |
| M2 | guard → `ContainsTypeParameter` | **5/5 red** |
| M3 | drop guard `|| ta.ClrType == null` | 5/5 green |
| M4 | drop ternary `|| ContainsSameCompilationUserType(ta)` | **2/5 red**; deeper dictionary/task rows and diagnostic pin kill it |
| M5 | drop ternary `ContainsTypeParameter(ta)` | 5/5 green |
| M6 | drop ternary `|| ta.ClrType == null` | 5/5 green |
| M7 | drop `ResolveClrTypeForGenericArg` fallback | 5/5 green |

M3/M5/M6/M7 are defensive parity with sibling blocks at `:3027` and `:4098`; no constructed probe made them observable. They stay to avoid recreating divergence. M1/M2/M4 are now directly pinned.

Nothing deferred from #2889. Follow-ups: #2918 and #2919.
