### PR TITLE
Prevent IlVerifier child process hangs

### DIFF
--- a/test/Compiler.Tests/IlVerifier.cs
+++ b/test/Compiler.Tests/IlVerifier.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit.Sdk;
 
 namespace GSharp.Compiler.Tests;
@@ -35,11 +36,16 @@ namespace GSharp.Compiler.Tests;
 ///   <item>If the <c>ilverify</c> tool cannot be located, the helper throws
 ///         (instead of silently passing) so CI failures are obvious. To bypass
 ///         in environments without the tool, set <c>GSHARP_SKIP_ILVERIFY=1</c>.</item>
+///   <item>Verification is limited to 30 seconds. On timeout, the helper kills
+///         the tool process tree and reports any partial stdout and stderr.</item>
 /// </list>
 /// </summary>
 internal static class IlVerifier
 {
     private const string SkipEnvVar = "GSHARP_SKIP_ILVERIFY";
+    private const int VerifyTimeoutMilliseconds = 30_000;
+    private const int KillGraceMilliseconds = 10_000;
+    private const string UnavailableOutput = "<unavailable: output pipe held by a surviving descendant>";
 
     private static readonly object ToolLocateSync = new();
     private static readonly Lazy<IReadOnlyList<string>> RuntimeReferences =
@@ -130,21 +136,10 @@ internal static class IlVerifier
             psi.ArgumentList.Add(a);
         }
 
-        using var proc = Process.Start(psi)
-            ?? throw new XunitException($"ilverify: failed to start '{command}'");
+        var (exitCode, stdout, stderr) =
+            RunProcess(psi, assemblyPath, VerifyTimeoutMilliseconds);
 
-        // Drain both pipes concurrently before waiting: reading stdout to EOF
-        // and only then stderr can deadlock when ilverify fills the stderr pipe
-        // buffer (~64 KB of error lines) while we are still blocked on stdout,
-        // leaving the child unable to exit. Awaiting both reads together avoids
-        // the classic redirected-pipe deadlock.
-        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
-        var stderrTask = proc.StandardError.ReadToEndAsync();
-        proc.WaitForExit();
-        var stdout = stdoutTask.GetAwaiter().GetResult();
-        var stderr = stderrTask.GetAwaiter().GetResult();
-
-        if (proc.ExitCode != 0)
+        if (exitCode != 0)
         {
             // ilverify writes one line per IL error. Surface its full output so
             // a CI failure points directly at the offending opcode/method.
@@ -152,7 +147,7 @@ internal static class IlVerifier
                 .Append("ilverify detected invalid IL in '")
                 .Append(assemblyPath)
                 .Append("' (exit ")
-                .Append(proc.ExitCode)
+                .Append(exitCode)
                 .AppendLine("):")
                 .AppendLine(stdout.TrimEnd())
                 .Append(stderr.TrimEnd())
@@ -167,6 +162,63 @@ internal static class IlVerifier
                 $"ilverify exited successfully without confirming verification of '{assemblyPath}'.{Environment.NewLine}" +
                 stdout.TrimEnd() + Environment.NewLine + stderr.TrimEnd());
         }
+    }
+
+    internal static (int ExitCode, string Stdout, string Stderr) RunProcess(
+        ProcessStartInfo startInfo,
+        string assemblyPath,
+        int timeoutMilliseconds)
+    {
+        using var proc = Process.Start(startInfo)
+            ?? throw new XunitException($"ilverify: failed to start '{startInfo.FileName}'");
+
+        // Drain both pipes concurrently before waiting: reading stdout to EOF
+        // and only then stderr can deadlock when ilverify fills the stderr pipe
+        // buffer (~64 KB of error lines) while we are still blocked on stdout,
+        // leaving the child unable to exit. Awaiting both reads together avoids
+        // the classic redirected-pipe deadlock.
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+        if (!proc.WaitForExit(timeoutMilliseconds))
+        {
+            proc.Kill(entireProcessTree: true);
+            proc.WaitForExit(KillGraceMilliseconds);
+
+            // Observation prevents a later unobserved-task escalation when a
+            // surviving descendant eventually closes a pipe with an error.
+            // It does not change task state: Wait/Result below still throw any
+            // fault that completes within the grace period.
+            _ = stdoutTask.ContinueWith(
+                task => _ = task.Exception,
+                TaskContinuationOptions.OnlyOnFaulted);
+            _ = stderrTask.ContinueWith(
+                task => _ = task.Exception,
+                TaskContinuationOptions.OnlyOnFaulted);
+
+            string Grab(Task<string> task) => task.Wait(KillGraceMilliseconds)
+                ? task.Result
+                : UnavailableOutput;
+            var timedOutStdout = Grab(stdoutTask);
+            var timedOutStderr = Grab(stderrTask);
+            var message = new StringBuilder()
+                .Append("process '")
+                .Append(startInfo.FileName)
+                .Append("' timed out after ")
+                .Append(timeoutMilliseconds)
+                .Append(" ms while verifying '")
+                .Append(assemblyPath)
+                .AppendLine("':")
+                .AppendLine("stdout:")
+                .AppendLine(timedOutStdout.TrimEnd())
+                .AppendLine("stderr:")
+                .Append(timedOutStderr.TrimEnd())
+                .ToString();
+            throw new XunitException(message);
+        }
+
+        var stdout = stdoutTask.GetAwaiter().GetResult();
+        var stderr = stderrTask.GetAwaiter().GetResult();
+        return (proc.ExitCode, stdout, stderr);
     }
 
     /// <summary>

--- a/test/Compiler.Tests/IlVerifierTests.cs
+++ b/test/Compiler.Tests/IlVerifierTests.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
@@ -148,5 +149,123 @@ public class IlVerifierTests
         {
             Environment.SetEnvironmentVariable("GSHARP_SKIP_ILVERIFY", prev);
         }
+    }
+
+    [Fact]
+    public void RunProcess_HungChild_TimesOutWithPartialOutput()
+    {
+        var assemblyPath = typeof(IlVerifierTests).Assembly.Location;
+        var stopwatch = Stopwatch.StartNew();
+        var exception = Assert.Throws<XunitException>(
+            () => IlVerifier.RunProcess(
+                CreateChildProcess(
+                    "[Console]::Out.Write('timeout-stdout'); [Console]::Error.Write('timeout-stderr'); Start-Sleep -Seconds 6",
+                    "printf timeout-stdout; printf timeout-stderr >&2; sleep 6"),
+                assemblyPath,
+                timeoutMilliseconds: 2_000));
+        stopwatch.Stop();
+
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), $"timeout took {stopwatch.Elapsed}");
+        Assert.Contains("timed out after 2000 ms", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(assemblyPath, exception.Message, StringComparison.Ordinal);
+        Assert.Contains("timeout-stdout", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("timeout-stderr", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RunProcess_LargeStdoutAndStderr_DrainsBothPipes()
+    {
+        // A regression that starts either drain after WaitForExit hangs this test.
+        // xUnit's Fact timeout is unavailable because this assembly disables test
+        // parallelization, so treat such a hang as the deadlock regression, not a flake.
+        const int OutputLength = 128 * 1024;
+        var result = IlVerifier.RunProcess(
+            CreateChildProcess(
+                $"[Console]::Out.Write('o' * {OutputLength}); [Console]::Error.Write('e' * {OutputLength})",
+                $"awk 'BEGIN {{ for (i = 0; i < {OutputLength}; i++) printf \"o\" }}'; " +
+                $"awk 'BEGIN {{ for (i = 0; i < {OutputLength}; i++) printf \"e\" }}' >&2"),
+            typeof(IlVerifierTests).Assembly.Location,
+            timeoutMilliseconds: 10_000);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(new string('o', OutputLength), result.Stdout);
+        Assert.Equal(new string('e', OutputLength), result.Stderr);
+    }
+
+    [Fact]
+    public void RunProcess_EscapedDescendantHoldingPipe_TimeoutRemainsBounded()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // Process has no portable API for creating a reparented Windows
+            // descendant that retains inherited redirected pipe handles.
+            return;
+        }
+
+        var pidPath = Path.Combine(
+            AppContext.BaseDirectory,
+            $"ilverify-escaped-{Guid.NewGuid():N}.pid");
+        try
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var exception = Assert.Throws<XunitException>(
+                () => IlVerifier.RunProcess(
+                    CreateChildProcess(
+                        string.Empty,
+                        $"(sleep 30 2>/dev/null & echo $! > '{pidPath}'); printf escaped-stdout; sleep 6"),
+                    typeof(IlVerifierTests).Assembly.Location,
+                    timeoutMilliseconds: 2_000));
+            stopwatch.Stop();
+
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(15), $"timeout took {stopwatch.Elapsed}");
+            Assert.Contains("process '/bin/sh' timed out after 2000 ms", exception.Message, StringComparison.Ordinal);
+            Assert.Contains(
+                "<unavailable: output pipe held by a surviving descendant>",
+                exception.Message,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (File.Exists(pidPath)
+                && int.TryParse(File.ReadAllText(pidPath), out var pid))
+            {
+                try
+                {
+                    using var escaped = Process.GetProcessById(pid);
+                    escaped.Kill(entireProcessTree: true);
+                    escaped.WaitForExit(5_000);
+                }
+                catch (ArgumentException)
+                {
+                }
+            }
+
+            File.Delete(pidPath);
+        }
+    }
+
+    private static ProcessStartInfo CreateChildProcess(string windowsCommand, string unixCommand)
+    {
+        var startInfo = new ProcessStartInfo(OperatingSystem.IsWindows() ? "powershell.exe" : "/bin/sh")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        if (OperatingSystem.IsWindows())
+        {
+            startInfo.ArgumentList.Add("-NoProfile");
+            startInfo.ArgumentList.Add("-NonInteractive");
+            startInfo.ArgumentList.Add("-Command");
+            startInfo.ArgumentList.Add(windowsCommand);
+        }
+        else
+        {
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add(unixCommand);
+        }
+
+        return startInfo;
     }
 }


### PR DESCRIPTION
## Summary

- bound each `dotnet-ilverify` run to 30 seconds
- kill the entire child process tree on timeout, then bound both recovery waits and pipe drains
- include partial output when available and a clear marker when a surviving descendant retains a pipe
- keep stdout and stderr draining concurrently to preserve the existing full-pipe deadlock fix
- add direct timeout, escaped-descendant, and dual-pipe regression coverage

Fixes #2934

## Verification

- Timeout pin: a child writes to both pipes and sleeps; a 2-second timeout kills it and reports command, timeout, assembly path, and partial output.
- Escaped-descendant pin (Unix): a double-forked descendant retains stdout after tree kill; recovery returns a diagnostic with the unavailable-output marker in about 12 seconds. Windows skips this test because managed `Process` APIs cannot portably create a reparented descendant retaining redirected handles.
- Recovery mutation: restoring the three unbounded recovery waits makes the escaped-descendant pin fail after about 30 seconds; hardened code passes under its 15-second bound.
- Lifetime mutations: restoring unbounded primary `WaitForExit()` or plain `Kill()` makes the timeout pin fail in 6 seconds.
- Pipe guard: a child writes 128 KiB to both stdout and stderr; both complete and are returned byte-for-byte. Sequential-drain mutation hangs and was killed at 120 seconds.
- Release build: 0 warnings, 0 errors.
- Base `8dddbbf2`: Core 7028 passed + 1 skipped; Compiler 3893 passed; Interpreter 489 passed; LSP 452 passed.
- Head: Core 7028 passed + 1 skipped; Compiler 3896 passed; Interpreter 489 passed; LSP 452 passed.

No corpus run: this changes only `Compiler.Tests` process lifetime management, not compiler production code. No local e2e run per repository task constraints.