### PR TITLE
Lower yield in function-literal iterator bodies

### DIFF
--- a/src/Core/CodeAnalysis/Emit/GenericRemapState.cs
+++ b/src/Core/CodeAnalysis/Emit/GenericRemapState.cs
@@ -233,6 +233,11 @@ internal sealed class GenericRemapState
         this.lambdaMethodTypeParamRemapsByFunction[function] = remap;
     }
 
+    internal bool TryGetLambdaMethodRemap(
+        FunctionSymbol function,
+        out Dictionary<TypeParameterSymbol, int> remap)
+        => this.lambdaMethodTypeParamRemapsByFunction.TryGetValue(function, out remap);
+
     internal readonly struct SmRemapScope : IDisposable
     {
         private readonly GenericRemapState owner;

--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -279,6 +279,7 @@ internal sealed class ImportedMemberRefFactory
             // active remap (class or method) maps to the synthesized class's
             // own VAR(idx) slot.
             if (this.remaps.ActiveIteratorStateMachineRemap != null
+                && tpSym.IsMethodTypeParameter
                 && this.remaps.ActiveIteratorStateMachineRemap.TryGetValue(tpSym, out var smClassOrd))
             {
                 encoder.GenericTypeParameter(smClassOrd);

--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -274,10 +274,6 @@ internal sealed class ImportedMemberRefFactory
 
             // Issue #810: inside an iterator state-machine method body,
             // outer-method TPs are remapped to the SM class's own TPs.
-            // Issue #1477: a synthesized closure / capture-box class is also
-            // generic over enclosing TYPE parameters, so any TP present in the
-            // active remap (class or method) maps to the synthesized class's
-            // own VAR(idx) slot.
             if (this.remaps.ActiveIteratorStateMachineRemap != null
                 && tpSym.IsMethodTypeParameter
                 && this.remaps.ActiveIteratorStateMachineRemap.TryGetValue(tpSym, out var smClassOrd))
@@ -291,6 +287,13 @@ internal sealed class ImportedMemberRefFactory
                 // generic-promoted non-capturing lambda's signature/body maps to
                 // the lambda method's own MVar(idx) slot.
                 encoder.GenericMethodTypeParameter(lambdaMethodOrd);
+            }
+            else if (this.remaps.ActiveIteratorStateMachineRemap != null
+                && this.remaps.ActiveIteratorStateMachineRemap.TryGetValue(tpSym, out var smClassOrd2))
+            {
+                // Issue #1477: synthesized closure, capture-box, and nested-type
+                // remaps still map class type parameters to their own VAR slots.
+                encoder.GenericTypeParameter(smClassOrd2);
             }
             else if (tpSym.IsMethodTypeParameter)
             {

--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -278,18 +278,18 @@ internal sealed class ImportedMemberRefFactory
             // generic over enclosing TYPE parameters, so any TP present in the
             // active remap (class or method) maps to the synthesized class's
             // own VAR(idx) slot.
-            if (this.remaps.ActiveLambdaMethodTypeParamRemap != null
+            if (this.remaps.ActiveIteratorStateMachineRemap != null
+                && this.remaps.ActiveIteratorStateMachineRemap.TryGetValue(tpSym, out var smClassOrd))
+            {
+                encoder.GenericTypeParameter(smClassOrd);
+            }
+            else if (this.remaps.ActiveLambdaMethodTypeParamRemap != null
                 && this.remaps.ActiveLambdaMethodTypeParamRemap.TryGetValue(tpSym, out var lambdaMethodOrd))
             {
                 // Issue #2118: reference to an enclosing type parameter inside a
                 // generic-promoted non-capturing lambda's signature/body maps to
                 // the lambda method's own MVar(idx) slot.
                 encoder.GenericMethodTypeParameter(lambdaMethodOrd);
-            }
-            else if (this.remaps.ActiveIteratorStateMachineRemap != null
-                && this.remaps.ActiveIteratorStateMachineRemap.TryGetValue(tpSym, out var smClassOrd))
-            {
-                encoder.GenericTypeParameter(smClassOrd);
             }
             else if (tpSym.IsMethodTypeParameter)
             {

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1208,20 +1208,22 @@ internal sealed class ReflectionMetadataEmitter
 
         this.closures.SynthesizeClosures(lambdaLiterals, hostPackageGuess);
 
-        // Generic iterator literals need their lambda-method type parameters
-        // before state-machine synthesis so the state machine mirrors them.
+        // Lower non-capturing literals once so iterator plans and emitted bodies
+        // share the same synthesized local symbols.
         foreach (var literal in lambdaLiterals)
         {
             if (literal.CapturedVariables.Length == 0
                 && !this.closures.ClosureInfos.ContainsKey(literal))
             {
+                var body = (BoundBlockStatement)Lowerer.Lower(literal.Body);
+                this.lambdaBodies[literal.Function] = body;
                 this.userTokens.TryPromoteNonCapturingGenericLambda(
                     literal,
-                    (BoundBlockStatement)Lowerer.Lower(literal.Body));
+                    body);
             }
         }
 
-        this.RetargetCapturedIteratorPlans(lambdaLiterals);
+        this.RetargetIteratorPlans(lambdaLiterals);
         this.closures.SynthesizeGoClosures(goStatements, hostPackageGuess);
         this.stateMachines.SynthesizeIteratorStateMachines(hostPackageGuess);
         this.stateMachines.SynthesizeAsyncIteratorStateMachines(hostPackageGuess);
@@ -1230,7 +1232,7 @@ internal sealed class ReflectionMetadataEmitter
         return lambdaLiterals;
     }
 
-    private void RetargetCapturedIteratorPlans(List<BoundFunctionLiteralExpression> lambdaLiterals)
+    private void RetargetIteratorPlans(List<BoundFunctionLiteralExpression> lambdaLiterals)
     {
         if (this.stateMachines.IteratorPlans.IsDefaultOrEmpty)
         {
@@ -1240,9 +1242,10 @@ internal sealed class ReflectionMetadataEmitter
         var plans = this.stateMachines.IteratorPlans.ToBuilder();
         foreach (var literal in lambdaLiterals)
         {
-            if (!this.closures.ClosureInfos.TryGetValue(literal, out var closure))
+            var function = literal.Function;
+            if (this.closures.ClosureInfos.TryGetValue(literal, out var closure))
             {
-                continue;
+                function = closure.InvokeMethod;
             }
 
             for (var i = 0; i < plans.Count; i++)
@@ -1252,8 +1255,8 @@ internal sealed class ReflectionMetadataEmitter
                     continue;
                 }
 
-                var body = this.lambdaBodies[closure.InvokeMethod];
-                if (IteratorRewriter.TryBuildPlan(closure.InvokeMethod, body, out var plan))
+                var body = this.lambdaBodies[function];
+                if (IteratorRewriter.TryBuildPlan(function, body, out var plan))
                 {
                     plans[i] = plan;
                 }
@@ -2920,9 +2923,6 @@ internal sealed class ReflectionMetadataEmitter
                 {
                     continue;
                 }
-
-                var loweredLambdaBody = (BoundBlockStatement)Lowerer.Lower(literal.Body);
-                this.lambdaBodies[literal.Function] = loweredLambdaBody;
 
                 hostBucket.Add(literal.Function);
             }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1205,13 +1205,64 @@ internal sealed class ReflectionMetadataEmitter
         var hostPackageGuess = this.emitCtx.Program.EntryPoint?.Package
             ?? this.emitCtx.Program.EntryPointPackage
             ?? (this.emitCtx.Program.Packages.IsDefaultOrEmpty ? null : this.emitCtx.Program.Packages[0]);
+
         this.closures.SynthesizeClosures(lambdaLiterals, hostPackageGuess);
+
+        // Generic iterator literals need their lambda-method type parameters
+        // before state-machine synthesis so the state machine mirrors them.
+        foreach (var literal in lambdaLiterals)
+        {
+            if (literal.CapturedVariables.Length == 0
+                && !this.closures.ClosureInfos.ContainsKey(literal))
+            {
+                this.userTokens.TryPromoteNonCapturingGenericLambda(
+                    literal,
+                    (BoundBlockStatement)Lowerer.Lower(literal.Body));
+            }
+        }
+
+        this.RetargetCapturedIteratorPlans(lambdaLiterals);
         this.closures.SynthesizeGoClosures(goStatements, hostPackageGuess);
         this.stateMachines.SynthesizeIteratorStateMachines(hostPackageGuess);
         this.stateMachines.SynthesizeAsyncIteratorStateMachines(hostPackageGuess);
         this.stateMachines.SynthesizeAsyncLambdaStateMachines(lambdaLiterals, hostPackageGuess);
 
         return lambdaLiterals;
+    }
+
+    private void RetargetCapturedIteratorPlans(List<BoundFunctionLiteralExpression> lambdaLiterals)
+    {
+        if (this.stateMachines.IteratorPlans.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var plans = this.stateMachines.IteratorPlans.ToBuilder();
+        foreach (var literal in lambdaLiterals)
+        {
+            if (!this.closures.ClosureInfos.TryGetValue(literal, out var closure))
+            {
+                continue;
+            }
+
+            for (var i = 0; i < plans.Count; i++)
+            {
+                if (!ReferenceEquals(plans[i].Function, literal.Function))
+                {
+                    continue;
+                }
+
+                var body = this.lambdaBodies[closure.InvokeMethod];
+                if (IteratorRewriter.TryBuildPlan(closure.InvokeMethod, body, out var plan))
+                {
+                    plans[i] = plan;
+                }
+
+                break;
+            }
+        }
+
+        this.stateMachines.IteratorPlans = plans.ToImmutable();
     }
 
     private void RegisterGeneratedGenericRemaps()
@@ -1224,6 +1275,17 @@ internal sealed class ReflectionMetadataEmitter
         foreach (var kvp in this.stateMachines.IteratorStateMachineInfos)
         {
             var remap = kvp.Value.BuildRemap();
+            if (this.remaps.TryGetLambdaMethodRemap(kvp.Value.Plan.Function, out var lambdaRemap))
+            {
+                remap ??= new Dictionary<TypeParameterSymbol, int>();
+                var offset = kvp.Value.ClassTypeParameters.Length
+                    - kvp.Value.OuterMethodTypeParameters.Length;
+                foreach (var pair in lambdaRemap)
+                {
+                    remap[pair.Key] = offset + pair.Value;
+                }
+            }
+
             if (remap != null)
             {
                 this.remaps.RegisterClassRemap(kvp.Key, remap);
@@ -2861,16 +2923,6 @@ internal sealed class ReflectionMetadataEmitter
 
                 var loweredLambdaBody = (BoundBlockStatement)Lowerer.Lower(literal.Body);
                 this.lambdaBodies[literal.Function] = loweredLambdaBody;
-
-                // Issue #2118: a non-capturing lambda hosted as a top-level
-                // <Program> static method must be promoted to a GENERIC method
-                // declaring its own type parameters (cloned, with constraints,
-                // from the enclosing type parameters its signature/body
-                // references) — otherwise its body's `!!0`/`!0` references a
-                // type parameter the method never declares, producing
-                // unverifiable IL (DelegateCtor at the delegate site and
-                // StackUnexpected on any `constrained.` call in the body).
-                this.userTokens.TryPromoteNonCapturingGenericLambda(literal, loweredLambdaBody);
 
                 hostBucket.Add(literal.Function);
             }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -1281,8 +1281,8 @@ internal sealed class ReflectionMetadataEmitter
             if (this.remaps.TryGetLambdaMethodRemap(kvp.Value.Plan.Function, out var lambdaRemap))
             {
                 remap ??= new Dictionary<TypeParameterSymbol, int>();
-                var offset = kvp.Value.ClassTypeParameters.Length
-                    - kvp.Value.OuterMethodTypeParameters.Length;
+                var offset = kvp.Value.SourceTypeParameters.Length
+                    - kvp.Value.Plan.Function.TypeParameters.Length;
                 foreach (var pair in lambdaRemap)
                 {
                     remap[pair.Key] = offset + pair.Value;

--- a/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
@@ -273,15 +273,6 @@ internal sealed class SignatureEncoder
                 encoder.GenericTypeParameter(classOrdinal);
             }
 
-            // Issue #1477: a synthesized closure / capture-box class is generic
-            // over enclosing TYPE parameters too, so any TP in the active remap
-            // (class or method) encodes the synthesized class's own Var(idx).
-            else if (this.remaps.ActiveIteratorStateMachineRemap != null
-                && this.remaps.ActiveIteratorStateMachineRemap.TryGetValue(tp, out var classOrdinal2))
-            {
-                encoder.GenericTypeParameter(classOrdinal2);
-            }
-
             // Issue #2118: inside a generic-promoted non-capturing lambda's
             // signature/body, references to the enclosing type parameters map to
             // the lambda method's own MVar(idx) slots.
@@ -289,6 +280,15 @@ internal sealed class SignatureEncoder
                 && this.remaps.ActiveLambdaMethodTypeParamRemap.TryGetValue(tp, out var lambdaMethodOrd))
             {
                 encoder.GenericMethodTypeParameter(lambdaMethodOrd);
+            }
+
+            // Issue #1477: a synthesized closure / capture-box class is generic
+            // over enclosing TYPE parameters too, so any remaining TP in the
+            // active remap encodes the synthesized class's own Var(idx).
+            else if (this.remaps.ActiveIteratorStateMachineRemap != null
+                && this.remaps.ActiveIteratorStateMachineRemap.TryGetValue(tp, out var classOrdinal2))
+            {
+                encoder.GenericTypeParameter(classOrdinal2);
             }
 
             // ADR-0087 §3 R2: a user-declared open type parameter encodes as

--- a/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/SignatureEncoder.cs
@@ -258,15 +258,6 @@ internal sealed class SignatureEncoder
         }
         else if (type is TypeParameterSymbol tp)
         {
-            // Issue #2118: inside a generic-promoted non-capturing lambda's
-            // signature/body, references to the enclosing type parameters map to
-            // the lambda method's own MVar(idx) slots.
-            if (this.remaps.ActiveLambdaMethodTypeParamRemap != null
-                && this.remaps.ActiveLambdaMethodTypeParamRemap.TryGetValue(tp, out var lambdaMethodOrd))
-            {
-                encoder.GenericMethodTypeParameter(lambdaMethodOrd);
-            }
-
             // Issue #810: when emitting a state-machine method (or the
             // state-machine class itself), references to the OUTER
             // method's type parameters are encoded as the SM class's
@@ -275,7 +266,7 @@ internal sealed class SignatureEncoder
             // `!0` on the SM class. The remap is pushed by
             // EmitIteratorStateMachineMember and is keyed by the
             // method TP's instance identity.
-            else if (this.remaps.ActiveIteratorStateMachineRemap != null
+            if (this.remaps.ActiveIteratorStateMachineRemap != null
                 && tp.IsMethodTypeParameter
                 && this.remaps.ActiveIteratorStateMachineRemap.TryGetValue(tp, out var classOrdinal))
             {
@@ -289,6 +280,15 @@ internal sealed class SignatureEncoder
                 && this.remaps.ActiveIteratorStateMachineRemap.TryGetValue(tp, out var classOrdinal2))
             {
                 encoder.GenericTypeParameter(classOrdinal2);
+            }
+
+            // Issue #2118: inside a generic-promoted non-capturing lambda's
+            // signature/body, references to the enclosing type parameters map to
+            // the lambda method's own MVar(idx) slots.
+            else if (this.remaps.ActiveLambdaMethodTypeParamRemap != null
+                && this.remaps.ActiveLambdaMethodTypeParamRemap.TryGetValue(tp, out var lambdaMethodOrd))
+            {
+                encoder.GenericMethodTypeParameter(lambdaMethodOrd);
             }
 
             // ADR-0087 §3 R2: a user-declared open type parameter encodes as

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -877,12 +877,7 @@ public sealed partial class Evaluator
     }
 
     private object InvokeMaterializedClosure(ClosureValue closure, object[] arguments)
-    {
-        var result = InvokeClosure(closure, arguments);
-        return closure.Function.IsAsync
-            ? WrapAsyncResult(closure.Function.Type, result)
-            : result;
-    }
+        => InvokeClosure(closure, arguments);
 
     private object InvokeClosure(ClosureValue closure, object[] arguments)
     {
@@ -899,7 +894,7 @@ public sealed partial class Evaluator
 
         using (PushFrame(frame))
         {
-            return EvaluateFunctionBody(closure.Body);
+            return EvaluateUserMethodBody(closure.Function, closure.Body);
         }
     }
 

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
@@ -36,34 +36,47 @@ public static class IteratorRewriter
         }
 
         var plans = ImmutableArray.CreateBuilder<IteratorStateMachinePlan>();
+        var nestedCollector = new NestedIteratorCollector(plans);
 
         foreach (var pair in program.Functions.OrderBy(p => p.Key.Name, StringComparer.Ordinal))
         {
             var function = pair.Key;
             var body = pair.Value;
 
-            if (!IteratorDetection.ContainsYield(body))
-            {
-                continue;
-            }
-
-            // Skip async iterators — they go through the async iterator rewriter path.
-            if (AsyncIteratorDetection.IsAsyncIteratorFunction(function, body))
-            {
-                continue;
-            }
-
-            var elementType = GetIteratorElementType(function.Type);
-            if (elementType == null)
-            {
-                continue;
-            }
-
-            var plan = BuildPlan(function, body, elementType);
-            plans.Add(plan);
+            AddPlan(function, body, plans);
+            nestedCollector.RewriteStatement(body);
         }
 
         return new IteratorRewriteResult(program, plans.ToImmutable());
+    }
+
+    internal static bool TryBuildPlan(
+        FunctionSymbol function,
+        BoundBlockStatement body,
+        out IteratorStateMachinePlan plan)
+    {
+        var elementType = GetIteratorElementType(function.Type);
+        if (!IteratorDetection.ContainsYield(body)
+            || AsyncIteratorDetection.IsAsyncIteratorFunction(function, body)
+            || elementType == null)
+        {
+            plan = null;
+            return false;
+        }
+
+        plan = BuildPlan(function, body, elementType);
+        return true;
+    }
+
+    private static void AddPlan(
+        FunctionSymbol function,
+        BoundBlockStatement body,
+        ImmutableArray<IteratorStateMachinePlan>.Builder plans)
+    {
+        if (TryBuildPlan(function, body, out var plan))
+        {
+            plans.Add(plan);
+        }
     }
 
     private static TypeSymbol GetIteratorElementType(TypeSymbol type)
@@ -138,6 +151,22 @@ public static class IteratorRewriter
         var collector = new LocalCollector();
         collector.Visit(body);
         return collector.Locals.ToImmutableArray();
+    }
+
+    private sealed class NestedIteratorCollector : NestedFunctionBodyRewriter
+    {
+        private readonly ImmutableArray<IteratorStateMachinePlan>.Builder plans;
+
+        public NestedIteratorCollector(ImmutableArray<IteratorStateMachinePlan>.Builder plans)
+        {
+            this.plans = plans;
+        }
+
+        protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+        {
+            AddPlan(node.Function, node.Body, this.plans);
+            return base.RewriteFunctionLiteralExpression(node);
+        }
     }
 
     private sealed class YieldStateCollector : BoundTreeWalker

--- a/test/Compiler.Tests/Emit/Issue2957FunctionLiteralIteratorTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2957FunctionLiteralIteratorTests.cs
@@ -69,7 +69,7 @@ public sealed class Issue2957FunctionLiteralIteratorTests
             "4\n4\n5\n");
 
         yield return Case(
-            "GenericElementType",
+            "GenericStateMachineSignatureRemap",
             """
             package Generic
             import System
@@ -83,6 +83,81 @@ public sealed class Issue2957FunctionLiteralIteratorTests
             }
             """,
             "ok\n");
+
+        yield return Case(
+            "LoweredForInEnumerator",
+            """
+            package ForIn
+            import System
+
+            let values = func() sequence[int32] {
+                for value in []int32{4, 5} {
+                    yield value
+                }
+            }
+
+            for value in values() {
+                Console.WriteLine(value)
+            }
+            """,
+            "4\n5\n");
+
+        yield return Case(
+            "LoweredForInEnumeratorWithCapture",
+            """
+            package ForInCapture
+            import System
+
+            func make(offset int32) () -> sequence[int32] {
+                return func() sequence[int32] {
+                    for value in []int32{4, 5} {
+                        yield offset + value
+                    }
+                }
+            }
+
+            for value in make(100)() {
+                Console.WriteLine(value)
+            }
+            """,
+            "104\n105\n");
+
+        yield return Case(
+            "LoweredForEllipsisCounter",
+            """
+            package ForEllipsis
+            import System
+
+            let values = func() sequence[int32] {
+                for value in 0 ... 2 {
+                    yield value
+                }
+            }
+
+            for value in values() {
+                Console.WriteLine(value)
+            }
+            """,
+            "0\n1\n");
+
+        yield return Case(
+            "GenericStateMachineElementTokenRemap",
+            """
+            package GenericToken
+            import System
+
+            func make[T any]() (T) -> sequence[T] {
+                return func(value T) sequence[T] {
+                    let copy = []T{value}
+                    yield copy[0]
+                }
+            }
+
+            for value in make[int32]()(42) {
+                Console.WriteLine(value)
+            }
+            """,
+            "42\n");
 
         yield return Case(
             "ImmediatelyInvoked",

--- a/test/Compiler.Tests/Emit/Issue2957FunctionLiteralIteratorTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2957FunctionLiteralIteratorTests.cs
@@ -1,0 +1,198 @@
+// <copyright file="Issue2957FunctionLiteralIteratorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2957: iterator function literals must receive iterator state-machine
+/// plans before their hosted bodies reach emission.
+/// </summary>
+public sealed class Issue2957FunctionLiteralIteratorTests
+{
+    public static IEnumerable<object[]> Cases()
+    {
+        yield return Case(
+            "ExactRepro",
+            """
+            package Repro
+            import System
+
+            let values = func() sequence[int32] { yield 2 }
+            for value in values() {
+                Console.WriteLine(value)
+            }
+            """,
+            "2\n");
+
+        yield return Case(
+            "NestedLiteral",
+            """
+            package Nested
+            import System
+
+            let outer = func() () -> sequence[int32] {
+                return func() sequence[int32] { yield 3 }
+            }
+
+            for value in outer()() {
+                Console.WriteLine(value)
+            }
+            """,
+            "3\n");
+
+        yield return Case(
+            "CapturedLocalAcrossYield",
+            """
+            package Capture
+            import System
+
+            func make(start int32) () -> sequence[int32] {
+                return func() sequence[int32] {
+                    yield start
+                    Console.WriteLine(start)
+                    yield start + 1
+                }
+            }
+
+            for value in make(4)() {
+                Console.WriteLine(value)
+            }
+            """,
+            "4\n4\n5\n");
+
+        yield return Case(
+            "GenericElementType",
+            """
+            package Generic
+            import System
+
+            func make[T any]() (T) -> sequence[T] {
+                return func(value T) sequence[T] { yield value }
+            }
+
+            for value in make[string]()("ok") {
+                Console.WriteLine(value)
+            }
+            """,
+            "ok\n");
+
+        yield return Case(
+            "ImmediatelyInvoked",
+            """
+            package Immediate
+            import System
+
+            for value in (func() sequence[int32] { yield 7 })() {
+                Console.WriteLine(value)
+            }
+            """,
+            "7\n");
+
+        yield return Case(
+            "NamedFunctionGuard",
+            """
+            package Named
+            import System
+
+            func values() sequence[int32] { yield 9 }
+            for value in values() {
+                Console.WriteLine(value)
+            }
+            """,
+            "9\n");
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void IteratorLiteral_LoadsAndRuns(string name, string source, string expectedOutput)
+    {
+        var assemblyPath = Compile(name, source);
+        IlVerifier.Verify(assemblyPath);
+        Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+        Assert.Equal(expectedOutput, RunBounded(name, assemblyPath));
+    }
+
+    private static object[] Case(string name, string source, string expectedOutput)
+        => new object[] { name, source, expectedOutput };
+
+    private static string Compile(string name, string source)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue2957FunctionLiteralIteratorTests),
+            name);
+        Directory.CreateDirectory(directory);
+
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var assemblyPath = Path.Combine(directory, "test.dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(exitCode == 0, $"{name}: gsc failed:\n{stdout}\n{stderr}");
+        return assemblyPath;
+    }
+
+    private static string RunBounded(string name, string assemblyPath)
+    {
+        using var process = Process.Start(new ProcessStartInfo("dotnet")
+        {
+            ArgumentList =
+            {
+                "exec",
+                "--runtimeconfig",
+                Path.ChangeExtension(assemblyPath, ".runtimeconfig.json"),
+                assemblyPath,
+            },
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        });
+
+        Assert.NotNull(process);
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        var exited = process.WaitForExit(5_000);
+        if (!exited)
+        {
+            process.Kill(entireProcessTree: true);
+            Assert.True(process.WaitForExit(5_000), $"{name}: child did not stop after kill");
+        }
+
+        var stdout = stdoutTask.GetAwaiter().GetResult().Replace("\r\n", "\n", StringComparison.Ordinal);
+        var stderr = stderrTask.GetAwaiter().GetResult();
+        Assert.True(exited, $"{name}: emitted program timed out");
+        Assert.True(process.ExitCode == 0, $"{name}: emitted program failed:\n{stderr}");
+        return stdout;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/GenericRemapPrecedenceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/GenericRemapPrecedenceTests.cs
@@ -1,0 +1,135 @@
+// <copyright file="GenericRemapPrecedenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Emit;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+public sealed class GenericRemapPrecedenceTests
+{
+    private static readonly PackageSymbol Package = new PackageSymbol("main", declaration: null);
+
+    [Fact]
+    public void ImportedElementToken_MethodTypeParameter_PrefersStateMachineRemap()
+    {
+        var typeParameter = new TypeParameterSymbol(
+            "T",
+            0,
+            TypeParameterConstraint.Any,
+            TypeParameterVariance.None)
+        {
+            IsMethodTypeParameter = true,
+        };
+
+        AssertEncoding(
+            typeParameter,
+            SignatureTypeCode.GenericTypeParameter,
+            expectedOrdinal: 1);
+    }
+
+    [Fact]
+    public void ImportedElementToken_ClassTypeParameter_UsesLambdaRemap()
+    {
+        var typeParameter = new TypeParameterSymbol(
+            "T",
+            0,
+            TypeParameterConstraint.Any,
+            TypeParameterVariance.None);
+
+        AssertEncoding(
+            typeParameter,
+            SignatureTypeCode.GenericMethodParameter,
+            expectedOrdinal: 2);
+    }
+
+    private static void AssertEncoding(
+        TypeParameterSymbol typeParameter,
+        SignatureTypeCode expectedCode,
+        int expectedOrdinal)
+    {
+        var emitter = CreateEmitter();
+        var stateMachine = new StructSymbol(
+            "StateMachine",
+            ImmutableArray<FieldSymbol>.Empty,
+            Accessibility.Internal,
+            declaration: null,
+            packageName: Package.Name,
+            isData: false,
+            isInline: false,
+            isClass: true);
+        var lambda = new FunctionSymbol(
+            "lambda",
+            ImmutableArray<ParameterSymbol>.Empty,
+            TypeSymbol.Void,
+            package: Package);
+
+        emitter.remaps.RegisterClassRemap(
+            stateMachine,
+            new Dictionary<TypeParameterSymbol, int> { [typeParameter] = 1 });
+        emitter.remaps.RegisterLambdaMethodRemap(
+            lambda,
+            new Dictionary<TypeParameterSymbol, int> { [typeParameter] = 2 });
+
+        emitter.emitCtx.Metadata.AddModule(
+            0,
+            emitter.emitCtx.Metadata.GetOrAddString("test"),
+            emitter.emitCtx.Metadata.GetOrAddGuid(Guid.Empty),
+            default,
+            default);
+
+        EntityHandle handle;
+        using (emitter.remaps.PushLambdaMethodRemap(lambda))
+        using (emitter.remaps.PushSmRemap(stateMachine))
+        {
+            handle = emitter.memberRefs.GetElementTypeToken(typeParameter);
+        }
+
+        var metadata = new BlobBuilder();
+        new MetadataRootBuilder(emitter.emitCtx.Metadata).Serialize(metadata, 0, 0);
+
+        using var provider = MetadataReaderProvider.FromMetadataImage(metadata.ToImmutableArray());
+        var reader = provider.GetMetadataReader();
+        var specification = reader.GetTypeSpecification((TypeSpecificationHandle)handle);
+        var signature = reader.GetBlobReader(specification.Signature);
+
+        Assert.Equal(expectedCode, signature.ReadSignatureTypeCode());
+        Assert.Equal(expectedOrdinal, signature.ReadCompressedInteger());
+    }
+
+    private static ReflectionMetadataEmitter CreateEmitter()
+    {
+        var program = new BoundProgram(
+            Package,
+            ImmutableArray.Create(Package),
+            ImmutableArray<Diagnostic>.Empty,
+            ImmutableDictionary<FunctionSymbol, BoundBlockStatement>.Empty,
+            entryPoint: null,
+            statement: new BoundBlockStatement(null, ImmutableArray<BoundStatement>.Empty),
+            structs: ImmutableArray<StructSymbol>.Empty,
+            interfaces: ImmutableArray<InterfaceSymbol>.Empty);
+        var constructor = typeof(ReflectionMetadataEmitter)
+            .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+            .Single();
+
+        return (ReflectionMetadataEmitter)constructor.Invoke(new object[]
+        {
+            program,
+            ReferenceResolver.Default(),
+            "GenericRemapPrecedenceTests",
+            false,
+            null,
+        });
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Iterators/IteratorRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Iterators/IteratorRewriterTests.cs
@@ -139,6 +139,83 @@ public class IteratorRewriterTests
     }
 
     [Fact]
+    public void Rewrite_FunctionLiteralYield_CreatesIteratorPlan()
+    {
+        var sequenceType = SequenceTypeSymbol.Get(TypeSymbol.Int32);
+        var literalFunction = new FunctionSymbol(
+            "literal",
+            ImmutableArray<ParameterSymbol>.Empty,
+            sequenceType,
+            package: Package);
+        var functionType = FunctionTypeSymbol.Get(ImmutableArray<TypeSymbol>.Empty, sequenceType);
+        var yield = new BoundYieldStatement(null, new BoundLiteralExpression(null, 1));
+        var literal = new BoundFunctionLiteralExpression(
+            null,
+            literalFunction,
+            functionType,
+            Block(yield),
+            ImmutableArray<VariableSymbol>.Empty);
+        var variable = new LocalVariableSymbol("values", isReadOnly: true, functionType);
+        var rootFunction = new FunctionSymbol(
+            "root",
+            ImmutableArray<ParameterSymbol>.Empty,
+            TypeSymbol.Void,
+            package: Package);
+
+        var result = IteratorRewriter.Rewrite(MakeProgram(
+            rootFunction,
+            Block(new BoundVariableDeclaration(null, variable, literal))));
+
+        var plan = Assert.Single(result.Plans);
+        Assert.Same(literalFunction, plan.Function);
+        Assert.Equal(1, plan.YieldStates[yield]);
+    }
+
+    [Fact]
+    public void Rewrite_NestedFunctionLiteralYield_CreatesDeepIteratorPlan()
+    {
+        var sequenceType = SequenceTypeSymbol.Get(TypeSymbol.Int32);
+        var innerFunction = new FunctionSymbol(
+            "inner",
+            ImmutableArray<ParameterSymbol>.Empty,
+            sequenceType,
+            package: Package);
+        var innerType = FunctionTypeSymbol.Get(ImmutableArray<TypeSymbol>.Empty, sequenceType);
+        var yield = new BoundYieldStatement(null, new BoundLiteralExpression(null, 1));
+        var innerLiteral = new BoundFunctionLiteralExpression(
+            null,
+            innerFunction,
+            innerType,
+            Block(yield),
+            ImmutableArray<VariableSymbol>.Empty);
+
+        var outerFunction = new FunctionSymbol(
+            "outer",
+            ImmutableArray<ParameterSymbol>.Empty,
+            innerType,
+            package: Package);
+        var outerType = FunctionTypeSymbol.Get(ImmutableArray<TypeSymbol>.Empty, innerType);
+        var outerLiteral = new BoundFunctionLiteralExpression(
+            null,
+            outerFunction,
+            outerType,
+            Block(new BoundReturnStatement(null, innerLiteral)),
+            ImmutableArray<VariableSymbol>.Empty);
+        var variable = new LocalVariableSymbol("factory", isReadOnly: true, outerType);
+        var rootFunction = new FunctionSymbol(
+            "root",
+            ImmutableArray<ParameterSymbol>.Empty,
+            TypeSymbol.Void,
+            package: Package);
+
+        var result = IteratorRewriter.Rewrite(MakeProgram(
+            rootFunction,
+            Block(new BoundVariableDeclaration(null, variable, outerLiteral))));
+
+        Assert.Same(innerFunction, Assert.Single(result.Plans).Function);
+    }
+
+    [Fact]
     public void Detection_TraversesBranchesAndTryFinally_ButNotNestedFunctions()
     {
         var yield = new BoundYieldStatement(null, new BoundLiteralExpression(null, 1));

--- a/test/Interpreter.Tests/Issue2976FunctionLiteralIteratorInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2976FunctionLiteralIteratorInterpreterTests.cs
@@ -62,6 +62,20 @@ public sealed class Issue2976FunctionLiteralIteratorInterpreterTests
             }
             """,
             "9\n");
+
+        yield return Case(
+            """
+            func values() sequence[int32] {
+                yield 7
+                yield 8
+            }
+
+            var getValues () -> sequence[int32] = values
+            for value in getValues() {
+                Console.WriteLine(value)
+            }
+            """,
+            "7\n8\n");
     }
 
     [Theory]

--- a/test/Interpreter.Tests/Issue2976FunctionLiteralIteratorInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2976FunctionLiteralIteratorInterpreterTests.cs
@@ -1,0 +1,89 @@
+// <copyright file="Issue2976FunctionLiteralIteratorInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2976: function-literal invocation must classify iterator bodies
+/// through the same path as named user functions.
+/// </summary>
+public sealed class Issue2976FunctionLiteralIteratorInterpreterTests
+{
+    public static IEnumerable<object[]> Cases()
+    {
+        yield return Case(
+            """
+            let values = func() sequence[int32] { yield 2 }
+            for value in values() {
+                Console.WriteLine(value)
+            }
+            """,
+            "2\n");
+
+        yield return Case(
+            """
+            func make(start int32) () -> sequence[int32] {
+                return func() sequence[int32] {
+                    yield start
+                    Console.WriteLine(start)
+                    yield start + 1
+                }
+            }
+
+            for value in make(4)() {
+                Console.WriteLine(value)
+            }
+            """,
+            "4\n4\n5\n");
+
+        yield return Case(
+            """
+            func make[T any]() (T) -> sequence[T] {
+                return func(value T) sequence[T] { yield value }
+            }
+
+            for value in make[string]()("ok") {
+                Console.WriteLine(value)
+            }
+            """,
+            "ok\n");
+
+        yield return Case(
+            """
+            func values() sequence[int32] { yield 9 }
+            for value in values() {
+                Console.WriteLine(value)
+            }
+            """,
+            "9\n");
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void IteratorLiteral_Runs(string source, string expectedOutput)
+    {
+        using var writer = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(writer);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(source);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        Assert.Equal(expectedOutput, writer.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+    }
+
+    private static object[] Case(string source, string expectedOutput)
+        => new object[] { source, expectedOutput };
+}


### PR DESCRIPTION
## Summary

- collect iterator plans from nested function-literal bodies
- lower each emitted function-literal body once, then build its iterator plan from that exact body instance
- retarget capture-bearing plans to synthesized closure `Invoke` methods
- preserve generic lambda/state-machine remaps, with state-machine remaps taking precedence only for method type parameters
- route interpreter closure calls through existing user-function iterator classification
- cover lowering-synthesized iterator locals and named iterators invoked through method-group delegates

Fixes #2957
Fixes #2976

## Root cause and blocker fix

`IteratorRewriter` originally scanned only `BoundProgram.Functions`, so hosted function-literal bodies had no iterator plan. The first version of this PR collected those bodies before lowering, while emission later lowered them separately.

That ordering omitted lowering-synthesized locals from the hoisting field map. A `for-in` enumerator therefore became `null` after the first suspension, and a `for-ellipsis` counter reset so the iterator silently stopped after its first element.

`ReflectionMetadataEmitter` now stores the canonical lowered body before state-machine synthesis. `RetargetIteratorPlans` rebuilds every literal iterator plan—capturing and non-capturing—from the same body instance that emission uses. This is important because lowering twice creates different local-symbol identities.

The interpreter has the mirror stage-ordering defect in #3003: its lambda body is never lowered. This PR fixes iterator classification only; it does not close #3003 or #2995.

## Base-to-head differential

Measured from the true PR base `b1e693bb1`:

| Probe | Base | Head |
|---|---|---|
| function-literal iterator with `for n in []int32{4,5}` | compile error `GS9998` | exit 0, `4\n5\n` |
| function-literal iterator with `for i in 0 ... 2` | compile error `GS9998` | exit 0, `0\n1\n` |
| named iterator through method-group delegate in `gsi` | `GS9999: 'yield' encountered outside of an iterator function` | exit 0, `7\n8\n` |

The pre-fix PR head reproduced the regressions exactly: `for-in` printed `4` then threw `NullReferenceException`; `for-ellipsis` exited 0 after printing only `0`.

## Generic remap precedence

The precedence changes in `SignatureEncoder` and `ImportedMemberRefFactory` apply whenever lambda-method and class/state-machine remaps are simultaneously active. State-machine `VAR` wins for method type parameters used by the synthesized state machine. Lambda `MVAR` remains next for class type parameters, followed by the existing class-remap fallback for synthesized closures, capture boxes, and nested generic types.

`ImportedMemberRefFactory` now has the same `IsMethodTypeParameter` guard and fallback shape. This preserves the nested-generic remaps added by #2978 while covering the narrower iterator-literal overlap.

Coverage:

- `GenericStateMachineSignatureRemap` kills a lambda-first `SignatureEncoder` mutant.
- `ImportedElementToken_MethodTypeParameter_PrefersStateMachineRemap` kills a lambda-first `ImportedMemberRefFactory` mutant.
- `ImportedElementToken_ClassTypeParameter_UsesLambdaRemap` kills removal of the new guard.

## Added coverage

Compiler cases:

- `LoweredForInEnumerator`
- `LoweredForInEnumeratorWithCapture`
- `LoweredForEllipsisCounter`
- `GenericStateMachineElementTokenRemap`
- renamed `GenericStateMachineSignatureRemap` to state its remap purpose

Core cases:

- `ImportedElementToken_MethodTypeParameter_PrefersStateMachineRemap`
- `ImportedElementToken_ClassTypeParameter_UsesLambdaRemap`

Interpreter coverage adds the named-iterator method-group delegate path.

Every compiler case runs `IlVerifier.Verify`, `Assembly.Load(File.ReadAllBytes(...))`, `GetTypes()`, and bounded child execution with concurrent reads of stdout and stderr.

## Rebase and scope

Rebased onto `main` at `87ca66e85`, then rebased again to `f70626452` after `main` advanced during verification. The first merge CI exposed #2978's `SourceTypeParameters` rename and a class-remap precedence interaction; both are incorporated in the final head. The `CheckAllPathsReturn` interaction from #2961 and nested-generic iterator coverage from #2978 pass together.

#2975 remains open. `NestedIteratorCollector` does not change `CollectHoistedLocals` or make `LocalCollector` reference-based. The restructuring moves that work from the old line 158 area to `LocalCollector` near line 187 (roughly line 174 before comment drift).

#3003 and #2995 remain open. Their interpreter lambda bodies are still unlowered.

#2976 has no independent compiled specification until #2957 lands because base `gsc` rejects function-literal `yield` with `GS9998`. Its backend-specific coverage is therefore unit-test-only; no golden compiled sample can pin it separately.

## Verification

Final solution build: 0 warnings, 0 errors. `GSharp.Core.dll` was non-empty and byte-identical across Compiler, Core.Tests, Compiler.Tests, and Interpreter.Tests (`9d2e0b1405e4692e9ac669ddd2f62bcd`).

| Suite | Result |
|---|---:|
| Core | 7033 passed, 1 skipped |
| Compiler | 3959 passed |
| Interpreter | 499 passed |
| Language Server | 452 passed |

Targeted rebase interaction:

- Core iterator/remap tests: 20/20
- Compiler #2921 + #2951 + #2957 tests: 40/40
- Interpreter #2921 + #2951 + #2976 tests: 9/9

The lowered-plan mutant produced the original `NullReferenceException` and silent truncation; restoring the fix returned `4\n5\n` and `0\n1\n`.

Final CI rollup: 8 successful checks and 2 skipped checks.
