### PR TITLE
Fix nullable generic iterator metadata

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -988,6 +988,14 @@ types are specialized into `class` and `struct` variants automatically.
 Other unconstrained sequence type positions still require an explicit
 `struct`, `class`, or base-class constraint.
 
+A call from another unconstrained generic context cannot select either
+specialized iterator variant. Constrain the enclosing type parameter to
+`struct`, `class`, or a base class. Named or explicit arguments do not resolve
+that call: until [#2958](https://github.com/DavidObando/gsharp/issues/2958),
+it reports GS0266, and a nullable value-type argument may instead report
+GS0152. G# rejects source overloads differentiated only by constraints with
+GS0264, even though iterator specialization synthesizes equivalent variants.
+
 ## Internal compiler error diagnostics (GS9998–GS9999)
 
 | ID | Severity | Description |

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -983,11 +983,10 @@ types are `System.Int32` and `System.Nullable<System.Int32>`.
 |----|----------|-------------|
 | GS0508 | Error | A nullable sequence element uses a type parameter that is not constrained to `struct` or a reference type. |
 
-`sequence[T?]` needs one stable CLR element representation. Use a `struct`
-constraint when `T?` must be `System.Nullable<T>`, or a `class`/base-class
-constraint when it must use reference-type nullability. An unconstrained `T`
-can represent either shape and is rejected until generic sequence
-specialization supports both.
+`sequence[T?]` needs one stable CLR element representation. Iterator return
+types are specialized into `class` and `struct` variants automatically.
+Other unconstrained sequence type positions still require an explicit
+`struct`, `class`, or base-class constraint.
 
 ## Internal compiler error diagnostics (GS9998–GS9999)
 

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1865,14 +1865,35 @@ public sealed class Binder
             && bodySyntax != null
             && cache.TryReuse(member, bodySyntax, out var reusedBody, out var reusedDiagnostics))
         {
-            diagnostics.AddRange(reusedDiagnostics);
+            AppendBodyDiagnostics(diagnostics, reusedDiagnostics, member);
             return reusedBody;
         }
 
         var (body, bodyDiagnostics) = bindAndLower();
-        diagnostics.AddRange(bodyDiagnostics);
+        AppendBodyDiagnostics(diagnostics, bodyDiagnostics, member);
         cache?.Store(member, bodySyntax, body, bodyDiagnostics);
         return body;
+    }
+
+    private static void AppendBodyDiagnostics(
+        ImmutableArray<Diagnostic>.Builder diagnostics,
+        ImmutableArray<Diagnostic> bodyDiagnostics,
+        FunctionSymbol member)
+    {
+        foreach (var diagnostic in bodyDiagnostics)
+        {
+            if (member.NullableSequenceSpecialization != NullableSequenceSpecializationKind.None
+                && diagnostics.Any(existing =>
+                    existing.Id == diagnostic.Id
+                    && existing.Severity == diagnostic.Severity
+                    && existing.Message == diagnostic.Message
+                    && existing.Location.CompareTo(diagnostic.Location) == 0))
+            {
+                continue;
+            }
+
+            diagnostics.Add(diagnostic);
+        }
     }
 
     /// <summary>
@@ -2942,7 +2963,8 @@ public sealed class Binder
                 return null;
             }
 
-            if (elementType is NullableTypeSymbol { UnderlyingType: TypeParameterSymbol typeParameter }
+            if (!ReferenceEquals(syntax, binderCtx.UnconstrainedNullableSequenceElementReturn)
+                && elementType is NullableTypeSymbol { UnderlyingType: TypeParameterSymbol typeParameter }
                 && !typeParameter.HasValueTypeConstraint
                 && !typeParameter.HasReferenceTypeConstraint
                 && typeParameter.ClassConstraint == null)

--- a/src/Core/CodeAnalysis/Binding/BinderContext.cs
+++ b/src/Core/CodeAnalysis/Binding/BinderContext.cs
@@ -104,6 +104,7 @@ internal sealed class BinderContext
     /// Mutated in place via <see cref="PushUnsafeContext"/>.
     /// </summary>
     public int UnsafeDepth;
+
 #pragma warning restore SA1401
 
     /// <summary>
@@ -157,6 +158,9 @@ internal sealed class BinderContext
     /// permitted.
     /// </summary>
     public bool InUnsafeContext => UnsafeDepth > 0;
+
+    /// <summary>Gets or sets the iterator return clause allowed to carry an unconstrained nullable sequence element.</summary>
+    public TypeClauseSyntax UnconstrainedNullableSequenceElementReturn { get; set; }
 
     /// <summary>
     /// Gets a value indicating whether the current <c>checked</c>/<c>unchecked</c>

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -305,6 +305,14 @@ public sealed class BoundScope
             return false;
         }
 
+        if (ReferenceEquals(a.Declaration, b.Declaration)
+            && a.NullableSequenceSpecialization != NullableSequenceSpecializationKind.None
+            && b.NullableSequenceSpecialization != NullableSequenceSpecializationKind.None
+            && a.NullableSequenceSpecialization != b.NullableSequenceSpecialization)
+        {
+            return false;
+        }
+
         var ap = SigCallableParameters(a);
         var bp = SigCallableParameters(b);
         if (ap.Length != bp.Length)

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Functions.cs
@@ -331,20 +331,25 @@ internal sealed partial class DeclarationBinder
             function.SetAttributes(functionAttributes);
             ValidateInlineDataNilArguments(functionAttributes, function.Parameters);
 
+            var methodCandidates = ExpandNullableSequenceIteratorSpecializations(function);
+
             // ADR-0063 §11: detect duplicate-signature against existing methods on the receiver.
-            foreach (var existingMethod in methodReceiverStruct.Methods)
+            foreach (var candidate in methodCandidates)
             {
-                if (BoundScope.FunctionSignaturesEqual(existingMethod, function))
+                foreach (var existingMethod in methodReceiverStruct.Methods)
                 {
-                    Diagnostics.ReportDuplicateOverloadSignature(
-                        syntax.Identifier.Location,
-                        methodName,
-                        Binder.FormatOverloadSignature(function));
-                    return;
+                    if (BoundScope.FunctionSignaturesEqual(existingMethod, candidate))
+                    {
+                        Diagnostics.ReportDuplicateOverloadSignature(
+                            syntax.Identifier.Location,
+                            methodName,
+                            Binder.FormatOverloadSignature(candidate));
+                        return;
+                    }
                 }
             }
 
-            methodReceiverStruct.AddMethods(ImmutableArray.Create(function));
+            methodReceiverStruct.AddMethods(methodCandidates);
 
             // ADR-0096 / issue #762: a receiver-clause method is
             // never a P/Invoke (GS0326 would also fire for the
@@ -385,35 +390,46 @@ internal sealed partial class DeclarationBinder
             PInvokeBinder.ReportMarshalAsOnNonPInvokeFunction(syntax, Diagnostics);
         }
 
+        var functions = ExpandNullableSequenceIteratorSpecializations(function);
+
         if (syntax.IsExtension)
         {
-            function.IsExtension = true;
-            function.ExtensionReceiverType = receiverType;
-
             // Issue #1188: extension functions overload like ordinary
             // methods and free functions. A collision now means a genuine
             // duplicate signature (same receiver type, name, and callable
             // parameters) — report it as a duplicate-overload-signature
             // error to match the method/free-function path rather than a
             // generic redeclaration.
-            if (function.Declaration.Identifier.Text != null && !scope.TryDeclareExtensionFunction(function))
+            foreach (var candidate in functions)
             {
-                Diagnostics.ReportDuplicateOverloadSignature(syntax.Identifier.Location, function.Name, Binder.FormatOverloadSignature(function));
+                candidate.IsExtension = true;
+                candidate.ExtensionReceiverType = Binder.SubstituteType(
+                    receiverType,
+                    BuildTypeParameterSubstitution(function.TypeParameters, candidate.TypeParameters));
+                if (candidate.Declaration.Identifier.Text != null && !scope.TryDeclareExtensionFunction(candidate))
+                {
+                    Diagnostics.ReportDuplicateOverloadSignature(syntax.Identifier.Location, candidate.Name, Binder.FormatOverloadSignature(candidate));
+                }
             }
 
             return;
         }
 
-        if (function.Declaration.Identifier.Text != null && !scope.TryDeclareFunction(function))
+        foreach (var candidate in functions)
         {
+            if (candidate.Declaration.Identifier.Text == null || scope.TryDeclareFunction(candidate))
+            {
+                continue;
+            }
+
             // ADR-0063 §11: if the collision is with another callable of
             // the same name, it is a duplicate-signature error rather
             // than a generic redeclaration.
-            var existingOverloads = scope.TryLookupFunctions(function.Name);
+            var existingOverloads = scope.TryLookupFunctions(candidate.Name);
             var duplicateSig = false;
             foreach (var existing in existingOverloads)
             {
-                if (BoundScope.FunctionSignaturesEqual(existing, function))
+                if (BoundScope.FunctionSignaturesEqual(existing, candidate))
                 {
                     duplicateSig = true;
                     break;
@@ -422,12 +438,153 @@ internal sealed partial class DeclarationBinder
 
             if (duplicateSig)
             {
-                Diagnostics.ReportDuplicateOverloadSignature(syntax.Identifier.Location, function.Name, Binder.FormatOverloadSignature(function));
+                Diagnostics.ReportDuplicateOverloadSignature(syntax.Identifier.Location, candidate.Name, Binder.FormatOverloadSignature(candidate));
             }
             else
             {
-                Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, function.Name);
+                Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, candidate.Name);
             }
+        }
+    }
+
+    private ImmutableArray<FunctionSymbol> ExpandNullableSequenceIteratorSpecializations(FunctionSymbol function)
+    {
+        if (function?.Declaration?.Body == null)
+        {
+            return ImmutableArray.Create(function);
+        }
+
+        if (!IteratorDetection.ContainsYield(function.Declaration.Body))
+        {
+            return ImmutableArray.Create(function);
+        }
+
+        var elementType = function.Type switch
+        {
+            SequenceTypeSymbol sequence => sequence.ElementType,
+            AsyncSequenceTypeSymbol sequence => sequence.ElementType,
+            _ => null,
+        };
+        if (elementType is not NullableTypeSymbol { UnderlyingType: TypeParameterSymbol target }
+            || target.HasValueTypeConstraint
+            || target.HasReferenceTypeConstraint
+            || target.ClassConstraint != null)
+        {
+            return ImmutableArray.Create(function);
+        }
+
+        var targetIndex = function.TypeParameters.IndexOf(target);
+        if (targetIndex < 0)
+        {
+            Diagnostics.ReportUnconstrainedNullableSequenceElement(
+                function.Declaration.Type.SequenceElementType.Location,
+                target.Name);
+            return ImmutableArray.Create(function);
+        }
+
+        return ImmutableArray.Create(
+            CreateNullableSequenceIteratorSpecialization(function, targetIndex, isValueType: false),
+            CreateNullableSequenceIteratorSpecialization(function, targetIndex, isValueType: true));
+    }
+
+    private FunctionSymbol CreateNullableSequenceIteratorSpecialization(
+        FunctionSymbol function,
+        int targetIndex,
+        bool isValueType)
+    {
+        var typeParameters = SynthesizedClosureReifier.CloneWithRemappedConstraints(function.TypeParameters);
+        typeParameters[targetIndex].HasReferenceTypeConstraint = !isValueType;
+        typeParameters[targetIndex].HasValueTypeConstraint = isValueType;
+        var substitution = BuildTypeParameterSubstitution(function.TypeParameters, typeParameters);
+        var parameters = ImmutableArray.CreateBuilder<ParameterSymbol>(function.Parameters.Length);
+        foreach (var parameter in function.Parameters)
+        {
+            var clone = new ParameterSymbol(
+                parameter.Name,
+                Binder.SubstituteType(parameter.Type, substitution),
+                parameter.IsVariadic,
+                parameter.DeclaringSyntax,
+                parameter.IsScoped,
+                parameter.RefKind);
+            if (parameter.HasExplicitDefaultValue)
+            {
+                clone.SetExplicitDefaultValue(parameter.ExplicitDefaultValue);
+            }
+
+            clone.SetAttributes(parameter.Attributes);
+            parameters.Add(clone);
+        }
+
+        var specializedParameters = parameters.MoveToImmutable();
+        ParameterSymbol specializedExplicitReceiver = null;
+        if (function.ExplicitReceiverParameter != null)
+        {
+            for (var i = 0; i < function.Parameters.Length; i++)
+            {
+                if (ReferenceEquals(function.Parameters[i], function.ExplicitReceiverParameter))
+                {
+                    specializedExplicitReceiver = specializedParameters[i];
+                    break;
+                }
+            }
+        }
+
+        var specializedReceiverType = Binder.SubstituteType(function.ReceiverType, substitution);
+        var specialized = new FunctionSymbol(
+            function.Name,
+            specializedParameters,
+            Binder.SubstituteType(function.Type, substitution),
+            function.Declaration,
+            function.Package,
+            function.Accessibility,
+            specializedReceiverType,
+            specializedExplicitReceiver,
+            function.IsOpen,
+            function.IsOverride);
+        specialized.TypeParameters = typeParameters;
+        specialized.OverriddenMethod = function.OverriddenMethod;
+        specialized.ExternalOverriddenMethod = function.ExternalOverriddenMethod;
+        specialized.ExternalOverrideContainingType = Binder.SubstituteType(function.ExternalOverrideContainingType, substitution);
+        specialized.IsAsync = function.IsAsync;
+        specialized.AsyncReturnsValueTask = function.AsyncReturnsValueTask;
+        specialized.IsUnsafe = function.IsUnsafe;
+        specialized.ReturnRefKind = function.ReturnRefKind;
+        specialized.IsStatic = function.IsStatic;
+        specialized.StaticOwnerType = Binder.SubstituteType(function.StaticOwnerType, substitution);
+        specialized.IsSpecialName = function.IsSpecialName;
+        specialized.SetAttributes(function.Attributes);
+        specialized.SetDocumentation(function.GetDocumentation());
+        specialized.NullableSequenceSpecialization = isValueType
+            ? NullableSequenceSpecializationKind.ValueType
+            : NullableSequenceSpecializationKind.ReferenceType;
+        return specialized;
+    }
+
+    private static Dictionary<TypeParameterSymbol, TypeSymbol> BuildTypeParameterSubstitution(
+        ImmutableArray<TypeParameterSymbol> originals,
+        ImmutableArray<TypeParameterSymbol> replacements)
+    {
+        var substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>(originals.Length);
+        for (var i = 0; i < originals.Length; i++)
+        {
+            substitution[originals[i]] = replacements[i];
+        }
+
+        return substitution;
+    }
+
+    private TypeSymbol BindIteratorReturnType(FunctionDeclarationSyntax syntax)
+    {
+        var previous = binderCtx.UnconstrainedNullableSequenceElementReturn;
+        binderCtx.UnconstrainedNullableSequenceElementReturn =
+            syntax.Body != null && IteratorDetection.ContainsYield(syntax.Body) ? syntax.Type : null;
+        try
+        {
+            return bindReturnTypeClause(syntax.Type, syntax.IsAsync) ?? TypeSymbol.Void;
+        }
+        finally
+        {
+            binderCtx.UnconstrainedNullableSequenceElementReturn = previous;
         }
     }
 
@@ -565,7 +722,7 @@ internal sealed partial class DeclarationBinder
         ParameterSymbol[] parameterSymbolBySyntax)
     {
         // ADR-0041: bind the return type with async-aware alias resolution.
-        var type = bindReturnTypeClause(syntax.Type, syntax.IsAsync) ?? TypeSymbol.Void;
+        var type = BindIteratorReturnType(syntax);
 
         // ADR-0146 (Kotlin visibility narrowing follow-up): infer/narrow the
         // return type when the (omitted-type) body is `-> object { ... }`.

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -995,7 +995,7 @@ internal sealed partial class DeclarationBinder
 
                     ValidateVariadicParameterShape(methodSyntax.Parameters);
 
-                    var returnType = bindReturnTypeClause(methodSyntax.Type, methodSyntax.IsAsync) ?? TypeSymbol.Void;
+                    var returnType = BindIteratorReturnType(methodSyntax);
                     var methodAccessibility = resolveAccessibility(methodSyntax.AccessibilityModifier);
 
                     // ADR-0146 (Kotlin visibility narrowing follow-up): infer/narrow the
@@ -1239,6 +1239,26 @@ internal sealed partial class DeclarationBinder
                             System.AttributeTargets.Method);
                         methodSymbol.SetAttributes(methodAttributes);
                         ValidateInlineDataNilArguments(methodAttributes, methodSymbol.Parameters);
+                    }
+
+                    var nullableSequenceSpecializations = ExpandNullableSequenceIteratorSpecializations(methodSymbol);
+                    if (nullableSequenceSpecializations.Length > 1)
+                    {
+                        foreach (var specialization in nullableSequenceSpecializations)
+                        {
+                            if (methodsBuilder.Any(existing => BoundScope.FunctionSignaturesEqual(existing, specialization)))
+                            {
+                                Diagnostics.ReportDuplicateOverloadSignature(
+                                    methodSyntax.Identifier.Location,
+                                    methodName,
+                                    Binder.FormatOverloadSignature(specialization));
+                                break;
+                            }
+
+                            methodsBuilder.Add(specialization);
+                        }
+
+                        continue;
                     }
 
                     // ADR-0149: a method declared with an explicit-interface
@@ -2238,7 +2258,7 @@ internal sealed partial class DeclarationBinder
 
                     ValidateVariadicParameterShape(methodSyntax.Parameters);
 
-                    var returnType = bindReturnTypeClause(methodSyntax.Type, methodSyntax.IsAsync) ?? TypeSymbol.Void;
+                    var returnType = BindIteratorReturnType(methodSyntax);
                     var methodAccessibility = resolveAccessibility(methodSyntax.AccessibilityModifier);
 
                     // ADR-0146 (Kotlin visibility narrowing follow-up): infer/narrow the
@@ -2294,6 +2314,26 @@ internal sealed partial class DeclarationBinder
                     if (!isStaticPInvoke)
                     {
                         PInvokeBinder.ReportMarshalAsOnNonPInvokeFunction(methodSyntax, Diagnostics);
+                    }
+
+                    var nullableSequenceSpecializations = ExpandNullableSequenceIteratorSpecializations(methodSymbol);
+                    if (nullableSequenceSpecializations.Length > 1)
+                    {
+                        foreach (var specialization in nullableSequenceSpecializations)
+                        {
+                            if (staticMethodsBuilder.Any(existing => BoundScope.FunctionSignaturesEqual(existing, specialization)))
+                            {
+                                Diagnostics.ReportDuplicateOverloadSignature(
+                                    methodSyntax.Identifier.Location,
+                                    methodName,
+                                    Binder.FormatOverloadSignature(specialization));
+                                break;
+                            }
+
+                            staticMethodsBuilder.Add(specialization);
+                        }
+
+                        continue;
                     }
 
                     // ADR-0063 §11: detect duplicate-signature within the static block.

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.CallBinding.cs
@@ -1075,8 +1075,36 @@ internal sealed partial class OverloadResolver
         // and, where useful, types). The legacy `TryLookupSymbol` returned the
         // first declared overload; we now consult the overload-set store.
         var overloadSet = Scope.TryLookupFunctions(syntax.Identifier.Text);
+        var explicitOverloadTypeArguments = default(ImmutableArray<TypeSymbol>);
         if (overloadSet.Length > 1)
         {
+            if (syntax.TypeArgumentList != null)
+            {
+                var explicitArguments = ImmutableArray.CreateBuilder<TypeSymbol>(syntax.TypeArgumentList.Arguments.Count);
+                foreach (var explicitArgument in syntax.TypeArgumentList.Arguments)
+                {
+                    var boundTypeArgument = bindTypeClause(explicitArgument);
+                    if (boundTypeArgument == null)
+                    {
+                        return new BoundErrorExpression(null);
+                    }
+
+                    explicitArguments.Add(boundTypeArgument);
+                }
+
+                explicitOverloadTypeArguments = explicitArguments.MoveToImmutable();
+                var constraintMatches = overloadSet
+                    .Where(candidate => candidate.TypeParameters.Length == explicitOverloadTypeArguments.Length)
+                    .Where(candidate => candidate.TypeParameters
+                        .Select((typeParameter, index) => satisfiesConstraint(explicitOverloadTypeArguments[index], typeParameter))
+                        .All(matches => matches))
+                    .ToImmutableArray();
+                if (!constraintMatches.IsDefaultOrEmpty)
+                {
+                    overloadSet = constraintMatches;
+                }
+            }
+
             var selected = SelectBestUserOverload(overloadSet, syntax.Arguments.Count, argumentNames, boundArguments, out var overloadAmbiguous, out var nullSafetyFailure, syntax.TypeArgumentList?.Arguments.Count ?? 0);
             if (selected == null)
             {
@@ -1234,7 +1262,9 @@ internal sealed partial class OverloadResolver
 
                 for (var i = 0; i < explicitArgs.Count; i++)
                 {
-                    var ta = bindTypeClause(explicitArgs[i]);
+                    var ta = !explicitOverloadTypeArguments.IsDefault
+                        ? explicitOverloadTypeArguments[i]
+                        : bindTypeClause(explicitArgs[i]);
                     if (ta == null)
                     {
                         return new BoundErrorExpression(null);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.Candidates.cs
@@ -38,6 +38,33 @@ internal sealed partial class OverloadResolver
         // selection so generic candidates are filtered for applicability against
         // either the explicit type arguments or, in their absence, type inference.
         var explicitTypeArgCount = ce.TypeArgumentList?.Arguments.Count ?? 0;
+        if (explicitTypeArgCount > 0)
+        {
+            var explicitTypeArguments = ImmutableArray.CreateBuilder<TypeSymbol>(explicitTypeArgCount);
+            foreach (var explicitArgument in ce.TypeArgumentList.Arguments)
+            {
+                var typeArgument = bindTypeClause(explicitArgument);
+                if (typeArgument == null)
+                {
+                    return null;
+                }
+
+                explicitTypeArguments.Add(typeArgument);
+            }
+
+            var boundTypeArguments = explicitTypeArguments.MoveToImmutable();
+            var constraintMatches = overloads
+                .Where(candidate => candidate.TypeParameters.Length == boundTypeArguments.Length)
+                .Where(candidate => candidate.TypeParameters
+                    .Select((typeParameter, index) => satisfiesConstraint(boundTypeArguments[index], typeParameter))
+                    .All(matches => matches))
+                .ToImmutableArray();
+            if (!constraintMatches.IsDefaultOrEmpty)
+            {
+                overloads = constraintMatches;
+            }
+        }
+
         var selected = SelectBestInstanceOverload(overloads, arguments.Length, argumentNames, arguments, out var ambiguous, out var nullSafetyFailure, explicitTypeArgCount);
         if (selected != null)
         {
@@ -223,6 +250,25 @@ internal sealed partial class OverloadResolver
             if (filtered.Count > 0)
             {
                 applicable = filtered;
+            }
+        }
+
+        if (applicable.Count > 1)
+        {
+            var constrained = new List<FunctionSymbol>(applicable.Count);
+            foreach (var cand in applicable)
+            {
+                if (!cand.IsGeneric
+                    || (GetCachedCandidateSubstitution(cand, boundArguments, argumentCount, substitutionCache, out var substitution)
+                        && cand.TypeParameters.All(tp => satisfiesConstraint(substitution[tp], tp))))
+                {
+                    constrained.Add(cand);
+                }
+            }
+
+            if (constrained.Count > 0)
+            {
+                applicable = constrained;
             }
         }
 

--- a/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -9,6 +9,19 @@ using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
+/// <summary>Identifies compiler-generated CLR-representation variants of an unconstrained nullable sequence iterator.</summary>
+internal enum NullableSequenceSpecializationKind
+{
+    /// <summary>Ordinary function.</summary>
+    None,
+
+    /// <summary>Reference-type specialization.</summary>
+    ReferenceType,
+
+    /// <summary>Value-type specialization.</summary>
+    ValueType,
+}
+
 /// <summary>
 /// Represents a function symbol in the language.
 /// </summary>
@@ -438,6 +451,8 @@ public sealed class FunctionSymbol : Symbol
 
     /// <summary>Gets or sets a value indicating whether this synthetic function represents a type's static-constructor context.</summary>
     internal bool IsStaticInitializer { get; set; }
+
+    internal NullableSequenceSpecializationKind NullableSequenceSpecialization { get; set; }
 
     /// <summary>
     /// ADR-0105 Phase 2 — re-points this (reused) function symbol at the

--- a/test/Compiler.Tests/Emit/Issue2927NullableSequenceElementTypeTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2927NullableSequenceElementTypeTests.cs
@@ -384,6 +384,26 @@ public class Issue2927NullableSequenceElementTypeTests
     }
 
     [Fact]
+    public void SpecializedGenericIteratorResultConvertsToConcreteNullableSequence()
+    {
+        const string Source = """
+            package Issue2927ConcreteSequence
+            import System
+
+            func text(value int32?) string { if value == nil { return "nil" } return value.ToString() }
+            func values[T](value T) sequence[T?] {
+                yield value
+                yield nil
+            }
+
+            var concrete sequence[int32?] = values[int32](5)
+            for value in concrete { Console.WriteLine(text(value)) }
+            """;
+
+        AssertEmittedProgram(Source, "5\nnil\n", nameof(SpecializedGenericIteratorResultConvertsToConcreteNullableSequence));
+    }
+
+    [Fact]
     public void GenericNullableSequenceSpecializesTopLevelExtensionInstanceAndStaticIterators()
     {
         const string Source = """
@@ -506,6 +526,21 @@ public class Issue2927NullableSequenceElementTypeTests
     }
 
     [Fact]
+    public void UnconstrainedNullableSequenceNonIteratorReturnStillReportsGS0508()
+    {
+        const string Source = """
+            package Issue2927NonIteratorReturnDiagnosticGuard
+            func consume[T]() sequence[T?] -> nil
+            """;
+
+        var result = InvokeCompiler(Source, nameof(UnconstrainedNullableSequenceNonIteratorReturnStillReportsGS0508));
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Equal(1, result.Output.Split('\n').Count(line => line.Contains("error GS0508:", StringComparison.Ordinal)));
+        Assert.Equal(1, result.Output.Split('\n').Count(line => line.Contains("error GS0155:", StringComparison.Ordinal)));
+        Assert.False(File.Exists(result.AssemblyPath));
+    }
+
+    [Fact]
     public void UnconstrainedEnclosingTypeParameterIteratorStillReportsSingleGS0508()
     {
         const string Source = """
@@ -534,6 +569,61 @@ public class Issue2927NullableSequenceElementTypeTests
         Assert.Equal(1, result.Output.Split('\n').Count(line => line.Contains("error GS0125:", StringComparison.Ordinal)));
         Assert.DoesNotContain("error GS0508:", result.Output, StringComparison.Ordinal);
         Assert.False(File.Exists(result.AssemblyPath));
+    }
+
+    [Fact]
+    public void UnconstrainedGenericCallsCharacterizeSpecializedIteratorDiagnostics()
+    {
+        const string InferredSource = """
+            package Issue2927InferredDiagnostic
+            func opt[T](v T) sequence[T?] {
+                yield v
+                yield nil
+            }
+            func relay[U](u U) { let values = opt(u) }
+            """;
+        const string NamedSource = """
+            package Issue2927NamedDiagnostic
+            func opt[T](v T) sequence[T?] {
+                yield v
+                yield nil
+            }
+            func relay[U](u U) { let values = opt(v: u) }
+            """;
+        const string ExplicitSource = """
+            package Issue2927ExplicitDiagnostic
+            func opt[T](v T) sequence[T?] {
+                yield v
+                yield nil
+            }
+            func relay[U](u U) { let values = opt[U](u) }
+            """;
+        const string NullableSource = """
+            package Issue2927NullableArgumentDiagnostic
+            func opt[T](v T) sequence[T?] {
+                yield v
+                yield nil
+            }
+            let value int32? = 1
+            let values = opt[int32?](2)
+            """;
+
+        AssertSingleDiagnostic(
+            InvokeCompiler(InferredSource, nameof(UnconstrainedGenericCallsCharacterizeSpecializedIteratorDiagnostics) + "_inferred"),
+            "GS0266",
+            "Disambiguate with explicit types or named arguments.");
+        AssertSingleDiagnostic(
+            InvokeCompiler(NamedSource, nameof(UnconstrainedGenericCallsCharacterizeSpecializedIteratorDiagnostics) + "_named"),
+            "GS0266",
+            "Disambiguate with explicit types or named arguments.");
+        AssertSingleDiagnostic(
+            InvokeCompiler(ExplicitSource, nameof(UnconstrainedGenericCallsCharacterizeSpecializedIteratorDiagnostics) + "_explicit"),
+            "GS0266",
+            "Disambiguate with explicit types or named arguments.");
+        AssertSingleDiagnostic(
+            InvokeCompiler(NullableSource, nameof(UnconstrainedGenericCallsCharacterizeSpecializedIteratorDiagnostics) + "_nullable"),
+            "GS0152",
+            "does not satisfy the 'struct' constraint.");
     }
 
     private static void AssertEmittedProgram(string source, string expected, string name)
@@ -620,6 +710,21 @@ public class Issue2927NullableSequenceElementTypeTests
         Assert.Single(diagnostics);
         Assert.Contains("error GS0508:", diagnostics[0], StringComparison.Ordinal);
         Assert.False(File.Exists(result.AssemblyPath), "gsc must not emit an assembly after GS0508");
+    }
+
+    private static void AssertSingleDiagnostic(
+        (int ExitCode, string Output, string AssemblyPath) result,
+        string id,
+        string message)
+    {
+        Assert.NotEqual(0, result.ExitCode);
+        var diagnostics = result.Output.Split('\n')
+            .Where(line => line.Contains("error GS", StringComparison.Ordinal))
+            .ToArray();
+        Assert.Single(diagnostics);
+        Assert.Contains($"error {id}:", diagnostics[0], StringComparison.Ordinal);
+        Assert.Contains(message, diagnostics[0], StringComparison.Ordinal);
+        Assert.False(File.Exists(result.AssemblyPath));
     }
 
     private static (int ExitCode, string Output, string AssemblyPath) InvokeCompiler(string source, string name)

--- a/test/Compiler.Tests/Emit/Issue2927NullableSequenceElementTypeTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2927NullableSequenceElementTypeTests.cs
@@ -295,88 +295,294 @@ public class Issue2927NullableSequenceElementTypeTests
         Assert.Equal("A\nnil\n", RunBounded(assemblyPath, nameof(NullableUserEnumSequenceGuardLoadsVerifiesAndRuns)));
     }
 
-    [Theory]
-    [InlineData("Direct", """
-        for value in values[int32](5) {
-            Console.WriteLine(value)
-        }
-        """)]
-    [InlineData("ConcreteParameter", """
-        func consume(values sequence[int32?]) {
-            for value in values {
-                Console.WriteLine(value)
-            }
-        }
-
-        consume(values[int32](5))
-        """)]
-    [InlineData("AnnotatedVariable", """
-        var concrete sequence[int32?] = values[int32](5)
-        for value in concrete {
-            Console.WriteLine(value)
-        }
-        """)]
-    [InlineData("PassthroughFunction", """
-        func pass(values sequence[int32?]) sequence[int32?] -> values
-        for value in pass(values[int32](5)) {
-            Console.WriteLine(value)
-        }
-        """)]
-    public void GenericNullableSequenceReportsSingleGS0508(string shape, string usage)
+    [Fact]
+    public void GenericNullableSequenceSpecializesValueAndReferenceElements()
     {
-        var source = $$"""
-            package Issue2927Generic{{shape}}
+        const string Source = """
+            package Issue2927GenericSync
             import System
+            import System.Collections.Generic
 
+            func intText(value int32?) string { if value == nil { return "nil" } return value.ToString() }
+            func boolText(value bool?) string { if value == nil { return "nil" } return value.ToString() }
+            func stringText(value string?) string { if value == nil { return "nil" } return value }
             func values[T](value T) sequence[T?] {
                 yield value
                 yield nil
             }
 
-            {{usage}}
+            func consume(values IEnumerable[int32?]) {
+                for value in values { Console.WriteLine(intText(value)) }
+            }
+
+            var iterator = values[int32](5).GetEnumerator()
+            iterator.MoveNext()
+            Console.WriteLine(intText(iterator.Current))
+            iterator.MoveNext()
+            Console.WriteLine(intText(iterator.Current))
+            consume(values[int32](7))
+            for value in values[bool](true) { Console.WriteLine(boolText(value)) }
+            for value in values[string]("x") { Console.WriteLine(stringText(value)) }
+            for value in values(9) { Console.WriteLine(intText(value)) }
+            for value in values("y") { Console.WriteLine(stringText(value)) }
             """;
 
-        // GS0508 prevents emission, so no assembly exists to load or pass to IlVerifier.
-        AssertSingleGS0508(source, $"{nameof(GenericNullableSequenceReportsSingleGS0508)}_{shape}");
+        AssertEmittedProgram(Source, "5\nnil\n7\nnil\nTrue\nnil\nx\nnil\n9\nnil\ny\nnil\n", nameof(GenericNullableSequenceSpecializesValueAndReferenceElements));
     }
 
     [Fact]
-    public void GenericAsyncNullableSequenceReportsSingleGS0508()
+    public void GenericAsyncNullableSequenceSpecializesValueAndReferenceElements()
     {
         const string Source = """
             package Issue2927GenericAsync
             import System
             import System.Threading.Tasks
 
-            func text(value int32?) string {
-                if value == nil {
-                    return "nil"
+            class Resource : IAsyncDisposable {
+                func DisposeAsync() ValueTask {
+                    Console.WriteLine("disposed")
+                    return ValueTask.CompletedTask
                 }
-
-                return value.ToString()
             }
 
+            func intText(value int32?) string { if value == nil { return "nil" } return value.ToString() }
+            func stringText(value string?) string { if value == nil { return "nil" } return value }
             async func values[T](value T) async sequence[T?] {
+                await using let resource = Resource{}
                 yield value
                 await Task.Delay(1)
                 yield nil
             }
 
-            public var result = ""
-
             async func collect() {
-                await for value in values[int32](5) {
-                    result = result + text(value) + ","
-                }
+                await for value in values[int32](5) { Console.WriteLine(intText(value)) }
+                await for value in values[string]("x") { Console.WriteLine(stringText(value)) }
             }
 
             collect().Wait()
-            Console.WriteLine(result)
             """;
 
-        // GS0508 prevents emission, so no assembly exists to load or pass to IlVerifier.
-        AssertSingleGS0508(Source, nameof(GenericAsyncNullableSequenceReportsSingleGS0508));
+        AssertEmittedProgram(Source, "5\nnil\ndisposed\nx\nnil\ndisposed\n", nameof(GenericAsyncNullableSequenceSpecializesValueAndReferenceElements));
     }
+
+    [Fact]
+    public void GenericNullableSequenceSupportsExplicitTypeArgumentsWithoutValueArguments()
+    {
+        const string Source = """
+            package Issue2927GenericExplicit
+            import System
+
+            func intText(value int32?) string { if value == nil { return "nil" } return value.ToString() }
+            func stringText(value string?) string { if value == nil { return "nil" } return value }
+            func empty[T]() sequence[T?] { yield nil }
+
+            for value in empty[int32]() { Console.WriteLine(intText(value)) }
+            for value in empty[string]() { Console.WriteLine(stringText(value)) }
+            """;
+
+        AssertEmittedProgram(Source, "nil\nnil\n", nameof(GenericNullableSequenceSupportsExplicitTypeArgumentsWithoutValueArguments));
+    }
+
+    [Fact]
+    public void GenericNullableSequenceSpecializesTopLevelExtensionInstanceAndStaticIterators()
+    {
+        const string Source = """
+            package Issue2927GenericForms
+            import System
+
+            func text(value int32?) string { if value == nil { return "nil" } return value.ToString() }
+            func top[T](value T) sequence[T?] {
+                yield value
+                yield nil
+            }
+
+            func (self string) extensionValues[T](value T) sequence[T?] {
+                yield value
+                yield nil
+            }
+
+            class Box {
+                func instanceValues[T](value T) sequence[T?] {
+                    yield value
+                    yield nil
+                }
+
+                func instanceEmpty[T]() sequence[T?] { yield nil }
+
+                shared {
+                    func staticValues[T](value T) sequence[T?] {
+                        yield value
+                        yield nil
+                    }
+
+                    func staticEmpty[T]() sequence[T?] { yield nil }
+                }
+            }
+
+            func (self Box) receiverValues[T](value T) sequence[T?] {
+                yield value
+                yield nil
+            }
+
+            for value in top[int32](1) { Console.WriteLine(text(value)) }
+            for value in "x".extensionValues[int32](2) { Console.WriteLine(text(value)) }
+            var box = Box()
+            for value in box.instanceValues[int32](3) { Console.WriteLine(text(value)) }
+            for value in Box.staticValues[int32](4) { Console.WriteLine(text(value)) }
+            for value in box.instanceEmpty[int32]() { Console.WriteLine(text(value)) }
+            for value in Box.staticEmpty[int32]() { Console.WriteLine(text(value)) }
+            for value in box.receiverValues[int32](5) { Console.WriteLine(text(value)) }
+            """;
+
+        AssertEmittedProgram(Source, "1\nnil\n2\nnil\n3\nnil\n4\nnil\nnil\nnil\n5\nnil\n", nameof(GenericNullableSequenceSpecializesTopLevelExtensionInstanceAndStaticIterators));
+    }
+
+    [Fact]
+    public void GenericNullableSequenceMetadataUsesMatchingSpecializedSignaturesAndInterfaces()
+    {
+        const string Source = """
+            package Issue2927GenericMetadata
+            import System
+            import System.Threading.Tasks
+
+            func values[T](value T) sequence[T?] {
+                yield value
+                yield nil
+            }
+
+            async func asyncValues[T](value T) async sequence[T?] {
+                yield value
+                await Task.Delay(1)
+                yield nil
+            }
+
+            Console.WriteLine("ok")
+            """;
+
+        var assemblyPath = Compile(Source, nameof(GenericNullableSequenceMetadataUsesMatchingSpecializedSignaturesAndInterfaces));
+        IlVerifier.Verify(assemblyPath);
+        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var types = assembly.GetTypes();
+        Assert.NotEmpty(types);
+
+        AssertSpecializedMethods(types, "values", typeof(IEnumerable<>));
+        AssertSpecializedMethods(types, "asyncValues", typeof(IAsyncEnumerable<>));
+        AssertSpecializedIteratorInterfaces(types, typeof(IEnumerable<>));
+        AssertSpecializedIteratorInterfaces(types, typeof(IAsyncEnumerable<>));
+        Assert.Equal("ok\n", RunBounded(assemblyPath, nameof(GenericNullableSequenceMetadataUsesMatchingSpecializedSignaturesAndInterfaces)));
+    }
+
+    [Fact]
+    public void NestedNullableSequenceGuardLoadsVerifiesAndRuns()
+    {
+        const string Source = """
+            package Issue2927Nested
+            import System
+
+            func text(value int32?) string { if value == nil { return "nil" } return value.ToString() }
+            func inner() sequence[int32?] {
+                yield 3
+                yield nil
+            }
+
+            func outer() sequence[sequence[int32?]] { yield inner() }
+            for group in outer() {
+                for value in group { Console.WriteLine(text(value)) }
+            }
+            """;
+
+        AssertEmittedProgram(Source, "3\nnil\n", nameof(NestedNullableSequenceGuardLoadsVerifiesAndRuns));
+    }
+
+    [Fact]
+    public void UnconstrainedNullableSequenceOutsideIteratorStillReportsSingleGS0508()
+    {
+        const string Source = """
+            package Issue2927DiagnosticGuard
+            func consume[T](values sequence[T?]) int32 -> 1
+            """;
+
+        AssertSingleGS0508(Source, nameof(UnconstrainedNullableSequenceOutsideIteratorStillReportsSingleGS0508));
+    }
+
+    [Fact]
+    public void UnconstrainedEnclosingTypeParameterIteratorStillReportsSingleGS0508()
+    {
+        const string Source = """
+            package Issue2927EnclosingTypeDiagnosticGuard
+            class Box[T] {
+                func values(value T) sequence[T?] {
+                    yield value
+                    yield nil
+                }
+            }
+            """;
+
+        AssertSingleGS0508(Source, nameof(UnconstrainedEnclosingTypeParameterIteratorStillReportsSingleGS0508));
+    }
+
+    [Fact]
+    public void SpecializedIteratorBodyDiagnosticIsReportedOnce()
+    {
+        const string Source = """
+            package Issue2927DiagnosticDeduplication
+            func values[T](value T) sequence[T?] { yield missing }
+            """;
+
+        var result = InvokeCompiler(Source, nameof(SpecializedIteratorBodyDiagnosticIsReportedOnce));
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Equal(1, result.Output.Split('\n').Count(line => line.Contains("error GS0125:", StringComparison.Ordinal)));
+        Assert.DoesNotContain("error GS0508:", result.Output, StringComparison.Ordinal);
+        Assert.False(File.Exists(result.AssemblyPath));
+    }
+
+    private static void AssertEmittedProgram(string source, string expected, string name)
+    {
+        var assemblyPath = Compile(source, name);
+        IlVerifier.Verify(assemblyPath);
+        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        Assert.NotEmpty(assembly.GetTypes());
+        Assert.Equal(expected, RunBounded(assemblyPath, name));
+    }
+
+    private static void AssertSpecializedMethods(Type[] types, string methodName, Type openReturnType)
+    {
+        var methods = types
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            .Where(method => method.Name == methodName)
+            .ToArray();
+        Assert.Equal(2, methods.Length);
+
+        var referenceMethod = methods.Single(method =>
+            (method.GetGenericArguments()[0].GenericParameterAttributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0);
+        var valueMethod = methods.Single(method =>
+            (method.GetGenericArguments()[0].GenericParameterAttributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0);
+
+        Assert.Equal(openReturnType, referenceMethod.ReturnType.GetGenericTypeDefinition());
+        Assert.True(referenceMethod.ReturnType.GetGenericArguments()[0].IsGenericParameter);
+        Assert.Equal(openReturnType, valueMethod.ReturnType.GetGenericTypeDefinition());
+        AssertNullableGenericParameter(valueMethod.ReturnType.GetGenericArguments()[0]);
+    }
+
+    private static void AssertSpecializedIteratorInterfaces(Type[] types, Type openInterface)
+    {
+        var elements = types
+            .SelectMany(type => type.GetInterfaces())
+            .Where(@interface => @interface.IsGenericType && @interface.GetGenericTypeDefinition() == openInterface)
+            .Select(@interface => @interface.GetGenericArguments()[0])
+            .ToArray();
+
+        Assert.Contains(elements, element => element.IsGenericParameter);
+        Assert.Contains(elements, IsNullableGenericParameter);
+    }
+
+    private static void AssertNullableGenericParameter(Type type)
+        => Assert.True(IsNullableGenericParameter(type), $"Expected Nullable<T>, got '{type}'.");
+
+    private static bool IsNullableGenericParameter(Type type)
+        => type.IsGenericType
+        && type.GetGenericTypeDefinition() == typeof(Nullable<>)
+        && type.GetGenericArguments()[0].IsGenericParameter;
 
     private static async Task AssertParity(string source, string expected, string name, bool evaluateWithInterpreter)
     {

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -1730,8 +1730,7 @@ different method.
 |----|----------|-------------|
 | GS0508 | Error | A nullable sequence element uses a type parameter that is not constrained to `struct` or a reference type. |
 
-`sequence[T?]` needs one stable CLR element representation. Use a `struct`
-constraint when `T?` must be `System.Nullable<T>`, or a `class`/base-class
-constraint when it must use reference-type nullability. An unconstrained `T`
-can represent either shape and is rejected until generic sequence
-specialization supports both.
+`sequence[T?]` needs one stable CLR element representation. Iterator return
+types are specialized into `class` and `struct` variants automatically.
+Other unconstrained sequence type positions still require an explicit
+`struct`, `class`, or base-class constraint.

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -1734,3 +1734,11 @@ different method.
 types are specialized into `class` and `struct` variants automatically.
 Other unconstrained sequence type positions still require an explicit
 `struct`, `class`, or base-class constraint.
+
+A call from another unconstrained generic context cannot select either
+specialized iterator variant. Constrain the enclosing type parameter to
+`struct`, `class`, or a base class. Named or explicit arguments do not resolve
+that call: until [#2958](https://github.com/DavidObando/gsharp/issues/2958),
+it reports GS0266, and a nullable value-type argument may instead report
+GS0152. G# rejects source overloads differentiated only by constraints with
+GS0264, even though iterator specialization synthesizes equivalent variants.


### PR DESCRIPTION
## Summary

- specialize unconstrained nullable generic iterator returns into `class` and `struct` CLR variants
- route top-level, extension, receiver-clause, instance, shared, sync, and async iterators through the same specialization
- filter specialized overloads by inferred or explicit type-argument constraints
- retain `GS0508` for unsupported non-iterator and enclosing-type-parameter sequence positions
- add load, reflection metadata, execution, conversion, consumption, and diagnostic regression coverage

## Baseline triage (`e21677f6`)

- Repro 1: already fixed. Sync `sequence[int32?]` assembly loaded via `Assembly.Load(...).GetTypes()` and executed successfully.
- Repro 2: already fixed by #2923. `List[int32?]` converted to `sequence[int32?]` and executed without `GS0154`.
- Repro 3: remained. Normal compiler reported `GS0508`; removing that guard as a control emitted a loadable assembly that failed at `IEnumerable<T>.GetEnumerator()` with `EntryPointNotFoundException`.

## Root cause

`NullableTypeSymbol` stores `UnderlyingType.ClrType`, so open `T?` is nullability-blind at the CLR leaf. `SignatureEncoder` can encode `T?` correctly only after `T` has a stable `class` or `struct` constraint. Call-site substitution produced `Nullable<int32>`, while the unspecialized generic iterator metadata encoded bare `T`, making bound type, method signature, and state-machine interface disagree.

This change creates constrained iterator variants before binding/emission. Existing signature and state-machine emit paths then encode matching `T` or `Nullable<T>` metadata. No `StateMachineEmitter` changes were needed.

## Review follow-ups

- Added a non-iterator `sequence[T?]` return guard. Build-green M4 (`syntax.Body != null` without `ContainsYield`) now fails exactly this test; restored control passes 20/20.
- Added execution coverage assigning `values[int32](5)` to a concrete `sequence[int32?]` and producing `5`, `nil`.
- Characterized the current GS0266/GS0152 behavior for unconstrained generic callers and documented the actual enclosing-constraint remedy. Diagnostic improvement tracked by #2958.
- Filed pre-existing issues #2959 (missing canonical GS0506 docs) and #2960 (unloadable struct interface-property assembly). Both are independent of this PR.

## Verification

- Issue tests: 20/20 pass
- Pins: 8 fail on main source and pass here
- Guards: 12 pass on both
- Semantic mutations: original unmutated control 17/17 and all 21 branch mutations killed after rebuild; review M4 is also build-green and killed by the new pin (1 failed, 19 passed)
- Current baseline `17789519`: Core 7007 + 1 skipped = 7008; Compiler 3876; Interpreter 472
- Final head: Core 7007 + 1 skipped = 7008; Compiler 3883; Interpreter 472
- Compiler delta: reviewed PR was +4, not +5; three review follow-up facts make the final delta +7
- Full 148-file corpus comparison: 148/148, `BYTEDIFF=0 DIAGDIFF=0 RCDIFF=0`
- Corpus is non-regression evidence only: 3/148 files contain `yield` text, 1/148 contains `sequence[`, and 0/148 use `sequence[T?]`
- Release compiler build: 0 warnings, 0 errors

Fixes #2927
