### PR TITLE
Fix definite return for try regions and exhaustive switches

### DIFF
--- a/docs/adr/0139-goto-and-general-labels.md
+++ b/docs/adr/0139-goto-and-general-labels.md
@@ -74,6 +74,10 @@ regions separately, however: a branch that leaves `try` or `catch` must run
 `finally` before reaching its target, and a branch that leaves `finally`
 cannot be emitted as CLR `leave` from the handler. The lowering pass therefore
 funnels those exits through a lifted finally body before dispatching them.
+If that lifted `finally` transfers control with `break`, `continue`, `goto`,
+or `return`, the transfer replaces the pending exception, so the exception is
+discarded. This matches evaluator behavior and ECMA-335 III.1.7.5; C# instead
+rejects transfers out of a `finally` with CS0157.
 
 ### Diagnostics
 

--- a/docs/adr/0139-goto-and-general-labels.md
+++ b/docs/adr/0139-goto-and-general-labels.md
@@ -68,10 +68,12 @@ introduces no new binder scope — `label: var x = 1` still declares `x` into
 the enclosing block, exactly like C#.
 
 No new `BoundNodeKind` is introduced (`BoundGotoStatement`/
-`BoundLabelStatement` already existed), so `ControlFlowGraph`,
-`RefKindDefiniteAssignmentAnalyzer`, `SlotPlanner`, `MethodBodyEmitter`, and
-the evaluator needed no changes — they already handle these bound nodes
-generically.
+`BoundLabelStatement` already existed). The emitter and evaluator handle the
+nodes generically. Definite-return analysis projects protected exception
+regions separately, however: a branch that leaves `try` or `catch` must run
+`finally` before reaching its target, and a branch that leaves `finally`
+cannot be emitted as CLR `leave` from the handler. The lowering pass therefore
+funnels those exits through a lifted finally body before dispatching them.
 
 ### Diagnostics
 
@@ -112,8 +114,8 @@ directly:
 
 **Positive.** `cs2gs` can now migrate C#'s full `goto`/label surface,
 including the `goto case`/`goto default` fall-through forms, with faithful
-semantics. No gsc runtime or emit changes were needed — only surface syntax
-and a label-name binder.
+semantics. Ordinary labels remain generic bound nodes; protected-region exits
+receive the exception-flow lowering required by CLR handler rules.
 
 **Negative.** Unstructured control flow is easy to write incorrectly by hand;
 G# still has no `goto`-into-scope diagnostic beyond "does not parse as a

--- a/docs/adr/0139-goto-and-general-labels.md
+++ b/docs/adr/0139-goto-and-general-labels.md
@@ -78,6 +78,9 @@ If that lifted `finally` transfers control with `break`, `continue`, `goto`,
 or `return`, the transfer replaces the pending exception, so the exception is
 discarded. This matches evaluator behavior and ECMA-335 III.1.7.5; C# instead
 rejects transfers out of a `finally` with CS0157.
+Known limitation [#2953](https://github.com/DavidObando/gsharp/issues/2953):
+`fixed`-containing non-void functions bypass the fall-through guard and
+silently return the fixed-return epilogue's default slot instead of throwing.
 
 ### Diagnostics
 

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1388,11 +1388,17 @@ public sealed class Binder
 
                     // ADR-0060 items #4/#5: out-parameter definite-assignment and
                     // 'ref'-arg unassigned-before-read checks.
-                    RefKindDefiniteAssignmentAnalyzer.Analyze(lowered, function, binder.Diagnostics);
+                    RefKindDefiniteAssignmentAnalyzer.Analyze(
+                        lowered.PreEmitAnalysisBody ?? lowered,
+                        function,
+                        binder.Diagnostics);
 
                     // Issue #2350: by-ref-like locals are only legal in an
                     // async function body when never live across an `await`.
-                    RefStructAsyncLivenessAnalyzer.Analyze(lowered, function, binder.Diagnostics);
+                    RefStructAsyncLivenessAnalyzer.Analyze(
+                        lowered.PreEmitAnalysisBody ?? lowered,
+                        function,
+                        binder.Diagnostics);
 
                     return (lowered, binder.Diagnostics.ToImmutableArray());
                 }));
@@ -1441,7 +1447,10 @@ public sealed class Binder
 
                     // Issue #2350: by-ref-like locals are only legal in an
                     // async function body when never live across an `await`.
-                    RefStructAsyncLivenessAnalyzer.Analyze(lowered, method, binder.Diagnostics);
+                    RefStructAsyncLivenessAnalyzer.Analyze(
+                        lowered.PreEmitAnalysisBody ?? lowered,
+                        method,
+                        binder.Diagnostics);
 
                     return (lowered, binder.Diagnostics.ToImmutableArray());
                 }));
@@ -1941,7 +1950,10 @@ public sealed class Binder
 
             // Issue #2350: by-ref-like locals are only legal in an async
             // function body when never live across an `await`.
-            RefStructAsyncLivenessAnalyzer.Analyze(lowered, method, binder.Diagnostics);
+            RefStructAsyncLivenessAnalyzer.Analyze(
+                lowered.PreEmitAnalysisBody ?? lowered,
+                method,
+                binder.Diagnostics);
 
             return (lowered, binder.Diagnostics.ToImmutableArray());
         }));
@@ -1991,7 +2003,10 @@ public sealed class Binder
 
             // Issue #2350: by-ref-like locals are only legal in an async
             // function body when never live across an `await`.
-            RefStructAsyncLivenessAnalyzer.Analyze(lowered, accessor, binder.Diagnostics);
+            RefStructAsyncLivenessAnalyzer.Analyze(
+                lowered.PreEmitAnalysisBody ?? lowered,
+                accessor,
+                binder.Diagnostics);
 
             return (lowered, binder.Diagnostics.ToImmutableArray());
         }));
@@ -2042,7 +2057,10 @@ public sealed class Binder
 
             // Issue #2350: by-ref-like locals are only legal in an async
             // function body when never live across an `await`.
-            RefStructAsyncLivenessAnalyzer.Analyze(lowered, member, binder.Diagnostics);
+            RefStructAsyncLivenessAnalyzer.Analyze(
+                lowered.PreEmitAnalysisBody ?? lowered,
+                member,
+                binder.Diagnostics);
 
             return (lowered, binder.Diagnostics.ToImmutableArray());
         }));
@@ -2087,7 +2105,10 @@ public sealed class Binder
 
             // Issue #2350: by-ref-like locals are only legal in an async
             // function body when never live across an `await`.
-            RefStructAsyncLivenessAnalyzer.Analyze(lowered, method, binder.Diagnostics);
+            RefStructAsyncLivenessAnalyzer.Analyze(
+                lowered.PreEmitAnalysisBody ?? lowered,
+                method,
+                binder.Diagnostics);
 
             return (lowered, binder.Diagnostics.ToImmutableArray());
         }));

--- a/src/Core/CodeAnalysis/Binding/BoundBlockStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBlockStatement.cs
@@ -18,18 +18,18 @@ public sealed class BoundBlockStatement : BoundStatement
     /// <param name="syntax">The originating syntax.</param>
     /// <param name="statements">The immutable array of bound statements.</param>
     public BoundBlockStatement(SyntaxNode syntax, ImmutableArray<BoundStatement> statements)
-        : this(syntax, statements, definiteReturnAnalysisBody: null)
+        : this(syntax, statements, preEmitAnalysisBody: null)
     {
     }
 
     internal BoundBlockStatement(
         SyntaxNode syntax,
         ImmutableArray<BoundStatement> statements,
-        BoundBlockStatement definiteReturnAnalysisBody)
+        BoundBlockStatement preEmitAnalysisBody)
         : base(syntax)
     {
         Statements = statements;
-        DefiniteReturnAnalysisBody = definiteReturnAnalysisBody;
+        PreEmitAnalysisBody = preEmitAnalysisBody;
     }
 
     /// <inheritdoc/>
@@ -41,7 +41,7 @@ public sealed class BoundBlockStatement : BoundStatement
     public ImmutableArray<BoundStatement> Statements { get; }
 
     /// <summary>
-    /// Gets the pre-emit-rewrite body used only by definite-return analysis.
+    /// Gets the pre-emit-rewrite body used by control-flow analyses.
     /// </summary>
-    internal BoundBlockStatement DefiniteReturnAnalysisBody { get; }
+    internal BoundBlockStatement PreEmitAnalysisBody { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundBlockStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBlockStatement.cs
@@ -18,9 +18,18 @@ public sealed class BoundBlockStatement : BoundStatement
     /// <param name="syntax">The originating syntax.</param>
     /// <param name="statements">The immutable array of bound statements.</param>
     public BoundBlockStatement(SyntaxNode syntax, ImmutableArray<BoundStatement> statements)
+        : this(syntax, statements, definiteReturnAnalysisBody: null)
+    {
+    }
+
+    internal BoundBlockStatement(
+        SyntaxNode syntax,
+        ImmutableArray<BoundStatement> statements,
+        BoundBlockStatement definiteReturnAnalysisBody)
         : base(syntax)
     {
         Statements = statements;
+        DefiniteReturnAnalysisBody = definiteReturnAnalysisBody;
     }
 
     /// <inheritdoc/>
@@ -30,4 +39,9 @@ public sealed class BoundBlockStatement : BoundStatement
     /// Gets the immutable array of bound statements.
     /// </summary>
     public ImmutableArray<BoundStatement> Statements { get; }
+
+    /// <summary>
+    /// Gets the pre-emit-rewrite body used only by definite-return analysis.
+    /// </summary>
+    internal BoundBlockStatement DefiniteReturnAnalysisBody { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundPatternSwitchStatement.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundPatternSwitchStatement.cs
@@ -14,11 +14,17 @@ public sealed class BoundPatternSwitchStatement : BoundStatement
     /// <param name="syntax">The originating syntax.</param>
     /// <param name="discriminant">The discriminant expression.</param>
     /// <param name="arms">The switch arms.</param>
-    public BoundPatternSwitchStatement(SyntaxNode syntax, BoundExpression discriminant, ImmutableArray<BoundPatternSwitchArm> arms)
+    /// <param name="isExhaustive">Whether closed-type analysis proved that the arms cover every value.</param>
+    public BoundPatternSwitchStatement(
+        SyntaxNode syntax,
+        BoundExpression discriminant,
+        ImmutableArray<BoundPatternSwitchArm> arms,
+        bool isExhaustive = false)
         : base(syntax)
     {
         Discriminant = discriminant;
         Arms = arms;
+        IsExhaustive = isExhaustive;
     }
 
     /// <inheritdoc/>
@@ -29,4 +35,7 @@ public sealed class BoundPatternSwitchStatement : BoundStatement
 
     /// <summary>Gets the switch arms.</summary>
     public ImmutableArray<BoundPatternSwitchArm> Arms { get; }
+
+    /// <summary>Gets a value indicating whether closed-type analysis proved that the switch is exhaustive.</summary>
+    public bool IsExhaustive { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -791,7 +791,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundPatternSwitchStatement(null, discriminant, builder?.MoveToImmutable() ?? node.Arms);
+        return new BoundPatternSwitchStatement(null, discriminant, builder?.MoveToImmutable() ?? node.Arms, node.IsExhaustive);
     }
 
     /// <summary>Rewrites a bound pattern.</summary>

--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -60,11 +60,11 @@ public sealed class ControlFlowGraph
     /// <returns>Whether all its paths return or not.</returns>
     public static bool AllPathsReturn(BoundBlockStatement body)
     {
-        body = body.DefiniteReturnAnalysisBody ?? body;
+        body = body.PreEmitAnalysisBody ?? body;
 
         // This projection is intentionally limited to definite-return. Other
-        // data-flow analyzers call Create(body) and still treat these compound
-        // statements as opaque, so their region-specific behavior is unchanged.
+        // data-flow analyzers use the same pre-emit body but retain their
+        // existing opaque treatment of compound statements.
         var graph = Create(ProjectRegionsForDefiniteReturn(body), treatThrowsAsTerminators: true);
 
         foreach (var branch in graph.End.Incoming)
@@ -212,16 +212,19 @@ public sealed class ControlFlowGraph
         BoundLabel methodExitLabel = null;
         BoundReturnStatement methodExitReturn = null;
 
-        if (statement is BoundBlockStatement functionBody
-            && functionBody.Statements.Length >= 3
-            && functionBody.Statements[0] is BoundVariableDeclaration returnTempDeclaration
-            && functionBody.Statements[^2] is BoundLabelStatement exitLabel
-            && functionBody.Statements[^1] is BoundReturnStatement { Expression: BoundVariableExpression returnExpression } exitReturn
-            && returnTempDeclaration.Variable.Name == "$returnTemp"
-            && ReferenceEquals(returnTempDeclaration.Variable, returnExpression.Variable))
+        if (statement is BoundBlockStatement functionBody && functionBody.Statements.Length >= 3)
         {
-            methodExitLabel = exitLabel.Label;
-            methodExitReturn = exitReturn;
+            var returnTempDeclaration = functionBody.Statements
+                .OfType<BoundVariableDeclaration>()
+                .FirstOrDefault(declaration => declaration.Variable.Name == "$returnTemp");
+            if (returnTempDeclaration != null
+                && functionBody.Statements[^2] is BoundLabelStatement exitLabel
+                && functionBody.Statements[^1] is BoundReturnStatement { Expression: BoundVariableExpression returnExpression } exitReturn
+                && ReferenceEquals(returnTempDeclaration.Variable, returnExpression.Variable))
+            {
+                methodExitLabel = exitLabel.Label;
+                methodExitReturn = exitReturn;
+            }
         }
 
         Add(statement);
@@ -402,7 +405,6 @@ public sealed class ControlFlowGraph
 
             foreach (var (body, label) in alternatives)
             {
-                var localLabels = CollectLabels(body);
                 builder.Add(new BoundLabelStatement(null, label));
 
                 if (tryStatement.FinallyBlock == null)
@@ -414,12 +416,6 @@ public sealed class ControlFlowGraph
 
                 void RouteThroughFinally(BoundStatement transfer)
                 {
-                    if (transfer is BoundGotoStatement go && localLabels.Contains(go.Label))
-                    {
-                        builder.Add(transfer);
-                        return;
-                    }
-
                     Add(CloneWithFreshLabels(tryStatement.FinallyBlock), outerRoute);
                     Add(transfer, outerRoute);
                 }

--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -60,6 +60,8 @@ public sealed class ControlFlowGraph
     /// <returns>Whether all its paths return or not.</returns>
     public static bool AllPathsReturn(BoundBlockStatement body)
     {
+        body = body.DefiniteReturnAnalysisBody ?? body;
+
         // This projection is intentionally limited to definite-return. Other
         // data-flow analyzers call Create(body) and still treat these compound
         // statements as opaque, so their region-specific behavior is unchanged.
@@ -207,17 +209,32 @@ public sealed class ControlFlowGraph
         var builder = System.Collections.Immutable.ImmutableArray.CreateBuilder<BoundStatement>();
         var labelOrdinal = 0;
         var choiceOrdinal = 0;
+        BoundLabel methodExitLabel = null;
+        BoundReturnStatement methodExitReturn = null;
+
+        if (statement is BoundBlockStatement functionBody
+            && functionBody.Statements.Length >= 3
+            && functionBody.Statements[0] is BoundVariableDeclaration returnTempDeclaration
+            && functionBody.Statements[^2] is BoundLabelStatement exitLabel
+            && functionBody.Statements[^1] is BoundReturnStatement { Expression: BoundVariableExpression returnExpression } exitReturn
+            && returnTempDeclaration.Variable.Name == "$returnTemp"
+            && ReferenceEquals(returnTempDeclaration.Variable, returnExpression.Variable))
+        {
+            methodExitLabel = exitLabel.Label;
+            methodExitReturn = exitReturn;
+        }
+
         Add(statement);
         return new BoundBlockStatement(null, builder.ToImmutable());
 
-        void Add(BoundStatement current)
+        void Add(BoundStatement current, Action<BoundStatement> routeTransfer = null)
         {
             switch (current)
             {
                 case BoundBlockStatement block:
                     foreach (var nested in block.Statements)
                     {
-                        Add(nested);
+                        Add(nested, routeTransfer);
                     }
 
                     break;
@@ -225,18 +242,40 @@ public sealed class ControlFlowGraph
                     // Fixed executes its body once; pin setup and normal-exit
                     // release remain emit concerns. Escaping exits currently
                     // skip that release epilogue (#2900).
-                    Add(fixedStatement.Body);
+                    Add(fixedStatement.Body, routeTransfer);
                     break;
                 case BoundScopeStatement scopeStatement:
                     // Scope also executes its body once in normal control flow.
                     // Its task join and failure rethrow remain emit-time behavior.
-                    Add(scopeStatement.Body);
+                    Add(scopeStatement.Body, routeTransfer);
                     break;
                 case BoundPatternSwitchStatement switchStatement:
-                    AddPatternSwitch(switchStatement);
+                    AddPatternSwitch(switchStatement, routeTransfer);
                     break;
                 case BoundSelectStatement selectStatement:
-                    AddSelect(selectStatement);
+                    AddSelect(selectStatement, routeTransfer);
+                    break;
+                case BoundTryStatement tryStatement:
+                    AddTry(tryStatement, routeTransfer);
+                    break;
+                case BoundLabelStatement labelStatement when ReferenceEquals(labelStatement.Label, methodExitLabel):
+                case BoundReturnStatement returnStatement when ReferenceEquals(returnStatement, methodExitReturn):
+                    break;
+                case BoundGotoStatement gotoStatement when ReferenceEquals(gotoStatement.Label, methodExitLabel):
+                    Add(new BoundReturnStatement(null, methodExitReturn.Expression), routeTransfer);
+                    break;
+                case BoundGotoStatement:
+                case BoundReturnStatement:
+                case BoundThrowStatement:
+                    if (routeTransfer == null)
+                    {
+                        builder.Add(current);
+                    }
+                    else
+                    {
+                        routeTransfer(current);
+                    }
+
                     break;
                 default:
                     builder.Add(current);
@@ -244,7 +283,7 @@ public sealed class ControlFlowGraph
             }
         }
 
-        void AddPatternSwitch(BoundPatternSwitchStatement switchStatement)
+        void AddPatternSwitch(BoundPatternSwitchStatement switchStatement, Action<BoundStatement> routeTransfer)
         {
             var endLabel = NewLabel("switchEnd");
             var arms = new List<(BoundPatternSwitchArm Arm, BoundLabel Label)>();
@@ -273,7 +312,7 @@ public sealed class ControlFlowGraph
                 builder.Add(new BoundConditionalGotoStatement(null, armLabel, NewChoice()));
             }
 
-            if (!dispatchComplete)
+            if (!dispatchComplete && !switchStatement.IsExhaustive)
             {
                 builder.Add(new BoundGotoStatement(null, defaultArm == null ? endLabel : defaultLabel));
             }
@@ -281,20 +320,20 @@ public sealed class ControlFlowGraph
             foreach (var (arm, armLabel) in arms)
             {
                 builder.Add(new BoundLabelStatement(null, armLabel));
-                Add(arm.Body);
+                Add(arm.Body, routeTransfer);
                 builder.Add(new BoundGotoStatement(null, endLabel));
             }
 
             if (defaultArm != null)
             {
                 builder.Add(new BoundLabelStatement(null, defaultLabel));
-                Add(defaultArm.Body);
+                Add(defaultArm.Body, routeTransfer);
             }
 
             builder.Add(new BoundLabelStatement(null, endLabel));
         }
 
-        void AddSelect(BoundSelectStatement selectStatement)
+        void AddSelect(BoundSelectStatement selectStatement, Action<BoundStatement> routeTransfer)
         {
             var dispatchLabel = NewLabel("selectDispatch");
             var endLabel = NewLabel("selectEnd");
@@ -322,18 +361,145 @@ public sealed class ControlFlowGraph
             foreach (var (@case, caseLabel) in cases)
             {
                 builder.Add(new BoundLabelStatement(null, caseLabel));
-                Add(@case.Body);
+                Add(@case.Body, routeTransfer);
                 builder.Add(new BoundGotoStatement(null, endLabel));
             }
 
             if (defaultCase != null)
             {
                 builder.Add(new BoundLabelStatement(null, defaultLabel));
-                Add(defaultCase.Body);
+                Add(defaultCase.Body, routeTransfer);
             }
 
             builder.Add(new BoundLabelStatement(null, endLabel));
         }
+
+        void AddTry(BoundTryStatement tryStatement, Action<BoundStatement> outerRoute)
+        {
+            var endLabel = NewLabel("tryEnd");
+            var exceptionLabel = tryStatement.FinallyBlock == null ? null : NewLabel("exceptionFinally");
+            var alternatives = new List<(BoundStatement Body, BoundLabel Label)>
+            {
+                (tryStatement.TryBlock, NewLabel("tryBody")),
+            };
+
+            foreach (var clause in tryStatement.CatchClauses)
+            {
+                alternatives.Add((clause.Body, NewLabel("catch")));
+            }
+
+            if (exceptionLabel != null)
+            {
+                builder.Add(new BoundConditionalGotoStatement(null, exceptionLabel, NewChoice()));
+            }
+
+            for (var i = 1; i < alternatives.Count; i++)
+            {
+                builder.Add(new BoundConditionalGotoStatement(null, alternatives[i].Label, NewChoice()));
+            }
+
+            builder.Add(new BoundGotoStatement(null, alternatives[0].Label));
+
+            foreach (var (body, label) in alternatives)
+            {
+                var localLabels = CollectLabels(body);
+                builder.Add(new BoundLabelStatement(null, label));
+
+                if (tryStatement.FinallyBlock == null)
+                {
+                    Add(body, outerRoute);
+                    builder.Add(new BoundGotoStatement(null, endLabel));
+                    continue;
+                }
+
+                void RouteThroughFinally(BoundStatement transfer)
+                {
+                    if (transfer is BoundGotoStatement go && localLabels.Contains(go.Label))
+                    {
+                        builder.Add(transfer);
+                        return;
+                    }
+
+                    Add(CloneWithFreshLabels(tryStatement.FinallyBlock), outerRoute);
+                    Add(transfer, outerRoute);
+                }
+
+                Add(body, RouteThroughFinally);
+                Add(CloneWithFreshLabels(tryStatement.FinallyBlock), outerRoute);
+                Add(new BoundGotoStatement(null, endLabel), outerRoute);
+            }
+
+            if (exceptionLabel != null)
+            {
+                builder.Add(new BoundLabelStatement(null, exceptionLabel));
+                Add(CloneWithFreshLabels(tryStatement.FinallyBlock), outerRoute);
+                Add(new BoundThrowStatement(null, NewChoice()), outerRoute);
+            }
+
+            builder.Add(new BoundLabelStatement(null, endLabel));
+        }
+
+        HashSet<BoundLabel> CollectLabels(BoundStatement root)
+        {
+            var labels = new HashSet<BoundLabel>();
+            Collect(root);
+            return labels;
+
+            void Collect(BoundStatement current)
+            {
+                switch (current)
+                {
+                    case BoundLabelStatement label:
+                        labels.Add(label.Label);
+                        break;
+                    case BoundBlockStatement block:
+                        foreach (var nested in block.Statements)
+                        {
+                            Collect(nested);
+                        }
+
+                        break;
+                    case BoundTryStatement nestedTry:
+                        Collect(nestedTry.TryBlock);
+                        foreach (var clause in nestedTry.CatchClauses)
+                        {
+                            Collect(clause.Body);
+                        }
+
+                        if (nestedTry.FinallyBlock != null)
+                        {
+                            Collect(nestedTry.FinallyBlock);
+                        }
+
+                        break;
+                    case BoundFixedStatement fixedStatement:
+                        Collect(fixedStatement.Body);
+                        break;
+                    case BoundScopeStatement scopeStatement:
+                        Collect(scopeStatement.Body);
+                        break;
+                    case BoundPatternSwitchStatement switchStatement:
+                        foreach (var arm in switchStatement.Arms)
+                        {
+                            Collect(arm.Body);
+                        }
+
+                        break;
+                    case BoundSelectStatement selectStatement:
+                        foreach (var @case in selectStatement.Cases)
+                        {
+                            Collect(@case.Body);
+                        }
+
+                        break;
+                }
+            }
+        }
+
+        BoundStatement CloneWithFreshLabels(BoundStatement root)
+            => new DefiniteReturnLabelRewriter(
+                CollectLabels(root),
+                () => NewLabel("finallyBody")).RewriteStatement(root);
 
         BoundLabel NewLabel(string name)
             => new($"<>definiteReturn_{name}_{labelOrdinal++}");
@@ -807,5 +973,35 @@ public sealed class ControlFlowGraph
             var op = BoundUnaryOperator.Bind(SyntaxKind.BangToken, TypeSymbol.Bool);
             return new BoundUnaryExpression(null, op, condition);
         }
+    }
+
+    private sealed class DefiniteReturnLabelRewriter : BoundTreeRewriter
+    {
+        private readonly Dictionary<BoundLabel, BoundLabel> labels = [];
+
+        public DefiniteReturnLabelRewriter(IEnumerable<BoundLabel> labels, Func<BoundLabel> createLabel)
+        {
+            foreach (var label in labels)
+            {
+                this.labels[label] = createLabel();
+            }
+        }
+
+        protected override BoundStatement RewriteLabelStatement(BoundLabelStatement node)
+            => labels.TryGetValue(node.Label, out var label)
+                ? new BoundLabelStatement(null, label)
+                : node;
+
+        protected override BoundStatement RewriteGotoStatement(BoundGotoStatement node)
+            => labels.TryGetValue(node.Label, out var label)
+                ? new BoundGotoStatement(null, label)
+                : node;
+
+        protected override BoundStatement RewriteConditionalGotoStatement(BoundConditionalGotoStatement node)
+            => new BoundConditionalGotoStatement(
+                null,
+                labels.TryGetValue(node.Label, out var label) ? label : node.Label,
+                RewriteExpression(node.Condition),
+                node.JumpIfTrue);
     }
 }

--- a/src/Core/CodeAnalysis/Binding/ExhaustivenessAnalyzer.cs
+++ b/src/Core/CodeAnalysis/Binding/ExhaustivenessAnalyzer.cs
@@ -23,8 +23,7 @@ public static class ExhaustivenessAnalyzer
     /// <returns>True for enum types, sealed interfaces, and sealed-hierarchy classes; otherwise false.</returns>
     public static bool IsExhaustiveDiscriminant(TypeSymbol type)
         => type is EnumSymbol
-        || (type?.ClrType.IsEnumSafe() == true
-            && !HasFlagsAttribute(type.ClrType))
+        || type?.ClrType.IsEnumSafe() == true
         || type is InterfaceSymbol { IsSealed: true }
         || type is StructSymbol { IsSealedHierarchy: true };
 
@@ -78,10 +77,6 @@ public static class ExhaustivenessAnalyzer
 
         return true;
     }
-
-    private static bool HasFlagsAttribute(System.Type type)
-        => type.GetCustomAttributesData()
-            .Any(attribute => attribute.AttributeType.FullName == typeof(System.FlagsAttribute).FullName);
 
     private static bool TryGetMissingVariants(
         TypeSymbol discriminantType,

--- a/src/Core/CodeAnalysis/Binding/ExhaustivenessAnalyzer.cs
+++ b/src/Core/CodeAnalysis/Binding/ExhaustivenessAnalyzer.cs
@@ -23,7 +23,8 @@ public static class ExhaustivenessAnalyzer
     /// <returns>True for enum types, sealed interfaces, and sealed-hierarchy classes; otherwise false.</returns>
     public static bool IsExhaustiveDiscriminant(TypeSymbol type)
         => type is EnumSymbol
-        || type?.ClrType.IsEnumSafe() == true
+        || (type?.ClrType.IsEnumSafe() == true
+            && !HasFlagsAttribute(type.ClrType))
         || type is InterfaceSymbol { IsSealed: true }
         || type is StructSymbol { IsSealedHierarchy: true };
 
@@ -56,18 +57,31 @@ public static class ExhaustivenessAnalyzer
     /// <param name="arms">The bound switch-statement arms.</param>
     /// <param name="structs">All user-defined aggregate types in scope.</param>
     /// <param name="diagnostics">The diagnostic sink.</param>
-    public static void AnalyzeSwitchStatement(
+    /// <returns>Whether the switch covers every value of a closed discriminant type.</returns>
+    public static bool AnalyzeSwitchStatement(
         TextLocation location,
         TypeSymbol discriminantType,
         ImmutableArray<BoundPatternSwitchArm> arms,
         ImmutableArray<StructSymbol> structs,
         DiagnosticBag diagnostics)
     {
+        if (!IsExhaustiveDiscriminant(discriminantType))
+        {
+            return false;
+        }
+
         if (TryGetMissingVariants(discriminantType, arms.Where(a => a.Guard == null).Select(a => a.Pattern), structs, out var discriminantDescription, out var missingNames))
         {
             diagnostics.ReportSwitchStatementNotExhaustive(location, discriminantDescription, missingNames);
+            return false;
         }
+
+        return true;
     }
+
+    private static bool HasFlagsAttribute(System.Type type)
+        => type.GetCustomAttributesData()
+            .Any(attribute => attribute.AttributeType.FullName == typeof(System.FlagsAttribute).FullName);
 
     private static bool TryGetMissingVariants(
         TypeSymbol discriminantType,

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Blocks.cs
@@ -154,14 +154,14 @@ internal sealed partial class StatementBinder
         }
 
         var boundArms = arms.ToImmutable();
-        ExhaustivenessAnalyzer.AnalyzeSwitchStatement(
+        var isExhaustive = ExhaustivenessAnalyzer.AnalyzeSwitchStatement(
             syntax.SwitchKeyword.Location,
             switchType,
             boundArms,
             scope.GetDeclaredStructs(),
             Diagnostics);
 
-        var result = new BoundPatternSwitchStatement(null, discriminant, boundArms);
+        var result = new BoundPatternSwitchStatement(null, discriminant, boundArms, isExhaustive);
 
         // ADR-0069 addendum / issue #712: park the merged narrowing on the
         // bound switch so the enclosing block walker can lift it. Only do

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
@@ -92,13 +92,6 @@ internal sealed partial class MethodBodyEmitter
         {
             this.EmitStatement(defaultArm.Body);
         }
-        else if (node.IsExhaustive)
-        {
-            var constructor = typeof(InvalidOperationException).GetConstructor(Type.EmptyTypes);
-            this.il.OpCode(ILOpCode.Newobj);
-            this.il.Token(this.outer.memberRefs.GetCtorReference(constructor));
-            this.il.OpCode(ILOpCode.Throw);
-        }
 
         this.il.MarkLabel(endLabel);
     }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
@@ -92,6 +92,13 @@ internal sealed partial class MethodBodyEmitter
         {
             this.EmitStatement(defaultArm.Body);
         }
+        else if (node.IsExhaustive)
+        {
+            var constructor = typeof(InvalidOperationException).GetConstructor(Type.EmptyTypes);
+            this.il.OpCode(ILOpCode.Newobj);
+            this.il.Token(this.outer.memberRefs.GetCtorReference(constructor));
+            this.il.OpCode(ILOpCode.Throw);
+        }
 
         this.il.MarkLabel(endLabel);
     }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -247,11 +247,16 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
-        // Preserve the legacy trailing ret on void bodies. For value bodies,
-        // cap only an emitted dead-code tail that follows the real terminator.
-        if (alwaysAppendRet || !this.currentPositionEndsInTerminator)
+        if (alwaysAppendRet)
         {
             this.il.OpCode(ILOpCode.Ret);
+        }
+        else if (!this.currentPositionEndsInTerminator)
+        {
+            var constructor = typeof(InvalidOperationException).GetConstructor(Type.EmptyTypes);
+            this.il.OpCode(ILOpCode.Newobj);
+            this.il.Token(this.outer.memberRefs.GetCtorReference(constructor));
+            this.il.OpCode(ILOpCode.Throw);
         }
     }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -253,7 +253,9 @@ internal sealed partial class MethodBodyEmitter
         }
         else if (!this.currentPositionEndsInTerminator)
         {
-            var constructor = typeof(InvalidOperationException).GetConstructor(Type.EmptyTypes);
+            const string Message = "Compiler-generated guard reached: non-void function fell through without returning a value.";
+            var constructor = typeof(InvalidOperationException).GetConstructor(new[] { typeof(string) });
+            this.il.LoadString(this.outer.emitCtx.Metadata.GetOrAddUserString(Message));
             this.il.OpCode(ILOpCode.Newobj);
             this.il.Token(this.outer.memberRefs.GetCtorReference(constructor));
             this.il.OpCode(ILOpCode.Throw);

--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -798,7 +798,7 @@ internal static class CaptureBoxingRewriter
                 return node;
             }
 
-            return new BoundPatternSwitchStatement(null, discriminant, builder?.MoveToImmutable() ?? node.Arms);
+            return new BoundPatternSwitchStatement(null, discriminant, builder?.MoveToImmutable() ?? node.Arms, node.IsExhaustive);
         }
 
         /// <inheritdoc/>

--- a/src/Core/CodeAnalysis/Lowering/FinallyExitRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/FinallyExitRewriter.cs
@@ -74,17 +74,17 @@ internal static class FinallyExitRewriter
     private sealed class ExitFunneler : BoundTreeRewriter
     {
         private readonly ExitPlan plan;
-        private readonly HashSet<BoundLabel> localLabels;
+        private readonly ProtectedRegionBranchAnalysis branches;
 
-        public ExitFunneler(ExitPlan plan, HashSet<BoundLabel> localLabels)
+        public ExitFunneler(ExitPlan plan, ProtectedRegionBranchAnalysis branches)
         {
             this.plan = plan;
-            this.localLabels = localLabels;
+            this.branches = branches;
         }
 
         protected override BoundStatement RewriteGotoStatement(BoundGotoStatement node)
         {
-            if (localLabels.Contains(node.Label))
+            if (branches.ContainsLabel(node.Label))
             {
                 return node;
             }
@@ -105,64 +105,6 @@ internal static class FinallyExitRewriter
                     new BoundLiteralExpression(null, discriminator)));
     }
 
-    private sealed class LabelCollector : BoundTreeWalker
-    {
-        private readonly HashSet<BoundLabel> labels = [];
-
-        public static HashSet<BoundLabel> Collect(BoundStatement body)
-        {
-            var collector = new LabelCollector();
-            collector.VisitStatement(body);
-            return collector.labels;
-        }
-
-        public override void VisitStatement(BoundStatement node)
-        {
-            if (node is BoundLabelStatement label)
-            {
-                labels.Add(label.Label);
-            }
-
-            base.VisitStatement(node);
-        }
-    }
-
-    private sealed class EscapingBranchDetector : BoundTreeWalker
-    {
-        private readonly HashSet<BoundLabel> localLabels;
-
-        private EscapingBranchDetector(HashSet<BoundLabel> localLabels)
-        {
-            this.localLabels = localLabels;
-        }
-
-        public bool Found { get; private set; }
-
-        public static bool ContainsEscapingBranch(BoundStatement body)
-        {
-            var detector = new EscapingBranchDetector(LabelCollector.Collect(body));
-            detector.VisitStatement(body);
-            return detector.Found;
-        }
-
-        public override void VisitStatement(BoundStatement node)
-        {
-            if (Found)
-            {
-                return;
-            }
-
-            if ((node is BoundGotoStatement go && !localLabels.Contains(go.Label))
-                || (node is BoundConditionalGotoStatement conditional && !localLabels.Contains(conditional.Label)))
-            {
-                Found = true;
-                return;
-            }
-
-            base.VisitStatement(node);
-        }
-    }
-
     private sealed class Rewriter : BoundTreeRewriter
     {
         private int ordinal;
@@ -170,8 +112,13 @@ internal static class FinallyExitRewriter
         protected override BoundStatement RewriteTryStatement(BoundTryStatement node)
         {
             var rewritten = (BoundTryStatement)base.RewriteTryStatement(node);
-            if (rewritten.FinallyBlock == null
-                || !EscapingBranchDetector.ContainsEscapingBranch(rewritten.FinallyBlock))
+            if (rewritten.FinallyBlock == null)
+            {
+                return rewritten;
+            }
+
+            var finallyBranches = ProtectedRegionBranchAnalysis.Create(rewritten.FinallyBlock);
+            if (!finallyBranches.HasEscapingBranch)
             {
                 return rewritten;
             }
@@ -182,13 +129,13 @@ internal static class FinallyExitRewriter
 
             var tryBody = new ExitFunneler(
                 plan,
-                LabelCollector.Collect(rewritten.TryBlock)).RewriteStatement(rewritten.TryBlock);
+                ProtectedRegionBranchAnalysis.Create(rewritten.TryBlock)).RewriteStatement(rewritten.TryBlock);
             var catches = ImmutableArray.CreateBuilder<BoundCatchClause>(rewritten.CatchClauses.Length);
             foreach (var clause in rewritten.CatchClauses)
             {
                 var catchBody = new ExitFunneler(
                     plan,
-                    LabelCollector.Collect(clause.Body)).RewriteStatement(clause.Body);
+                    ProtectedRegionBranchAnalysis.Create(clause.Body)).RewriteStatement(clause.Body);
                 catches.Add(new BoundCatchClause(clause.ExceptionType, clause.Variable, catchBody));
             }
 

--- a/src/Core/CodeAnalysis/Lowering/FinallyExitRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/FinallyExitRewriter.cs
@@ -1,0 +1,319 @@
+// <copyright file="FinallyExitRewriter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Lowering;
+
+/// <summary>
+/// Lifts a finally body out of its CLR handler when it contains a branch that
+/// exits the handler. CLR forbids <c>leave</c> from finally, so exits from the
+/// protected body are funneled through the lifted body and dispatched after it.
+/// </summary>
+internal static class FinallyExitRewriter
+{
+    /// <summary>Rewrites finally handlers that contain escaping branches.</summary>
+    /// <param name="body">The lowered function body.</param>
+    /// <returns>The rewritten body.</returns>
+    public static BoundBlockStatement Rewrite(BoundBlockStatement body)
+        => (BoundBlockStatement)new Rewriter().RewriteStatement(body);
+
+    private readonly struct DispatchArm
+    {
+        public DispatchArm(int discriminator, BoundLabel target)
+        {
+            Discriminator = discriminator;
+            Target = target;
+        }
+
+        public int Discriminator { get; }
+
+        public BoundLabel Target { get; }
+    }
+
+    private sealed class ExitPlan
+    {
+        private readonly Dictionary<BoundLabel, int> discriminators = [];
+        private readonly List<DispatchArm> arms = [];
+        private int nextDiscriminator = 1;
+
+        public ExitPlan(int ordinal)
+        {
+            PendingBranch = new LocalVariableSymbol(
+                $"<>finally_branch_{ordinal}",
+                isReadOnly: false,
+                TypeSymbol.Int32);
+            TailLabel = new BoundLabel($"<>finally_tail_{ordinal}");
+        }
+
+        public LocalVariableSymbol PendingBranch { get; }
+
+        public BoundLabel TailLabel { get; }
+
+        public IReadOnlyList<DispatchArm> Arms => arms;
+
+        public int GetDiscriminator(BoundLabel target)
+        {
+            if (!discriminators.TryGetValue(target, out var discriminator))
+            {
+                discriminator = nextDiscriminator++;
+                discriminators[target] = discriminator;
+                arms.Add(new DispatchArm(discriminator, target));
+            }
+
+            return discriminator;
+        }
+    }
+
+    private sealed class ExitFunneler : BoundTreeRewriter
+    {
+        private readonly ExitPlan plan;
+        private readonly HashSet<BoundLabel> localLabels;
+
+        public ExitFunneler(ExitPlan plan, HashSet<BoundLabel> localLabels)
+        {
+            this.plan = plan;
+            this.localLabels = localLabels;
+        }
+
+        protected override BoundStatement RewriteGotoStatement(BoundGotoStatement node)
+        {
+            if (localLabels.Contains(node.Label))
+            {
+                return node;
+            }
+
+            return new BoundBlockStatement(
+                null,
+                ImmutableArray.Create<BoundStatement>(
+                    AssignBranch(plan.GetDiscriminator(node.Label)),
+                    new BoundGotoStatement(null, plan.TailLabel)));
+        }
+
+        private BoundStatement AssignBranch(int discriminator)
+            => new BoundExpressionStatement(
+                null,
+                new BoundAssignmentExpression(
+                    null,
+                    plan.PendingBranch,
+                    new BoundLiteralExpression(null, discriminator)));
+    }
+
+    private sealed class LabelCollector : BoundTreeWalker
+    {
+        private readonly HashSet<BoundLabel> labels = [];
+
+        public static HashSet<BoundLabel> Collect(BoundStatement body)
+        {
+            var collector = new LabelCollector();
+            collector.VisitStatement(body);
+            return collector.labels;
+        }
+
+        public override void VisitStatement(BoundStatement node)
+        {
+            if (node is BoundLabelStatement label)
+            {
+                labels.Add(label.Label);
+            }
+
+            base.VisitStatement(node);
+        }
+    }
+
+    private sealed class EscapingBranchDetector : BoundTreeWalker
+    {
+        private readonly HashSet<BoundLabel> localLabels;
+
+        private EscapingBranchDetector(HashSet<BoundLabel> localLabels)
+        {
+            this.localLabels = localLabels;
+        }
+
+        public bool Found { get; private set; }
+
+        public static bool ContainsEscapingBranch(BoundStatement body)
+        {
+            var detector = new EscapingBranchDetector(LabelCollector.Collect(body));
+            detector.VisitStatement(body);
+            return detector.Found;
+        }
+
+        public override void VisitStatement(BoundStatement node)
+        {
+            if (Found)
+            {
+                return;
+            }
+
+            if ((node is BoundGotoStatement go && !localLabels.Contains(go.Label))
+                || (node is BoundConditionalGotoStatement conditional && !localLabels.Contains(conditional.Label)))
+            {
+                Found = true;
+                return;
+            }
+
+            base.VisitStatement(node);
+        }
+    }
+
+    private sealed class Rewriter : BoundTreeRewriter
+    {
+        private int ordinal;
+
+        protected override BoundStatement RewriteTryStatement(BoundTryStatement node)
+        {
+            var rewritten = (BoundTryStatement)base.RewriteTryStatement(node);
+            if (rewritten.FinallyBlock == null
+                || !EscapingBranchDetector.ContainsEscapingBranch(rewritten.FinallyBlock))
+            {
+                return rewritten;
+            }
+
+            var currentOrdinal = ordinal++;
+            var plan = new ExitPlan(currentOrdinal);
+            BoundLabel NewLabel() => new($"<>finally_skip_{currentOrdinal}_{ordinal++}");
+
+            var tryBody = new ExitFunneler(
+                plan,
+                LabelCollector.Collect(rewritten.TryBlock)).RewriteStatement(rewritten.TryBlock);
+            var catches = ImmutableArray.CreateBuilder<BoundCatchClause>(rewritten.CatchClauses.Length);
+            foreach (var clause in rewritten.CatchClauses)
+            {
+                var catchBody = new ExitFunneler(
+                    plan,
+                    LabelCollector.Collect(clause.Body)).RewriteStatement(clause.Body);
+                catches.Add(new BoundCatchClause(clause.ExceptionType, clause.Variable, catchBody));
+            }
+
+            var exceptionType = TypeSymbol.FromClrType(typeof(Exception));
+            var pendingException = new LocalVariableSymbol(
+                $"<>finally_exception_{currentOrdinal}",
+                isReadOnly: false,
+                NullableTypeSymbol.Get(exceptionType));
+            var catchVariable = new LocalVariableSymbol(
+                $"<>finally_catch_{currentOrdinal}",
+                isReadOnly: true,
+                exceptionType);
+            var captureException = new BoundExpressionStatement(
+                null,
+                new BoundAssignmentExpression(
+                    null,
+                    pendingException,
+                    new BoundVariableExpression(null, catchVariable)));
+
+            var innerStatement = catches.Count == 0
+                ? tryBody
+                : new BoundTryStatement(null, tryBody, catches.ToImmutable(), finallyBlock: null);
+            var exceptionCaptureTry = new BoundTryStatement(
+                null,
+                new BoundBlockStatement(null, ImmutableArray.Create(innerStatement)),
+                ImmutableArray.Create(
+                    new BoundCatchClause(
+                        exceptionType,
+                        catchVariable,
+                        new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(captureException)))),
+                finallyBlock: null);
+
+            var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+            statements.Add(new BoundVariableDeclaration(
+                null,
+                plan.PendingBranch,
+                new BoundLiteralExpression(null, 0)));
+            statements.Add(new BoundVariableDeclaration(
+                null,
+                pendingException,
+                new BoundLiteralExpression(null, null, TypeSymbol.Null)));
+            statements.Add(exceptionCaptureTry);
+            statements.Add(new BoundLabelStatement(null, plan.TailLabel));
+            AddStatements(statements, rewritten.FinallyBlock);
+
+            var rethrowEnd = NewLabel();
+            statements.Add(new BoundConditionalGotoStatement(
+                null,
+                rethrowEnd,
+                new BoundBinaryExpression(
+                    null,
+                    new BoundVariableExpression(null, pendingException),
+                    BoundBinaryOperator.Bind(
+                        SyntaxKind.EqualsEqualsToken,
+                        pendingException.Type,
+                        TypeSymbol.Null),
+                    new BoundLiteralExpression(null, null, TypeSymbol.Null)),
+                jumpIfTrue: true));
+            statements.Add(BuildExceptionDispatchThrow(
+                new BoundVariableExpression(null, pendingException)));
+            statements.Add(new BoundLabelStatement(null, rethrowEnd));
+
+            foreach (var arm in plan.Arms)
+            {
+                var skip = NewLabel();
+                statements.Add(new BoundConditionalGotoStatement(
+                    null,
+                    skip,
+                    new BoundBinaryExpression(
+                        null,
+                        new BoundVariableExpression(null, plan.PendingBranch),
+                        BoundBinaryOperator.Bind(
+                            SyntaxKind.EqualsEqualsToken,
+                            TypeSymbol.Int32,
+                            TypeSymbol.Int32),
+                        new BoundLiteralExpression(null, arm.Discriminator)),
+                    jumpIfTrue: false));
+                statements.Add(new BoundGotoStatement(null, arm.Target));
+                statements.Add(new BoundLabelStatement(null, skip));
+            }
+
+            return new BoundBlockStatement(null, statements.ToImmutable());
+        }
+
+        private static void AddStatements(
+            ImmutableArray<BoundStatement>.Builder statements,
+            BoundStatement statement)
+        {
+            if (statement is BoundBlockStatement block)
+            {
+                statements.AddRange(block.Statements);
+            }
+            else
+            {
+                statements.Add(statement);
+            }
+        }
+
+        private static BoundStatement BuildExceptionDispatchThrow(BoundExpression exception)
+        {
+            var ediType = typeof(System.Runtime.ExceptionServices.ExceptionDispatchInfo);
+            var captureMethod = ediType.GetMethod(
+                nameof(System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture),
+                new[] { typeof(Exception) });
+            var throwMethod = ediType.GetMethod(
+                nameof(System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw),
+                Type.EmptyTypes);
+            var ediClass = new ImportedClassSymbol(ediType, declaration: null);
+            var captureFunction = new ImportedFunctionSymbol(
+                captureMethod.Name,
+                ediClass,
+                captureMethod,
+                declaration: null);
+            var captureCall = new BoundImportedCallExpression(
+                null,
+                captureFunction,
+                ImmutableArray.Create(exception));
+            return new BoundExpressionStatement(
+                null,
+                new BoundImportedInstanceCallExpression(
+                    null,
+                    captureCall,
+                    throwMethod,
+                    TypeSymbol.Void,
+                    ImmutableArray<BoundExpression>.Empty));
+        }
+    }
+}

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -1386,7 +1386,13 @@ public sealed class Lowerer : BoundTreeRewriter
     private static BoundBlockStatement RewriteProtectedRegionEntries(BoundStatement statement)
     {
         var flattened = Flatten(statement);
-        return Flatten(ProtectedRegionBranchRewriter.Rewrite(flattened));
+        var definiteReturnBody = Flatten(ProtectedRegionBranchRewriter.Rewrite(flattened));
+        flattened = FinallyExitRewriter.Rewrite(flattened);
+        var emittedBody = Flatten(ProtectedRegionBranchRewriter.Rewrite(flattened));
+        return new BoundBlockStatement(
+            emittedBody.Syntax,
+            emittedBody.Statements,
+            definiteReturnBody);
     }
 
     /// <summary>
@@ -1486,7 +1492,7 @@ public sealed class Lowerer : BoundTreeRewriter
                     flatArms.Add(new BoundPatternSwitchArm(null, arm.Pattern, arm.Guard, Flatten(arm.Body)));
                 }
 
-                builder.Add(new BoundPatternSwitchStatement(null, ps.Discriminant, flatArms.ToImmutable()));
+                builder.Add(new BoundPatternSwitchStatement(null, ps.Discriminant, flatArms.ToImmutable(), ps.IsExhaustive));
             }
             else if (current is BoundSelectStatement sel)
             {

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -1386,13 +1386,13 @@ public sealed class Lowerer : BoundTreeRewriter
     private static BoundBlockStatement RewriteProtectedRegionEntries(BoundStatement statement)
     {
         var flattened = Flatten(statement);
-        var definiteReturnBody = Flatten(ProtectedRegionBranchRewriter.Rewrite(flattened));
+        var preEmitAnalysisBody = Flatten(ProtectedRegionBranchRewriter.Rewrite(flattened));
         flattened = FinallyExitRewriter.Rewrite(flattened);
         var emittedBody = Flatten(ProtectedRegionBranchRewriter.Rewrite(flattened));
         return new BoundBlockStatement(
             emittedBody.Syntax,
             emittedBody.Statements,
-            definiteReturnBody);
+            preEmitAnalysisBody);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Lowering/ProtectedRegionBranchAnalysis.cs
+++ b/src/Core/CodeAnalysis/Lowering/ProtectedRegionBranchAnalysis.cs
@@ -1,0 +1,121 @@
+// <copyright file="ProtectedRegionBranchAnalysis.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+
+namespace GSharp.Core.CodeAnalysis.Lowering;
+
+/// <summary>
+/// Records branch targets and their enclosing protected try regions.
+/// </summary>
+internal sealed class ProtectedRegionBranchAnalysis
+{
+    private readonly Dictionary<BoundLabel, ImmutableArray<BoundTryStatement>> labelRegions;
+
+    private ProtectedRegionBranchAnalysis(
+        Dictionary<BoundLabel, ImmutableArray<BoundTryStatement>> labelRegions,
+        List<Branch> branches)
+    {
+        this.labelRegions = labelRegions;
+        Branches = branches;
+    }
+
+    public IReadOnlyList<Branch> Branches { get; }
+
+    public bool HasEscapingBranch
+    {
+        get
+        {
+            foreach (var branch in Branches)
+            {
+                if (!labelRegions.ContainsKey(branch.Target))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public static ProtectedRegionBranchAnalysis Create(BoundStatement body)
+    {
+        var walker = new Walker();
+        walker.VisitStatement(body);
+        return new ProtectedRegionBranchAnalysis(walker.LabelRegions, walker.Branches);
+    }
+
+    public bool ContainsLabel(BoundLabel label)
+        => labelRegions.ContainsKey(label);
+
+    public bool TryGetLabelRegions(
+        BoundLabel label,
+        out ImmutableArray<BoundTryStatement> regions)
+        => labelRegions.TryGetValue(label, out regions);
+
+    internal readonly struct Branch
+    {
+        public Branch(
+            BoundStatement statement,
+            BoundLabel target,
+            ImmutableArray<BoundTryStatement> regions)
+        {
+            Statement = statement;
+            Target = target;
+            Regions = regions;
+        }
+
+        public BoundStatement Statement { get; }
+
+        public BoundLabel Target { get; }
+
+        public ImmutableArray<BoundTryStatement> Regions { get; }
+    }
+
+    private sealed class Walker : BoundTreeWalker
+    {
+        private readonly List<BoundTryStatement> tryStack = new();
+
+        public Dictionary<BoundLabel, ImmutableArray<BoundTryStatement>> LabelRegions { get; } = new();
+
+        public List<Branch> Branches { get; } = new();
+
+        public override void VisitStatement(BoundStatement node)
+        {
+            switch (node)
+            {
+                case BoundLabelStatement label:
+                    LabelRegions[label.Label] = tryStack.ToImmutableArray();
+                    return;
+                case BoundGotoStatement go:
+                    Branches.Add(new Branch(go, go.Label, tryStack.ToImmutableArray()));
+                    return;
+                case BoundConditionalGotoStatement conditional:
+                    Branches.Add(new Branch(conditional, conditional.Label, tryStack.ToImmutableArray()));
+                    break;
+            }
+
+            base.VisitStatement(node);
+        }
+
+        protected override void VisitTryStatement(BoundTryStatement node)
+        {
+            tryStack.Add(node);
+            VisitStatement(node.TryBlock);
+            tryStack.RemoveAt(tryStack.Count - 1);
+
+            foreach (var clause in node.CatchClauses)
+            {
+                VisitStatement(clause.Body);
+            }
+
+            if (node.FinallyBlock != null)
+            {
+                VisitStatement(node.FinallyBlock);
+            }
+        }
+    }
+}

--- a/src/Core/CodeAnalysis/Lowering/ProtectedRegionBranchRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/ProtectedRegionBranchRewriter.cs
@@ -71,53 +71,17 @@ internal static class ProtectedRegionBranchRewriter
         public bool HasRoutes => Routes.Count != 0;
     }
 
-    private sealed class Planner : BoundTreeWalker
+    private sealed class Planner
     {
-        private readonly List<BoundTryStatement> tryStack = new();
-        private readonly Dictionary<BoundLabel, ImmutableArray<BoundTryStatement>> labelRegions = new();
-        private readonly List<(BoundStatement Branch, BoundLabel Target, ImmutableArray<BoundTryStatement> Regions)> branches = new();
+        private readonly ProtectedRegionBranchAnalysis analysis;
+
+        private Planner(ProtectedRegionBranchAnalysis analysis)
+        {
+            this.analysis = analysis;
+        }
 
         public static Plan Create(BoundStatement body)
-        {
-            var planner = new Planner();
-            planner.VisitStatement(body);
-            return planner.Build();
-        }
-
-        public override void VisitStatement(BoundStatement node)
-        {
-            switch (node)
-            {
-                case BoundLabelStatement label:
-                    labelRegions[label.Label] = tryStack.ToImmutableArray();
-                    return;
-                case BoundGotoStatement go:
-                    branches.Add((go, go.Label, tryStack.ToImmutableArray()));
-                    return;
-                case BoundConditionalGotoStatement conditional:
-                    branches.Add((conditional, conditional.Label, tryStack.ToImmutableArray()));
-                    break;
-            }
-
-            base.VisitStatement(node);
-        }
-
-        protected override void VisitTryStatement(BoundTryStatement node)
-        {
-            tryStack.Add(node);
-            VisitStatement(node.TryBlock);
-            tryStack.RemoveAt(tryStack.Count - 1);
-
-            foreach (var clause in node.CatchClauses)
-            {
-                VisitStatement(clause.Body);
-            }
-
-            if (node.FinallyBlock != null)
-            {
-                VisitStatement(node.FinallyBlock);
-            }
-        }
+            => new Planner(ProtectedRegionBranchAnalysis.Create(body)).Build();
 
         private Plan Build()
         {
@@ -126,17 +90,17 @@ internal static class ProtectedRegionBranchRewriter
             var nextSelector = 1;
             var nextEntry = 0;
 
-            foreach (var (branch, target, sourceRegions) in branches)
+            foreach (var branch in analysis.Branches)
             {
-                if (!labelRegions.TryGetValue(target, out var targetRegions))
+                if (!analysis.TryGetLabelRegions(branch.Target, out var targetRegions))
                 {
                     continue;
                 }
 
                 var commonDepth = 0;
-                while (commonDepth < sourceRegions.Length
+                while (commonDepth < branch.Regions.Length
                     && commonDepth < targetRegions.Length
-                    && ReferenceEquals(sourceRegions[commonDepth], targetRegions[commonDepth]))
+                    && ReferenceEquals(branch.Regions[commonDepth], targetRegions[commonDepth]))
                 {
                     commonDepth++;
                 }
@@ -146,11 +110,11 @@ internal static class ProtectedRegionBranchRewriter
                     continue;
                 }
 
-                if (!selectors.TryGetValue(target, out var selector))
+                if (!selectors.TryGetValue(branch.Target, out var selector))
                 {
                     selector = nextSelector++;
-                    selectors[target] = selector;
-                    plan.RoutedTargets.Add(target);
+                    selectors[branch.Target] = selector;
+                    plan.RoutedTargets.Add(branch.Target);
                 }
 
                 BoundLabel EntryLabel(BoundTryStatement tryStatement)
@@ -164,13 +128,13 @@ internal static class ProtectedRegionBranchRewriter
                     return label;
                 }
 
-                plan.Routes[branch] = new Route(selector, EntryLabel(targetRegions[commonDepth]));
+                plan.Routes[branch.Statement] = new Route(selector, EntryLabel(targetRegions[commonDepth]));
 
                 for (var depth = commonDepth; depth < targetRegions.Length; depth++)
                 {
                     var region = targetRegions[depth];
                     var dispatchTarget = depth + 1 == targetRegions.Length
-                        ? target
+                        ? branch.Target
                         : EntryLabel(targetRegions[depth + 1]);
 
                     if (!plan.DispatchEntries.TryGetValue(region, out var entries))

--- a/test/Compiler.Tests/Emit/Issue2891TryRegionFlowEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2891TryRegionFlowEmitTests.cs
@@ -471,6 +471,75 @@ public class Issue2891TryRegionFlowEmitTests
             """);
     }
 
+    /// <summary>Gets nested branch-analysis shapes that require runtime execution guards.</summary>
+    public static IEnumerable<object[]> BranchAnalysisExecutionCases()
+    {
+        yield return OutputCase("LocalGotoInTry", "fin#1\nr=1301\n", """
+            import System
+            func F() int32 {
+                var result = 100
+                for {
+                    try {
+                    again:
+                        result += 1
+                        if result < 103 {
+                            goto again
+                        }
+                        result += 1198
+                    } finally {
+                        Console.WriteLine("fin#1")
+                        break
+                    }
+                }
+                return result
+            }
+            Console.WriteLine("r=" + F().ToString())
+            """);
+        yield return OutputCase("LocalGotoInNestedFinally", "outerfin\nr=5\n", """
+            import System
+            func F() int32 {
+                var result = 0
+                for {
+                    try {
+                        try {
+                        } finally {
+                            goto local
+                        local:
+                            result = 5
+                        }
+                    } finally {
+                        Console.WriteLine("outerfin")
+                        break
+                    }
+                }
+                return result
+            }
+            Console.WriteLine("r=" + F().ToString())
+            """);
+        yield return OutputCase("LocalGotoInNestedCatch", "outerfin\nr=3\n", """
+            import System
+            func F() int32 {
+                var result = 0
+                for {
+                    try {
+                        try {
+                            throw Exception("enter catch")
+                        } catch (ex Exception) {
+                            goto local
+                        local:
+                            result = 3
+                        }
+                    } finally {
+                        Console.WriteLine("outerfin")
+                        break
+                    }
+                }
+                return result
+            }
+            Console.WriteLine("r=" + F().ToString())
+            """);
+    }
+
     [Theory]
     [MemberData(nameof(FiniteCases))]
     public void AcceptedFiniteShape_VerifiesLoadsAndRuns(string name, int expected, string source)
@@ -478,6 +547,11 @@ public class Issue2891TryRegionFlowEmitTests
         var assembly = CompileVerifyLoadAndRun(name, source);
         Assert.Equal(expected, GetField(assembly, "result"));
     }
+
+    [Theory]
+    [MemberData(nameof(BranchAnalysisExecutionCases))]
+    public void NestedBranchAnalysis_LoadsAndRunsInChild(string name, string expectedOutput, string source)
+        => CompileLoadAndRunChild(name, source, expectedOutput);
 
     [Theory]
     [InlineData("FinallyInfiniteLoop", false)]
@@ -514,11 +588,14 @@ public class Issue2891TryRegionFlowEmitTests
             F()
             """;
 
-        CompileVerifyLoadAndRunChild(name, source);
+        CompileLoadAndRunChild(name, source);
     }
 
     private static object[] Case(string name, int expected, string body)
         => new object[] { name, expected, $"package Issue2891.Emit{name}{Environment.NewLine}{body}" };
+
+    private static object[] OutputCase(string name, string expectedOutput, string body)
+        => new object[] { name, expectedOutput, $"package Issue2891.Emit{name}{Environment.NewLine}{body}" };
 
     private static Assembly CompileVerifyLoadAndRun(string name, string source)
     {
@@ -562,7 +639,10 @@ public class Issue2891TryRegionFlowEmitTests
         return assembly;
     }
 
-    private static void CompileVerifyLoadAndRunChild(string name, string source)
+    private static void CompileLoadAndRunChild(
+        string name,
+        string source,
+        string expectedOutput = null)
     {
         var prefix = $"Issue2891_{name}_{Guid.NewGuid():N}";
         var directory = Directory.GetCurrentDirectory();
@@ -597,17 +677,27 @@ public class Issue2891TryRegionFlowEmitTests
             using var process = Process.Start(start)!;
             var stdoutTask = process.StandardOutput.ReadToEndAsync();
             var stderrTask = process.StandardError.ReadToEndAsync();
-            var exited = process.WaitForExit(3_000);
+            var exited = process.WaitForExit(expectedOutput == null ? 3_000 : 10_000);
             if (!exited)
             {
                 process.Kill(entireProcessTree: true);
                 Assert.True(process.WaitForExit(5_000), $"{name} child did not stop after kill");
             }
 
-            var stdout = stdoutTask.GetAwaiter().GetResult();
+            var stdout = stdoutTask.GetAwaiter().GetResult().Replace("\r\n", "\n", StringComparison.Ordinal);
             var stderr = stderrTask.GetAwaiter().GetResult();
-            Assert.False(exited, $"{name} unexpectedly completed\nstdout:\n{stdout}\nstderr:\n{stderr}");
-            Assert.Contains("entered", stdout, StringComparison.Ordinal);
+            if (expectedOutput == null)
+            {
+                Assert.False(exited, $"{name} unexpectedly completed\nstdout:\n{stdout}\nstderr:\n{stderr}");
+                Assert.Contains("entered", stdout, StringComparison.Ordinal);
+            }
+            else
+            {
+                Assert.True(exited, $"{name} execution timed out");
+                Assert.Equal(0, process.ExitCode);
+                Assert.Equal(string.Empty, stderr);
+                Assert.Equal(expectedOutput, stdout);
+            }
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2891TryRegionFlowEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2891TryRegionFlowEmitTests.cs
@@ -1,0 +1,626 @@
+// <copyright file="Issue2891TryRegionFlowEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2891: accepted try-region control-flow shapes must emit verifiable
+/// assemblies, load successfully, and execute their finally behavior.
+/// </summary>
+public class Issue2891TryRegionFlowEmitTests
+{
+    /// <summary>Gets finite accepted try-region programs and their expected result.</summary>
+    public static IEnumerable<object[]> FiniteCases()
+    {
+        yield return Case("TryContinue", 3, """
+            func F() int32 {
+                var count = 0
+                for i in 0 ... 3 {
+                    try {
+                        continue
+                    } finally {
+                        count += 1
+                    }
+                }
+                return count
+            }
+            public var result = F()
+            """);
+        yield return Case("LabeledTryContinue", 2, """
+            func F() int32 {
+                var count = 0
+                outer: for i in 0 ... 2 {
+                    for j in 0 ... 2 {
+                        try {
+                            continue outer
+                        } finally {
+                            count += 1
+                        }
+                    }
+                }
+                return count
+            }
+            public var result = F()
+            """);
+        yield return Case("CatchContinue", 3, """
+            import System
+            func F() int32 {
+                var count = 0
+                for i in 0 ... 3 {
+                    try {
+                        throw Exception("boom")
+                    } catch (ex Exception) {
+                        count += 1
+                        continue
+                    }
+                }
+                return count
+            }
+            public var result = F()
+            """);
+        yield return Case("FinallyContinue", 3, """
+            func F() int32 {
+                var count = 0
+                for i in 0 ... 3 {
+                    try {
+                    } finally {
+                        count += 1
+                        continue
+                    }
+                }
+                return count
+            }
+            public var result = F()
+            """);
+        yield return Case("LabeledCatchContinue", 2, """
+            import System
+            func F() int32 {
+                var count = 0
+                outer: for i in 0 ... 2 {
+                    for j in 0 ... 2 {
+                        try {
+                            throw Exception("boom")
+                        } catch (ex Exception) {
+                            count += 1
+                            continue outer
+                        }
+                    }
+                }
+                return count
+            }
+            public var result = F()
+            """);
+        yield return Case("LabeledFinallyContinue", 2, """
+            func F() int32 {
+                var count = 0
+                outer: for i in 0 ... 2 {
+                    for j in 0 ... 2 {
+                        try {
+                        } finally {
+                            count += 1
+                            continue outer
+                        }
+                    }
+                }
+                return count
+            }
+            public var result = F()
+            """);
+        yield return Case("TryFinallyReturn", 3, """
+            public var finalCount = 0
+            func F() int32 {
+                try {
+                    return 2
+                } finally {
+                    finalCount += 1
+                }
+            }
+            public var result = F() + finalCount
+            """);
+        yield return Case("FinallyReturn", 2, """
+            func F() int32 {
+                try {
+                    return 1
+                } finally {
+                    return 2
+                }
+            }
+            public var result = F()
+            """);
+        yield return Case("ConditionalFinallyReturnOverException", 9, """
+            import System
+            func F(replace bool) int32 {
+                try {
+                    throw Exception("origin")
+                } finally {
+                    if replace {
+                        return 2
+                    }
+                }
+            }
+            public var result = F(true)
+            try {
+                F(false)
+            } catch (ex Exception) {
+                result += ex.Message == "origin" ? 7 : -100
+            }
+            """);
+        yield return Case("ConditionalFinallyReturnOverReturn", 3, """
+            func F(replace bool) int32 {
+                try {
+                    return 1
+                } finally {
+                    if replace {
+                        return 2
+                    }
+                }
+            }
+            public var result = F(false) + F(true)
+            """);
+        yield return Case("ConditionalFinallyReturnOverBreak", 2, """
+            func F(replace bool) int32 {
+                var count = 0
+                for i in 0 ... 3 {
+                    try {
+                        break
+                    } finally {
+                        if replace {
+                            return 2
+                        }
+                    }
+                    count += 1
+                }
+                return count
+            }
+            public var result = F(false) + F(true)
+            """);
+        yield return Case("RethrowPreservesOriginStack", 7, """
+            import System
+            func Origin() {
+                throw Exception("origin")
+            }
+            func F(replace bool) int32 {
+                try {
+                    Origin()
+                    return 0
+                } finally {
+                    if replace {
+                        return 2
+                    }
+                }
+            }
+            public var result = F(true)
+            try {
+                F(false)
+            } catch (ex Exception) {
+                result += ex.StackTrace.Contains("<Program>.Origin") ? 5 : -100
+            }
+            """);
+        yield return Case("ExceptionSuppressedByFinallyBreak", 4, """
+            import System
+            func F() int32 {
+                for {
+                    try {
+                        throw Exception("origin")
+                    } finally {
+                        break
+                    }
+                }
+                return 4
+            }
+            public var result = F()
+            """);
+        yield return Case("ExceptionSuppressedByFinallyContinue", 3, """
+            import System
+            func F() int32 {
+                var count = 0
+                for i in 0 ... 3 {
+                    try {
+                        throw Exception("origin")
+                    } finally {
+                        count += 1
+                        continue
+                    }
+                }
+                return count
+            }
+            public var result = F()
+            """);
+        yield return Case("ExceptionSuppressedByFinallyGoto", 5, """
+            import System
+            func F() int32 {
+                try {
+                    throw Exception("origin")
+                } finally {
+                    goto done
+                }
+            done:
+                return 5
+            }
+            public var result = F()
+            """);
+        yield return Case("TryCatchReturns", 3, """
+            import System
+            func F(flag bool) int32 {
+                try {
+                    if flag {
+                        return 1
+                    }
+                    throw Exception("boom")
+                } catch (ex Exception) {
+                    return 2
+                }
+            }
+            public var result = F(true) + F(false)
+            """);
+        yield return Case("TryCatchFinallyReturns", 5, """
+            import System
+            public var finalCount = 0
+            func F(flag bool) int32 {
+                try {
+                    if flag {
+                        return 1
+                    }
+                    throw Exception("boom")
+                } catch (ex Exception) {
+                    return 2
+                } finally {
+                    finalCount += 1
+                }
+            }
+            public var result = F(true) + F(false) + finalCount
+            """);
+        yield return Case("ConditionalFinallyReturnOverCatchReturn", 3, """
+            import System
+            func F(replace bool) int32 {
+                try {
+                    throw Exception("origin")
+                } catch (ex Exception) {
+                    return 1
+                } finally {
+                    if replace {
+                        return 2
+                    }
+                }
+            }
+            public var result = F(false) + F(true)
+            """);
+        yield return Case("CatchRethrows", 7, """
+            import System
+            func F() int32 {
+                try {
+                    throw Exception("first")
+                } catch (ex Exception) {
+                    throw Exception("second")
+                }
+            }
+            public var result = 0
+            try {
+                F()
+            } catch (ex Exception) {
+                result = ex.Message == "second" ? 7 : -1
+            }
+            """);
+        yield return Case("FinallyThrows", 9, """
+            import System
+            func F() int32 {
+                try {
+                    var value = 1
+                } finally {
+                    throw Exception("stop")
+                }
+            }
+            public var result = 0
+            try {
+                F()
+            } catch (ex Exception) {
+                result = ex.Message == "stop" ? 9 : -1
+            }
+            """);
+        yield return Case("ReturnAfterTryBreak", 7, """
+            func F() int32 {
+                for {
+                    try {
+                        break
+                    } finally {
+                    }
+                }
+                return 7
+            }
+            public var result = F()
+            """);
+        yield return Case("ReturnAfterCatchBreak", 8, """
+            import System
+            func F() int32 {
+                for {
+                    try {
+                        throw Exception("boom")
+                    } catch (ex Exception) {
+                        break
+                    }
+                }
+                return 8
+            }
+            public var result = F()
+            """);
+        yield return Case("TryGotoThenReturn", 3, """
+            public var finalCount = 0
+            func F() int32 {
+                try {
+                    goto done
+                } finally {
+                    finalCount += 1
+                }
+                return 1
+            done:
+                return 2
+            }
+            public var result = F() + finalCount
+            """);
+        yield return Case("CatchGotoThenReturn", 2, """
+            import System
+            func F() int32 {
+                try {
+                    throw Exception("boom")
+                } catch (ex Exception) {
+                    goto done
+                }
+                return 1
+            done:
+                return 2
+            }
+            public var result = F()
+            """);
+        yield return Case("FinallyGotoThenReturn", 2, """
+            func F() int32 {
+                try {
+                    return 1
+                } finally {
+                    goto done
+                }
+            done:
+                return 2
+            }
+            public var result = F()
+            """);
+        yield return Case("TryInsideFinallyReturns", 1, """
+            func F() int32 {
+                try {
+                    return 1
+                } finally {
+                    try {
+                        var value = 2
+                    } finally {
+                    }
+                }
+            }
+            public var result = F()
+            """);
+        yield return Case("NestedFinallyBreakThenReturn", 6, """
+            func F() int32 {
+                for {
+                    try {
+                        return 1
+                    } finally {
+                        try {
+                            break
+                        } finally {
+                        }
+                    }
+                }
+                return 6
+            }
+            public var result = F()
+            """);
+        yield return Case("SwitchInsideTryBreakOverriddenByReturn", 1, """
+            func F() int32 {
+                for {
+                    try {
+                        switch 0 {
+                            default { break }
+                        }
+                    } finally {
+                        return 1
+                    }
+                }
+            }
+            public var result = F()
+            """);
+        yield return Case("SelectInsideTryBreakOverriddenByReturn", 2, """
+            import Gsharp.Extensions.Go
+            func F() int32 {
+                for {
+                    try {
+                        select {
+                            default { break }
+                        }
+                    } finally {
+                        return 2
+                    }
+                }
+            }
+            public var result = F()
+            """);
+        yield return Case("ScopeInsideTryBreakOverriddenByReturn", 4, """
+            import Gsharp.Extensions.Go
+            func F() int32 {
+                for {
+                    try {
+                        scope {
+                            break
+                        }
+                    } finally {
+                        return 4
+                    }
+                }
+            }
+            public var result = F()
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(FiniteCases))]
+    public void AcceptedFiniteShape_VerifiesLoadsAndRuns(string name, int expected, string source)
+    {
+        var assembly = CompileVerifyLoadAndRun(name, source);
+        Assert.Equal(expected, GetField(assembly, "result"));
+    }
+
+    [Theory]
+    [InlineData("FinallyInfiniteLoop", false)]
+    [InlineData("BreakSuppressedByInfiniteFinally", true)]
+    public void InfiniteFinally_VerifiesLoadsStartsAndIsBounded(string name, bool startsWithBreak)
+    {
+        var body = startsWithBreak
+            ? """
+                for {
+                    try {
+                        break
+                    } finally {
+                        Console.WriteLine("entered")
+                        for {
+                        }
+                    }
+                }
+                """
+            : """
+                try {
+                    var value = 1
+                } finally {
+                    Console.WriteLine("entered")
+                    for {
+                    }
+                }
+                """;
+        var source = $$"""
+            package Issue2891.Emit{{name}}
+            import System
+            func F() int32 {
+            {{body}}
+            }
+            F()
+            """;
+
+        CompileVerifyLoadAndRunChild(name, source);
+    }
+
+    private static object[] Case(string name, int expected, string body)
+        => new object[] { name, expected, $"package Issue2891.Emit{name}{Environment.NewLine}{body}" };
+
+    private static Assembly CompileVerifyLoadAndRun(string name, string source)
+    {
+        using var peStream = new MemoryStream();
+        EmitResult result;
+        try
+        {
+            result = new Compilation(SyntaxTree.Parse(SourceText.From(source))).Emit(peStream);
+        }
+        catch (Exception exception)
+        {
+            throw new Xunit.Sdk.XunitException(exception.ToString());
+        }
+
+        Assert.True(
+            result.Success,
+            string.Join(
+                Environment.NewLine,
+                result.Diagnostics.Select(diagnostic => $"{diagnostic.Id}: {diagnostic.Message}")));
+
+        var bytes = peStream.ToArray();
+        var assemblyPath = Path.Combine(Directory.GetCurrentDirectory(), $"Issue2891_{name}_{Guid.NewGuid():N}.dll");
+        try
+        {
+            File.WriteAllBytes(assemblyPath, bytes);
+            IlVerifier.Verify(assemblyPath);
+        }
+        finally
+        {
+            File.Delete(assemblyPath);
+        }
+
+        var assembly = Assembly.Load(bytes);
+        var types = assembly.GetTypes();
+        Assert.NotEmpty(types);
+        var program = types.Single(type => type.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
+        var execution = Task.Run(
+            () => entry.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() }));
+        Assert.True(execution.Wait(TimeSpan.FromSeconds(10)), $"{name} execution timed out");
+        return assembly;
+    }
+
+    private static void CompileVerifyLoadAndRunChild(string name, string source)
+    {
+        var prefix = $"Issue2891_{name}_{Guid.NewGuid():N}";
+        var directory = Directory.GetCurrentDirectory();
+        var sourcePath = Path.Combine(directory, prefix + ".gs");
+        var assemblyPath = Path.Combine(directory, prefix + ".dll");
+        try
+        {
+            File.WriteAllText(sourcePath, source);
+            var exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+            Assert.Equal(0, exitCode);
+            IlVerifier.Verify(assemblyPath);
+            Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+
+            var start = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            start.ArgumentList.Add("exec");
+            start.ArgumentList.Add("--runtimeconfig");
+            start.ArgumentList.Add(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+            start.ArgumentList.Add(assemblyPath);
+
+            using var process = Process.Start(start)!;
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            var exited = process.WaitForExit(3_000);
+            if (!exited)
+            {
+                process.Kill(entireProcessTree: true);
+                Assert.True(process.WaitForExit(5_000), $"{name} child did not stop after kill");
+            }
+
+            var stdout = stdoutTask.GetAwaiter().GetResult();
+            var stderr = stderrTask.GetAwaiter().GetResult();
+            Assert.False(exited, $"{name} unexpectedly completed\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            Assert.Contains("entered", stdout, StringComparison.Ordinal);
+        }
+        finally
+        {
+            foreach (var path in Directory.EnumerateFiles(directory, prefix + "*"))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    private static int GetField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+        return (int)program.GetField(name, BindingFlags.Public | BindingFlags.Static)!.GetValue(null)!;
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
@@ -1,0 +1,290 @@
+// <copyright file="Issue2906ExhaustiveSwitchReturnEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2906: exhaustive closed-type switches without default arms must emit
+/// a defensive no-match throw, verify, load, and execute their matched arms.
+/// </summary>
+public class Issue2906ExhaustiveSwitchReturnEmitTests
+{
+    /// <summary>Gets exhaustive switch programs and their expected result.</summary>
+    public static IEnumerable<object[]> Cases()
+    {
+        yield return Case("OneMember", 1, """
+            enum E { A }
+            func F(x E) int32 {
+                switch x {
+                    case E.A { return 1 }
+                }
+            }
+            public var result = F(E.A)
+            """);
+        yield return Case("TwoMembers", 3, """
+            enum E { A, B }
+            func F(x E) int32 {
+                switch x {
+                    case E.A { return 1 }
+                    case E.B { return 2 }
+                }
+            }
+            public var result = F(E.A) + F(E.B)
+            """);
+        yield return Case("ManyMembers", 10, """
+            enum E { A, B, C, D }
+            func F(x E) int32 {
+                switch x {
+                    case E.A { return 1 }
+                    case E.B { return 2 }
+                    case E.C { return 3 }
+                    case E.D { return 4 }
+                }
+            }
+            public var result = F(E.A) + F(E.B) + F(E.C) + F(E.D)
+            """);
+        yield return Case("RedundantDefault", 2, """
+            enum E { A, B }
+            func F(x E) int32 {
+                switch x {
+                    case E.A { return 1 }
+                    case E.B { return 2 }
+                    default { return 3 }
+                }
+            }
+            public var result = F(E.B)
+            """);
+        yield return Case("DuplicateCompleteArms", 4, """
+            enum E { A, B }
+            func F(x E) int32 {
+                switch x {
+                    case E.A { return 1 }
+                    case E.A { return 2 }
+                    case E.B { return 3 }
+                }
+            }
+            public var result = F(E.A) + F(E.B)
+            """);
+        yield return Case("OrPattern", 3, """
+            enum E { A, B, C }
+            func F(x E) int32 {
+                switch x {
+                    case E.A or E.B { return 1 }
+                    case E.C { return 2 }
+                }
+            }
+            public var result = F(E.B) + F(E.C)
+            """);
+        yield return Case("SealedInterface", 3, """
+            sealed interface Expr { }
+            class Add : Expr { }
+            class Mul : Expr { }
+            func F(x Expr) int32 {
+                switch x {
+                    case _ is Add { return 1 }
+                    case _ is Mul { return 2 }
+                }
+            }
+            public var result = F(Add()) + F(Mul())
+            """);
+        yield return Case("SealedClass", 3, """
+            sealed class Shape { }
+            class Circle : Shape { }
+            class Square : Shape { }
+            func F(x Shape) int32 {
+                switch x {
+                    case _ is Circle { return 1 }
+                    case _ is Square { return 2 }
+                }
+            }
+            public var result = F(Circle()) + F(Square())
+            """);
+        yield return Case("SwitchInsideTry", 2, """
+            enum E { A, B }
+            func F(x E) int32 {
+                try {
+                    switch x {
+                        case E.A { return 1 }
+                        case E.B { return 2 }
+                    }
+                } finally {
+                }
+            }
+            public var result = F(E.B)
+            """);
+        yield return Case("TryInsideArms", 3, """
+            enum E { A, B }
+            func F(x E) int32 {
+                switch x {
+                    case E.A {
+                        try {
+                            return 1
+                        } finally {
+                        }
+                    }
+                    case E.B {
+                        try {
+                            return 2
+                        } finally {
+                        }
+                    }
+                }
+            }
+            public var result = F(E.A) + F(E.B)
+            """);
+        yield return Case("SwitchInsideSelect", 2, """
+            import Gsharp.Extensions.Go
+            enum E { A, B }
+            func F(x E) int32 {
+                select {
+                    default {
+                        switch x {
+                            case E.A { return 1 }
+                            case E.B { return 2 }
+                        }
+                    }
+                }
+            }
+            public var result = F(E.B)
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void ExhaustiveSwitch_VerifiesLoadsAndRuns(string name, int expected, string source)
+    {
+        var assembly = CompileVerifyLoadAndRun(name, source);
+        Assert.Equal(expected, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void ExhaustiveEnum_UnnamedRuntimeValue_ThrowsDefensively()
+    {
+        const string Source = """
+            package Issue2906.EmitUnnamed
+            import System
+            enum E { A, B }
+            func F(x E) int32 {
+                switch x {
+                    case E.A { return 1 }
+                    case E.B { return 2 }
+                }
+            }
+            public var result = 0
+            try {
+                F(E(99))
+            } catch (ex InvalidOperationException) {
+                result = 7
+            }
+            """;
+
+        var assembly = CompileVerifyLoadAndRun("Unnamed", Source);
+        Assert.Equal(7, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void ExhaustiveEnum_FollowedByCode_StillThrowsOnUnnamedValue()
+    {
+        const string Source = """
+            package Issue2906.EmitUnnamedBeforeReturn
+            import System
+            enum E { A, B }
+            func F(x E) int32 {
+                switch x {
+                    case E.A { return 1 }
+                    case E.B { return 2 }
+                }
+                return 99
+            }
+            public var result = 0
+            try {
+                F(E(99))
+            } catch (ex InvalidOperationException) {
+                result = 7
+            }
+            """;
+
+        var assembly = CompileVerifyLoadAndRun("UnnamedBeforeReturn", Source);
+        Assert.Equal(7, GetField(assembly, "result"));
+    }
+
+    [Fact]
+    public void CapturedArmState_PreservesExhaustiveEmitterMarker()
+    {
+        const string Source = """
+            package Issue2906.EmitCaptured
+            import System
+            enum E { A, B }
+            func F(x E) int32 {
+                var value = 0
+                let read = func() int32 { return value }
+                switch x {
+                    case E.A { value = 1 }
+                    case E.B { value = 2 }
+                }
+                return read()
+            }
+            public var result = 0
+            try {
+                F(E(99))
+            } catch (ex InvalidOperationException) {
+                result = 7
+            }
+            """;
+
+        var assembly = CompileVerifyLoadAndRun("Captured", Source);
+        Assert.Equal(7, GetField(assembly, "result"));
+    }
+
+    private static object[] Case(string name, int expected, string body)
+        => new object[] { name, expected, $"package Issue2906.Emit{name}{Environment.NewLine}{body}" };
+
+    private static Assembly CompileVerifyLoadAndRun(string name, string source)
+    {
+        using var peStream = new MemoryStream();
+        var result = new Compilation(SyntaxTree.Parse(SourceText.From(source))).Emit(peStream);
+        Assert.True(
+            result.Success,
+            string.Join(Environment.NewLine, result.Diagnostics.Select(diagnostic => diagnostic.ToString())));
+
+        var bytes = peStream.ToArray();
+        var assemblyPath = Path.Combine(Directory.GetCurrentDirectory(), $"Issue2906_{name}_{Guid.NewGuid():N}.dll");
+        try
+        {
+            File.WriteAllBytes(assemblyPath, bytes);
+            IlVerifier.Verify(assemblyPath);
+        }
+        finally
+        {
+            File.Delete(assemblyPath);
+        }
+
+        var assembly = Assembly.Load(bytes);
+        var types = assembly.GetTypes();
+        Assert.NotEmpty(types);
+        var program = types.Single(type => type.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
+        var execution = Task.Run(
+            () => entry.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() }));
+        Assert.True(execution.Wait(TimeSpan.FromSeconds(10)), $"{name} execution timed out");
+        return assembly;
+    }
+
+    private static int GetField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+        return (int)program.GetField(name, BindingFlags.Public | BindingFlags.Static)!.GetValue(null)!;
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
@@ -286,10 +286,44 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
         Assert.Equal(7, GetField(assembly, "result"));
     }
 
+    [Fact]
+    public void ExhaustiveEnum_UnnamedValueWithFixedReturn_UsesFixedEpilogueDefault()
+    {
+        const string Source = """
+            package Issue2906.EmitUnnamedFixed
+            import System
+            func F(x DateTimeKind, values []int32) int32 {
+                switch x {
+                    case DateTimeKind.Unspecified {
+                        unsafe {
+                            fixed p *int32 = values {
+                                return *p
+                            }
+                        }
+                    }
+                    case DateTimeKind.Utc { return 2 }
+                    case DateTimeKind.Local { return 3 }
+                }
+            }
+            public var result = F(DateTimeKind(99), []int32{7})
+            """;
+
+        var assembly = CompileVerifyLoadAndRun(
+            "UnnamedFixed",
+            Source,
+            ignoredVerificationErrors: new[] { "ExpectedNumericType" });
+        // The fixed-return epilogue is intentionally emitted before the
+        // missing-return guard, so an unmatched value returns its default slot.
+        Assert.Equal(0, GetField(assembly, "result"));
+    }
+
     private static object[] Case(string name, int expected, string body)
         => new object[] { name, expected, $"package Issue2906.Emit{name}{Environment.NewLine}{body}" };
 
-    private static Assembly CompileVerifyLoadAndRun(string name, string source)
+    private static Assembly CompileVerifyLoadAndRun(
+        string name,
+        string source,
+        IEnumerable<string> ignoredVerificationErrors = null)
     {
         using var peStream = new MemoryStream();
         var result = new Compilation(SyntaxTree.Parse(SourceText.From(source))).Emit(peStream);
@@ -302,7 +336,7 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
         try
         {
             File.WriteAllBytes(assemblyPath, bytes);
-            IlVerifier.Verify(assemblyPath);
+            IlVerifier.Verify(assemblyPath, ignoredErrorCodes: ignoredVerificationErrors);
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
@@ -312,8 +312,9 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
             "UnnamedFixed",
             Source,
             ignoredVerificationErrors: new[] { "ExpectedNumericType" });
-        // The fixed-return epilogue is intentionally emitted before the
-        // missing-return guard, so an unmatched value returns its default slot.
+        // Known limitation (#2953): the fixed-return epilogue must be emitted first,
+        // so fixed-containing non-void functions bypass the fall-through guard and
+        // silently return the default slot instead of throwing.
         Assert.Equal(0, GetField(assembly, "result"));
     }
 

--- a/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
@@ -16,8 +17,8 @@ using Xunit;
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>
-/// Issue #2906: exhaustive closed-type switches without default arms must emit
-/// a defensive no-match throw, verify, load, and execute their matched arms.
+/// Issue #2906: exhaustive closed-type switches can satisfy definite return,
+/// while ordinary switch statements retain unmatched-value fallthrough.
 /// </summary>
 public class Issue2906ExhaustiveSwitchReturnEmitTests
 {
@@ -161,10 +162,99 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
             """);
     }
 
+    /// <summary>Gets exhaustive switch statements whose unmatched runtime value must fall through.</summary>
+    public static IEnumerable<object[]> FallthroughCases()
+    {
+        yield return Case("ReturnAfterSwitch", 99, """
+            import System
+            func F(x DateTimeKind) int32 {
+                switch x {
+                    case DateTimeKind.Unspecified { return 1 }
+                    case DateTimeKind.Utc { return 2 }
+                    case DateTimeKind.Local { return 3 }
+                }
+                return 99
+            }
+            public var result = F(DateTimeKind(99))
+            result
+            """);
+        yield return Case("NonTerminalArms", 0, """
+            import System
+            func F(x DateTimeKind) int32 {
+                var value = 0
+                switch x {
+                    case DateTimeKind.Unspecified { value = 1 }
+                    case DateTimeKind.Utc { value = 2 }
+                    case DateTimeKind.Local { value = 3 }
+                }
+                return value
+            }
+            public var result = F(DateTimeKind(99))
+            result
+            """);
+        yield return Case("VoidFunctionContinues", 7, """
+            import System
+            func F(x DateTimeKind, out value int32) {
+                switch x {
+                    case DateTimeKind.Unspecified { value = 1 }
+                    case DateTimeKind.Utc { value = 2 }
+                    case DateTimeKind.Local { value = 3 }
+                }
+                value = 7
+            }
+            var result int32
+            F(DateTimeKind(99), &result)
+            result
+            """);
+        yield return Case("CapturedArmState", 0, """
+            import System
+            func F(x DateTimeKind) int32 {
+                var value = 0
+                let read = func() int32 { return value }
+                switch x {
+                    case DateTimeKind.Unspecified { value = 1 }
+                    case DateTimeKind.Utc { value = 2 }
+                    case DateTimeKind.Local { value = 3 }
+                }
+                return read()
+            }
+            public var result = F(DateTimeKind(99))
+            result
+            """);
+        yield return Case("SealedInterfaceNil", 0, """
+            sealed interface Expr { }
+            class Literal : Expr { }
+            func F(x Expr) int32 {
+                switch x {
+                    case _ is Literal { return 1 }
+                }
+                return 0
+            }
+            public var result = F(nil)
+            result
+            """);
+    }
+
     [Theory]
     [MemberData(nameof(Cases))]
     public void ExhaustiveSwitch_VerifiesLoadsAndRuns(string name, int expected, string source)
     {
+        var assembly = CompileVerifyLoadAndRun(name, source);
+        Assert.Equal(expected, GetField(assembly, "result"));
+    }
+
+    [Theory]
+    [MemberData(nameof(FallthroughCases))]
+    public void ExhaustiveSwitchStatement_UnmatchedValueFallsThroughInBothEngines(
+        string name,
+        int expected,
+        string source)
+    {
+        var evaluation = new Compilation(SyntaxTree.Parse(SourceText.From(source)))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(evaluation.Diagnostics);
+        Assert.Equal(expected, evaluation.Value);
+
         var assembly = CompileVerifyLoadAndRun(name, source);
         Assert.Equal(expected, GetField(assembly, "result"));
     }
@@ -186,65 +276,13 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
             try {
                 F(E(99))
             } catch (ex InvalidOperationException) {
-                result = 7
+                result = ex.Message == "Compiler-generated guard reached: non-void function fell through without returning a value."
+                    ? 7
+                    : -1
             }
             """;
 
         var assembly = CompileVerifyLoadAndRun("Unnamed", Source);
-        Assert.Equal(7, GetField(assembly, "result"));
-    }
-
-    [Fact]
-    public void ExhaustiveEnum_FollowedByCode_StillThrowsOnUnnamedValue()
-    {
-        const string Source = """
-            package Issue2906.EmitUnnamedBeforeReturn
-            import System
-            enum E { A, B }
-            func F(x E) int32 {
-                switch x {
-                    case E.A { return 1 }
-                    case E.B { return 2 }
-                }
-                return 99
-            }
-            public var result = 0
-            try {
-                F(E(99))
-            } catch (ex InvalidOperationException) {
-                result = 7
-            }
-            """;
-
-        var assembly = CompileVerifyLoadAndRun("UnnamedBeforeReturn", Source);
-        Assert.Equal(7, GetField(assembly, "result"));
-    }
-
-    [Fact]
-    public void CapturedArmState_PreservesExhaustiveEmitterMarker()
-    {
-        const string Source = """
-            package Issue2906.EmitCaptured
-            import System
-            enum E { A, B }
-            func F(x E) int32 {
-                var value = 0
-                let read = func() int32 { return value }
-                switch x {
-                    case E.A { value = 1 }
-                    case E.B { value = 2 }
-                }
-                return read()
-            }
-            public var result = 0
-            try {
-                F(E(99))
-            } catch (ex InvalidOperationException) {
-                result = 7
-            }
-            """;
-
-        var assembly = CompileVerifyLoadAndRun("Captured", Source);
         Assert.Equal(7, GetField(assembly, "result"));
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2891SiblingAnalyzerNoDriftTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2891SiblingAnalyzerNoDriftTests.cs
@@ -68,6 +68,24 @@ public class Issue2891SiblingAnalyzerNoDriftTests
                 var reached = true
             }
             """);
+        yield return Case("OutNestedEscapingFinallyClean", "", """
+            func F(out value int32) {
+                outer: for {
+                    try {
+                        for {
+                            try {
+                            } finally {
+                                goto innerDone
+                            }
+                        }
+                    innerDone:
+                        value = 1
+                    } finally {
+                        break outer
+                    }
+                }
+            }
+            """);
         yield return Case("RefTryOnlyCatchCompletes", "GS0239", """
             import System
             func Bump(ref value int32) {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2891SiblingAnalyzerNoDriftTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2891SiblingAnalyzerNoDriftTests.cs
@@ -1,0 +1,182 @@
+// <copyright file="Issue2891SiblingAnalyzerNoDriftTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Guards the two analyzers that share <see cref="ControlFlowGraph.Create"/>:
+/// definite-return-only try and exhaustiveness projection must not change
+/// GS0238/GS0239 assignment or GS0219 async ref-struct diagnostics.
+/// </summary>
+public class Issue2891SiblingAnalyzerNoDriftTests
+{
+    /// <summary>Gets sibling-analyzer shapes and expected relevant diagnostic IDs.</summary>
+    public static IEnumerable<object[]> Cases()
+    {
+        yield return Case("OutFinallyAssigned", "", """
+            func F(out value int32) {
+                try {
+                } finally {
+                    value = 1
+                }
+            }
+            """);
+        yield return Case("OutTryOnlyCatchCompletes", "GS0238", """
+            import System
+            func F(out value int32) {
+                try {
+                    value = 1
+                } catch (ex Exception) {
+                }
+            }
+            """);
+        yield return Case("OutTryAndCatchAssigned", "", """
+            import System
+            func F(out value int32) {
+                try {
+                    value = 1
+                } catch (ex Exception) {
+                    value = 2
+                }
+            }
+            """);
+        yield return Case("OutTryCatchFinallyAssigned", "", """
+            import System
+            func F(out value int32) {
+                try {
+                } catch (ex Exception) {
+                } finally {
+                    value = 3
+                }
+            }
+            """);
+        yield return Case("RefTryOnlyCatchCompletes", "GS0239", """
+            import System
+            func Bump(ref value int32) {
+                value += 1
+            }
+            func F() {
+                var value int32
+                try {
+                    value = 1
+                } catch (ex Exception) {
+                }
+                Bump(&value)
+            }
+            """);
+        yield return Case("RefFinallyAssigned", "", """
+            func Bump(ref value int32) {
+                value += 1
+            }
+            func F() {
+                var value int32
+                try {
+                } finally {
+                    value = 1
+                }
+                Bump(&value)
+            }
+            """);
+        yield return Case("OutExhaustiveEnumNoDefault", "GS0238", """
+            enum E { A, B }
+            func F(out value int32, x E) {
+                switch x {
+                    case E.A { value = 1 }
+                    case E.B { value = 2 }
+                }
+            }
+            """);
+        yield return Case("OutEnumWithDefault", "", """
+            enum E { A, B }
+            func F(out value int32, x E) {
+                switch x {
+                    case E.A { value = 1 }
+                    default { value = 2 }
+                }
+            }
+            """);
+        yield return Case("RefExhaustiveEnumNoDefault", "GS0239", """
+            enum E { A, B }
+            func Bump(ref value int32) {
+                value += 1
+            }
+            func F(x E) {
+                var value int32
+                switch x {
+                    case E.A { value = 1 }
+                    case E.B { value = 2 }
+                }
+                Bump(&value)
+            }
+            """);
+        yield return Case("SpanTryDeadBeforeAwait", "", """
+            import System
+            import System.Threading.Tasks
+            async func F(values []int32) Task[int32] {
+                var span ReadOnlySpan[int32] = values
+                var length = 0
+                try {
+                    length = span.Length
+                } finally {
+                }
+                await Task.Yield()
+                return length
+            }
+            """);
+        yield return Case("SpanTryLiveAcrossAwait", "GS0219", """
+            import System
+            import System.Threading.Tasks
+            async func F(values []int32) Task[int32] {
+                var span ReadOnlySpan[int32] = values
+                try {
+                    await Task.Yield()
+                } finally {
+                    var length = span.Length
+                }
+                return 0
+            }
+            """);
+        yield return Case("SpanExhaustiveSwitchLiveAcrossAwait", "GS0219", """
+            import System
+            import System.Threading.Tasks
+            enum E { A, B }
+            async func F(values []int32, x E) Task[int32] {
+                var span ReadOnlySpan[int32] = values
+                await Task.Yield()
+                switch x {
+                    case E.A { return span.Length }
+                    case E.B { return span.Length + 1 }
+                }
+            }
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void SharedCfgDiagnosticsRemainUnchanged(string name, string expectedIds, string source)
+    {
+        _ = name;
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        var actual = compilation.GlobalScope.Diagnostics
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .Where(diagnostic => diagnostic.Id is "GS0219" or "GS0238" or "GS0239")
+            .Select(diagnostic => diagnostic.Id)
+            .Distinct()
+            .OrderBy(id => id);
+        var expected = expectedIds
+            .Split(',', System.StringSplitOptions.RemoveEmptyEntries)
+            .OrderBy(id => id);
+        Assert.Equal(expected, actual);
+    }
+
+    private static object[] Case(string name, string expectedIds, string body)
+        => new object[] { name, expectedIds, $"package Issue2891.NoDrift{name}{System.Environment.NewLine}{body}" };
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2891SiblingAnalyzerNoDriftTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2891SiblingAnalyzerNoDriftTests.cs
@@ -58,6 +58,16 @@ public class Issue2891SiblingAnalyzerNoDriftTests
                 }
             }
             """);
+        yield return Case("OutEscapingFinallyGoto", "GS0238", """
+            func F(out value int32) {
+                try {
+                } finally {
+                    goto done
+                }
+            done:
+                var reached = true
+            }
+            """);
         yield return Case("RefTryOnlyCatchCompletes", "GS0239", """
             import System
             func Bump(ref value int32) {
@@ -142,6 +152,20 @@ public class Issue2891SiblingAnalyzerNoDriftTests
                     var length = span.Length
                 }
                 return 0
+            }
+            """);
+        yield return Case("SpanEscapingFinallyGotoLiveAcrossAwait", "GS0219", """
+            import System
+            import System.Threading.Tasks
+            async func F(values []int32) Task[int32] {
+                var span ReadOnlySpan[int32] = values
+                try {
+                    await Task.Yield()
+                } finally {
+                    goto done
+                }
+            done:
+                return span.Length
             }
             """);
         yield return Case("SpanExhaustiveSwitchLiveAcrossAwait", "GS0219", """

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2891TryRegionFlowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2891TryRegionFlowTests.cs
@@ -131,6 +131,21 @@ public class Issue2891TryRegionFlowTests
                 var reached = true
             }
             """);
+        yield return Case("GotoIntoTryThenBreak", """
+            func F(returnFromTry bool) int32 {
+                for {
+                    goto inside
+                    try {
+                    inside:
+                        if returnFromTry {
+                            return 1
+                        }
+                        break
+                    } finally {
+                    }
+                }
+            }
+            """);
         yield return Case("CatchGoto", """
             import System
             func F() int32 {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2891TryRegionFlowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2891TryRegionFlowTests.cs
@@ -1,0 +1,793 @@
+// <copyright file="Issue2891TryRegionFlowTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2891: definite-return analysis must model try, catch, and finally
+/// regions without hiding escaping branches or treating handlers sequentially.
+/// </summary>
+public class Issue2891TryRegionFlowTests
+{
+    /// <summary>Gets try-region shapes that must report GS0100.</summary>
+    public static IEnumerable<object[]> MissingReturnCases()
+    {
+        yield return Case("TryFinallyBreak", """
+            func F() int32 {
+                for {
+                    try {
+                        break
+                    } finally {
+                    }
+                }
+            }
+            """);
+        yield return Case("TryCatchBreak", """
+            import System
+            func F() int32 {
+                for {
+                    try {
+                        break
+                    } catch (ex Exception) {
+                        return 1
+                    }
+                }
+            }
+            """);
+        yield return Case("TryCatchFinallyBreak", """
+            import System
+            func F() int32 {
+                for {
+                    try {
+                        break
+                    } catch (ex Exception) {
+                        return 1
+                    } finally {
+                    }
+                }
+            }
+            """);
+        yield return Case("CatchBreak", """
+            import System
+            func F() int32 {
+                for {
+                    try {
+                        throw Exception("boom")
+                    } catch (ex Exception) {
+                        break
+                    }
+                }
+            }
+            """);
+        yield return Case("FinallyBreak", """
+            func F() int32 {
+                for {
+                    try {
+                        return 1
+                    } finally {
+                        break
+                    }
+                }
+            }
+            """);
+        yield return Case("LabeledTryBreak", """
+            func F() int32 {
+                outer: for {
+                    for {
+                        try {
+                            break outer
+                        } finally {
+                        }
+                    }
+                }
+            }
+            """);
+        yield return Case("LabeledCatchBreak", """
+            import System
+            func F() int32 {
+                outer: for {
+                    for {
+                        try {
+                            throw Exception("boom")
+                        } catch (ex Exception) {
+                            break outer
+                        }
+                    }
+                }
+            }
+            """);
+        yield return Case("LabeledFinallyBreak", """
+            func F() int32 {
+                outer: for {
+                    for {
+                        try {
+                            return 1
+                        } finally {
+                            break outer
+                        }
+                    }
+                }
+            }
+            """);
+        yield return Case("TryGoto", """
+            func F() int32 {
+                try {
+                    goto done
+                } finally {
+                }
+                return 1
+            done:
+                var reached = true
+            }
+            """);
+        yield return Case("CatchGoto", """
+            import System
+            func F() int32 {
+                try {
+                    throw Exception("boom")
+                } catch (ex Exception) {
+                    goto done
+                }
+                return 1
+            done:
+                var reached = true
+            }
+            """);
+        yield return Case("FinallyGoto", """
+            func F() int32 {
+                try {
+                    return 1
+                } finally {
+                    goto done
+                }
+            done:
+                var reached = true
+            }
+            """);
+        yield return Case("ExceptionSuppressedByFinallyGotoMissingReturn", """
+            import System
+            func F() int32 {
+                try {
+                    throw Exception("origin")
+                } finally {
+                    goto done
+                }
+            done:
+                var reached = true
+            }
+            """);
+        yield return Case("ImplicitExceptionSuppressedByFinallyGoto", """
+            import System
+            func Crash() {
+                throw Exception("origin")
+            }
+            func F() int32 {
+                try {
+                    for {
+                        Crash()
+                    }
+                } finally {
+                    goto done
+                }
+            done:
+                var reached = true
+            }
+            """);
+        yield return Case("NestedTryBreak", """
+            func F() int32 {
+                for {
+                    try {
+                        try {
+                            break
+                        } finally {
+                        }
+                    } finally {
+                    }
+                }
+            }
+            """);
+        yield return Case("TryInsideCatchBreak", """
+            import System
+            func F() int32 {
+                for {
+                    try {
+                        throw Exception("outer")
+                    } catch (ex Exception) {
+                        try {
+                            break
+                        } finally {
+                        }
+                    }
+                }
+            }
+            """);
+        yield return Case("TryInsideFinallyBreak", """
+            func F() int32 {
+                for {
+                    try {
+                        return 1
+                    } finally {
+                        try {
+                            break
+                        } finally {
+                        }
+                    }
+                }
+            }
+            """);
+        yield return Case("TryInsideSwitchArmBreak", """
+            func F(x int32) int32 {
+                for {
+                    switch x {
+                        default {
+                            try {
+                                break
+                            } finally {
+                            }
+                        }
+                    }
+                }
+            }
+            """);
+        yield return Case("SwitchInsideTryBreak", """
+            func F(x int32) int32 {
+                for {
+                    try {
+                        switch x {
+                            default { break }
+                        }
+                    } finally {
+                    }
+                }
+            }
+            """);
+        yield return Case("TryInsideSelectBreak", """
+            import Gsharp.Extensions.Go
+            func F() int32 {
+                for {
+                    select {
+                        default {
+                            try {
+                                break
+                            } finally {
+                            }
+                        }
+                    }
+                }
+            }
+            """);
+        yield return Case("SelectInsideTryBreak", """
+            import Gsharp.Extensions.Go
+            func F() int32 {
+                for {
+                    try {
+                        select {
+                            default { break }
+                        }
+                    } finally {
+                    }
+                }
+            }
+            """);
+        yield return Case("TryInsideFixedBreak", """
+            func F(xs []int32) int32 {
+                unsafe {
+                    for {
+                        fixed p *int32 = xs {
+                            try {
+                                break
+                            } finally {
+                            }
+                        }
+                    }
+                }
+            }
+            """);
+        yield return Case("TryInsideScopeBreak", """
+            import Gsharp.Extensions.Go
+            func F() int32 {
+                for {
+                    scope {
+                        try {
+                            break
+                        } finally {
+                        }
+                    }
+                }
+            }
+            """);
+        yield return Case("TryInsideUsingBreak", """
+            import System.IO
+            func F() int32 {
+                for {
+                    using let stream = MemoryStream()
+                    try {
+                        break
+                    } finally {
+                    }
+                }
+            }
+            """);
+        yield return Case("MixedCatchEscape", """
+            import System
+            func F(flag bool) int32 {
+                for {
+                    try {
+                        if flag {
+                            return 1
+                        }
+                        throw Exception("boom")
+                    } catch (ex Exception) {
+                        break
+                    } finally {
+                    }
+                }
+            }
+            """);
+        yield return Case("NormalTryCompletion", """
+            func F() int32 {
+                try {
+                    var value = 1
+                } finally {
+                }
+            }
+            """);
+        yield return Case("ExistingLoopBreak", """
+            func F() int32 {
+                for {
+                    break
+                }
+            }
+            """);
+    }
+
+    /// <summary>Gets try-region shapes that must not report GS0100.</summary>
+    public static IEnumerable<object[]> CompleteCases()
+    {
+        yield return Case("TryContinue", """
+            func F() int32 {
+                for {
+                    try {
+                        continue
+                    } finally {
+                    }
+                    break
+                }
+            }
+            """);
+        yield return Case("LabeledTryContinue", """
+            func F() int32 {
+                outer: for {
+                    for {
+                        try {
+                            continue outer
+                        } finally {
+                        }
+                        break outer
+                    }
+                }
+            }
+            """);
+        yield return Case("CatchContinue", """
+            import System
+            func F() int32 {
+                for {
+                    try {
+                        throw Exception("boom")
+                    } catch (ex Exception) {
+                        continue
+                    }
+                    break
+                }
+            }
+            """);
+        yield return Case("FinallyContinue", """
+            func F() int32 {
+                for {
+                    try {
+                        var value = 1
+                    } finally {
+                        continue
+                    }
+                    break
+                }
+            }
+            """);
+        yield return Case("LabeledCatchContinue", """
+            import System
+            func F() int32 {
+                outer: for {
+                    for {
+                        try {
+                            throw Exception("boom")
+                        } catch (ex Exception) {
+                            continue outer
+                        }
+                        break outer
+                    }
+                }
+            }
+            """);
+        yield return Case("LabeledFinallyContinue", """
+            func F() int32 {
+                outer: for {
+                    for {
+                        try {
+                            var value = 1
+                        } finally {
+                            continue outer
+                        }
+                        break outer
+                    }
+                }
+            }
+            """);
+        yield return Case("TryFinallyReturn", """
+            func F() int32 {
+                try {
+                    return 1
+                } finally {
+                }
+            }
+            """);
+        yield return Case("FinallyReturn", """
+            func F() int32 {
+                try {
+                    return 1
+                } finally {
+                    return 2
+                }
+            }
+            """);
+        yield return Case("ConditionalFinallyReturnOverException", """
+            import System
+            func F(replace bool) int32 {
+                try {
+                    throw Exception("origin")
+                } finally {
+                    if replace {
+                        return 2
+                    }
+                }
+            }
+            """);
+        yield return Case("ConditionalFinallyReturnOverReturn", """
+            func F(replace bool) int32 {
+                try {
+                    return 1
+                } finally {
+                    if replace {
+                        return 2
+                    }
+                }
+            }
+            """);
+        yield return Case("ConditionalFinallyReturnOverBreak", """
+            func F(replace bool) int32 {
+                var count = 0
+                for i in 0 ... 3 {
+                    try {
+                        break
+                    } finally {
+                        if replace {
+                            return 2
+                        }
+                    }
+                    count += 1
+                }
+                return count
+            }
+            """);
+        yield return Case("RethrowPreservesOriginStack", """
+            import System
+            func Origin() {
+                throw Exception("origin")
+            }
+            func F(replace bool) int32 {
+                try {
+                    Origin()
+                    return 0
+                } finally {
+                    if replace {
+                        return 2
+                    }
+                }
+            }
+            """);
+        yield return Case("ExceptionSuppressedByFinallyBreak", """
+            import System
+            func F() int32 {
+                for {
+                    try {
+                        throw Exception("origin")
+                    } finally {
+                        break
+                    }
+                }
+                return 4
+            }
+            """);
+        yield return Case("ExceptionSuppressedByFinallyContinue", """
+            import System
+            func F() int32 {
+                for i in 0 ... 3 {
+                    try {
+                        throw Exception("origin")
+                    } finally {
+                        continue
+                    }
+                }
+                return 3
+            }
+            """);
+        yield return Case("ExceptionSuppressedByFinallyGoto", """
+            import System
+            func F() int32 {
+                try {
+                    throw Exception("origin")
+                } finally {
+                    goto done
+                }
+            done:
+                return 5
+            }
+            """);
+        yield return Case("TryCatchReturns", """
+            import System
+            func F(flag bool) int32 {
+                try {
+                    if flag {
+                        return 1
+                    }
+                    throw Exception("boom")
+                } catch (ex Exception) {
+                    return 2
+                }
+            }
+            """);
+        yield return Case("TryCatchFinallyReturns", """
+            import System
+            func F(flag bool) int32 {
+                try {
+                    if flag {
+                        return 1
+                    }
+                    throw Exception("boom")
+                } catch (ex Exception) {
+                    return 2
+                } finally {
+                }
+            }
+            """);
+        yield return Case("ConditionalFinallyReturnOverCatchReturn", """
+            import System
+            func F(replace bool) int32 {
+                try {
+                    throw Exception("origin")
+                } catch (ex Exception) {
+                    return 1
+                } finally {
+                    if replace {
+                        return 2
+                    }
+                }
+            }
+            """);
+        yield return Case("CatchRethrows", """
+            import System
+            func F(flag bool) int32 {
+                try {
+                    if flag {
+                        return 1
+                    }
+                    throw Exception("first")
+                } catch (ex Exception) {
+                    throw Exception("second")
+                }
+            }
+            """);
+        yield return Case("FinallyThrows", """
+            import System
+            func F() int32 {
+                try {
+                    var value = 1
+                } finally {
+                    throw Exception("stop")
+                }
+            }
+            """);
+        yield return Case("FinallyInfiniteLoop", """
+            func F() int32 {
+                try {
+                    var value = 1
+                } finally {
+                    for {
+                    }
+                }
+            }
+            """);
+        yield return Case("BreakSuppressedByInfiniteFinally", """
+            func F() int32 {
+                for {
+                    try {
+                        break
+                    } finally {
+                        for {
+                        }
+                    }
+                }
+            }
+            """);
+        yield return Case("ReturnAfterTryBreak", """
+            func F() int32 {
+                for {
+                    try {
+                        break
+                    } finally {
+                    }
+                }
+                return 7
+            }
+            """);
+        yield return Case("ReturnAfterCatchBreak", """
+            import System
+            func F() int32 {
+                for {
+                    try {
+                        throw Exception("boom")
+                    } catch (ex Exception) {
+                        break
+                    }
+                }
+                return 8
+            }
+            """);
+        yield return Case("TryGotoThenReturn", """
+            func F() int32 {
+                try {
+                    goto done
+                } finally {
+                }
+                return 1
+            done:
+                return 2
+            }
+            """);
+        yield return Case("CatchGotoThenReturn", """
+            import System
+            func F() int32 {
+                try {
+                    throw Exception("boom")
+                } catch (ex Exception) {
+                    goto done
+                }
+                return 1
+            done:
+                return 2
+            }
+            """);
+        yield return Case("FinallyGotoThenReturn", """
+            func F() int32 {
+                try {
+                    return 1
+                } finally {
+                    goto done
+                }
+            done:
+                return 2
+            }
+            """);
+        yield return Case("TryInsideFinallyReturns", """
+            func F() int32 {
+                try {
+                    return 1
+                } finally {
+                    try {
+                        var value = 2
+                    } finally {
+                    }
+                }
+            }
+            """);
+        yield return Case("NestedFinallyBreakThenReturn", """
+            func F() int32 {
+                for {
+                    try {
+                        return 1
+                    } finally {
+                        try {
+                            break
+                        } finally {
+                        }
+                    }
+                }
+                return 6
+            }
+            """);
+        yield return Case("SwitchInsideTryBreakOverriddenByReturn", """
+            func F() int32 {
+                for {
+                    try {
+                        switch 0 {
+                            default { break }
+                        }
+                    } finally {
+                        return 1
+                    }
+                }
+            }
+            """);
+        yield return Case("SelectInsideTryBreakOverriddenByReturn", """
+            import Gsharp.Extensions.Go
+            func F() int32 {
+                for {
+                    try {
+                        select {
+                            default { break }
+                        }
+                    } finally {
+                        return 2
+                    }
+                }
+            }
+            """);
+        yield return Case("ScopeInsideTryBreakOverriddenByReturn", """
+            import Gsharp.Extensions.Go
+            func F() int32 {
+                for {
+                    try {
+                        scope {
+                            break
+                        }
+                    } finally {
+                        return 4
+                    }
+                }
+            }
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(MissingReturnCases))]
+    public void EscapingOrCompletingPath_ReportsGs0100(string name, string source)
+    {
+        _ = name;
+        var (diagnostics, emittedLength) = Compile(source);
+        var diagnostic = Assert.Single(diagnostics.Where(candidate => candidate.IsError));
+        Assert.Equal("GS0100", diagnostic.Id);
+        Assert.Equal("F", diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+        Assert.Equal(0, emittedLength);
+    }
+
+    [Theory]
+    [MemberData(nameof(CompleteCases))]
+    public void EveryPathTerminates_DoesNotReportGs0100(string name, string source)
+    {
+        _ = name;
+        var (diagnostics, emittedLength) = Compile(source);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+        Assert.True(emittedLength > 0);
+    }
+
+    private static object[] Case(string name, string body)
+        => new object[] { name, $"package Issue2891.{name}{Environment.NewLine}{body}" };
+
+    private static (System.Collections.Immutable.ImmutableArray<Diagnostic> Diagnostics, long EmittedLength) Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        return (compilation.Emit(peStream).Diagnostics, peStream.Length);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2906ExhaustiveSwitchReturnFlowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2906ExhaustiveSwitchReturnFlowTests.cs
@@ -16,8 +16,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>
 /// Issue #2906: closed-discriminant exhaustiveness must feed definite-return
-/// analysis without treating guarded, nullable, flags, or incomplete switches
-/// as total.
+/// analysis without treating guarded, nullable, or incomplete switches as total.
 /// </summary>
 public class Issue2906ExhaustiveSwitchReturnFlowTests
 {
@@ -188,16 +187,6 @@ public class Issue2906ExhaustiveSwitchReturnFlowTests
                 }
             }
             """);
-        yield return Case("FlagsEnum", """
-            import System
-            func F(x StringSplitOptions) int32 {
-                switch x {
-                    case StringSplitOptions.None { return 1 }
-                    case StringSplitOptions.RemoveEmptyEntries { return 2 }
-                    case StringSplitOptions.TrimEntries { return 3 }
-                }
-            }
-            """);
         yield return Case("OrdinaryInt", """
             func F(x int32) int32 {
                 switch x {
@@ -226,6 +215,35 @@ public class Issue2906ExhaustiveSwitchReturnFlowTests
         var (diagnostics, emittedLength) = Compile(source);
         Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0100");
         Assert.Equal(0, emittedLength);
+    }
+
+    [Fact]
+    public void ImportedFlagsEnums_RetainStatementAndExpressionExhaustivenessDiagnostics()
+    {
+        const string StatementSource = """
+            package Issue2906.FlagsStatement
+            import System
+            func F(x StringSplitOptions) {
+                switch x {
+                    case StringSplitOptions.None { }
+                }
+            }
+            """;
+        const string ExpressionSource = """
+            package Issue2906.FlagsExpression
+            import System
+            func F(x StringSplitOptions) int32 {
+                return switch x {
+                    case StringSplitOptions.None: 0
+                }
+            }
+            """;
+
+        var (statementDiagnostics, _) = Compile(StatementSource);
+        var (expressionDiagnostics, _) = Compile(ExpressionSource);
+        Assert.Contains(statementDiagnostics, diagnostic => diagnostic.Id == "GS0178");
+        Assert.Contains(expressionDiagnostics, diagnostic => diagnostic.Id == "GS0177");
+        Assert.DoesNotContain(expressionDiagnostics, diagnostic => diagnostic.Id == "GS0176");
     }
 
     private static object[] Case(string name, string body)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2906ExhaustiveSwitchReturnFlowTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2906ExhaustiveSwitchReturnFlowTests.cs
@@ -1,0 +1,241 @@
+// <copyright file="Issue2906ExhaustiveSwitchReturnFlowTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2906: closed-discriminant exhaustiveness must feed definite-return
+/// analysis without treating guarded, nullable, flags, or incomplete switches
+/// as total.
+/// </summary>
+public class Issue2906ExhaustiveSwitchReturnFlowTests
+{
+    /// <summary>Gets exhaustive switches that must not report GS0100.</summary>
+    public static IEnumerable<object[]> ExhaustiveCases()
+    {
+        yield return Case("OneMember", """
+            enum E { A }
+            func F(x E) int32 {
+                switch x {
+                    case E.A { return 1 }
+                }
+            }
+            """);
+        yield return Case("TwoMembers", """
+            enum E { A, B }
+            func F(x E) int32 {
+                switch x {
+                    case E.A { return 1 }
+                    case E.B { return 2 }
+                }
+            }
+            """);
+        yield return Case("ManyMembers", """
+            enum E { A, B, C, D }
+            func F(x E) int32 {
+                switch x {
+                    case E.A { return 1 }
+                    case E.B { return 2 }
+                    case E.C { return 3 }
+                    case E.D { return 4 }
+                }
+            }
+            """);
+        yield return Case("RedundantDefault", """
+            enum E { A, B }
+            func F(x E) int32 {
+                switch x {
+                    case E.A { return 1 }
+                    case E.B { return 2 }
+                    default { return 3 }
+                }
+            }
+            """);
+        yield return Case("DuplicateCompleteArms", """
+            enum E { A, B }
+            func F(x E) int32 {
+                switch x {
+                    case E.A { return 1 }
+                    case E.A { return 2 }
+                    case E.B { return 3 }
+                }
+            }
+            """);
+        yield return Case("OrPattern", """
+            enum E { A, B, C }
+            func F(x E) int32 {
+                switch x {
+                    case E.A or E.B { return 1 }
+                    case E.C { return 2 }
+                }
+            }
+            """);
+        yield return Case("SealedInterface", """
+            sealed interface Expr { }
+            class Add : Expr { }
+            class Mul : Expr { }
+            func F(x Expr) int32 {
+                switch x {
+                    case _ is Add { return 1 }
+                    case _ is Mul { return 2 }
+                }
+            }
+            """);
+        yield return Case("SealedClass", """
+            sealed class Shape { }
+            class Circle : Shape { }
+            class Square : Shape { }
+            func F(x Shape) int32 {
+                switch x {
+                    case _ is Circle { return 1 }
+                    case _ is Square { return 2 }
+                }
+            }
+            """);
+        yield return Case("SwitchInsideTry", """
+            enum E { A, B }
+            func F(x E) int32 {
+                try {
+                    switch x {
+                        case E.A { return 1 }
+                        case E.B { return 2 }
+                    }
+                } finally {
+                }
+            }
+            """);
+        yield return Case("TryInsideArms", """
+            enum E { A, B }
+            func F(x E) int32 {
+                switch x {
+                    case E.A {
+                        try {
+                            return 1
+                        } finally {
+                        }
+                    }
+                    case E.B {
+                        try {
+                            return 2
+                        } finally {
+                        }
+                    }
+                }
+            }
+            """);
+        yield return Case("SwitchInsideSelect", """
+            import Gsharp.Extensions.Go
+            enum E { A, B }
+            func F(x E) int32 {
+                select {
+                    default {
+                        switch x {
+                            case E.A { return 1 }
+                            case E.B { return 2 }
+                        }
+                    }
+                }
+            }
+            """);
+    }
+
+    /// <summary>Gets non-total switches that must still report GS0100.</summary>
+    public static IEnumerable<object[]> NonExhaustiveCases()
+    {
+        yield return Case("MissingMember", """
+            enum E { A, B }
+            func F(x E) int32 {
+                switch x {
+                    case E.A { return 1 }
+                }
+            }
+            """);
+        yield return Case("DuplicateMissingMember", """
+            enum E { A, B }
+            func F(x E) int32 {
+                switch x {
+                    case E.A { return 1 }
+                    case E.A { return 2 }
+                }
+            }
+            """);
+        yield return Case("GuardedMember", """
+            enum E { A, B }
+            func F(x E, allow bool) int32 {
+                switch x {
+                    case E.A { return 1 }
+                    case E.B when allow { return 2 }
+                }
+            }
+            """);
+        yield return Case("NullableEnum", """
+            enum E { A, B }
+            func F(x E?) int32 {
+                switch x {
+                    case E.A { return 1 }
+                    case E.B { return 2 }
+                }
+            }
+            """);
+        yield return Case("FlagsEnum", """
+            import System
+            func F(x StringSplitOptions) int32 {
+                switch x {
+                    case StringSplitOptions.None { return 1 }
+                    case StringSplitOptions.RemoveEmptyEntries { return 2 }
+                    case StringSplitOptions.TrimEntries { return 3 }
+                }
+            }
+            """);
+        yield return Case("OrdinaryInt", """
+            func F(x int32) int32 {
+                switch x {
+                    case 0 { return 1 }
+                    case 1 { return 2 }
+                }
+            }
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExhaustiveCases))]
+    public void ExhaustiveClosedSwitch_DoesNotReportGs0100(string name, string source)
+    {
+        _ = name;
+        var (diagnostics, emittedLength) = Compile(source);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+        Assert.True(emittedLength > 0);
+    }
+
+    [Theory]
+    [MemberData(nameof(NonExhaustiveCases))]
+    public void NonTotalSwitch_ReportsGs0100(string name, string source)
+    {
+        _ = name;
+        var (diagnostics, emittedLength) = Compile(source);
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0100");
+        Assert.Equal(0, emittedLength);
+    }
+
+    private static object[] Case(string name, string body)
+        => new object[] { name, $"package Issue2906.{name}{Environment.NewLine}{body}" };
+
+    private static (System.Collections.Immutable.ImmutableArray<Diagnostic> Diagnostics, long EmittedLength) Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        return (compilation.Emit(peStream).Diagnostics, peStream.Length);
+    }
+}

--- a/test/Interpreter.Tests/Issue2906ExhaustiveSwitchStatementInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2906ExhaustiveSwitchStatementInterpreterTests.cs
@@ -1,0 +1,39 @@
+// <copyright file="Issue2906ExhaustiveSwitchStatementInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2906: exhaustive switch statements still fall through when no
+/// runtime pattern matches.
+/// </summary>
+public class Issue2906ExhaustiveSwitchStatementInterpreterTests
+{
+    [Fact]
+    public void SealedInterfaceNil_FallsThroughToFollowingReturn()
+    {
+        const string Source = """
+            sealed interface Expr { }
+            class Literal : Expr { }
+            func F(x Expr) int32 {
+                switch x {
+                    case _ is Literal { return 1 }
+                }
+                return 0
+            }
+            F(nil)
+            """;
+
+        var result = new Compilation(SyntaxTree.Parse(Source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+}


### PR DESCRIPTION
Fixes #2891
Fixes #2906

Follow-ups: #2940, #2941, #2942

## Root causes and fixes

### #2891 — definite return through protected regions

Definite-return analysis treated lowered `BoundTryStatement` nodes as opaque, hiding `break`, `continue`, `goto`, and protected returns from the enclosing CFG.

The lowering pipeline now preserves a pre-emit body before `FinallyExitRewriter` transforms escaping-finally control flow. `AllPathsReturn`, `RefKindDefiniteAssignmentAnalyzer`, and `RefStructAsyncLivenessAnalyzer` use that pre-emit body. Definite-return projection models try/catch alternatives, exceptional finally entry, escaping transfers through cloned finally bodies, and protected returns through the `$returnTemp` epilogue.

Method-exit detection searches top-level declarations instead of assuming `$returnTemp` is statement zero; protected-region entry rewriting may prepend `<>ai_seh_branch`.

CLR forbids `leave` from a finally handler. `FinallyExitRewriter` lifts finally bodies containing escaping branches, funnels try/catch exits through the lifted body, captures pending exceptions, preserves rethrow stacks with `ExceptionDispatchInfo`, and dispatches the pending branch afterward. Shared `ProtectedRegionBranchAnalysis` supplies label/branch/try-region bookkeeping to both protected-region rewriters.

ADR-0139 documents that an escaping transfer from `finally` replaces and discards a pending exception, matching the interpreter and ECMA-335 III.1.7.5.

### #2906 — exhaustive enum switch and definite return

`ExhaustivenessAnalyzer` proved closed enum/sealed-hierarchy switches exhaustive, but the proof was discarded before CFG construction. `BoundPatternSwitchStatement.IsExhaustive` now carries the proof through rewriting and CFG removes the impossible no-match edge for definite-return analysis.

The defensive throw exists only at a non-void method tail. Ordinary switch statements retain no-match fallthrough, matching the interpreter. The runtime exception identifies itself as a compiler-generated missing-return guard.

The attempted imported CLR `[Flags]` carve-out was reverted. Existing statement/expression diagnostics remain unchanged; consistent flags semantics are tracked in #2941.

## Review corrections

- Deleted the seven-line per-switch throw and its two regression-pinning tests.
- Added five compiler/interpreter fallthrough cases plus a dedicated Interpreter.Tests case.
- Added child-process execution guards for local gotos in a try, nested finally, and nested catch. These catch runtime-invalid IL that `ilverify` can accept.
- Added the nested escaping-finally GS0238 no-drift case that pins use of the pre-emit analysis body.
- Rebased onto `origin/main` `e21677f6`; `EmitFixedReturnEpilogue()` remains first with its early return, followed by the missing-return guard.
- Added the fixed-return/exhaustive-switch interaction case, documenting the current default-slot result for an unnamed value.
- Deleted the unobservable local-label short-circuit in definite-return projection rather than retaining an unpinned branch.
- Updated #2940 to describe an analysis-metadata invariant, not a current runtime/IL hole.

## Coverage metrics

Round-2 recount found **68 pins / 71 independent guards** over the prior 139 Core+Compiler issue cases. This update adds three mutation-detecting branch-analysis pins plus two independent no-drift/interaction guards:

| Category | Count |
|---|---:|
| Pins | **71** |
| Independent guards | **73** |
| Core+Compiler issue cases | **144** |

The dedicated Interpreter.Tests parity case is additional and excluded from that table.

## Validation at `1960b64de15a280ab118f2d634cd3bdf64594d00`

- Release static-graph build: **0 warnings, 0 errors**.
- Issue-focused Core (`Issue2891|Issue2906`): **91 passed**.
- Interaction filter (`Issue2891|Issue2906|Issue2900Fixed`): **64 Compiler tests passed**.
- Interpreter.Tests: **469 passed**.
- Core.Tests: **7004 passed, 1 skipped**.
- Compiler.Tests: **3809 passed**.
