### PR TITLE
Fix struct receiver capture in state machines

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -61,7 +61,7 @@ internal sealed partial class MethodBodyEmitter
         {
             this.il.LoadArgument(argIndex);
             if (ps.RefKind != RefKind.None
-                || (argIndex == 0 && ReferenceEquals(ps, this.structThisParameter)))
+                || ReferenceEquals(ps, this.structThisParameter))
             {
                 // Ref parameters and value-type `this` slots hold managed
                 // pointers; an ordinary value read must dereference them.

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -60,10 +60,11 @@ internal sealed partial class MethodBodyEmitter
         if (variable is ParameterSymbol ps && this.parameters.TryGetValue(ps, out var argIndex))
         {
             this.il.LoadArgument(argIndex);
-            if (ps.RefKind != RefKind.None)
+            if (ps.RefKind != RefKind.None
+                || (argIndex == 0 && ReferenceEquals(ps, this.structThisParameter)))
             {
-                // ADR-0060: the parameter slot holds a managed pointer T&; an
-                // ordinary read of `p` in the body must dereference it.
+                // Ref parameters and value-type `this` slots hold managed
+                // pointers; an ordinary value read must dereference them.
                 this.EmitLoadIndirect(ps.Type);
             }
 

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -1594,6 +1594,12 @@ internal sealed class StateMachineEmitter
             var thisFieldHandle = this.resolveFieldToken(kickoffSmStruct, plan.FieldMap.ThisField);
             il.LoadLocalAddress(0);
             il.LoadArgument(0);
+            if (function.ReceiverType is StructSymbol { IsClass: false } receiverStruct)
+            {
+                il.OpCode(ILOpCode.Ldobj);
+                il.Token(this.getStructTypeToken(receiverStruct));
+            }
+
             il.OpCode(ILOpCode.Stfld);
             il.Token(thisFieldHandle);
         }

--- a/test/Compiler.Tests/Emit/Issue2931StructReceiverStateMachineTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2931StructReceiverStateMachineTests.cs
@@ -27,7 +27,19 @@ public class Issue2931StructReceiverStateMachineTests
             struct Box {
                 var N int32
                 func vals() sequence[int32] { yield N }
+
+                func runSyncClosure() int32 {
+                    var read = func() int32 { return N }
+                    return read()
+                }
+
+                func runAsyncClosure() int32 {
+                    var read = async func() int32 { return N }
+                    return read().Result
+                }
             }
+
+            func (box Box) receiverVals() sequence[int32] { yield box.N }
 
             struct Holder {
                 var B Box
@@ -103,12 +115,15 @@ public class Issue2931StructReceiverStateMachineTests
             print(repeated)
 
             print(OuterIterator{B: Box{N: 180}}.vals())
+            Console.WriteLine(Box{N: 81}.runSyncClosure())
+            Console.WriteLine(Box{N: 82}.runAsyncClosure())
+            print(Box{N: 101}.receiverVals())
             """;
 
         AssertRunsWithExactOutput(
             Source,
             nameof(StructIteratorReceiversRetainValueCopies),
-            "100\n110\n120\n130\n140\n150\n160\n163\n3\n160\n170\n170\n180\n");
+            "100\n110\n120\n130\n140\n150\n160\n163\n3\n160\n170\n170\n180\n81\n82\n101\n");
     }
 
     [Fact]
@@ -201,17 +216,25 @@ public class Issue2931StructReceiverStateMachineTests
                 }
             }
 
+            class CBox(N int32) {
+                async func val() int32 {
+                    await Task.Delay(1)
+                    return N
+                }
+            }
+
             Console.WriteLine(Box{N: 300}.val().Result)
 
             var box = Box{N: 310}
             Console.WriteLine(box.val().Result)
             Console.WriteLine(GenericBox[int32]{Value: 320}.val().Result)
+            Console.WriteLine(CBox(91).val().Result)
             """;
 
         AssertRunsWithExactOutput(
             Source,
             nameof(AsyncStructMethodReceiversRetainValueCopies),
-            "300\n310\n320\n");
+            "300\n310\n320\n91\n");
     }
 
     [Fact]

--- a/test/Compiler.Tests/Emit/Issue2931StructReceiverStateMachineTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2931StructReceiverStateMachineTests.cs
@@ -1,0 +1,350 @@
+// <copyright file="Issue2931StructReceiverStateMachineTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2931: value-type instance state machines must capture the value
+/// addressed by the managed-pointer <c>this</c> argument, not the pointer bits.
+/// </summary>
+public class Issue2931StructReceiverStateMachineTests
+{
+    [Fact]
+    public void StructIteratorReceiversRetainValueCopies()
+    {
+        const string Source = """
+            package Issue2931Sync
+            import System
+
+            struct Box {
+                var N int32
+                func vals() sequence[int32] { yield N }
+            }
+
+            struct Holder {
+                var B Box
+            }
+
+            struct Inner {
+                var N int32
+            }
+
+            struct Nested {
+                var Value Inner
+                func vals() sequence[int32] { yield Value.N }
+            }
+
+            class Cell(N int32) {}
+
+            struct WithReference {
+                var C Cell
+                func vals() sequence[int32] { yield C.N }
+            }
+
+            struct GenericBox[T] {
+                var Value T
+                func vals() sequence[T] { yield Value }
+            }
+
+            struct Pair {
+                var A int32
+                var B int32
+
+                func vals() sequence[int32] {
+                    yield A
+                    A = A + B
+                    yield A
+                    yield B
+                }
+            }
+
+            struct OuterIterator {
+                var B Box
+
+                func vals() sequence[int32] {
+                    for value in B.vals() {
+                        yield value
+                    }
+                }
+            }
+
+            func print(values sequence[int32]) {
+                for value in values {
+                    Console.WriteLine(value)
+                }
+            }
+
+            print(Box{N: 100}.vals())
+
+            var local = Box{N: 110}
+            print(local.vals())
+
+            var holder = Holder{B: Box{N: 120}}
+            print(holder.B.vals())
+
+            print(Nested{Value: Inner{N: 130}}.vals())
+            print(WithReference{C: Cell(140)}.vals())
+            print(GenericBox[int32]{Value: 150}.vals())
+
+            var pair = Pair{A: 160, B: 3}
+            print(pair.vals())
+            Console.WriteLine(pair.A)
+
+            let repeated = Box{N: 170}.vals()
+            print(repeated)
+            print(repeated)
+
+            print(OuterIterator{B: Box{N: 180}}.vals())
+            """;
+
+        AssertRunsWithExactOutput(
+            Source,
+            nameof(StructIteratorReceiversRetainValueCopies),
+            "100\n110\n120\n130\n140\n150\n160\n163\n3\n160\n170\n170\n180\n");
+    }
+
+    [Fact]
+    public void AsyncStructIteratorReceiversRetainValueCopies()
+    {
+        const string Source = """
+            package Issue2931AsyncIterator
+            import System
+            import System.Threading.Tasks
+
+            struct Box {
+                var N int32
+
+                async func vals() async sequence[int32] {
+                    yield N
+                    await Task.Delay(1)
+                    yield N + 1
+                }
+            }
+
+            struct GenericBox[T] {
+                var Value T
+
+                async func vals() async sequence[T] {
+                    yield Value
+                    await Task.Delay(1)
+                    yield Value
+                }
+            }
+
+            class ClassBox(N int32) {
+                async func vals() async sequence[int32] {
+                    yield N
+                    await Task.Delay(1)
+                    yield N + 1
+                }
+            }
+
+            let temporary = Box{N: 200}.vals().GetAsyncEnumerator()
+            for temporary.MoveNextAsync().AsTask().Result {
+                Console.WriteLine(temporary.Current)
+            }
+
+            var box = Box{N: 210}
+            let local = box.vals().GetAsyncEnumerator()
+            for local.MoveNextAsync().AsTask().Result {
+                Console.WriteLine(local.Current)
+            }
+
+            let generic = GenericBox[int32]{Value: 220}.vals().GetAsyncEnumerator()
+            for generic.MoveNextAsync().AsTask().Result {
+                Console.WriteLine(generic.Current)
+            }
+
+            let classControl = ClassBox(230).vals().GetAsyncEnumerator()
+            for classControl.MoveNextAsync().AsTask().Result {
+                Console.WriteLine(classControl.Current)
+            }
+            """;
+
+        AssertRunsWithExactOutput(
+            Source,
+            nameof(AsyncStructIteratorReceiversRetainValueCopies),
+            "200\n201\n210\n211\n220\n220\n230\n231\n");
+    }
+
+    [Fact]
+    public void AsyncStructMethodReceiversRetainValueCopies()
+    {
+        const string Source = """
+            package Issue2931AsyncMethod
+            import System
+            import System.Threading.Tasks
+
+            struct Box {
+                var N int32
+
+                async func val() int32 {
+                    await Task.Delay(1)
+                    return N
+                }
+            }
+
+            struct GenericBox[T] {
+                var Value T
+
+                async func val() T {
+                    await Task.Delay(1)
+                    return Value
+                }
+            }
+
+            Console.WriteLine(Box{N: 300}.val().Result)
+
+            var box = Box{N: 310}
+            Console.WriteLine(box.val().Result)
+            Console.WriteLine(GenericBox[int32]{Value: 320}.val().Result)
+            """;
+
+        AssertRunsWithExactOutput(
+            Source,
+            nameof(AsyncStructMethodReceiversRetainValueCopies),
+            "300\n310\n320\n");
+    }
+
+    [Fact]
+    public void NonIteratorStructReceiverControlRemainsCorrect()
+    {
+        const string Source = """
+            package Issue2931NonIteratorControl
+            import System
+
+            struct Box {
+                var N int32
+                func val() int32 -> N
+            }
+
+            Console.WriteLine(Box{N: 320}.val())
+
+            var box = Box{N: 330}
+            Console.WriteLine(box.val())
+            """;
+
+        AssertRunsWithExactOutput(
+            Source,
+            nameof(NonIteratorStructReceiverControlRemainsCorrect),
+            "320\n330\n");
+    }
+
+    [Fact]
+    public void ClassIteratorReceiverControlRemainsCorrect()
+    {
+        const string Source = """
+            package Issue2931ClassControl
+            import System
+
+            class Box(N int32) {
+                func vals() sequence[int32] { yield N }
+            }
+
+            for value in Box(400).vals() {
+                Console.WriteLine(value)
+            }
+
+            let box = Box(410)
+            for value in box.vals() {
+                Console.WriteLine(value)
+            }
+            """;
+
+        AssertRunsWithExactOutput(
+            Source,
+            nameof(ClassIteratorReceiverControlRemainsCorrect),
+            "400\n410\n");
+    }
+
+    private static void AssertRunsWithExactOutput(string source, string name, string expected)
+    {
+        var assemblyPath = Compile(source, name);
+        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        Assert.NotEmpty(assembly.GetTypes());
+
+        for (var i = 0; i < 6; i++)
+        {
+            Assert.Equal(expected, RunBounded(assemblyPath, name));
+        }
+
+        IlVerifier.Verify(assemblyPath);
+    }
+
+    private static string Compile(string source, string name)
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, nameof(Issue2931StructReceiverStateMachineTests), name);
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var assemblyPath = Path.Combine(directory, name + ".dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousErr = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousErr);
+        }
+
+        Assert.True(exitCode == 0, $"{name}: gsc failed:\n{stdout}\n{stderr}");
+        return assemblyPath;
+    }
+
+    private static string RunBounded(string assemblyPath, string name)
+    {
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                assemblyPath,
+            },
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+
+        Assert.NotNull(process);
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        var exited = process.WaitForExit(30_000);
+        if (!exited)
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+        }
+
+        Assert.True(exited, $"{name}: emitted program timed out");
+        var output = outputTask.GetAwaiter().GetResult();
+        var error = errorTask.GetAwaiter().GetResult();
+        Assert.True(process.ExitCode == 0, $"{name}: emitted program failed:\n{error}");
+        return output.Replace("\r\n", "\n");
+    }
+}

--- a/test/Interpreter.Tests/Issue2931StructReceiverIteratorTests.cs
+++ b/test/Interpreter.Tests/Issue2931StructReceiverIteratorTests.cs
@@ -1,0 +1,83 @@
+// <copyright file="Issue2931StructReceiverIteratorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2931 interpreter parity for struct receiver iterators.
+/// </summary>
+public class Issue2931StructReceiverIteratorTests
+{
+    [Fact]
+    public void StructIteratorReceiversUseValueSemantics()
+    {
+        const string Source = """
+            import System
+
+            struct Box {
+                var N int32
+                func vals() sequence[int32] { yield N }
+            }
+
+            struct Pair {
+                var A int32
+                var B int32
+
+                func vals() sequence[int32] {
+                    yield A
+                    A = A + B
+                    yield A
+                    yield B
+                }
+            }
+
+            class ClassBox(N int32) {
+                func vals() sequence[int32] { yield N }
+            }
+
+            for value in Box{N: 100}.vals() {
+                Console.WriteLine(value)
+            }
+
+            var box = Box{N: 110}
+            for value in box.vals() {
+                Console.WriteLine(value)
+            }
+
+            var pair = Pair{A: 160, B: 3}
+            for value in pair.vals() {
+                Console.WriteLine(value)
+            }
+            Console.WriteLine(pair.A)
+
+            for value in ClassBox(400).vals() {
+                Console.WriteLine(value)
+            }
+            """;
+
+        Assert.Equal("100\n110\n160\n163\n3\n160\n400\n", RunSubmission(Source));
+    }
+
+    private static string RunSubmission(string source)
+    {
+        using var output = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(source);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return output.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary

- dereference value-type `this` when shared bound-value emission captures it by value, fixing sync/async iterators, sync closures, async closures, and receiver-clause iterators
- apply the same value copy in the direct ordinary-async kickoff emitter, guarded to exclude class receivers
- add runtime/load/IL regression coverage for required receiver shapes, top-level generic structs, class controls, and interpreter parity
- track the separate pre-existing nested-generic-struct iterator failure in #2951

## Root cause

CLR value-type instance methods receive `this` as `T&`. Shared bound-value emission loaded only `ldarg.0` when synthesized iterator/closure kickoff code captured whole-value `this`, storing managed-pointer bits into a value-typed field. Ordinary async methods use a separate hand-written kickoff path with the same missing `ldobj T`. Result was loadable, executable assemblies that returned nondeterministic garbage.

Class receivers are object references and must not be dereferenced. Ordinary non-state-machine struct field reads are correct because their address-aware member path intentionally consumes managed-pointer `this` directly.

Async iterators and ordinary async struct methods shared the compiler defect and are fixed. Interpreter already used value semantics; its test is a parity guard.

## Runtime regression evidence

Every emitted-program test performs `Assembly.Load(File.ReadAllBytes(...))`, calls `GetTypes()`, executes a child `dotnet` process six times with stdout/stderr drained concurrently, asserts exact output, then runs IL verification.

Exact base `914b42a788960f35a7cffab0adcb0b86a370f3e1`:
- **Pins: 3** compiler tests failed exact-output assertions:
  - sync iterator/capture shapes expected `100 110 120 130 140 150 160 163 3 160 170 170 180 81 82 101`
  - async iterator shapes expected `200 201 210 211 220 220 230 231`
  - ordinary async shapes expected `300 310 320 91`
- **Guards: 3** passed on base and head:
  - non-iterator compiler control: `320 330`
  - class iterator compiler control: `400 410`
  - interpreter parity: `100 110 160 163 3 160 400`

Top-level `GenericBox[T]` shapes are covered. Nested generic struct iterators are not claimed as covered; their unrelated pre-existing type reification failures are #2951.

The issue body's minimal snippet is JIT-shape-sensitive: exact-base IL is wrong, but RyuJIT may launder the mismatched store into a copy. The larger pin fails reliably. Recorded on #2931: https://github.com/DavidObando/gsharp/issues/2931#issuecomment-5144733996

## Review follow-up and mutation testing

Added ordinary async class control `CBox(91).val()` and whole-value captures through sync closure (`81`), async closure (`82`), and receiver-clause iterator (`101`). Simplified the shared predicate by removing redundant `argIndex == 0`.

| Production hunk | Build-green semantic mutation | Detection |
|---|---|---|
| `MethodBodyEmitter.MemberAccess.cs` shared whole-value load | remove struct-`this` dereference while retaining ref-parameter handling | sync and async-iterator pins fail; added `81`, `82`, and `101` assertions become garbage |
| `StateMachineEmitter.cs` direct async capture | delete `{ IsClass: false }` while retaining `is StructSymbol receiverStruct` | ordinary async class assertion fails exactly: expected `91`, got `512` |

Unmutated control passed all 5 compiler tests before and after probes. Each mutation was restored and followed by a fresh Release rebuild before the next probe.

## Rebased validation

Base `914b42a788960f35a7cffab0adcb0b86a370f3e1` (executed Release suites):
- Core.Tests: 6915 passed, 1 skipped
- Compiler.Tests: 3802 passed
- Interpreter.Tests: 470 passed

Head `7f7c5da8130b142aaee0ab138374b2d81bde61dd` (executed Release suites):
- Core.Tests: 6915 passed, 1 skipped
- Compiler.Tests: 3807 passed
- Interpreter.Tests: 471 passed
- Release solution build: 0 warnings, 0 errors

Fixes #2931
