### PR TITLE
Fix fixed pointer conversion IL

### DIFF
--- a/docs/adr/0125-fixed-pinned-statement.md
+++ b/docs/adr/0125-fixed-pinned-statement.md
@@ -112,7 +112,8 @@ brfalse NULL
 ldloc pinned; ldlen; conv.i4; brtrue NOTEMPTY
 NULL:     ldc.i4.0; conv.u; stloc ptr       // empty/null ⇒ null pointer
           br AFTER
-NOTEMPTY: ldloc pinned; ldc.i4.0; ldelema <elem>; conv.u; stloc ptr
+NOTEMPTY: ldloc pinned; ldc.i4.0; ldelema <elem>
+          call void* Unsafe.AsPointer<elem>(ref elem); stloc ptr
 AFTER:    <body>
           leave DONE
 FINALLY:  ldnull; stloc pinned              // release on every exit
@@ -123,20 +124,21 @@ DONE:
 **String** (`string pinned`):
 
 ```
-EmitExpr(source); dup; stloc pinned; conv.i
-dup; brfalse SKIP
-call get_OffsetToStringData; add            // skip the string header
-SKIP: conv.u; stloc ptr
+EmitExpr(source); dup; stloc pinned; brfalse NULL
+ldloc pinned; call char& string.GetPinnableReference()
+call void* Unsafe.AsPointer<char>(ref char); stloc ptr
+br AFTER
+NULL: ldc.i4.0; conv.u; stloc ptr
+AFTER:
 try { <body> } finally {
     ldnull; stloc pinned                     // release on every exit
 }
 ```
 
-`RuntimeHelpers.OffsetToStringData` is `[Obsolete]`, so the property getter is
-resolved reflectively (string literal, not `nameof`) to avoid CS0618. The
-classic `OffsetToStringData` lowering is used deliberately instead of
-`string.GetPinnableReference()` to avoid the `modreq(InAttribute)` ref-return
-signature noted above.
+`string.GetPinnableReference()` returns `ref readonly char`; the MemberRef
+retains its `modreq(InAttribute)` return signature. `Unsafe.AsPointer<T>`
+converts that managed pointer to the numeric native pointer stored in the
+user-visible `*T` local.
 
 **Span-like / `GetPinnableReference`** (`T& pinned`, issue #1043):
 
@@ -144,7 +146,7 @@ signature noted above.
 EmitExpr(span); stloc src                    // spill the source for addressing
 ldloca src; call instance T& GetPinnableReference()
 stloc pinned                                 // T& pinned = ref
-ldloc pinned; conv.u; stloc ptr
+ldloc pinned; call void* Unsafe.AsPointer<T>(ref T); stloc ptr
 try { <body> } finally {
     ldc.i4.0; conv.u; stloc pinned            // release on every exit
 }
@@ -162,6 +164,11 @@ emitted MemberRef carries the real BCL signature, including
 return-signature encoder reproduces required custom modifiers on by-ref returns
 (the same mechanism used for `ref readonly` indexers in ADR-0056), so the call
 binds at runtime instead of throwing `MissingMethodException`.
+
+The `Unsafe.AsPointer<T>` call is deliberate for every managed-pointer source.
+Emitting `conv.u` directly after `ldelema` or a ref-return leaves a managed
+pointer at an instruction that requires a numeric stack value, producing
+ilverify's `ExpectedNumericType` error even though RyuJIT accepts the method.
 
 ### 5. New node kinds, exhaustiveness, coverage matrix
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
@@ -97,11 +97,10 @@ internal sealed partial class MethodBodyEmitter
 
     // Array-pin form: pin the array reference (`T[] pinned`) and derive
     // `&a[0]` via `ldelema`, guarding the null / zero-length array (→ null
-    // pointer), exactly as the C# compiler does.
+    // pointer).
     private void EmitFixedArrayPin(BoundFixedStatement node, int pinnedSlot, int pointerSlot)
     {
         var elementType = ((Symbols.PointerTypeSymbol)node.PointerVariable.Type).PointeeType;
-
         var nullLabel = this.il.DefineLabel();
         var notEmptyLabel = this.il.DefineLabel();
         var afterLabel = this.il.DefineLabel();
@@ -129,45 +128,50 @@ internal sealed partial class MethodBodyEmitter
         this.il.LoadConstantI4(0);
         this.il.OpCode(ILOpCode.Ldelema);
         this.il.Token(this.outer.memberRefs.GetElementTypeToken(elementType));
-        this.il.OpCode(ILOpCode.Conv_u);
+        this.EmitManagedPointerAsUnmanagedPointer(elementType);
         this.il.StoreLocal(pointerSlot);
 
         this.il.MarkLabel(afterLabel);
     }
 
     // String-pin form: pin the `string` reference (`string pinned`) and derive
-    // the char-data pointer via `RuntimeHelpers.OffsetToStringData`, guarding
-    // null (→ null pointer). This classic lowering avoids the `modreq`-bearing
-    // `string.GetPinnableReference()` ref-return that the member-ref encoder
-    // cannot reproduce.
+    // the char-data pointer through `GetPinnableReference`, guarding null
+    // (→ null pointer).
     private void EmitFixedStringPin(BoundFixedStatement node, int pinnedSlot, int pointerSlot)
     {
-        var skipLabel = this.il.DefineLabel();
+        var nullLabel = this.il.DefineLabel();
+        var afterLabel = this.il.DefineLabel();
 
         this.EmitExpression(node.PinnedSource); // string reference
         this.il.OpCode(ILOpCode.Dup);
         this.il.StoreLocal(pinnedSlot);          // pinned = s
-        this.il.OpCode(ILOpCode.Conv_i);         // (nint)s — address of the object
-        this.il.OpCode(ILOpCode.Dup);
-        this.il.Branch(ILOpCode.Brfalse, skipLabel); // null -> leave 0 as the pointer
+        this.il.Branch(ILOpCode.Brfalse, nullLabel);
 
-        var offsetGetter = typeof(System.Runtime.CompilerServices.RuntimeHelpers)
-            .GetProperty("OffsetToStringData")!
-            .GetGetMethod()!;
-        this.il.Call(this.outer.memberRefs.GetMethodReference(offsetGetter));
-        this.il.OpCode(ILOpCode.Add);            // address + OffsetToStringData = &s[0]
+        this.il.LoadLocal(pinnedSlot);
+        var getPinnableReference = typeof(string).GetMethod(
+            "GetPinnableReference",
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            types: Type.EmptyTypes,
+            modifiers: null);
+        this.il.Call(this.outer.memberRefs.GetMethodReference(getPinnableReference));
+        this.EmitManagedPointerAsUnmanagedPointer(TypeSymbol.Char);
+        this.il.StoreLocal(pointerSlot);
+        this.il.Branch(ILOpCode.Br, afterLabel);
 
-        this.il.MarkLabel(skipLabel);
+        this.il.MarkLabel(nullLabel);
+        this.il.LoadConstantI4(0);
         this.il.OpCode(ILOpCode.Conv_u);
-        this.il.StoreLocal(pointerSlot);         // p = (char*)result
+        this.il.StoreLocal(pointerSlot);
+        this.il.MarkLabel(afterLabel);
     }
 
     // Span-like pin form (ADR-0125 / issue #1043): pin the `T&` returned by a
     // public instance `ref T GetPinnableReference()` (e.g. `System.Span[T]` /
     // `System.ReadOnlySpan[T]`) into a `T& pinned` local, then derive `*T` via
-    // `conv.u`. Mirrors C# `fixed (T* p = span)`. `GetPinnableReference()` already
-    // returns the data pointer for an empty span (a ref to where element 0 would
-    // be), so no null/empty guard is required — matching C#'s codegen.
+    // `Unsafe.AsPointer<T>`. `GetPinnableReference()` already returns the data
+    // pointer for an empty span (a ref to where element 0 would be), so no
+    // null/empty guard is required.
     private void EmitFixedPinnableReferencePin(BoundFixedStatement node, int pinnedSlot, int pointerSlot)
     {
         var sourceSlot = this.locals[node.SourceVariable];
@@ -203,8 +207,22 @@ internal sealed partial class MethodBodyEmitter
         this.il.Token(this.outer.memberRefs.GetMethodEntityHandle(getPinnableReference, node.PinnedSource.Type)); // -> T&
         this.il.StoreLocal(pinnedSlot);          // T& pinned = ref
         this.il.LoadLocal(pinnedSlot);
-        this.il.OpCode(ILOpCode.Conv_u);
+        this.EmitManagedPointerAsUnmanagedPointer(
+            ((Symbols.PointerTypeSymbol)node.PointerVariable.Type).PointeeType);
         this.il.StoreLocal(pointerSlot);         // p = (T*)ref
+    }
+
+    private void EmitManagedPointerAsUnmanagedPointer(TypeSymbol pointeeType)
+    {
+        var openAsPointer = typeof(System.Runtime.CompilerServices.Unsafe)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(method => method.Name == "AsPointer"
+                && method.IsGenericMethodDefinition
+                && method.GetParameters().Length == 1);
+        var closedAsPointer = openAsPointer.MakeGenericMethod(pointeeType.ClrType ?? typeof(object));
+        this.il.Call(this.outer.memberRefs.GetMethodEntityHandle(
+            closedAsPointer,
+            ImmutableArray.Create(pointeeType)));
     }
 
     private void EmitTryStatement(BoundTryStatement node)

--- a/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
@@ -311,7 +311,7 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
         var assembly = CompileVerifyLoadAndRun(
             "UnnamedFixed",
             Source,
-            ignoredVerificationErrors: new[] { "ExpectedNumericType" });
+            ignoredVerificationErrors: new[] { "UnmanagedPointer", "StackByRef" });
         // Known limitation (#2953): the fixed-return epilogue must be emitted first,
         // so fixed-containing non-void functions bypass the fall-through guard and
         // silently return the default slot instead of throwing.

--- a/test/Compiler.Tests/Emit/Issue2922FixedSwitchIlTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2922FixedSwitchIlTests.cs
@@ -1,0 +1,459 @@
+// <copyright file="Issue2922FixedSwitchIlTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading.Tasks;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2922: fixed sources must become numeric unmanaged pointers before
+/// switch control flow is emitted.
+/// </summary>
+public class Issue2922FixedSwitchIlTests
+{
+    private const string ExpectedMatrixOutput = "2\n3\n12\n12\n3\n3\n2\n2\n2\n12\n3\n3\n2\n2\nSI\n";
+
+    private const string MatrixSource = """
+        package Issue2922.Matrix
+        import System
+
+        var trace = ""
+
+        struct Holder {
+            public var Values []int32
+        }
+
+        func AllSwitch(x int32, xs []int32) int32 {
+            unsafe {
+                fixed p *int32 = xs {
+                    switch x {
+                        case 0 { return xs.Length }
+                        default { return 1 }
+                    }
+                }
+            }
+        }
+
+        func SomeSwitch(x int32, xs []int32) int32 {
+            unsafe {
+                fixed p *int32 = xs {
+                    switch x {
+                        case 0 { return xs.Length }
+                    }
+                }
+            }
+            return 3
+        }
+
+        func BreakSwitch(x int32, xs []int32) int32 {
+            var value = 0
+            switchLoop: for {
+                unsafe {
+                    fixed p *int32 = xs {
+                        switch x {
+                            case 0 {
+                                value = xs.Length
+                                break switchLoop
+                            }
+                            default {
+                                value = 1
+                                break switchLoop
+                            }
+                        }
+                    }
+                }
+            }
+            return value + 10
+        }
+
+        func NestedSwitch(x int32, xs []int32) int32 {
+            unsafe {
+                fixed p *int32 = xs {
+                    switch x {
+                        case 0 {
+                            switch xs.Length {
+                                case 2 { return 12 }
+                                default { return -1 }
+                            }
+                        }
+                        default { return 1 }
+                    }
+                }
+            }
+        }
+
+        func LoopSwitch(xs []int32) int32 {
+            var total = 0
+            unsafe {
+                fixed p *int32 = xs {
+                    for var i = 0; i < 2; i++ {
+                        switch i {
+                            case 0 { total = total + xs.Length }
+                            default { total = total + 1 }
+                        }
+                    }
+                }
+            }
+            return total
+        }
+
+        func MultipleSwitch(x int32, xs []int32, ys []int32) int32 {
+            unsafe {
+                fixed p *int32 = xs {
+                    fixed q *int32 = ys {
+                        switch x {
+                            case 0 { return xs.Length + ys.Length }
+                            default { return 1 }
+                        }
+                    }
+                }
+            }
+        }
+
+        func StringSwitch(x int32, text string) int32 {
+            unsafe {
+                fixed p *uint16 = text {
+                    switch x {
+                        case 0 { return text.Length }
+                        default { return 1 }
+                    }
+                }
+            }
+        }
+
+        func StructFieldSwitch(x int32, holder Holder) int32 {
+            unsafe {
+                fixed p *int32 = holder.Values {
+                    switch x {
+                        case 0 { return holder.Values.Length }
+                        default { return 1 }
+                    }
+                }
+            }
+        }
+
+        func AllIf(x int32, xs []int32) int32 {
+            unsafe {
+                fixed p *int32 = xs {
+                    if x == 0 { return xs.Length }
+                    return 1
+                }
+            }
+        }
+
+        func NestedIf(x int32, xs []int32) int32 {
+            unsafe {
+                fixed p *int32 = xs {
+                    if x == 0 {
+                        if xs.Length == 2 { return 12 }
+                        return -1
+                    }
+                    return 1
+                }
+            }
+        }
+
+        func LoopIf(xs []int32) int32 {
+            var total = 0
+            unsafe {
+                fixed p *int32 = xs {
+                    for var i = 0; i < 2; i++ {
+                        if i == 0 { total = total + xs.Length }
+                        else { total = total + 1 }
+                    }
+                }
+            }
+            return total
+        }
+
+        func MultipleIf(x int32, xs []int32, ys []int32) int32 {
+            unsafe {
+                fixed p *int32 = xs {
+                    fixed q *int32 = ys {
+                        if x == 0 { return xs.Length + ys.Length }
+                        return 1
+                    }
+                }
+            }
+        }
+
+        func StringIf(x int32, text string) int32 {
+            unsafe {
+                fixed p *uint16 = text {
+                    if x == 0 { return text.Length }
+                    return 1
+                }
+            }
+        }
+
+        func StructFieldIf(x int32, holder Holder) int32 {
+            unsafe {
+                fixed p *int32 = holder.Values {
+                    if x == 0 { return holder.Values.Length }
+                    return 1
+                }
+            }
+        }
+
+        func VoidSwitch(x int32, xs []int32) {
+            unsafe {
+                fixed p *int32 = xs {
+                    switch x {
+                        case 0 { trace = trace + "S" }
+                        default { trace = trace + "X" }
+                    }
+                }
+            }
+        }
+
+        func VoidIf(x int32, xs []int32) {
+            unsafe {
+                fixed p *int32 = xs {
+                    if x == 0 { trace = trace + "I" }
+                    else { trace = trace + "X" }
+                }
+            }
+        }
+
+        let xs = []int32{1, 2}
+        let ys = []int32{3}
+        let holder = Holder{ Values: xs }
+        Console.WriteLine(AllSwitch(0, xs))
+        Console.WriteLine(SomeSwitch(1, xs))
+        Console.WriteLine(BreakSwitch(0, xs))
+        Console.WriteLine(NestedSwitch(0, xs))
+        Console.WriteLine(LoopSwitch(xs))
+        Console.WriteLine(MultipleSwitch(0, xs, ys))
+        Console.WriteLine(StringSwitch(0, "AB"))
+        Console.WriteLine(StructFieldSwitch(0, holder))
+        Console.WriteLine(AllIf(0, xs))
+        Console.WriteLine(NestedIf(0, xs))
+        Console.WriteLine(LoopIf(xs))
+        Console.WriteLine(MultipleIf(0, xs, ys))
+        Console.WriteLine(StringIf(0, "AB"))
+        Console.WriteLine(StructFieldIf(0, holder))
+        VoidSwitch(0, xs)
+        VoidIf(0, xs)
+        Console.WriteLine(trace)
+        """;
+
+    /// <summary>Gets fixed source kinds whose old conv.u lowering failed verification.</summary>
+    public static IEnumerable<object[]> PinKinds()
+    {
+        yield return new object[]
+        {
+            "Slice",
+            """
+            package Issue2922.Slice
+            import System
+            func F(x int32, xs []int32) int32 {
+                unsafe {
+                    fixed p *int32 = xs {
+                        switch x {
+                            case 0 { return xs.Length }
+                            default { return 1 }
+                        }
+                    }
+                }
+            }
+            Console.WriteLine(F(0, []int32{1, 2}))
+            """,
+            "2\n",
+            Array.Empty<string>(),
+        };
+        yield return new object[]
+        {
+            "String",
+            """
+            package Issue2922.String
+            import System
+            func F(x int32, text string) int32 {
+                unsafe {
+                    fixed p *uint16 = text {
+                        switch x {
+                            case 0 { return text.Length }
+                            default { return 1 }
+                        }
+                    }
+                }
+            }
+            Console.WriteLine(F(0, "AB"))
+            Console.WriteLine(F(0, ""))
+            """,
+            "2\n0\n",
+            Array.Empty<string>(),
+        };
+        yield return new object[]
+        {
+            "Span",
+            """
+            package Issue2922.Span
+            import System
+            func F(x int32, xs []int32) int32 {
+                var span Span[int32] = xs
+                unsafe {
+                    fixed p *int32 = span {
+                        switch x {
+                            case 0 { return xs.Length }
+                            default { return 1 }
+                        }
+                    }
+                }
+            }
+            Console.WriteLine(F(0, []int32{1, 2}))
+            """,
+            "2\n",
+            new[] { "StackUnexpected" },
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(PinKinds))]
+    public void FixedSource_VerifiesLoadsAndRuns(
+        string name,
+        string source,
+        string expectedOutput,
+        string[] ignoredVerificationErrors)
+    {
+        using var program = Compile(name, source);
+        IlVerifier.Verify(
+            program.AssemblyPath,
+            additionalReferences: null,
+            ignoredErrorCodes: ignoredVerificationErrors);
+        program.AssertLoadable();
+        Assert.Equal(expectedOutput, program.Run());
+    }
+
+    [Fact]
+    public void FixedControlFlowMatrix_Verifies()
+    {
+        using var program = Compile("MatrixVerify", MatrixSource);
+        IlVerifier.Verify(program.AssemblyPath);
+    }
+
+    [Fact]
+    public void FixedControlFlowMatrix_LoadsAndRuns()
+    {
+        using var program = Compile("MatrixRun", MatrixSource);
+        program.AssertLoadable();
+        Assert.Equal(ExpectedMatrixOutput, program.Run());
+    }
+
+    [Fact]
+    public void SlicePin_ConvertsManagedPointerThroughUnsafeAsPointer()
+    {
+        using var program = Compile("Instruction", PinKinds().First()[1].ToString()!);
+        var assembly = program.Load();
+        var method = assembly.GetTypes()
+            .Single(type => type.Name == "<Program>")
+            .GetMethod("F", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
+        var il = method.GetMethodBody()!.GetILAsByteArray()!;
+        var loadElementAddress = Array.IndexOf(il, unchecked((byte)OpCodes.Ldelema.Value));
+
+        Assert.True(loadElementAddress >= 0);
+        var callOffset = loadElementAddress + 5;
+        Assert.Equal(unchecked((byte)OpCodes.Call.Value), il[callOffset]);
+        var calledMethod = method.Module.ResolveMethod(BitConverter.ToInt32(il, callOffset + 1));
+        Assert.Equal("AsPointer", calledMethod!.Name);
+    }
+
+    private static CompiledProgram Compile(string name, string source)
+    {
+        var directory = Directory.CreateTempSubdirectory($"gs_i2922_{name}_").FullName;
+        var sourcePath = Path.Combine(directory, "Program.gs");
+        var assemblyPath = Path.Combine(directory, "Program.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(
+            exitCode == 0,
+            $"gsc failed:\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return new CompiledProgram(directory, assemblyPath);
+    }
+
+    private sealed class CompiledProgram : IDisposable
+    {
+        private readonly string directory;
+
+        public CompiledProgram(string directory, string assemblyPath)
+        {
+            this.directory = directory;
+            AssemblyPath = assemblyPath;
+        }
+
+        public string AssemblyPath { get; }
+
+        public Assembly Load() => Assembly.Load(File.ReadAllBytes(AssemblyPath));
+
+        public void AssertLoadable() => Assert.NotEmpty(Load().GetTypes());
+
+        public string Run()
+        {
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add(AssemblyPath);
+
+            using var process = Process.Start(startInfo)!;
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(10_000))
+            {
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit();
+                throw new Xunit.Sdk.XunitException("Compiled program timed out.");
+            }
+
+            Task.WaitAll(stdoutTask, stderrTask);
+            Assert.True(
+                process.ExitCode == 0,
+                $"dotnet exec exited {process.ExitCode}:\n{stderrTask.Result}");
+            return stdoutTask.Result.Replace("\r\n", "\n");
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(this.directory))
+            {
+                Directory.Delete(this.directory, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2922.

`fixed` pin setup converted managed pointers with `conv.u`. ILVerify requires a numeric operand for `conv.u`, but `ldelema` and `GetPinnableReference()` leave managed byrefs on the stack. RyuJIT accepted the malformed transition, so programs executed while verification failed.

`MethodBodyEmitter.Statements.cs:101-225` now passes each managed byref through `System.Runtime.CompilerServices.Unsafe.AsPointer<T>`, whose signature consumes `T&` and returns a numeric unmanaged pointer. Array/slice, string, and pinnable-reference sources share the conversion helper. Fixed return epilogue ordering from #2926 is untouched.

## Offending and corrected IL

Original issue repro:

```il
IL_001A: ldelema System.Int32
IL_001F: conv.u                         // stack contains Int32&, not numeric
IL_0020: stloc.2                        // int32*
```

Corrected:

```il
IL_001A: ldelema System.Int32
IL_001F: call void* Unsafe::AsPointer<int32>(!!0&)
IL_0024: stloc.2                        // int32*
```

The call consumes the managed pointer according to its parameter signature and returns the native numeric pointer required by the destination local. String pinning similarly uses `string.GetPinnableReference()` followed by `Unsafe.AsPointer<char>`; span-like pinning converts its pinned `T&` through the same helper.

## Diff

| File | Delta |
|---|---:|
| `src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs` | +40/-22 |
| `docs/adr/0125-fixed-pinned-statement.md` | +18/-11 |
| `test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs` | +1/-1 |
| `test/Compiler.Tests/Emit/Issue2922FixedSwitchIlTests.cs` | +459/-0 |

Production delta: +40/-22, 62 changed lines. No `MethodBodyEmitter.EmitMethodBody` or `EmitFixedReturnEpilogue` ordering change.

## Pins and guards

Exact-base run at `17789519` with the new tests: **6 failed pins, 1 passed guard**. HEAD: **7/7 passed**.

| Test branch | Base | HEAD | Role |
|---|---:|---:|---|
| slice fixed source verifies | fail `ExpectedNumericType` | pass | pin |
| string fixed source verifies | fail `ExpectedNumericType` | pass | pin |
| span fixed source has no `ExpectedNumericType` | fail | pass | pin |
| full switch/if control-flow matrix verifies | fail | pass | pin |
| array pin emits `ldelema; call Unsafe.AsPointer; stloc` | fail | pass | pin |
| #2906 fixed-return test without `ExpectedNumericType` suppression | fail | pass | pin |
| matrix loads and executes in a bounded child process | pass | pass | guard |

The matrix covers all-arm returns, partial returns, a switch-arm break escaping a labeled loop, nested switches, switch inside a loop inside `fixed`, nested fixed declarations, slice, string, struct-field sources, matching `if` controls, and void variants. G# has no standalone switch `break`; `break` targets loops, so the valid escaping shape is a branch from a switch arm to its labeled enclosing loop.

Existing fixed emission guards also pass: 40/40 across #1026, #1043, #2838, #2900, and #2906.

## Mutation checks

Unmutated control ran first. Every mutation was build-green; each restore was rebuilt before the next mutation.

| Semantic branch | Neutral mutation | Detection |
|---|---|---|
| array/slice byref conversion | restore `conv.u` after `ldelema` | slice pin, matrix verifier, and IL-sequence pin fail |
| string byref conversion | replace `Unsafe.AsPointer<char>` with `conv.u` | string pin and matrix verifier fail |
| span-like byref conversion | replace helper call with `conv.u` | span pin fails |
| symbolic generic pointee mapping | omit `ImmutableArray<TypeSymbol>` from MethodSpec creation | #2838 generic pointer guard fails: `AsPointer` closes over erased `System.Object` |
| #2906 suppression removal | restore old array `conv.u` while ignoring only inherent pointer errors | test fails with `ExpectedNumericType` |

## Verification

Both required axes run:

- ILVerify: exact repro and full array/string control-flow matrix verify with no ignored errors.
- Load/runtime: assemblies are loaded with `Assembly.Load`, enumerated with `GetTypes()`, then executed in child processes with both pipes drained asynchronously, a 10-second bound, and `Kill(entireProcessTree: true)` on timeout.
- Span pin test ignores only its pre-existing pinned-byref cleanup `StackUnexpected`; `ExpectedNumericType` is not ignored.
- #2906's `ExpectedNumericType` suppression is removed. Its `*p` dereference still requires `UnmanagedPointer` and `StackByRef`, inherent unsafe-pointer diagnostics unrelated to this issue.
- #2953 behavior is unchanged: unnamed exhaustive fallthrough still returns the default fixed-return slot (`0`).

Executed suites:

| Suite | base `17789519` | head `0b34855f` |
|---|---:|---:|
| Core.Tests | 7007 passed, 1 skipped | 7007 passed, 1 skipped |
| Compiler.Tests | 3876 passed | 3882 passed |
| Interpreter.Tests | 472 passed | 472 passed |
| LanguageServer.Tests | 452 passed | 452 passed |

An initial head LSP run under two concurrent Compiler suites timed out in the pre-existing background-workspace timing test; the unloaded full rerun passed 452/452.

Release solution build: 0 warnings, 0 errors.

## Corpus

All **148** non-aspirational sample `.gs` files were compiled independently with `/deterministic+` by base and head compilers. **142 binaries** were produced on each side; six files had identical compile failures. Comparison covered SHA-256, normalized diagnostics, compile exits, runtime exits, stdout, and stderr: **0 differences**.

Samples containing executable `fixed` syntax: **0/148**. Corpus is non-regression evidence only; hand-written pins carry the fix.

## gsi parity

Compiled probe verifies and prints `2`. `gsi` exits 1 with:

```text
GS9999: 'fixed' (pinning) statements are not supported in the interpreter; they require the CIL pinned-local emit path.
```

This is not an emitter defect: the interpreter has an explicit rejection and no pinning/cleanup runtime model. Filed #2956 to implement interpreter semantics or document a compiled-only boundary.
