### PR TITLE
Pin source-generic returned function calls

### DIFF
--- a/test/Compiler.Tests/Emit/Issue2936SourceGenericReceiverCallTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2936SourceGenericReceiverCallTests.cs
@@ -1,0 +1,126 @@
+// <copyright file="Issue2936SourceGenericReceiverCallTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2936: calls through source-generic member results retain their
+/// substituted function type.
+/// </summary>
+public class Issue2936SourceGenericReceiverCallTests
+{
+    [Fact]
+    public void SourceGenericReceiverReturnedFunction_LoadsAndRuns()
+    {
+        const string Source = """
+            package SourceGenericFunctionReceiver
+            import System
+
+            class Src { let N int32
+                        init(n int32) { N = n } }
+
+            class Box[T any] { let Value T
+                               init(value T) { Value = value }
+                               func Get(index int32) T -> Value }
+
+            func Main() {
+                let box = Box[(Src) -> int32]((item Src) -> item.N)
+                Console.WriteLine(box.Get(0)(Src(5)))
+            }
+            """;
+
+        var directory = Directory.CreateTempSubdirectory("gsharp_issue2936_").FullName;
+        try
+        {
+            var assemblyPath = Compile(Source, directory);
+            IlVerifier.Verify(assemblyPath);
+            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            Assert.NotEmpty(assembly.GetTypes());
+            Assert.Equal("5\n", RunBounded(assemblyPath));
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static string Compile(string source, string directory)
+    {
+        var sourcePath = Path.Combine(directory, "Program.gs");
+        var assemblyPath = Path.Combine(directory, "Issue2936.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(exitCode == 0, $"gsc failed:\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return assemblyPath;
+    }
+
+    private static string RunBounded(string assemblyPath)
+    {
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                assemblyPath,
+            },
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+
+        Assert.NotNull(process);
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        var exited = process.WaitForExit(30_000);
+        if (!exited)
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+        }
+
+        var stdout = stdoutTask.GetAwaiter().GetResult();
+        var stderr = stderrTask.GetAwaiter().GetResult();
+        Assert.True(exited, "emitted program timed out");
+        Assert.True(process.ExitCode == 0, $"emitted program failed:\n{stderr}");
+        return stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Result

Issue #2936 no longer reproduces. `main` at `b78bb1f1` compiles the exact report and `dotnet` prints `5`. #2932's receiver-wide indirect-invocation parse shape already covers `box.Get(0)(Src(5))`, so #2936 was closed with execution evidence.

## Change

Test-only regression pin for the exact source-generic receiver shape. No production files changed.

The test:

- compiles the reported program as an executable
- runs `IlVerifier.Verify`
- loads emitted bytes with `Assembly.Load` and calls `GetTypes()`
- executes through a bounded child `dotnet` process
- starts asynchronous reads of both redirected pipes before waiting
- kills the full process tree on timeout
- requires exact stdout `5\n`

## Known-bad control

The same test was built and executed against `d4038f1d`. It fails with exit 1 and the expected `GS0159: Cannot find function .`. It passes on this branch and current `main`.

## Root cause / scope

#2932 changed postfix parsing so the complete member-call result, `box.Get(0)`, becomes the callee of the following invocation. Generic substitution was already correct; no source-generic special case is needed.

This does **not** cover #2937 or #2948. Those concern imported erased-slot lambda target typing: mismatched arity and nominal imported delegate identity, respectively. This PR touches neither `ExpressionBinder.Calls.cs` nor any production file.

## Pins, guards, mutations

- Against current base `8dddbbf2`: 0 pins, 1 guard; behavior is already fixed on main.
- Against known-bad `d4038f1d`: 1/1 historical regression pin fails for the exact GS0159 and passes here.
- Mutation testing: not applicable; production delta is zero and there are no semantic production branches to mutate.

## Validation

Same-base executed counts:

| Suite | `8dddbbf2` base | `d88b4d40` head |
|---|---:|---:|
| Core.Tests | 7028 passed, 1 skipped | 7028 passed, 1 skipped |
| Compiler.Tests | 3893 passed | 3894 passed |
| Interpreter.Tests | 489 passed | 489 passed |
| LanguageServer.Tests | 452 passed | 452 passed |

Delta is exactly this PR's one Compiler regression test.

Release warnings-as-errors build: 0 warnings, 0 errors.

## Corpus and interpreter parity

All 148 `samples/**` + `e2etests/**` files were compiled with separately preserved base and branch compilers:

- exit status: 148/148 identical
- diagnostics/output: 148/148 byte-identical
- emitted assemblies: 139/139 SHA-256 identical
- corpus files calling a call result through a generic receiver: **0**

Hand-written exact-shape probe: compiled output `5`; `gsi` output `5`.
