### PR TITLE
Fix nested generic iterator and method metadata

### DIFF
--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -263,12 +263,12 @@ internal sealed class StateMachineEmitter
         public IteratorStateMachineInfo(
             IteratorStateMachinePlan plan,
             StructSymbol classSym,
-            ImmutableArray<TypeParameterSymbol> outerMethodTypeParameters,
+            ImmutableArray<TypeParameterSymbol> sourceTypeParameters,
             ImmutableArray<TypeParameterSymbol> classTypeParameters)
         {
             this.Plan = plan;
             this.ClassSym = classSym;
-            this.OuterMethodTypeParameters = outerMethodTypeParameters;
+            this.SourceTypeParameters = sourceTypeParameters;
             this.ClassTypeParameters = classTypeParameters;
         }
 
@@ -277,44 +277,38 @@ internal sealed class StateMachineEmitter
         public StructSymbol ClassSym { get; }
 
         /// <summary>
-        /// Gets the OUTER method's type parameters (those declared on
-        /// <see cref="IteratorStateMachinePlan.Function"/>) that the
-        /// state-machine class is reified over (issue #810). Empty for
-        /// non-generic iterators.
+        /// Gets the original receiver and method type parameters that the
+        /// state-machine class is reified over, in state-machine slot order.
         /// </summary>
-        public ImmutableArray<TypeParameterSymbol> OuterMethodTypeParameters { get; }
+        public ImmutableArray<TypeParameterSymbol> SourceTypeParameters { get; }
 
         /// <summary>
         /// Gets the state-machine class's own type parameters (issue #810),
         /// constructed as ordinal-aligned mirrors of
-        /// <see cref="OuterMethodTypeParameters"/> with
+        /// <see cref="SourceTypeParameters"/> with
         /// <see cref="TypeParameterSymbol.IsMethodTypeParameter"/> set to
         /// <see langword="false"/>. Empty for non-generic iterators.
         /// </summary>
         public ImmutableArray<TypeParameterSymbol> ClassTypeParameters { get; }
 
         /// <summary>
-        /// Issue #810 + #1465: returns the emit-time remap from each
-        /// outer-method type parameter to its corresponding class-type-parameter
-        /// ordinal on the synthesized state machine, or <see langword="null"/>
-        /// when this iterator method has no method-level type parameters. The
-        /// state machine's leading type parameters mirror the enclosing generic
-        /// type's parameters, so a method type parameter maps to the slot
-        /// offset by the enclosing class type-parameter count. Used by
+        /// Issue #810 + #1465 + #2951: returns the emit-time remap from each
+        /// original receiver/method type parameter to its corresponding
+        /// class-type-parameter ordinal on the synthesized state machine, or
+        /// <see langword="null"/> when none are in scope. Used by
         /// <see cref="GenericRemapState.ActiveIteratorStateMachineRemap"/>.
         /// </summary>
         public Dictionary<TypeParameterSymbol, int> BuildRemap()
         {
-            if (this.OuterMethodTypeParameters.IsDefaultOrEmpty)
+            if (this.SourceTypeParameters.IsDefaultOrEmpty)
             {
                 return null;
             }
 
-            var offset = this.ClassTypeParameters.Length - this.OuterMethodTypeParameters.Length;
-            var map = new Dictionary<TypeParameterSymbol, int>(this.OuterMethodTypeParameters.Length);
-            for (var i = 0; i < this.OuterMethodTypeParameters.Length; i++)
+            var map = new Dictionary<TypeParameterSymbol, int>(this.SourceTypeParameters.Length);
+            for (var i = 0; i < this.SourceTypeParameters.Length; i++)
             {
-                map[this.OuterMethodTypeParameters[i]] = offset + i;
+                map[this.SourceTypeParameters[i]] = i;
             }
 
             return map;
@@ -323,46 +317,42 @@ internal sealed class StateMachineEmitter
 
     /// <summary>
     /// Issue #1489: minimal carrier for an async-iterator SM's generic
-    /// reification — the outer (kickoff) method's type parameters and the
+    /// reification — the source function's in-scope type parameters and the
     /// state-machine class's own ordinal-aligned type parameters. Used to
-    /// build the outer-method-TP → class-TP-ordinal remap (mirroring
+    /// build the source-TP → class-TP-ordinal remap (mirroring
     /// <see cref="IteratorStateMachineInfo.BuildRemap"/>) without a sync
     /// iterator plan.
     /// </summary>
     public sealed class IteratorStateMachineGenericInfo
     {
         public IteratorStateMachineGenericInfo(
-            ImmutableArray<TypeParameterSymbol> outerMethodTypeParameters,
+            ImmutableArray<TypeParameterSymbol> sourceTypeParameters,
             ImmutableArray<TypeParameterSymbol> classTypeParameters)
         {
-            this.OuterMethodTypeParameters = outerMethodTypeParameters;
+            this.SourceTypeParameters = sourceTypeParameters;
             this.ClassTypeParameters = classTypeParameters;
         }
 
-        public ImmutableArray<TypeParameterSymbol> OuterMethodTypeParameters { get; }
+        public ImmutableArray<TypeParameterSymbol> SourceTypeParameters { get; }
 
         public ImmutableArray<TypeParameterSymbol> ClassTypeParameters { get; }
 
         /// <summary>
-        /// Returns the emit-time remap from each outer-method type parameter to
-        /// its class-type-parameter ordinal on the synthesized state machine,
-        /// or <see langword="null"/> when the method has no type parameters.
-        /// The leading class type parameters mirror the enclosing generic
-        /// type's parameters, so a method type parameter maps to the slot
-        /// offset by the enclosing class type-parameter count.
+        /// Returns the emit-time remap from each original receiver/method type
+        /// parameter to its class-type-parameter ordinal on the synthesized
+        /// state machine, or <see langword="null"/> when none are in scope.
         /// </summary>
         public Dictionary<TypeParameterSymbol, int> BuildRemap()
         {
-            if (this.OuterMethodTypeParameters.IsDefaultOrEmpty)
+            if (this.SourceTypeParameters.IsDefaultOrEmpty)
             {
                 return null;
             }
 
-            var offset = this.ClassTypeParameters.Length - this.OuterMethodTypeParameters.Length;
-            var map = new Dictionary<TypeParameterSymbol, int>(this.OuterMethodTypeParameters.Length);
-            for (var i = 0; i < this.OuterMethodTypeParameters.Length; i++)
+            var map = new Dictionary<TypeParameterSymbol, int>(this.SourceTypeParameters.Length);
+            for (var i = 0; i < this.SourceTypeParameters.Length; i++)
             {
-                map[this.OuterMethodTypeParameters[i]] = offset + i;
+                map[this.SourceTypeParameters[i]] = i;
             }
 
             return map;
@@ -435,6 +425,29 @@ internal sealed class StateMachineEmitter
         public StandaloneSignatureHandle LocalsSignature { get; }
     }
 
+    private static ImmutableArray<TypeParameterSymbol> GetIteratorTypeParametersInScope(FunctionSymbol function)
+    {
+        var builder = ImmutableArray.CreateBuilder<TypeParameterSymbol>();
+        var containingType = function.ReceiverType as StructSymbol
+            ?? function.StaticOwnerType as StructSymbol;
+        if (containingType != null)
+        {
+            var definition = containingType.Definition ?? containingType;
+            builder.AddRange(StructSymbol.CollectEnclosingTypeParameters(definition));
+            if (!definition.TypeParameters.IsDefaultOrEmpty)
+            {
+                builder.AddRange(definition.TypeParameters);
+            }
+        }
+
+        if (!function.TypeParameters.IsDefaultOrEmpty)
+        {
+            builder.AddRange(function.TypeParameters);
+        }
+
+        return builder.ToImmutable();
+    }
+
     #region Iterator state-machine synthesis
 
     public void SynthesizeIteratorStateMachines(PackageSymbol hostPackage)
@@ -465,22 +478,11 @@ internal sealed class StateMachineEmitter
             // activeIteratorStateMachineRemap encode-time hook. The class TPs
             // themselves are not used directly in any bound expression — the
             // substitution lives at the encoder.
-            var enclosingClassTPs = plan.Function.ReceiverType is StructSymbol iterRecv
-                ? (iterRecv.Definition ?? iterRecv).TypeParameters
-                : ImmutableArray<TypeParameterSymbol>.Empty;
-            if (enclosingClassTPs.IsDefault)
-            {
-                enclosingClassTPs = ImmutableArray<TypeParameterSymbol>.Empty;
-            }
-
-            var outerMethodTPs = plan.Function.TypeParameters.IsDefaultOrEmpty
-                ? ImmutableArray<TypeParameterSymbol>.Empty
-                : plan.Function.TypeParameters;
-
-            // Combined in-scope type parameters: enclosing class first, then
-            // method. Drives the SM's own generic parameters and the
+            // Combined in-scope type parameters: flattened enclosing receiver
+            // types first, then the receiver's own parameters, then method
+            // parameters. Drives the SM's own generic parameters and the
             // self-instantiation type arguments used by the kickoff.
-            var scopeTPs = enclosingClassTPs.AddRange(outerMethodTPs);
+            var scopeTPs = GetIteratorTypeParametersInScope(plan.Function);
             ImmutableArray<TypeParameterSymbol> classTPs;
             if (scopeTPs.IsDefaultOrEmpty)
             {
@@ -638,8 +640,8 @@ internal sealed class StateMachineEmitter
             // CreateIteratorStateMachineLiteral helper and let the encoder
             // routing decide. The kickoff body lives inside the user's
             // generic method whose type parameters are still active
-            // (`MVar(0)`), so we explicitly construct the SM type over the
-            // outer method's TPs.
+            // (`MVar(0)`), so we explicitly construct the SM type over every
+            // type parameter in scope.
             var kickoffSmType = classTPs.IsDefaultOrEmpty
                 ? smClass
                 // Issue #2037: project imported constructed-generic hoisted
@@ -660,7 +662,7 @@ internal sealed class StateMachineEmitter
                 ImmutableArray.Create<BoundStatement>(
                 new BoundReturnStatement(null, this.CreateIteratorStateMachineLiteral(kickoffSmType, stateField, parameterFields, plan.Function.Parameters, p => new BoundVariableExpression(null, p),
                     thisProxyField, plan.Function.ThisParameter != null ? new BoundVariableExpression(null, plan.Function.ThisParameter) : null)))));
-            this.IteratorStateMachineInfos[smClass] = new IteratorStateMachineInfo(plan, smClass, outerMethodTPs, classTPs);
+            this.IteratorStateMachineInfos[smClass] = new IteratorStateMachineInfo(plan, smClass, scopeTPs, classTPs);
 
             // Issue #2907: closure materialization inside the SYNC MoveNext body is
             // emitter-owned and bypasses IteratorMoveNextBodyBuilder's variable->field
@@ -728,19 +730,7 @@ internal sealed class StateMachineEmitter
             // signature is translated to the matching class-TP slot via the
             // activeIteratorStateMachineRemap encode-time hook (registered in
             // RME from AsyncIteratorStateMachineGenericInfos).
-            var enclosingClassTPs = plan.Function.ReceiverType is StructSymbol aiRecv
-                ? (aiRecv.Definition ?? aiRecv).TypeParameters
-                : ImmutableArray<TypeParameterSymbol>.Empty;
-            if (enclosingClassTPs.IsDefault)
-            {
-                enclosingClassTPs = ImmutableArray<TypeParameterSymbol>.Empty;
-            }
-
-            var outerMethodTPs = plan.Function.TypeParameters.IsDefaultOrEmpty
-                ? ImmutableArray<TypeParameterSymbol>.Empty
-                : plan.Function.TypeParameters;
-
-            var scopeTPs = enclosingClassTPs.AddRange(outerMethodTPs);
+            var scopeTPs = GetIteratorTypeParametersInScope(plan.Function);
             ImmutableArray<TypeParameterSymbol> classTPs;
             if (scopeTPs.IsDefaultOrEmpty)
             {
@@ -857,7 +847,7 @@ internal sealed class StateMachineEmitter
             {
                 smClass.SetTypeParameters(classTPs);
                 this.AsyncIteratorStateMachineGenericInfos[smClass] =
-                    new IteratorStateMachineGenericInfo(outerMethodTPs, classTPs);
+                    new IteratorStateMachineGenericInfo(scopeTPs, classTPs);
             }
 
             // Methods: MoveNext, get_Current, MoveNextAsync, DisposeAsync, GetAsyncEnumerator

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -1313,6 +1313,9 @@ internal sealed class UserTokenResolver
         string methodName,
         BlobBuilder signature)
     {
+        // A caller may encode the signature under containingType's registered
+        // remap, then restore the ambient remap used here. containingType
+        // determines that signature remap and is already part of the key.
         var key = (containingType, openMethodDef, (object)this.remaps.ActiveIteratorStateMachineRemap, (object)this.remaps.ActiveLambdaMethodTypeParamRemap);
         if (this.userStructMethodRefCache.TryGetValue(key, out var cached))
         {

--- a/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
+++ b/src/Core/CodeAnalysis/Emit/UserTokenResolver.cs
@@ -1398,6 +1398,18 @@ internal sealed class UserTokenResolver
         return sigBlob;
     }
 
+    private BlobBuilder EncodeOpenStructMethodSignature(
+        StructSymbol containingType,
+        FunctionSymbol openMethod)
+    {
+        // Nested generic definitions re-ordinalize enclosing and own type
+        // parameters into one CLR VAR vector. Match the MethodDef encoding.
+        using (this.remaps.PushSmRemap(containingType.Definition ?? containingType))
+        {
+            return this.EncodeOpenMethodSignature(openMethod);
+        }
+    }
+
     /// <summary>
     /// ADR-0087 §3 R3: resolves the right token for a call to a user
     /// instance method. For a non-generic containing type returns the
@@ -1443,7 +1455,11 @@ internal sealed class UserTokenResolver
             return openDef;
         }
 
-        return this.GetUserStructMethodRef(containingType, openDef, method.Name, this.EncodeOpenMethodSignature(method));
+        return this.GetUserStructMethodRef(
+            containingType,
+            openDef,
+            method.Name,
+            this.EncodeOpenStructMethodSignature(containingType, method));
     }
 
     /// <summary>
@@ -1515,7 +1531,11 @@ internal sealed class UserTokenResolver
             return openDef;
         }
 
-        return this.GetUserStructMethodRef(containingType, openDef, method.Name, this.EncodeOpenMethodSignature(method));
+        return this.GetUserStructMethodRef(
+            containingType,
+            openDef,
+            method.Name,
+            this.EncodeOpenStructMethodSignature(containingType, method));
     }
 
     /// <summary>Resolves a generic static accessor whose MethodDef is tracked outside the method caches.</summary>
@@ -1530,7 +1550,11 @@ internal sealed class UserTokenResolver
             return openDef;
         }
 
-        return this.GetUserStructMethodRef(containingType, openDef, method.Name, this.EncodeOpenMethodSignature(method));
+        return this.GetUserStructMethodRef(
+            containingType,
+            openDef,
+            method.Name,
+            this.EncodeOpenStructMethodSignature(containingType, method));
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue2951NestedGenericStructIteratorTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2951NestedGenericStructIteratorTests.cs
@@ -12,8 +12,8 @@ using Xunit;
 namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>
-/// Issue #2951: nested generic iterator state machines retain every enclosing
-/// and receiver type parameter in their emitted type and call signatures.
+/// Issue #2951 and #1537 residual: nested generic state machines and method
+/// references retain every enclosing and receiver type-parameter ordinal.
 /// </summary>
 public class Issue2951NestedGenericStructIteratorTests
 {
@@ -133,6 +133,161 @@ public class Issue2951NestedGenericStructIteratorTests
     }
 
     [Fact]
+    public void NonGenericOuterLevelDoesNotShiftGenericMiddleParameter()
+    {
+        const string Source = """
+            package Issue2951AsymmetricOuter
+            import System
+
+            class Outer {
+                struct Mid[U] {
+                    struct Inner {
+                        var Value U
+                        func vals() sequence[U] { yield Value }
+                    }
+                }
+            }
+
+            var value = Outer.Mid[string].Inner{Value: "q"}
+            for item in value.vals() {
+                Console.WriteLine(item)
+            }
+            """;
+
+        AssertLoadsAndRuns(
+            Source,
+            nameof(NonGenericOuterLevelDoesNotShiftGenericMiddleParameter),
+            "q\n");
+    }
+
+    [Fact]
+    public void NonGenericClassMiddleDoesNotShiftOuterAndInnerParameters()
+    {
+        const string Source = """
+            package Issue2951AsymmetricClassMiddle
+            import System
+
+            class Outer[T] {
+                class Mid {
+                    struct Inner[V] {
+                        var A T
+                        var B V
+                        func vals() sequence[string] {
+                            yield A.ToString() + "|" + B.ToString()
+                        }
+                    }
+                }
+            }
+
+            var value = Outer[int32].Mid.Inner[string]{A: 7, B: "z"}
+            for item in value.vals() {
+                Console.WriteLine(item)
+            }
+            """;
+
+        AssertLoadsAndRuns(
+            Source,
+            nameof(NonGenericClassMiddleDoesNotShiftOuterAndInnerParameters),
+            "7|z\n");
+    }
+
+    [Fact]
+    public void NonGenericStructMiddleDoesNotShiftOuterAndInnerParameters()
+    {
+        const string Source = """
+            package Issue2951AsymmetricStructMiddle
+            import System
+
+            class Outer[T] {
+                struct Mid {
+                    struct Inner[V] {
+                        var A T
+                        var B V
+                        func vals() sequence[string] {
+                            yield A.ToString() + "|" + B.ToString()
+                        }
+                    }
+                }
+            }
+
+            var value = Outer[bool].Mid.Inner[int32]{A: true, B: 5}
+            for item in value.vals() {
+                Console.WriteLine(item)
+            }
+            """;
+
+        AssertLoadsAndRuns(
+            Source,
+            nameof(NonGenericStructMiddleDoesNotShiftOuterAndInnerParameters),
+            "True|5\n");
+    }
+
+    [Fact]
+    public void NonGenericOuterDoesNotShiftTwoNestedOwnParameters()
+    {
+        const string Source = """
+            package Issue2951AsymmetricOwnParameters
+            import System
+
+            class Outer {
+                class Mid[U] {
+                    struct Inner[V] {
+                        var A U
+                        var B V
+                        func vals() sequence[string] {
+                            yield A.ToString() + "|" + B.ToString()
+                        }
+                    }
+                }
+            }
+
+            var value = Outer.Mid[string].Inner[int32]{A: "k", B: 9}
+            for item in value.vals() {
+                Console.WriteLine(item)
+            }
+            """;
+
+        AssertLoadsAndRuns(
+            Source,
+            nameof(NonGenericOuterDoesNotShiftTwoNestedOwnParameters),
+            "k|9\n");
+    }
+
+    [Fact]
+    public void AsyncNonGenericMiddleDoesNotShiftOuterAndInnerParameters()
+    {
+        const string Source = """
+            package Issue2951AsymmetricAsync
+            import System
+            import System.Threading.Tasks
+
+            class Outer[T] {
+                class Mid {
+                    struct Inner[V] {
+                        var A T
+                        var B V
+                        async func vals() async sequence[string] {
+                            yield A.ToString() + "|" + B.ToString()
+                            await Task.Delay(1)
+                        }
+                    }
+                }
+            }
+
+            var value = Outer[int32].Mid.Inner[string]{A: 3, B: "w"}
+            let iterator = value.vals().GetAsyncEnumerator()
+            for iterator.MoveNextAsync().AsTask().Result {
+                Console.WriteLine(iterator.Current)
+            }
+            """;
+
+        AssertLoadsAndRuns(
+            Source,
+            nameof(AsyncNonGenericMiddleDoesNotShiftOuterAndInnerParameters),
+            "3|w\n");
+    }
+
+    [Fact]
     public void NestedClassIteratorUsesEnclosingTypeParameter()
     {
         const string Source = """
@@ -240,6 +395,33 @@ public class Issue2951NestedGenericStructIteratorTests
             """;
 
         AssertLoadsAndRuns(Source, nameof(SharedNestedGenericStructIteratorUsesOwnTypeParameter), "shared\n");
+    }
+
+    [Fact]
+    public void NestedGenericNonIteratorMethodUsesDistinctParameterOrdinals()
+    {
+        const string Source = """
+            package Issue2951MethodMemberRef
+            import System
+
+            class Outer[T] {
+                struct Cell[U] {
+                    var A T
+                    var B U
+                    func echo(u U, t T) string {
+                        return u.ToString() + "/" + t.ToString()
+                    }
+                }
+            }
+
+            var value = Outer[int32].Cell[string]{A: 1, B: "b"}
+            Console.WriteLine(value.echo("z", 9))
+            """;
+
+        AssertLoadsAndRuns(
+            Source,
+            nameof(NestedGenericNonIteratorMethodUsesDistinctParameterOrdinals),
+            "z/9\n");
     }
 
     [Fact]

--- a/test/Compiler.Tests/Emit/Issue2951NestedGenericStructIteratorTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2951NestedGenericStructIteratorTests.cs
@@ -1,0 +1,407 @@
+// <copyright file="Issue2951NestedGenericStructIteratorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2951: nested generic iterator state machines retain every enclosing
+/// and receiver type parameter in their emitted type and call signatures.
+/// </summary>
+public class Issue2951NestedGenericStructIteratorTests
+{
+    [Fact]
+    public void NestedNonGenericStructUsesEnclosingTypeParameter()
+    {
+        const string Source = """
+            package Issue2951Enclosing
+            import System
+
+            class Wrap[T] {
+                struct Cell {
+                    var A T
+                    func vals() sequence[T] { yield A }
+                }
+            }
+
+            for value in Wrap[int32].Cell{A: 42}.vals() {
+                Console.WriteLine(value)
+            }
+            """;
+
+        AssertLoadsAndRuns(Source, nameof(NestedNonGenericStructUsesEnclosingTypeParameter), "42\n");
+    }
+
+    [Fact]
+    public void NestedGenericStructUsesOwnTypeParameterDirectlyAndInLoop()
+    {
+        const string Source = """
+            package Issue2951Own
+            import System
+
+            class Wrap[T] {
+                struct Cell[U] {
+                    var A U
+                    func vals() sequence[U] { yield A }
+                }
+            }
+
+            var cell = Wrap[int32].Cell[string]{A: "x"}
+            let iterator = cell.vals().GetEnumerator()
+            if iterator.MoveNext() {
+                Console.WriteLine(iterator.Current)
+            }
+
+            for value in cell.vals() {
+                Console.WriteLine(value)
+            }
+            """;
+
+        AssertLoadsAndRuns(Source, nameof(NestedGenericStructUsesOwnTypeParameterDirectlyAndInLoop), "x\nx\n");
+    }
+
+    [Fact]
+    public void NestedGenericStructUsesBothParametersAtTwoInstantiations()
+    {
+        const string Source = """
+            package Issue2951Both
+            import System
+
+            class Outer[T] {
+                struct Cell[U] {
+                    var A T
+                    var B U
+                    func vals() sequence[string] { yield A.ToString() + B.ToString() }
+                }
+            }
+
+            var first = Outer[int32].Cell[string]{A: 42, B: "x"}
+            for value in first.vals() {
+                Console.WriteLine(value)
+            }
+
+            var second = Outer[string].Cell[int32]{A: "y", B: 7}
+            for value in second.vals() {
+                Console.WriteLine(value)
+            }
+            """;
+
+        AssertLoadsAndRuns(
+            Source,
+            nameof(NestedGenericStructUsesBothParametersAtTwoInstantiations),
+            "42x\ny7\n");
+    }
+
+    [Fact]
+    public void TwoNestedGenericLevelsUseAllParameters()
+    {
+        const string Source = """
+            package Issue2951TwoLevels
+            import System
+
+            class Outer[T] {
+                struct Middle[U] {
+                    struct Inner[V] {
+                        var A T
+                        var B U
+                        var C V
+                        func vals() sequence[string] {
+                            yield A.ToString() + B.ToString() + C.ToString()
+                        }
+                    }
+                }
+            }
+
+            var value = Outer[int32].Middle[string].Inner[bool]{
+                A: 4,
+                B: "z",
+                C: true
+            }
+            for item in value.vals() {
+                Console.WriteLine(item)
+            }
+            """;
+
+        AssertLoadsAndRuns(Source, nameof(TwoNestedGenericLevelsUseAllParameters), "4zTrue\n");
+    }
+
+    [Fact]
+    public void NestedClassIteratorUsesEnclosingTypeParameter()
+    {
+        const string Source = """
+            package Issue2951Class
+            import System
+
+            class Outer[T](Seed T) {
+                class Cell(Value T) {
+                    func vals() sequence[T] { yield Value }
+                }
+
+                func print() {
+                    for value in Cell(Seed).vals() {
+                        Console.WriteLine(value)
+                    }
+                }
+            }
+
+            Outer[int32](43).print()
+            """;
+
+        AssertLoadsAndRuns(Source, nameof(NestedClassIteratorUsesEnclosingTypeParameter), "43\n");
+    }
+
+    [Fact]
+    public void AsyncNestedGenericStructIteratorUsesBothParameters()
+    {
+        const string Source = """
+            package Issue2951Async
+            import System
+            import System.Threading.Tasks
+
+            class Outer[T] {
+                struct Cell[U] {
+                    var A T
+                    var B U
+                    async func vals() async sequence[string] {
+                        yield A.ToString() + B.ToString()
+                        await Task.Delay(1)
+                    }
+                }
+            }
+
+            var cell = Outer[int32].Cell[string]{A: 44, B: "a"}
+            let iterator = cell.vals().GetAsyncEnumerator()
+            for iterator.MoveNextAsync().AsTask().Result {
+                Console.WriteLine(iterator.Current)
+            }
+            """;
+
+        AssertLoadsAndRuns(Source, nameof(AsyncNestedGenericStructIteratorUsesBothParameters), "44a\n");
+    }
+
+    [Fact]
+    public void NestedIteratorComposesWithNullableGenericSpecialization()
+    {
+        const string Source = """
+            package Issue2951Nullable
+            import System
+
+            class Outer[T] {
+                struct Cell {
+                    var Marker T
+                    func vals[U](value U) sequence[U?] {
+                        Console.WriteLine(Marker)
+                        yield value
+                        yield nil
+                    }
+                }
+            }
+
+            var cell = Outer[int32].Cell{Marker: 45}
+            for value in cell.vals[int32](46) {
+                Console.WriteLine(value == nil ? "int:nil" : value.ToString())
+            }
+            for value in cell.vals[string]("s") {
+                Console.WriteLine(value == nil ? "string:nil" : value)
+            }
+            """;
+
+        AssertLoadsAndRuns(
+            Source,
+            nameof(NestedIteratorComposesWithNullableGenericSpecialization),
+            "45\n46\nint:nil\n45\ns\nstring:nil\n");
+    }
+
+    [Fact]
+    public void SharedNestedGenericStructIteratorUsesOwnTypeParameter()
+    {
+        const string Source = """
+            package Issue2951Shared
+            import System
+
+            class Outer[T] {
+                struct Cell[U] {
+                    shared {
+                        func vals(value U) sequence[U] { yield value }
+                    }
+                }
+            }
+
+            for value in Outer[int32].Cell[string].vals("shared") {
+                Console.WriteLine(value)
+            }
+            """;
+
+        AssertLoadsAndRuns(Source, nameof(SharedNestedGenericStructIteratorUsesOwnTypeParameter), "shared\n");
+    }
+
+    [Fact]
+    public void NestedEnumIteratorRemainsValid()
+    {
+        const string Source = """
+            package Issue2951EnumGuard
+            import System
+
+            class Outer[T] {
+                enum Kind { A }
+                func vals() sequence[Kind] { yield Kind.A }
+            }
+
+            var outer = Outer[int32]()
+            for value in outer.vals() {
+                Console.WriteLine(value)
+            }
+            """;
+
+        AssertLoadsAndRuns(Source, nameof(NestedEnumIteratorRemainsValid), "0\n");
+    }
+
+    [Fact]
+    public void TopLevelGenericStructIteratorRemainsValid()
+    {
+        const string Source = """
+            package Issue2951TopLevelGuard
+            import System
+
+            struct Cell[T] {
+                var A T
+                func vals() sequence[T] { yield A }
+            }
+
+            var cell = Cell[int32]{A: 45}
+            for value in cell.vals() {
+                Console.WriteLine(value)
+            }
+            """;
+
+        AssertLoadsAndRuns(Source, nameof(TopLevelGenericStructIteratorRemainsValid), "45\n");
+    }
+
+    [Fact]
+    public void NonGenericNestedStructIteratorRemainsValid()
+    {
+        const string Source = """
+            package Issue2951NonGenericGuard
+            import System
+
+            class Outer {
+                struct Cell {
+                    var A int32
+                    func vals() sequence[int32] { yield A }
+                }
+            }
+
+            for value in Outer.Cell{A: 46}.vals() {
+                Console.WriteLine(value)
+            }
+            """;
+
+        AssertLoadsAndRuns(Source, nameof(NonGenericNestedStructIteratorRemainsValid), "46\n");
+    }
+
+    [Fact]
+    public void TopLevelFunctionIteratorRemainsValid()
+    {
+        const string Source = """
+            package Issue2951FunctionGuard
+            import System
+
+            func vals() sequence[int32] { yield 47 }
+
+            for value in vals() {
+                Console.WriteLine(value)
+            }
+            """;
+
+        AssertLoadsAndRuns(Source, nameof(TopLevelFunctionIteratorRemainsValid), "47\n");
+    }
+
+    private static void AssertLoadsAndRuns(string source, string name, string expected)
+    {
+        var assemblyPath = Compile(source, name);
+        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        Assert.NotEmpty(assembly.GetTypes());
+        Assert.Equal(expected, RunBounded(assemblyPath, name));
+    }
+
+    private static string Compile(string source, string name)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue2951NestedGenericStructIteratorTests),
+            name);
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var assemblyPath = Path.Combine(directory, name + ".dll");
+        File.WriteAllText(sourcePath, source);
+        File.Delete(assemblyPath);
+        File.Delete(Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"));
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousErr = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousErr);
+        }
+
+        Assert.True(exitCode == 0, $"{name}: gsc failed:\n{stdout}\n{stderr}");
+        return assemblyPath;
+    }
+
+    private static string RunBounded(string assemblyPath, string name)
+    {
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                assemblyPath,
+            },
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+
+        Assert.NotNull(process);
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        var exited = process.WaitForExit(30_000);
+        if (!exited)
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+        }
+
+        Assert.True(exited, $"{name}: emitted program timed out");
+        var output = outputTask.GetAwaiter().GetResult();
+        var error = errorTask.GetAwaiter().GetResult();
+        Assert.True(process.ExitCode == 0, $"{name}: emitted program failed:\n{error}");
+        return output.Replace("\r\n", "\n");
+    }
+}

--- a/test/Interpreter.Tests/Issue2951NestedGenericStructIteratorTests.cs
+++ b/test/Interpreter.Tests/Issue2951NestedGenericStructIteratorTests.cs
@@ -1,0 +1,82 @@
+// <copyright file="Issue2951NestedGenericStructIteratorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2951 interpreter parity for nested generic struct iterators.
+/// </summary>
+public class Issue2951NestedGenericStructIteratorTests
+{
+    [Fact]
+    public void NestedStructIteratorUsesEnclosingTypeParameter()
+    {
+        const string Source = """
+            import System
+
+            class Wrap[T] {
+                struct Cell {
+                    var A T
+                    func vals() sequence[T] { yield A }
+                }
+            }
+
+            for value in Wrap[int32].Cell{A: 42}.vals() {
+                Console.WriteLine(value)
+            }
+            """;
+
+        Assert.Equal("42\n", RunSubmission(Source));
+    }
+
+    [Fact]
+    public void NestedGenericStructIteratorUsesEnclosingAndOwnTypeParameters()
+    {
+        const string Source = """
+            import System
+
+            class Outer[T] {
+                struct Cell[U] {
+                    var A T
+                    var B U
+                    func vals() sequence[string] { yield A.ToString() + B.ToString() }
+                }
+            }
+
+            var first = Outer[int32].Cell[string]{A: 42, B: "x"}
+            for value in first.vals() {
+                Console.WriteLine(value)
+            }
+
+            var second = Outer[string].Cell[int32]{A: "y", B: 7}
+            for value in second.vals() {
+                Console.WriteLine(value)
+            }
+            """;
+
+        Assert.Equal("42x\ny7\n", RunSubmission(Source));
+    }
+
+    private static string RunSubmission(string source)
+    {
+        using var output = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(source);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return output.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary

- reify sync and async iterator state machines over the full CLR type-parameter scope: flattened enclosing types, the receiver's own parameters, then method parameters
- remap every source type parameter to its state-machine `VAR` slot
- encode nested-generic method `MemberRef` signatures under the declaring type's registered re-ordinalization, including ordinary non-iterator methods
- add load-and-execute coverage for asymmetric nesting, nested structs/classes, ordinary methods, two constructions, async/shared iterators, nullable specialization, and direct `GetEnumerator` use

Fixes #2951

## Root cause

The repros expose two metadata mismatches:

1. `StateMachineEmitter.cs` included only the receiver's own parameters plus method parameters. It omitted flattened enclosing parameters, and its emit-time remap covered only method parameters. A nested receiver such as `Wrap<T>.Cell` therefore left `T` open in state-machine fields; `Wrap<T>.Cell<U>` also assigned the wrong CLR `VAR` ordinal to `U`.
2. `UserTokenResolver.cs` encoded a nested-generic method's call-site `MemberRef` signature without the declaring type's registered re-ordinalization. The MethodDef encoded `U` as `VAR(1)` in `Wrap<T>.Cell<U>`, while the MemberRef encoded it as `VAR(0)`, producing `MissingMethodException`.

The second fix is general metadata plumbing, not iterator-specific: ordinary nested-generic methods used the same broken MemberRef path. The added `echo(U, T)` test pins that residual nested-generic behavior related to #1537.

Sync and async iterators shared the state-machine defect. Nested classes shared it. Non-generic nesting levels contribute zero parameters; asymmetric nesting tests now pin that their presence does not shift later ordinals.

**This PR does not fix #2977.** The ticket's direct chained literal spelling binder-fails before emit, identically on base and this head. The equivalent local-variable form reproduces the documented metadata failure. #2977 tracks that independent binder residual.

## Verification

Known-bad compiler: `8dddbbf2`.

- **Pins:** 14 compiler tests fail on the known-bad compiler and pass here.
- **Guards:** 4 compiler tests and 2 interpreter parity tests pass on both.
- All 18 compiler tests use `Assembly.Load(File.ReadAllBytes(...))`, `GetTypes()`, and bounded child-process execution with exact stdout.
- `gsi` vs compiled parity: 3/3 probes byte-equal stdout (`42`, `x\nx`, `42x\ny7`).
- Final targeted controls: Issue2951 **18/18**, overlapping Issue2927 **20/20**, interpreter parity **2/2**.
- Serial Release solution build: **0 warnings, 0 errors**.
- All four Compiler/Compiler.Tests/Core.Tests/Interpreter.Tests `GSharp.Core.dll` copies matched and were non-zero after the final build.

### Semantic mutations

Unmutated controls: Issue2951 **18/18 passed**; the no-owner-path probe used the broader Issue2927 **20/20 passed** control.

| Mutation | Result |
|---|---:|
| omit enclosing parameters | 12 failed / 6 passed |
| omit receiver-own parameters | 11 failed / 7 passed |
| omit method parameters | 1 failed / 17 passed |
| ignore shared/static owner | 1 failed / 17 passed |
| omit top-level method parameters on the no-owner path | 9 failed / 11 passed |
| bypass sync scope helper | 13 failed / 5 passed |
| retain old sync remap source | 8 failed / 10 passed |
| bypass async scope helper | 2 failed / 16 passed |
| retain old async remap source | 2 failed / 16 passed |
| reverse sync `VAR` slots | 8 failed / 10 passed |
| reverse async `VAR` slots | 2 failed / 16 passed |
| omit method-signature remap | 3 failed / 15 passed |

Every accepted mutant built successfully via `dotnet build GSharp.sln -c Release -m:1`. The Compiler, Compiler.Tests, Core.Tests, and Interpreter.Tests copies of `GSharp.Core.dll` had matching, non-zero MD5s that differed from pristine; every restore rebuild returned all four to the pristine MD5 and the control behavior passed again.

### Suites

Base `a6b1561f2` → head `6b76a4281`, both from successful CI runs:

- Core: 7028 passed + 1 skipped → 7028 passed + 1 skipped
- Compiler: 3906 → 3924
- Interpreter: 491 → 493
- LanguageServer: 452 → 452

### Corpus

Current base `a6b1561f2` vs head: 148/148 samples, `BYTEDIFF=0`, `DIAGDIFF=0`, `RCDIFF=0` using SHA-256 per emitted file.

This is weak evidence for the `UserTokenResolver` hunk: **0/148 samples declare any nested type**, so the registered remap path is inert across the corpus. The meaningful non-regression evidence for that path is the reviewer's nested-generic, type-parameter-free method probe, which emitted byte-identically on base and head (MD5 `8e2b4e5983700b5f4484d54f81becc7b`).

## Collision notes

- `StateMachineEmitter.cs`: touched; narrow iterator generic-scope change only.
- `UserTokenResolver.cs`: touched; nested-generic method-signature remap.
- `StructSymbol.cs`: **not touched**.

