### PR TITLE
Fix interpreter delegate exception diagnostics

### DIFF
--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -330,7 +330,7 @@ public class Compilation
             ex.Node?.WriteTo(textWriter);
             var sourceText = SourceText.From(textWriter.ToString());
             var location = new TextLocation(sourceText, new TextSpan(0, sourceText.Length));
-            var message = ex.Message;
+            var message = Evaluator.UnwrapRuntimeException(ex).Message;
             var diagnostic = new Diagnostic(location, ex.DiagnosticId, ex.Severity, message);
             return new EvaluationResult(allWarnings.Add(diagnostic), null);
         }

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -330,7 +330,7 @@ public class Compilation
             ex.Node?.WriteTo(textWriter);
             var sourceText = SourceText.From(textWriter.ToString());
             var location = new TextLocation(sourceText, new TextSpan(0, sourceText.Length));
-            var message = Evaluator.UnwrapRuntimeException(ex).Message;
+            var message = Evaluator.UnwrapDiagnosticException(ex).Message;
             var diagnostic = new Diagnostic(location, ex.DiagnosticId, ex.Severity, message);
             return new EvaluationResult(allWarnings.Add(diagnostic), null);
         }

--- a/src/Core/CodeAnalysis/Evaluator.Statements.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Statements.cs
@@ -33,8 +33,7 @@ public sealed partial class Evaluator
     /// nothing catches it). That wrapping must not leak into typed catch
     /// matching or handler-variable binding, so unwrap repeatedly down to the
     /// innermost real exception. TargetInvocationException (thrown by
-    /// reflection-based CLR calls) gets the same treatment, including when it
-    /// is the sole unambiguous child of an AggregateException.
+    /// reflection-based CLR calls) gets the same treatment.
     /// </summary>
     /// <param name="ex">Exception to unwrap.</param>
     /// <returns>Innermost runtime exception.</returns>
@@ -55,17 +54,27 @@ public sealed partial class Evaluator
                 continue;
             }
 
-            if (ex is AggregateException aggregate
-                && aggregate.InnerExceptions.Count == 1
-                && aggregate.InnerException is TargetInvocationException aggregateInner
-                && IsReflectionInvocationWrapper(aggregateInner))
-            {
-                ex = aggregateInner;
-                continue;
-            }
-
             return ex;
         }
+    }
+
+    /// <summary>
+    /// Unwraps runtime transport exceptions for diagnostic messages without
+    /// changing catch matching or handler-variable binding.
+    /// </summary>
+    /// <param name="ex">Exception to unwrap.</param>
+    /// <returns>Innermost diagnostic exception.</returns>
+    internal static Exception UnwrapDiagnosticException(Exception ex)
+    {
+        var unwrapped = UnwrapRuntimeException(ex);
+        if (unwrapped is AggregateException { InnerExceptions.Count: 1 } aggregate
+            && aggregate.InnerException is TargetInvocationException inner
+            && IsReflectionInvocationWrapper(inner))
+        {
+            return UnwrapRuntimeException(inner);
+        }
+
+        return unwrapped;
     }
 
     // Reflection-generated wrappers are thrown from CoreLib; a user-thrown

--- a/src/Core/CodeAnalysis/Evaluator.Statements.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Statements.cs
@@ -48,7 +48,8 @@ public sealed partial class Evaluator
                 continue;
             }
 
-            if (ex is TargetInvocationException { InnerException: { } tieInner })
+            if (ex is TargetInvocationException { InnerException: { } tieInner } tie
+                && IsReflectionInvocationWrapper(tie))
             {
                 ex = tieInner;
                 continue;
@@ -56,7 +57,8 @@ public sealed partial class Evaluator
 
             if (ex is AggregateException aggregate
                 && aggregate.InnerExceptions.Count == 1
-                && aggregate.InnerException is TargetInvocationException aggregateInner)
+                && aggregate.InnerException is TargetInvocationException aggregateInner
+                && IsReflectionInvocationWrapper(aggregateInner))
             {
                 ex = aggregateInner;
                 continue;
@@ -65,6 +67,12 @@ public sealed partial class Evaluator
             return ex;
         }
     }
+
+    // Reflection-generated wrappers are thrown from CoreLib; a user-thrown
+    // TargetInvocationException retains the user's/evaluator's target site.
+    private static bool IsReflectionInvocationWrapper(TargetInvocationException ex)
+        => ex.TargetSite?.DeclaringType?.Assembly is not { } assembly
+            || assembly == typeof(TargetInvocationException).Assembly;
 
     private object EvaluateStatement(BoundBlockStatement body)
     {

--- a/src/Core/CodeAnalysis/Evaluator.Statements.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Statements.cs
@@ -33,7 +33,8 @@ public sealed partial class Evaluator
     /// nothing catches it). That wrapping must not leak into typed catch
     /// matching or handler-variable binding, so unwrap repeatedly down to the
     /// innermost real exception. TargetInvocationException (thrown by
-    /// reflection-based CLR calls) gets the same treatment.
+    /// reflection-based CLR calls) gets the same treatment, including when it
+    /// is the sole unambiguous child of an AggregateException.
     /// </summary>
     /// <param name="ex">Exception to unwrap.</param>
     /// <returns>Innermost runtime exception.</returns>
@@ -50,6 +51,14 @@ public sealed partial class Evaluator
             if (ex is TargetInvocationException { InnerException: { } tieInner })
             {
                 ex = tieInner;
+                continue;
+            }
+
+            if (ex is AggregateException aggregate
+                && aggregate.InnerExceptions.Count == 1
+                && aggregate.InnerException is TargetInvocationException aggregateInner)
+            {
+                ex = aggregateInner;
                 continue;
             }
 

--- a/src/Core/CodeAnalysis/Evaluator.Statements.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Statements.cs
@@ -27,6 +27,36 @@ namespace GSharp.Core.CodeAnalysis;
 public sealed partial class Evaluator
 #pragma warning restore CA1001
 {
+    /// <summary>
+    /// Issue #1649: EvaluateExpression wraps every non-EvaluatorException in an
+    /// EvaluatorException to attach node context (for GS9999 reporting when
+    /// nothing catches it). That wrapping must not leak into typed catch
+    /// matching or handler-variable binding, so unwrap repeatedly down to the
+    /// innermost real exception. TargetInvocationException (thrown by
+    /// reflection-based CLR calls) gets the same treatment.
+    /// </summary>
+    /// <param name="ex">Exception to unwrap.</param>
+    /// <returns>Innermost runtime exception.</returns>
+    internal static Exception UnwrapRuntimeException(Exception ex)
+    {
+        while (true)
+        {
+            if (ex is EvaluatorException { InnerException: { } inner })
+            {
+                ex = inner;
+                continue;
+            }
+
+            if (ex is TargetInvocationException { InnerException: { } tieInner })
+            {
+                ex = tieInner;
+                continue;
+            }
+
+            return ex;
+        }
+    }
+
     private object EvaluateStatement(BoundBlockStatement body)
     {
         var labelToIndex = GetLabelToIndex(body);
@@ -699,40 +729,6 @@ public sealed partial class Evaluator
 
         throw new Exception(value?.ToString());
     }
-
-    /// <summary>
-    /// Issue #1649: EvaluateExpression wraps every non-EvaluatorException in an
-    /// EvaluatorException to attach node context (for GS9999 reporting when
-    /// nothing catches it). That wrapping must not leak into typed catch
-    /// matching or handler-variable binding, so unwrap repeatedly down to the
-    /// real exception. Reflection-generated TargetInvocationException wrappers
-    /// get the same treatment, while a user-thrown TargetInvocationException
-    /// remains visible to catch matching and handler-variable binding.
-    /// </summary>
-    private static Exception UnwrapRuntimeException(Exception ex)
-    {
-        while (true)
-        {
-            if (ex is EvaluatorException { InnerException: { } inner })
-            {
-                ex = inner;
-                continue;
-            }
-
-            if (ex is TargetInvocationException { InnerException: { } tieInner } tie
-                && IsReflectionInvocationWrapper(tie))
-            {
-                ex = tieInner;
-                continue;
-            }
-
-            return ex;
-        }
-    }
-
-    private static bool IsReflectionInvocationWrapper(TargetInvocationException ex)
-        => ex.TargetSite?.DeclaringType?.Assembly is not { } assembly
-            || assembly == typeof(TargetInvocationException).Assembly;
 
     private static bool TryFindCatchHandler(BoundTryStatement node, Exception ex, out BoundCatchClause matched)
     {

--- a/test/Interpreter.Tests/Issue2938DelegateExceptionDiagnosticTests.cs
+++ b/test/Interpreter.Tests/Issue2938DelegateExceptionDiagnosticTests.cs
@@ -233,6 +233,30 @@ public class Issue2938DelegateExceptionDiagnosticTests
     }
 
     [Fact]
+    public void SingleAggregateTargetInvocation_RemainsCatchableAsAggregateException()
+    {
+        const string Source = """
+            import System
+            import System.Reflection
+
+            var message = "none"
+            try {
+                throw AggregateException(TargetInvocationException(DivideByZeroException("boom")))
+            } catch (ex AggregateException) {
+                message = "caught-aggregate"
+            } catch (ex DivideByZeroException) {
+                message = "caught-dbz"
+            }
+            message
+            """;
+
+        var result = Evaluate(Source);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("caught-aggregate", result.Value);
+    }
+
+    [Fact]
     public void ClrMemberDelegateDiagnostic_RemainsAnchoredAtCallSite()
     {
         const string Source = """

--- a/test/Interpreter.Tests/Issue2938DelegateExceptionDiagnosticTests.cs
+++ b/test/Interpreter.Tests/Issue2938DelegateExceptionDiagnosticTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -22,6 +23,8 @@ public class Issue2938DelegateExceptionDiagnosticTests
     /// <summary>
     /// Gets delegate-storage cases that cover CLR and interpreter containers.
     /// </summary>
+    // Reflection-routed storage reports the call site, while closure-routed
+    // storage reports the lambda body. This is a known inconsistency, not a contract.
     public static TheoryData<string, string, string> StorageCases => new()
     {
         {
@@ -180,6 +183,56 @@ public class Issue2938DelegateExceptionDiagnosticTests
     }
 
     [Fact]
+    public void UserThrownTargetInvocationException_IsIntentionallyUnwrapped()
+    {
+        const string Source = """
+            import System
+            import System.Reflection
+
+            let handler () -> int32 = () -> throw TargetInvocationException(
+                "author outer",
+                InvalidOperationException("author inner"))
+            handler()
+            """;
+
+        var diagnostic = Assert.Single(Evaluate(Source).Diagnostics);
+
+        Assert.Equal("GS9999", diagnostic.Id);
+        Assert.Equal("author inner", diagnostic.Message);
+    }
+
+    [Fact]
+    public void AwaitedChannelValue_SingleAggregateTargetInvocation_UnwrapsInnerMessage()
+    {
+        const string Source = """
+            import GSharp.Interpreter.Tests
+            import Gsharp.Extensions.Go
+            import System.Threading.Tasks
+
+            let ch = make(chan ValueTask[int32], 1)
+            ch <- Issue2938ExceptionProbe.CreateSingleAggregateValueTaskAsync()
+            await <-ch
+            """;
+
+        AssertDiagnostic(Source, "aggregate await boom", "await <-ch");
+    }
+
+    [Fact]
+    public void MultipleAggregateExceptions_RemainAggregate()
+    {
+        const string Source = """
+            import GSharp.Interpreter.Tests
+
+            await Issue2938ExceptionProbe.CreateMultipleAggregateValueTaskAsync()
+            """;
+
+        AssertDiagnostic(
+            Source,
+            "One or more errors occurred. (Exception has been thrown by the target of an invocation.) (second aggregate boom)",
+            "await GSharp.Interpreter.Tests.Issue2938ExceptionProbe.CreateMultipleAggregateValueTaskAsync()");
+    }
+
+    [Fact]
     public void ClrMemberDelegateDiagnostic_RemainsAnchoredAtCallSite()
     {
         const string Source = """
@@ -227,8 +280,6 @@ public class Issue2938DelegateExceptionDiagnosticTests
         Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
         Assert.Equal(message, diagnostic.Message);
         Assert.Equal(sourceNode, diagnostic.Location.Text.ToString(diagnostic.Location.Span));
-        Assert.Equal(0, diagnostic.Location.StartLine);
-        Assert.Equal(0, diagnostic.Location.StartCharacter);
     }
 
     private static EvaluationResult Evaluate(string source)
@@ -265,4 +316,25 @@ public static class Issue2938ExceptionProbe
         => new InvalidOperationException(
             "outer boom",
             new DivideByZeroException("inner boom"));
+
+    /// <summary>
+    /// Creates an awaitable whose result throws a single-inner aggregate wrapper.
+    /// </summary>
+    /// <returns>Awaitable exception probe.</returns>
+    public static ValueTask<int> CreateSingleAggregateValueTaskAsync()
+        => new(Task.FromException<int>(
+            new AggregateException(
+                new TargetInvocationException(
+                    new DivideByZeroException("aggregate await boom")))));
+
+    /// <summary>
+    /// Creates an awaitable whose result throws a multi-inner aggregate wrapper.
+    /// </summary>
+    /// <returns>Awaitable exception probe.</returns>
+    public static ValueTask<int> CreateMultipleAggregateValueTaskAsync()
+        => new(Task.FromException<int>(
+            new AggregateException(
+                new TargetInvocationException(
+                    new DivideByZeroException("aggregate await boom")),
+                new InvalidOperationException("second aggregate boom"))));
 }

--- a/test/Interpreter.Tests/Issue2938DelegateExceptionDiagnosticTests.cs
+++ b/test/Interpreter.Tests/Issue2938DelegateExceptionDiagnosticTests.cs
@@ -153,17 +153,17 @@ public class Issue2938DelegateExceptionDiagnosticTests
     }
 
     [Fact]
-    public void NestedTargetInvocationExceptions_UnwrapRecursively()
+    public void NestedReflectionTargetInvocationExceptions_UnwrapRecursively()
     {
         const string Source = """
             import GSharp.Interpreter.Tests
 
-            let handler () -> int32 = () -> Issue2938ExceptionProbe.ThrowDoubleWrapped()
+            let handler () -> int32 = () -> Issue2938ExceptionProbe.InvokeNullReferenceReflectively()
             let pair = (handler, 0)
             pair.Item1()
             """;
 
-        AssertDiagnostic(Source, "double wrapped boom", "pair.Item1.Invoke()");
+        AssertDiagnostic(Source, "null boom", "pair.Item1.Invoke()");
     }
 
     [Fact]
@@ -183,7 +183,7 @@ public class Issue2938DelegateExceptionDiagnosticTests
     }
 
     [Fact]
-    public void UserThrownTargetInvocationException_IsIntentionallyUnwrapped()
+    public void UserThrownTargetInvocationException_KeepsOuterMessage()
     {
         const string Source = """
             import System
@@ -198,7 +198,7 @@ public class Issue2938DelegateExceptionDiagnosticTests
         var diagnostic = Assert.Single(Evaluate(Source).Diagnostics);
 
         Assert.Equal("GS9999", diagnostic.Id);
-        Assert.Equal("author inner", diagnostic.Message);
+        Assert.Equal("author outer", diagnostic.Message);
     }
 
     [Fact]
@@ -300,13 +300,13 @@ public static class Issue2938ExceptionProbe
         => throw new NullReferenceException("null boom");
 
     /// <summary>
-    /// Throws two nested target-invocation wrappers.
+    /// Invokes a throwing method through reflection to create nested runtime wrappers.
     /// </summary>
     /// <returns>This method never returns.</returns>
-    public static int ThrowDoubleWrapped()
-        => throw new TargetInvocationException(
-            new TargetInvocationException(
-                new InvalidOperationException("double wrapped boom")));
+    public static int InvokeNullReferenceReflectively()
+        => (int)typeof(Issue2938ExceptionProbe)
+            .GetMethod(nameof(ThrowNullReference))
+            .Invoke(null, null);
 
     /// <summary>
     /// Creates an ordinary exception that itself has an inner exception.
@@ -324,8 +324,7 @@ public static class Issue2938ExceptionProbe
     public static ValueTask<int> CreateSingleAggregateValueTaskAsync()
         => new(Task.FromException<int>(
             new AggregateException(
-                new TargetInvocationException(
-                    new DivideByZeroException("aggregate await boom")))));
+                CreateReflectionTargetInvocationException())));
 
     /// <summary>
     /// Creates an awaitable whose result throws a multi-inner aggregate wrapper.
@@ -334,7 +333,27 @@ public static class Issue2938ExceptionProbe
     public static ValueTask<int> CreateMultipleAggregateValueTaskAsync()
         => new(Task.FromException<int>(
             new AggregateException(
-                new TargetInvocationException(
-                    new DivideByZeroException("aggregate await boom")),
+                CreateReflectionTargetInvocationException(),
                 new InvalidOperationException("second aggregate boom"))));
+
+    private static TargetInvocationException CreateReflectionTargetInvocationException()
+    {
+        try
+        {
+            typeof(Issue2938ExceptionProbe)
+                .GetMethod(
+                    nameof(ThrowAggregateAwaitBoom),
+                    BindingFlags.NonPublic | BindingFlags.Static)
+                .Invoke(null, null);
+        }
+        catch (TargetInvocationException ex)
+        {
+            return ex;
+        }
+
+        throw new InvalidOperationException("Reflection probe did not throw.");
+    }
+
+    private static int ThrowAggregateAwaitBoom()
+        => throw new DivideByZeroException("aggregate await boom");
 }

--- a/test/Interpreter.Tests/Issue2938DelegateExceptionDiagnosticTests.cs
+++ b/test/Interpreter.Tests/Issue2938DelegateExceptionDiagnosticTests.cs
@@ -1,0 +1,268 @@
+// <copyright file="Issue2938DelegateExceptionDiagnosticTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2938: uncaught exceptions from delegates reached through CLR members
+/// retain their real message and source node.
+/// </summary>
+public class Issue2938DelegateExceptionDiagnosticTests
+{
+    /// <summary>
+    /// Gets delegate-storage cases that cover CLR and interpreter containers.
+    /// </summary>
+    public static TheoryData<string, string, string> StorageCases => new()
+    {
+        {
+            "tuple",
+            """
+            let handler (int32) -> int32 = (value int32) -> 1 / value
+            let pair = (handler, 0)
+            pair.Item1(0)
+            """,
+            "pair.Item1.Invoke(0)"
+        },
+        {
+            "list",
+            """
+            import System.Collections.Generic
+
+            let handler (int32) -> int32 = (value int32) -> 1 / value
+            let handlers = List[(int32) -> int32]{ handler }
+            handlers[0](0)
+            """,
+            "handlers[0].Invoke(0)"
+        },
+        {
+            "array",
+            """
+            let handler (int32) -> int32 = (value int32) -> 1 / value
+            let handlers = []((int32) -> int32){ handler }
+            handlers[0](0)
+            """,
+            "1 / value"
+        },
+        {
+            "struct-field",
+            """
+            struct Holder {
+                var Handler (int32) -> int32
+            }
+
+            let holder = Holder{Handler: (value int32) -> 1 / value}
+            holder.Handler(0)
+            """,
+            "1 / value"
+        },
+        {
+            "class-field",
+            """
+            class Holder {
+                var Handler (int32) -> int32
+            }
+
+            let holder = Holder{}
+            holder.Handler = (value int32) -> 1 / value
+            holder.Handler(0)
+            """,
+            "1 / value"
+        },
+        {
+            "returned",
+            """
+            func Handler() (int32) -> int32 {
+                return (value int32) -> 1 / value
+            }
+
+            Handler()(0)
+            """,
+            "1 / value"
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(StorageCases))]
+    public void StoredDelegate_UncaughtExceptionKeepsMessageAndSourceNode(
+        string _,
+        string source,
+        string expectedLocation)
+    {
+        AssertDiagnostic(
+            source,
+            "Attempted to divide by zero.",
+            expectedLocation);
+    }
+
+    [Fact]
+    public void NestedDelegate_UncaughtExceptionKeepsInnermostMessage()
+    {
+        const string Source = """
+            let inner (int32) -> int32 = (value int32) -> 1 / value
+            let outer (int32) -> int32 = (value int32) -> inner(value)
+            let pair = (outer, 0)
+            pair.Item1(0)
+            """;
+
+        AssertDiagnostic(
+            Source,
+            "Attempted to divide by zero.",
+            "pair.Item1.Invoke(0)");
+    }
+
+    [Fact]
+    public void UserThrownException_KeepsMessage()
+    {
+        const string Source = """
+            import System
+            import System.Collections.Generic
+
+            let handler () -> int32 = () -> throw InvalidOperationException("user boom")
+            let handlers = List[() -> int32]{ handler }
+            handlers[0]()
+            """;
+
+        AssertDiagnostic(Source, "user boom", "handlers[0].Invoke()");
+    }
+
+    [Fact]
+    public void NullReferenceException_KeepsMessage()
+    {
+        const string Source = """
+            import GSharp.Interpreter.Tests
+
+            let handler () -> int32 = () -> Issue2938ExceptionProbe.ThrowNullReference()
+            let pair = (handler, 0)
+            pair.Item1()
+            """;
+
+        AssertDiagnostic(Source, "null boom", "pair.Item1.Invoke()");
+    }
+
+    [Fact]
+    public void NestedTargetInvocationExceptions_UnwrapRecursively()
+    {
+        const string Source = """
+            import GSharp.Interpreter.Tests
+
+            let handler () -> int32 = () -> Issue2938ExceptionProbe.ThrowDoubleWrapped()
+            let pair = (handler, 0)
+            pair.Item1()
+            """;
+
+        AssertDiagnostic(Source, "double wrapped boom", "pair.Item1.Invoke()");
+    }
+
+    [Fact]
+    public void NonTargetInvocationInnerException_IsNotOverUnwrapped()
+    {
+        const string Source = """
+            import GSharp.Interpreter.Tests
+
+            let handler () -> int32 = () -> throw Issue2938ExceptionProbe.CreateWithOrdinaryInner()
+            handler()
+            """;
+
+        AssertDiagnostic(
+            Source,
+            "outer boom",
+            "throw GSharp.Interpreter.Tests.Issue2938ExceptionProbe.CreateWithOrdinaryInner()");
+    }
+
+    [Fact]
+    public void ClrMemberDelegateDiagnostic_RemainsAnchoredAtCallSite()
+    {
+        const string Source = """
+            let handler (int32) -> int32 = (value int32) -> 1 / value
+            let pair = (handler, 0)
+            pair.Item1(0)
+            """;
+
+        var diagnostic = Assert.Single(Evaluate(Source).Diagnostics);
+
+        Assert.Equal(
+            "pair.Item1.Invoke(0)",
+            diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void TypedCatch_StillReceivesRealException()
+    {
+        const string Source = """
+            import System
+            import GSharp.Interpreter.Tests
+
+            let handler () -> int32 = () -> throw Issue2938ExceptionProbe.CreateWithOrdinaryInner()
+            let pair = (handler, 0)
+            var message = ""
+            try {
+                pair.Item1()
+            } catch (ex InvalidOperationException) {
+                message = ex.Message
+            }
+            message
+            """;
+
+        var result = Evaluate(Source);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("outer boom", result.Value);
+    }
+
+    private static void AssertDiagnostic(string source, string message, string sourceNode)
+    {
+        var diagnostic = Assert.Single(Evaluate(source).Diagnostics);
+
+        Assert.Equal("GS9999", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Equal(message, diagnostic.Message);
+        Assert.Equal(sourceNode, diagnostic.Location.Text.ToString(diagnostic.Location.Span));
+        Assert.Equal(0, diagnostic.Location.StartLine);
+        Assert.Equal(0, diagnostic.Location.StartCharacter);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+        => new Compilation(SyntaxTree.Parse(source))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+}
+
+/// <summary>
+/// CLR exception shapes used by issue #2938 interpreter tests.
+/// </summary>
+public static class Issue2938ExceptionProbe
+{
+    /// <summary>
+    /// Throws a null-reference exception with a stable message.
+    /// </summary>
+    /// <returns>This method never returns.</returns>
+    public static int ThrowNullReference()
+        => throw new NullReferenceException("null boom");
+
+    /// <summary>
+    /// Throws two nested target-invocation wrappers.
+    /// </summary>
+    /// <returns>This method never returns.</returns>
+    public static int ThrowDoubleWrapped()
+        => throw new TargetInvocationException(
+            new TargetInvocationException(
+                new InvalidOperationException("double wrapped boom")));
+
+    /// <summary>
+    /// Creates an ordinary exception that itself has an inner exception.
+    /// </summary>
+    /// <returns>Exception with a non-target-invocation inner exception.</returns>
+    public static Exception CreateWithOrdinaryInner()
+        => new InvalidOperationException(
+            "outer boom",
+            new DivideByZeroException("inner boom"));
+}


### PR DESCRIPTION
Fixes #2938

## Summary

- Use a diagnostic-only `Evaluator.UnwrapDiagnosticException` when `Compilation.Evaluate` creates an uncaught interpreter `GS9999` diagnostic.
- Preserve the outer `EvaluatorException` and its rendered bound node; only the diagnostic message is taken from the unwrapped runtime exception.
- Preserve `EvaluatorException.DiagnosticId` and `Severity`, including deliberate interpreter diagnostics added by #3028.
- Preserve a user-thrown `TargetInvocationException` and its outer message while continuing to unwrap reflection-runtime transport wrappers recursively.
- Unwrap a single-inner `AggregateException` only on the diagnostic-message path when its unique child is a reflection-generated `TargetInvocationException`; catch matching remains unchanged.
- Keep `InvokeDelegate`'s existing `DynamicInvoke` catch unchanged. It remains load-bearing for direct/closure-routed delegate calls.

## Review decisions

### User-authored `TargetInvocationException`

User-authored instances keep their outer message. Reflection-generated wrappers have a runtime/CoreLib target site; exceptions explicitly thrown by G# retain the evaluator/user target site. The uncaught-diagnostic path uses that distinction to unwrap only transport wrappers. A regression test now expects `author outer`, while a separate nested-reflection probe proves recursive runtime-wrapper unwrapping still reaches the real cause.

Main preserves user-authored wrappers during catch matching through #3023, which closed #2999. Catch matching continues to use `UnwrapRuntimeException` unchanged. The diagnostic-only helper reuses its wrapper classification without adding aggregate unwrapping to catch matching or handler-variable binding.

### `AggregateException`

The limitation is reachable. The regression probe sends a faulted `ValueTask[int32]` through a G# channel and awaits it; its authentic failure shape is built from a reflection invocation:

```text
AggregateException(TargetInvocationException(DivideByZeroException))
```

Before the aggregate change, the probe reported `One or more errors occurred...`; after it, `GS9999` reports `aggregate await boom`. A second test proves an aggregate with two inner exceptions remains aggregated.

Aggregate unwrapping is deliberately diagnostic-only. A catch regression test constructs `AggregateException(TargetInvocationException(DivideByZeroException))` and asserts that G# catches `AggregateException`, matching the `gsc` oracle. Direct TIE and two-inner aggregate probes remain unchanged.

### Helper relocation

The relocation remains. Returning the now-`internal` helper to its former position beside `TryFindCatchHandler` makes the enforced StyleCop build fail with `SA1202: 'internal' members should come before 'private' members`. Keeping it at the top of the partial class is the smallest warning-free change and avoids a local analyzer suppression.

## Root cause

Expression evaluation already attached source context with `EvaluatorException`, and typed catches already used recursive runtime-exception unwrapping. The final uncaught-diagnostic boundary instead read `EvaluatorException.Message` directly, so reflection-routed calls leaked `TargetInvocationException`'s generic message.

This is a message-only fix. The rendered diagnostic node is unchanged byte-for-byte. `gsi` prints only `ID: message`; the rich location renderer is used by the interactive REPL and `gsc`. No source location was lost or recovered.

Reflection-routed storage currently reports the call site, while closure-routed storage reports the lambda body. Tests document that known inconsistency; it is not a designed location contract.

## Reachability classification

Ten of the eleven reachable categories are pins. `await` was already correct on the base through `BlockOnValueTask` and is a guard.

| Category | Classification |
|---|---|
| Instance method | pin |
| Static method | pin |
| Constructor | pin |
| Property get | pin |
| Property set | pin |
| Indexer | pin |
| Operator | pin |
| Conversion | pin |
| Delegate | pin |
| Channel | pin |
| Await | guard — already correct on base |

Field access is excluded: the claimed path is unreachable because binding reports `GS0158`.

## Verification

- Rebased base: `61b7a08c1758c4b2df2714c295e03017fe19c169`.
- Solution build with `dotnet build GSharp.sln -p:ContinuousIntegrationBuild=true`: exit 0, 0 warnings, 0 errors.
- Build freshness gates passed in order: exit code, 96 nonzero `GSharp.Core.dll` copies, then matching MD5 across five ordinary Compiler/Core/Repl/test outputs.
- The user-authored-wrapper test is a base guard that preserves the behavior the interim PR had regressed.
- Final issue test class against head: 17 passed.
- #3028 diagnostic-ID/severity guard: 8 passed.
- Combined post-rebase targeted run: 25 passed.
- `gsc` and `gsi` agree on all three CLI probes: `caught-aggregate`, `caught-tie`, `caught-aggregate2`; every compile/run exits 0.

### Mutation checks

Each mutant built successfully before its test result was read:

- Restoring aggregate unwrapping to shared `UnwrapRuntimeException`: `SingleAggregateTargetInvocation_RemainsCatchableAsAggregateException` failed, expected `caught-aggregate`, actual `caught-dbz`.
- Pointing `Compilation` back at `UnwrapRuntimeException`: `AwaitedChannelValue_SingleAggregateTargetInvocation_UnwrapsInnerMessage` failed with the generic aggregate message.
- Removing the aggregate arm from `UnwrapDiagnosticException`: the same awaited-message test failed.
- Reverting the headline message hunk to `ex.Message`: 7 failed / 10 passed.

Restoring each hunk flipped its targeted test back to green. Full-suite counts from earlier bases were removed rather than mixed with the new base; current CI supplies merge-state coverage.
