### PR TITLE
Fix interpreter callable materialization

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -600,6 +600,14 @@ public sealed partial class Evaluator
 
             return value;
         }
+        else if (value is Delegate sourceDelegate
+            && node.Type?.ClrType is Type delegateType
+            && typeof(Delegate).IsAssignableFrom(delegateType))
+        {
+            return delegateType.IsInstanceOfType(sourceDelegate)
+                ? sourceDelegate
+                : CreateInterpreterDelegate(delegateType, sourceDelegate.DynamicInvoke);
+        }
         else if (node.Type == TypeSymbol.Object
             || node.Type is InterfaceSymbol
             || (node.Type is StructSymbol upcastTarget && upcastTarget.IsClass)

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -817,9 +817,7 @@ public sealed partial class Evaluator
         {
             if (InterpreterClosures.TryGetValue(target, out var closure))
             {
-                return closure.Function.IsAsync
-                    ? InvokeMaterializedClosure(closure, arguments)
-                    : InvokeClosure(closure, arguments);
+                return InvokeMaterializedClosure(closure, arguments);
             }
 
             return InvokeDelegate(target, arguments);

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -756,7 +756,7 @@ public sealed partial class Evaluator
             captured[v] = LookupVariable(v);
         }
 
-        return new ClosureValue(node.Function, node.Body, node.FunctionType, captured);
+        return MaterializeClosure(new ClosureValue(node.Function, node.Body, node.FunctionType, captured));
     }
 
     private object EvaluateMethodGroupExpression(BoundMethodGroupExpression node)
@@ -775,7 +775,7 @@ public sealed partial class Evaluator
             captured[node.Function.ThisParameter] = EvaluateExpression(node.Receiver);
         }
 
-        return new ClosureValue(node.Function, body, node.FunctionType, captured);
+        return MaterializeClosure(new ClosureValue(node.Function, body, node.FunctionType, captured));
     }
 
     private object EvaluateClrMethodGroupExpression(BoundClrMethodGroupExpression node)
@@ -804,16 +804,77 @@ public sealed partial class Evaluator
             throw new EvaluatorException("Attempted to invoke a nil function.", node);
         }
 
-        var closure = (ClosureValue)targetValue;
+        var arguments = new object[node.Arguments.Length];
+        for (var i = 0; i < node.Arguments.Length; i++)
+        {
+            arguments[i] = EvaluateExpression(node.Arguments[i]);
+        }
+
+        if (targetValue is Delegate target)
+        {
+            return InvokeDelegate(target, arguments);
+        }
+
+        return InvokeClosure((ClosureValue)targetValue, arguments);
+    }
+
+    private object MaterializeClosure(ClosureValue closure)
+    {
+        return closure.FunctionType.ClrType is Type delegateType
+            ? CreateInterpreterDelegate(delegateType, args => InvokeMaterializedClosure(closure, args))
+            : closure;
+    }
+
+    private static Delegate CreateInterpreterDelegate(Type delegateType, Func<object[], object> invoke)
+    {
+        var invokeMethod = delegateType.GetMethod(nameof(Action.Invoke));
+        var parameters = invokeMethod.GetParameters()
+            .Select(parameter => System.Linq.Expressions.Expression.Parameter(parameter.ParameterType, parameter.Name))
+            .ToArray();
+        var arguments = System.Linq.Expressions.Expression.NewArrayInit(
+            typeof(object),
+            parameters.Select(parameter => System.Linq.Expressions.Expression.Convert(parameter, typeof(object))));
+        var invocation = System.Linq.Expressions.Expression.Invoke(
+            System.Linq.Expressions.Expression.Constant(invoke),
+            arguments);
+        System.Linq.Expressions.Expression body = invokeMethod.ReturnType.IsSameAs(typeof(void))
+            ? System.Linq.Expressions.Expression.Block(invocation, System.Linq.Expressions.Expression.Empty())
+            : System.Linq.Expressions.Expression.Convert(invocation, invokeMethod.ReturnType);
+        return System.Linq.Expressions.Expression.Lambda(delegateType, body, parameters).Compile();
+    }
+
+    private static object InvokeDelegate(Delegate target, object[] arguments)
+    {
+        try
+        {
+            return target.DynamicInvoke(arguments);
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException != null)
+        {
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw;
+        }
+    }
+
+    private object InvokeMaterializedClosure(ClosureValue closure, object[] arguments)
+    {
+        var result = InvokeClosure(closure, arguments);
+        return closure.Function.IsAsync
+            ? WrapAsyncResult(closure.Function.Type, result)
+            : result;
+    }
+
+    private object InvokeClosure(ClosureValue closure, object[] arguments)
+    {
         var frame = new ConcurrentDictionary<VariableSymbol, object>();
         foreach (var kv in closure.CapturedLocals)
         {
             frame[kv.Key] = kv.Value;
         }
 
-        for (var i = 0; i < node.Arguments.Length; i++)
+        for (var i = 0; i < arguments.Length; i++)
         {
-            frame[closure.Function.Parameters[i]] = EvaluateExpression(node.Arguments[i]);
+            frame[closure.Function.Parameters[i]] = arguments[i];
         }
 
         using (PushFrame(frame))

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -27,6 +27,9 @@ namespace GSharp.Core.CodeAnalysis;
 public sealed partial class Evaluator
 #pragma warning restore CA1001
 {
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Type, Func<Func<object[], object>, Delegate>> InterpreterDelegateFactories = new();
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Delegate, ClosureValue> InterpreterClosures = new();
+
     private object EvaluateExpression(BoundExpression node)
     {
         try
@@ -812,6 +815,13 @@ public sealed partial class Evaluator
 
         if (targetValue is Delegate target)
         {
+            if (InterpreterClosures.TryGetValue(target, out var closure))
+            {
+                return closure.Function.IsAsync
+                    ? InvokeMaterializedClosure(closure, arguments)
+                    : InvokeClosure(closure, arguments);
+            }
+
             return InvokeDelegate(target, arguments);
         }
 
@@ -820,14 +830,23 @@ public sealed partial class Evaluator
 
     private object MaterializeClosure(ClosureValue closure)
     {
-        return closure.FunctionType.ClrType is Type delegateType
-            ? CreateInterpreterDelegate(delegateType, args => InvokeMaterializedClosure(closure, args))
-            : closure;
+        if (closure.FunctionType.ClrType is not Type delegateType)
+        {
+            return closure;
+        }
+
+        var result = CreateInterpreterDelegate(delegateType, args => InvokeMaterializedClosure(closure, args));
+        InterpreterClosures.Add(result, closure);
+        return result;
     }
 
     private static Delegate CreateInterpreterDelegate(Type delegateType, Func<object[], object> invoke)
+        => InterpreterDelegateFactories.GetValue(delegateType, BuildInterpreterDelegateFactory)(invoke);
+
+    private static Func<Func<object[], object>, Delegate> BuildInterpreterDelegateFactory(Type delegateType)
     {
         var invokeMethod = delegateType.GetMethod(nameof(Action.Invoke));
+        var invokeParameter = System.Linq.Expressions.Expression.Parameter(typeof(Func<object[], object>), "invoke");
         var parameters = invokeMethod.GetParameters()
             .Select(parameter => System.Linq.Expressions.Expression.Parameter(parameter.ParameterType, parameter.Name))
             .ToArray();
@@ -835,12 +854,15 @@ public sealed partial class Evaluator
             typeof(object),
             parameters.Select(parameter => System.Linq.Expressions.Expression.Convert(parameter, typeof(object))));
         var invocation = System.Linq.Expressions.Expression.Invoke(
-            System.Linq.Expressions.Expression.Constant(invoke),
+            invokeParameter,
             arguments);
         System.Linq.Expressions.Expression body = invokeMethod.ReturnType.IsSameAs(typeof(void))
             ? System.Linq.Expressions.Expression.Block(invocation, System.Linq.Expressions.Expression.Empty())
             : System.Linq.Expressions.Expression.Convert(invocation, invokeMethod.ReturnType);
-        return System.Linq.Expressions.Expression.Lambda(delegateType, body, parameters).Compile();
+        var inner = System.Linq.Expressions.Expression.Lambda(delegateType, body, parameters);
+        return System.Linq.Expressions.Expression.Lambda<Func<Func<object[], object>, Delegate>>(
+            inner,
+            invokeParameter).Compile();
     }
 
     private static object InvokeDelegate(Delegate target, object[] arguments)

--- a/test/Compiler.Tests/Emit/Issue2928TupleFunctionParityTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2928TupleFunctionParityTests.cs
@@ -1,0 +1,103 @@
+// <copyright file="Issue2928TupleFunctionParityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2928: tuple-contained function values execute identically through
+/// interpreter and compiled backends.
+/// </summary>
+public class Issue2928TupleFunctionParityTests
+{
+    private const string Source = """
+        package TupleFunctionInterpreter
+        import System
+
+        let handler (int32) -> int32 = (value int32) -> value + 1
+        let t = (handler, 0)
+        Console.WriteLine(t.Item1(41))
+        """;
+
+    [Fact]
+    public void TupleFunction_InterpreterAndCompiledOutputsMatch()
+    {
+        Assert.Equal(CompileAndRun(Source), Interpret(Source));
+    }
+
+    [Fact]
+    public void TupleFunction_CompiledBackendExecutes()
+    {
+        Assert.Equal("42\n", CompileAndRun(Source));
+    }
+
+    [Fact]
+    public void CompileAndRunHarness_PropagatesKnownBadProgram()
+    {
+        const string KnownBadSource = """
+            package TupleFunctionKnownBad
+            import System
+
+            throw InvalidOperationException("known bad")
+            """;
+
+        var exception = Assert.Throws<TargetInvocationException>(() => CompileAndRun(KnownBadSource));
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
+    }
+
+    private static string Interpret(string source)
+    {
+        using var writer = new StringWriter();
+        var previous = Console.Out;
+        Console.SetOut(writer);
+        try
+        {
+            var result = new Compilation(SyntaxTree.Parse(source))
+                .Evaluate(new Dictionary<VariableSymbol, object>());
+            Assert.Empty(result.Diagnostics);
+        }
+        finally
+        {
+            Console.SetOut(previous);
+        }
+
+        return writer.ToString().Replace("\r\n", "\n");
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        using var peStream = new MemoryStream();
+        var result = new Compilation(SyntaxTree.Parse(source)).Emit(peStream);
+        Assert.True(
+            result.Success,
+            string.Join(Environment.NewLine, result.Diagnostics.Select(diagnostic => diagnostic.ToString())));
+
+        var assembly = Assembly.Load(peStream.ToArray());
+        var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
+        using var writer = new StringWriter();
+        var previous = Console.Out;
+        Console.SetOut(writer);
+        try
+        {
+            entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+        }
+        finally
+        {
+            Console.SetOut(previous);
+        }
+
+        return writer.ToString().Replace("\r\n", "\n");
+    }
+}

--- a/test/Interpreter.Tests/Issue2928CallableMaterializationTests.cs
+++ b/test/Interpreter.Tests/Issue2928CallableMaterializationTests.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -156,6 +157,22 @@ public class Issue2928CallableMaterializationTests
     }
 
     [Fact]
+    public void Callable_DelegateFactoryIsReusedPerType()
+    {
+        const string Source = """
+            let first (int32) -> int32 = (value int32) -> value + 1
+            let second (int32) -> int32 = (value int32) -> value + 2
+            (first, second)
+            """;
+
+        var pair = Assert.IsType<ValueTuple<Func<int, int>, Func<int, int>>>(Evaluate(Source));
+
+        Assert.Equal(pair.Item1.Method, pair.Item2.Method);
+        Assert.Equal(2, pair.Item1(1));
+        Assert.Equal(3, pair.Item2(1));
+    }
+
+    [Fact]
     public void Callable_ExceptionStillReachesInterpreterCatch()
     {
         const string Source = """
@@ -175,7 +192,7 @@ public class Issue2928CallableMaterializationTests
     }
 
     [Fact]
-    public void Callable_UncaughtExceptionKeepsOriginalDiagnostic()
+    public void Callable_DirectUncaughtExceptionKeepsOriginalDiagnostic()
     {
         const string Source = """
             import System

--- a/test/Interpreter.Tests/Issue2928CallableMaterializationTests.cs
+++ b/test/Interpreter.Tests/Issue2928CallableMaterializationTests.cs
@@ -157,6 +157,19 @@ public class Issue2928CallableMaterializationTests
     }
 
     [Fact]
+    public void Callable_AsyncDirectInvocation_ReturnsAwaitableTask()
+    {
+        const string Source = """
+            import System.Threading.Tasks
+
+            let handler (int32) -> Task[int32] = async (value int32) -> value + 1
+            await handler(41)
+            """;
+
+        Assert.Equal(42, Evaluate(Source));
+    }
+
+    [Fact]
     public void Callable_DelegateFactoryIsReusedPerType()
     {
         const string Source = """

--- a/test/Interpreter.Tests/Issue2928CallableMaterializationTests.cs
+++ b/test/Interpreter.Tests/Issue2928CallableMaterializationTests.cs
@@ -1,0 +1,203 @@
+// <copyright file="Issue2928CallableMaterializationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2928: interpreter closures must materialize as CLR delegates before
+/// entering CLR tuples, arrays, collections, constructors, and method calls.
+/// </summary>
+public class Issue2928CallableMaterializationTests
+{
+    public static TheoryData<string, string, object> ClrConsumerCases => new()
+    {
+        {
+            "tuple",
+            """
+            let handler (int32) -> int32 = (value int32) -> value + 1
+            let pair = (handler, 0)
+            pair.Item1(41)
+            """,
+            42
+        },
+        {
+            "predicate",
+            """
+            import System.Collections.Generic
+
+            let predicate (int32) -> bool = (value int32) -> value == 41
+            let values = List[int32]{ 41 }
+            values.Exists(predicate)
+            """,
+            true
+        },
+        {
+            "list",
+            """
+            import System.Collections.Generic
+
+            let handler (int32) -> int32 = (value int32) -> value + 1
+            let handlers = List[(int32) -> int32]()
+            handlers.Add(handler)
+            handlers[0](41)
+            """,
+            42
+        },
+        {
+            "array",
+            """
+            let handler (int32) -> int32 = (value int32) -> value + 1
+            let handlers = []((int32) -> int32){ handler }
+            handlers[0](41)
+            """,
+            42
+        },
+        {
+            "dictionary",
+            """
+            import System.Collections.Generic
+
+            let handler (int32) -> int32 = (value int32) -> value + 1
+            let handlers = Dictionary[string, (int32) -> int32]()
+            handlers.Add("answer", handler)
+            handlers["answer"](41)
+            """,
+            42
+        },
+        {
+            "map",
+            """
+            let handler (int32) -> int32 = (value int32) -> value + 1
+            let handlers = map[string,(int32) -> int32]{ "answer": handler }
+            handlers["answer"](41)
+            """,
+            42
+        },
+        {
+            "generic-constructor",
+            """
+            import System
+
+            let factory () -> int32 = () -> 42
+            let value = Lazy[int32](factory)
+            value.Value
+            """,
+            42
+        },
+        {
+            "action",
+            """
+            import System.Collections.Generic
+
+            func run() int32 {
+                var result = 0
+                let handler (int32) -> void = (value int32) -> { result = value + 1 }
+                List[int32]{ 41 }.ForEach(handler)
+                return result
+            }
+
+            run()
+            """,
+            42
+        },
+        {
+            "method-group",
+            """
+            import System.Collections.Generic
+
+            func increment(value int32) int32 { return value + 1 }
+            let handlers = List[(int32) -> int32]()
+            handlers.Add(increment)
+            handlers[0](41)
+            """,
+            42
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(ClrConsumerCases))]
+    public void Callable_Materializes_ForClrConsumer(string _, string source, object expected)
+    {
+        Assert.Equal(expected, Evaluate(source));
+    }
+
+    [Fact]
+    public void Callable_StoredInInterpreterField_StillInvokes()
+    {
+        const string Source = """
+            class Holder {
+                var Handler (int32) -> int32
+            }
+
+            let holder = Holder{}
+            holder.Handler = (value int32) -> value + 1
+            holder.Handler(41)
+            """;
+
+        Assert.Equal(42, Evaluate(Source));
+    }
+
+    [Fact]
+    public void Callable_DirectInvocation_StillWorks()
+    {
+        const string Source = """
+            let handler (int32) -> int32 = (value int32) -> value + 1
+            handler(41)
+            """;
+
+        Assert.Equal(42, Evaluate(Source));
+    }
+
+    [Fact]
+    public void Callable_ExceptionStillReachesInterpreterCatch()
+    {
+        const string Source = """
+            import System
+
+            let handler () -> int32 = () -> throw InvalidOperationException("boom")
+            var message = ""
+            try {
+                handler()
+            } catch (ex InvalidOperationException) {
+                message = ex.Message
+            }
+            message
+            """;
+
+        Assert.Equal("boom", Evaluate(Source));
+    }
+
+    [Fact]
+    public void Callable_UncaughtExceptionKeepsOriginalDiagnostic()
+    {
+        const string Source = """
+            import System
+
+            let handler () -> int32 = () -> throw InvalidOperationException("boom")
+            handler()
+            """;
+
+        var result = new Compilation(SyntaxTree.Parse(Source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Contains("boom", diagnostic.Message);
+        Assert.DoesNotContain("target of an invocation", diagnostic.Message);
+    }
+
+    private static object Evaluate(string source)
+    {
+        var result = new Compilation(SyntaxTree.Parse(source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        return result.Value;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2928.

Interpreter function literals and user method groups were represented by `ClosureValue` instances (`src/Core/CodeAnalysis/Evaluator.Expressions.cs:754-781`). CLR consumers such as the `ValueTuple<Func<int, int>, int>` constructor received that interpreter-only object unchanged at `Evaluator.Expressions.cs:704-717`, so reflection could not bind the constructor. The evaluator now materializes closures as delegates of their exact CLR type at the producer boundary, invokes both materialized delegates and legacy closure fallbacks, adapts structural delegates to named CLR delegate types, and wraps async results correctly.

Direct indirect-call invocation unwraps `TargetInvocationException`. Reflection member calls such as tuple/list element `.Invoke` still have a pre-existing uncaught-diagnostic leak, tracked separately in #2938.

## Production diff

- `src/Core/CodeAnalysis/Evaluator.Expressions.cs`: +86/-5
- `src/Core/CodeAnalysis/Evaluator.Calls.cs`: +8/-0
- Total: +94/-5, 99 changed production lines

No binder, parser, compiler-emitter, or non-evaluator production files changed.

## Pins (fail on `origin/main`, pass on this branch)

| Pin | Main | HEAD |
|---|---:|---:|
| Tuple containing `Func<int, int>` | fail | pass |
| CLR `Predicate<int>` method argument | fail | pass |
| `List<(int32) -> int32>` | fail | pass |
| delegate array | fail | pass |
| delegate-valued `Dictionary` | fail | pass |
| delegate-valued G# map | fail | pass |
| `Lazy<int32>` delegate constructor argument | fail | pass |
| `Action<int32>` with captured local | fail | pass |
| user method group stored in CLR collection | fail | pass |
| interpreter/compiled tuple-output parity | fail | pass |
| directly awaited async lambda in a function-typed slot | fail | pass |

## Guards (pass on both `origin/main` and HEAD)

| Guard | Main | HEAD |
|---|---:|---:|
| Interpreter class field callable invocation | pass | pass |
| Direct callable invocation | pass | pass |
| Callable exception reaches typed interpreter catch | pass | pass |
| Direct uncaught callable exception keeps original diagnostic | pass | pass |
| Compiled tuple function executes through real assembly load/invocation | pass | pass |
| Compile-and-run harness rejects known-bad program | pass | pass |

`Callable_DelegateFactoryIsReusedPerType` is an additional cache regression test. It cannot run on `main` because `main` fails to construct its tuple; on this branch it proves two closures of the same delegate type share one compiled bridge method while retaining distinct behavior.

`Callable_AsyncDirectInvocation_ReturnsAwaitableTask` is a pin: it fails on `origin/main` and when the evaluator-owned delegate shortcut is mutated to return raw `InvokeClosure` output (`'await' operand did not evaluate to a Task.`), and passes on HEAD.

## Semantic mutation checks

Each mutation was build-green. An unmutated control ran first; each mutation was restored and rebuilt before the next.

| Branch | Neutral mutation | Detection |
|---|---|---|
| Function literal materialization | return raw `ClosureValue` | literal CLR-consumer pins and parity fail |
| User method-group materialization | return raw `ClosureValue` | method-group pin fails |
| Closure materialization helper | return closure unchanged | CLR-consumer pins fail |
| Named delegate adaptation | return source delegate unchanged | `Predicate<int>` pin fails |
| Materialized delegate invocation | force delegate branch false | callable invocation pins fail |
| Non-void expression bridge | return default expression instead of invocation result | value-returning pins fail |
| Void expression bridge | omit invocation | `Action<int32>` pin fails |
| Argument forwarding | pass empty argument array | parameterized callable pins fail |
| Captured-local forwarding | skip captured-local copy | capture pin fails |
| Reflection exception unwrapping | rethrow `TargetInvocationException` | direct exception guards fail |
| Async result wrapping | return raw interpreter result | `AsyncLambda_Inference_WrapsReturnInTask`, `TrailingLambda_AsyncSoleArgument_BindsWithoutDiagnostics`, and `TrailingLambda_AsyncWithPrecedingArgs_BindsWithoutDiagnostics` fail in Core.Tests |
| Delegate-factory cache | call `BuildInterpreterDelegateFactory` for every closure | cache regression test fails with distinct generated methods |
| Evaluator-owned delegate shortcut | make weak-map lookup unreachable | recursion depth regresses below `main` |
| Evaluator-owned async result | return `InvokeClosure` directly | async direct-invocation pin fails because `await` receives a raw value |

## Cache and indirect-call cost

Factories are cached by delegate `Type` in a `ConditionalWeakTable`, so projected `MetadataLoadContext` types are not pinned. A second weak table maps evaluator-owned delegates to their `ClosureValue`; indirect calls bypass `DynamicInvoke` and call the closure directly. Async closures retain the `Task` wrapping path.

Round-2 review measurements (interleaved, seven repetitions, median):

| Program | `main` | first revision `632d133d` | cached `72490605` |
|---|---:|---:|---:|
| `create10k` | 0.252 s | 0.646 s | 0.266 s (+6%) |
| `create100k` | 0.299 s | 4.520 s | 0.341 s (+14%) |
| `create300k` | 0.422 s | 15.805 s | 0.489 s (+16%) |
| `call100k` | 0.304 s | 0.459 s | 0.275 s (-10%) |
| `create300k` peak RSS | 83.4 MB | 103.3 MB | 97.8 MB (+17%) |

The cache is about 32x faster than the first revision on creation-heavy work, remains within 16% of `main` there, and is about 10% faster on call-heavy work. Peak RSS is about 17% above `main`. The weak-map shortcut removes the recursion-depth regression and restores parity with `main`; absolute stack limits are machine- and load-dependent.

Trade-off: closures of the same delegate type intentionally share one interpreter bridge `MethodInfo`. Compiled closures retain distinct generated method identities, while delegate targets and equality semantics remain distinct. `FuncToSystemDelegate.gs` therefore requires normalization or exclusion in interpreter golden-sample coverage (#2939).

## Related-shape probes

| Shape | `origin/main` | HEAD |
|---|---|---|
| Tuple | broken | fixed |
| CLR method expecting `Predicate<T>` | broken | fixed |
| `List<Func<...>>` | broken | fixed |
| delegate array | broken | fixed |
| delegate-valued dictionary | broken | fixed |
| delegate-valued map | broken | fixed |
| CLR generic constructor (`Lazy<T>`) | broken | fixed |
| `Action<T>` and captured state | broken | fixed |
| User method group in CLR collection | broken | fixed |
| G# class field | working | working |
| Compiled tuple path | working | working |

Producer-site materialization is required: reverting only the two producer returns makes all nine interpreter consumer pins fail. Review also found nine improvements across the 122 shipped samples and zero regressions. Compiled output remained untouched: 119 deterministic assemblies had zero byte differences.

## Follow-up issues and coordination

- #2938 tracks the pre-existing uncaught `TargetInvocationException` diagnostic leak through CLR member calls.
- #2939 tracks missing interpreter golden-sample conformance coverage.
- Numeric tuple-selector invocation `t.0(41)` needs both this PR and #2932. #2932 is still open, so its author was asked to add the combined passing pin if this PR lands first: https://github.com/DavidObando/gsharp/pull/2932#issuecomment-5141179781

No known callable-materialization shape remains broken.

## Validation

Rebased onto `origin/main` at `60e5b8bf`; validation head is `84c2970e`.

| Suite | `origin/main` (`60e5b8bf`) | `84c2970e` |
|---|---:|---:|
| Interpreter.Tests | 453 passed | **468 passed** |
| Core.Tests | 6913 passed, 1 skipped | **6913 passed, 1 skipped** |
| Compiler.Tests | approximately 3740 passed | **3745 passed** |

- Targeted Interpreter issue tests: 15 passed
- Async pin mutation: 1 failed with `'await' operand did not evaluate to a Task.`; restored control passed
- Targeted Compiler issue tests: 3 passed
- Release solution build with warnings as errors: 0 warnings, 0 errors
