### PR TITLE
gsc: preserve async select receive bindings

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
@@ -641,7 +641,7 @@ internal sealed partial class MethodBodyEmitter
         this.il.OpCode(ILOpCode.Callvirt);
         this.il.Token(this.outer.memberRefs.GetMethodReference(tryRead));
         this.il.Branch(ILOpCode.Brfalse, closedLabel);
-        this.EmitStatement(arm.Body);
+        this.EmitSelectReceiveArmBody(arm, slots.OutSlots[index]);
         this.il.Branch(ILOpCode.Br, endLabel);
 
         this.il.MarkLabel(closedLabel);
@@ -654,9 +654,24 @@ internal sealed partial class MethodBodyEmitter
         this.il.Token(this.outer.memberRefs.GetMethodReference(isCompleted));
         this.il.Branch(ILOpCode.Brfalse, nextLabel);
         this.EmitZeroInit(slots.OutSlots[index], chType.ElementType, elementClr);
-        this.EmitStatement(arm.Body);
+        this.EmitSelectReceiveArmBody(arm, slots.OutSlots[index]);
         this.il.Branch(ILOpCode.Br, endLabel);
         this.il.MarkLabel(nextLabel);
+    }
+
+    private void EmitSelectReceiveArmBody(BoundSelectCase arm, int outSlot)
+    {
+        if (arm.Variable != null
+            && this.asyncFieldMap != null
+            && this.asyncFieldMap.TryGetHoistedField(arm.Variable, out _))
+        {
+            // TryRead writes through the local out slot; the rewritten
+            // MoveNext arm body reads the hoisted state-machine field.
+            this.il.LoadLocal(outSlot);
+            this.EmitStoreVariable(arm.Variable);
+        }
+
+        this.EmitStatement(arm.Body);
     }
 
     private void EmitSelectSendProbe(

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
@@ -661,14 +661,17 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitSelectReceiveArmBody(BoundSelectCase arm, int outSlot)
     {
+        FieldSymbol hoistedField = null;
         if (arm.Variable != null
-            && this.asyncFieldMap != null
-            && this.asyncFieldMap.TryGetHoistedField(arm.Variable, out _))
+            && ((this.asyncFieldMap != null && this.asyncFieldMap.TryGetHoistedField(arm.Variable, out hoistedField))
+                || (this.iteratorEmitCtx != null && this.iteratorEmitCtx.FieldMap.TryGetValue(arm.Variable, out hoistedField))))
         {
             // TryRead writes through the local out slot; the rewritten
             // MoveNext arm body reads the hoisted state-machine field.
+            this.il.OpCode(ILOpCode.Ldarg_0);
             this.il.LoadLocal(outSlot);
-            this.EmitStoreVariable(arm.Variable);
+            this.il.OpCode(ILOpCode.Stfld);
+            this.il.Token(this.ResolveCurrentStateMachineFieldToken(hoistedField));
         }
 
         this.EmitStatement(arm.Body);

--- a/test/Compiler.Tests/Emit/Issue2933AsyncSelectArmBindingTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2933AsyncSelectArmBindingTests.cs
@@ -1,0 +1,360 @@
+// <copyright file="Issue2933AsyncSelectArmBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2933: select receive bindings inside async state machines retain
+/// their received values.
+/// </summary>
+public class Issue2933AsyncSelectArmBindingTests
+{
+    /// <summary>Gets requested async-select runtime shapes.</summary>
+    public static IEnumerable<object[]> SelectShapes()
+    {
+        yield return Case("MultipleAndDefault", "14,5\n", """
+            package Issue2933.MultipleAndDefault
+            import System
+            import Gsharp.Extensions.Go
+
+            async func Run() string {
+                let empty = make(chan int32, 1)
+                let ready = make(chan int32, 1)
+                ready <- 4
+                var selected = 0
+                select {
+                    case let ignored = <-empty { selected = -100 }
+                    case let value = <-ready { selected = 10 + value }
+                    default { selected = -200 }
+                }
+
+                var fallback = 0
+                select {
+                    case let ignored = <-empty { fallback = -100 }
+                    default { fallback = 5 }
+                }
+                return selected.ToString() + "," + fallback.ToString()
+            }
+            Console.WriteLine(Run().GetAwaiter().GetResult())
+            """);
+        yield return Case("SendArm", "10\n", """
+            package Issue2933.SendArm
+            import System
+            import Gsharp.Extensions.Go
+
+            async func Run() int32 {
+                let ch = make(chan int32, 1)
+                var result = 0
+                select {
+                    case ch <- 3 { result = 7 }
+                    default { result = -100 }
+                }
+                return result + <-ch
+            }
+            Console.WriteLine(Run().GetAwaiter().GetResult())
+            """);
+        yield return Case("LoopAndNested", "6,7\n", """
+            package Issue2933.LoopAndNested
+            import System
+            import Gsharp.Extensions.Go
+
+            async func Run() string {
+                let ch = make(chan int32, 1)
+                var total = 0
+                for i in 0 ... 3 {
+                    ch <- i + 1
+                    select { case let value = <-ch { total += value } }
+                }
+
+                let outer = make(chan int32, 1)
+                let inner = make(chan int32, 1)
+                outer <- 3
+                inner <- 4
+                var nested = 0
+                select {
+                    case let first = <-outer {
+                        select {
+                            case let second = <-inner { nested = first + second }
+                        }
+                    }
+                }
+                return total.ToString() + "," + nested.ToString()
+            }
+            Console.WriteLine(Run().GetAwaiter().GetResult())
+            """);
+        yield return Case("AsyncLambdaAndCapture", "3,3\n", """
+            package Issue2933.AsyncLambdaAndCapture
+            import System
+            import Gsharp.Extensions.Go
+
+            let run = async () -> {
+                let ch = make(chan int32, 1)
+                ch <- 3
+                var direct = 0
+                var captured = 0
+                select {
+                    case let value = <-ch {
+                        direct = value
+                        let read = () -> value
+                        captured = read()
+                    }
+                }
+                return direct.ToString() + "," + captured.ToString()
+            }
+            Console.WriteLine(run().GetAwaiter().GetResult())
+            """);
+        yield return Case("AwaitAfterRead", "6\n", """
+            package Issue2933.AwaitAfterRead
+            import System
+            import System.Threading.Tasks
+            import Gsharp.Extensions.Go
+
+            async func Run() int32 {
+                let ch = make(chan int32, 1)
+                ch <- 3
+                var result = 0
+                select {
+                    case let value = <-ch {
+                        result = value
+                        await Task.Yield()
+                        result += value
+                    }
+                }
+                return result
+            }
+            Console.WriteLine(Run().GetAwaiter().GetResult())
+            """);
+        yield return Case("ReferenceAndStruct", "3,31\n", """
+            package Issue2933.ReferenceAndStruct
+            import System
+            import Gsharp.Extensions.Go
+
+            async func Run() string {
+                let refs = make(chan string?, 1)
+                let structs = make(chan DateTime, 1)
+                refs <- "abc"
+                structs <- DateTime(2026, 7, 31)
+                var refResult = 0
+                var structResult = 0
+                select {
+                    case let value = <-refs {
+                        if value == nil { refResult = -1 }
+                        else { refResult = value.Length }
+                    }
+                }
+                select {
+                    case let value = <-structs { structResult = value.Day }
+                }
+                return refResult.ToString() + "," + structResult.ToString()
+            }
+            Console.WriteLine(Run().GetAwaiter().GetResult())
+            """);
+        yield return Case("Unbuffered", "4\n", """
+            package Issue2933.Unbuffered
+            import System
+            import Gsharp.Extensions.Go
+
+            async func Run() int32 {
+                let ch = make(chan int32)
+                ch <- 4
+                var result = 0
+                select { case let value = <-ch { result = value } }
+                return result
+            }
+            Console.WriteLine(Run().GetAwaiter().GetResult())
+            """);
+        yield return Case("ClosedChannelResetsBinding", "30\n", """
+            package Issue2933.ClosedChannel
+            import System
+            import Gsharp.Extensions.Go
+
+            async func Run() int32 {
+                let ch = make(chan int32, 1)
+                ch <- 3
+                close(ch)
+                var result = 0
+                for i in 0 ... 2 {
+                    select {
+                        case let value = <-ch { result = result * 10 + value }
+                    }
+                }
+                return result
+            }
+            Console.WriteLine(Run().GetAwaiter().GetResult())
+            """);
+    }
+
+    [Fact]
+    public void AsyncAndSynchronousReceiveBindingsAreEqualAtRuntime()
+    {
+        const string Source = """
+            package Issue2933.Parity
+            import System
+            import Gsharp.Extensions.Go
+
+            async func Async() int32 {
+                let ch = make(chan int32, 1)
+                ch <- 3
+                var result = 0
+                select {
+                    case let value = <-ch { result = 7 + value }
+                }
+                return result
+            }
+
+            func Sync() int32 {
+                let ch = make(chan int32, 1)
+                ch <- 3
+                var result = 0
+                select {
+                    case let value = <-ch { result = 7 + value }
+                }
+                return result
+            }
+
+            Console.WriteLine(Async().GetAwaiter().GetResult())
+            Console.WriteLine(Sync())
+            """;
+
+        var output = CompileLoadAndRun(Source, nameof(AsyncAndSynchronousReceiveBindingsAreEqualAtRuntime));
+        var values = output.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(int.Parse)
+            .ToArray();
+
+        Assert.Equal(2, values.Length);
+        Assert.Equal(values[1], values[0]);
+        Assert.Equal(10, values[0]);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectShapes))]
+    public void RequestedSelectShapesLoadAndRun(string name, string expectedOutput, string source)
+    {
+        Assert.Equal(expectedOutput, CompileLoadAndRun(source, name));
+    }
+
+    [Fact]
+    public void SiblingAsyncBindingFormsRemainCorrect()
+    {
+        const string Source = """
+            package Issue2933.SiblingBindings
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            async func Run() string {
+                await Task.Yield()
+
+                var rangeResult = 0
+                let values = List[int32]{2, 3}
+                for value in values { rangeResult += value }
+
+                var patternResult = 0
+                switch object("abc") {
+                    case value is string { patternResult = value.Length }
+                    default { patternResult = -1 }
+                }
+
+                var catchResult = 0
+                try { throw Exception("xy") }
+                catch (ex Exception) { catchResult = ex.Message.Length }
+
+                return rangeResult.ToString() + "," +
+                    patternResult.ToString() + "," +
+                    catchResult.ToString()
+            }
+            Console.WriteLine(Run().GetAwaiter().GetResult())
+            """;
+
+        Assert.Equal("5,3,2\n", CompileLoadAndRun(Source, nameof(SiblingAsyncBindingFormsRemainCorrect)));
+    }
+
+    private static object[] Case(string name, string expectedOutput, string source) =>
+        new object[] { name, expectedOutput, source };
+
+    private static string CompileLoadAndRun(string source, string name)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue2933AsyncSelectArmBindingTests),
+            name);
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var assemblyPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+        File.Delete(assemblyPath);
+        File.Delete(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousErr = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousErr);
+        }
+
+        Assert.True(exitCode == 0, $"{name}: gsc failed:\n{stdout}\n{stderr}");
+        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        Assert.NotEmpty(assembly.GetTypes());
+        return RunBounded(assemblyPath, name);
+    }
+
+    private static string RunBounded(string assemblyPath, string name)
+    {
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                assemblyPath,
+            },
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+
+        Assert.NotNull(process);
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        var exited = process.WaitForExit(30_000);
+        if (!exited)
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+        }
+
+        Assert.True(exited, $"{name}: emitted program timed out");
+        var output = outputTask.GetAwaiter().GetResult();
+        var error = errorTask.GetAwaiter().GetResult();
+        Assert.True(process.ExitCode == 0, $"{name}: emitted program failed:\n{error}");
+        return output.Replace("\r\n", "\n");
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2933AsyncSelectArmBindingTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2933AsyncSelectArmBindingTests.cs
@@ -236,6 +236,61 @@ public class Issue2933AsyncSelectArmBindingTests
         Assert.Equal(10, values[0]);
     }
 
+    [Fact]
+    public void AsyncIteratorReceiveBindingsMatchAsyncFunctionAtRuntime()
+    {
+        const string Source = """
+            package Issue2933.StateMachineKinds
+            import System
+            import Gsharp.Extensions.Go
+
+            async func AsyncFunction() int32 {
+                let ch = make(chan int32, 1)
+                ch <- 3
+                var result = 0
+                select {
+                    case let value = <-ch { result = 7 + value }
+                }
+                return result
+            }
+
+            async func YieldInArm() async sequence[int32] {
+                let ch = make(chan int32, 1)
+                ch <- 3
+                select {
+                    case let value = <-ch { yield 7 + value }
+                }
+            }
+
+            async func YieldAfterArm() async sequence[int32] {
+                let ch = make(chan int32, 1)
+                ch <- 3
+                var result = 0
+                select {
+                    case let value = <-ch { result = 7 + value }
+                }
+                yield result
+            }
+
+            func First(values async sequence[int32]) int32 {
+                let e = values.GetAsyncEnumerator()
+                if e.MoveNextAsync().AsTask().Result { return e.Current }
+                return -1
+            }
+
+            Console.WriteLine(AsyncFunction().GetAwaiter().GetResult())
+            Console.WriteLine(First(YieldInArm()))
+            Console.WriteLine(First(YieldAfterArm()))
+            """;
+
+        var output = CompileLoadAndRun(Source, nameof(AsyncIteratorReceiveBindingsMatchAsyncFunctionAtRuntime));
+        var values = output.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(int.Parse)
+            .ToArray();
+
+        Assert.Equal(new[] { 10, 10, 10 }, values);
+    }
+
     [Theory]
     [MemberData(nameof(SelectShapes))]
     public void RequestedSelectShapesLoadAndRun(string name, string expectedOutput, string source)

--- a/test/Interpreter.Tests/Issue2933AsyncSelectArmBindingInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2933AsyncSelectArmBindingInterpreterTests.cs
@@ -1,0 +1,43 @@
+// <copyright file="Issue2933AsyncSelectArmBindingInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2933: interpreter and emitted async select receive bindings agree.
+/// </summary>
+public class Issue2933AsyncSelectArmBindingInterpreterTests
+{
+    [Fact]
+    public void InterpreterPreservesAsyncSelectReceiveBinding()
+    {
+        const string Source = """
+            import Gsharp.Extensions.Go
+
+            async func Run() int32 {
+                let ch = make(chan int32, 1)
+                ch <- 3
+                var result = 0
+                select {
+                    case let value = <-ch { result = 7 + value }
+                }
+                return result
+            }
+
+            Run().GetAwaiter().GetResult()
+            """;
+
+        var result = new Compilation(SyntaxTree.Parse(Source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(10, result.Value);
+    }
+}


### PR DESCRIPTION
## Summary

- synchronize selected receive-arm out slots into hoisted async-function and async-iterator state-machine fields before emitting arm bodies
- cover successful reads and closed-channel zero-value paths
- preserve synchronous selects, send/default arms, and sibling binding forms
- add emitted child-process runtime coverage across state-machine kinds; retain interpreter behavior as a guard

Fixes #2933

## Confirmed mechanism

`AsyncCaptureWalker` hoists a receive-arm variable when the arm body references it, and state-machine rewriting changes body reads to field reads. `EmitSelectReceiveProbe` instead passed the ordinary local slot directly to `ChannelReader<T>.TryRead(out T)`, then emitted the rewritten body without copying that value to the state-machine field. The arm ran, but body reads saw the field's CLR default.

Async functions use `asyncFieldMap`; async iterators use `iteratorEmitCtx.FieldMap`. The original fix handled only the first state-machine kind. The final fix follows the existing `EmitCapturedVariableLoad` pattern, resolves either map, and emits `ldarg.0`, `ldloc`, `stfld` through `ResolveCurrentStateMachineFieldToken`. `EmitStoreVariable` is not used because it redirects only through `asyncFieldMap`.

The same field transfer runs after a closed channel zero-initializes the out slot, preventing a loop from reusing a previous received value.

## Production delta

- `MethodBodyEmitter.Statements.cs`: +20 / -2

No state-machine layout or capture-analysis changes. PR #2950's struct-`this` handling remains untouched.

## Runtime proof

Known-bad base compiler (`17789519`): emitted async function stdout `7`, while synchronous and interpreted controls produce `10`.

Final head:

- async function: `10`
- async iterator yielding inside the receive arm: `10`
- async iterator computing in the arm and yielding afterward: `10`
- synchronous control: `10`
- assemblies load and `GetTypes()` succeeds before bounded child execution

The async-iterator regression compares state-machine kinds directly. Removing the iterator field-map alternative changes its exact output from `10,10,10` to `10,7,7`.

Both stdout/stderr pipes are drained before the bounded wait; timeout kills the full process tree.

## Binding-form and state-machine-kind axes

Binding-form audit:

- `for ... in` bindings lower through ordinary assignments/stores
- type/list pattern bindings call `EmitStoreVariable`
- catch bindings call `EmitStoreVariable`
- G# plain-switch binding is pattern-based
- send/default/discard select arms carry no receive variable

State-machine-kind coverage now includes async functions and async iterators. Merging this PR leaves the pre-existing synchronous-iterator output at `1,7` when the binding is read across a yield; this is #2975, not a regression from this change. `IteratorRewriter.cs`'s declaration-based `LocalCollector` does not recognize bare `BoundSelectCase.Variable` bindings, while the async path uses the reference-based `AsyncCaptureWalker.ReferenceCollector`. `HoistedFieldRewriter` only consumes the resulting field map; it does not build it. #2982 was closed as a duplicate. Once #2975 supplies the iterator field, this emitter transfer remains necessary to write the received value into it.

## Pins

- buffered async receive parity with synchronous execution
- async iterator yielding inside the arm
- async iterator yielding after the arm
- multiple receive arms
- select in a loop
- nested select
- select inside an async lambda
- receive binding captured by a closure
- binding read before and after `await`
- nullable reference and imported CLR struct bindings
- unbuffered channel
- closed-channel zero reset after a prior received value

## Guards

- synchronous receive binding
- default and send arms
- async range, pattern, and catch bindings
- assembly load/type discovery and exact child stdout
- interpreter remains correct at 10; it evaluates the bound tree and never exercised the faulty IL path

## Mutations

Three build-green semantic mutations were killed, restoring and rebuilding between probes:

1. remove ready-read transfer: 8 of the original 10 Compiler cases fail
2. remove closed-channel transfer: stale-value case alone fails (`33` instead of `30`)
3. remove async-iterator field-map alternative: targeted control 11/11; mutation 10/11, with state-machine-kind output `10,7,7`

Interpreter 1/1 stays green under emitter mutations, confirming it is a guard rather than a pin.

## Corpus

All 148 sample programs were compiled with base and head compilers: 0 exit-code drift, 0 diagnostic drift, and 0 SHA-256 output-binary drift.

- samples containing `select`: 3
- samples containing `select` inside async: **0**
- samples containing `select` inside iterators: **0**

Corpus therefore supplies synchronous non-regression evidence only; emitted-runtime tests carry the state-machine evidence.

## Executed suites

Final base `210126dd90f4ab3edbe1b7f9219946594685afc7`:

- Core: 7029 passed, 1 skipped
- Compiler: 3952 passed
- Interpreter: 494 passed
- LSP: 452 passed

Final head `323fc5c71fa0b817cebb617e735d95c8e957265e` in green CI:

- Core: 7029 passed, 1 skipped
- Compiler: 3963 passed
- Interpreter: 495 passed
- LSP: 452 passed

Delta: +11 Compiler and +1 Interpreter.

Post-rebase targeted validation:

- `Select|Issue2933|Iterator|Async|Yield|Sequence`: 479 passed
- Compiler Issue2933 pins: 11 passed
- Interpreter Issue2933 guard: 1 passed

Release solution build: 0 warnings, 0 errors. Ordinary `GSharp.Core.dll` outputs were nonempty and byte-identical after propagation.

## Independent findings

User-defined G# struct channel elements produce `InvalidProgramException` in synchronous and async selects independently of state machines; tracked by #2965.

Synchronous iterator select bindings live across yield lose their value because the binding is not hoisted; tracked by #2975.




