### PR TITLE
Fix inline lambdas through erased generic receivers

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3069,45 +3069,10 @@ public sealed class Binder
                     return null;
                 }
 
-                // #313: an in-scope generic type parameter used as a type
-                // argument (e.g. `List[T]` inside `func First[T](...)`) is a
-                // valid type in any position. Under the type-erased generic
-                // model (ADR-0004; type parameters encode as System.Object at
-                // emit) the type argument projects onto `object` for the closed
-                // CLR shape so member / index / conversion resolution keeps
-                // working, while the symbolic `[T]` is preserved on the result
-                // for inference, substitution, and erased emit.
-                if (TypeSymbol.RequiresSymbolicProjection(ta))
-                {
-                    hasSymbolicArg = true;
-
-                    // Issue #2391: source enums use Int32 as their established
-                    // CLR ride-through. Preserve that surrogate when closing
-                    // an imported generic receiver as well; using object for a
-                    // struct-constrained interface leaves Nullable<T> member
-                    // signatures unconstructable and hides parameterized
-                    // methods from overload resolution.
-                    if (TypeSymbol.ContainsTypeParameter(ta) || TypeSymbol.ContainsSameCompilationUserType(ta))
-                    {
-                        var erasedArgument = ta is EnumSymbol ? typeof(int) : typeof(object);
-                        clrArgs[i] = scope.References.MapClrTypeToReferences(erasedArgument);
-                    }
-                    else
-                    {
-                        clrArgs[i] = ResolveClrTypeForGenericArg(ta)
-                            ?? scope.References.MapClrTypeToReferences(ta.ClrType);
-                    }
-
-                    continue;
-                }
-
-                // Project host CLR type arguments onto the resolver's reference
-                // set so they share clrOpenType's load context (its
-                // MetadataLoadContext when references are supplied via /r:),
-                // which MakeGenericType requires.
-                // Issue #530: use ResolveClrTypeForGenericArg so that
-                // `int32?` resolves to `Nullable<int>` (not bare `int`).
-                clrArgs[i] = ResolveClrTypeForGenericArg(ta) ?? scope.References.MapClrTypeToReferences(ta.ClrType);
+                // Issue #2391: this caller alone retains the established Int32
+                // ride-through for a top-level source enum.
+                var erasedArgument = ta is EnumSymbol ? typeof(int) : typeof(object);
+                clrArgs[i] = ProjectGenericArgument(ta, erasedArgument, ref hasSymbolicArg);
             }
 
             try
@@ -3903,21 +3868,7 @@ public sealed class Binder
                 return null;
             }
 
-            // #313 / #671: keep any symbolic projection alongside the erased
-            // closed CLR shape, including nested generic/array/nullable forms.
-            if (TypeSymbol.RequiresSymbolicProjection(ta) || ta.ClrType == null)
-            {
-                hasSymbolicArg = true;
-                clrArgs[i] = TypeSymbol.ContainsTypeParameter(ta)
-                    || TypeSymbol.ContainsSameCompilationUserType(ta)
-                    || ta.ClrType == null
-                        ? scope.References.MapClrTypeToReferences(typeof(object))
-                        : ResolveClrTypeForGenericArg(ta)
-                            ?? scope.References.MapClrTypeToReferences(ta.ClrType);
-                continue;
-            }
-
-            clrArgs[i] = ResolveClrTypeForGenericArg(ta) ?? scope.References.MapClrTypeToReferences(ta.ClrType);
+            clrArgs[i] = ProjectGenericArgument(ta, typeof(object), ref hasSymbolicArg);
         }
 
         try
@@ -4146,21 +4097,7 @@ public sealed class Binder
                 return null;
             }
 
-            // #313 / #671: in-scope type parameters and user types without a
-            // ClrType project onto System.Object under the type-erased model.
-            if (TypeSymbol.RequiresSymbolicProjection(ta) || ta.ClrType == null)
-            {
-                hasSymbolicArg = true;
-                clrArgs[i] = TypeSymbol.ContainsTypeParameter(ta)
-                    || TypeSymbol.ContainsSameCompilationUserType(ta)
-                    || ta.ClrType == null
-                        ? scope.References.MapClrTypeToReferences(typeof(object))
-                        : ResolveClrTypeForGenericArg(ta)
-                            ?? scope.References.MapClrTypeToReferences(ta.ClrType);
-                continue;
-            }
-
-            clrArgs[i] = ResolveClrTypeForGenericArg(ta) ?? scope.References.MapClrTypeToReferences(ta.ClrType);
+            clrArgs[i] = ProjectGenericArgument(ta, typeof(object), ref hasSymbolicArg);
         }
 
         try
@@ -4178,6 +4115,40 @@ public sealed class Binder
             Diagnostics.ReportTypeNotGeneric(syntax.Identifier.Location, syntax.DottedName);
             return null;
         }
+    }
+
+    /// <summary>
+    /// Projects a symbolic generic argument onto a closed CLR type while
+    /// retaining any type information that the CLR shape cannot represent.
+    /// </summary>
+    /// <param name="type">The symbolic generic argument.</param>
+    /// <param name="erasedArgument">
+    /// The caller-specific CLR surrogate for a same-compilation user type.
+    /// </param>
+    /// <param name="hasSymbolicArgument">
+    /// Set when the symbolic argument must be retained beside the CLR shape.
+    /// </param>
+    /// <returns>The reference-context CLR argument used to close the generic.</returns>
+    private Type ProjectGenericArgument(
+        TypeSymbol type,
+        Type erasedArgument,
+        ref bool hasSymbolicArgument)
+    {
+        // #313 / #671: preserve symbolic type parameters, user types, and
+        // nested generic/array/nullable shapes beside their erased CLR form.
+        if (TypeSymbol.RequiresSymbolicProjection(type) || type.ClrType == null)
+        {
+            hasSymbolicArgument = true;
+            return TypeSymbol.ContainsTypeParameter(type)
+                || TypeSymbol.ContainsSameCompilationUserType(type)
+                || type.ClrType == null
+                    ? scope.References.MapClrTypeToReferences(erasedArgument)
+                    : ResolveClrTypeForGenericArg(type)
+                        ?? scope.References.MapClrTypeToReferences(type.ClrType);
+        }
+
+        return ResolveClrTypeForGenericArg(type)
+            ?? scope.References.MapClrTypeToReferences(type.ClrType);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -782,21 +782,6 @@ internal sealed partial class ExpressionBinder
         Type openDefinition,
         ImmutableArray<TypeSymbol> symbolicArgs,
         out FunctionTypeSymbol target)
-        => TryBuildSymbolicDelegateTarget(
-            openParameterType,
-            openDefinition,
-            symbolicArgs,
-            openMethodDefinition: null,
-            methodTypeArguments: default,
-            out target);
-
-    private static bool TryBuildSymbolicDelegateTarget(
-        Type openParameterType,
-        Type openDefinition,
-        ImmutableArray<TypeSymbol> symbolicArgs,
-        MethodInfo openMethodDefinition,
-        ImmutableArray<TypeSymbol> methodTypeArguments,
-        out FunctionTypeSymbol target)
     {
         target = null;
         if (openParameterType == null)
@@ -810,18 +795,8 @@ internal sealed partial class ExpressionBinder
         var mapped = MemberLookup.MapOpenClrTypeToSymbolic(
             openParameterType,
             openDefinition,
-            symbolicArgs,
-            openMethodDefinition,
-            methodTypeArguments);
-        if (!MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(mapped, out var candidate)
-            || candidate == null)
-        {
-            return false;
-        }
-
-        var carries = TypeSymbol.RequiresSymbolicProjection(candidate.ReturnType)
-            || candidate.ParameterTypes.Any(TypeSymbol.RequiresSymbolicProjection);
-        if (!carries)
+            symbolicArgs);
+        if (!MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(mapped, out var candidate))
         {
             return false;
         }
@@ -1488,15 +1463,11 @@ internal sealed partial class ExpressionBinder
                 FunctionTypeSymbol functionType;
                 if (openParameterType.IsGenericParameter)
                 {
-                    if (!AllMethodTypeParametersResolved(openParameterType, openMethod, inferred)
-                        || !TryBuildSymbolicDelegateTarget(
+                    if (!TryBuildSymbolicDelegateTarget(
                             openParameterType,
                             receiverOpenDefinition,
                             receiverTypeArguments,
-                            openMethod,
-                            methodTypeArgs,
-                            out functionType)
-                        || functionType.ParameterTypes.Length != arityByIndex[idx])
+                            out functionType))
                     {
                         candidateUsable = false;
                         break;
@@ -1529,6 +1500,17 @@ internal sealed partial class ExpressionBinder
                         break;
                     }
 
+                    // Issue #903: only trust this candidate's delegate parameter
+                    // shape when every method type parameter reachable from it was
+                    // actually resolved by unifying the receiver/arguments. When a
+                    // candidate's "this" parameter does not match the receiver
+                    // shape (e.g. a `Single` overload over `IQueryable<T>` against a
+                    // `List` receiver), the relevant slot stays unresolved and
+                    // MapOpenClrTypeToSymbolic would otherwise surface a bogus open
+                    // parameter (an ImportedTypeSymbol named "T") that neither
+                    // ContainsTypeParameter nor ContainsSameCompilationUserType
+                    // flags — which would then disagree with the correct candidate
+                    // and abort the whole inference. Skip such candidates instead.
                     var unresolvedSlot = false;
                     foreach (var invokeParameter in invokeParameters)
                     {
@@ -1582,17 +1564,6 @@ internal sealed partial class ExpressionBinder
                     functionType = FunctionTypeSymbol.Get(parameterTypes.ToImmutable(), mappedReturnType);
                 }
 
-                // Issue #903: only trust this candidate's delegate parameter
-                // shape when every method type parameter reachable from it was
-                // actually resolved by unifying the receiver/arguments. When a
-                // candidate's "this" parameter does not match the receiver
-                // shape (e.g. a `Single` overload over `IQueryable<T>` against a
-                // `List` receiver), the relevant slot stays unresolved and
-                // MapOpenClrTypeToSymbolic would otherwise surface a bogus open
-                // parameter (an ImportedTypeSymbol named "T") that neither
-                // ContainsTypeParameter nor ContainsSameCompilationUserType
-                // flags — which would then disagree with the correct candidate
-                // and abort the whole inference. Skip such candidates instead.
                 foreach (var parameterType in functionType.ParameterTypes)
                 {
                     if (TypeSymbol.RequiresSymbolicProjection(parameterType))

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -666,6 +666,8 @@ internal sealed partial class ExpressionBinder
             var openParamType = openParameters[i].ParameterType;
             var symbolicParamType = MemberLookup.MapOpenClrTypeToSymbolic(openParamType, openDef, symbolicArgs);
 
+            // Nominal identity remains on the explicit symbolicDelegateParam
+            // conversion below; only the mapped Invoke shape is needed here.
             if (LambdaBinder.TryGetFunctionLiteral(argument, out var functionLiteral)
                 && symbolicParamType is ImportedTypeSymbol symbolicDelegateParam
                 && symbolicDelegateParam.OpenDefinition != null

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -782,6 +782,21 @@ internal sealed partial class ExpressionBinder
         Type openDefinition,
         ImmutableArray<TypeSymbol> symbolicArgs,
         out FunctionTypeSymbol target)
+        => TryBuildSymbolicDelegateTarget(
+            openParameterType,
+            openDefinition,
+            symbolicArgs,
+            openMethodDefinition: null,
+            methodTypeArguments: default,
+            out target);
+
+    private static bool TryBuildSymbolicDelegateTarget(
+        Type openParameterType,
+        Type openDefinition,
+        ImmutableArray<TypeSymbol> symbolicArgs,
+        MethodInfo openMethodDefinition,
+        ImmutableArray<TypeSymbol> methodTypeArguments,
+        out FunctionTypeSymbol target)
     {
         target = null;
         if (openParameterType == null)
@@ -789,32 +804,29 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        // Issue #2365: an `Expression<TDelegate>` parameter is not itself a
-        // delegate (it exposes no `Invoke`), so unwrap it to the wrapped open
-        // delegate type first, mirroring the identical unwrap in the
-        // method-parameter sibling <see cref="TryBuildSymbolicDelegateTargetForMethodParam"/>.
-        if (MemberLookup.TryGetExpressionTreeDelegateType(openParameterType, out var unwrappedParameterType))
-        {
-            openParameterType = unwrappedParameterType;
-        }
-
-        var invoke = openParameterType?.GetMethodSafe("Invoke");
-        if (invoke == null)
+        // Issue #2918: substitute the complete parameter before asking whether
+        // it is a lambda target. The open parameter may itself be `T`, while
+        // the receiver or method closes `T` to `Action[Src]`.
+        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(
+            openParameterType,
+            openDefinition,
+            symbolicArgs,
+            openMethodDefinition,
+            methodTypeArguments);
+        if (!MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(mapped, out var candidate)
+            || candidate == null)
         {
             return false;
         }
 
-        var invokeParameters = invoke.GetParameters();
-        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(invokeParameters.Length);
-        foreach (var parameter in invokeParameters)
+        var carries = TypeSymbol.RequiresSymbolicProjection(candidate.ReturnType)
+            || candidate.ParameterTypes.Any(TypeSymbol.RequiresSymbolicProjection);
+        if (!carries)
         {
-            parameterTypes.Add(MemberLookup.MapOpenClrParameterTypeToSymbolic(parameter.ParameterType, openDefinition, symbolicArgs));
+            return false;
         }
 
-        var returnType = invoke.ReturnType.IsSameAs(typeof(void))
-            ? TypeSymbol.Void
-            : MemberLookup.MapOpenClrTypeToSymbolic(invoke.ReturnType, openDefinition, symbolicArgs);
-        target = FunctionTypeSymbol.Get(parameterTypes.ToImmutable(), returnType);
+        target = candidate;
         return true;
     }
 
@@ -1472,29 +1484,102 @@ internal sealed partial class ExpressionBinder
                     break;
                 }
 
-                MethodInfo invoke;
-                ParameterInfo[] invokeParameters;
-                try
+                var openParameterType = openParameters[paramIndex].ParameterType;
+                FunctionTypeSymbol functionType;
+                if (openParameterType.IsGenericParameter)
                 {
-                    var delegateType = openParameters[paramIndex].ParameterType;
-                    if (MemberLookup.TryGetExpressionTreeDelegateType(delegateType, out var unwrappedDelegateType))
+                    if (!AllMethodTypeParametersResolved(openParameterType, openMethod, inferred)
+                        || !TryBuildSymbolicDelegateTarget(
+                            openParameterType,
+                            receiverOpenDefinition,
+                            receiverTypeArguments,
+                            openMethod,
+                            methodTypeArgs,
+                            out functionType)
+                        || functionType.ParameterTypes.Length != arityByIndex[idx])
                     {
-                        delegateType = unwrappedDelegateType;
+                        candidateUsable = false;
+                        break;
+                    }
+                }
+                else
+                {
+                    MethodInfo invoke;
+                    ParameterInfo[] invokeParameters;
+                    try
+                    {
+                        var delegateType = openParameterType;
+                        if (MemberLookup.TryGetExpressionTreeDelegateType(delegateType, out var unwrappedDelegateType))
+                        {
+                            delegateType = unwrappedDelegateType;
+                        }
+
+                        invoke = delegateType?.GetMethodSafe("Invoke");
+                        invokeParameters = invoke?.GetParameters();
+                    }
+                    catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+                    {
+                        candidateUsable = false;
+                        break;
                     }
 
-                    invoke = delegateType?.GetMethodSafe("Invoke");
-                    invokeParameters = invoke?.GetParameters();
-                }
-                catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
-                {
-                    candidateUsable = false;
-                    break;
-                }
+                    if (invoke == null || invokeParameters == null || invokeParameters.Length != arityByIndex[idx])
+                    {
+                        candidateUsable = false;
+                        break;
+                    }
 
-                if (invoke == null || invokeParameters == null || invokeParameters.Length != arityByIndex[idx])
-                {
-                    candidateUsable = false;
-                    break;
+                    var unresolvedSlot = false;
+                    foreach (var invokeParameter in invokeParameters)
+                    {
+                        if (!AllMethodTypeParametersResolved(invokeParameter.ParameterType, openMethod, inferred))
+                        {
+                            unresolvedSlot = true;
+                            break;
+                        }
+                    }
+
+                    if (unresolvedSlot)
+                    {
+                        candidateUsable = false;
+                        break;
+                    }
+
+                    var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(invokeParameters.Length);
+                    var slotUsable = true;
+                    foreach (var invokeParameter in invokeParameters)
+                    {
+                        var mapped = MemberLookup.MapOpenClrParameterTypeToSymbolic(
+                            invokeParameter.ParameterType,
+                            receiverOpenDefinition,
+                            receiverTypeArguments,
+                            openMethod,
+                            methodTypeArgs);
+                        if (mapped == null || mapped == TypeSymbol.Error)
+                        {
+                            slotUsable = false;
+                            break;
+                        }
+
+                        parameterTypes.Add(mapped);
+                    }
+
+                    if (!slotUsable)
+                    {
+                        candidateUsable = false;
+                        break;
+                    }
+
+                    var returnClrType = invoke.ReturnType;
+                    var mappedReturnType = returnClrType != null && returnClrType.IsSameAs(typeof(void))
+                        ? TypeSymbol.Void
+                        : MemberLookup.MapOpenClrTypeToSymbolic(
+                            returnClrType,
+                            receiverOpenDefinition,
+                            receiverTypeArguments,
+                            openMethod,
+                            methodTypeArgs);
+                    functionType = FunctionTypeSymbol.Get(parameterTypes.ToImmutable(), mappedReturnType);
                 }
 
                 // Issue #903: only trust this candidate's delegate parameter
@@ -1508,52 +1593,15 @@ internal sealed partial class ExpressionBinder
                 // ContainsTypeParameter nor ContainsSameCompilationUserType
                 // flags — which would then disagree with the correct candidate
                 // and abort the whole inference. Skip such candidates instead.
-                var unresolvedSlot = false;
-                foreach (var invokeParameter in invokeParameters)
+                foreach (var parameterType in functionType.ParameterTypes)
                 {
-                    if (!AllMethodTypeParametersResolved(invokeParameter.ParameterType, openMethod, inferred))
-                    {
-                        unresolvedSlot = true;
-                        break;
-                    }
-                }
-
-                if (unresolvedSlot)
-                {
-                    candidateUsable = false;
-                    break;
-                }
-
-                var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(invokeParameters.Length);
-                var slotUsable = true;
-                foreach (var invokeParameter in invokeParameters)
-                {
-                    var mapped = MemberLookup.MapOpenClrParameterTypeToSymbolic(
-                        invokeParameter.ParameterType,
-                        receiverOpenDefinition,
-                        receiverTypeArguments,
-                        openMethod,
-                        methodTypeArgs);
-                    if (mapped == null || mapped == TypeSymbol.Error)
-                    {
-                        slotUsable = false;
-                        break;
-                    }
-
-                    parameterTypes.Add(mapped);
-                    if (TypeSymbol.RequiresSymbolicProjection(mapped))
+                    if (TypeSymbol.RequiresSymbolicProjection(parameterType))
                     {
                         candidateHasSymbolicType = true;
                     }
                 }
 
-                if (!slotUsable)
-                {
-                    candidateUsable = false;
-                    break;
-                }
-
-                slotTargets[idx] = parameterTypes.ToImmutable();
+                slotTargets[idx] = functionType.ParameterTypes;
 
                 // Issue #2345: recover the delegate's return shape too, when it
                 // is fully closed by this unification (most commonly `void`,
@@ -1562,15 +1610,7 @@ internal sealed partial class ExpressionBinder
                 // containing an unresolved method type parameter) fall back to
                 // the pre-existing placeholder + inferReturnTypeFromBody
                 // behavior for that slot.
-                var returnClrType = invoke.ReturnType;
-                var mappedReturn = returnClrType != null && returnClrType.IsSameAs(typeof(void))
-                    ? TypeSymbol.Void
-                    : MemberLookup.MapOpenClrTypeToSymbolic(
-                        returnClrType,
-                        receiverOpenDefinition,
-                        receiverTypeArguments,
-                        openMethod,
-                        methodTypeArgs);
+                var mappedReturn = functionType.ReturnType;
                 if (mappedReturn != null && mappedReturn != TypeSymbol.Error && !TypeSymbol.ContainsTypeParameter(mappedReturn))
                 {
                     slotReturnTypes[idx] = mappedReturn;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -670,7 +670,12 @@ internal sealed partial class ExpressionBinder
                 && symbolicParamType is ImportedTypeSymbol symbolicDelegateParam
                 && symbolicDelegateParam.OpenDefinition != null
                 && symbolicDelegateParam.HasTypeParameterArgument
-                && TryBuildSymbolicDelegateTarget(openParamType, openDef, symbolicArgs, out var symbolicDelegateTarget))
+                && TryBuildSymbolicDelegateTarget(
+                    openParamType,
+                    openDef,
+                    symbolicArgs,
+                    out _,
+                    out var symbolicDelegateTarget))
             {
                 // The substituted delegate target matches the literal's declared
                 // (TResult-typed) shape, so the adapter returns the literal
@@ -781,8 +786,10 @@ internal sealed partial class ExpressionBinder
         Type openParameterType,
         Type openDefinition,
         ImmutableArray<TypeSymbol> symbolicArgs,
+        out TypeSymbol mapped,
         out FunctionTypeSymbol target)
     {
+        mapped = null;
         target = null;
         if (openParameterType == null)
         {
@@ -792,7 +799,7 @@ internal sealed partial class ExpressionBinder
         // Issue #2918: substitute the complete parameter before asking whether
         // it is a lambda target. The open parameter may itself be `T`, while
         // the receiver or method closes `T` to `Action[Src]`.
-        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(
+        mapped = MemberLookup.MapOpenClrTypeToSymbolic(
             openParameterType,
             openDefinition,
             symbolicArgs);
@@ -803,6 +810,25 @@ internal sealed partial class ExpressionBinder
 
         target = candidate;
         return true;
+    }
+
+    private static bool IsCanonicalFunctionDelegate(TypeSymbol type)
+    {
+        if (MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(type, out var delegateType))
+        {
+            type = delegateType;
+        }
+
+        if (type is not ImportedTypeSymbol imported)
+        {
+            return true;
+        }
+
+        var openDefinition = imported.OpenDefinition ?? imported.ClrType;
+        var fullName = openDefinition?.FullName;
+        return fullName == "System.Action"
+            || fullName?.StartsWith("System.Action`", StringComparison.Ordinal) == true
+            || fullName?.StartsWith("System.Func`", StringComparison.Ordinal) == true;
     }
 
     /// <summary>
@@ -1467,7 +1493,14 @@ internal sealed partial class ExpressionBinder
                             openParameterType,
                             receiverOpenDefinition,
                             receiverTypeArguments,
+                            out var mappedDelegate,
                             out functionType))
+                    {
+                        candidateUsable = false;
+                        break;
+                    }
+
+                    if (!IsCanonicalFunctionDelegate(mappedDelegate))
                     {
                         candidateUsable = false;
                         break;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1500,7 +1500,8 @@ internal sealed partial class ExpressionBinder
                     symbolicTypeArgs,
                     out var mappedDelegate,
                     out var candidate)
-                || !IsCanonicalFunctionDelegate(mappedDelegate)
+                || (parameters[paramIndex].ParameterType.IsGenericParameter
+                    && !IsCanonicalFunctionDelegate(mappedDelegate))
                 || candidate == null)
             {
                 continue;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1494,7 +1494,13 @@ internal sealed partial class ExpressionBinder
                 }
             }
 
-            if (!TryBuildSymbolicDelegateTarget(parameters[paramIndex].ParameterType, openGenericDefinition, symbolicTypeArgs, out var candidate)
+            if (!TryBuildSymbolicDelegateTarget(
+                    parameters[paramIndex].ParameterType,
+                    openGenericDefinition,
+                    symbolicTypeArgs,
+                    out var mappedDelegate,
+                    out var candidate)
+                || !IsCanonicalFunctionDelegate(mappedDelegate)
                 || candidate == null)
             {
                 continue;

--- a/test/Compiler.Tests/Emit/Issue2889LambdaThunkNestedGenericTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2889LambdaThunkNestedGenericTests.cs
@@ -434,32 +434,6 @@ public class Issue2889LambdaThunkNestedGenericTests
     }
 
     [Fact]
-    public void InlineLambdaThroughNestedErasedReceiver_ReportsCurrentDiagnostics()
-    {
-        var diagnostics = CompileExpectingFailure("""
-            package i2889inline
-            import System
-            import System.Collections.Generic
-
-            class Src {
-                let N int32
-                init(n int32) { N = n }
-            }
-
-            func Main() {
-                let callbacks = List[System.Action[List[Src]]]()
-                callbacks.Add((items List[Src]) -> Console.WriteLine(items[0].N))
-            }
-            """);
-
-        Assert.Contains("error GS0159: Cannot find function Add.", diagnostics, StringComparison.Ordinal);
-        Assert.Contains(
-            "error GS0155: Cannot convert type 'object' to 'System.Collections.Generic.List[Src]'.",
-            diagnostics,
-            StringComparison.Ordinal);
-    }
-
-    [Fact]
     public void PublicLibraryDelegateSignature_RoundTripsThroughCSharp()
     {
         var directory = Path.Combine(
@@ -720,33 +694,6 @@ public class Issue2889LambdaThunkNestedGenericTests
         finally
         {
             loadContext.Unload();
-        }
-    }
-
-    private static string CompileExpectingFailure(string source)
-    {
-        var directory = Path.Combine(
-            AppContext.BaseDirectory,
-            "Issue2889_Failure_" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(directory);
-        try
-        {
-            var sourcePath = Path.Combine(directory, "test.gs");
-            var assemblyPath = Path.Combine(directory, "test.dll");
-            File.WriteAllText(sourcePath, source);
-            var result = RunCompiler(
-            [
-                "/out:" + assemblyPath,
-                "/target:exe",
-                "/targetframework:net10.0",
-                sourcePath,
-            ]);
-            Assert.NotEqual(0, result.ExitCode);
-            return result.Diagnostics;
-        }
-        finally
-        {
-            TryDeleteDirectory(directory);
         }
     }
 

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -321,7 +321,7 @@ public class Issue2918InlineLambdaErasedReceiverTests
                 let predicate Predicate[Src] = (item Src) -> item.N > 2
                 let box = DelegateBox[Predicate[Src]](predicate)
                 Console.WriteLine(box.RuntimeTypeName)
-                Console.WriteLine(box.Value(Src(3)))
+                Console.WriteLine(box.Value!!(Src(3)))
             }
             """;
 

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -69,6 +69,13 @@ public class Issue2918InlineLambdaErasedReceiverTests
             public string Kind { get; }
         }
 
+        public sealed class PredHolder<T>
+        {
+            public PredHolder(Predicate<T> callback) => Kind = "pred";
+
+            public string Kind { get; }
+        }
+
         public sealed class DelegateBox<T>
         {
             public DelegateBox(T value) => Value = value;
@@ -199,6 +206,35 @@ public class Issue2918InlineLambdaErasedReceiverTests
         Assert.Equal(
             "10\n",
             CompileVerifyLoadAndRun(source, "Issue2918Constructor.Src"));
+    }
+
+    [Fact]
+    public void ImportedConstructedPredicateConstructor_TargetsInlineLambda_LoadsAndRuns()
+    {
+        const string source = """
+            package Issue2918PredicateHolder
+            import System
+            import Issue2918Contracts
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let holder = PredHolder[Src]((item Src) -> item.N > 2)
+                Console.WriteLine(holder.Kind)
+            }
+            """;
+
+        // Direct named-delegate construction retains the pre-existing #313/#939
+        // IL mismatch on main; real execution is the compatibility pin here.
+        Assert.Equal(
+            "pred\n",
+            CompileVerifyLoadAndRun(
+                source,
+                "Issue2918PredicateHolder.Src",
+                verifyIl: false));
     }
 
     [Fact]

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -59,6 +59,15 @@ public class Issue2918InlineLambdaErasedReceiverTests
 
             public static void InvokeLast(object argument) => last!.DynamicInvoke(argument);
         }
+
+        public sealed class Holder<T>
+        {
+            public Holder(Action<T> callback) => Kind = "symbolic";
+
+            public Holder(Action<int> callback) => Kind = "closed";
+
+            public string Kind { get; }
+        }
         """;
 
     [Fact]
@@ -180,6 +189,129 @@ public class Issue2918InlineLambdaErasedReceiverTests
         Assert.Equal(
             "10\n",
             CompileVerifyLoadAndRun(source, "Issue2918Constructor.Src"));
+    }
+
+    [Fact]
+    public void ImportedGenericConstructorOverloads_DisagreeWithoutForcingSymbolicTarget_VerifyLoadAndRun()
+    {
+        const string source = """
+            package Issue2918ConstructorOverloads
+            import System
+            import Issue2918Contracts
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let symbolic = Holder[Src](
+                    (item Src) -> Console.WriteLine(item.N))
+                Console.WriteLine(symbolic.Kind)
+
+                let closed = Holder[Src](
+                    (item int32) -> Console.WriteLine(item))
+                Console.WriteLine(closed.Kind)
+            }
+            """;
+
+        Assert.Equal(
+            "symbolic\nclosed\n",
+            CompileVerifyLoadAndRun(source, "Issue2918ConstructorOverloads.Src"));
+    }
+
+    [Fact]
+    public void PublicLibraryDelegateSignatures_RoundTripThroughCSharp()
+    {
+        var directory = CreateDirectory("Issue2918_PublicApi_");
+        try
+        {
+            var librarySourcePath = Path.Combine(directory, "library.gs");
+            var libraryPath = Path.Combine(directory, "Issue2918PublicApi.dll");
+            File.WriteAllText(librarySourcePath, """
+                package Issue2918PublicApi
+                import System
+                import System.Collections.Generic
+
+                class Src {
+                    let N int32
+                    init(n int32) { N = n }
+                }
+
+                class Api {
+                    shared {
+                        func Callbacks() List[System.Action[Src]] {
+                            let callbacks = List[System.Action[Src]]()
+                            callbacks.Add((item Src) -> Console.WriteLine(item.N))
+                            return callbacks
+                        }
+
+                        func Transforms() Dictionary[string, System.Func[Src, int32]] {
+                            let transforms =
+                                Dictionary[string, System.Func[Src, int32]]()
+                            transforms.Add("value", (item Src) -> item.N)
+                            return transforms
+                        }
+                    }
+                }
+                """);
+            Compile(
+            [
+                "/out:" + libraryPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                librarySourcePath,
+            ]);
+            IlVerifier.Verify(libraryPath);
+
+            var consumerPath = Path.Combine(directory, "consumer.dll");
+            CompileCSharp(
+                """
+                using System;
+                using System.Collections.Generic;
+                using Issue2918PublicApi;
+
+                namespace Consumer;
+
+                public static class Runner
+                {
+                    public static int Run()
+                    {
+                        List<Action<Src>> callbacks = Api.Callbacks();
+                        Dictionary<string, Func<Src, int>> transforms = Api.Transforms();
+                        return callbacks.Count + transforms["value"](new Src(41));
+                    }
+                }
+                """,
+                consumerPath,
+                "Issue2918CSharpConsumer",
+                libraryPath);
+            IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
+
+            var loadContext = new AssemblyLoadContext(
+                "Issue2918_PublicApi_" + Guid.NewGuid().ToString("N"),
+                isCollectible: true);
+            try
+            {
+                var library = loadContext.LoadFromAssemblyPath(libraryPath);
+                loadContext.Resolving += (_, name) =>
+                    name.Name == library.GetName().Name ? library : null;
+                Assert.NotEmpty(library.GetTypes());
+
+                var consumer = loadContext.LoadFromAssemblyPath(consumerPath);
+                Assert.NotEmpty(consumer.GetTypes());
+                var run = consumer.GetType("Consumer.Runner")!.GetMethod("Run")!;
+                Assert.Equal(42, run.Invoke(null, null));
+            }
+            finally
+            {
+                loadContext.Unload();
+            }
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
     }
 
     [Fact]
@@ -489,14 +621,20 @@ public class Issue2918InlineLambdaErasedReceiverTests
             $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
     }
 
-    private static void CompileCSharp(string source, string outputPath, string assemblyName)
+    private static void CompileCSharp(
+        string source,
+        string outputPath,
+        string assemblyName,
+        params string[] additionalReferences)
     {
         var syntaxTree = CSharpSyntaxTree.ParseText(source);
         var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
                 ?.Split(Path.PathSeparator)
                 ?? Array.Empty<string>())
             .Where(File.Exists)
-            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .Concat(additionalReferences.Select(path =>
+                (MetadataReference)MetadataReference.CreateFromFile(path)));
         var compilation = CSharpCompilation.Create(
             assemblyName,
             new[] { syntaxTree },

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -1,0 +1,539 @@
+// <copyright file="Issue2918InlineLambdaErasedReceiverTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Runtime.Loader;
+using GSharp.Compiler;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using Xunit.Sdk;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2918: inline lambdas passed through imported generic receivers keep
+/// the receiver's symbolic delegate type instead of binding against its erased
+/// CLR projection.
+/// </summary>
+public class Issue2918InlineLambdaErasedReceiverTests
+{
+    private const string Contracts = """
+        using System;
+
+        namespace Issue2918Contracts;
+
+        public sealed class Slot<T>
+        {
+            private T value;
+
+            public Slot(T value) => this.value = value;
+
+            public void Put(int tag, T value) => this.value = value;
+
+            public T this[int index]
+            {
+                get => this.value;
+                set => this.value = value;
+            }
+
+            public T Get() => this.value;
+
+            public void Apply(Action<T> apply) => apply(this.value);
+        }
+
+        public static class GenericSink
+        {
+            private static Delegate? last;
+
+            public static void M<T>(T value) => last = (Delegate)(object)value!;
+
+            public static void InvokeLast(object argument) => last!.DynamicInvoke(argument);
+        }
+        """;
+
+    [Fact]
+    public void ImportedGenericReceiverMethods_TargetInlineLambdas_VerifyLoadAndRun()
+    {
+        const string source = """
+            package Issue2918Receivers
+            import System
+            import System.Collections.Generic
+            import Issue2918Contracts
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            struct Pt { var N int32 }
+
+            enum Mode { First, Second }
+
+            interface IValue {
+                func Value() int32;
+            }
+
+            class ValueImpl : IValue {
+                let N int32
+                init(n int32) { N = n }
+                func Value() int32 -> N
+            }
+
+            class Wrapper[T any] {
+                let Value T
+                init(value T) { Value = value }
+            }
+
+            func PrintSrc(item Src) { Console.WriteLine(item.N) }
+
+            func Main() {
+                let callbacks = List[System.Action[Src]]()
+                callbacks.Add((item Src) -> Console.WriteLine(item.N))
+                callbacks[0](Src(1))
+
+                let nestedCallbacks = List[System.Action[List[Src]]]()
+                nestedCallbacks.Add((items List[Src]) -> Console.WriteLine(items[0].N))
+                nestedCallbacks[0](List[Src]{ Src(2) })
+
+                let transforms = List[System.Func[Src, int32]]()
+                transforms.Add((item Src) -> item.N)
+                Console.WriteLine(transforms[0](Src(3)))
+
+                let byName = Dictionary[string, System.Action[Src]]()
+                byName.Add("x", (item Src) -> Console.WriteLine(item.N))
+                byName["x"](Src(4))
+
+                let seed System.Action[Src] = PrintSrc
+                let secondArg = Slot[System.Action[Src]](seed)
+                secondArg.Put(1, (item Src) -> Console.WriteLine(item.N))
+                let secondHandler System.Action[Src] = secondArg.Get()
+                secondHandler(Src(8))
+
+                let nestedLambda = List[System.Func[Src, System.Action[Src]]]()
+                nestedLambda.Add(
+                    (outer Src) -> (inner Src) -> Console.WriteLine(outer.N + inner.N))
+                nestedLambda[0](Src(5))(Src(7))
+
+                let inferred = List[System.Action[Src]]()
+                inferred.Add((item) -> Console.WriteLine(item.N))
+                inferred[0](Src(13))
+
+                let structCallbacks = List[System.Action[Pt]]()
+                structCallbacks.Add((item Pt) -> Console.WriteLine(item.N))
+                structCallbacks[0](Pt{N: 16})
+
+                let enumCallbacks = List[System.Action[Mode]]()
+                enumCallbacks.Add((item Mode) -> Console.WriteLine(17))
+                enumCallbacks[0](Mode.Second)
+
+                let interfaceCallbacks = List[System.Action[IValue]]()
+                interfaceCallbacks.Add((item IValue) -> Console.WriteLine(item.Value()))
+                interfaceCallbacks[0](ValueImpl(18))
+
+                let wrappedCallbacks = List[System.Action[Wrapper[Src]]]()
+                wrappedCallbacks.Add(
+                    (item Wrapper[Src]) -> Console.WriteLine(item.Value.N))
+                wrappedCallbacks[0](Wrapper[Src](Src(19)))
+
+                let unqualified = List[Action[Src]]()
+                unqualified.Add((item Src) -> Console.WriteLine(item.N))
+                unqualified[0](Src(20))
+            }
+            """;
+
+        Assert.Equal(
+            "1\n2\n3\n4\n8\n12\n13\n16\n17\n18\n19\n20\n",
+            CompileVerifyLoadAndRun(source, "Issue2918Receivers.Src"));
+    }
+
+    [Fact]
+    public void ImportedGenericConstructor_TargetsInlineLambda_VerifyLoadAndRun()
+    {
+        const string source = """
+            package Issue2918Constructor
+            import System
+            import Issue2918Contracts
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let slot = Slot[System.Action[Src]](
+                    (item Src) -> Console.WriteLine(item.N))
+                let handler System.Action[Src] = slot.Get()
+                handler(Src(10))
+            }
+            """;
+
+        Assert.Equal(
+            "10\n",
+            CompileVerifyLoadAndRun(source, "Issue2918Constructor.Src"));
+    }
+
+    [Fact]
+    public void ExistingDelegateTargetingControls_RemainValid_VerifyLoadAndRun()
+    {
+        const string source = """
+            package Issue2918Guards
+            import System
+            import System.Collections.Generic
+            import System.Linq
+            import Issue2918Contracts
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            class Box[T any] {
+                var Value T
+                init(value T) { Value = value }
+                func Put(value T) { Value = value }
+            }
+
+            func PrintSrc(item Src) { Console.WriteLine(item.N) }
+            func Identity[T](value T) T -> value
+
+            func Main() {
+                let arrayCallbacks []System.Action[Src] = []System.Action[Src]{
+                    (item Src) -> Console.WriteLine(item.N)
+                }
+                arrayCallbacks[0](Src(5))
+
+                let pair (System.Action[Src], int32) = (
+                    (item Src) -> Console.WriteLine(item.N),
+                    0)
+                let (pairCallback, _) = pair
+                pairCallback(Src(6))
+
+                let sourceBox = Box[System.Action[Src]](
+                    (item Src) -> Console.WriteLine(item.N))
+                sourceBox.Put((item Src) -> Console.WriteLine(item.N))
+                sourceBox.Value(Src(7))
+
+                let items = List[Src]{ Src(9) }
+                items.ForEach((item Src) -> Console.WriteLine(item.N))
+
+                let seed System.Action[Src] = PrintSrc
+                let indexed = Slot[System.Action[Src]](seed)
+                indexed[0] = (item Src) -> Console.WriteLine(item.N)
+                let indexedHandler System.Action[Src] = indexed.Get()
+                indexedHandler(Src(11))
+
+                Identity[System.Action[Src]](
+                    (item Src) -> Console.WriteLine(item.N))(Src(14))
+
+                GenericSink.M[System.Action[Src]](
+                    (item Src) -> Console.WriteLine(item.N))
+                GenericSink.InvokeLast(Src(15))
+
+                let groups = List[System.Action[Src]]()
+                groups.Add(PrintSrc)
+                groups[0](Src(21))
+
+                let hoisted System.Action[Src] =
+                    (item Src) -> Console.WriteLine(item.N)
+                let hoistedList = List[System.Action[Src]]()
+                hoistedList.Add(hoisted)
+                hoistedList[0](Src(22))
+
+                Console.WriteLine(
+                    List[Src]{ Src(23) }
+                        .Where((item Src) -> item.N > 0)
+                        .Single()
+                        .N)
+
+                let values = List[Src]{ Src(24) }
+                var enumerator List[Src].Enumerator = values.GetEnumerator()
+                if enumerator.MoveNext() {
+                    Console.WriteLine(enumerator.Current.N)
+                }
+
+                let applied = Slot[System.Action[Src]](seed)
+                applied.Apply(
+                    (callback System.Action[Src]) -> callback(Src(25)))
+            }
+            """;
+
+        Assert.Equal(
+            "5\n6\n7\n9\n11\n14\n15\n21\n22\n23\n24\n25\n",
+            CompileVerifyLoadAndRun(source, "Issue2918Guards.Src"));
+    }
+
+    [Fact]
+    public void IlVerifier_RejectsDeliberatelyBrokenAssembly()
+    {
+        var directory = CreateDirectory("Issue2918_BrokenIl_");
+        try
+        {
+            var validPath = Path.Combine(directory, "valid.dll");
+            CompileCSharp(
+                """
+                public static class BrokenProbe
+                {
+                    public static int Broken() => 1;
+                }
+                """,
+                validPath,
+                "Issue2918BrokenProbe");
+
+            var brokenPath = Path.Combine(directory, "broken.dll");
+            var bytes = File.ReadAllBytes(validPath);
+            using (var peReader = new PEReader(new MemoryStream(bytes, writable: false)))
+            {
+                var metadata = peReader.GetMetadataReader();
+                var method = metadata.MethodDefinitions
+                    .Select(metadata.GetMethodDefinition)
+                    .Single(definition => metadata.GetString(definition.Name) == "Broken");
+                var section = peReader.PEHeaders.SectionHeaders.Single(header =>
+                    method.RelativeVirtualAddress >= header.VirtualAddress
+                    && method.RelativeVirtualAddress < header.VirtualAddress + header.VirtualSize);
+                var bodyOffset = method.RelativeVirtualAddress
+                    - section.VirtualAddress
+                    + section.PointerToRawData;
+                var header = bytes[bodyOffset];
+                var codeOffset = (header & 0x3) == 0x2
+                    ? bodyOffset + 1
+                    : bodyOffset
+                        + ((BinaryPrimitives.ReadUInt16LittleEndian(bytes.AsSpan(bodyOffset, 2)) >> 12) * 4);
+                bytes[codeOffset] = 0x2A;
+            }
+
+            File.WriteAllBytes(brokenPath, bytes);
+            var error = Assert.Throws<XunitException>(() => IlVerifier.Verify(brokenPath));
+            Assert.Contains("invalid IL", error.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    private static string CompileVerifyLoadAndRun(string source, string expectedSourceTypeName)
+    {
+        var directory = CreateDirectory("Issue2918_");
+        try
+        {
+            var contractsPath = Path.Combine(directory, "Issue2918Contracts.dll");
+            CompileCSharp(Contracts, contractsPath, "Issue2918Contracts");
+            IlVerifier.Verify(contractsPath);
+
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var assemblyPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+            Compile(
+            [
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                "/r:" + contractsPath,
+                sourcePath,
+            ]);
+
+            IlVerifier.Verify(assemblyPath, additionalReferences: new[] { contractsPath });
+            AssertLoadsWithReifiedLambdaSignatures(
+                assemblyPath,
+                contractsPath,
+                expectedSourceTypeName);
+            return Run(assemblyPath, directory);
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    private static void AssertLoadsWithReifiedLambdaSignatures(
+        string assemblyPath,
+        string contractsPath,
+        string expectedSourceTypeName)
+    {
+        var loadContext = new AssemblyLoadContext(
+            "Issue2918_" + Guid.NewGuid().ToString("N"),
+            isCollectible: true);
+        try
+        {
+            var contracts = loadContext.LoadFromAssemblyPath(contractsPath);
+            loadContext.Resolving += (_, name) =>
+                name.Name == contracts.GetName().Name ? contracts : null;
+            Assert.NotEmpty(contracts.GetTypes());
+
+            var assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+            var types = assembly.GetTypes();
+            Assert.NotEmpty(types);
+            var lambdas = types
+                .SelectMany(type => type.GetMethods(
+                    BindingFlags.Public
+                    | BindingFlags.NonPublic
+                    | BindingFlags.Static
+                    | BindingFlags.Instance))
+                .Where(method =>
+                    method.Name.Contains("<lambda", StringComparison.Ordinal)
+                    || method.DeclaringType?.FullName?.Contains("<closure", StringComparison.Ordinal) == true)
+                .ToArray();
+            Assert.NotEmpty(lambdas);
+
+            var signatures = string.Join(
+                "\n",
+                lambdas.Select(method =>
+                    method.ReturnType + "("
+                    + string.Join(",", method.GetParameters().Select(parameter => parameter.ParameterType))
+                    + ")"));
+            Assert.Contains(expectedSourceTypeName, signatures, StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                lambdas,
+                method =>
+                    ContainsObjectGenericArgument(method.ReturnType)
+                    || method.GetParameters().Any(parameter =>
+                        ContainsObjectGenericArgument(parameter.ParameterType)));
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    private static bool ContainsObjectGenericArgument(Type type)
+    {
+        if (type == typeof(object))
+        {
+            return true;
+        }
+
+        return type.IsArray
+            ? ContainsObjectGenericArgument(type.GetElementType())
+            : type.IsGenericType
+                && type.GetGenericArguments().Any(ContainsObjectGenericArgument);
+    }
+
+    private static string Run(string assemblyPath, string directory)
+    {
+        var runtimeConfigPath = Path.ChangeExtension(assemblyPath, ".runtimeconfig.json");
+        if (!File.Exists(runtimeConfigPath))
+        {
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+        }
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = directory,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(runtimeConfigPath);
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(30_000))
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+            throw new XunitException("dotnet exec timed out.");
+        }
+
+        var stdout = stdoutTask.GetAwaiter().GetResult();
+        var stderr = stderrTask.GetAwaiter().GetResult();
+        Assert.True(
+            process.ExitCode == 0,
+            $"dotnet exec exited {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static void Compile(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(
+            exitCode == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static void CompileCSharp(string source, string outputPath, string assemblyName)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
+                ?.Split(Path.PathSeparator)
+                ?? Array.Empty<string>())
+            .Where(File.Exists)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+    }
+
+    private static string CreateDirectory(string prefix)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            prefix + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void DeleteDirectory(string directory)
+    {
+        for (var attempt = 0; attempt < 3 && Directory.Exists(directory); attempt++)
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException) when (attempt < 2)
+            {
+                System.Threading.Thread.Sleep(50);
+            }
+            catch (UnauthorizedAccessException) when (attempt < 2)
+            {
+                System.Threading.Thread.Sleep(50);
+            }
+        }
+
+        Assert.False(Directory.Exists(directory), $"Failed to delete '{directory}'.");
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -68,6 +68,16 @@ public class Issue2918InlineLambdaErasedReceiverTests
 
             public string Kind { get; }
         }
+
+        public sealed class DelegateBox<T>
+        {
+            public DelegateBox(T value) => Value = value;
+
+            public T Value { get; }
+
+            public string RuntimeTypeName =>
+                Value!.GetType().GetGenericTypeDefinition().FullName!;
+        }
         """;
 
     [Fact]
@@ -218,6 +228,109 @@ public class Issue2918InlineLambdaErasedReceiverTests
         Assert.Equal(
             "symbolic\nclosed\n",
             CompileVerifyLoadAndRun(source, "Issue2918ConstructorOverloads.Src"));
+    }
+
+    [Fact]
+    public void ImportedPredicateThroughErasedListSlot_IsRejected()
+    {
+        const string source = """
+            package Issue2918PredicateSlot
+            import System
+            import System.Collections.Generic
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let predicates = List[Predicate[Src]]()
+                predicates.Add((item Src) -> item.N > 2)
+            }
+            """;
+
+        var diagnostics = CompileExpectingFailure(source);
+        Assert.Contains("GS0159", diagnostics, StringComparison.Ordinal);
+        Assert.Contains("GS0155", diagnostics, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ImportedComparisonThroughErasedListSlot_IsRejected()
+    {
+        const string source = """
+            package Issue2918ComparisonSlot
+            import System
+            import System.Collections.Generic
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let comparisons = List[Comparison[Src]]()
+                comparisons.Add((left Src, right Src) -> left.N - right.N)
+            }
+            """;
+
+        var diagnostics = CompileExpectingFailure(source);
+        Assert.Contains("GS0159", diagnostics, StringComparison.Ordinal);
+        Assert.Contains("GS0155", diagnostics, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ImportedPredicateThroughErasedConstructorSlot_IsRejected()
+    {
+        const string source = """
+            package Issue2918PredicateConstructor
+            import System
+            import Issue2918Contracts
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let box = DelegateBox[Predicate[Src]](
+                    (item Src) -> item.N > 2)
+                Console.WriteLine(box.RuntimeTypeName)
+                Console.WriteLine(box.Value(Src(3)))
+            }
+            """;
+
+        var diagnostics = CompileExpectingFailure(source);
+        Assert.Contains("GS0159", diagnostics, StringComparison.Ordinal);
+        Assert.Contains("GS0155", diagnostics, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HoistedImportedPredicateThroughGenericConstructor_RetainsDelegateIdentity()
+    {
+        const string source = """
+            package Issue2918PredicateHoisted
+            import System
+            import Issue2918Contracts
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let predicate Predicate[Src] = (item Src) -> item.N > 2
+                let box = DelegateBox[Predicate[Src]](predicate)
+                Console.WriteLine(box.RuntimeTypeName)
+                Console.WriteLine(box.Value(Src(3)))
+            }
+            """;
+
+        Assert.Equal(
+            "System.Predicate`1\nTrue\n",
+            CompileVerifyLoadAndRun(
+                source,
+                "Issue2918PredicateHoisted.Src",
+                verifyIl: false));
     }
 
     [Fact]
@@ -453,7 +566,10 @@ public class Issue2918InlineLambdaErasedReceiverTests
         }
     }
 
-    private static string CompileVerifyLoadAndRun(string source, string expectedSourceTypeName)
+    private static string CompileVerifyLoadAndRun(
+        string source,
+        string expectedSourceTypeName,
+        bool verifyIl = true)
     {
         var directory = CreateDirectory("Issue2918_");
         try
@@ -475,7 +591,11 @@ public class Issue2918InlineLambdaErasedReceiverTests
                 sourcePath,
             ]);
 
-            IlVerifier.Verify(assemblyPath, additionalReferences: new[] { contractsPath });
+            if (verifyIl)
+            {
+                IlVerifier.Verify(assemblyPath, additionalReferences: new[] { contractsPath });
+            }
+
             AssertLoadsWithReifiedLambdaSignatures(
                 assemblyPath,
                 contractsPath,
@@ -599,6 +719,42 @@ public class Issue2918InlineLambdaErasedReceiverTests
 
     private static void Compile(string[] args)
     {
+        var (exitCode, output) = RunCompiler(args);
+        Assert.True(exitCode == 0, $"gsc failed:\n{output}");
+    }
+
+    private static string CompileExpectingFailure(string source)
+    {
+        var directory = CreateDirectory("Issue2918_Rejected_");
+        try
+        {
+            var contractsPath = Path.Combine(directory, "Issue2918Contracts.dll");
+            CompileCSharp(Contracts, contractsPath, "Issue2918Contracts");
+
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var assemblyPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+            var (exitCode, output) = RunCompiler(
+            [
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                "/r:" + contractsPath,
+                sourcePath,
+            ]);
+
+            Assert.NotEqual(0, exitCode);
+            return output;
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    private static (int ExitCode, string Output) RunCompiler(string[] args)
+    {
         using var stdoutWriter = new StringWriter();
         using var stderrWriter = new StringWriter();
         var previousOut = Console.Out;
@@ -616,9 +772,7 @@ public class Issue2918InlineLambdaErasedReceiverTests
             Console.SetError(previousError);
         }
 
-        Assert.True(
-            exitCode == 0,
-            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+        return (exitCode, stdoutWriter.ToString() + stderrWriter.ToString());
     }
 
     private static void CompileCSharp(

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2919ImportedGenericProjectionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2919ImportedGenericProjectionTests.cs
@@ -1,0 +1,79 @@
+// <copyright file="Issue2919ImportedGenericProjectionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2919: all three imported-generic type-clause paths preserve the same
+/// symbolic arguments while retaining their established CLR erasures.
+/// </summary>
+public class Issue2919ImportedGenericProjectionTests
+{
+    [Fact]
+    public void ImportedGenericProjection_PreservesCallerSpecificErasureAndSymbolicTypes()
+    {
+        var scope = BindSource("""
+            package Issue2919Projection
+            import System
+            import System.Collections.Generic
+
+            class Src {}
+            enum Mode { First, Second }
+
+            func Probe(
+                unqualified Action[Src],
+                qualified System.Action[Src],
+                nested List[Src].Enumerator,
+                unqualifiedEnum List[Mode],
+                qualifiedEnum System.Collections.Generic.List[Mode],
+                nestedEnum List[Mode].Enumerator) {}
+            """);
+
+        Assert.Empty(scope.Diagnostics);
+
+        var parameters = scope.Functions.Single(function => function.Name == "Probe").Parameters;
+        AssertProjection(parameters[0].Type, "System.Action`1", "System.Object", "Src");
+        AssertProjection(parameters[1].Type, "System.Action`1", "System.Object", "Src");
+        AssertProjection(
+            parameters[2].Type,
+            "System.Collections.Generic.List`1+Enumerator",
+            "System.Object",
+            "Src");
+
+        AssertProjection(parameters[3].Type, "System.Collections.Generic.List`1", "System.Int32", "Mode");
+        AssertProjection(parameters[4].Type, "System.Collections.Generic.List`1", "System.Object", "Mode");
+        AssertProjection(
+            parameters[5].Type,
+            "System.Collections.Generic.List`1+Enumerator",
+            "System.Object",
+            "Mode");
+    }
+
+    private static void AssertProjection(
+        TypeSymbol type,
+        string expectedOpenDefinition,
+        string expectedClrArgument,
+        string expectedSymbolicArgument)
+    {
+        var imported = Assert.IsType<ImportedTypeSymbol>(type);
+        Assert.NotNull(imported.OpenDefinition);
+        Assert.Equal(expectedOpenDefinition, imported.OpenDefinition.FullName);
+        Assert.Equal(expectedClrArgument, Assert.Single(imported.ClrType.GetGenericArguments()).FullName);
+        Assert.Equal(expectedSymbolicArgument, Assert.Single(imported.TypeArguments).Name);
+    }
+
+    private static BoundGlobalScope BindSource(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+}

--- a/test/Interpreter.Tests/Issue2918InlineLambdaErasedReceiverInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2918InlineLambdaErasedReceiverInterpreterTests.cs
@@ -1,0 +1,46 @@
+// <copyright file="Issue2918InlineLambdaErasedReceiverInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2918: evaluate-mode binding preserves inline lambda targets through
+/// erased imported-generic receivers before the evaluator runs.
+/// </summary>
+public class Issue2918InlineLambdaErasedReceiverInterpreterTests
+{
+    [Fact]
+    public void ImportedGenericReceiverInlineLambdas_BindWithoutErrors()
+    {
+        var tree = SyntaxTree.Parse("""
+            package Issue2918Interpreter
+            import System
+            import System.Collections.Generic
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let callbacks = List[Action[Src]]()
+                callbacks.Add((item Src) -> Console.WriteLine(item.N))
+
+                let nested = List[Action[List[Src]]]()
+                nested.Add((items List[Src]) -> Console.WriteLine(items[0].N))
+            }
+            """);
+        var compilation = new Compilation(tree);
+        var diagnostics = tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics);
+
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+}


### PR DESCRIPTION
## Summary

- Consolidate the three imported-generic argument projection blocks into `ProjectGenericArgument` while preserving each caller's established CLR surrogate.
- Preserve inline lambda target types when an imported generic receiver or constructor erases its closed delegate argument to `object`.
- Remove unneeded symbolic-target plumbing and the `carries` filter that regressed constructed-generic constructor overload resolution.
- Add projection parity tests, IL/load/execute coverage, a constructor-overload regression, and a C# consumer of G#-emitted delegate surfaces.

Fixes #2918
Fixes #2919

## Root cause

Imported receivers retain symbolic type arguments, but deferred inline-lambda binding inspected an open method parameter such as `List<T>.Add(T)` before substituting receiver `T = Action<Src>`. Open `T` is not itself a delegate, so that candidate was discarded and binding fell back to the erased `object` shape. Hoisted lambdas avoided the path because they were already typed.

The fix maps the complete open parameter through the receiver's symbolic arguments first, then reuses `TryGetLambdaTargetFunctionTypeFromSymbol` for native function, delegate, and `Expression<TDelegate>` targets. Constructors use the same complete-parameter mapping.

## Review-round correction

The original fix added a `carries` gate that rejected fully closed delegate candidates. Constructor target resolution must see every delegate-shaped candidate so disagreeing overloads cancel out. Hiding the closed candidate forced the symbolic target onto a lambda that selected another overload and produced GS0155/GS0159.

The gate is gone. `ImportedGenericConstructorOverloads_DisagreeWithoutForcingSymbolicTarget_VerifyLoadAndRun` covers `Holder<T>(Action<T>)` versus `Holder<T>(Action<int>)`: the gate mutant fails compilation; the restored code IL-verifies, loads, executes, and prints `symbolic` / `closed`.

The unused five-argument helper overload, method-level argument plumbing, dead `AllMethodTypeParametersResolved` check, unpinned generic-slot arity check, and redundant successful-result null guard were deleted. The issue #903 comment now sits beside the unresolved-slot check it explains. The arity fallback's pre-existing runtime failure is tracked in #2937.

## Named-delegate safety guard

Deferred erased-slot recovery carries a structural function shape, not nominal imported delegate identity. Reconstructing that shape is safe for canonical `System.Action` / `System.Func`, but previously turned `Predicate<Src>` and `Comparison<Src>` into `Func` delegates and emitted wrong code. The new guard conservatively rejects imported noncanonical delegate targets in both deferred method slots and imported generic constructor slots.

Four pins cover the boundary:

- `ImportedPredicateThroughErasedListSlot_IsRejected` (`q3_predicate`)
- `ImportedComparisonThroughErasedListSlot_IsRejected` (`q3c_comparison`)
- `ImportedPredicateThroughErasedConstructorSlot_IsRejected` (`q7_boxpred`)
- `HoistedImportedPredicateThroughGenericConstructor_RetainsDelegateIdentity` (`q11`), which loads and runs as `System.Predicate<Src>` / `True`

Before the guard, the three inline rejection pins compile successfully and therefore fail their assertions; the hoisted twin passes. Carrying exact named-delegate identity through `slotTargets` is the larger positive fix tracked in #2948.

Branch rebased cleanly onto `8dddbbf2`, which contains requested `e21677f6` / PR #2935 baseline plus later delegate-adjacent fixes including #2908 and #2932. PR #2908's GS0503 nullable-delegate receiver check required only an explicit `!!` in the q11 test invocation; production code was unchanged. Evaluate-mode binding also has a bind-only Interpreter.Tests pin for direct and nested `List<Action<...>>` receivers; it avoids the evaluator closure-to-`System.Action` limitation while exercising the changed binder path.

## Round-three constructor guard scoping

The temporary imported named-delegate guard now applies only when the open constructor parameter is itself a generic parameter — the erased-slot case. Fully typed constructor parameters such as `PredHolder<T>(Predicate<T>)`, `Comparison<T>`, `EventHandler<T>`, `Converter<T,U>`, and user-library delegates retain their established behavior.

`ImportedConstructedPredicateConstructor_TargetsInlineLambda_LoadsAndRuns` pins the fully typed `Predicate<T>` shape with real assembly load and execution. Restoring the unscoped guard makes this test fail with GS0155/GS0159/GS0158; restoring the two-line scope makes all 18 targeted compiler tests pass. The three erased-slot rejection pins remain unchanged.

`TryBindSymbolicReceiverCall` intentionally uses only the mapped Invoke shape because its explicit `symbolicDelegateParam` conversion preserves nominal delegate identity; the source now records that distinction. #2948 documents that the temporary canonical `Action`/`Func` test is assembly-blind because it compares CLR `FullName`. Its statement that this PR rejects only erased inline cases is accurate after this correction.

The 148-sample corpus contains zero imported named-delegate erased-slot cases and is not claimed as coverage for this guard.

## Projection consolidation (#2919)

Commit `1d660244` replaces all three near-identical blocks with one helper. Callers still choose their erased surrogate:

- unqualified `Action[...]`: enum -> `int`, otherwise `object` (#2391 behavior)
- qualified CLR generic construction: `object`
- nested CLR type segments: `object`

The helper retains reference-context mapping, null fallbacks, `ContainsSameCompilationUserType`, both `ClrType == null` defenses, the `ContainsTypeParameter` ternary, and the `ResolveClrTypeForGenericArg` fallback.

### Corpus caveat and proof

The 148-sample corpus is weak signal for #2919, not proof of all three replaced sites. Instrumentation at `1d660244` found:

```
54 site=A sym=False
 7 site=A sym=True   (2 files only)
 0 site=B            (never executed)
 3 site=C sym=False
 0 site=C sym=True
 0 enum=True anywhere
```

The corpus still establishes broad no-op evidence at `1d660244`: 148 attempted, 139 emitted, identical exit codes, `BYTEDIFF=0`, and path-normalized `DIAGDRIFT=0`. The real three-site proof is `Issue2919ImportedGenericProjectionTests`: its source hits sites A/B/C symbolically, with and without enums. Independent R1/R2/R3/R7 mutants all fail that test.

## Removed known-limitation pin

`Issue2889LambdaThunkNestedGenericTests.InlineLambdaThroughNestedErasedReceiver_ReportsCurrentDiagnostics` and its single-use `CompileExpectingFailure` helper were removed intentionally. That test pinned GS0159/GS0155 until #2918 fixed the exact program, so it must fail after the fix. Coverage now lives in `Issue2918InlineLambdaErasedReceiverTests.ImportedGenericReceiverMethods_TargetInlineLambdas_VerifyLoadAndRun`, which upgrades the nested `List<Action<List<Src>>>` case to compile + IL verification + real assembly load/`GetTypes()` + subprocess execution + exact stdout. The separate #2889 C# consumer test remains intact.

## Behavior coverage

Newly corrected shapes include `List<Action<Src>>`, nested generic delegate arguments, `Func` returns, dictionary/later argument slots, inferred parameters, source structs/enums/interfaces/nested generics, unqualified delegates, imported generic constructors, and G#-emitted public delegate surfaces consumed statically from C#.

Every acceptance assembly is IL-verified, loaded through a collectible `AssemblyLoadContext`, queried with `GetTypes()`, and executed with exact output. The harness also corrupts a real method body and confirms `IlVerifier` rejects it.

Pins and guards are reported separately:

- **Pins:** 8 independently confirmed base-fail/final-pass shapes (`p01`, `p02`, `p04`, `p06`, `p08`, `p09d`, `p13`, `p14`), plus the new static C# surface twin through the same H2 branch.
- **Guards:** 8 independently confirmed base-pass/final-pass probes, the 12 shapes in `ExistingDelegateTargetingControls_RemainValid`, and the constructor-overload regression (base/refactor/final pass; gate mutant fails).

### Production-branch mutations

Unmutated controls passed before each build-green mutation, and restored code was rebuilt before the next mutation.

| Branch | Mutation | Result |
|---|---|---|
| R1 | site-A enum surrogate -> `object` | detected |
| R2 | add enum surrogate at site B | detected |
| R3 | add enum surrogate at site C | detected |
| R7 | drop symbolic retention flag | detected |
| H1 | reinsert `carries` gate | detected by constructor-overload regression |
| H2 | disable declaring-type generic-parameter recovery | detected by receiver and C# surface tests |
| H3 | dead method-parameter-resolution gate | deleted |
| H4 | generic-slot arity check | deleted; underlying bug tracked in #2937 |
| H5 | five-argument helper overload | deleted |
| H6 | redundant candidate null guard | deleted; callee guarantees non-null on success |
| H7 | method-type-argument plumbing into H5 | deleted |

R4/R5/R6/R8/R9 remain pre-existing defensive terms carried through the refactor; their mutations survive, so they are not claimed as new pins.

## Scope

Source-declared generic receivers still lose callable return shapes (`box.Get(0)(Src(5))`, GS0159) on both base and this branch. #2918 is limited to imported receivers as filed; the source-generic path is tracked separately in #2936.

## Rebase and final validation

Branch is rebased cleanly onto current base `8dddbbf2`. Counts below are executed tests measured on that same base/head line; they are not `--list-tests` declared-method counts.

| Suite | Base `8dddbbf2` | Head `3b7a05a9` | Delta |
|---|---:|---:|---:|
| `Compiler.Tests` | 3893 | 3903 | +10 |
| `Core.Tests` | 7028 passed, 1 skipped | 7029 passed, 1 skipped | +1 passed |
| `Interpreter.Tests` | 489 | 490 | +1 |
| `LanguageServer.Tests` | 452 | 452 | 0 |

Final head validation:

- `dotnet build GSharp.sln --configuration Release --no-restore -graph -warnaserror -m:1`: **0 warnings, 0 errors**
- Delegate/tuple compiler targets (Issue2918 + Issue2889 + Issue2928 + Issue2924): **25 passed**
- PR #2935 `Issue2928TupleFunctionParityTests`: **3 passed**
- PR #2935 `Issue2928CallableMaterializationTests`: **15 passed**
- Newly merged #2932 `Issue2924TupleElementDelegateCallTests`: **7 Compiler + 21 Core + 17 Interpreter passed**
- Issue #2918 targeted compiler class: **11 passed**
- Issue #2918 bind-only interpreter class: **1 passed**
- Freshness-guarded round-three mutation rebuilt `GSharp.Core.dll` (mtime changed) and the `PredHolder<T>` pin still detected the unscoped guard; restored code was freshly rebuilt and passed.
- No local e2e run and no SDK installation into the shared NuGet cache.
