### PR TITLE
Fix tuple-element delegate calls

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -24,6 +24,36 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 
 internal sealed partial class ExpressionBinder
 {
+    private static bool TryGetTupleElementIndex(
+        string memberName,
+        TupleTypeSymbol tupleType,
+        out int zeroBased)
+    {
+        if (int.TryParse(memberName, out var numericIndex)
+            && numericIndex < tupleType.Arity)
+        {
+            zeroBased = numericIndex;
+            return true;
+        }
+
+        if (memberName.StartsWith("Item", System.StringComparison.Ordinal)
+            && int.TryParse(memberName.Substring(4), out var oneBased)
+            && oneBased >= 1
+            && oneBased <= tupleType.Arity)
+        {
+            zeroBased = oneBased - 1;
+            return true;
+        }
+
+        zeroBased = -1;
+        return false;
+    }
+
+    private static string GetTupleFieldName(string memberName, TupleTypeSymbol tupleType) =>
+        TryGetTupleElementIndex(memberName, tupleType, out var index)
+            ? "Item" + (index + 1).ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : memberName;
+
     private BoundExpression BindAccessorStep(
         BoundExpression receiver,
         ImportedClassSymbol classSymbol,
@@ -439,22 +469,7 @@ internal sealed partial class ExpressionBinder
                     // Phase 4.5 / issue #2924: tuple element access via
                     // one-based Item1..ItemN or zero-based .0...N selectors.
                     var memberName = ne.IdentifierToken.Text;
-                    var zeroBased = -1;
-                    if (int.TryParse(memberName, out var numericIndex)
-                        && numericIndex >= 0
-                        && numericIndex < tupleSym.Arity)
-                    {
-                        zeroBased = numericIndex;
-                    }
-                    else if (memberName.StartsWith("Item", System.StringComparison.Ordinal)
-                        && int.TryParse(memberName.Substring(4), out var oneBased)
-                        && oneBased >= 1
-                        && oneBased <= tupleSym.Arity)
-                    {
-                        zeroBased = oneBased - 1;
-                    }
-
-                    if (zeroBased >= 0)
+                    if (TryGetTupleElementIndex(memberName, tupleSym, out var zeroBased))
                     {
                         return new BoundTupleElementAccessExpression(null, receiver, tupleSym, zeroBased);
                     }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -29,7 +29,14 @@ internal sealed partial class ExpressionBinder
         TupleTypeSymbol tupleType,
         out int zeroBased)
     {
+        if (string.IsNullOrEmpty(memberName))
+        {
+            zeroBased = -1;
+            return false;
+        }
+
         if (int.TryParse(memberName, out var numericIndex)
+            && numericIndex >= 0
             && numericIndex < tupleType.Arity)
         {
             zeroBased = numericIndex;
@@ -52,7 +59,7 @@ internal sealed partial class ExpressionBinder
     private static string GetTupleFieldName(string memberName, TupleTypeSymbol tupleType) =>
         TryGetTupleElementIndex(memberName, tupleType, out var index)
             ? "Item" + (index + 1).ToString(System.Globalization.CultureInfo.InvariantCulture)
-            : memberName;
+            : memberName ?? string.Empty;
 
     private BoundExpression BindAccessorStep(
         BoundExpression receiver,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -436,13 +436,27 @@ internal sealed partial class ExpressionBinder
                 }
                 else if (receiver != null && receiver.Type is TupleTypeSymbol tupleSym)
                 {
-                    // Phase 4.5: tuple element access via Item1..ItemN.
+                    // Phase 4.5 / issue #2924: tuple element access via
+                    // one-based Item1..ItemN or zero-based .0...N selectors.
                     var memberName = ne.IdentifierToken.Text;
-                    if (memberName.StartsWith("Item", System.StringComparison.Ordinal)
-                        && int.TryParse(memberName.Substring(4), out var oneBased)
-                        && oneBased >= 1 && oneBased <= tupleSym.Arity)
+                    var zeroBased = -1;
+                    if (int.TryParse(memberName, out var numericIndex)
+                        && numericIndex >= 0
+                        && numericIndex < tupleSym.Arity)
                     {
-                        return new BoundTupleElementAccessExpression(null, receiver, tupleSym, oneBased - 1);
+                        zeroBased = numericIndex;
+                    }
+                    else if (memberName.StartsWith("Item", System.StringComparison.Ordinal)
+                        && int.TryParse(memberName.Substring(4), out var oneBased)
+                        && oneBased >= 1
+                        && oneBased <= tupleSym.Arity)
+                    {
+                        zeroBased = oneBased - 1;
+                    }
+
+                    if (zeroBased >= 0)
+                    {
+                        return new BoundTupleElementAccessExpression(null, receiver, tupleSym, zeroBased);
                     }
 
                     return BindExtensionMethodGroupOrError(receiver, ne);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -2062,8 +2062,10 @@ internal sealed partial class ExpressionBinder
             return receiver;
         }
 
-        var fieldName = syntax.FieldIdentifier.Text;
         var receiverType = receiver.Type;
+        var fieldName = receiverType is TupleTypeSymbol tupleType
+            ? GetTupleFieldName(syntax.FieldIdentifier.Text, tupleType)
+            : syntax.FieldIdentifier.Text;
         BoundExpression value = null;
         BoundExpression BindValue(TypeSymbol targetType) => value ??= BindAssignmentRhs(syntax.Value, targetType);
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -212,6 +212,11 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
+            if (boundReceiver.Type is TupleTypeSymbol tupleType)
+            {
+                eventName = GetTupleFieldName(eventName, tupleType);
+            }
+
             // Check for user-defined event on a StructSymbol before falling through to CLR reflection.
             // ADR-0112 A5: TryGetEvent walks the base chain, so inherited instance
             // events on `open class` bases now resolve (parity with the bare-`this`

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Invocations.cs
@@ -128,7 +128,7 @@ internal sealed partial class OverloadResolver
     private BoundExpression BuildNullConditionalDelegateResult(
         CallExpressionSyntax syntax,
         BoundExpression receiverLoad,
-        LocalVariableSymbol capture,
+        VariableSymbol capture,
         BoundExpression whenNotNull,
         TypeSymbol returnType)
     {
@@ -685,9 +685,44 @@ internal sealed partial class OverloadResolver
             return callee;
         }
 
+        BoundNullConditionalAccessExpression nullConditionalCallee = null;
+        var assertions = new Stack<BoundUnaryExpression>();
+        var assertedCallee = callee;
+        while (assertedCallee is BoundUnaryExpression assertion
+            && assertion.Op.Kind == BoundUnaryOperatorKind.NullAssertion)
+        {
+            assertions.Push(assertion);
+            assertedCallee = assertion.Operand;
+        }
+
+        if (assertedCallee is BoundNullConditionalAccessExpression assertedNullConditional)
+        {
+            nullConditionalCallee = assertedNullConditional;
+            callee = assertedNullConditional.WhenNotNull;
+            while (assertions.TryPop(out var assertion))
+            {
+                var assertionOperator = BoundUnaryOperator.Bind(SyntaxKind.BangBangToken, callee.Type);
+                callee = new BoundUnaryExpression(
+                    assertion.Syntax,
+                    assertionOperator,
+                    callee,
+                    assertion.IsChecked);
+            }
+        }
+
         // The verbatim source spelling of the callee (`(value)`, `handler!!`, ...)
         // used in diagnostics — SyntaxNode.ToString() pretty-prints the whole tree.
         var calleeName = syntax.Callee.SyntaxTree.Text.ToString(syntax.Callee.Span);
+
+        BoundExpression CompleteInvocation(BoundExpression invocation) =>
+            nullConditionalCallee == null
+                ? invocation
+                : BuildNullConditionalDelegateResult(
+                    syntax,
+                    nullConditionalCallee.Receiver,
+                    nullConditionalCallee.Capture,
+                    invocation,
+                    invocation.Type);
 
         // Named args have no meaning without preserved parameter names.
         if (!TryAnalyzeCallArgumentLayout(syntax.Arguments, out _, out var argumentNames))
@@ -746,7 +781,7 @@ internal sealed partial class OverloadResolver
                 return new BoundErrorExpression(null);
             }
 
-            return new BoundIndirectCallExpression(syntax, callee, fnType, convertedArgs);
+            return CompleteInvocation(new BoundIndirectCallExpression(syntax, callee, fnType, convertedArgs));
         }
 
         if (callee.Type is DelegateTypeSymbol delegateSym)
@@ -762,12 +797,12 @@ internal sealed partial class OverloadResolver
                 return new BoundErrorExpression(null);
             }
 
-            return new BoundIndirectCallExpression(
+            return CompleteInvocation(new BoundIndirectCallExpression(
                 syntax,
                 callee,
                 delegateSym.EquivalentFunctionType,
                 convertedDelegateArgs,
-                delegateRefKinds);
+                delegateRefKinds));
         }
 
         // A value whose CLR type is a delegate (e.g. `Func[int32, int32]`) is
@@ -776,7 +811,7 @@ internal sealed partial class OverloadResolver
         {
             if (tryBindInheritedClrInstanceCall(callee, calleeClrType, "Invoke", boundArguments.ToImmutable(), syntax, out var invokeCall, null, default, argumentNames))
             {
-                return invokeCall;
+                return CompleteInvocation(invokeCall);
             }
         }
 

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.Creation.cs
@@ -583,7 +583,7 @@ public partial class Parser
         return false;
     }
 
-    private ExpressionSyntax ParseNameOrCallExpression()
+    private ExpressionSyntax ParseNameOrCallExpression(bool stopBeforeIndirectInvocation = false)
     {
         ExpressionSyntax current;
         if (Current.Kind == SyntaxKind.IdentifierToken
@@ -656,7 +656,7 @@ public partial class Parser
             current = ParseNameExpression();
         }
 
-        return ParsePostfixChain(current);
+        return ParsePostfixChain(current, stopBeforeIndirectInvocation);
     }
 
     // Phase 4.1 / ADR-0020: bounded-lookahead disambiguation between

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.cs
@@ -688,13 +688,13 @@ public partial class Parser
     // iterative, but an index argument re-enters the full expression grammar
     // (`a[a[a[…`), so the chain participates in the recursion cycle and ticks
     // the guard while an index (or accessor) argument parse is in flight.
-    private ExpressionSyntax ParsePostfixChain(ExpressionSyntax current)
+    private ExpressionSyntax ParsePostfixChain(ExpressionSyntax current, bool stopBeforeIndirectInvocation = false)
     {
         EnsureNestedParseAllowed();
         recursionDepth++;
         try
         {
-            return ParsePostfixChainCore(current);
+            return ParsePostfixChainCore(current, stopBeforeIndirectInvocation);
         }
         finally
         {
@@ -702,11 +702,30 @@ public partial class Parser
         }
     }
 
-    private ExpressionSyntax ParsePostfixChainCore(ExpressionSyntax current)
+    private ExpressionSyntax ParsePostfixChainCore(ExpressionSyntax current, bool stopBeforeIndirectInvocation)
     {
         while (true)
         {
-            if (Current.Kind == SyntaxKind.DotToken || Current.Kind == SyntaxKind.QuestionDotToken)
+            if (IsTupleElementSelectorToken(Current, includesDot: true))
+            {
+                // Issue #2924: the lexer keeps `.5` as a leading-dot float
+                // token. In postfix position the same token spells a zero-based
+                // tuple selector, so split it into the existing accessor shape.
+                var selectorToken = NextToken();
+                var dotToken = new SyntaxToken(syntaxTree, SyntaxKind.DotToken, selectorToken.Position, ".", null);
+                var identifierToken = new SyntaxToken(
+                    syntaxTree,
+                    SyntaxKind.IdentifierToken,
+                    selectorToken.Position + 1,
+                    selectorToken.Text.Substring(1),
+                    null);
+                current = new AccessorExpressionSyntax(
+                    syntaxTree,
+                    current,
+                    dotToken,
+                    new NameExpressionSyntax(syntaxTree, identifierToken));
+            }
+            else if (Current.Kind == SyntaxKind.DotToken || Current.Kind == SyntaxKind.QuestionDotToken)
             {
                 var dotToken = NextToken();
 
@@ -732,7 +751,7 @@ public partial class Parser
                 {
                     var rightSide = dotToken.Kind == SyntaxKind.QuestionDotToken
                         ? ParseNullConditionalContinuation()
-                        : ParseNameOrCallExpression();
+                        : ParseMemberContinuation();
                     current = new AccessorExpressionSyntax(syntaxTree, current, dotToken, rightSide);
                 }
             }
@@ -776,6 +795,11 @@ public partial class Parser
             else if (Current.Kind == SyntaxKind.OpenParenthesisToken
                 && !IsCurrentOnNewLineAfter(current))
             {
+                if (stopBeforeIndirectInvocation)
+                {
+                    break;
+                }
+
                 // Issue #2185: a same-line `(args)` following an arbitrary
                 // postfix expression is an *indirect* invocation of that
                 // expression's (function-typed) value — e.g. `(h)(value)`,
@@ -822,7 +846,7 @@ public partial class Parser
 
     private ExpressionSyntax ParseNullConditionalContinuation()
     {
-        var continuation = ParseNameOrCallExpression();
+        var continuation = ParseMemberContinuation();
         while (Current.Kind == SyntaxKind.BangBangToken)
         {
             var bangBangToken = NextToken();
@@ -831,6 +855,46 @@ public partial class Parser
         }
 
         return continuation;
+    }
+
+    private ExpressionSyntax ParseMemberContinuation()
+    {
+        if (!IsTupleElementSelectorToken(Current, includesDot: false))
+        {
+            return ParseNameOrCallExpression(stopBeforeIndirectInvocation: true);
+        }
+
+        var selectorToken = NextToken();
+        var identifierToken = new SyntaxToken(
+            syntaxTree,
+            SyntaxKind.IdentifierToken,
+            selectorToken.Position,
+            selectorToken.Text,
+            null);
+        return new NameExpressionSyntax(syntaxTree, identifierToken);
+    }
+
+    private static bool IsTupleElementSelectorToken(SyntaxToken token, bool includesDot)
+    {
+        var text = token.Text;
+        var digitStart = includesDot ? 1 : 0;
+        if (token.Kind != SyntaxKind.NumberToken
+            || string.IsNullOrEmpty(text)
+            || text.Length <= digitStart
+            || (includesDot ? text[0] != '.' : text[0] == '.'))
+        {
+            return false;
+        }
+
+        for (var i = digitStart; i < text.Length; i++)
+        {
+            if (text[i] < '0' || text[i] > '9')
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     // Issue #1016: parse the argument of an index expression, allowing a

--- a/src/Core/CodeAnalysis/Syntax/Parser.Expressions.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Expressions.cs
@@ -763,7 +763,7 @@ public partial class Parser
                 // emitter reuse the existing `(*p).field` / `(*p).method(...)`
                 // bound shape without any new bound-node kinds.
                 var arrowToken = NextToken();
-                var rightSide = ParseNameOrCallExpression();
+                var rightSide = ParseNameOrCallExpression(stopBeforeIndirectInvocation: true);
                 var starToken = new SyntaxToken(syntaxTree, SyntaxKind.StarToken, arrowToken.Position, "*", null);
                 var deref = new UnaryExpressionSyntax(syntaxTree, starToken, current);
                 current = new AccessorExpressionSyntax(syntaxTree, deref, arrowToken, rightSide);
@@ -851,7 +851,7 @@ public partial class Parser
         {
             var bangBangToken = NextToken();
             continuation = new UnaryExpressionSyntax(syntaxTree, bangBangToken, continuation);
-            continuation = ParsePostfixChain(continuation);
+            continuation = ParsePostfixChain(continuation, stopBeforeIndirectInvocation: true);
         }
 
         return continuation;
@@ -880,7 +880,6 @@ public partial class Parser
         var digitStart = includesDot ? 1 : 0;
         if (token.Kind != SyntaxKind.NumberToken
             || string.IsNullOrEmpty(text)
-            || text.Length <= digitStart
             || (includesDot ? text[0] != '.' : text[0] == '.'))
         {
             return false;

--- a/test/Compiler.Tests/Emit/Issue2924TupleElementDelegateCallTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2924TupleElementDelegateCallTests.cs
@@ -1,0 +1,290 @@
+// <copyright file="Issue2924TupleElementDelegateCallTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2924: numeric tuple-element values must survive parsing and invoke
+/// through the same delegate/function paths as ItemN element access.
+/// </summary>
+public class Issue2924TupleElementDelegateCallTests
+{
+    [Fact]
+    public void TupleElementCallShapes_EmitVerifyLoadAndRun()
+    {
+        const string Source = """
+            package Issue2924Runtime
+            import System
+
+            data struct Holder(Value (System.Action[int32], int32))
+
+            class Factory {
+                func Make() (int32) -> int32 {
+                    return (value int32) -> value + 2
+                }
+            }
+
+            func MakeTuple(handler System.Action[int32]) (System.Action[int32], int32) {
+                return (handler, 0)
+            }
+
+            func Call(handler System.Action[int32], value int32) {
+                handler(value)
+            }
+
+            let handler System.Action[int32] = (value int32) -> Console.WriteLine("call:{0}", value)
+            let t = (handler, 0)
+            let copied System.Action[int32] = t.0
+            copied(1)
+            t.0(2)
+            Call(t.0, 9)
+
+            let higher = (0, handler)
+            higher.1(3)
+
+            let increment (int32) -> int32 = (value int32) -> value + 1
+            let functions = (increment, 0)
+            let answer = functions.0(41)
+            Console.WriteLine(answer)
+
+            let nested = ((0, increment), 0)
+            Console.WriteLine(nested.0.1(40))
+
+            let wide = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            Console.WriteLine(wide.10)
+
+            MakeTuple(handler).0(4)
+            let holder = Holder((handler, 0))
+            holder.Value.0(5)
+            t.0.Invoke(6)
+
+            t.Item1(7)
+            let itemName System.Action[int32] = t.Item1
+            itemName(8)
+
+            let factory = Factory()
+            Console.WriteLine(factory.Make()(40))
+            Console.WriteLine(.5 + .25)
+            """;
+
+        var output = CompileVerifyLoadAndRun(Source);
+
+        Assert.Equal(
+            "call:1\ncall:2\ncall:9\ncall:3\n42\n41\n10\ncall:4\ncall:5\ncall:6\ncall:7\ncall:8\n42\n0.75\n",
+            output);
+    }
+
+    [Fact]
+    public void ExistingItemNameIndirectCallAndFloatSyntax_RemainSupported()
+    {
+        const string Source = """
+            package Issue2924Guards
+            import System
+
+            let handler System.Action[int32] = (value int32) -> Console.WriteLine("call:{0}", value)
+            let t = (handler, 0)
+            t.Item1(1)
+
+            let increment (int32) -> int32 = (value int32) -> value + 1
+            Console.WriteLine((increment)(41))
+            Console.WriteLine(.5 + .25)
+            """;
+
+        var output = CompileVerifyLoadAndRun(Source);
+
+        Assert.Equal("call:1\n42\n0.75\n", output);
+    }
+
+    [Fact]
+    public void NonCallableTupleElement_ReportsNotAFunction()
+    {
+        var result = Compile("""
+            package Issue2924NotCallable
+            let t = (41, 0)
+            t.0(1)
+            """);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("GS0131", result.Diagnostics);
+    }
+
+    [Fact]
+    public void OutOfRangeNumericSelector_ReportsMissingMember()
+    {
+        var result = Compile("""
+            package Issue2924OutOfRange
+            let t = (41, 0)
+            let value = t.2
+            """);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("GS0158", result.Diagnostics);
+    }
+
+    [Fact]
+    public void NilTupleElementDelegate_ThrowsWhenInvoked()
+    {
+        const string Source = """
+            package Issue2924Nil
+            import System
+
+            let handler System.Action[int32] = default(System.Action[int32])
+            let t = (handler, 0)
+            t.0(1)
+            """;
+
+        var assembly = CompileAndLoad(Source, out var outputPath);
+        try
+        {
+            var entry = GetEntryPoint(assembly);
+            var exception = Assert.Throws<TargetInvocationException>(() => InvokeEntryPoint(entry));
+            Assert.IsType<NullReferenceException>(exception.InnerException);
+        }
+        finally
+        {
+            DeleteOutputDirectory(outputPath);
+        }
+    }
+
+    private static string CompileVerifyLoadAndRun(string source)
+    {
+        var assembly = CompileAndLoad(source, out var outputPath);
+        try
+        {
+            var entry = GetEntryPoint(assembly);
+            var previousOut = Console.Out;
+            using var output = new StringWriter();
+            Console.SetOut(output);
+            try
+            {
+                InvokeEntryPoint(entry);
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+            }
+
+            return output.ToString().Replace("\r\n", "\n");
+        }
+        finally
+        {
+            DeleteOutputDirectory(outputPath);
+        }
+    }
+
+    private static Assembly CompileAndLoad(string source, out string outputPath)
+    {
+        var outputDirectory = Directory.CreateTempSubdirectory("gsharp_issue2924_").FullName;
+        var sourcePath = Path.Combine(outputDirectory, "Program.gs");
+        outputPath = Path.Combine(outputDirectory, $"Issue2924_{Guid.NewGuid():N}.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var standardOut = new StringWriter();
+        using var standardError = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(standardOut);
+        Console.SetError(standardError);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(
+            exitCode == 0,
+            $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
+        IlVerifier.Verify(outputPath);
+        var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+        _ = assembly.GetTypes();
+        return assembly;
+    }
+
+    private static MethodInfo GetEntryPoint(Assembly assembly)
+    {
+        var programType = assembly.GetTypes().Single(type => type.Name == "<Program>");
+        return Assert.IsAssignableFrom<MethodInfo>(programType.GetMethod(
+            "<Main>$",
+            BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic));
+    }
+
+    private static void InvokeEntryPoint(MethodInfo entryPoint)
+    {
+        entryPoint.Invoke(
+            null,
+            entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+    }
+
+    private static (int ExitCode, string Diagnostics) Compile(string source)
+    {
+        var outputDirectory = Directory.CreateTempSubdirectory("gsharp_issue2924_diag_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(outputDirectory, "Program.gs");
+            var outputPath = Path.Combine(outputDirectory, "Program.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var standardOut = new StringWriter();
+            using var standardError = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(standardOut);
+            Console.SetError(standardError);
+            try
+            {
+                var exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+                return (exitCode, standardOut.ToString() + standardError.ToString());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static void DeleteOutputDirectory(string outputPath)
+    {
+        try
+        {
+            Directory.Delete(Path.GetDirectoryName(outputPath)!, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2924TupleElementDelegateCallTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2924TupleElementDelegateCallTests.cs
@@ -134,11 +134,20 @@ public class Issue2924TupleElementDelegateCallTests
                 }
             }
 
+            var receiverEvaluations int32
+
+            func Next(value Guard) Guard {
+                receiverEvaluations += 1
+                return value
+            }
+
             let live = Guard()
             Console.WriteLine(live?.Make(40)(2))
             Console.WriteLine(live?.MakeNamed(40)(2))
             Console.WriteLine(live?.Make(40)!!(2))
             Console.WriteLine(live?.Make(40)!!!!(2))
+            Console.WriteLine(Next(live)?.Make(40)(2))
+            Console.WriteLine(receiverEvaluations)
 
             let g Guard = nil
             g?.Plain(1)
@@ -153,6 +162,8 @@ public class Issue2924TupleElementDelegateCallTests
             Console.WriteLine("B repeated assertion ok")
             g?.Get().0(1)
             Console.WriteLine("C ok")
+            Next(g)?.Get().0(1)
+            Console.WriteLine(receiverEvaluations)
 
             let t (System.Action[int32], int32)? = nil
             t?.0(1)
@@ -164,7 +175,7 @@ public class Issue2924TupleElementDelegateCallTests
 
         var output = CompileVerifyLoadAndRun(Source);
 
-        Assert.Equal("42\n42\n42\n42\nA ok\nB ok\nB named ok\nB asserted ok\nB repeated assertion ok\nC ok\nD ok\nE ok\n", output);
+        Assert.Equal("42\n42\n42\n42\n42\n1\nA ok\nB ok\nB named ok\nB asserted ok\nB repeated assertion ok\nC ok\n2\nD ok\nE ok\n", output);
     }
 
     [Fact]

--- a/test/Compiler.Tests/Emit/Issue2924TupleElementDelegateCallTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2924TupleElementDelegateCallTests.cs
@@ -103,6 +103,92 @@ public class Issue2924TupleElementDelegateCallTests
     }
 
     [Fact]
+    public void NullConditionalLiftedCalls_ShortCircuitAndInvoke()
+    {
+        const string Source = """
+            package Issue2924NullConditional
+            import System
+
+            type Mapper = delegate func(value int32) int32
+
+            class Guard {
+                func Plain(value int32) {
+                    Console.WriteLine("plain:{0}", value)
+                }
+
+                func Make(seed int32) (int32) -> int32 {
+                    return (value int32) -> seed + value
+                }
+
+                func MakeNamed(seed int32) Mapper {
+                    return (value int32) -> seed + value
+                }
+
+                func Get() (System.Action[int32], int32) {
+                    let handler System.Action[int32] = (value int32) -> Console.WriteLine("tuple:{0}", value)
+                    return (handler, 0)
+                }
+
+                func Arr() []int32 {
+                    return []int32{41}
+                }
+            }
+
+            let live = Guard()
+            Console.WriteLine(live?.Make(40)(2))
+            Console.WriteLine(live?.MakeNamed(40)(2))
+            Console.WriteLine(live?.Make(40)!!(2))
+            Console.WriteLine(live?.Make(40)!!!!(2))
+
+            let g Guard = nil
+            g?.Plain(1)
+            Console.WriteLine("A ok")
+            g?.Make(40)(2)
+            Console.WriteLine("B ok")
+            g?.MakeNamed(40)(2)
+            Console.WriteLine("B named ok")
+            g?.Make(40)!!(2)
+            Console.WriteLine("B asserted ok")
+            g?.Make(40)!!!!(2)
+            Console.WriteLine("B repeated assertion ok")
+            g?.Get().0(1)
+            Console.WriteLine("C ok")
+
+            let t (System.Action[int32], int32)? = nil
+            t?.0(1)
+            Console.WriteLine("D ok")
+
+            let ignored = g?.Arr()[0]
+            Console.WriteLine("E ok")
+            """;
+
+        var output = CompileVerifyLoadAndRun(Source);
+
+        Assert.Equal("42\n42\n42\n42\nA ok\nB ok\nB named ok\nB asserted ok\nB repeated assertion ok\nC ok\nD ok\nE ok\n", output);
+    }
+
+    [Fact]
+    public void NumericSelectorAssignments_WriteTupleElement()
+    {
+        const string Source = """
+            package Issue2924Assignments
+            import System
+
+            var assigned = (1, 2)
+            assigned.0 = 5
+            Console.WriteLine(assigned.0)
+
+            var compounded = (1, 2)
+            compounded.0 += 6
+            Console.WriteLine(compounded.0)
+            """;
+
+        var output = CompileVerifyLoadAndRun(Source);
+
+        Assert.Equal("5\n7\n", output);
+    }
+
+    [Fact]
     public void NonCallableTupleElement_ReportsNotAFunction()
     {
         var result = Compile("""

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2924TupleElementDelegateCallTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2924TupleElementDelegateCallTests.cs
@@ -115,6 +115,123 @@ public class Issue2924TupleElementDelegateCallTests
     }
 
     [Fact]
+    public void PointerMemberCurriedCall_ParsesAsReceiverWideIndirectCall()
+    {
+        var tree = SyntaxTree.Parse("""
+            package P
+            q[0]->m(x)(y)
+            """);
+
+        Assert.Empty(tree.Diagnostics);
+        var call = Walk(tree.Root)
+            .OfType<CallExpressionSyntax>()
+            .Single(expression => expression.Callee != null);
+        Assert.Equal("q[0]->m(x)", tree.Text.ToString(call.Callee.Span));
+    }
+
+    [Fact]
+    public void NullConditionalAssertedCurriedCall_ParsesAsReceiverWideIndirectCall()
+    {
+        var tree = SyntaxTree.Parse("""
+            package P
+            a?.b!!(x)(y)
+            """);
+
+        Assert.Empty(tree.Diagnostics);
+        var calls = Walk(tree.Root)
+            .OfType<CallExpressionSyntax>()
+            .Where(expression => expression.Callee != null)
+            .OrderBy(expression => expression.Span.Length)
+            .ToArray();
+        Assert.Equal(2, calls.Length);
+        Assert.Equal("a?.b!!", tree.Text.ToString(calls[0].Callee.Span));
+        Assert.Equal("a?.b!!(x)", tree.Text.ToString(calls[1].Callee.Span));
+    }
+
+    [Fact]
+    public void NullConditionalCurriedMemberCall_ShortCircuitsNilReceiver()
+    {
+        var result = Evaluate("""
+            class Factory {
+                func Make(seed int32) (int32) -> int32 {
+                    return (value int32) -> seed + value
+                }
+            }
+            let factory Factory = nil
+            factory?.Make(40)(2)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.Value);
+    }
+
+    [Fact]
+    public void NullConditionalCurriedMemberCall_InvokesNonNilReceiver()
+    {
+        var result = Evaluate("""
+            class Factory {
+                func Make(seed int32) (int32) -> int32 {
+                    return (value int32) -> seed + value
+                }
+            }
+            let factory = Factory()
+            factory?.Make(40)(2)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void NullConditionalNumericSelectorCall_ShortCircuitsNilTuple()
+    {
+        var result = Evaluate("""
+            let t (System.Func[int32, int32], int32)? = nil
+            t?.0(1)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.Value);
+    }
+
+    [Fact]
+    public void NullConditionalAssertedCall_InvokesAndShortCircuits()
+    {
+        var result = Evaluate("""
+            class Factory {
+                func Make(seed int32) (int32) -> int32 {
+                    return (value int32) -> seed + value
+                }
+            }
+            let live = Factory()
+            let answer = live?.Make(40)!!(2)
+            let repeated = live?.Make(40)!!!!(2)
+            let missing Factory = nil
+            missing?.Make(40)!!(2)
+            missing?.Make(40)!!!!(2)
+            answer + repeated
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(84, result.Value);
+    }
+
+    [Fact]
+    public void NumericSelectorAssignments_WriteTupleElement()
+    {
+        var result = Evaluate("""
+            var assigned = (1, 2)
+            assigned.0 = 5
+            var compounded = (1, 2)
+            compounded.0 += 6
+            assigned.0 + compounded.0
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(12, result.Value);
+    }
+
+    [Fact]
     public void NonCallableTupleElement_ReportsNotAFunction()
     {
         var result = Evaluate("""
@@ -169,6 +286,19 @@ public class Issue2924TupleElementDelegateCallTests
 
         Assert.Empty(result.Diagnostics);
         Assert.Equal(5.0, result.Value);
+    }
+
+    [Fact]
+    public void AllDigitLeadingDotAcrossNewline_IsTupleSelector()
+    {
+        var result = Evaluate("""
+            let t = (0, 1, 2, 3, 4, 5)
+            t
+            .5
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2924TupleElementDelegateCallTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2924TupleElementDelegateCallTests.cs
@@ -1,0 +1,205 @@
+// <copyright file="Issue2924TupleElementDelegateCallTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2924: zero-based numeric tuple selectors remain attached to their
+/// receiver and participate in ordinary indirect-call binding.
+/// </summary>
+public class Issue2924TupleElementDelegateCallTests
+{
+    [Fact]
+    public void NumericSelectorCall_ParsesAsIndirectCall()
+    {
+        var tree = SyntaxTree.Parse("""
+            package P
+            let handler (int32) -> int32 = (value int32) -> value + 1
+            let t = (handler, 0)
+            t.0(1)
+            """);
+
+        Assert.Empty(tree.Diagnostics);
+        var call = Walk(tree.Root)
+            .OfType<CallExpressionSyntax>()
+            .Single(expression => expression.Callee != null);
+        var accessor = Assert.IsType<AccessorExpressionSyntax>(call.Callee);
+        Assert.Equal("t", Assert.IsType<NameExpressionSyntax>(accessor.LeftPart).IdentifierToken.Text);
+        Assert.Equal("0", Assert.IsType<NameExpressionSyntax>(accessor.RightPart).IdentifierToken.Text);
+    }
+
+    [Fact]
+    public void NumericSelectors_ReadHigherAndNestedElements()
+    {
+        var result = Evaluate("""
+            let t = ((10, 20), 30)
+            t.0.1
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(20, result.Value);
+    }
+
+    [Fact]
+    public void NullConditionalNumericSelector_ReadsElement()
+    {
+        var result = Evaluate("""
+            let t (int32, int32)? = (41, 0)
+            t?.0
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(41, result.Value);
+    }
+
+    [Fact]
+    public void SeparatedDotNumericSelector_ReadsElement()
+    {
+        var result = Evaluate("""
+            let t = (41, 0)
+            t. 0
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(41, result.Value);
+    }
+
+    [Fact]
+    public void NestedMemberTupleSelectorCall_ParsesAsReceiverWideIndirectCall()
+    {
+        var tree = SyntaxTree.Parse("""
+            package P
+            import System
+            data struct Holder(Value (System.Action[int32], int32))
+            let handler System.Action[int32] = (value int32) -> Console.WriteLine(value)
+            let holder = Holder((handler, 0))
+            holder.Value.0(1)
+            """);
+
+        Assert.Empty(tree.Diagnostics);
+        var call = Walk(tree.Root)
+            .OfType<CallExpressionSyntax>()
+            .Single(expression => expression.Callee != null);
+        Assert.Equal("holder.Value.0", tree.Text.ToString(call.Callee.Span));
+    }
+
+    [Fact]
+    public void CurriedMemberCall_ParsesAsReceiverWideIndirectCall()
+    {
+        var tree = SyntaxTree.Parse("""
+            package P
+            class Factory {
+                func Make() (int32) -> int32 {
+                    return (value int32) -> value + 1
+                }
+            }
+            let factory = Factory()
+            factory.Make()(41)
+            """);
+
+        Assert.Empty(tree.Diagnostics);
+        var call = Walk(tree.Root)
+            .OfType<CallExpressionSyntax>()
+            .Single(expression => expression.Callee != null);
+        Assert.Equal("factory.Make()", tree.Text.ToString(call.Callee.Span));
+    }
+
+    [Fact]
+    public void NonCallableTupleElement_ReportsNotAFunction()
+    {
+        var result = Evaluate("""
+            let t = (41, 0)
+            t.0(1)
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.IsError && diagnostic.Id == "GS0131");
+    }
+
+    [Fact]
+    public void ItemNameSelector_RemainsSupported()
+    {
+        var result = Evaluate("""
+            let t = (41, 0)
+            t.Item1
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(41, result.Value);
+    }
+
+    [Fact]
+    public void ParenthesizedIndirectCall_RemainsSupported()
+    {
+        var result = Evaluate("""
+            let increment (int32) -> int32 = (value int32) -> value + 1
+            (increment)(41)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void LeadingDotFloat_RemainsLiteralInPrimaryPosition()
+    {
+        var result = Evaluate(".5 + .25");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0.75, result.Value);
+    }
+
+    [Fact]
+    public void ExponentFloatAfterExpression_RemainsSeparateLiteral()
+    {
+        var result = Evaluate("""
+            let t = (41, 0)
+            t
+            .5e1
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5.0, result.Value);
+    }
+
+    [Fact]
+    public void IntegerAfterExpression_RemainsSeparateLiteral()
+    {
+        var result = Evaluate("""
+            let t = (41, 0)
+            t
+            10
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(10, result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+
+    private static IEnumerable<SyntaxNode> Walk(SyntaxNode node)
+    {
+        yield return node;
+        foreach (var child in node.GetChildren().OfType<SyntaxNode>())
+        {
+            foreach (var descendant in Walk(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2924TupleElementDelegateCallTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2924TupleElementDelegateCallTests.cs
@@ -94,24 +94,25 @@ public class Issue2924TupleElementDelegateCallTests
     }
 
     [Fact]
-    public void CurriedMemberCall_ParsesAsReceiverWideIndirectCall()
+    public void CurriedMemberCallShapes_ParseAsReceiverWideIndirectCalls()
     {
-        var tree = SyntaxTree.Parse("""
-            package P
-            class Factory {
-                func Make() (int32) -> int32 {
-                    return (value int32) -> value + 1
-                }
-            }
-            let factory = Factory()
-            factory.Make()(41)
-            """);
+        var shapes = new[]
+        {
+            ("factory.Make(40)(2)", "factory.Make(40)"),
+            ("factory.Make[int32](40)(2)", "factory.Make[int32](40)"),
+            ("factory.Make(40)[0](2)", "factory.Make(40)[0]"),
+            ("factory.Make(40)(2)(3)", "factory.Make(40)(2)"),
+        };
 
-        Assert.Empty(tree.Diagnostics);
-        var call = Walk(tree.Root)
-            .OfType<CallExpressionSyntax>()
-            .Single(expression => expression.Callee != null);
-        Assert.Equal("factory.Make()", tree.Text.ToString(call.Callee.Span));
+        foreach (var (expression, expectedCallee) in shapes)
+        {
+            var tree = SyntaxTree.Parse($"package P\n{expression}");
+            Assert.Empty(tree.Diagnostics);
+            Assert.Contains(
+                Walk(tree.Root).OfType<CallExpressionSyntax>(),
+                call => call.Callee != null
+                    && tree.Text.ToString(call.Callee.Span) == expectedCallee);
+        }
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2924TupleElementDelegateCallTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2924TupleElementDelegateCallTests.cs
@@ -233,6 +233,18 @@ public class Issue2924TupleElementDelegateCallTests
     }
 
     [Fact]
+    public void MissingTupleSelector_ReportsCleanDiagnostic()
+    {
+        var result = Evaluate("""
+            var t = (1, 2)
+            t. = 5
+            """);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0158");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "GS9998");
+    }
+
+    [Fact]
     public void NonCallableTupleElement_ReportsNotAFunction()
     {
         var result = Evaluate("""

--- a/test/Interpreter.Tests/Issue2924TupleElementDelegateCallTests.cs
+++ b/test/Interpreter.Tests/Issue2924TupleElementDelegateCallTests.cs
@@ -1,0 +1,167 @@
+// <copyright file="Issue2924TupleElementDelegateCallTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Interpreter parity for issue #2924's shared numeric tuple-selector syntax
+/// and binding behavior.
+/// </summary>
+public class Issue2924TupleElementDelegateCallTests
+{
+    [Fact]
+    public void NumericSelectors_ReadHigherAndNestedElements()
+    {
+        var output = RunSubmission("""
+            let t = ((10, 20), 30)
+            let selected = t.0.1
+            Console.WriteLine(selected)
+            """);
+
+        Assert.Equal("20\n", output);
+    }
+
+    [Fact]
+    public void NullConditionalNumericSelector_ReadsElement()
+    {
+        var output = RunSubmission("""
+            let t (int32, int32)? = (41, 0)
+            let selected = t?.0
+            Console.WriteLine(selected)
+            """);
+
+        Assert.Equal("41\n", output);
+    }
+
+    [Fact]
+    public void NumericSelectorValue_FlowsThroughAssignmentAndArgument()
+    {
+        var output = RunSubmission("""
+            func Show(value int32) {
+                Console.WriteLine(value)
+            }
+            let t = (41, 0)
+            let selected int32 = t.0
+            Show(t.0)
+            """);
+
+        Assert.Equal("41\n", output);
+    }
+
+    [Fact]
+    public void FunctionReturnedTuple_NumericSelectorReadsElement()
+    {
+        var output = RunSubmission("""
+            func Make() (int32, int32) {
+                return (41, 0)
+            }
+            Console.WriteLine(Make().0)
+            """);
+
+        Assert.Equal("41\n", output);
+    }
+
+    [Fact]
+    public void StructTupleField_NumericSelectorReadsElement()
+    {
+        var output = RunSubmission("""
+            data struct Holder(Value (int32, int32))
+            let holder = Holder((41, 0))
+            Console.WriteLine(holder.Value.0)
+            """);
+
+        Assert.Equal("41\n", output);
+    }
+
+    [Fact]
+    public void CurriedMemberCall_InvokesReceiverWideCallee()
+    {
+        var output = RunSubmission("""
+            class Factory {
+                func Make() (int32) -> int32 {
+                    return (value int32) -> value + 1
+                }
+            }
+            let factory = Factory()
+            Console.WriteLine(factory.Make()(41))
+            """);
+
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void NonCallableTupleElement_ReportsNotAFunction()
+    {
+        var output = RunSubmission("""
+            let t = (41, 0)
+            t.0(1)
+            """);
+
+        Assert.Contains("GS0131", output);
+    }
+
+    [Fact]
+    public void NilTupleElementDelegate_ReportsRuntimeFailure()
+    {
+        var output = RunSubmission("""
+            let handler System.Action[int32] = default(System.Action[int32])
+            let t = (handler, 0)
+            t.0(1)
+            """);
+
+        Assert.Contains("error GS", output);
+    }
+
+    [Fact]
+    public void OutOfRangeNumericSelector_ReportsMissingMember()
+    {
+        var output = RunSubmission("""
+            let t = (41, 0)
+            t.2
+            """);
+
+        Assert.Contains("GS0158", output);
+    }
+
+    [Fact]
+    public void ItemNameSelector_RemainsSupported()
+    {
+        var output = RunSubmission("""
+            let t = (41, 0)
+            Console.WriteLine(t.Item1)
+            """);
+
+        Assert.Equal("41\n", output);
+    }
+
+    [Fact]
+    public void LeadingDotFloat_RemainsLiteralInPrimaryPosition()
+    {
+        var output = RunSubmission("Console.WriteLine(.5 + .25)");
+
+        Assert.Equal("0.75\n", output);
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var output = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return output.ToString().Replace("\r\n", "\n");
+    }
+}

--- a/test/Interpreter.Tests/Issue2924TupleElementDelegateCallTests.cs
+++ b/test/Interpreter.Tests/Issue2924TupleElementDelegateCallTests.cs
@@ -95,6 +95,88 @@ public class Issue2924TupleElementDelegateCallTests
     }
 
     [Fact]
+    public void NullConditionalCurriedMemberCall_InvokesNonNilReceiver()
+    {
+        var output = RunSubmission("""
+            class Factory {
+                func Make(seed int32) (int32) -> int32 {
+                    return (value int32) -> seed + value
+                }
+            }
+            let factory = Factory()
+            Console.WriteLine(factory?.Make(40)(2))
+            """);
+
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void NullConditionalCurriedMemberCall_ShortCircuitsNilReceiver()
+    {
+        var output = RunSubmission("""
+            class Factory {
+                func Make(seed int32) (int32) -> int32 {
+                    return (value int32) -> seed + value
+                }
+            }
+            let factory Factory = nil
+            factory?.Make(40)(2)
+            Console.WriteLine("end")
+            """);
+
+        Assert.Equal("end\n", output);
+    }
+
+    [Fact]
+    public void NullConditionalNumericSelectorCall_ShortCircuitsNilTuple()
+    {
+        var output = RunSubmission("""
+            let t (System.Func[int32, int32], int32)? = nil
+            t?.0(1)
+            Console.WriteLine("end")
+            """);
+
+        Assert.Equal("end\n", output);
+    }
+
+    [Fact]
+    public void NullConditionalAssertedCall_InvokesAndShortCircuits()
+    {
+        var output = RunSubmission("""
+            class Factory {
+                func Make(seed int32) (int32) -> int32 {
+                    return (value int32) -> seed + value
+                }
+            }
+            let live = Factory()
+            Console.WriteLine(live?.Make(40)!!(2))
+            Console.WriteLine(live?.Make(40)!!!!(2))
+            let missing Factory = nil
+            missing?.Make(40)!!(2)
+            missing?.Make(40)!!!!(2)
+            Console.WriteLine("end")
+            """);
+
+        Assert.Equal("42\n42\nend\n", output);
+    }
+
+    [Fact]
+    public void NumericSelectorAssignments_WriteTupleElement()
+    {
+        var output = RunSubmission("""
+            var assigned = (1, 2)
+            assigned.0 = 5
+            Console.WriteLine(assigned.0)
+
+            var compounded = (1, 2)
+            compounded.0 += 6
+            Console.WriteLine(compounded.0)
+            """);
+
+        Assert.Equal("5\n7\n", output);
+    }
+
+    [Fact]
     public void NonCallableTupleElement_ReportsNotAFunction()
     {
         var output = RunSubmission("""
@@ -114,7 +196,7 @@ public class Issue2924TupleElementDelegateCallTests
             t.0(1)
             """);
 
-        Assert.Contains("error GS", output);
+        Assert.Contains("Non-static method requires a target.", output);
     }
 
     [Fact]

--- a/test/Interpreter.Tests/Issue2924TupleElementDelegateCallTests.cs
+++ b/test/Interpreter.Tests/Issue2924TupleElementDelegateCallTests.cs
@@ -95,6 +95,17 @@ public class Issue2924TupleElementDelegateCallTests
     }
 
     [Fact]
+    public void TupleHeldFunction_NumericSelectorInvokesCallable()
+    {
+        var output = RunSubmission("""
+            let functions = ((value int32) -> value + 1, 0)
+            Console.WriteLine(functions.0(41))
+            """);
+
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
     public void NullConditionalCurriedMemberCall_InvokesNonNilReceiver()
     {
         var output = RunSubmission("""


### PR DESCRIPTION
## Root cause

The lexer tokenizes `.0`, `.1`, etc. as leading-dot `NumberToken`s. Postfix parsing did not contextualize those tokens as member selectors, and member continuations greedily consumed following indirect invocations into the accessor's right-hand side. Therefore `t.0(1)` never became a call whose callee was the full `t.0` accessor; on `main` it was accepted as separate expressions and silently dropped. Tuple member binding also recognized only `Item1`…`ItemN`.

Review exposed two adjacent gaps. Lifted calls escaped `BoundNullConditionalAccessExpression`, so their arguments and invocation executed outside the nil guard. Assignment binding also had independent member lookup, so numeric selectors worked for reads but not writes.

## Fix

- Contextually split digits-only leading-dot number tokens in postfix position into the existing accessor syntax shape, preserving source spelling and exact spans.
- Accept zero-based numeric continuations after `.` and `?.`, while preserving one-based `ItemN` access.
- Stop member continuations before indirect invocation so the full receiver becomes the callee. This also fixes #2944, the independent curried-member-call `GS0159` bug.
- Apply the same reshape to pointer-arrow and null-assertion continuations.
- When an indirect callee is null-conditional, bind against `WhenNotNull` and rebuild the null-conditional result around the completed invocation. Arguments and invocation now remain inside the nil guard for structural functions, named delegates, and CLR delegates.
- Normalize valid tuple selectors to their CLR `ItemN` field names in both simple and compound assignment lookup.

This is the narrowest complete shape. A lexer change would add state, alter raw token consumers, and still miss spaced `t. 0`. A postfix-core-only change misses nested receivers such as `holder.Value.0(5)` and `factory.Make()(41)`. Lifting without invocation re-rooting breaks `?.`; suppressing the lift reintroduces silent elision. Assignment needs its own two call sites because it intentionally bypasses read lookup, but both use one shared tuple-index helper.

Production diff from latest base `17789519`: 162 insertions, 21 deletions across six files (183 changed lines, net +141).

## Review blocker probes

Compiled with the branch compiler and executed as a real `dotnet <app>.dll` process:

| Probe | Result |
|---|---|
| nil `g?.Plain(1)` | short-circuited; `A ok` printed |
| nil `g?.Make(40)(2)` | short-circuited; `B ok` printed |
| nil `g?.Get().0(1)` | short-circuited; `C ok` printed |
| nil `t?.0(1)` | short-circuited; `D ok` printed |
| nil `g?.Arr()[0]` | unchanged; `E ok` printed |

The compiled non-nil structural, named-delegate, and asserted forms each produced `42`. A side-effecting receiver probe confirms both live and nil lifted calls evaluate the receiver exactly once. Interpreter pins produce `42` for non-nil `g?.Make(40)(2)`, `end` for nil `g?.Make(40)(2)`, `end` for nil `t?.0(1)`, and `42`/`end` for the asserted live/nil pair.

## #2908 rebase composition

Originally rebased across #2908 at `914b42a7`; final rebase targets latest `main` at `17789519` (including requested `f2ecef88` plus #2950). The sole semantic conflict was the shared accessor junction in `ExpressionBinder.Access.MemberLookup.cs`. Its resolution keeps both fixes:

- #2908's `receiverSyntax` parameter on `BindAccessorStep`
- `nested.LeftPart` passed as the receiver syntax for nested accessor calls
- `receiverSyntax` forwarded into `BindAccessorCall`, preserving GS0503 reporting
- this PR's shared tuple-index helpers and numeric tuple read binding

Post-resolution targeted controls pass: B1 Compiler tests **7/7**, #2885 Compiler tests **45/45**, and #2885 Interpreter tests **2/2**. The combined Issue2924 + Issue2885 Compiler run is **52/52** after the latest rebase. Thus guarded lifted calls short-circuit, while nullable CLR-delegate calls without valid narrowing still report GS0503.

Rebase preservation is byte-for-byte at the production patch level: `914b42a7..c6be1ba6` and `17789519..571caa46` are both 347 patch lines with identical sorted `+`/`-` line sets. Including the NIT hardening, old and new production patches are both 354 lines with identical sorted line sets.

## Review findings

- **B1:** fixed by re-rooting completed indirect invocations into null-conditional `WhenNotNull`; live and nil receivers are each evaluated exactly once.
- **S1:** fixed. `t.0 = 5` and independent `t.0 += 6` pins pass compiled and interpreted.
- **S2:** fixed and directly covered after merging #2935. The nil test requires `Non-static method requires a target.`, and a live G# lambda stored in a tuple now executes through `functions.0(41)` and prints `42` in the interpreter.
- **S3:** fixed for pointer-arrow and `?.` + `!!` continuations, with parse pins and asserted-call runtime coverage.
- **#2944 pins:** plain `factory.Make(40)(2)`, generic `factory.Make[int32](40)(2)`, indexing `factory.Make(40)[0](2)`, and longer `factory.Make(40)(2)(3)` chains.

## Pin / guard split

Against `d4038f1d`, one classification per issue test:

| Project | Pins failing on main | Guards passing on main |
|---|---:|---:|
| Core.Tests | 15 | 5 |
| Compiler.Tests | 6 | 1 |
| Interpreter.Tests | 15 | 2 |
| **Total** | **36** | **8** |

All 44 feature tests pass on this branch. A separate missing-selector ICE regression pin also passes.

## Mutation testing

The original audit is corrected to **13/15 killed + 2 equivalent**. Both guards are unreachable from source. The parser guard was deleted; `numericIndex >= 0` was re-added defensively after selector normalization grew to three call sites.

Each review mutation below was applied alone, stayed build-green, had an unmutated same-worktree control immediately before it, and was restored before the next row.

| # | Semantic mutation | Control | Mutant result |
|---:|---|---|---|
| R1 | Disable null-conditional target recognition | Core 20/20 | 4 failed |
| R2 | Disable asserted null-conditional callee re-root | Core 20/20 | 1 failed |
| R2b | Stop after one null assertion | Core 20/20 | 1 failed |
| R3 | Return invocation outside null guard | Core 20/20 | 4 failed |
| R4 | Remove numeric normalization from simple assignment | Core 20/20 | 1 failed |
| R5 | Remove numeric normalization from compound assignment | Core 20/20 | 1 failed |
| R6 | Drop pointer-arrow stop flag | Core 20/20 | 1 failed |
| R7 | Drop null-assertion continuation stop flag | Core 20/20 | 2 failed |
| R8 | Make shared tuple field normalization inert | Core 20/20 | 1 failed |
| R9 | Disable numeric tuple-index resolution | Core 20/20 | 7 failed |
| R10 | Reuse pre-invocation null-conditional result type | Compiler 7/7 | 1 failed |
| R11 | Skip wrapper on structural-function invocation | Core 20/20 | 3 failed |
| R12 | Skip wrapper on named-delegate invocation | Compiler 7/7 | 1 failed |
| R13 | Skip wrapper on CLR-delegate invocation | Compiler 7/7 | 1 failed |

Post-review result: **14/14 reachable semantic mutants killed**.

## Over-fire corpus

Compiled all 148 `samples/**` + `e2etests/**` `.gs` files with separately published `914b42a7` and branch compilers, using identical assembly names/output paths:

- exit status: 148/148 identical
- diagnostics/output: 148/148 byte-identical
- emitted assemblies: 139/139 byte-identical
- failures: 9/9 failed identically

Parser inspection found 7/148 files containing tuple syntax, 0 numeric selectors, and 0 receiver-wide indirect member calls. Corpus signal is therefore strictly non-regression evidence for the global reshape; handwritten tests carry all feature signal.

## Validation

- Release warnings-as-errors solution build: 0 warnings, 0 errors

| Suite | `914b42a7` control | `d901683a` (914-based head) |
|---|---:|---:|
| Core.Tests | 6915 passed, 1 skipped | 6936 passed, 1 skipped |
| Compiler.Tests | 3802 passed | 3809 passed |
| Interpreter.Tests | 470 passed | 487 passed |
| LanguageServer.Tests | 452 passed | 452 passed |
| Extensions.Tests | 104 passed | 104 passed |
| SDK.Tests | 57 passed | 57 passed |

Additional executed baseline at `f2ecef88`: Core.Tests **7007 passed + 1 skipped**; Compiler.Tests **3871 passed**. Latest-head Release warnings-as-errors build passes with 0 warnings/errors; full latest-head results are carried by PR CI.

Compiler runtime tests compile, IlVerify, `Assembly.Load`, call `GetTypes()`, and execute. The five blocker probes were also run as real `dotnet` processes.

## Invocation-binding footprint

`ExpressionBinder.Calls.Invocation.cs` remains untouched. In `OverloadResolver.Invocations.cs`, only:

- `BuildNullConditionalDelegateResult` capture parameter type (local -> variable), and
- `BindIndirectCallExpression` null-conditional target extraction/completion paths

were changed. No other invocation-binding region was modified.

## Separate issues

- #2928 accurately tracked interpreter callable-tuple materialization; merged PR #2935 fixes it, and this branch now includes the combined numeric-selector invocation pin.
- #2944 tracks the independent curried-member-call `GS0159` bug fixed by the parser reshape here.

Fixes #2924
Fixes #2944
