### PR TITLE
Support implicit interface indexers on classes and structs

### DIFF
--- a/docs/adr/0118-user-indexer-member-declaration.md
+++ b/docs/adr/0118-user-indexer-member-declaration.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-06-22
 - **Phase**: v0.2 — language surface
 - **Related**: ADR-0051 (Property declarations — `prop Name T { get; set }`), ADR-0020 (Generic type-parameter brackets — Go-style `[T]`), ADR-0087 (Constructed generic user-type method references), ADR-0115 (C#→G# migration tool), issue #507 (member index assignment)
-- **Issue**: [#944](https://github.com/DavidObando/gsharp/issues/944)
+- **Issues**: [#944](https://github.com/DavidObando/gsharp/issues/944), [#2915](https://github.com/DavidObando/gsharp/issues/2915), [#2954](https://github.com/DavidObando/gsharp/issues/2954), [#2960](https://github.com/DavidObando/gsharp/issues/2960)
 
 ## Context
 
@@ -137,6 +137,37 @@ accessors and call sites resolve through the existing constructed
 generic user-type machinery (ADR-0087: method references parented at the
 constructed `TypeSpec`, signatures encoded with `!0`).
 
+#### Interface contracts
+
+An indexer may implement a G# interface indexer either implicitly or
+explicitly. Implicit matching uses the index-parameter types, value type,
+and required accessors, with generic substitutions applied for a
+constructed interface:
+
+```gsharp
+interface IRepo[T] {
+    prop this[key string] T { get; }
+}
+
+class Store : IRepo[int32] {
+    prop this[key string] int32 -> 1
+}
+```
+
+This applies uniformly to plain and constructed interfaces and to class
+and value-type implementations. Value-type property accessors that satisfy
+an interface contract receive the same virtual slot promotion as methods
+and events. The interpreter resolves interface calls through property
+accessors as well as ordinary methods.
+
+Before issue #2915, plain interfaces happened to use name lookup, which
+excluded indexers, while constructed interfaces used signature lookup,
+which accepted them. This ADR had not defined interface-indexer
+implementation semantics; the plain rejection was an implementation
+artifact, not a language decision. Rejecting both forms was considered,
+but would have removed working constructed-interface behavior and hidden
+the small emitter and interpreter defects that prevented uniform support.
+
 ### 3. Access binding — `obj[i]` / `obj[i] = v` on a user type
 
 When the target of an index expression is a user-defined type
@@ -214,6 +245,13 @@ emit + interpreter), with emit-and-run regression tests:
 - **get/set** indexer on a non-generic class: write via `obj[i] = v`,
   read back via `obj[i]`.
 - **non-generic get-only** indexer.
+- implicit and explicit implementation of plain and constructed-generic
+  interface indexer contracts by classes and structs (issues #2915 and
+  #2954), including interface-typed dispatch in emitted and interpreted
+  programs.
+- value-type property accessors receive the interface-slot attributes
+  required for loadable metadata, including sequence-valued properties
+  (issue #2960).
 - index access binding for both read and write to the declared indexer,
   including inside the type's own methods.
 - the old crashing shape now compiles and runs — **no GS9998**.

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -508,7 +508,6 @@ internal sealed partial class DeclarationBinder
             // property implemented (or inherited) ANYWHERE in the base chain.
             var found = TryGetConstructedInterfacePropertyImplementation(
                 structSymbol,
-                iface,
                 iprop,
                 typeParameterMap,
                 out var implProp,
@@ -516,7 +515,6 @@ internal sealed partial class DeclarationBinder
             if (!found
                 && HasMatchingImportedBaseProperty(
                     structSymbol,
-                    iface,
                     iprop,
                     typeParameterMap))
             {
@@ -702,12 +700,6 @@ internal sealed partial class DeclarationBinder
             typeParameterMap,
             eraseReferenceNullability: true);
 
-    private static bool IsUnsupportedImplicitInterfaceIndexer(
-        InterfaceSymbol iface,
-        PropertySymbol interfaceProperty)
-        => interfaceProperty.IsIndexer
-            && ReferenceEquals(iface.Definition ?? iface, iface);
-
     private static TypeSymbol SubstituteInterfacePropertyType(
         TypeSymbol interfaceType,
         Dictionary<TypeParameterSymbol, TypeSymbol> typeParameterMap)
@@ -740,7 +732,6 @@ internal sealed partial class DeclarationBinder
 
     private static bool TryGetConstructedInterfacePropertyImplementation(
         StructSymbol structSymbol,
-        InterfaceSymbol iface,
         PropertySymbol interfaceProperty,
         Dictionary<TypeParameterSymbol, TypeSymbol> typeParameterMap,
         out PropertySymbol implementation,
@@ -753,7 +744,6 @@ internal sealed partial class DeclarationBinder
             {
                 if (candidate.HasExplicitInterfaceClause
                     || candidate.Name != interfaceProperty.Name
-                    || IsUnsupportedImplicitInterfaceIndexer(iface, interfaceProperty)
                     || (!ReferenceEquals(current, structSymbol) && candidate.Accessibility != Accessibility.Public)
                     || candidate.IsIndexer != interfaceProperty.IsIndexer
                     || candidate.Parameters.Length != interfaceProperty.Parameters.Length)
@@ -800,13 +790,11 @@ internal sealed partial class DeclarationBinder
 
     private static bool HasMatchingImportedBaseProperty(
         StructSymbol structSymbol,
-        InterfaceSymbol iface,
         PropertySymbol interfaceProperty,
         Dictionary<TypeParameterSymbol, TypeSymbol> typeParameterMap)
     {
         var importedBase = TypeMemberModel.GetNearestImportedBase(structSymbol);
-        if (importedBase?.ClrType == null
-            || IsUnsupportedImplicitInterfaceIndexer(iface, interfaceProperty))
+        if (importedBase?.ClrType == null)
         {
             return false;
         }

--- a/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
@@ -5,6 +5,7 @@
 #pragma warning disable SA1202 // 'public' members should come before 'private' members (organized by feature: each public entry point is followed by its own private helpers — instance-property group, static-property group, instance-event group, static-event group, interface group)
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -355,7 +356,7 @@ internal sealed class MemberDefEmitter
         {
             methodAttrs |= MethodAttributes.Virtual | MethodAttributes.NewSlot;
         }
-        else if (this.PropertyImplicitlyImplementsInterface(structSym, prop))
+        else if (PropertyImplicitlyImplementsInterface(structSym, prop))
         {
             // Issue #248: implicit interface implementation requires Virtual | NewSlot.
             methodAttrs |= MethodAttributes.Virtual | MethodAttributes.NewSlot;
@@ -365,13 +366,11 @@ internal sealed class MemberDefEmitter
             // Issue #2362: a mangled-name explicit interface property
             // implementation is bound to its interface slot purely via an
             // explicit MethodImpl row (see
-            // EmitExplicitInterfacePropertyMethodImpls) — its accessor's own
-            // name never matches the interface member's name, so
-            // PropertyImplicitlyImplementsInterface (a name-based check)
-            // never fires for it. Per ECMA-335 §II.10.3.3, a MethodImpl body
-            // method must be virtual; Final additionally prevents a derived
-            // class from accidentally overriding this synthetic accessor by
-            // name (it has no natural override point, exactly like the
+            // EmitExplicitInterfacePropertyMethodImpls).
+            // PropertyImplicitlyImplementsInterface deliberately excludes explicit implementations.
+            // Per ECMA-335 §II.10.3.3, a MethodImpl body method must be virtual;
+            // Final prevents a derived class from overriding this synthetic accessor
+            // by name (it has no natural override point, exactly like the
             // #2010 mangled explicit method convention's own methods, which
             // get Virtual | NewSlot | Final unconditionally via EmitFunction).
             methodAttrs |= MethodAttributes.Virtual | MethodAttributes.NewSlot | MethodAttributes.Final;
@@ -470,7 +469,7 @@ internal sealed class MemberDefEmitter
         {
             methodAttrs |= MethodAttributes.Virtual | MethodAttributes.NewSlot;
         }
-        else if (this.PropertyImplicitlyImplementsInterface(structSym, prop))
+        else if (PropertyImplicitlyImplementsInterface(structSym, prop))
         {
             // Issue #248: implicit interface implementation requires Virtual | NewSlot.
             methodAttrs |= MethodAttributes.Virtual | MethodAttributes.NewSlot;
@@ -878,8 +877,16 @@ internal sealed class MemberDefEmitter
     /// Issue #248: determines whether a property on a class/struct implicitly implements
     /// an interface property (same name and type on any implemented interface).
     /// </summary>
-    private bool PropertyImplicitlyImplementsInterface(StructSymbol structSym, PropertySymbol prop)
+    /// <param name="structSym">The type declaring the candidate property.</param>
+    /// <param name="prop">The candidate property.</param>
+    /// <returns><see langword="true"/> when the property implements an interface property.</returns>
+    internal static bool PropertyImplicitlyImplementsInterface(StructSymbol structSym, PropertySymbol prop)
     {
+        if (prop.HasExplicitInterfaceClause)
+        {
+            return false;
+        }
+
         if (!structSym.Interfaces.IsDefaultOrEmpty)
         {
             foreach (var iface in structSym.Interfaces)
@@ -901,9 +908,10 @@ internal sealed class MemberDefEmitter
                     continue;
                 }
 
+                var typeParameterMap = DeclarationBinder.BuildInterfaceTypeParameterMap(iface);
                 foreach (var ifaceProp in defIface.Properties)
                 {
-                    if (ifaceProp.Name == prop.Name)
+                    if (PropertyMatchesInterfaceSlot(prop, ifaceProp, typeParameterMap))
                     {
                         return true;
                     }
@@ -925,7 +933,6 @@ internal sealed class MemberDefEmitter
             // (ILVerify: "Class implements interface but not method"). The
             // binder-side `MemberLookup.FindMatchingProperty` already gets
             // this right; this call brings the emitter in line with it.
-            var propClr = NullableLifting.GetEffectiveClrType(prop.Type);
             foreach (var ifaceSym in structSym.ImplementedClrInterfaces)
             {
                 var clrIface = ifaceSym?.ClrType;
@@ -936,7 +943,34 @@ internal sealed class MemberDefEmitter
 
                 foreach (var clrProp in clrIface.GetProperties(BindingFlags.Public | BindingFlags.Instance))
                 {
-                    if (clrProp.Name == prop.Name && (propClr == null || ClrTypeUtilities.AreSame(propClr, clrProp.PropertyType)))
+                    var indexParameters = clrProp.GetIndexParameters();
+                    if (clrProp.Name != prop.Name
+                        || prop.IsIndexer != (indexParameters.Length > 0)
+                        || prop.Parameters.Length != indexParameters.Length
+                        || (clrProp.GetMethod != null && !prop.HasGetter)
+                        || (clrProp.SetMethod != null && !prop.HasSetter)
+                        || !DeclarationBinder.IsInterfacePropertyTypeCompatible(
+                            prop.Type,
+                            MemberLookup.GetClrPropertyTypeSymbol(ifaceSym, clrProp),
+                            clrProp.SetMethod != null,
+                            typeParameterMap: null))
+                    {
+                        continue;
+                    }
+
+                    var parametersMatch = true;
+                    for (var i = 0; i < indexParameters.Length; i++)
+                    {
+                        if (!DeclarationBinder.TypeSignaturesEquivalent(
+                            prop.Parameters[i].Type,
+                            MemberLookup.GetIndexerParameterTypeSymbol(ifaceSym, clrProp, i)))
+                        {
+                            parametersMatch = false;
+                            break;
+                        }
+                    }
+
+                    if (parametersMatch)
                     {
                         return true;
                     }
@@ -945,6 +979,39 @@ internal sealed class MemberDefEmitter
         }
 
         return false;
+    }
+
+    private static bool PropertyMatchesInterfaceSlot(
+        PropertySymbol property,
+        PropertySymbol interfaceProperty,
+        Dictionary<TypeParameterSymbol, TypeSymbol> typeParameterMap)
+    {
+        if (property.Name != interfaceProperty.Name
+            || property.IsIndexer != interfaceProperty.IsIndexer
+            || property.Parameters.Length != interfaceProperty.Parameters.Length
+            || (interfaceProperty.HasGetter && !property.HasGetter)
+            || (interfaceProperty.HasSetter && !property.HasSetter)
+            || !DeclarationBinder.IsInterfacePropertyTypeCompatible(
+                property.Type,
+                interfaceProperty.Type,
+                interfaceProperty.HasSetter,
+                typeParameterMap))
+        {
+            return false;
+        }
+
+        for (var i = 0; i < property.Parameters.Length; i++)
+        {
+            if (!DeclarationBinder.TypeSignaturesEquivalent(
+                interfaceProperty.Parameters[i].Type,
+                property.Parameters[i].Type,
+                typeParameterMap))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodInfoHelpers.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodInfoHelpers.cs
@@ -45,6 +45,17 @@ internal static class MethodInfoHelpers
             return true;
         }
 
+        foreach (var property in receiverStruct.Properties)
+        {
+            if ((ReferenceEquals(property.GetterSymbol, function)
+                    || ReferenceEquals(property.SetterSymbol, function))
+                && (property.HasExplicitInterfaceClause
+                    || MemberDefEmitter.PropertyImplicitlyImplementsInterface(receiverStruct, property)))
+            {
+                return true;
+            }
+        }
+
         return MethodImplicitlyImplementsInterface(receiverStruct, function);
     }
 

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -197,7 +197,7 @@ public sealed partial class Evaluator
     {
         if (type is Symbols.SequenceTypeSymbol seq)
         {
-            return seq.ElementType.ClrType ?? typeof(object);
+            return NullableLifting.GetEffectiveClrType(seq.ElementType) ?? typeof(object);
         }
 
         var clr = type?.ClrType;
@@ -262,6 +262,63 @@ public sealed partial class Evaluator
                 if (t.TryGetMethod(method.Name, out var candidate))
                 {
                     implMethod = candidate;
+                    break;
+                }
+
+                FunctionSymbol implicitAccessor = null;
+                foreach (var property in t.Properties)
+                {
+                    var getterMatches = property.GetterSymbol?.Name == method.Name;
+                    var accessor = getterMatches
+                        ? property.GetterSymbol
+                        : property.SetterSymbol?.Name == method.Name ? property.SetterSymbol : null;
+                    if (accessor == null)
+                    {
+                        continue;
+                    }
+
+                    var explicitAccessor = getterMatches
+                        ? property.ExplicitInterfaceMember?.GetterSymbol
+                        : property.ExplicitInterfaceMember?.SetterSymbol;
+                    if (ReferenceEquals(explicitAccessor, method)
+                        || (property.ExplicitInterfaceClauseTarget != null
+                            && DeclarationBinder.TypeSignaturesEquivalent(
+                                property.ExplicitInterfaceClauseTarget,
+                                method.ReceiverType)))
+                    {
+                        implMethod = accessor;
+                        break;
+                    }
+
+                    if (!property.HasExplicitInterfaceClause)
+                    {
+                        implicitAccessor ??= accessor;
+                    }
+                }
+
+                implMethod ??= implicitAccessor;
+                if (implMethod == null && ifaceSv.ClrBacking != null)
+                {
+                    var importedAccessor = ifaceSv.ClrBacking.GetType()
+                        .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                        .FirstOrDefault(candidate =>
+                            candidate.IsSpecialName
+                            && candidate.Name == method.Name
+                            && candidate.GetParameters().Length == node.Arguments.Length);
+                    if (importedAccessor != null)
+                    {
+                        var importedArguments = new object[node.Arguments.Length];
+                        for (var i = 0; i < node.Arguments.Length; i++)
+                        {
+                            importedArguments[i] = EvaluateExpression(node.Arguments[i]);
+                        }
+
+                        return importedAccessor.Invoke(ifaceSv.ClrBacking, importedArguments);
+                    }
+                }
+
+                if (implMethod != null)
+                {
                     break;
                 }
             }

--- a/test/Compiler.Tests/Emit/Issue2370ExplicitInterfaceEventIndexerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2370ExplicitInterfaceEventIndexerEmitTests.cs
@@ -442,22 +442,8 @@ public class Issue2370ExplicitInterfaceEventIndexerEmitTests
     // imported (BCL) interfaces.
     // ----------------------------------------------------------------------
     [Fact]
-    public void PlainNonExplicitIndexer_DoesNotSatisfyInterfaceIndexerContract_ReportsGS0187()
+    public void PlainNonExplicitIndexer_DispatchesThroughInterfaceTypedReceiver()
     {
-        // ADR-0118 (issue #944): an indexer's CLR name ("Item") is not
-        // reachable by ordinary member-name lookup — only through `obj[i]`
-        // index syntax — so `TypeMemberModel.TryGetProperty` deliberately
-        // excludes indexers, and `VerifyInterfaceImplementations` has no
-        // separate by-shape indexer-matching path. By design (pre-existing,
-        // unrelated to this fix), only an EXPLICIT `(IFace)` clause indexer
-        // implementation can satisfy an interface's indexer contract; a
-        // plain non-explicit indexer of the identical shape does not count
-        // and GS0187 correctly fires. This is a control confirming the new
-        // interface-typed-receiver dispatch work does not (and should not)
-        // change that pre-existing, intentional restriction. See
-        // ImportedBclInterfaceIndexer_DispatchesThroughInterfaceTypedReceiver
-        // below for the genuine "ordinary" (non-G#-explicit-clause) control
-        // proving the receiver-dispatch fix itself is general.
         const string source = """
             package GapCheck
 
@@ -468,44 +454,14 @@ public class Issue2370ExplicitInterfaceEventIndexerEmitTests
             class Store : IRepo {
                 prop this[key string] int32 { get { return 1 } set { } }
             }
+
+            var store = Store()
+            var asIface IRepo = store
+            asIface["key"] = 99
+            public var result = asIface["key"]
             """;
 
-        var (exitCode, output) = CompileExpectingFailure(source);
-        Assert.NotEqual(0, exitCode);
-        Assert.Contains("GS0187", output);
-    }
-
-    private static (int ExitCode, string Output) CompileExpectingFailure(string source)
-    {
-        var tempDir = Directory.CreateTempSubdirectory("gs_issue2370_fail_").FullName;
-        var srcPath = Path.Combine(tempDir, "test.gs");
-        var outPath = Path.Combine(tempDir, "test.dll");
-        File.WriteAllText(srcPath, source);
-
-        using var stdoutWriter = new StringWriter();
-        using var stderrWriter = new StringWriter();
-        var prevOut = Console.Out;
-        var prevErr = Console.Error;
-        Console.SetOut(stdoutWriter);
-        Console.SetError(stderrWriter);
-        int compileExit;
-        try
-        {
-            compileExit = Program.Main(new[]
-            {
-                "/out:" + outPath,
-                "/target:library",
-                "/targetframework:net10.0",
-                srcPath,
-            });
-        }
-        finally
-        {
-            Console.SetOut(prevOut);
-            Console.SetError(prevErr);
-        }
-
-        return (compileExit, stdoutWriter.ToString() + stderrWriter.ToString());
+        Assert.Equal(1, RunAndGetIntResult(source));
     }
 
     [Fact]

--- a/test/Compiler.Tests/Emit/Issue2915ImplicitInterfaceIndexerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2915ImplicitInterfaceIndexerEmitTests.cs
@@ -1,0 +1,485 @@
+// <copyright file="Issue2915ImplicitInterfaceIndexerEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+using Xunit.Sdk;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issues #2915, #2954, #2960, and #3001: interface property accessors bind and emit
+/// correctly for classes, structs, plain interfaces, and constructed interfaces.
+/// </summary>
+public class Issue2915ImplicitInterfaceIndexerEmitTests
+{
+    private const string IndexerMatrixSource = """
+        package Issue2915Matrix
+        import System
+
+        interface IPlainClassGet {
+            prop this[key string] int32 { get; }
+        }
+
+        class PlainClassGet : IPlainClassGet {
+            prop this[key string] int32 -> key.Length + 8
+        }
+
+        interface IPlainClassSet {
+            prop this[index int32] int32 { get; set; }
+        }
+
+        class PlainClassSet : IPlainClassSet {
+            var Stored int32
+            prop this[index int32] int32 {
+                get { return Stored + index }
+                set { Stored = value - index }
+            }
+        }
+
+        interface IConstructedGet[T] {
+            prop this[key string] T { get; }
+        }
+
+        class ConstructedGet : IConstructedGet[int32] {
+            prop this[key string] int32 -> 17
+        }
+
+        class GenericGet[T] : IConstructedGet[T] {
+            let Stored T
+            init(value T) { Stored = value }
+            prop this[key string] T -> Stored
+        }
+
+        interface IConstructedSet[T] {
+            prop this[index int32] T { get; set; }
+        }
+
+        class ConstructedSet : IConstructedSet[int32] {
+            var Stored int32
+            prop this[index int32] int32 {
+                get { return Stored + index }
+                set { Stored = value - index }
+            }
+        }
+
+        interface IPlainStructGet {
+            prop this[index int32] int32 { get; }
+        }
+
+        struct PlainStructGet(Base int32) : IPlainStructGet {
+            prop this[index int32] int32 -> Base + index
+        }
+
+        interface IPlainStructSet {
+            prop this[index int32] int32 { get; set; }
+        }
+
+        struct PlainStructSet : IPlainStructSet {
+            var Stored int32
+            prop this[index int32] int32 {
+                get { return Stored + index }
+                set { Stored = value - index }
+            }
+        }
+
+        interface IConstructedStructGet[T] {
+            prop this[index int32] T { get; }
+        }
+
+        struct ConstructedStructGet(Base int32) : IConstructedStructGet[int32] {
+            prop this[index int32] int32 -> Base + index
+        }
+
+        interface IConstructedStructSet[T] {
+            prop this[index int32] T { get; set; }
+        }
+
+        struct ConstructedStructSet : IConstructedStructSet[int32] {
+            var Stored int32
+            prop this[index int32] int32 {
+                get { return Stored + index }
+                set { Stored = value - index }
+            }
+        }
+
+        interface IExplicitPlain {
+            prop this[index int32] int32 { get; }
+        }
+
+        class ExplicitPlain : IExplicitPlain {
+            prop this[index int32] int32 -> 1
+            private prop (IExplicitPlain) this[index int32] int32 -> 2
+        }
+
+        interface IExplicitConstructed[T] {
+            prop this[index int32] T { get; }
+        }
+
+        class ExplicitConstructed : IExplicitConstructed[int32] {
+            private prop (IExplicitConstructed[int32]) this[index int32] int32 -> 4
+        }
+
+        var plainClassGet IPlainClassGet = PlainClassGet()
+        Console.WriteLine(plainClassGet["abc"])
+
+        var plainClassSet IPlainClassSet = PlainClassSet()
+        plainClassSet[2] = 42
+        Console.WriteLine(plainClassSet[2])
+
+        var constructedGet IConstructedGet[int32] = ConstructedGet()
+        Console.WriteLine(constructedGet["value"])
+
+        var constructedSet IConstructedSet[int32] = ConstructedSet()
+        constructedSet[3] = 43
+        Console.WriteLine(constructedSet[3])
+
+        var genericGet IConstructedGet[int32] = GenericGet[int32](19)
+        Console.WriteLine(genericGet["value"])
+
+        var plainStructGet IPlainStructGet = PlainStructGet(30)
+        Console.WriteLine(plainStructGet[5])
+
+        var plainStructSet IPlainStructSet = PlainStructSet{}
+        plainStructSet[4] = 44
+        Console.WriteLine(plainStructSet[4])
+
+        var constructedStructGet IConstructedStructGet[int32] = ConstructedStructGet(40)
+        Console.WriteLine(constructedStructGet[6])
+
+        var constructedStructSet IConstructedStructSet[int32] = ConstructedStructSet{}
+        constructedStructSet[7] = 47
+        Console.WriteLine(constructedStructSet[7])
+
+        var explicitPlain = ExplicitPlain()
+        var explicitPlainInterface IExplicitPlain = explicitPlain
+        Console.WriteLine(explicitPlainInterface[0])
+        Console.WriteLine(explicitPlain[0])
+
+        var explicitConstructed IExplicitConstructed[int32] = ExplicitConstructed()
+        Console.WriteLine(explicitConstructed[0])
+        """;
+
+    private const string IndexerMatrixOutput =
+        "11\n42\n17\n43\n19\n35\n44\n46\n47\n2\n1\n4\n";
+
+    [Fact]
+    public void ChildHarness_ReportsKnownBadProgramAfterLoad()
+    {
+        const string source = """
+            package Issue2915KnownBad
+            import System
+
+            throw InvalidOperationException("known bad control")
+            """;
+
+        var failure = Assert.ThrowsAny<XunitException>(
+            () => CompileLoadAndRunChild("known_bad", source));
+        Assert.Contains("known bad control", failure.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ImplicitIndexers_LoadAndDispatchThroughInterfaceTypedReceivers()
+    {
+        Assert.Equal(
+            Normalize(IndexerMatrixOutput),
+            CompileLoadAndRunChild("indexer_matrix", IndexerMatrixSource));
+    }
+
+    [Fact]
+    public void ImportedBasePlainIndexer_LoadsAndDispatchesThroughInterface()
+    {
+        const string source = """
+            package Issue2915ImportedBase
+            import System
+            import System.Collections.Generic
+
+            interface IStore {
+                prop this[index int32] int32 { get; set; }
+            }
+
+            class Store : List[int32], IStore { }
+
+            var store = Store()
+            store.Add(7)
+            var value IStore = store
+            Console.WriteLine(value[0])
+            value[0] = 9
+            Console.WriteLine(value[0])
+            """;
+
+        Assert.Equal("7\n9\n", CompileLoadAndRunChild("imported_base", source));
+    }
+
+    [Fact]
+    public void ExplicitStructIndexer_LoadsAndDispatchesThroughInterface()
+    {
+        const string source = """
+            package Issue2954ExplicitStruct
+            import System
+
+            interface IExplicit {
+                prop this[key int32] int32 { get; }
+            }
+
+            struct ExplicitValue(Base int32) : IExplicit {
+                private prop (IExplicit) this[key int32] int32 -> Base + key
+            }
+
+            var explicitValue IExplicit = ExplicitValue(5)
+            Console.WriteLine(explicitValue[7])
+            """;
+
+        Assert.Equal("12\n", CompileLoadAndRunChild("explicit_struct", source));
+    }
+
+    [Fact]
+    public void NullableSequenceStructProperty_LoadsAndDispatchesThroughInterface()
+    {
+        const string source = """
+            package Issue2960NullableSequence
+            import System
+
+            interface IBox {
+                prop Vals sequence[int32?] { get; }
+            }
+
+            func values() sequence[int32?] {
+                yield 5
+                yield nil
+            }
+
+            struct Box : IBox {
+                prop Vals sequence[int32?] -> values()
+            }
+
+            var box IBox = Box{}
+            for value in box.Vals {
+                Console.WriteLine(value == nil ? "nil" : value.ToString())
+            }
+            """;
+
+        Assert.Equal("5\nnil\n", CompileLoadAndRunChild("nullable_sequence", source));
+    }
+
+    [Fact]
+    public void ComputedStructGetOnlyProperty_LoadsAndDispatchesThroughInterface()
+    {
+        const string source = """
+            package Issue3001ComputedGetOnly
+            import System
+
+            interface ILabel {
+                prop Label string { get; }
+            }
+            struct LabelValue : ILabel {
+                prop Label string -> "hi"
+            }
+
+            var label ILabel = LabelValue{}
+            Console.WriteLine(label.Label)
+            """;
+
+        Assert.Equal("hi\n", CompileLoadAndRunChild("computed_get_only", source));
+    }
+
+    [Fact]
+    public void ComputedStructGetSetProperty_LoadsAndDispatchesThroughInterface()
+    {
+        const string source = """
+            package Issue3001ComputedGetSet
+            import System
+
+            interface ICounter {
+                prop Value int32 { get; set; }
+            }
+            struct Counter : ICounter {
+                var Stored int32
+                prop Value int32 {
+                    get { return Stored }
+                    set { Stored = value }
+                }
+            }
+
+            var counter ICounter = Counter{}
+            counter.Value = 42
+            Console.WriteLine(counter.Value)
+            """;
+
+        Assert.Equal("42\n", CompileLoadAndRunChild("computed_get_set", source));
+    }
+
+    [Fact]
+    public void AutoStructProperty_LoadsAndDispatchesThroughInterface()
+    {
+        const string source = """
+            package Issue3001AutoProperty
+            import System
+
+            interface ICounter {
+                prop Value int32 { get; set; }
+            }
+            struct Counter : ICounter {
+                prop Value int32 { get; set; }
+            }
+
+            var counter ICounter = Counter{}
+            counter.Value = 42
+            Console.WriteLine(counter.Value)
+            """;
+
+        Assert.Equal("42\n", CompileLoadAndRunChild("auto_property", source));
+    }
+
+    [Fact]
+    public void MismatchedStructIndexer_StaysNonVirtual()
+    {
+        const string source = """
+            package Issue2915MismatchedIndexer
+            import System
+
+            interface ITextIndexer {
+                prop this[key string] int32 { get; }
+            }
+            struct MixedIndexer : ITextIndexer {
+                prop this[key int32] int32 -> 1
+                private prop (ITextIndexer) this[key string] int32 -> 2
+            }
+
+            var mixed = MixedIndexer{}
+            var textIndexer ITextIndexer = mixed
+            Console.WriteLine(textIndexer["key"])
+            Console.WriteLine(mixed[0])
+            """;
+
+        Assert.Equal(
+            "2\n1\n",
+            CompileLoadAndRunChild(
+                "mismatched_indexer",
+                source,
+                assembly =>
+                {
+                    var type = assembly.GetType("Issue2915MismatchedIndexer.MixedIndexer");
+                    var ordinaryGetter = type.GetMethod(
+                        "get_Item",
+                        BindingFlags.Public | BindingFlags.Instance,
+                        binder: null,
+                        types: new[] { typeof(int) },
+                        modifiers: null);
+                    Assert.NotNull(ordinaryGetter);
+                    Assert.False(ordinaryGetter.IsVirtual);
+
+                    var explicitGetter = type
+                        .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+                        .Single(method =>
+                            method.Name.EndsWith(".get_Item", StringComparison.Ordinal)
+                            && method.GetParameters() is [{ ParameterType: var parameterType }]
+                            && parameterType == typeof(string));
+                    Assert.True(explicitGetter.IsVirtual);
+                }));
+    }
+
+    private static string CompileLoadAndRunChild(
+        string tag,
+        string source,
+        Action<Assembly> inspectAssembly = null)
+    {
+        var directory = Directory.CreateTempSubdirectory($"gs_i2915_{tag}_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var assemblyPath = Path.Combine(directory, "test.dll");
+            var runtimeConfigPath = Path.Combine(directory, "test.runtimeconfig.json");
+            File.WriteAllText(sourcePath, source);
+            File.WriteAllText(
+                runtimeConfigPath,
+                """{"runtimeOptions":{"tfm":"net10.0","framework":{"name":"Microsoft.NETCore.App","version":"10.0.0"}}}""");
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var previousOutput = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + assemblyPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOutput);
+                Console.SetError(previousError);
+            }
+
+            if (exitCode != 0)
+            {
+                throw new XunitException(
+                    "gsc failed:" + Environment.NewLine +
+                    stdoutWriter + stderrWriter.ToString());
+            }
+
+            IlVerifier.Verify(assemblyPath);
+            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            _ = assembly.GetTypes();
+            inspectAssembly?.Invoke(assembly);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            startInfo.ArgumentList.Add(assemblyPath);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new XunitException("Failed to start compiled child process.");
+            var childOutputTask = process.StandardOutput.ReadToEndAsync();
+            var childErrorTask = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(milliseconds: 30_000))
+            {
+                process.Kill(entireProcessTree: true);
+                throw new XunitException("Compiled child process timed out.");
+            }
+
+            var childOutput = childOutputTask.GetAwaiter().GetResult();
+            var childError = childErrorTask.GetAwaiter().GetResult();
+            if (process.ExitCode != 0)
+            {
+                throw new XunitException(
+                    $"Compiled child exited {process.ExitCode}:{Environment.NewLine}" +
+                    childOutput + childError);
+            }
+
+            return Normalize(childOutput);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    private static string Normalize(string value)
+        => value.Replace("\r\n", "\n", StringComparison.Ordinal);
+}

--- a/test/Compiler.Tests/Emit/Issue2945StaticVirtualNullableErasureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2945StaticVirtualNullableErasureTests.cs
@@ -97,6 +97,21 @@ public class Issue2945StaticVirtualNullableErasureTests
                     }
                 }
             }
+
+            sealed interface ISliceGet[T] { shared { prop Value []T? { get; } } }
+            struct SliceGet : ISliceGet[int32] { shared { prop Value []int32 -> []int32{1} } }
+
+            sealed interface IArrayGet[T] { shared { prop Value [3]T? { get; } } }
+            struct ArrayGet : IArrayGet[int32] { shared { prop Value [3]int32 -> [3]int32{1, 2, 3} } }
+
+            sealed interface IMapGet[T] { shared { prop Value map[string,T?] { get; } } }
+            struct MapGet : IMapGet[int32] { shared { prop Value map[string,int32] -> map[string,int32]{"one": 1} } }
+
+            sealed interface IFuncArgumentGet[T] { shared { prop Value func(T?) int32 { get; } } }
+            struct FuncArgumentGet : IFuncArgumentGet[int32] { shared { prop Value func(int32) int32 -> func(value int32) int32 { return value + 1 } } }
+
+            sealed interface IFuncReturnGet[T] { shared { prop Value func(int32) T? { get; } } }
+            struct FuncReturnGet : IFuncReturnGet[int32] { shared { prop Value func(int32) int32 -> func(value int32) int32 { return value + 2 } } }
             """;
 
         const string consumer = """
@@ -245,6 +260,7 @@ public class Issue2945StaticVirtualNullableErasureTests
     {
         const string source = """
             package Issue2945Rejected
+            import System.Collections.Generic
 
             sealed interface IConcrete {
                 shared { prop Value int32? { get; } }
@@ -280,6 +296,13 @@ public class Issue2945StaticVirtualNullableErasureTests
             class WrongType : IWrongType {
                 shared { prop Value string -> "wrong" }
             }
+
+            interface INestedList[T] {
+                prop Value List[T?] { get; }
+            }
+            class NestedListMismatch : INestedList[int32] {
+                prop Value List[int32] { get; }
+            }
             """;
 
         var directory = CreateWorkDirectory();
@@ -298,6 +321,7 @@ public class Issue2945StaticVirtualNullableErasureTests
             Assert.NotEqual(0, exitCode);
             Assert.False(File.Exists(outputPath));
             Assert.Equal(5, CountOccurrences(output, "error GS0397:"));
+            Assert.Equal(1, CountOccurrences(output, "error GS0187:"));
         }
         finally
         {

--- a/test/Interpreter.Tests/Issue2915ImplicitInterfaceIndexerInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2915ImplicitInterfaceIndexerInterpreterTests.cs
@@ -1,0 +1,246 @@
+// <copyright file="Issue2915ImplicitInterfaceIndexerInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issues #2915, #2954, and #2960: interpreter dispatch resolves interface
+/// property accessors on classes and structs.
+/// </summary>
+public class Issue2915ImplicitInterfaceIndexerInterpreterTests
+{
+    [Fact]
+    public void ImplicitIndexers_DispatchForPlainAndConstructedClassesAndStructs()
+    {
+        const string source = """
+            import System
+
+            interface IPlainClassGet {
+                prop this[key string] int32 { get; }
+            }
+            class PlainClassGet : IPlainClassGet {
+                prop this[key string] int32 -> key.Length + 8
+            }
+
+            interface IPlainClassSet {
+                prop this[index int32] int32 { get; set; }
+            }
+            class PlainClassSet : IPlainClassSet {
+                var Stored int32
+                prop this[index int32] int32 {
+                    get { return Stored + index }
+                    set { Stored = value - index }
+                }
+            }
+
+            interface IConstructedGet[T] {
+                prop this[key string] T { get; }
+            }
+            class ConstructedGet : IConstructedGet[int32] {
+                prop this[key string] int32 -> 17
+            }
+            class GenericGet[T] : IConstructedGet[T] {
+                let Stored T
+                init(value T) { Stored = value }
+                prop this[key string] T -> Stored
+            }
+
+            interface IConstructedSet[T] {
+                prop this[index int32] T { get; set; }
+            }
+            class ConstructedSet : IConstructedSet[int32] {
+                var Stored int32
+                prop this[index int32] int32 {
+                    get { return Stored + index }
+                    set { Stored = value - index }
+                }
+            }
+
+            interface IPlainStructGet {
+                prop this[index int32] int32 { get; }
+            }
+            struct PlainStructGet(Base int32) : IPlainStructGet {
+                prop this[index int32] int32 -> Base + index
+            }
+
+            interface IPlainStructSet {
+                prop this[index int32] int32 { get; set; }
+            }
+            class Cell {
+                var Stored int32
+                func Set(value int32) { Stored = value }
+            }
+            struct PlainStructSet(Cell Cell) : IPlainStructSet {
+                prop this[index int32] int32 {
+                    get { return Cell.Stored + index }
+                    set { Cell.Set(value - index) }
+                }
+            }
+
+            interface IConstructedStructGet[T] {
+                prop this[index int32] T { get; }
+            }
+            struct ConstructedStructGet(Base int32) : IConstructedStructGet[int32] {
+                prop this[index int32] int32 -> Base + index
+            }
+
+            interface IConstructedStructSet[T] {
+                prop this[index int32] T { get; set; }
+            }
+            struct ConstructedStructSet(Cell Cell) : IConstructedStructSet[int32] {
+                prop this[index int32] int32 {
+                    get { return Cell.Stored + index }
+                    set { Cell.Set(value - index) }
+                }
+            }
+
+            var plainClassGet IPlainClassGet = PlainClassGet()
+            Console.WriteLine(plainClassGet["abc"])
+
+            var plainClassSet IPlainClassSet = PlainClassSet()
+            plainClassSet[2] = 42
+            Console.WriteLine(plainClassSet[2])
+
+            var constructedGet IConstructedGet[int32] = ConstructedGet()
+            Console.WriteLine(constructedGet["value"])
+
+            var constructedSet IConstructedSet[int32] = ConstructedSet()
+            constructedSet[3] = 43
+            Console.WriteLine(constructedSet[3])
+
+            var genericGet IConstructedGet[int32] = GenericGet[int32](19)
+            Console.WriteLine(genericGet["value"])
+
+            var plainStructGet IPlainStructGet = PlainStructGet(30)
+            Console.WriteLine(plainStructGet[5])
+
+            var plainStructSet IPlainStructSet = PlainStructSet(Cell())
+            plainStructSet[4] = 44
+            Console.WriteLine(plainStructSet[4])
+
+            var constructedStructGet IConstructedStructGet[int32] = ConstructedStructGet(40)
+            Console.WriteLine(constructedStructGet[6])
+
+            var constructedStructSet IConstructedStructSet[int32] = ConstructedStructSet(Cell())
+            constructedStructSet[7] = 47
+            Console.WriteLine(constructedStructSet[7])
+            """;
+
+        Assert.Equal("11\n42\n17\n43\n19\n35\n44\n46\n47\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void ExplicitIndexers_DispatchToQualifiedClassAndStructAccessors()
+    {
+        const string source = """
+            import System
+
+            interface IPlain {
+                prop this[index int32] int32 { get; }
+            }
+            class Plain : IPlain {
+                prop this[index int32] int32 -> 1
+                private prop (IPlain) this[index int32] int32 -> 2
+            }
+
+            interface IGeneric[T] {
+                prop this[index int32] T { get; }
+            }
+            class Generic : IGeneric[int32] {
+                private prop (IGeneric[int32]) this[index int32] int32 -> 4
+            }
+
+            struct Value(Base int32) : IPlain {
+                private prop (IPlain) this[index int32] int32 -> Base + index
+            }
+
+            var plain = Plain()
+            var plainInterface IPlain = plain
+            Console.WriteLine(plainInterface[0])
+            Console.WriteLine(plain[0])
+
+            var genericInterface IGeneric[int32] = Generic()
+            Console.WriteLine(genericInterface[0])
+
+            var value IPlain = Value(5)
+            Console.WriteLine(value[7])
+            """;
+
+        Assert.Equal("2\n1\n4\n12\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void NullableSequenceInterfaceProperty_DispatchesAndPreservesNil()
+    {
+        const string source = """
+            import System
+
+            interface IBox {
+                prop Vals sequence[int32?] { get; }
+            }
+
+            func values() sequence[int32?] {
+                yield 5
+                yield nil
+            }
+
+            struct Box : IBox {
+                prop Vals sequence[int32?] -> values()
+            }
+
+            var box IBox = Box{}
+            for value in box.Vals {
+                Console.WriteLine(value == nil ? "nil" : value.ToString())
+            }
+            """;
+
+        Assert.Equal("5\nnil\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void ImportedBaseIndexer_DispatchesThroughConstructedInterface()
+    {
+        const string source = """
+            import System
+            import System.Collections.Generic
+
+            interface IStore[T] {
+                prop this[index int32] T { get; set; }
+            }
+
+            class Store : List[int32], IStore[int32] { }
+
+            var store = Store()
+            store.Add(7)
+            var value IStore[int32] = store
+            Console.WriteLine(value[0])
+            value[0] = 9
+            Console.WriteLine(value[0])
+            """;
+
+        Assert.Equal("7\n9\n", RunSubmission(source));
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var output = new StringWriter();
+        var previousOutput = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(previousOutput);
+        }
+
+        return output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

- Accept implicit G# interface indexers uniformly for plain and constructed interfaces, on classes and structs.
- Promote computed struct property accessors into exact interface slots, fixing explicit struct indexers, ordinary computed struct properties, and sequence-valued interface properties.
- Resolve interface property accessors in `gsi`, including explicit implementations and imported CLR base members.
- Document the upward-unification decision in ADR-0118.

Fixes #2915
Fixes #2954
Fixes #2960
Fixes #3001

## Design decision

I first implemented and tested the reject-both alternative. That decision did not survive investigation: class implementations already emitted verifiable, loadable metadata and dispatched correctly, while every failure used to justify rejection came from a small defect elsewhere.

- The struct failures shared one emitter gap: computed property accessors did not receive the value-type virtual promotion already used by methods, events, and auto-properties.
- The interpreter failure shared one dispatch gap: interface calls searched `StructSymbol.Methods` but not property getter/setter symbols.
- The #2960 interpreter probe also exposed nullable iterator storage using the erased underlying CLR type instead of `Nullable<T>`.

#3001 needs no interpreter change: `gsi` already handles ordinary computed struct interface properties. The evaluator delta remains limited to the indexer dispatch failures in #2915/#2954.

Fixing those roots is smaller and preserves the deliberate constructed-generic capability added by `9354651e` for #2370. Rejecting both would remove working behavior and hide the real defects. ADR-0118 previously contained no interface rule; the historical plain rejection was an artifact of name lookup excluding indexers, not a design decision.

## Production delta

Against parent `e80132516`:

- `DeclarationBinder.InterfaceVerification.cs` **+1/-13**: remove the plain-indexer rejection from declared/base-chain and imported-base signature matching. The removed `iface` parameters existed only for that guard; construction substitution remains in `typeParameterMap`.
- `MemberDefEmitter.cs` **+80/-13**: route auto-property and computed-accessor emission through one implicit-interface matcher; compare name, indexer kind, accessor availability, property type, parameter arity, and every index parameter type (including constructed-interface substitution and imported CLR interfaces); keep explicit properties out of implicit matching.
- `MethodInfoHelpers.cs` **+11/-0**: recognize getter/setter functions owned by explicit or implicit interface properties when deciding value-type virtual attributes.
- `Evaluator.Calls.cs` **+58/-1**: resolve implicit and explicit property accessors, invoke imported CLR backing accessors, and preserve nullable iterator element CLR types.

## Existing tests changed explicitly

- `PlainNonExplicitIndexer_DoesNotSatisfyInterfaceIndexerContract_ReportsGS0187` is now `PlainNonExplicitIndexer_DispatchesThroughInterfaceTypedReceiver`; it changed from asserting GS0187 to compiling, loading, and returning `1`. This is the behavior #2915 intentionally changes.
- `OrdinaryGenericInterfaceIndexer_DispatchesThroughInterfaceTypedReceiver` is restored to its original `10`-returning form and rationale from #2370.
- The `Issue2888` constructed-generic fixture is restored from explicit back to implicit. It has no net diff from `e80132516`.
- The obsolete failure-compilation helper used only by the former plain-rejection test was removed.

## Additional #2955 coverage

The existing `NullableErasureMatrix_LoadsAndDispatchesThroughClrSlots` fact now also pins the five widened nullable-erasure shapes from merged #2955: slice element, fixed-array element, map value, function argument, and function return. The existing rejection fact also pins the boundary: `List[T?]` does not match `List[int32]` and reports GS0187. This adds no test method and does not change suite counts; the three affected #2945 facts pass at HEAD.

## Executed evidence

The compiled child matrix covers class/struct × plain/constructed × get-only/get-set, generic enclosing type, `string` and `int32` indexes, interface-typed dispatch, explicit regression cases, and imported CLR-base inheritance. Three indexer-free struct-property tests independently pin #3001's computed get-only (`hi`), computed get/set (`42`), and the existing field-backed auto-property path (`42`) as a no-regression guard. It also proves a same-name `int32` indexer does not satisfy a `string` indexer slot: reflection keeps that ordinary getter non-virtual while the explicit matching getter is virtual. Every output assembly runs through ILVerify, `Assembly.Load(...).GetTypes()`, and a bounded child process with both pipes drained asynchronously. A known-bad post-load child control is detected.

Actual `gsi` child runs cover the same eight implicit shapes plus explicit plain/constructed class and struct dispatch, imported CLR-base dispatch, and nullable sequence `nil` preservation. Outputs were `11/42/17/43/19/35/44/46/47`, `2/1/4/12`, `7/9`, and `5/nil`. A known-bad `gsi` control exited 1 and was detected.

Issue repros at base and head:

- #2954: `e80132516` compiles, then exits `-6` with `TypeLoadException` saying `I.get_Item` must be virtual. HEAD loads and prints `12`.
- #2960: `e80132516` compiles, then exits `-6` with `TypeLoadException` saying `Box.get_Vals` has no implementation. HEAD loads and prints `5` then `nil`.
- #3001: `e80132516` compiles the ordinary computed struct interface property, then exits `-6` with `TypeLoadException` saying `LabelValue.get_Label` has no implementation. HEAD loads and prints `hi`.

The ordinary computed-property case is intentionally fixed here, not deferred or silently bundled: it shares the exact value-type accessor-promotion root with #2954/#2960. Separate get-only and get/set regressions pin `Assembly.GetTypes()` and bounded execution; the auto-property guard proves the separate field-backed emit path remains intact.

## Mutation results

Semantic branches: **11 pins / 11 guards**. Every mutant built warnings-clean; code was restored and rebuilt between probes. Each mutant pin turned red while a guard stayed green on the same verified artifact. The signature mutant changed the ordinary-instance `GSharp.Core.dll` MD5 from `eeed8d231f7b88f39eb4a094d431e226` to `437e9cb5f8c1b4a5b574448b0a0f9d25`; restoration returned exactly to `eeed8d231f7b88f39eb4a094d431e226`. Removing the shared computed-property accessor arm changed it to `ef9a4eac74939ca41ebd1b844693a52e`: both indexer-free computed-property tests turned red, the auto-property guard stayed green, and restoration returned exactly to the original MD5 with all three green.

| removed behavior | pin | guard |
|---|---|---|
| declared/base-chain plain indexer matching | plain class/struct matrix reports GS0187 | imported-base probe passes |
| imported-base plain indexer matching | imported `List[int32]` probe reports GS0187 | declared matrix passes |
| getter accessor promotion | #3001 get-only/get-set fail `Assembly.GetTypes()`; #2954/#2960 also fail | auto-property and class implementations pass |
| setter accessor promotion | #3001 get/set and plain/constructed struct setters fail | get-only #3001 and auto-property pass |
| explicit-property promotion | #2954 fails type load | implicit #2960 passes |
| implicit-property promotion | #2960 reports missing getter | explicit #2954 passes |
| full property-slot signature matching | same-name `int32` indexer is wrongly promoted for a `string` slot | matching explicit struct indexer still loads and dispatches |
| implicit `gsi` accessor dispatch | matrix reports GS9999 dictionary-key failure | explicit dispatch passes |
| explicit `gsi` accessor dispatch | explicit outputs regress and GS9999 fires | implicit dispatch passes |
| imported CLR-backing dispatch | imported probe reports GS9999 | G# implicit dispatch passes |
| nullable iterator element CLR type | `nil` reports GS9999 “Value cannot be null” | indexer matrix passes |

## Validation

Default-parallelism release build at `df7cbbe4d`: **0 warnings / 0 errors**. The five ordinary-instance `GSharp.Core.dll` copies were nonzero and MD5-identical (`eeed8d231f7b88f39eb4a094d431e226`).

Executed counts, same commands and machine state, against the requested parent baseline:

| suite | `e80132516` | `df7cbbe4d` | delta |
|---|---:|---:|---:|
| Core | 7028 passed, 1 skipped | 7028 passed, 1 skipped | 0 |
| Compiler | 3931 passed | 3940 passed | +9 |
| Interpreter | 493 passed | 497 passed | +4 |
| LanguageServer | 452 passed | 452 passed | 0 |

148-file corpus: 139 compiled, 9 retained identical diagnostics, 0 timeouts, and **0 differences** in exit code, normalized diagnostics, or SHA-256 output binary between base behavior and HEAD. **0/148 files declare an interface indexer**, so the corpus is non-regression evidence only; feature evidence comes from the probes above.
