### PR TITLE
Funnel conditional gotos through lifted finally handlers

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/FinallyExitRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/FinallyExitRewriter.cs
@@ -75,6 +75,7 @@ internal static class FinallyExitRewriter
     {
         private readonly ExitPlan plan;
         private readonly ProtectedRegionBranchAnalysis branches;
+        private int skipOrdinal;
 
         public ExitFunneler(ExitPlan plan, ProtectedRegionBranchAnalysis branches)
         {
@@ -94,6 +95,27 @@ internal static class FinallyExitRewriter
                 ImmutableArray.Create<BoundStatement>(
                     AssignBranch(plan.GetDiscriminator(node.Label)),
                     new BoundGotoStatement(null, plan.TailLabel)));
+        }
+
+        protected override BoundStatement RewriteConditionalGotoStatement(BoundConditionalGotoStatement node)
+        {
+            if (branches.ContainsLabel(node.Label))
+            {
+                return node;
+            }
+
+            var skip = new BoundLabel("<>finally_exit_skip_" + skipOrdinal++);
+            return new BoundBlockStatement(
+                null,
+                ImmutableArray.Create<BoundStatement>(
+                    new BoundConditionalGotoStatement(
+                        null,
+                        skip,
+                        node.Condition,
+                        jumpIfTrue: !node.JumpIfTrue),
+                    AssignBranch(plan.GetDiscriminator(node.Label)),
+                    new BoundGotoStatement(null, plan.TailLabel),
+                    new BoundLabelStatement(null, skip)));
         }
 
         private BoundStatement AssignBranch(int discriminator)

--- a/test/Compiler.Tests/Emit/Issue2942ConditionalGotoFinallyFunnelTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2942ConditionalGotoFinallyFunnelTests.cs
@@ -79,8 +79,8 @@ public class Issue2942ConditionalGotoFinallyFunnelTests
 
     [Theory]
     [InlineData(1, 11)]
-    [InlineData(2, 21)]
-    [InlineData(3, 120)]
+    [InlineData(2, 61)]
+    [InlineData(3, 200)]
     public void EmittedMultipleConditionalExits_DispatchSelectedTarget_AndRunFinallyOnce(
         int selectedTarget,
         int expectedExitCode)
@@ -262,9 +262,13 @@ public class Issue2942ConditionalGotoFinallyFunnelTests
             new BoundLabelStatement(null, firstExit),
             new BoundReturnStatement(null, Read(result)),
             new BoundLabelStatement(null, secondExit),
-            new BoundReturnStatement(null, Read(result)),
+            new BoundReturnStatement(
+                null,
+                Binary(Read(result), SyntaxKind.PlusToken, Literal(40))),
             new BoundLabelStatement(null, returnLabel),
-            new BoundReturnStatement(null, Read(result)),
+            new BoundReturnStatement(
+                null,
+                Binary(Read(result), SyntaxKind.PlusToken, Literal(80))),
             new BoundLabelStatement(null, finallyExit),
             new BoundReturnStatement(null, Literal(-1)));
     }

--- a/test/Compiler.Tests/Emit/Issue2942ConditionalGotoFinallyFunnelTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2942ConditionalGotoFinallyFunnelTests.cs
@@ -1,0 +1,281 @@
+// <copyright file="Issue2942ConditionalGotoFinallyFunnelTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Lowering;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2942: conditional exits from protected code must run a lifted
+/// <c>finally</c> body before dispatching to their original target.
+/// No source form currently produces this shape, so these tests inject the
+/// sanctioned bound-tree regression directly into the emit pipeline.
+/// </summary>
+public class Issue2942ConditionalGotoFinallyFunnelTests
+{
+    private static readonly FieldInfo BoundProgramField = typeof(Compilation).GetField(
+        "boundProgram",
+        BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    [Theory]
+    [InlineData(true, 1)]
+    [InlineData(false, 2)]
+    public void Lowerer_FunnelsConditionalExit_AndLiftsConditionalFinallyExit(
+        bool jumpIfTrue,
+        int comparedValue)
+    {
+        var (body, tryExit, localTarget) = BuildBody(jumpIfTrue, comparedValue);
+
+        var lowered = Lowerer.Lower(body);
+        var escapingCollector = new BranchCollector(tryExit);
+        escapingCollector.VisitStatement(lowered);
+        var localCollector = new BranchCollector(localTarget);
+        localCollector.VisitStatement(lowered);
+
+        Assert.Equal(0, escapingCollector.ConditionalTargetCount);
+        Assert.Equal(0, escapingCollector.FinallyCount);
+        Assert.Equal(1, localCollector.ConditionalTargetCount);
+    }
+
+    [Theory]
+    [InlineData(true, 1, 3)]
+    [InlineData(false, 2, 3)]
+    [InlineData(true, 2, 221)]
+    [InlineData(false, 1, 221)]
+    public void EmittedConditionalExit_PreservesPolarity_EvaluatesConditionOnce_AndRunsFinally(
+        bool jumpIfTrue,
+        int comparedValue,
+        int expectedExitCode)
+    {
+        var (body, _, _) = BuildBody(jumpIfTrue, comparedValue);
+        var program = BuildProgram(Lowerer.Lower(body));
+
+        var bytes = Emit(program);
+        VerifyLoadAndRunChild(bytes, expectedExitCode);
+    }
+
+    private static (BoundBlockStatement Body, BoundLabel TryExit, BoundLabel LocalTarget) BuildBody(
+        bool jumpIfTrue,
+        int comparedValue)
+    {
+        var counter = new LocalVariableSymbol("counter", isReadOnly: false, TypeSymbol.Int32);
+        var result = new LocalVariableSymbol("result", isReadOnly: false, TypeSymbol.Int32);
+        var finallyFlag = new LocalVariableSymbol("finallyFlag", isReadOnly: false, TypeSymbol.Bool);
+        var tryExit = new BoundLabel("tryExit");
+        var finallyExit = new BoundLabel("finallyExit");
+        var localTarget = new BoundLabel("localTarget");
+
+        BoundExpression Read(VariableSymbol variable) => new BoundVariableExpression(null, variable);
+        BoundExpression Literal(int value) => new BoundLiteralExpression(null, value);
+        BoundExpression Binary(BoundExpression left, SyntaxKind kind, BoundExpression right)
+            => new BoundBinaryExpression(
+                null,
+                left,
+                BoundBinaryOperator.Bind(kind, left.Type, right.Type),
+                right);
+        BoundStatement Assign(VariableSymbol variable, BoundExpression expression)
+            => new BoundExpressionStatement(
+                null,
+                new BoundAssignmentExpression(null, variable, expression));
+
+        var incrementCounter = new BoundAssignmentExpression(
+            null,
+            counter,
+            Binary(Read(counter), SyntaxKind.PlusToken, Literal(1)));
+        var condition = Binary(
+            incrementCounter,
+            SyntaxKind.EqualsEqualsToken,
+            Literal(comparedValue));
+
+        var tryBlock = Block(
+            new BoundConditionalGotoStatement(
+                null,
+                localTarget,
+                new BoundLiteralExpression(null, true),
+                jumpIfTrue: true),
+            Assign(result, Literal(50)),
+            new BoundLabelStatement(null, localTarget),
+            new BoundConditionalGotoStatement(null, tryExit, condition, jumpIfTrue),
+            Assign(result, Literal(9)));
+        var finallyBlock = Block(
+            new BoundConditionalGotoStatement(
+                null,
+                finallyExit,
+                Read(finallyFlag),
+                jumpIfTrue: true),
+            Assign(result, Binary(Read(result), SyntaxKind.PlusToken, Literal(1))));
+
+        return (
+            Block(
+                new BoundVariableDeclaration(null, counter, Literal(0)),
+                new BoundVariableDeclaration(null, result, Literal(0)),
+                new BoundVariableDeclaration(
+                    null,
+                    finallyFlag,
+                    new BoundLiteralExpression(null, false)),
+                new BoundTryStatement(
+                    null,
+                    tryBlock,
+                    ImmutableArray<BoundCatchClause>.Empty,
+                    finallyBlock),
+                Assign(result, Binary(Read(result), SyntaxKind.PlusToken, Literal(100))),
+                new BoundLabelStatement(null, tryExit),
+                new BoundReturnStatement(
+                    null,
+                    Binary(
+                        Binary(Read(result), SyntaxKind.StarToken, Literal(2)),
+                        SyntaxKind.PlusToken,
+                        Read(counter))),
+                new BoundLabelStatement(null, finallyExit),
+                new BoundReturnStatement(null, Literal(-1))),
+            tryExit,
+            localTarget);
+    }
+
+    private static BoundProgram BuildProgram(BoundBlockStatement body)
+    {
+        var package = new PackageSymbol("Issue2942", declaration: null);
+        var entryPoint = new FunctionSymbol(
+            "Main",
+            ImmutableArray<ParameterSymbol>.Empty,
+            TypeSymbol.Int32,
+            package: package);
+        return new BoundProgram(
+            package,
+            ImmutableArray.Create(package),
+            ImmutableArray<Diagnostic>.Empty,
+            ImmutableDictionary<FunctionSymbol, BoundBlockStatement>.Empty.Add(entryPoint, body),
+            entryPoint,
+            Block());
+    }
+
+    private static byte[] Emit(BoundProgram program)
+    {
+        var compilation = new Compilation(
+            SyntaxTree.Parse(SourceText.From("package Issue2942\nfunc Placeholder() {}")));
+        BoundProgramField.SetValue(compilation, program);
+
+        using var peStream = new MemoryStream();
+        var emit = compilation.Emit(peStream);
+        Assert.True(
+            emit.Success,
+            string.Join(
+                Environment.NewLine,
+                emit.Diagnostics.Select(diagnostic => $"{diagnostic.Id}: {diagnostic.Message}")));
+        return peStream.ToArray();
+    }
+
+    private static void VerifyLoadAndRunChild(byte[] bytes, int expectedExitCode)
+    {
+        var prefix = $"Issue2942_{Guid.NewGuid():N}";
+        var directory = Directory.GetCurrentDirectory();
+        var assemblyPath = Path.Combine(directory, prefix + ".dll");
+        var runtimeConfigPath = Path.Combine(directory, prefix + ".runtimeconfig.json");
+        try
+        {
+            File.WriteAllBytes(assemblyPath, bytes);
+            File.WriteAllText(
+                runtimeConfigPath,
+                $$"""
+                  {
+                    "runtimeOptions": {
+                      "tfm": "net{{Environment.Version.Major}}.0",
+                      "framework": {
+                        "name": "Microsoft.NETCore.App",
+                        "version": "{{Environment.Version.Major}}.0.0"
+                      }
+                    }
+                  }
+                  """);
+
+            IlVerifier.Verify(assemblyPath);
+            Assert.NotEmpty(Assembly.Load(bytes).GetTypes());
+
+            var start = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            start.ArgumentList.Add("exec");
+            start.ArgumentList.Add("--runtimeconfig");
+            start.ArgumentList.Add(runtimeConfigPath);
+            start.ArgumentList.Add(assemblyPath);
+
+            using var process = Process.Start(start)!;
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            var exited = process.WaitForExit(10_000);
+            if (!exited)
+            {
+                process.Kill(entireProcessTree: true);
+                Assert.True(process.WaitForExit(5_000), "child did not stop after kill");
+            }
+
+            var stdout = stdoutTask.GetAwaiter().GetResult();
+            var stderr = stderrTask.GetAwaiter().GetResult();
+            Assert.True(exited, $"child execution timed out\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            Assert.Equal(expectedExitCode, process.ExitCode);
+            Assert.Equal(string.Empty, stdout);
+            Assert.Equal(string.Empty, stderr);
+        }
+        finally
+        {
+            File.Delete(assemblyPath);
+            File.Delete(runtimeConfigPath);
+        }
+    }
+
+    private static BoundBlockStatement Block(params BoundStatement[] statements)
+        => new(null, statements.ToImmutableArray());
+
+    private sealed class BranchCollector : BoundTreeWalker
+    {
+        private readonly BoundLabel target;
+
+        public BranchCollector(BoundLabel target)
+        {
+            this.target = target;
+        }
+
+        public int ConditionalTargetCount { get; private set; }
+
+        public int FinallyCount { get; private set; }
+
+        public override void VisitStatement(BoundStatement node)
+        {
+            if (node is BoundConditionalGotoStatement conditional
+                && ReferenceEquals(conditional.Label, target))
+            {
+                ConditionalTargetCount++;
+            }
+
+            base.VisitStatement(node);
+        }
+
+        protected override void VisitTryStatement(BoundTryStatement node)
+        {
+            if (node.FinallyBlock != null)
+            {
+                FinallyCount++;
+            }
+
+            base.VisitTryStatement(node);
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2942ConditionalGotoFinallyFunnelTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2942ConditionalGotoFinallyFunnelTests.cs
@@ -68,6 +68,29 @@ public class Issue2942ConditionalGotoFinallyFunnelTests
         VerifyLoadAndRunChild(bytes, expectedExitCode);
     }
 
+    [Fact]
+    public void EmittedCatchConditionalExit_RunsFinallyBeforeDispatch()
+    {
+        var program = BuildProgram(Lowerer.Lower(BuildCatchBody()));
+
+        var bytes = Emit(program);
+        VerifyLoadAndRunChild(bytes, expectedExitCode: 10);
+    }
+
+    [Theory]
+    [InlineData(1, 11)]
+    [InlineData(2, 21)]
+    [InlineData(3, 120)]
+    public void EmittedMultipleConditionalExits_DispatchSelectedTarget_AndRunFinallyOnce(
+        int selectedTarget,
+        int expectedExitCode)
+    {
+        var program = BuildProgram(Lowerer.Lower(BuildMultipleTargetBody(selectedTarget)));
+
+        var bytes = Emit(program);
+        VerifyLoadAndRunChild(bytes, expectedExitCode);
+    }
+
     private static (BoundBlockStatement Body, BoundLabel TryExit, BoundLabel LocalTarget) BuildBody(
         bool jumpIfTrue,
         int comparedValue)
@@ -78,19 +101,6 @@ public class Issue2942ConditionalGotoFinallyFunnelTests
         var tryExit = new BoundLabel("tryExit");
         var finallyExit = new BoundLabel("finallyExit");
         var localTarget = new BoundLabel("localTarget");
-
-        BoundExpression Read(VariableSymbol variable) => new BoundVariableExpression(null, variable);
-        BoundExpression Literal(int value) => new BoundLiteralExpression(null, value);
-        BoundExpression Binary(BoundExpression left, SyntaxKind kind, BoundExpression right)
-            => new BoundBinaryExpression(
-                null,
-                left,
-                BoundBinaryOperator.Bind(kind, left.Type, right.Type),
-                right);
-        BoundStatement Assign(VariableSymbol variable, BoundExpression expression)
-            => new BoundExpressionStatement(
-                null,
-                new BoundAssignmentExpression(null, variable, expression));
 
         var incrementCounter = new BoundAssignmentExpression(
             null,
@@ -145,6 +155,140 @@ public class Issue2942ConditionalGotoFinallyFunnelTests
             tryExit,
             localTarget);
     }
+
+    private static BoundBlockStatement BuildCatchBody()
+    {
+        var zero = new LocalVariableSymbol("zero", isReadOnly: false, TypeSymbol.Int32);
+        var result = new LocalVariableSymbol("result", isReadOnly: false, TypeSymbol.Int32);
+        var finallyFlag = new LocalVariableSymbol("finallyFlag", isReadOnly: false, TypeSymbol.Bool);
+        var caught = new LocalVariableSymbol(
+            "caught",
+            isReadOnly: true,
+            TypeSymbol.FromClrType(typeof(DivideByZeroException)));
+        var catchExit = new BoundLabel("catchExit");
+        var finallyExit = new BoundLabel("finallyExit");
+
+        var tryBlock = Block(
+            Assign(result, Binary(Literal(1), SyntaxKind.SlashToken, Read(zero))));
+        var catchBlock = Block(
+            new BoundConditionalGotoStatement(
+                null,
+                catchExit,
+                new BoundLiteralExpression(null, true),
+                jumpIfTrue: true),
+            Assign(result, Literal(99)));
+        var finallyBlock = Block(
+            new BoundConditionalGotoStatement(
+                null,
+                finallyExit,
+                Read(finallyFlag),
+                jumpIfTrue: true),
+            Assign(result, Binary(Read(result), SyntaxKind.PlusToken, Literal(3))));
+
+        return Block(
+            new BoundVariableDeclaration(null, zero, Literal(0)),
+            new BoundVariableDeclaration(null, result, Literal(7)),
+            new BoundVariableDeclaration(
+                null,
+                finallyFlag,
+                new BoundLiteralExpression(null, false)),
+            new BoundTryStatement(
+                null,
+                tryBlock,
+                ImmutableArray.Create(
+                    new BoundCatchClause(caught.Type, caught, catchBlock)),
+                finallyBlock),
+            Assign(result, Literal(100)),
+            new BoundLabelStatement(null, catchExit),
+            new BoundReturnStatement(null, Read(result)),
+            new BoundLabelStatement(null, finallyExit),
+            new BoundReturnStatement(null, Literal(-1)));
+    }
+
+    private static BoundBlockStatement BuildMultipleTargetBody(int selectedTarget)
+    {
+        var counter = new LocalVariableSymbol("counter", isReadOnly: false, TypeSymbol.Int32);
+        var result = new LocalVariableSymbol("result", isReadOnly: false, TypeSymbol.Int32);
+        var finallyFlag = new LocalVariableSymbol("finallyFlag", isReadOnly: false, TypeSymbol.Bool);
+        var firstExit = new BoundLabel("firstExit");
+        var secondExit = new BoundLabel("secondExit");
+        var returnLabel = new BoundLabel("return");
+        var finallyExit = new BoundLabel("finallyExit");
+
+        BoundExpression NextCounterEqualsSelection()
+            => Binary(
+                new BoundAssignmentExpression(
+                    null,
+                    counter,
+                    Binary(Read(counter), SyntaxKind.PlusToken, Literal(1))),
+                SyntaxKind.EqualsEqualsToken,
+                Literal(selectedTarget));
+
+        var tryBlock = Block(
+            Assign(result, Literal(10)),
+            new BoundConditionalGotoStatement(
+                null,
+                firstExit,
+                NextCounterEqualsSelection(),
+                jumpIfTrue: true),
+            Assign(result, Literal(20)),
+            new BoundConditionalGotoStatement(
+                null,
+                secondExit,
+                NextCounterEqualsSelection(),
+                jumpIfTrue: true),
+            Assign(result, Literal(119)));
+        var finallyBlock = Block(
+            new BoundConditionalGotoStatement(
+                null,
+                finallyExit,
+                Read(finallyFlag),
+                jumpIfTrue: true),
+            Assign(result, Binary(Read(result), SyntaxKind.PlusToken, Literal(1))));
+
+        return Block(
+            new BoundVariableDeclaration(null, counter, Literal(0)),
+            new BoundVariableDeclaration(null, result, Literal(0)),
+            new BoundVariableDeclaration(
+                null,
+                finallyFlag,
+                new BoundLiteralExpression(null, false)),
+            new BoundTryStatement(
+                null,
+                tryBlock,
+                ImmutableArray<BoundCatchClause>.Empty,
+                finallyBlock),
+            new BoundGotoStatement(null, returnLabel),
+            new BoundLabelStatement(null, firstExit),
+            new BoundReturnStatement(null, Read(result)),
+            new BoundLabelStatement(null, secondExit),
+            new BoundReturnStatement(null, Read(result)),
+            new BoundLabelStatement(null, returnLabel),
+            new BoundReturnStatement(null, Read(result)),
+            new BoundLabelStatement(null, finallyExit),
+            new BoundReturnStatement(null, Literal(-1)));
+    }
+
+    private static BoundExpression Read(VariableSymbol variable)
+        => new BoundVariableExpression(null, variable);
+
+    private static BoundExpression Literal(int value)
+        => new BoundLiteralExpression(null, value);
+
+    private static BoundExpression Binary(
+        BoundExpression left,
+        SyntaxKind kind,
+        BoundExpression right)
+        => new BoundBinaryExpression(
+            null,
+            left,
+            BoundBinaryOperator.Bind(kind, left.Type, right.Type),
+            right);
+
+    private static BoundStatement Assign(VariableSymbol variable, BoundExpression expression)
+        => new BoundExpressionStatement(
+            null,
+            new BoundAssignmentExpression(null, variable, expression));
 
     private static BoundProgram BuildProgram(BoundBlockStatement body)
     {


### PR DESCRIPTION
Fixes #2942

## Chosen fork

Implemented `FinallyExitRewriter.ExitFunneler.RewriteConditionalGotoStatement`.

The rewrite mirrors the established protected-region and async-finally funnels:

1. branch to a local skip label on the inverse of `JumpIfTrue`;
2. assign the target discriminator;
3. jump to the lifted finally tail;
4. dispatch to the original target after the finally body.

This evaluates the original condition exactly once and preserves both true and false polarity.

## Producer proof

Every `BoundConditionalGotoStatement` construction site was classified:

- statement binder loop conditions (`while`, `for`, `do`): target labels remain inside the same lowered loop;
- ordinary lowerer (`if`, ranges, `foreach`, async-foreach): targets are local body/end labels in the same generated block;
- interpolated-string handler gating: local append-end labels, introduced after this pass;
- protected-region/finally rewriters: internal routing, rethrow, and dispatch labels;
- ordinary iterator builder: it assembles dispatch before its final `Lowerer.Lower`; the outer dispatch is outside the user try, while inner dispatch labels stay inside that same try, so `ContainsLabel` makes the funnel decline;
- async and async-iterator builders/spillers: ordinary body lowering, including `FinallyExitRewriter`, runs before state-machine assembly, so it never sees generated async dispatch; generated async exception handling has its own equivalent conditional funnel;
- `StateMachineEmitter`: emit-time state dispatch;
- `ControlFlowGraph`: analysis-only synthetic branches;
- `BoundTreeRewriter`: copies existing nodes rather than producing a new target relationship.

Source attempts covered goto from finally inside loops, nested try/finally, an enclosing switch arm, and break/continue/labeled goto combinations. Their lowered trees use an inverse conditional jump to a local skip label plus an unconditional escaping goto. Disabling the new conditional funnel changed none of their outputs. No source-level producer was found, so the regression constructs the sanctioned bound-tree shape directly.

## Regression and runtime evidence

The direct tree contains:

- an internal conditional target, proving it must not be funnelled;
- an escaping conditional target in the protected try;
- a conditional escape in the finally, forcing the handler lift;
- side-effecting conditions for taken/not-taken true and false polarity.

All emitted cases run through `IlVerifier`, `Assembly.Load(bytes).GetTypes()`, then bounded child-process execution with both pipes drained asynchronously.

Known-bad controls:

- disabling the conditional funnel remained IL-valid and loadable, but child execution returned `1` instead of `3`, proving the lifted finally was skipped;
- disabling conditional-branch detection produced `ILVerify LeaveOutOfFinally`.

## Mutation matrix

Re-measured serially against the 10-test file. Clean control passed 10/10 before the matrix and again after every mutant was restored. Every row examined all 10 issue tests.

| Mutation | Semantic branch | Result |
|---|---|---:|
| Internal-target guard removed | preserve internal target | 4 failed |
| M-A: conditional funnel forced to a no-op | funnel escaping targets | 7 failed |
| Inverse polarity removed | preserve polarity | 8 failed |
| Condition replaced with a constant | preserve condition value | 6 failed |
| Condition evaluated twice | evaluate condition once | 6 failed |
| Discriminator assignment forced to zero | assign discriminator | 5 failed |
| Tail transfer redirected to the skip label | transfer to finally tail | 5 failed |
| Not-taken branch redirected to the tail | preserve not-taken skip path | 4 failed |
| Conditional branches omitted from analysis | detector records conditional branches | 10 failed |
| M-B: every discriminator routed to the first arm | select the matching target | 1 failed |

## Verification

Base: `210126dd90f4ab3edbe1b7f9219946594685afc7`

Executed counts from the base push run and this PR run, on the same base:

| Suite | Base | Head |
|---|---:|---:|
| Core | 7029 passed, 1 skipped | 7029 passed, 1 skipped |
| Compiler | 3952 passed | 3962 passed |
| Interpreter | 494 passed | 494 passed |
| Language Server | 452 passed | 452 passed |

Local final-head issue suite: 10/10 passed. Release solution build with warnings as errors: 0 warnings, 0 errors. All PR checks pass.

Corpus: 148 files, 139 emitted on both base and head, 0 diagnostic differences, 0 byte differences. Source-level `goto` usage is 0/148; the only textual occurrence is in a comment. Corpus therefore carries no direct signal for this bug.







