### PR TITLE
Invalidate narrowing across loop back-edges

### DIFF
--- a/docs/adr/0069-smart-cast-flow-narrowing.md
+++ b/docs/adr/0069-smart-cast-flow-narrowing.md
@@ -313,6 +313,24 @@ A member-path narrowing is conservatively dropped when anything in scope could c
 
 This is intentionally stricter than Kotlin (which keeps `val`-member casts across benign calls), but it satisfies the issue's explicit "intervening call invalidates" requirement and is trivially sound. Local-root narrowings retain their previous, more precise invalidation behavior.
 
+### Loop back-edges (issue #2943)
+
+A narrowing inherited from outside a loop is invalidated before the body when
+an assignment or member-path mutation can reach that loop's back-edge. This
+applies to condition, C-style, infinite, ellipsis, range, async-range, and
+`do…while` loops, including writes inside nested control flow and paths ending
+in `continue`. A write on a path that exits the loop with `break`, `return`,
+`throw`, or `goto` does not invalidate the body because that path cannot begin
+another iteration.
+
+Narrowing proved anew for each iteration remains valid. In particular,
+`while x != nil`, `while x is T`, and equivalent C-style loop conditions keep
+their condition-derived narrowing, while a guard or non-null assignment inside
+the body may re-establish narrowing after an inherited narrowing is removed.
+A C-style initializer is processed as an ordinary preceding statement: its
+writes invalidate incoming narrowing, and a statically non-null assignment may
+establish a fresh narrowing for the first body entry.
+
 ### Where it applies
 
 Member-path narrowing is produced by the same classifiers as local narrowing — `is` / `!is` tests (statement and expression level, including `&&` / `||` threading and `if`-as-expression), nil-guards, and `switch` arm discriminators — and consumed at every field/property *read* site (`ApplyMemberNarrowing`). Emit inserts the same `castclass` / `unbox.any` after the `ldfld` / `ldsfld` / getter call for a narrowed member read; the lowerer and rewriter carry the narrowed type through (including auto-property reads that lower to backing-field access).

--- a/docs/adr/0069-smart-cast-flow-narrowing.md
+++ b/docs/adr/0069-smart-cast-flow-narrowing.md
@@ -325,11 +325,30 @@ another iteration.
 
 Narrowing proved anew for each iteration remains valid. In particular,
 `while x != nil`, `while x is T`, and equivalent C-style loop conditions keep
-their condition-derived narrowing, while a guard or non-null assignment inside
-the body may re-establish narrowing after an inherited narrowing is removed.
-A C-style initializer is processed as an ordinary preceding statement: its
-writes invalidate incoming narrowing, and a statically non-null assignment may
-establish a fresh narrowing for the first body entry.
+their condition-derived narrowing, while a guard or proven-non-null assignment
+inside the body may re-establish narrowing after an inherited narrowing is
+removed. This applies equally to function locals and top-level globals, so
+compiled top-level programs and `gsi` scripts use the same back-edge rules.
+
+Assignment precision is limited to plain storage whose identity the flow pass
+tracks directly: ordinary locals (including captured locals and `if let`
+bindings), value parameters, and top-level globals. By-reference locals and
+`ref`/`out`/`in` parameters are excluded because another alias may mutate the
+same storage. Fields, properties, and indexed values remain under the
+conservative member-path invalidation rules.
+
+Static non-nullability alone is not proof that an assigned runtime value is
+non-null across a back-edge. Fresh constructor results, immutable variables
+initialized from a proven-non-null value, and user functions whose returns are
+all proven non-null may preserve a narrowing. Parameters are not proof because
+a caller can pass a runtime-null value through a statically non-null field.
+Uninitialized fields, unproved function results, imported calls with nullable
+results, nullable or `nil` assignments, and incompatible subtype assignments
+invalidate it. This back-edge proof is deliberately stricter than issue
+#1123's existing straight-line assignment narrowing. A C-style initializer is
+processed as an ordinary preceding statement: its writes invalidate incoming
+narrowing, and only a proven-non-null assignment may establish a fresh
+narrowing for the first body entry.
 
 ### Where it applies
 

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1368,7 +1368,7 @@ internal sealed class LambdaBinder
     /// treats member reads as fragile because another call or another
     /// receiver's assignment could mutate the member through an alias the
     /// closure's own narrowing analysis never observes — the same reasoning
-    /// <see cref="StatementBinder.InvalidateNarrowingsForAssignedVariables(SyntaxNode)"/>
+    /// <see cref="StatementBinder.InvalidateNarrowingsForAssignedVariables(SyntaxNode, BoundStatement)"/>
     /// applies at ordinary statement boundaries. Widening that guarantee to
     /// "safe forever, even across a closure capture" would be unsound, so
     /// this method conservatively keeps the pre-existing behaviour (drop) for

--- a/src/Core/CodeAnalysis/Binding/SmartCastStability.cs
+++ b/src/Core/CodeAnalysis/Binding/SmartCastStability.cs
@@ -38,6 +38,25 @@ internal static class SmartCastStability
     }
 
     /// <summary>
+    /// Returns whether assignment flow can track <paramref name="variable"/>
+    /// by exact symbol identity. Plain locals (including captured locals and
+    /// value parameters) and top-level globals qualify. By-reference locals
+    /// and parameters are excluded because another alias may mutate their
+    /// storage; fields and properties use member-path invalidation instead.
+    /// </summary>
+    /// <param name="variable">The candidate assignment target.</param>
+    /// <returns><see langword="true"/> when assignment flow can track the variable.</returns>
+    public static bool IsAssignmentNarrowingRoot(VariableSymbol variable)
+    {
+        return variable switch
+        {
+            LocalVariableSymbol local => local.RefKind == RefKind.None,
+            GlobalVariableSymbol => true,
+            _ => false,
+        };
+    }
+
+    /// <summary>
     /// Returns whether <paramref name="field"/> is an immutable instance field
     /// (declared with <c>let</c>, hence emitted <c>initonly</c>, or a <c>const</c>)
     /// that may appear as a stable link. A <c>var</c> field is excluded.

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
@@ -168,6 +168,7 @@ internal sealed partial class StatementBinder
         var pendingSwitchExitFrames = binderCtx.PendingSwitchExitFrames.ToArray();
         var definedUserLabels = binderCtx.DefinedUserLabels.ToArray();
         var userGotoHandlerSnapshot = userGotoHandlerRegions.ToArray();
+        var syntheticLocalCounter = binderCtx.SyntheticLocalCounter;
 
         // Issue #2943: first bind supplies exact assignment symbols and lowered
         // control flow. If a write can reach the back-edge, restore speculative
@@ -206,6 +207,7 @@ internal sealed partial class StatementBinder
         RestoreSet(binderCtx.DefinedUserLabels, definedUserLabels);
         userGotoHandlerRegions.Clear();
         userGotoHandlerRegions.AddRange(userGotoHandlerSnapshot);
+        binderCtx.SyntheticLocalCounter = syntheticLocalCounter;
 
         InvalidateInheritedNarrowings(
             mutations,

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
@@ -137,21 +137,118 @@ internal sealed partial class StatementBinder
     /// <param name="labelName">The ADR-0070 label, or <see langword="null"/>.</param>
     /// <param name="breakLabel">The synthesized break label.</param>
     /// <param name="continueLabel">The synthesized continue label.</param>
+    /// <param name="inheritedNarrowingFrameCount">Number of active frames whose
+    /// narrowings predate this loop iteration.</param>
+    /// <param name="backEdgeTail">Optional post/condition evaluation executed
+    /// between body completion and the next iteration.</param>
+    /// <param name="backEdgeCondition">Optional condition that must be true
+    /// before control reaches the next iteration.</param>
     private BoundStatement BindLoopBody(
         StatementSyntax body,
         string labelName,
         out BoundLabel breakLabel,
-        out BoundLabel continueLabel)
+        out BoundLabel continueLabel,
+        int inheritedNarrowingFrameCount = -1,
+        BoundStatement backEdgeTail = null,
+        BoundExpression backEdgeCondition = null)
     {
-        binderCtx.LabelCounter++;
-        breakLabel = new BoundLabel($"break{binderCtx.LabelCounter}");
-        continueLabel = new BoundLabel($"continue{binderCtx.LabelCounter}");
+        inheritedNarrowingFrameCount = inheritedNarrowingFrameCount < 0
+            ? binderCtx.NarrowedVariables.Count
+            : inheritedNarrowingFrameCount;
+        if (!HasActiveNarrowings(inheritedNarrowingFrameCount))
+        {
+            return BindCore(out breakLabel, out continueLabel);
+        }
 
-        binderCtx.LoopStack.Push((labelName, breakLabel, continueLabel));
-        var boundBody = BindStatement(body);
-        binderCtx.LoopStack.Pop();
+        var diagnosticCount = Diagnostics.Count;
+        var narrowingSnapshots = binderCtx.NarrowedVariables
+            .Select(frame => new Dictionary<AccessPath, TypeSymbol>(frame))
+            .ToArray();
+        var pendingEarlyExitFrames = binderCtx.PendingEarlyExitFrames.ToArray();
+        var pendingSwitchExitFrames = binderCtx.PendingSwitchExitFrames.ToArray();
+        var definedUserLabels = binderCtx.DefinedUserLabels.ToArray();
+        var userGotoHandlerSnapshot = userGotoHandlerRegions.ToArray();
 
-        return boundBody;
+        // Issue #2943: first bind supplies exact assignment symbols and lowered
+        // control flow. If a write can reach the back-edge, restore speculative
+        // state, remove only inherited narrowings, and bind the body again.
+        var firstBody = BindCore(out var firstBreakLabel, out var firstContinueLabel);
+        var mutations = CollectLoopBackEdgeMutations(
+            firstBody,
+            firstBreakLabel,
+            firstContinueLabel,
+            backEdgeTail,
+            backEdgeCondition);
+        if (!InvalidatesInheritedNarrowing(
+                mutations,
+                mutations.MayMutateMemberPaths,
+                inheritedNarrowingFrameCount,
+                narrowingSnapshots))
+        {
+            breakLabel = firstBreakLabel;
+            continueLabel = firstContinueLabel;
+            return firstBody;
+        }
+
+        Diagnostics.TruncateTo(diagnosticCount);
+        for (var i = 0; i < narrowingSnapshots.Length; i++)
+        {
+            var frame = binderCtx.NarrowedVariables[i];
+            frame.Clear();
+            foreach (var entry in narrowingSnapshots[i])
+            {
+                frame.Add(entry.Key, entry.Value);
+            }
+        }
+
+        RestoreDictionary(binderCtx.PendingEarlyExitFrames, pendingEarlyExitFrames);
+        RestoreDictionary(binderCtx.PendingSwitchExitFrames, pendingSwitchExitFrames);
+        RestoreSet(binderCtx.DefinedUserLabels, definedUserLabels);
+        userGotoHandlerRegions.Clear();
+        userGotoHandlerRegions.AddRange(userGotoHandlerSnapshot);
+
+        InvalidateInheritedNarrowings(
+            mutations,
+            mutations.MayMutateMemberPaths,
+            inheritedNarrowingFrameCount);
+        return BindCore(out breakLabel, out continueLabel);
+
+        BoundStatement BindCore(out BoundLabel localBreakLabel, out BoundLabel localContinueLabel)
+        {
+            binderCtx.LabelCounter++;
+            localBreakLabel = new BoundLabel($"break{binderCtx.LabelCounter}");
+            localContinueLabel = new BoundLabel($"continue{binderCtx.LabelCounter}");
+
+            binderCtx.LoopStack.Push((labelName, localBreakLabel, localContinueLabel));
+            try
+            {
+                return BindStatement(body);
+            }
+            finally
+            {
+                binderCtx.LoopStack.Pop();
+            }
+        }
+
+        static void RestoreDictionary<TKey, TValue>(
+            Dictionary<TKey, TValue> destination,
+            KeyValuePair<TKey, TValue>[] snapshot)
+        {
+            destination.Clear();
+            foreach (var entry in snapshot)
+            {
+                destination.Add(entry.Key, entry.Value);
+            }
+        }
+
+        static void RestoreSet<T>(HashSet<T> destination, T[] snapshot)
+        {
+            destination.Clear();
+            foreach (var item in snapshot)
+            {
+                destination.Add(item);
+            }
+        }
     }
 
     private BoundStatement BindBreakStatement(BreakStatementSyntax syntax)

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Jumps.cs
@@ -180,11 +180,12 @@ internal sealed partial class StatementBinder
             firstContinueLabel,
             backEdgeTail,
             backEdgeCondition);
-        if (!InvalidatesInheritedNarrowing(
-                mutations,
-                mutations.MayMutateMemberPaths,
-                inheritedNarrowingFrameCount,
-                narrowingSnapshots))
+        var narrowingInvalidations = CollectInheritedNarrowingInvalidations(
+            mutations,
+            mutations.MayMutateMemberPaths,
+            inheritedNarrowingFrameCount,
+            narrowingSnapshots);
+        if (narrowingInvalidations.Count == 0)
         {
             breakLabel = firstBreakLabel;
             continueLabel = firstContinueLabel;
@@ -209,10 +210,7 @@ internal sealed partial class StatementBinder
         userGotoHandlerRegions.AddRange(userGotoHandlerSnapshot);
         binderCtx.SyntheticLocalCounter = syntheticLocalCounter;
 
-        InvalidateInheritedNarrowings(
-            mutations,
-            mutations.MayMutateMemberPaths,
-            inheritedNarrowingFrameCount);
+        InvalidateInheritedNarrowings(narrowingInvalidations);
         return BindCore(out breakLabel, out continueLabel);
 
         BoundStatement BindCore(out BoundLabel localBreakLabel, out BoundLabel localContinueLabel)

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Loops.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Loops.cs
@@ -534,7 +534,9 @@ internal sealed partial class StatementBinder
             bodySyntax,
             labelName,
             out var breakLabel,
-            out var continueLabel);
+            out var continueLabel,
+            backEdgeTail: null,
+            backEdgeCondition: condition);
 
         scope = scope.Parent;
 
@@ -583,6 +585,17 @@ internal sealed partial class StatementBinder
         scope = new BoundScope(scope);
 
         var init = syntax.Initializer == null ? null : BindStatement(syntax.Initializer);
+        if (init != null)
+        {
+            InvalidateNarrowingsForAssignedVariables(syntax.Initializer, init);
+            if (binderCtx.NarrowedVariables.Count > 0)
+            {
+                ApplyAssignmentNarrowing(
+                    init,
+                    binderCtx.NarrowedVariables[binderCtx.NarrowedVariables.Count - 1]);
+            }
+        }
+
         var condition = syntax.Condition == null ? null : bindExpressionWithTargetType(syntax.Condition, TypeSymbol.Bool);
         var post = syntax.Post == null ? null : BindStatement(syntax.Post);
         var body = BindConditionedLoopBody(
@@ -590,7 +603,9 @@ internal sealed partial class StatementBinder
             syntax.Body,
             labelName,
             out var breakLabel,
-            out var continueLabel);
+            out var continueLabel,
+            post,
+            condition);
 
         scope = scope.Parent;
 
@@ -632,20 +647,37 @@ internal sealed partial class StatementBinder
         StatementSyntax bodySyntax,
         string labelName,
         out BoundLabel breakLabel,
-        out BoundLabel continueLabel)
+        out BoundLabel continueLabel,
+        BoundStatement backEdgeTail,
+        BoundExpression backEdgeCondition)
     {
+        var inheritedNarrowingFrameCount = binderCtx.NarrowedVariables.Count;
         var loopNarrow = condition == null
             ? null
             : ComputeConditionNarrowing(condition).Then;
         if (loopNarrow == null)
         {
-            return BindLoopBody(bodySyntax, labelName, out breakLabel, out continueLabel);
+            return BindLoopBody(
+                bodySyntax,
+                labelName,
+                out breakLabel,
+                out continueLabel,
+                inheritedNarrowingFrameCount,
+                backEdgeTail,
+                backEdgeCondition);
         }
 
         binderCtx.NarrowedVariables.Add(loopNarrow);
         try
         {
-            return BindLoopBody(bodySyntax, labelName, out breakLabel, out continueLabel);
+            return BindLoopBody(
+                bodySyntax,
+                labelName,
+                out breakLabel,
+                out continueLabel,
+                inheritedNarrowingFrameCount,
+                backEdgeTail,
+                backEdgeCondition);
         }
         finally
         {
@@ -777,7 +809,13 @@ internal sealed partial class StatementBinder
         scope = new BoundScope(scope);
 
         var condition = bindExpressionWithTargetType(conditionSyntax, TypeSymbol.Bool);
-        var body = BindLoopBody(bodySyntax, labelName, out var breakLabel, out var continueLabel);
+        var body = BindLoopBody(
+            bodySyntax,
+            labelName,
+            out var breakLabel,
+            out var continueLabel,
+            backEdgeTail: null,
+            backEdgeCondition: condition);
 
         scope = scope.Parent;
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -953,34 +953,42 @@ internal sealed partial class StatementBinder
 
         public override void VisitExpression(BoundExpression node)
         {
-            switch (node?.Kind)
+            if (node != null && IsPotentiallyMutatingMemberPathExpression(node.Kind))
             {
-                case BoundNodeKind.CallExpression:
-                case BoundNodeKind.FunctionPointerInvocationExpression:
-                case BoundNodeKind.ImportedCallExpression:
-                case BoundNodeKind.ImportedInstanceCallExpression:
-                case BoundNodeKind.ConstrainedStaticCallExpression:
-                case BoundNodeKind.ConstructorCallExpression:
-                case BoundNodeKind.UserInstanceCallExpression:
-                case BoundNodeKind.BaseInterfaceCallExpression:
-                case BoundNodeKind.BaseClassCallExpression:
-                case BoundNodeKind.IndirectCallExpression:
-                case BoundNodeKind.ClrConstructorCallExpression:
-                case BoundNodeKind.ClrStaticCallExpression:
-                case BoundNodeKind.ClrConversionCallExpression:
-                case BoundNodeKind.FieldAssignmentExpression:
-                case BoundNodeKind.PropertyAssignmentExpression:
-                case BoundNodeKind.IndexAssignmentExpression:
-                case BoundNodeKind.ClrPropertyAssignmentExpression:
-                case BoundNodeKind.ClrIndexAssignmentExpression:
-                case BoundNodeKind.IndirectAssignmentExpression:
-                    MayMutateMemberPaths = true;
-                    break;
+                MayMutateMemberPaths = true;
             }
 
             base.VisitExpression(node);
         }
     }
+
+    /// <summary>
+    /// Returns whether an expression kind can invoke user code or assign
+    /// through a member-bearing path.
+    /// </summary>
+    /// <param name="kind">Bound expression kind.</param>
+    /// <returns><see langword="true"/> when member-path narrowings must be invalidated.</returns>
+    internal static bool IsPotentiallyMutatingMemberPathExpression(BoundNodeKind kind)
+        => kind is
+            BoundNodeKind.CallExpression
+            or BoundNodeKind.FunctionPointerInvocationExpression
+            or BoundNodeKind.ImportedCallExpression
+            or BoundNodeKind.ImportedInstanceCallExpression
+            or BoundNodeKind.ConstrainedStaticCallExpression
+            or BoundNodeKind.ConstructorCallExpression
+            or BoundNodeKind.UserInstanceCallExpression
+            or BoundNodeKind.BaseInterfaceCallExpression
+            or BoundNodeKind.BaseClassCallExpression
+            or BoundNodeKind.IndirectCallExpression
+            or BoundNodeKind.ClrConstructorCallExpression
+            or BoundNodeKind.ClrStaticCallExpression
+            or BoundNodeKind.ClrConversionCallExpression
+            or BoundNodeKind.FieldAssignmentExpression
+            or BoundNodeKind.PropertyAssignmentExpression
+            or BoundNodeKind.IndexAssignmentExpression
+            or BoundNodeKind.ClrPropertyAssignmentExpression
+            or BoundNodeKind.ClrIndexAssignmentExpression
+            or BoundNodeKind.IndirectAssignmentExpression;
 
     /// <summary>
     /// Issue #1123: whether <paramref name="type"/> is a reference-like type —

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -101,7 +101,9 @@ internal sealed partial class StatementBinder
         }
     }
 
-    private void InvalidateNarrowingsForAssignedVariables(SyntaxNode statementSyntax)
+    private void InvalidateNarrowingsForAssignedVariables(
+        SyntaxNode statementSyntax,
+        BoundStatement boundStatement = null)
     {
         // Issue #1639: `NarrowedVariables.Count == 0` never fires in practice —
         // `BindBlockStatements` pushes a (usually empty) memberNotNullFrame for
@@ -131,14 +133,37 @@ internal sealed partial class StatementBinder
         var assignedNames = new HashSet<string>();
         var dropAllMemberPaths = CollectAssignedNamesAndMemberMutation(statementSyntax, assignedNames);
 
-        // Resolve the set of reassigned root variables so we can also drop any
-        // member path rooted at one of them.
-        var assignedRoots = new HashSet<VariableSymbol>();
-        foreach (var name in assignedNames)
+        // Issue #2943: use bound assignment targets when available so symbol
+        // identity, not a same-named variable in an enclosing scope, decides
+        // which root and member paths are invalidated. Special lowering paths
+        // that invalidate before producing one bound statement retain the
+        // syntax-name fallback.
+        HashSet<VariableSymbol> assignedRoots;
+        if (boundStatement != null)
         {
-            if (scope.TryLookupSymbol(name) is VariableSymbol v)
+            var collector = new AssignedRootsCollector();
+            collector.Visit(boundStatement);
+            assignedRoots = collector.Roots;
+            foreach (var frame in binderCtx.NarrowedVariables)
             {
-                assignedRoots.Add(v);
+                foreach (var path in frame.Keys)
+                {
+                    if (collector.AssignsRoot(path.Root))
+                    {
+                        assignedRoots.Add(path.Root);
+                    }
+                }
+            }
+        }
+        else
+        {
+            assignedRoots = new HashSet<VariableSymbol>();
+            foreach (var name in assignedNames)
+            {
+                if (scope.TryLookupSymbol(name) is VariableSymbol v)
+                {
+                    assignedRoots.Add(v);
+                }
             }
         }
 
@@ -147,11 +172,6 @@ internal sealed partial class StatementBinder
             return;
         }
 
-        // Resolve each name through the current scope and drop any matching
-        // narrowing from ALL active frames. We don't need to be conservative
-        // about scope shadowing: the narrowed variable lives in an outer scope,
-        // so an inner shadowing declaration with the same name will resolve to a
-        // different symbol, and the narrowing will simply not be triggered.
         // Issue #208: iterate ALL frames (not just the top) because the
         // memberNotNullFrame sits above the if-condition frames; dropping from
         // only the top would miss narrowings added by if-condition analysis.
@@ -196,7 +216,12 @@ internal sealed partial class StatementBinder
     /// </summary>
     private bool HasAnyActiveNarrowings()
     {
-        for (var i = binderCtx.NarrowedVariables.Count - 1; i >= 0; i--)
+        return HasActiveNarrowings(binderCtx.NarrowedVariables.Count);
+    }
+
+    private bool HasActiveNarrowings(int frameCount)
+    {
+        for (var i = Math.Min(frameCount, binderCtx.NarrowedVariables.Count) - 1; i >= 0; i--)
         {
             if (binderCtx.NarrowedVariables[i].Count > 0)
             {
@@ -205,6 +230,113 @@ internal sealed partial class StatementBinder
         }
 
         return false;
+    }
+
+    private bool InvalidatesInheritedNarrowing(
+        AssignedRootsCollector mutations,
+        bool mayMutateMemberPaths,
+        int frameCount,
+        IReadOnlyList<Dictionary<AccessPath, TypeSymbol>> frames)
+    {
+        for (var i = Math.Min(frameCount, frames.Count) - 1; i >= 0; i--)
+        {
+            foreach (var path in frames[i].Keys)
+            {
+                if (mutations.AssignsRoot(path.Root) || (path.HasMembers && mayMutateMemberPaths))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private void InvalidateInheritedNarrowings(
+        AssignedRootsCollector mutations,
+        bool mayMutateMemberPaths,
+        int frameCount)
+    {
+        for (var i = Math.Min(frameCount, binderCtx.NarrowedVariables.Count) - 1; i >= 0; i--)
+        {
+            var frame = binderCtx.NarrowedVariables[i];
+            var removed = frame.Keys
+                .Where(path => mutations.AssignsRoot(path.Root) || (path.HasMembers && mayMutateMemberPaths))
+                .ToArray();
+            foreach (var path in removed)
+            {
+                frame.Remove(path);
+            }
+        }
+    }
+
+    private static LoopBackEdgeMutationCollector CollectLoopBackEdgeMutations(
+            BoundStatement body,
+            BoundLabel breakLabel,
+            BoundLabel continueLabel,
+            BoundStatement backEdgeTail,
+            BoundExpression backEdgeCondition)
+    {
+        var markerLabel = new BoundLabel("loopBackEdge");
+        var marker = new BoundExpressionStatement(null, new BoundLiteralExpression(null, true));
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        statements.Add(body);
+        statements.Add(new BoundLabelStatement(null, continueLabel));
+        if (backEdgeTail != null)
+        {
+            statements.Add(backEdgeTail);
+        }
+
+        if (backEdgeCondition != null)
+        {
+            statements.Add(new BoundConditionalGotoStatement(
+                null,
+                markerLabel,
+                backEdgeCondition,
+                jumpIfTrue: true));
+            statements.Add(new BoundGotoStatement(null, breakLabel));
+            statements.Add(new BoundLabelStatement(null, markerLabel));
+        }
+
+        statements.Add(marker);
+        statements.Add(new BoundLabelStatement(null, breakLabel));
+
+        var graph = ControlFlowGraph.Create(
+            Lowerer.Lower(new BoundBlockStatement(null, statements.ToImmutable())));
+        var markerBlock = graph.Blocks.FirstOrDefault(
+            block => block.Statements.Any(statement => ReferenceEquals(statement, marker)));
+        var collector = new LoopBackEdgeMutationCollector();
+        if (markerBlock == null)
+        {
+            return collector;
+        }
+
+        var reachesBackEdge = new HashSet<ControlFlowGraph.BasicBlock>();
+        var pending = new Stack<ControlFlowGraph.BasicBlock>();
+        pending.Push(markerBlock);
+        while (pending.Count > 0)
+        {
+            var block = pending.Pop();
+            if (!reachesBackEdge.Add(block))
+            {
+                continue;
+            }
+
+            foreach (var incoming in block.Incoming)
+            {
+                pending.Push(incoming.From);
+            }
+        }
+
+        foreach (var block in reachesBackEdge)
+        {
+            foreach (var statement in block.Statements)
+            {
+                collector.Visit(statement);
+            }
+        }
+
+        return collector;
     }
 
     /// <summary>
@@ -369,7 +501,7 @@ internal sealed partial class StatementBinder
         // A possibly-null right-hand side does not narrow (invalidation already
         // cleared any prior narrowing). Only a statically non-nullable value
         // proves the local is non-null after the assignment.
-        if (assignedType is NullableTypeSymbol)
+        if (assignedType == TypeSymbol.Null || assignedType is NullableTypeSymbol)
         {
             return false;
         }
@@ -741,9 +873,25 @@ internal sealed partial class StatementBinder
     /// plain assignment target in a subtree, used to conservatively invalidate
     /// join narrowings across constructs the flow analysis does not model.
     /// </summary>
-    private sealed class AssignedRootsCollector : BoundTreeWalker
+    private class AssignedRootsCollector : BoundTreeWalker
     {
+        private readonly HashSet<(VariableSymbol Receiver, FieldSymbol Field)> assignedFields = new();
+        private readonly HashSet<(VariableSymbol Receiver, PropertySymbol Property)> assignedProperties = new();
+
         public HashSet<VariableSymbol> Roots { get; } = new HashSet<VariableSymbol>();
+
+        public bool AssignsRoot(VariableSymbol root)
+        {
+            return Roots.Contains(root)
+                || (root is ImplicitFieldVariableSymbol field
+                    && assignedFields.Contains((field.Receiver, field.Field)))
+                || (root is ImplicitStaticFieldVariableSymbol staticField
+                    && assignedFields.Contains((null, staticField.Field)))
+                || (root is ImplicitPropertyVariableSymbol property
+                    && assignedProperties.Contains((property.Receiver, property.Property)))
+                || (root is ImplicitStaticPropertyVariableSymbol staticProperty
+                    && assignedProperties.Contains((null, staticProperty.Property)));
+        }
 
         protected override void VisitAssignmentExpression(BoundAssignmentExpression node)
         {
@@ -753,6 +901,62 @@ internal sealed partial class StatementBinder
             }
 
             base.VisitAssignmentExpression(node);
+        }
+
+        protected override void VisitFieldAssignmentExpression(BoundFieldAssignmentExpression node)
+        {
+            if (node.ReceiverExpression == null)
+            {
+                assignedFields.Add((node.Receiver, node.Field));
+            }
+
+            base.VisitFieldAssignmentExpression(node);
+        }
+
+        protected override void VisitPropertyAssignmentExpression(BoundPropertyAssignmentExpression node)
+        {
+            var receiver = (node.Receiver as BoundVariableExpression)?.Variable;
+            if (node.Receiver == null || receiver != null)
+            {
+                assignedProperties.Add((receiver, node.Property));
+            }
+
+            base.VisitPropertyAssignmentExpression(node);
+        }
+    }
+
+    private sealed class LoopBackEdgeMutationCollector : AssignedRootsCollector
+    {
+        public bool MayMutateMemberPaths { get; private set; }
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            switch (node?.Kind)
+            {
+                case BoundNodeKind.CallExpression:
+                case BoundNodeKind.FunctionPointerInvocationExpression:
+                case BoundNodeKind.ImportedCallExpression:
+                case BoundNodeKind.ImportedInstanceCallExpression:
+                case BoundNodeKind.ConstrainedStaticCallExpression:
+                case BoundNodeKind.ConstructorCallExpression:
+                case BoundNodeKind.UserInstanceCallExpression:
+                case BoundNodeKind.BaseInterfaceCallExpression:
+                case BoundNodeKind.BaseClassCallExpression:
+                case BoundNodeKind.IndirectCallExpression:
+                case BoundNodeKind.ClrConstructorCallExpression:
+                case BoundNodeKind.ClrStaticCallExpression:
+                case BoundNodeKind.ClrConversionCallExpression:
+                case BoundNodeKind.FieldAssignmentExpression:
+                case BoundNodeKind.PropertyAssignmentExpression:
+                case BoundNodeKind.IndexAssignmentExpression:
+                case BoundNodeKind.ClrPropertyAssignmentExpression:
+                case BoundNodeKind.ClrIndexAssignmentExpression:
+                case BoundNodeKind.IndirectAssignmentExpression:
+                    MayMutateMemberPaths = true;
+                    break;
+            }
+
+            base.VisitExpression(node);
         }
     }
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -141,7 +141,7 @@ internal sealed partial class StatementBinder
         HashSet<VariableSymbol> assignedRoots;
         if (boundStatement != null)
         {
-            var collector = new AssignedRootsCollector();
+            var collector = new AssignedRootsCollector(null);
             collector.Visit(boundStatement);
             assignedRoots = collector.Roots;
             foreach (var frame in binderCtx.NarrowedVariables)
@@ -263,7 +263,7 @@ internal sealed partial class StatementBinder
         }
     }
 
-    private static LoopBackEdgeMutationCollector CollectLoopBackEdgeMutations(
+    private LoopBackEdgeMutationCollector CollectLoopBackEdgeMutations(
             BoundStatement body,
             BoundLabel breakLabel,
             BoundLabel continueLabel,
@@ -298,7 +298,7 @@ internal sealed partial class StatementBinder
             Lowerer.Lower(new BoundBlockStatement(null, statements.ToImmutable())));
         var markerBlock = graph.Blocks.FirstOrDefault(
             block => block.Statements.Any(statement => ReferenceEquals(statement, marker)));
-        var collector = new LoopBackEdgeMutationCollector();
+        var collector = new LoopBackEdgeMutationCollector(AssignmentPreservesNarrowing);
         if (markerBlock == null)
         {
             return collector;
@@ -434,8 +434,8 @@ internal sealed partial class StatementBinder
 
     /// <summary>
     /// Issue #1123: assignment-based smart cast. When the bound statement is a
-    /// plain <c>x = rhs</c> assignment whose target is a nullable <c>var</c>
-    /// local and whose right-hand side is statically a <em>non-nullable</em>
+    /// plain <c>x = rhs</c> assignment whose target is a nullable flow-tracked
+    /// variable and whose right-hand side is statically <em>non-nullable</em>
     /// value assignable to the local's underlying type, record a narrowing of
     /// <c>x</c> to that underlying non-nullable type in
     /// <paramref name="persistentFrame"/>. Mirrors the post-guard narrowing of
@@ -448,39 +448,37 @@ internal sealed partial class StatementBinder
     private void ApplyAssignmentNarrowing(BoundStatement statement, Dictionary<AccessPath, TypeSymbol> persistentFrame)
     {
         if (statement is BoundExpressionStatement { Expression: BoundAssignmentExpression assign }
-            && TryClassifyNonNullAssignment(assign, out var local, out var underlying))
+            && TryClassifyNonNullAssignment(assign, out var variable, out var underlying))
         {
-            persistentFrame[local] = underlying;
+            persistentFrame[variable] = underlying;
         }
     }
 
     /// <summary>
     /// Issue #1123 / issue #2159: classifies whether <paramref name="assign"/>
-    /// assigns a statically <em>non-nullable</em> value to a nullable
-    /// reference-like <c>var</c> local, proving the local is non-null after the
-    /// assignment. Shared by <see cref="ApplyAssignmentNarrowing"/> (straight-
-    /// line assignment narrowing) and the <c>if</c>-join narrowing pass (which
-    /// consults it to decide whether a branch leaves the local non-null).
+    /// assigns a statically <em>non-nullable</em> value to a nullable reference-like
+    /// flow-tracked variable, proving the variable is non-null after the
+    /// assignment. Shared by <see cref="ApplyAssignmentNarrowing"/>
+    /// (straight-line assignment narrowing) and the <c>if</c>-join narrowing
+    /// pass (which consults it to decide whether a branch leaves the variable
+    /// non-null).
     /// </summary>
     /// <param name="assign">The bound assignment to classify.</param>
-    /// <param name="local">On success, the narrowed local.</param>
-    /// <param name="underlying">On success, the local's underlying non-nullable type.</param>
-    /// <returns><see langword="true"/> when the assignment narrows the local.</returns>
-    private bool TryClassifyNonNullAssignment(BoundAssignmentExpression assign, out LocalVariableSymbol local, out TypeSymbol underlying)
+    /// <param name="variable">On success, the narrowed variable.</param>
+    /// <param name="underlying">On success, the variable's underlying non-nullable type.</param>
+    /// <returns><see langword="true"/> when the assignment narrows the variable.</returns>
+    private bool TryClassifyNonNullAssignment(BoundAssignmentExpression assign, out VariableSymbol variable, out TypeSymbol underlying)
     {
-        local = null;
+        variable = null;
         underlying = null;
 
-        // Narrow locals only — never parameters, fields, or read-only `let`
-        // locals (a `let` cannot be reassigned, so it never reaches here with a
-        // re-narrowable shape anyway). This matches the receiver-stability rule
-        // the type-test smart cast applies to `var` locals.
-        if (assign.Variable is not LocalVariableSymbol l || l.IsReadOnly)
+        if (!SmartCastStability.IsAssignmentNarrowingRoot(assign.Variable)
+            || assign.Variable.IsReadOnly)
         {
             return false;
         }
 
-        if (l.Type is not NullableTypeSymbol nullable)
+        if (assign.Variable.Type is not NullableTypeSymbol nullable)
         {
             return false;
         }
@@ -497,22 +495,25 @@ internal sealed partial class StatementBinder
             return false;
         }
 
-        // The right-hand side must be implicitly convertible to the local's
-        // underlying non-nullable type. The assignment itself already proved the
-        // value converts to the nullable declared type; this guards the value
-        // narrowing to the underlying type (e.g. excludes shapes where the only
-        // conversion to the bare underlying type would be explicit).
-        if (!AssignmentPreservesNarrowing(assign.AssignedValueType, u))
+        if (!AssignmentTypePreservesNarrowing(assign.AssignedValueType, u))
         {
             return false;
         }
 
-        local = l;
+        variable = assign.Variable;
         underlying = u;
         return true;
     }
 
-    private static bool AssignmentPreservesNarrowing(TypeSymbol assignedType, TypeSymbol narrowedType)
+    private bool AssignmentPreservesNarrowing(BoundAssignmentExpression assignment, TypeSymbol narrowedType)
+    {
+        // Loop back-edges need stronger proof than straight-line issue #1123
+        // narrowing because the assigned value feeds a later iteration.
+        return AssignmentTypePreservesNarrowing(assignment.AssignedValueType, narrowedType)
+            && IsDefinitelyNonNullValue(assignment.Expression);
+    }
+
+    private static bool AssignmentTypePreservesNarrowing(TypeSymbol assignedType, TypeSymbol narrowedType)
     {
         if (assignedType == null
             || assignedType == TypeSymbol.Error
@@ -524,6 +525,96 @@ internal sealed partial class StatementBinder
 
         var conversion = Conversion.Classify(assignedType, narrowedType);
         return conversion.Exists && conversion.IsImplicit;
+    }
+
+    private bool IsDefinitelyNonNullValue(BoundExpression expression)
+    {
+        while (expression is BoundConversionExpression conversion)
+        {
+            expression = conversion.Expression;
+        }
+
+        return expression switch
+        {
+            BoundConstructorCallExpression => true,
+            BoundClrConstructorCallExpression => true,
+            BoundTypeParameterConstructionExpression => true,
+            BoundLiteralExpression literal => literal.Value != null,
+            BoundVariableExpression { NarrowedType: not null } variable
+                when variable.Variable.Type is NullableTypeSymbol
+                    && variable.NarrowedType is not NullableTypeSymbol => true,
+            BoundVariableExpression variable => IsDefinitelyNonNullVariable(variable.Variable),
+            BoundCallExpression call => FunctionReturnsDefinitelyNonNull(call.Function),
+            _ => false,
+        };
+    }
+
+    private static bool IsDefinitelyNonNullVariable(VariableSymbol variable)
+    {
+        if (variable is ParameterSymbol)
+        {
+            return false;
+        }
+
+        if (!SmartCastStability.IsAssignmentNarrowingRoot(variable)
+            || !variable.IsReadOnly
+            || variable.Type is NullableTypeSymbol)
+        {
+            return false;
+        }
+
+        return variable.HasDefinitelyNonNullValue;
+    }
+
+    private bool FunctionReturnsDefinitelyNonNull(FunctionSymbol function)
+    {
+        if (function?.Declaration?.Body == null || function.Type is NullableTypeSymbol)
+        {
+            return false;
+        }
+
+        var descendants = DescendantsAndSelf(function.Declaration.Body).ToArray();
+        if (descendants.Any(node =>
+                node is VariableDeclarationSyntax variable
+                && string.Equals(variable.Identifier.Text, function.Type.Name, StringComparison.Ordinal)))
+        {
+            return false;
+        }
+
+        var returns = descendants.OfType<ReturnStatementSyntax>().ToArray();
+        return returns.Length > 0
+            && returns.All(statement => IsDefinitelyNonNullSyntax(statement.Expression, function.Type));
+    }
+
+    private bool IsDefinitelyNonNullSyntax(ExpressionSyntax expression, TypeSymbol expectedType)
+    {
+        if (expression is LiteralExpressionSyntax literal)
+        {
+            return literal.Value != null;
+        }
+
+        if (expression is not CallExpressionSyntax call
+            || call.Callee != null
+            || call.NullableQuestionToken != null)
+        {
+            return false;
+        }
+
+        return expectedType is StructSymbol
+            && string.Equals(call.Identifier.Text, expectedType.Name, StringComparison.Ordinal)
+            && scope.TryLookupFunctions(call.Identifier.Text).IsDefaultOrEmpty;
+    }
+
+    private static IEnumerable<SyntaxNode> DescendantsAndSelf(SyntaxNode node)
+    {
+        yield return node;
+        foreach (var child in node.GetChildren())
+        {
+            foreach (var descendant in DescendantsAndSelf(child))
+            {
+                yield return descendant;
+            }
+        }
     }
 
     /// <summary>
@@ -580,13 +671,13 @@ internal sealed partial class StatementBinder
         {
             var path = kv.Key;
 
-            // Lift plain nullable reference-like `var` locals only, matching the
+            // Lift plain nullable reference-like flow variables only, matching the
             // scope of the straight-line assignment narrowing. Value-type
             // nullables and member paths are intentionally excluded.
             if (path.HasMembers
-                || path.Root is not LocalVariableSymbol local
-                || local.IsReadOnly
-                || local.Type is not NullableTypeSymbol nullable
+                || !SmartCastStability.IsAssignmentNarrowingRoot(path.Root)
+                || path.Root.IsReadOnly
+                || path.Root.Type is not NullableTypeSymbol nullable
                 || !IsReferenceLikeType(nullable.UnderlyingType))
             {
                 continue;
@@ -774,10 +865,9 @@ internal sealed partial class StatementBinder
 
     /// <summary>
     /// Issue #2159: returns a fresh dictionary combining <paramref name="baseState"/>
-    /// with the plain-local entries of <paramref name="add"/> (a
-    /// condition-narrowing frame). Only plain-variable paths rooted at a local
-    /// are kept — parameters and member paths are outside the join pass's lift
-    /// scope.
+    /// with the plain-variable entries of <paramref name="add"/> (a
+    /// condition-narrowing frame). Member paths and by-reference roots are
+    /// outside the join pass's lift scope.
     /// </summary>
     private static Dictionary<AccessPath, TypeSymbol> MergeLocalNonNull(Dictionary<AccessPath, TypeSymbol> baseState, Dictionary<AccessPath, TypeSymbol> add)
     {
@@ -789,7 +879,8 @@ internal sealed partial class StatementBinder
         {
             foreach (var kv in add)
             {
-                if (!kv.Key.HasMembers && kv.Key.Root is LocalVariableSymbol)
+                if (!kv.Key.HasMembers
+                    && SmartCastStability.IsAssignmentNarrowingRoot(kv.Key.Root))
                 {
                     result[kv.Key] = kv.Value;
                 }
@@ -845,14 +936,14 @@ internal sealed partial class StatementBinder
     /// Issue #2159: conservatively drops every narrowing on a local that
     /// <paramref name="node"/>'s bound subtree assigns anywhere.
     /// </summary>
-    private static void ClearAssignedRoots(BoundNode node, Dictionary<AccessPath, TypeSymbol> state)
+    private void ClearAssignedRoots(BoundNode node, Dictionary<AccessPath, TypeSymbol> state)
     {
         if (state.Count == 0)
         {
             return;
         }
 
-        var collector = new AssignedRootsCollector();
+        var collector = new AssignedRootsCollector(null);
         collector.Visit(node);
         foreach (var root in collector.Roots)
         {
@@ -867,9 +958,15 @@ internal sealed partial class StatementBinder
     /// </summary>
     private class AssignedRootsCollector : BoundTreeWalker
     {
+        private readonly Func<BoundAssignmentExpression, TypeSymbol, bool> assignmentPreservesNarrowing;
         private readonly HashSet<(VariableSymbol Receiver, FieldSymbol Field)> assignedFields = new();
         private readonly HashSet<(VariableSymbol Receiver, PropertySymbol Property)> assignedProperties = new();
-        private readonly Dictionary<VariableSymbol, List<TypeSymbol>> assignedValueTypes = new();
+        private readonly Dictionary<VariableSymbol, List<BoundAssignmentExpression>> assignments = new();
+
+        public AssignedRootsCollector(Func<BoundAssignmentExpression, TypeSymbol, bool> assignmentPreservesNarrowing)
+        {
+            this.assignmentPreservesNarrowing = assignmentPreservesNarrowing;
+        }
 
         public HashSet<VariableSymbol> Roots { get; } = new HashSet<VariableSymbol>();
 
@@ -893,9 +990,10 @@ internal sealed partial class StatementBinder
                 return AssignsRoot(root);
             }
 
-            return root is not LocalVariableSymbol
-                || !assignedValueTypes.TryGetValue(root, out var types)
-                || types.Any(type => !AssignmentPreservesNarrowing(type, narrowedType));
+            return !SmartCastStability.IsAssignmentNarrowingRoot(root)
+                || assignmentPreservesNarrowing == null
+                || !assignments.TryGetValue(root, out var rootAssignments)
+                || rootAssignments.Any(assignment => !assignmentPreservesNarrowing(assignment, narrowedType));
         }
 
         public override void VisitExpression(BoundExpression node)
@@ -913,13 +1011,13 @@ internal sealed partial class StatementBinder
             if (node.Variable != null)
             {
                 Roots.Add(node.Variable);
-                if (!assignedValueTypes.TryGetValue(node.Variable, out var types))
+                if (!assignments.TryGetValue(node.Variable, out var rootAssignments))
                 {
-                    types = new List<TypeSymbol>();
-                    assignedValueTypes.Add(node.Variable, types);
+                    rootAssignments = new List<BoundAssignmentExpression>();
+                    assignments.Add(node.Variable, rootAssignments);
                 }
 
-                types.Add(node.AssignedValueType);
+                rootAssignments.Add(node);
             }
 
             base.VisitAssignmentExpression(node);
@@ -949,6 +1047,11 @@ internal sealed partial class StatementBinder
 
     private sealed class LoopBackEdgeMutationCollector : AssignedRootsCollector
     {
+        public LoopBackEdgeMutationCollector(Func<BoundAssignmentExpression, TypeSymbol, bool> assignmentPreservesNarrowing)
+            : base(assignmentPreservesNarrowing)
+        {
+        }
+
         public bool MayMutateMemberPaths { get; private set; }
 
         public override void VisitExpression(BoundExpression node)
@@ -1251,6 +1354,9 @@ internal sealed partial class StatementBinder
 
         var accessibility = resolveAccessibility(syntax.AccessibilityModifier);
         var variable = bindLocalVariableWithAccessibility(syntax.Identifier, isReadOnly, variableType, accessibility);
+        variable.HasDefinitelyNonNullValue = isReadOnly
+            && variableType is not NullableTypeSymbol
+            && IsDefinitelyNonNullValue(convertedInitializer);
 
         // ADR-0058 / issue #376: propagate `scoped` modifier from syntax to the local symbol,
         // or infer function-local escape scope from the initializer (STE data-flow propagation).

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -232,41 +232,34 @@ internal sealed partial class StatementBinder
         return false;
     }
 
-    private bool InvalidatesInheritedNarrowing(
+    private static List<(int FrameIndex, AccessPath Path)> CollectInheritedNarrowingInvalidations(
         AssignedRootsCollector mutations,
         bool mayMutateMemberPaths,
         int frameCount,
         IReadOnlyList<Dictionary<AccessPath, TypeSymbol>> frames)
     {
+        var invalidations = new List<(int FrameIndex, AccessPath Path)>();
         for (var i = Math.Min(frameCount, frames.Count) - 1; i >= 0; i--)
         {
             foreach (var path in frames[i].Keys)
             {
-                if (mutations.AssignsRoot(path.Root) || (path.HasMembers && mayMutateMemberPaths))
+                if (mutations.InvalidatesNarrowing(path.Root, frames[i][path])
+                    || (path.HasMembers && mayMutateMemberPaths))
                 {
-                    return true;
+                    invalidations.Add((i, path));
                 }
             }
         }
 
-        return false;
+        return invalidations;
     }
 
     private void InvalidateInheritedNarrowings(
-        AssignedRootsCollector mutations,
-        bool mayMutateMemberPaths,
-        int frameCount)
+        IReadOnlyList<(int FrameIndex, AccessPath Path)> invalidations)
     {
-        for (var i = Math.Min(frameCount, binderCtx.NarrowedVariables.Count) - 1; i >= 0; i--)
+        foreach (var (frameIndex, path) in invalidations)
         {
-            var frame = binderCtx.NarrowedVariables[i];
-            var removed = frame.Keys
-                .Where(path => mutations.AssignsRoot(path.Root) || (path.HasMembers && mayMutateMemberPaths))
-                .ToArray();
-            foreach (var path in removed)
-            {
-                frame.Remove(path);
-            }
+            binderCtx.NarrowedVariables[frameIndex].Remove(path);
         }
     }
 
@@ -492,20 +485,6 @@ internal sealed partial class StatementBinder
             return false;
         }
 
-        var assignedType = assign.AssignedValueType;
-        if (assignedType == null || assignedType == TypeSymbol.Error)
-        {
-            return false;
-        }
-
-        // A possibly-null right-hand side does not narrow (invalidation already
-        // cleared any prior narrowing). Only a statically non-nullable value
-        // proves the local is non-null after the assignment.
-        if (assignedType == TypeSymbol.Null || assignedType is NullableTypeSymbol)
-        {
-            return false;
-        }
-
         // Issue #1123 is scoped to reference (and interface) types. Nullable
         // value types (`int32?` → `int32`) are excluded: the existing narrowed-
         // read emit path does not unwrap `Nullable<T>` to its underlying value
@@ -523,8 +502,7 @@ internal sealed partial class StatementBinder
         // value converts to the nullable declared type; this guards the value
         // narrowing to the underlying type (e.g. excludes shapes where the only
         // conversion to the bare underlying type would be explicit).
-        var conversion = Conversion.Classify(assignedType, u);
-        if (!conversion.Exists || !conversion.IsImplicit)
+        if (!AssignmentPreservesNarrowing(assign.AssignedValueType, u))
         {
             return false;
         }
@@ -532,6 +510,20 @@ internal sealed partial class StatementBinder
         local = l;
         underlying = u;
         return true;
+    }
+
+    private static bool AssignmentPreservesNarrowing(TypeSymbol assignedType, TypeSymbol narrowedType)
+    {
+        if (assignedType == null
+            || assignedType == TypeSymbol.Error
+            || assignedType == TypeSymbol.Null
+            || assignedType is NullableTypeSymbol)
+        {
+            return false;
+        }
+
+        var conversion = Conversion.Classify(assignedType, narrowedType);
+        return conversion.Exists && conversion.IsImplicit;
     }
 
     /// <summary>
@@ -877,6 +869,7 @@ internal sealed partial class StatementBinder
     {
         private readonly HashSet<(VariableSymbol Receiver, FieldSymbol Field)> assignedFields = new();
         private readonly HashSet<(VariableSymbol Receiver, PropertySymbol Property)> assignedProperties = new();
+        private readonly Dictionary<VariableSymbol, List<TypeSymbol>> assignedValueTypes = new();
 
         public HashSet<VariableSymbol> Roots { get; } = new HashSet<VariableSymbol>();
 
@@ -891,6 +884,18 @@ internal sealed partial class StatementBinder
                     && assignedProperties.Contains((property.Receiver, property.Property)))
                 || (root is ImplicitStaticPropertyVariableSymbol staticProperty
                     && assignedProperties.Contains((null, staticProperty.Property)));
+        }
+
+        public bool InvalidatesNarrowing(VariableSymbol root, TypeSymbol narrowedType)
+        {
+            if (!Roots.Contains(root))
+            {
+                return AssignsRoot(root);
+            }
+
+            return root is not LocalVariableSymbol
+                || !assignedValueTypes.TryGetValue(root, out var types)
+                || types.Any(type => !AssignmentPreservesNarrowing(type, narrowedType));
         }
 
         public override void VisitExpression(BoundExpression node)
@@ -908,6 +913,13 @@ internal sealed partial class StatementBinder
             if (node.Variable != null)
             {
                 Roots.Add(node.Variable);
+                if (!assignedValueTypes.TryGetValue(node.Variable, out var types))
+                {
+                    types = new List<TypeSymbol>();
+                    assignedValueTypes.Add(node.Variable, types);
+                }
+
+                types.Add(node.AssignedValueType);
             }
 
             base.VisitAssignmentExpression(node);

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -893,6 +893,16 @@ internal sealed partial class StatementBinder
                     && assignedProperties.Contains((null, staticProperty.Property)));
         }
 
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node is BoundFunctionLiteralExpression literal && literal.Body != null)
+            {
+                VisitStatement(literal.Body);
+            }
+
+            base.VisitExpression(node);
+        }
+
         protected override void VisitAssignmentExpression(BoundAssignmentExpression node)
         {
             if (node.Variable != null)

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -415,7 +415,7 @@ internal sealed partial class StatementBinder
                 // a statement that writes to a narrowed variable, drop its
                 // narrowing from the current frame so subsequent reads in this
                 // block see the variable at its declared (nullable) type again.
-                InvalidateNarrowingsForAssignedVariables(statementSyntax);
+                InvalidateNarrowingsForAssignedVariables(statementSyntax, statement);
 
                 // Issue #1123: assignment-based smart cast. After invalidation
                 // (which clears any stale narrowing on the assigned variable),

--- a/src/Core/CodeAnalysis/Symbols/VariableSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/VariableSymbol.cs
@@ -50,4 +50,10 @@ public abstract class VariableSymbol : Symbol
     /// state-machine locals) the hoisted-local-scope <c>CustomDebugInformation</c>.
     /// </summary>
     public SyntaxNode DeclaringSyntax { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this read-only variable's
+    /// initializer was proven non-null from its bound expression.
+    /// </summary>
+    internal bool HasDefinitelyNonNullValue { get; set; }
 }

--- a/test/Compiler.Tests/Emit/Issue2943LoopBackEdgeNarrowingTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2943LoopBackEdgeNarrowingTests.cs
@@ -83,6 +83,132 @@ public class Issue2943LoopBackEdgeNarrowingTests
         Assert.Equal(expectedOutput, CompileAndRun(BuildAcceptedSource(shape), shape));
     }
 
+    [Theory]
+    [InlineData("constructor", "c = C(33)")]
+    [InlineData("local", "c = fresh")]
+    [InlineData("function", "c = Mk(33)")]
+    public void NonNullAssignmentAfterUse_PreservesInheritedNarrowing(
+        string shape,
+        string secondIterationAssignment)
+    {
+        var source = $$"""
+            import System
+
+            class C {
+                let Value int32
+
+                init(value int32) {
+                    Value = value
+                }
+
+                func Print() {
+                    Console.WriteLine(Value)
+                }
+            }
+
+            func Mk(value int32) C {
+                return C(value)
+            }
+
+            func Main() {
+                var c C? = C(11)
+                let fresh C = C(33)
+                if c != nil {
+                    for var i = 0; i < 3; i++ {
+                        c.Print()
+                        if i == 0 {
+                            c = C(22)
+                        }
+                        if i == 1 {
+                            {{secondIterationAssignment}}
+                        }
+                    }
+                }
+            }
+            """;
+
+        Assert.Equal("11\n22\n33\n", CompileAndRun(source, "non-null-after-use-" + shape));
+    }
+
+    [Fact]
+    public void UnrelatedMemberInvalidation_DoesNotMaskNonNullLocalAssignment()
+    {
+        const string Source = """
+            import System
+
+            class C {
+                let Value int32
+
+                init(value int32) {
+                    Value = value
+                }
+
+                func Print() {
+                    Console.WriteLine(Value)
+                }
+            }
+
+            class Box {
+                var Value C?
+            }
+
+            func Main() {
+                var c C? = C(11)
+                let box = Box{}
+                box.Value = C(99)
+                if c != nil {
+                    if box.Value != nil {
+                        for var i = 0; i < 3; i++ {
+                            c.Print()
+                            if i == 0 {
+                                c = C(22)
+                            }
+                            if i == 1 {
+                                c = C(33)
+                            }
+                        }
+                    }
+                }
+            }
+            """;
+
+        Assert.Equal("11\n22\n33\n", CompileAndRun(Source, "non-null-with-member-invalidation"));
+    }
+
+    [Fact]
+    public void NonNullAssignmentToDifferentSubtype_InvalidatesTypeNarrowing()
+    {
+        const string Source = """
+            open class Base {
+            }
+
+            class A : Base {
+                func OnlyA() {
+                }
+            }
+
+            class B : Base {
+            }
+
+            func Run() {
+                var value Base? = A()
+                if value is A {
+                    for var i = 0; i < 3; i++ {
+                        value.OnlyA()
+                        if i == 1 {
+                            value = B()
+                        }
+                    }
+                }
+            }
+            """;
+
+        var errors = Compile(Source).BoundProgram.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
+
+        var error = Assert.Single(errors);
+        Assert.Equal("GS0159", error.Id);
+    }
+
     [Fact]
     public void SpeculativeRebind_RollsBackDiagnosticsAndLabelState()
     {
@@ -637,7 +763,7 @@ public class Issue2943LoopBackEdgeNarrowingTests
             var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
             _ = assembly.GetTypes();
 
-            using var process = Process.Start(new ProcessStartInfo("dotnet")
+            var startInfo = new ProcessStartInfo("dotnet")
             {
                 ArgumentList =
                 {
@@ -650,20 +776,9 @@ public class Issue2943LoopBackEdgeNarrowingTests
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
-            });
-            Assert.NotNull(process);
-            var outputTask = process.StandardOutput.ReadToEndAsync();
-            var errorTask = process.StandardError.ReadToEndAsync();
-            if (!process.WaitForExit(30_000))
-            {
-                process.Kill(entireProcessTree: true);
-                process.WaitForExit();
-                Assert.Fail("dotnet exec timed out");
-            }
-
-            var output = outputTask.GetAwaiter().GetResult();
-            var error = errorTask.GetAwaiter().GetResult();
-            Assert.True(process.ExitCode == 0, error);
+            };
+            var (processExitCode, output, error) = IlVerifier.RunProcess(startInfo, assemblyPath, 30_000);
+            Assert.True(processExitCode == 0, error);
             return output.Replace("\r\n", "\n", StringComparison.Ordinal);
         }
         finally

--- a/test/Compiler.Tests/Emit/Issue2943LoopBackEdgeNarrowingTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2943LoopBackEdgeNarrowingTests.cs
@@ -235,6 +235,36 @@ public class Issue2943LoopBackEdgeNarrowingTests
     }
 
     [Fact]
+    public void SpeculativeRebind_DoesNotDuplicateLambdaReturnDiagnostic()
+    {
+        const string Source = """
+            class C {
+                func M() { }
+            }
+
+            func Run() {
+                var c C? = C()
+                if c != nil {
+                    for var i = 0; i < 2; i++ {
+                        let choose = func(flag bool) int32 {
+                            if flag {
+                                return 1
+                            }
+                        }
+                        c.M()
+                        c = nil
+                    }
+                }
+            }
+            """;
+
+        var errors = Compile(Source).BoundProgram.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
+
+        Assert.Single(errors, diagnostic => diagnostic.Id == "GS0100");
+        Assert.Single(errors, diagnostic => diagnostic.Id == "GS0159");
+    }
+
+    [Fact]
     public void SpeculativeRebind_RestoresLoopStack()
     {
         const string Source = """

--- a/test/Compiler.Tests/Emit/Issue2943LoopBackEdgeNarrowingTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2943LoopBackEdgeNarrowingTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
@@ -38,6 +39,7 @@ public class Issue2943LoopBackEdgeNarrowingTests
     [InlineData("before-use", "GS0159")]
     [InlineData("member-call", "GS0159")]
     [InlineData("implicit-field", "GS0159")]
+    [InlineData("closure", "GS0159")]
     public void AssignmentReachingBackEdge_InvalidatesInheritedNarrowing(
         string shape,
         string expectedDiagnostic)
@@ -46,6 +48,20 @@ public class Issue2943LoopBackEdgeNarrowingTests
         var errors = compilation.BoundProgram.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
 
         Assert.Contains(errors, diagnostic => diagnostic.Id == expectedDiagnostic);
+    }
+
+    [Theory]
+    [InlineData("function-literal")]
+    [InlineData("arrow-lambda")]
+    [InlineData("inline-argument")]
+    public void ClosureWrite_InvalidatesNarrowingOutsideLoop(string shape)
+    {
+        var errors = Compile(BuildClosureWriteSource(shape))
+            .BoundProgram.Diagnostics
+            .Where(diagnostic => diagnostic.IsError)
+            .ToArray();
+
+        Assert.Contains(errors, diagnostic => diagnostic.Id == "GS0159");
     }
 
     [Theory]
@@ -118,6 +134,42 @@ public class Issue2943LoopBackEdgeNarrowingTests
     }
 
     [Fact]
+    public void SpeculativeRebind_RestoresSyntheticLambdaOrdinal()
+    {
+        const string Source = """
+            import System
+
+            class C {
+                func M() { }
+            }
+
+            func Run() {
+                var c C? = C()
+                if c != nil {
+                    for var i = 0; i < 2; i++ {
+                        let print = func() { Console.WriteLine(i) }
+                        print()
+                        if c != nil {
+                            c.M()
+                        }
+                        c = nil
+                    }
+                }
+            }
+            """;
+
+        var program = Compile(Source).BoundProgram;
+        var collector = new FunctionLiteralNameCollector();
+        foreach (var body in program.Functions.Values)
+        {
+            collector.VisitStatement(body);
+        }
+
+        Assert.Contains("<lambda1>", collector.Names);
+        Assert.DoesNotContain("<lambda2>", collector.Names);
+    }
+
+    [Fact]
     public void SpeculativeRebind_DoesNotDuplicateGotoHandlerDiagnostics()
     {
         const string Source = """
@@ -128,12 +180,15 @@ public class Issue2943LoopBackEdgeNarrowingTests
             }
 
             func Run() {
-                goto handler
                 var c C? = C()
                 if c != nil {
                     for var i = 0; i < 2; i++ {
+                        if i == 0 {
+                            goto handler
+                        }
                         c.M()
                         c = nil
+                        c.M()
                     }
                 }
                 try {
@@ -149,6 +204,7 @@ public class Issue2943LoopBackEdgeNarrowingTests
         var errors = Compile(Source).BoundProgram.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
 
         Assert.Single(errors, diagnostic => diagnostic.Id == "GS0498");
+        Assert.Equal(2, errors.Count(diagnostic => diagnostic.Id == "GS0159"));
     }
 
     private static GsCompilation Compile(string source)
@@ -294,6 +350,13 @@ public class Issue2943LoopBackEdgeNarrowingTests
                     c.M()
                 }
                 """,
+            "closure" => """
+                for var i = 0; i < 2; i++ {
+                    c.M()
+                    let clear = func() { c = nil }
+                    clear()
+                }
+                """,
             "while" => """
                 var i = 0
                 while i < 2 {
@@ -340,6 +403,45 @@ public class Issue2943LoopBackEdgeNarrowingTests
                 var c C? = C()
                 if c != nil {
                     {{loop}}
+                }
+            }
+            """;
+    }
+
+    private static string BuildClosureWriteSource(string shape)
+    {
+        var closure = shape switch
+        {
+            "function-literal" => """
+                let clear = func() { c = nil }
+                clear()
+                """,
+            "arrow-lambda" => """
+                let clear Action = () -> c = nil
+                clear()
+                """,
+            "inline-argument" => """
+                Apply(func() { c = nil })
+                """,
+            _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, null),
+        };
+
+        return $$"""
+            import System
+
+            class C {
+                func M() { }
+            }
+
+            func Apply(action Action) {
+                action()
+            }
+
+            func Run() {
+                var c C? = C()
+                if c != nil {
+                    {{closure}}
+                    c.M()
                 }
             }
             """;
@@ -573,6 +675,28 @@ public class Issue2943LoopBackEdgeNarrowingTests
             catch
             {
             }
+        }
+    }
+
+    private sealed class FunctionLiteralNameCollector : BoundTreeWalker
+    {
+        /// <summary>Gets function-literal symbol names found in visited bodies.</summary>
+        public System.Collections.Generic.List<string> Names { get; } = [];
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node is BoundFunctionLiteralExpression literal)
+            {
+                Names.Add(literal.Function.Name);
+                if (literal.Body != null)
+                {
+                    VisitStatement(literal.Body);
+                }
+
+                return;
+            }
+
+            base.VisitExpression(node);
         }
     }
 }

--- a/test/Compiler.Tests/Emit/Issue2943LoopBackEdgeNarrowingTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2943LoopBackEdgeNarrowingTests.cs
@@ -84,14 +84,18 @@ public class Issue2943LoopBackEdgeNarrowingTests
     }
 
     [Theory]
-    [InlineData("constructor", "c = C(33)")]
-    [InlineData("local", "c = fresh")]
-    [InlineData("function", "c = Mk(33)")]
+    [InlineData("constructor", "c = C(33)", "function")]
+    [InlineData("local", "c = fresh", "function")]
+    [InlineData("function", "c = Mk(33)", "function")]
+    [InlineData("constructor", "c = C(33)", "top-level")]
+    [InlineData("local", "c = fresh", "top-level")]
+    [InlineData("function", "c = Mk(33)", "top-level")]
     public void NonNullAssignmentAfterUse_PreservesInheritedNarrowing(
         string shape,
-        string secondIterationAssignment)
+        string secondIterationAssignment,
+        string scope)
     {
-        var source = $$"""
+        var declarations = """
             import System
 
             class C {
@@ -109,25 +113,208 @@ public class Issue2943LoopBackEdgeNarrowingTests
             func Mk(value int32) C {
                 return C(value)
             }
-
-            func Main() {
-                var c C? = C(11)
-                let fresh C = C(33)
-                if c != nil {
-                    for var i = 0; i < 3; i++ {
-                        c.Print()
-                        if i == 0 {
-                            c = C(22)
-                        }
-                        if i == 1 {
-                            {{secondIterationAssignment}}
-                        }
+            """;
+        var body = $$"""
+            var c C? = C(11)
+            let fresh C = C(33)
+            if c != nil {
+                for var i = 0; i < 3; i++ {
+                    c.Print()
+                    if i == 0 {
+                        c = C(22)
+                    }
+                    if i == 1 {
+                        {{secondIterationAssignment}}
                     }
                 }
             }
             """;
+        var source = scope == "top-level"
+            ? declarations + Environment.NewLine + body
+            : declarations + Environment.NewLine + $$"""
 
-        Assert.Equal("11\n22\n33\n", CompileAndRun(source, "non-null-after-use-" + shape));
+            func Main() {
+            {{Indent(body)}}
+            }
+            """;
+
+        Assert.Equal("11\n22\n33\n", CompileAndRun(source, $"non-null-after-use-{shape}-{scope}"));
+    }
+
+    [Theory]
+    [InlineData("function")]
+    [InlineData("top-level")]
+    public void OriginalAssignmentAfterUse_RemainsRejected(string scope)
+    {
+        const string Declarations = """
+            class C {
+                func Print() { }
+            }
+            """;
+        const string Body = """
+            var c C? = C()
+            if c != nil {
+                for var i = 0; i < 2; i++ {
+                    c.Print()
+                    c = nil
+                }
+            }
+            """;
+        var source = scope == "top-level"
+            ? Declarations + Environment.NewLine + Body
+            : Declarations + Environment.NewLine + $$"""
+                func Main() {
+                {{Indent(Body)}}
+                }
+                """;
+
+        var (exitCode, output) = CompileWithDriver(source, $"original-rejected-{scope}");
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0159", output, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("straight-line")]
+    [InlineData("while")]
+    public void TopLevelNullableReassignment_RemainsRejected(string shape)
+    {
+        var body = shape switch
+        {
+            "straight-line" => """
+                var c C? = C()
+                if c != nil {
+                    c.Print()
+                }
+                c = nil
+                c.Print()
+                """,
+            "while" => """
+                var c C? = C()
+                if c != nil {
+                    var i = 0
+                    while i < 2 {
+                        c.Print()
+                        c = nil
+                        i++
+                    }
+                }
+                """,
+            _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, null),
+        };
+        var source = """
+            class C {
+                func Print() { }
+            }
+            """ + Environment.NewLine + body;
+
+        var (exitCode, output) = CompileWithDriver(source, $"top-level-rejected-{shape}");
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0159", output, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("field")]
+    [InlineData("function")]
+    [InlineData("shadowed-constructor")]
+    [InlineData("out-alias")]
+    [InlineData("imported")]
+    [InlineData("parameter")]
+    public void RuntimeNullableSource_DoesNotPreserveInheritedNarrowing(string shape)
+    {
+        var source = shape switch
+        {
+            "field" => """
+                class C { func M() { } }
+                class Box { var Value C }
+                func Run() {
+                    let box = Box{}
+                    var c C? = C()
+                    if c != nil {
+                        for var i = 0; i < 2; i++ {
+                            c.M()
+                            c = box.Value
+                        }
+                    }
+                }
+                """,
+            "function" => """
+                class C { func M() { } }
+                class Box { var Value C }
+                func Bad() C { return Box{}.Value }
+                func Run() {
+                    var c C? = C()
+                    if c != nil {
+                        for var i = 0; i < 2; i++ {
+                            c.M()
+                            c = Bad()
+                        }
+                    }
+                }
+                """,
+            "shadowed-constructor" => """
+                class C { func M() { } }
+                class Box { var Value C }
+                func C() C { return Box{}.Value }
+                func Mk() C { return C() }
+                func Run() {
+                    var c C? = C{}
+                    if c != nil {
+                        for var i = 0; i < 2; i++ {
+                            c.M()
+                            c = Mk()
+                        }
+                    }
+                }
+                """,
+            "out-alias" => """
+                class C { func M() { } }
+                func Run(out c C?, ref alias C?) {
+                    c = C()
+                    if c != nil {
+                        for var i = 0; i < 2; i++ {
+                            c.M()
+                            c = C()
+                            alias = nil
+                        }
+                    }
+                }
+                var x C? = nil
+                Run(out x, ref x)
+                """,
+            "imported" => """
+                import System
+                func Run() {
+                    var value string? = "ok"
+                    if value != nil {
+                        for var i = 0; i < 2; i++ {
+                            let length = value.Length
+                            value = Console.ReadLine()
+                        }
+                    }
+                }
+                """,
+            "parameter" => """
+                class C { func M() { } }
+                class Box { var Value C }
+                func Run(value C) {
+                    var c C? = C()
+                    if c != nil {
+                        for var i = 0; i < 2; i++ {
+                            c.M()
+                            c = value
+                        }
+                    }
+                }
+                Run(Box{}.Value)
+                """,
+            _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, null),
+        };
+
+        Assert.Contains(
+            Compile(source).BoundProgram.Diagnostics,
+            diagnostic => diagnostic.IsError);
     }
 
     [Fact]
@@ -365,6 +552,11 @@ public class Issue2943LoopBackEdgeNarrowingTests
 
     private static GsCompilation Compile(string source)
         => new(GsSyntaxTree.Parse(SourceText.From(source)));
+
+    private static string Indent(string source)
+        => string.Join(
+            Environment.NewLine,
+            source.Split(Environment.NewLine).Select(line => "    " + line));
 
     private static string BuildRejectedSource(string shape)
     {
@@ -810,6 +1002,54 @@ public class Issue2943LoopBackEdgeNarrowingTests
             var (processExitCode, output, error) = IlVerifier.RunProcess(startInfo, assemblyPath, 30_000);
             Assert.True(processExitCode == 0, error);
             return output.Replace("\r\n", "\n", StringComparison.Ordinal);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static (int ExitCode, string Output) CompileWithDriver(string source, string caseName)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2943-artifacts",
+            caseName + "-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var assemblyPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousErr = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            try
+            {
+                var exitCode = Program.Main(
+                [
+                    "/out:" + assemblyPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                ]);
+                return (exitCode, stdout + Environment.NewLine + stderr);
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousErr);
+            }
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2943LoopBackEdgeNarrowingTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2943LoopBackEdgeNarrowingTests.cs
@@ -1,0 +1,578 @@
+// <copyright file="Issue2943LoopBackEdgeNarrowingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Compiler;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
+using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2943: writes that can reach a loop back-edge must invalidate
+/// narrowing inherited from outside that loop.
+/// </summary>
+public class Issue2943LoopBackEdgeNarrowingTests
+{
+    [Theory]
+    [InlineData("initializer", "GS0159")]
+    [InlineData("for-clause", "GS0159")]
+    [InlineData("while", "GS0503")]
+    [InlineData("infinite", "GS0159")]
+    [InlineData("ellipsis", "GS0159")]
+    [InlineData("range", "GS0159")]
+    [InlineData("await-range", "GS0159")]
+    [InlineData("do-while", "GS0159")]
+    [InlineData("nested-loop", "GS0159")]
+    [InlineData("nested-if", "GS0159")]
+    [InlineData("continue", "GS0159")]
+    [InlineData("labeled-continue", "GS0159")]
+    [InlineData("post", "GS0159")]
+    [InlineData("before-use", "GS0159")]
+    [InlineData("member-call", "GS0159")]
+    [InlineData("implicit-field", "GS0159")]
+    public void AssignmentReachingBackEdge_InvalidatesInheritedNarrowing(
+        string shape,
+        string expectedDiagnostic)
+    {
+        var compilation = Compile(BuildRejectedSource(shape));
+        var errors = compilation.BoundProgram.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
+
+        Assert.Contains(errors, diagnostic => diagnostic.Id == expectedDiagnostic);
+    }
+
+    [Theory]
+    [InlineData("unchanged", "ok\nok\n")]
+    [InlineData("condition-renarrow", "ok\n")]
+    [InlineData("inner-renarrow", "ok\n")]
+    [InlineData("assignment-renarrow", "ok\nok\n")]
+    [InlineData("initializer-renarrow", "ok\n")]
+    [InlineData("break-only", "ok\n")]
+    [InlineData("literal-false-do-while", "ok\n")]
+    [InlineData("literal-false-while", "")]
+    [InlineData("shadowed-assignment", "ok\nok\n")]
+    [InlineData("labeled-break", "ok\n")]
+    [InlineData("post-condition-renarrow", "ok\n")]
+    [InlineData("type-test-condition", "5\n")]
+    [InlineData("other-instance-field", "ok\nok\n")]
+    public void SafeNarrowing_RemainsAcceptedAndRuns(string shape, string expectedOutput)
+    {
+        Assert.Equal(expectedOutput, CompileAndRun(BuildAcceptedSource(shape), shape));
+    }
+
+    [Fact]
+    public void SpeculativeRebind_RollsBackDiagnosticsAndLabelState()
+    {
+        const string Source = """
+            class C {
+                func M() { }
+            }
+
+            func Run() {
+                var c C? = C()
+                if c != nil {
+                    for var i = 0; i < 2; i++ {
+                        mutation: c = nil
+                        c.M()
+                    }
+                }
+            }
+            """;
+
+        var errors = Compile(Source).BoundProgram.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
+
+        var diagnostic = Assert.Single(errors);
+        Assert.Equal("GS0159", diagnostic.Id);
+    }
+
+    [Fact]
+    public void SpeculativeRebind_RestoresLoopStack()
+    {
+        const string Source = """
+            class C {
+                func M() { }
+            }
+
+            func Run() {
+                var c C? = C()
+                if c != nil {
+                    for var i = 0; i < 2; i++ {
+                        c.M()
+                        c = nil
+                    }
+                }
+                break
+            }
+            """;
+
+        var errors = Compile(Source).BoundProgram.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
+
+        Assert.Contains(errors, diagnostic => diagnostic.Id == "GS0120");
+    }
+
+    [Fact]
+    public void SpeculativeRebind_DoesNotDuplicateGotoHandlerDiagnostics()
+    {
+        const string Source = """
+            import System
+
+            class C {
+                func M() { }
+            }
+
+            func Run() {
+                goto handler
+                var c C? = C()
+                if c != nil {
+                    for var i = 0; i < 2; i++ {
+                        c.M()
+                        c = nil
+                    }
+                }
+                try {
+                    throw Exception("boom")
+                } catch (ex Exception) {
+                    handler:
+                    {
+                    }
+                }
+            }
+            """;
+
+        var errors = Compile(Source).BoundProgram.Diagnostics.Where(diagnostic => diagnostic.IsError).ToArray();
+
+        Assert.Single(errors, diagnostic => diagnostic.Id == "GS0498");
+    }
+
+    private static GsCompilation Compile(string source)
+        => new(GsSyntaxTree.Parse(SourceText.From(source)));
+
+    private static string BuildRejectedSource(string shape)
+    {
+        if (shape == "implicit-field")
+        {
+            return """
+                import System.Diagnostics.CodeAnalysis
+
+                class C {
+                    func M() { }
+                }
+
+                class Box {
+                    var _c C?
+
+                    @MemberNotNull("_c")
+                    func EnsureInit() {
+                        _c = C()
+                    }
+
+                    func Run() {
+                        this.EnsureInit()
+                        for var i = 0; i < 2; i++ {
+                            _c.M()
+                            _c = nil
+                        }
+                    }
+                }
+                """;
+        }
+
+        if (shape == "member-call")
+        {
+            return """
+                open class Animal { }
+                class Dog : Animal {
+                    func Bark() { }
+                }
+                class Box {
+                    let Pet Animal
+                }
+
+                func Run(box Box) {
+                    if box.Pet is Dog {
+                        for var i = 0; i < 2; i++ {
+                            box.Pet.Bark()
+                        }
+                    }
+                }
+                """;
+        }
+
+        var loop = shape switch
+        {
+            "initializer" => """
+                for c = nil; true; {
+                    c.M()
+                    break
+                }
+                """,
+            "for-clause" => """
+                for var i = 0; i < 2; i++ {
+                    c.M()
+                    c = nil
+                }
+                """,
+            "infinite" => """
+                for {
+                    c.M()
+                    c = nil
+                    continue
+                }
+                """,
+            "ellipsis" => """
+                for i in 0 ... 2 {
+                    c.M()
+                    c = nil
+                }
+                """,
+            "range" => """
+                for i in []int32{1, 2} {
+                    c.M()
+                    c = nil
+                }
+                """,
+            "await-range" => """
+                await for i in Numbers() {
+                    c.M()
+                    c = nil
+                }
+                """,
+            "do-while" => """
+                do {
+                    c.M()
+                    c = nil
+                } while true
+                """,
+            "nested-loop" => """
+                for var i = 0; i < 2; i++ {
+                    c.M()
+                    for var j = 0; j < 1; j++ {
+                        c = nil
+                    }
+                }
+                """,
+            "nested-if" => """
+                for var i = 0; i < 2; i++ {
+                    c.M()
+                    if i == 0 {
+                        c = nil
+                    }
+                }
+                """,
+            "continue" => """
+                for var i = 0; i < 2; i++ {
+                    c.M()
+                    c = nil
+                    continue
+                }
+                """,
+            "labeled-continue" => """
+                outer: for var i = 0; i < 2; i++ {
+                    c.M()
+                    for var j = 0; j < 1; j++ {
+                        c = nil
+                        continue outer
+                    }
+                }
+                """,
+            "post" => """
+                for var i = 0; i < 2; c = nil {
+                    c.M()
+                    i++
+                }
+                """,
+            "before-use" => """
+                for var i = 0; i < 2; i++ {
+                    c = nil
+                    c.M()
+                }
+                """,
+            "while" => """
+                var i = 0
+                while i < 2 {
+                    d(i)
+                    d = nil
+                    i++
+                }
+                """,
+            _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, null),
+        };
+
+        if (shape == "while")
+        {
+            return $$"""
+                import System
+
+                func Run() {
+                    var d System.Action[int32]? = (value int32) -> Console.WriteLine(value)
+                    if d != nil {
+                        {{loop}}
+                    }
+                }
+                """;
+        }
+
+        var asyncPrefix = shape == "await-range"
+            ? """
+                import System.Collections.Generic
+
+                async func Numbers() IAsyncEnumerable[int32] {
+                    yield 1
+                    yield 2
+                }
+
+                """
+            : string.Empty;
+        var functionKeyword = shape == "await-range" ? "async func" : "func";
+        return $$"""
+            {{asyncPrefix}}class C {
+                func M() { }
+            }
+
+            {{functionKeyword}} Run() {
+                var c C? = C()
+                if c != nil {
+                    {{loop}}
+                }
+            }
+            """;
+    }
+
+    private static string BuildAcceptedSource(string shape)
+    {
+        if (shape == "other-instance-field")
+        {
+            return """
+                import System
+                import System.Diagnostics.CodeAnalysis
+
+                class C {
+                    func M() {
+                        Console.WriteLine("ok")
+                    }
+                }
+
+                class Box {
+                    var _c C?
+
+                    @MemberNotNull("_c")
+                    func EnsureInit() {
+                        _c = C()
+                    }
+
+                    func Run(other Box) {
+                        this.EnsureInit()
+                        for var i = 0; i < 2; i++ {
+                            other._c = nil
+                            _c.M()
+                        }
+                    }
+                }
+
+                func Main() {
+                    Box{}.Run(Box{})
+                }
+                """;
+        }
+
+        var loop = shape switch
+        {
+            "unchanged" => """
+                for var i = 0; i < 2; i++ {
+                    c.M()
+                }
+                """,
+            "condition-renarrow" => """
+                while c != nil {
+                    c.M()
+                    c = nil
+                }
+                """,
+            "inner-renarrow" => """
+                for var i = 0; i < 2; i++ {
+                    if c != nil {
+                        c.M()
+                    }
+                    c = nil
+                }
+                """,
+            "assignment-renarrow" => """
+                for var i = 0; i < 2; i++ {
+                    c = C()
+                    c.M()
+                }
+                """,
+            "initializer-renarrow" => """
+                for c = C(); true; {
+                    c.M()
+                    break
+                }
+                """,
+            "break-only" => """
+                for var i = 0; i < 2; i++ {
+                    c.M()
+                    c = nil
+                    break
+                }
+                """,
+            "literal-false-do-while" => """
+                do {
+                    c.M()
+                    c = nil
+                } while false
+                """,
+            "literal-false-while" => """
+                while false {
+                    c.M()
+                    c = nil
+                }
+                """,
+            "shadowed-assignment" => """
+                for var i = 0; i < 2; i++ {
+                    {
+                        var c C? = nil
+                        c = nil
+                    }
+                    c.M()
+                }
+                """,
+            "labeled-break" => """
+                outer: for var i = 0; i < 2; i++ {
+                    c.M()
+                    for var j = 0; j < 1; j++ {
+                        c = nil
+                        break outer
+                    }
+                }
+                """,
+            "post-condition-renarrow" => """
+                for ; c != nil; c = nil {
+                    c.M()
+                }
+                """,
+            "type-test-condition" => """
+                while o is string {
+                    Console.WriteLine(o.Length)
+                    break
+                }
+                """,
+            _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, null),
+        };
+
+        if (shape == "type-test-condition")
+        {
+            return $$"""
+                import System
+
+                func Main() {
+                    let o object = "hello"
+                    {{loop}}
+                }
+                """;
+        }
+
+        return $$"""
+            import System
+
+            class C {
+                func M() {
+                    Console.WriteLine("ok")
+                }
+            }
+
+            func Main() {
+                var c C? = C()
+                if c != nil {
+                    {{loop}}
+                }
+            }
+            """;
+    }
+
+    private static string CompileAndRun(string source, string caseName)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue2943-artifacts",
+            caseName + "-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var assemblyPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousErr = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            try
+            {
+                var exitCode = Program.Main(
+                [
+                    "/out:" + assemblyPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                ]);
+                Assert.True(exitCode == 0, $"gsc failed:\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousErr);
+            }
+
+            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            _ = assembly.GetTypes();
+
+            using var process = Process.Start(new ProcessStartInfo("dotnet")
+            {
+                ArgumentList =
+                {
+                    "exec",
+                    "--runtimeconfig",
+                    Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                    assemblyPath,
+                },
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            });
+            Assert.NotNull(process);
+            var outputTask = process.StandardOutput.ReadToEndAsync();
+            var errorTask = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(30_000))
+            {
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit();
+                Assert.Fail("dotnet exec timed out");
+            }
+
+            var output = outputTask.GetAwaiter().GetResult();
+            var error = errorTask.GetAwaiter().GetResult();
+            Assert.True(process.ExitCode == 0, error);
+            return output.Replace("\r\n", "\n", StringComparison.Ordinal);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2943LoopBackEdgeMutationKindTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2943LoopBackEdgeMutationKindTests.cs
@@ -1,0 +1,39 @@
+// <copyright file="Issue2943LoopBackEdgeMutationKindTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Guards issue #2943's member-path mutation classification against new
+/// call- or assignment-shaped bound expression kinds.
+/// </summary>
+public class Issue2943LoopBackEdgeMutationKindTests
+{
+    [Fact]
+    public void CallAndAssignmentShapedKinds_AreClassifiedAsPotentiallyMutating()
+    {
+        var uncovered = Enum.GetValues<BoundNodeKind>()
+            .Where(IsCallOrAssignmentShaped)
+            .Where(kind => !StatementBinder.IsPotentiallyMutatingMemberPathExpression(kind))
+            .ToArray();
+
+        Assert.Empty(uncovered);
+    }
+
+    private static bool IsCallOrAssignmentShaped(BoundNodeKind kind)
+    {
+        var name = kind.ToString();
+
+        // Plain variable assignment is handled by exact root identity.
+        return name.EndsWith("CallExpression", StringComparison.Ordinal)
+            || (kind != BoundNodeKind.AssignmentExpression
+                && name.EndsWith("AssignmentExpression", StringComparison.Ordinal))
+            || name.EndsWith("InvocationExpression", StringComparison.Ordinal);
+    }
+}

--- a/test/Interpreter.Tests/Issue2943LoopBackEdgeNarrowingInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2943LoopBackEdgeNarrowingInterpreterTests.cs
@@ -1,0 +1,73 @@
+// <copyright file="Issue2943LoopBackEdgeNarrowingInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Interpreter coverage for issue #2943 loop back-edge narrowing.
+/// </summary>
+public class Issue2943LoopBackEdgeNarrowingInterpreterTests
+{
+    [Fact]
+    public void AssignmentAfterUse_ReportsNullableReceiver()
+    {
+        const string Source = """
+            class C {
+                func M() { }
+            }
+
+            func run() {
+                var c C? = C()
+                if c != nil {
+                    for var i = 0; i < 2; i++ {
+                        c.M()
+                        c = nil
+                    }
+                }
+            }
+
+            run()
+            """;
+
+        var result = new Compilation(SyntaxTree.Parse(Source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0159");
+    }
+
+    [Fact]
+    public void LoopConditionReestablishesNarrowing()
+    {
+        const string Source = """
+            class C {
+                func M() { }
+            }
+
+            func run() int32 {
+                var c C? = C()
+                var count = 0
+                while c != nil {
+                    c.M()
+                    count++
+                    c = nil
+                }
+                return count
+            }
+
+            run()
+            """;
+
+        var result = new Compilation(SyntaxTree.Parse(Source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+}

--- a/test/Interpreter.Tests/Issue2943LoopBackEdgeNarrowingInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2943LoopBackEdgeNarrowingInterpreterTests.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -15,31 +16,101 @@ namespace GSharp.Interpreter.Tests;
 /// </summary>
 public class Issue2943LoopBackEdgeNarrowingInterpreterTests
 {
-    [Fact]
-    public void AssignmentAfterUse_ReportsNullableReceiver()
+    [Theory]
+    [InlineData("function")]
+    [InlineData("top-level")]
+    public void AssignmentAfterUse_ReportsNullableReceiver(string scope)
     {
-        const string Source = """
+        const string Declarations = """
             class C {
-                func M() { }
+                func Print() { }
             }
+            """;
+        const string Body = """
+            var c C? = C()
+            if c != nil {
+                for var i = 0; i < 2; i++ {
+                    c.Print()
+                    c = nil
+                }
+            }
+            """;
+        var source = scope == "top-level"
+            ? Declarations + Environment.NewLine + Body
+            : Declarations + Environment.NewLine + $$"""
 
             func run() {
-                var c C? = C()
-                if c != nil {
-                    for var i = 0; i < 2; i++ {
-                        c.M()
-                        c = nil
-                    }
-                }
+            {{Indent(Body)}}
             }
 
             run()
             """;
 
-        var result = new Compilation(SyntaxTree.Parse(Source))
+        var result = new Compilation(SyntaxTree.Parse(source))
             .Evaluate(new Dictionary<VariableSymbol, object>());
 
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0159");
+    }
+
+    [Theory]
+    [InlineData("constructor", "c = C(33)", "function")]
+    [InlineData("local", "c = fresh", "function")]
+    [InlineData("function", "c = Mk(33)", "function")]
+    [InlineData("constructor", "c = C(33)", "top-level")]
+    [InlineData("local", "c = fresh", "top-level")]
+    [InlineData("function", "c = Mk(33)", "top-level")]
+    public void NonNullAssignmentAfterUse_PreservesInheritedNarrowing(
+        string shape,
+        string secondIterationAssignment,
+        string scope)
+    {
+        const string Declarations = """
+            class C {
+                let Value int32
+
+                init(value int32) {
+                    Value = value
+                }
+            }
+
+            func Mk(value int32) C {
+                return C(value)
+            }
+            """;
+        var body = $$"""
+            var c C? = C(11)
+            let fresh C = C(33)
+            var sum = 0
+            if c != nil {
+                for var i = 0; i < 3; i++ {
+                    sum = sum + c.Value
+                    if i == 0 {
+                        c = C(22)
+                    }
+                    if i == 1 {
+                        {{secondIterationAssignment}}
+                    }
+                }
+            }
+            """;
+        var source = scope == "top-level"
+            ? Declarations + Environment.NewLine + body + Environment.NewLine + "sum"
+            : Declarations + Environment.NewLine + $$"""
+                func run() int32 {
+                {{Indent(body)}}
+                    return sum
+                }
+
+                run()
+                """;
+
+        var result = new Compilation(SyntaxTree.Parse(source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.True(
+            result.Diagnostics.IsEmpty,
+            $"{shape}/{scope}: {string.Join(Environment.NewLine, result.Diagnostics)}");
+        Assert.Equal(66, result.Value);
     }
 
     [Fact]
@@ -70,4 +141,7 @@ public class Issue2943LoopBackEdgeNarrowingInterpreterTests
         Assert.Empty(result.Diagnostics);
         Assert.Equal(1, result.Value);
     }
+
+    private static string Indent(string source)
+        => "    " + source.Replace(Environment.NewLine, Environment.NewLine + "    ", StringComparison.Ordinal);
 }


### PR DESCRIPTION
Fixes #2943

## Summary

- speculatively bind narrowed loop bodies, then use lowered CFG reachability to find writes and potentially mutating calls that can reach a back-edge
- remove only narrowing inherited from outside the loop before rebinding; preserve condition-derived and in-body re-narrowing
- track assignment roots by bound symbol identity across locals, captures, and top-level globals
- preserve inherited narrowing only when every reaching assignment has compatible type and proven runtime-non-null provenance
- descend into bound function-literal bodies so closure writes invalidate narrowing
- restore speculative diagnostics, label/goto state, loop state, and synthetic lambda ordinals before rebinding
- document top-level, `gsi`, and conservative runtime-null rules in ADR-0069

Covered loop forms: C-style `for`, infinite `for`, ellipsis, sync/async range, `while`, and `do…while`, including nested control flow and direct/labeled `continue`/`break`.

## Top-level and function behavior

Fresh `GSharp.sln` build used for all driver probes. `out/bin/Release/Core`, `Compiler`, and `Repl` copies of `GSharp.Core.dll` had matching post-build mtimes.

| assignment after use | `gsc` top-level | `gsc` function | `gsi` top-level | `gsi` function |
|---|---|---|---|---|
| `c = C(33)` | rc 0, `11/22/33` | rc 0, `11/22/33` | rc 0, `11/22/33` | rc 0, `11/22/33` |
| `c = fresh` | rc 0, `11/22/33` | rc 0, `11/22/33` | rc 0, `11/22/33` | rc 0, `11/22/33` |
| `c = Mk(33)` | rc 0, `11/22/33` | rc 0, `11/22/33` | rc 0, `11/22/33` | rc 0, `11/22/33` |

`gsi` also prints final expression value `3`; program output is identical.

Required rejection controls:

| shape | `gsc` top-level | `gsc` function | `gsi` top-level | `gsi` function |
|---|---|---|---|---|
| original #2943: use, then `c = nil` | GS0159, rc 1 | GS0159, rc 1 | GS0159, rc 1 | GS0159, rc 1 |
| straight-line `c = nil; c.Print()` | GS0159, rc 1 | — | GS0159, rc 1 | — |
| `while` use, then `c = nil` | GS0159, rc 1 | — | GS0159, rc 1 | — |

## Deliberate symbol policy

`SmartCastStability.IsAssignmentNarrowingRoot` is shared by straight-line assignment narrowing, if-join flow, and loop back-edge invalidation.

- ordinary local: accepted; exact symbol identity is trackable
- captured/closure local: accepted; same `LocalVariableSymbol`, and closure bodies are traversed
- top-level global: accepted; required for top-level `gsc` and all `gsi` execution
- value parameter: accepted as an identity root when `RefKind.None`, but never accepted as proof that an assigned RHS is runtime non-null
- `if let` binding: accepted local identity, but read-only and therefore not a writable assignment source
- `ref`/`out`/`in` parameter or ref local: rejected because aliases can mutate storage
- field/property/indexer: rejected as plain roots; conservative member-path invalidation handles them

## Runtime-null attack results

Static non-nullability alone does not preserve a loop narrowing. Both drivers reject every valid product probe:

| assigned source | `gsc` | `gsi` |
|---|---|---|
| uninitialized field | GS0159, rc 1 | GS0159, rc 1 |
| user function returning uninitialized field | GS0159, rc 1 | GS0159, rc 1 |
| function shadowing constructor syntax | GS0159, rc 1 | GS0159, rc 1 |
| aliased `out`/`ref` storage | GS0159, rc 1 | GS0159, rc 1 |
| imported CLR result | GS0158, rc 1 | GS0158, rc 1 |
| parameter receiving uninitialized field | GS0159, rc 1 | GS0159, rc 1 |

Fresh constructor results, immutable locals with proven non-null initializers, and user functions whose every return is proven non-null remain accepted. This loop proof is intentionally stricter than issue #1123 straight-line behavior.

## Independent mutation evidence

Re-run after current rebase. Each mutant changed product code, built successfully, and was restored byte-exactly before next mutant.

| product mutant | Compiler issue matrix | Interpreter issue matrix | result |
|---|---:|---:|---|
| invert direct-root invalidation | 41 failed / 15 passed | 8 failed / 1 passed | killed |
| invert member-path invalidation | 1 failed / 55 passed | 0 failed / 9 passed | killed by Compiler; Interpreter has no member-path case |
| disable `GlobalVariableSymbol` assignment roots | 3 failed / 53 passed | 3 failed / 6 passed | killed by top-level pins in both suites |

Clean round trip: Compiler 56/56; Interpreter 9/9.

## Current-tree verification

Anchors:

- fresh `origin/main` and merge base: `33bea4afeef197c89da73f9edf0b20c36180f80f`
- PR head: `c7641b63516b32aeb58c0336ffa6a758db4e98c5`
- `git merge-tree --write-tree origin/main HEAD`: `1baacffb9ddadd568c4d00d553c3b59e8f86f813`
- `HEAD^{tree}`: same tree, so branch validation is merged-tree validation

Results:

- Release solution build with `ContinuousIntegrationBuild=true`: 0 warnings, 0 errors
- Compiler full suite: **4107 passed / 0 failed / 4107 total**
- targeted Compiler issue matrix: 56/56
- targeted Interpreter issue matrix: 9/9
- bidirectional diagnostic-doc gate: 4/4; neither `docs/diagnostics.md` nor `website/docs/ref/diagnostics.md` changed
- pinned Oahu C# validation: 342/342 + 2/2 + 5/5
- cs2gs pinned Oahu migration/runtime gate: 15/15 apps green
- GitHub required checks, including `cs2gs-corpus`, `cs2gs-oahu`, build, e2e, Compiler shards, Interpreter, and Core: green

GS0159 wording remains tracked separately in #3034.
