### PR TITLE
gsc: enforce GS0100 on lambda bodies

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -255,6 +255,7 @@ public sealed class Binder
             bindBlockStatement: syntax => statements.BindBlockStatement(syntax),
             bindTypeClause: BindTypeClause,
             bindReturnTypeClause: (syntax, isAsync) => BindReturnTypeClause(syntax, isAsync),
+            isIteratorReturnType: IsIteratorReturnType,
             isAsyncIteratorReturnType: IsAsyncIteratorReturnType,
             resolveClrTypeForGenericArg: ResolveClrTypeForGenericArg,
             getCurrentFunction: () => this.function,

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -71,6 +71,7 @@ internal sealed class LambdaBinder
     private readonly Func<BlockStatementSyntax, BoundStatement> bindBlockStatement;
     private readonly Func<TypeClauseSyntax, TypeSymbol> bindTypeClause;
     private readonly Func<TypeClauseSyntax, bool, TypeSymbol> bindReturnTypeClause;
+    private readonly Func<TypeSymbol, bool> isIteratorReturnType;
     private readonly Func<TypeSymbol, bool> isAsyncIteratorReturnType;
     private readonly Func<TypeSymbol, Type> resolveClrTypeForGenericArg;
     private readonly Func<FunctionSymbol> getCurrentFunction;
@@ -101,6 +102,9 @@ internal sealed class LambdaBinder
     /// declared return-type clause, with the <c>isAsync</c> flag so
     /// the still-on-Binder helper can apply the async-specific
     /// validation it already performs.</param>
+    /// <param name="isIteratorReturnType">Callback that returns
+    /// <c>true</c> when the supplied return type is an iterator shape
+    /// and therefore does not require an ordinary value return.</param>
     /// <param name="isAsyncIteratorReturnType">Callback that returns
     /// <c>true</c> when the supplied return type is an async-iterator
     /// shape (ADR-0041) and therefore does NOT participate in the
@@ -143,6 +147,7 @@ internal sealed class LambdaBinder
         Func<BlockStatementSyntax, BoundStatement> bindBlockStatement,
         Func<TypeClauseSyntax, TypeSymbol> bindTypeClause,
         Func<TypeClauseSyntax, bool, TypeSymbol> bindReturnTypeClause,
+        Func<TypeSymbol, bool> isIteratorReturnType,
         Func<TypeSymbol, bool> isAsyncIteratorReturnType,
         Func<TypeSymbol, Type> resolveClrTypeForGenericArg,
         Func<FunctionSymbol> getCurrentFunction,
@@ -156,6 +161,7 @@ internal sealed class LambdaBinder
         this.bindBlockStatement = bindBlockStatement ?? throw new ArgumentNullException(nameof(bindBlockStatement));
         this.bindTypeClause = bindTypeClause ?? throw new ArgumentNullException(nameof(bindTypeClause));
         this.bindReturnTypeClause = bindReturnTypeClause ?? throw new ArgumentNullException(nameof(bindReturnTypeClause));
+        this.isIteratorReturnType = isIteratorReturnType ?? throw new ArgumentNullException(nameof(isIteratorReturnType));
         this.isAsyncIteratorReturnType = isAsyncIteratorReturnType ?? throw new ArgumentNullException(nameof(isAsyncIteratorReturnType));
         this.resolveClrTypeForGenericArg = resolveClrTypeForGenericArg ?? throw new ArgumentNullException(nameof(resolveClrTypeForGenericArg));
         this.getCurrentFunction = getCurrentFunction ?? throw new ArgumentNullException(nameof(getCurrentFunction));
@@ -385,6 +391,7 @@ internal sealed class LambdaBinder
         // existing statement-body handling (no implicit return) so the #889
         // Action-style void-delegate path is preserved.
         body = SynthesizeFunctionLiteralTrailingReturn((BoundBlockStatement)body, syntax, returnType);
+        CheckAllPathsReturn((BoundBlockStatement)body, returnType, syntax.Body.Location);
 
         var captured = CollectCapturedVariables(body, synthetic.Parameters);
 
@@ -878,6 +885,7 @@ internal sealed class LambdaBinder
         }
 
         var bodyBlock = new BoundBlockStatement(syntax.Body, bodyStatements.ToImmutable());
+        CheckAllPathsReturn(bodyBlock, returnType, syntax.Body.Location);
         var fnType = FunctionTypeSymbol.Get(parameterTypes.MoveToImmutable(), BuildVariadicFlagsIfAny(parameterSymbols), observableReturnType);
         var captured = CollectCapturedVariables(bodyBlock, synthetic.Parameters);
 
@@ -1289,6 +1297,17 @@ internal sealed class LambdaBinder
         }
 
         return element;
+    }
+
+    private void CheckAllPathsReturn(BoundBlockStatement body, TypeSymbol returnType, TextLocation location)
+    {
+        if (returnType != TypeSymbol.Void
+            && returnType != TypeSymbol.Error
+            && !isIteratorReturnType(returnType)
+            && !ControlFlowGraph.AllPathsReturn(Lowerer.Lower(body)))
+        {
+            Diagnostics.ReportAllPathsMustReturn(location);
+        }
     }
 
     /// <summary>Binds and attaches user annotations on a lambda parameter.</summary>

--- a/test/Compiler.Tests/Emit/Issue2921LambdaBodyDefiniteReturnTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2921LambdaBodyDefiniteReturnTests.cs
@@ -176,6 +176,20 @@ public class Issue2921LambdaBodyDefiniteReturnTests
         Assert.Equal(expectedOutput, RunBounded(result.AssemblyPath, name));
     }
 
+    [Fact]
+    public void UnknownReturnTypeDoesNotCascadeGs0100()
+    {
+        var result = InvokeCompiler("""
+            package Issue2921.UnknownReturnType
+            var bad (bool) -> MissingType[int32] = (v bool) -> {
+                if v { return MissingFunction() }
+            }
+            """, "UnknownReturnType");
+
+        Assert.Contains("error GS0113:", result.Output, StringComparison.Ordinal);
+        Assert.DoesNotContain("error GS0100:", result.Output, StringComparison.Ordinal);
+    }
+
     private static object[] Case(string name, string source) => new object[] { name, source };
 
     private static object[] Case(string name, string expectedOutput, string source) =>
@@ -244,7 +258,7 @@ public class Issue2921LambdaBodyDefiniteReturnTests
         if (!exited)
         {
             process.Kill(entireProcessTree: true);
-            process.WaitForExit();
+            Assert.True(process.WaitForExit(5_000), $"{name}: emitted program did not stop after kill");
         }
 
         Assert.True(exited, $"{name}: emitted program timed out");

--- a/test/Compiler.Tests/Emit/Issue2921LambdaBodyDefiniteReturnTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2921LambdaBodyDefiniteReturnTests.cs
@@ -1,0 +1,256 @@
+// <copyright file="Issue2921LambdaBodyDefiniteReturnTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2921: non-void lambda bodies enforce GS0100 before emission.
+/// </summary>
+public class Issue2921LambdaBodyDefiniteReturnTests
+{
+    /// <summary>Gets lambda bodies with a reachable fall-through path.</summary>
+    public static IEnumerable<object[]> MissingReturnCases()
+    {
+        yield return Case("SwitchEscape", """
+            package Issue2921.SwitchEscape
+            func G(f (int32) -> int32) int32 { return f(1) }
+            func F(x int32) int32 {
+                return G(func(v int32) int32 {
+                    for {
+                        switch v {
+                            case 1 { break }
+                            default { return 1 }
+                        }
+                    }
+                })
+            }
+            public var result = F(0)
+            """);
+        yield return Case("ConditionalFunctionLiteral", """
+            package Issue2921.ConditionalFunctionLiteral
+            func G(f (int32) -> int32) int32 { return f(1) }
+            func F() int32 {
+                return G(func(v int32) int32 { if v == 0 { return 1 } })
+            }
+            public var result = F()
+            """);
+        yield return Case("InferredArrowLambda", """
+            package Issue2921.InferredArrowLambda
+            func Use(f (int32) -> int32) { }
+            Use((v int32) -> { if v == 0 { return 1 } })
+            """);
+        yield return Case("AsyncFunctionLiteral", """
+            package Issue2921.AsyncFunctionLiteral
+            let bad = async func(v int32) int32 { if v == 0 { return 1 } }
+            """);
+        yield return Case("TryFinally", """
+            package Issue2921.TryFinally
+            func Use(f (int32) -> int32) { }
+            Use(func(v int32) int32 {
+                try { if v == 0 { return 1 } }
+                finally { }
+            })
+            """);
+        yield return Case("NestedFunctionLiteral", """
+            package Issue2921.NestedFunctionLiteral
+            let outer = func() (int32) -> int32 {
+                return func(v int32) int32 { if v == 0 { return 1 } }
+            }
+            """);
+        yield return Case("FixedFunctionLiteral", """
+            package Issue2921.FixedFunctionLiteral
+            func Use(f () -> int32) { }
+            func F(xs []int32) {
+                Use(func() int32 {
+                    unsafe {
+                        fixed p *int32 = xs {
+                            if xs.Length > 0 { return 1 }
+                        }
+                    }
+                })
+            }
+            F([]int32{})
+            """);
+    }
+
+    /// <summary>Gets accepted lambda programs and their expected output.</summary>
+    public static IEnumerable<object[]> AcceptedCases()
+    {
+        yield return Case("OrdinaryShapes", "30\n", """
+            package Issue2921.OrdinaryShapes
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            let expression = (x int32) -> x + 1
+            let block = (x int32) -> {
+                if x == 0 { return 10 }
+                return x + 1
+            }
+            let nested = (x int32) -> { return (y int32) -> x + y }
+
+            var seen = 0
+            let action = func(v int32) { seen = v }
+            action(3)
+
+            let nums = List[int32]()
+            nums.Add(2)
+            let selected = nums.Select((x) -> { return x * 3 }).Single()
+            Console.WriteLine(expression(1) + block(0) + nested(4)(5) + selected + seen)
+            """);
+        yield return Case("TerminatingBodies", "5\n", """
+            package Issue2921.TerminatingBodies
+            import System
+
+            let box = Lazy[string](valueFactory: () -> {
+                throw InvalidOperationException("not called")
+            })
+            let forever = func() int32 { for { } }
+
+            var finalCount = 0
+            let guarded = func(v int32) int32 {
+                try { return v }
+                finally { finalCount += 1 }
+            }
+            Console.WriteLine(guarded(4) + finalCount)
+            """);
+        yield return Case("AsyncFunctionLiteral", "3\n", """
+            package Issue2921.AsyncFunctionLiteralGuard
+            import System
+
+            let asyncRead = async func(v int32) int32 { return v + 1 }
+            Console.WriteLine(asyncRead(2).Result)
+            """);
+        yield return Case("FixedFunctionLiteral", "3\n", """
+            package Issue2921.FixedFunctionLiteralGuard
+            import System
+
+            func F(xs []int32) int32 {
+                let read = func() int32 {
+                    unsafe {
+                        fixed p *int32 = xs {
+                            return xs.Length
+                        }
+                    }
+                }
+                return read()
+            }
+            Console.WriteLine(F([]int32{1, 2, 3}))
+            """);
+    }
+
+    [Theory]
+    [MemberData(nameof(MissingReturnCases))]
+    public void MissingReturnReportsSingleGs0100AndDoesNotEmit(string name, string source)
+    {
+        var result = InvokeCompiler(source, name);
+
+        Assert.NotEqual(0, result.ExitCode);
+        var errors = result.Output.Split('\n')
+            .Where(line => line.Contains("error GS", StringComparison.Ordinal))
+            .ToArray();
+        Assert.Single(errors);
+        Assert.Contains("error GS0100: Not all code paths return a value.", errors[0], StringComparison.Ordinal);
+        Assert.False(File.Exists(result.AssemblyPath));
+    }
+
+    [Theory]
+    [MemberData(nameof(AcceptedCases))]
+    public void AcceptedLambdasLoadAndRunInChildProcess(string name, string expectedOutput, string source)
+    {
+        var result = InvokeCompiler(source, name);
+
+        Assert.Equal(0, result.ExitCode);
+        var assembly = Assembly.Load(File.ReadAllBytes(result.AssemblyPath));
+        Assert.NotEmpty(assembly.GetTypes());
+        Assert.Equal(expectedOutput, RunBounded(result.AssemblyPath, name));
+    }
+
+    private static object[] Case(string name, string source) => new object[] { name, source };
+
+    private static object[] Case(string name, string expectedOutput, string source) =>
+        new object[] { name, expectedOutput, source };
+
+    private static (int ExitCode, string Output, string AssemblyPath) InvokeCompiler(string source, string name)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue2921LambdaBodyDefiniteReturnTests),
+            name);
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var assemblyPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+        File.Delete(assemblyPath);
+        File.Delete(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousErr = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousErr);
+        }
+
+        return (exitCode, stdout.ToString() + stderr.ToString(), assemblyPath);
+    }
+
+    private static string RunBounded(string assemblyPath, string name)
+    {
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                assemblyPath,
+            },
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+
+        Assert.NotNull(process);
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        var exited = process.WaitForExit(30_000);
+        if (!exited)
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+        }
+
+        Assert.True(exited, $"{name}: emitted program timed out");
+        var output = outputTask.GetAwaiter().GetResult();
+        var error = errorTask.GetAwaiter().GetResult();
+        Assert.True(process.ExitCode == 0, $"{name}: emitted program failed:\n{error}");
+        return output.Replace("\r\n", "\n");
+    }
+}

--- a/test/Interpreter.Tests/Issue2921LambdaBodyDefiniteReturnInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2921LambdaBodyDefiniteReturnInterpreterTests.cs
@@ -1,0 +1,55 @@
+// <copyright file="Issue2921LambdaBodyDefiniteReturnInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2921: compiled and interpreted lambda binding share GS0100 behavior.
+/// </summary>
+public class Issue2921LambdaBodyDefiniteReturnInterpreterTests
+{
+    [Fact]
+    public void MissingReturnHasCompiledAndInterpretedDiagnosticParity()
+    {
+        const string Source = """
+            func Use(f (int32) -> int32) { }
+            Use((v int32) -> { if v == 0 { return 1 } })
+            """;
+
+        using var output = new MemoryStream();
+        var emitResult = new Compilation(SyntaxTree.Parse(Source)).Emit(output);
+        var evaluationResult = new Compilation(SyntaxTree.Parse(Source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Equal(
+            new[] { "GS0100" },
+            emitResult.Diagnostics.Where(diagnostic => diagnostic.IsError).Select(diagnostic => diagnostic.Id));
+        Assert.Equal(
+            new[] { "GS0100" },
+            evaluationResult.Diagnostics.Where(diagnostic => diagnostic.IsError).Select(diagnostic => diagnostic.Id));
+    }
+
+    [Fact]
+    public void SequenceLambdaDoesNotRequireOrdinaryReturn()
+    {
+        const string Source = """
+            let values = func() sequence[int32] { yield 2 }
+            0
+            """;
+
+        var result = new Compilation(SyntaxTree.Parse(Source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+}


### PR DESCRIPTION
## Summary

- enforce GS0100 for non-void function-literal and arrow-lambda bodies with reachable fall-through paths
- reuse the existing lowered `ControlFlowGraph.AllPathsReturn` analysis, including protected-region and exhaustive-switch projection from #2926
- preserve void, error, iterator, throw-only, infinite-loop, async, fixed, nested, expression-bodied, and imported-delegate lambda behavior
- add compiled/interpreted diagnostic parity and child-process runtime coverage

Fixes #2921

## Root cause

The issue description identified the arrow-lambda inference path: `InferLambdaReturnType` used `ControlFlowGraph.AllPathsReturn` only to infer whether a body completed normally, never to report GS0100. The exact repros use explicit `func(...) R { ... }` function literals, which bypass that inference path entirely and also lacked definite-return enforcement. Both binding paths now call one shared check after their final `BoundBlockStatement` is formed.

## Production delta

- `Binder.cs`: +1 line, inject the existing full iterator-return predicate
- `LambdaBinder.cs`: +19 lines, two call sites plus one shared definite-return check and callback plumbing

No new control-flow analyzer or emitter fallback was added.

## Verification

- exact switch and conditional repros: base emits; head reports one GS0100 and emits nothing
- current pre-fix symptom at base `17789519`: assemblies load and `GetTypes()` succeeds, then bounded child execution exits 134 with #2926's compiler-generated `InvalidOperationException` fall-through guard; the issue's older `InvalidProgramException` / `ReturnMissing` description is stale
- accepted outputs: `Assembly.Load` + `GetTypes()` + bounded child-process execution
- targeted tests at current head: Compiler 12/12, Interpreter 2/2
- Release solution build: 0 warnings, 0 errors

### Executed suites after rebase

Base `8dddbbf2`:

| suite | result |
|---|---:|
| Core | 7028 passed, 1 skipped |
| Compiler | 3893 passed, 0 failed |
| Interpreter | 489 passed, 0 failed |
| LSP | 452 passed, 0 failed |

Head `e02815ba`:

| suite | result |
|---|---:|
| Core | 7028 passed, 1 skipped |
| Compiler | 3905 passed, 0 failed |
| Interpreter | 491 passed, 0 failed |
| LSP | 452 passed, 0 failed |

Delta: +12 Compiler and +2 Interpreter = 14 tests.

Reviewer-confirmed pre-rebase head `1bff3720`: Core 7007 passed / 1 skipped, Compiler 3887 passed, Interpreter 474 passed. Its base `17789519` was Core 7007+1 / Compiler 3876 / Interpreter 472 / LSP 452.

### Pins

- function-literal switch escape
- function-literal conditional fall-through
- inferred arrow-lambda fall-through
- async, try/finally, nested, and fixed-containing fall-through
- no output after GS0100

### Guards

- void and expression-bodied lambdas
- nested valid lambdas
- throw-only and infinite-loop bodies
- try/finally and fixed bodies that return
- async lambdas
- imported generic delegate inference through LINQ and `Lazy<T>` (#891)
- iterator return types excluded from ordinary definite return
- error return types suppress cascading GS0100
- compiled/interpreted diagnostic parity

### Mutations

All five build-green semantic mutations were killed:

1. remove function-literal check: 6 Compiler cases fail
2. remove arrow-lambda check: Compiler and Interpreter parity pins fail
3. remove void exemption: accepted lambda guard fails
4. remove iterator exemption: sequence/yield guard fails
5. remove error-type exemption: new unknown-return-type guard fails

M5 control: 12 passed / 0 failed. M5 mutation: 11 passed / 1 failed, with the new test detecting the spurious GS0100 cascade while retaining GS0113.

### Corpus

All 148 sample programs were compiled with base and head compilers. Results: 142 successes on each side, 0 exit-code drift, 0 diagnostic drift, and 0 SHA-256 output-binary drift. The corpus contains 19 files with a non-void lambda; no corpus sample exercises a missing-return lambda. Reviewer follow-up independently found zero false positives across all 148 samples plus approximately 16 hand-written multi-shape probe files.

## Fixed and sequence notes

A missing-return lambda containing `fixed` now reports GS0100 before emission, shrinking #2953 to named functions. A valid all-returning fixed lambda still loads and executes.

A regular function-literal iterator remains blocked by the pre-existing `yield reached the emitter before iterator lowering` GS9998 failure on base and head. The iterator exemption itself is covered through interpreted binding. Follow-up: #2957.
