### PR TITLE
Build: isolate SDK staging intermediate outputs

### DIFF
--- a/build/gsharp.build.props
+++ b/build/gsharp.build.props
@@ -58,7 +58,7 @@
     <BaseOutputPath>$(OutRoot)/bin/$(Configuration)</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)/$(MSBuildProjectName)</OutputPath>
     <BaseIntermediateOutputPath>$(OutRoot)/obj/$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <!-- <IntermediateOutputPath>$(BaseIntermediateOutputPath)/$(MSBuildProjectName)</IntermediateOutputPath> -->
+    <IntermediateOutputPath Condition="'$(GsharpObjRoot)'!=''">$(GsharpObjRoot)/$(MSBuildProjectName)/$(Configuration)/</IntermediateOutputPath>
     <PackageOutputPath>$(BaseOutputPath)/nupkgs</PackageOutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AssemblyName>GSharp.$(MSBuildProjectName)</AssemblyName>

--- a/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj
+++ b/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj
@@ -99,7 +99,7 @@
     <RemoveDir Directories="$(_GsharpCompilerPublishDir)" Condition="Exists('$(_GsharpCompilerPublishDir)')" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\Compiler\Compiler.csproj"
              Targets="Publish"
-             Properties="Configuration=$(Configuration);TargetFramework=$(GsharpCompilerPackageTargetFramework);PublishDir=$(_GsharpCompilerPublishDir);BaseOutputPath=$(_GsharpCompilerStagingOutDir);SelfContained=false;PublishReadyToRun=false;PublishSingleFile=false" />
+             Properties="Configuration=$(Configuration);TargetFramework=$(GsharpCompilerPackageTargetFramework);PublishDir=$(_GsharpCompilerPublishDir);BaseOutputPath=$(_GsharpCompilerStagingOutDir);GsharpObjRoot=$(IntermediateOutputPath)gsc-staging-obj;SelfContained=false;PublishReadyToRun=false;PublishSingleFile=false" />
     <ItemGroup>
       <_GsharpCompilerPayload Include="$(_GsharpCompilerPublishDir)**\*" />
     </ItemGroup>
@@ -125,7 +125,7 @@
     <RemoveDir Directories="$(_GsgenPublishDir)" Condition="Exists('$(_GsgenPublishDir)')" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\..\tools\gsgen\Gsgen.Cli\Gsgen.Cli.csproj"
              Targets="Publish"
-             Properties="Configuration=$(Configuration);TargetFramework=$(GsharpCompilerPackageTargetFramework);PublishDir=$(_GsgenPublishDir);BaseOutputPath=$(_GsgenStagingOutDir);SelfContained=false;PublishReadyToRun=false;PublishSingleFile=false" />
+             Properties="Configuration=$(Configuration);TargetFramework=$(GsharpCompilerPackageTargetFramework);PublishDir=$(_GsgenPublishDir);BaseOutputPath=$(_GsgenStagingOutDir);GsharpObjRoot=$(IntermediateOutputPath)gsgen-staging-obj;SelfContained=false;PublishReadyToRun=false;PublishSingleFile=false" />
     <ItemGroup>
       <_GsgenPayload Include="$(_GsgenPublishDir)**\*" />
     </ItemGroup>


### PR DESCRIPTION
## Summary

Isolate intermediate outputs for the two SDK packaging `Publish` project instances so parallel solution builds cannot read or write the ordinary build's `obj` files.

## Mechanism

`Gsharp.NET.Sdk` sets `GeneratePackageOnBuild=true`. Its compiler and gsgen package targets invoke nested `MSBuild` `Publish` calls with distinct global properties. Those globals fork new instances of every project in each `ProjectReference` closure and propagate to `Core.csproj`.

The staging calls already redirect `BaseOutputPath`, but `build/gsharp.build.props` defines `BaseIntermediateOutputPath` independently. Ordinary, gsc-staging, and gsgen-staging instances therefore shared `out/obj/<Project>/Release/`. A `csc` rewrite of `GSharp.Core.dll` could race another instance's `Copy` or `CopyRefAssembly`. `Gsharp.Extensions` only consumes the resulting corrupted assembly; it does not cause the race.

## Fix

Pass a distinct `GsharpObjRoot` global property to each staging call and derive `IntermediateOutputPath` from it, project name, and configuration. The three instance families now use disjoint file sets while `BaseIntermediateOutputPath` and restore assets remain unchanged.

## Bidirectional reproduction

Every iteration touched `src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs` before running:

```text
dotnet build GSharp.sln -c Release -graph
```

Build exit status was checked first. Successful builds then required all four propagated `GSharp.Core.dll` files to be nonzero and have identical MD5 hashes.

| State | Runs | Race hits | MSB3026 | MSB3883 | Hard failures | DLL integrity failures |
|---|---:|---:|---:|---:|---:|---:|
| Unfixed | 6 | 2 | 2 | 0 | 0 | 0 |
| Fixed | 6 | 0 | 0 | 0 | 0 | 0 |
| Reverted | 8 | 1 | 1 | 0 | 0 | 0 |

These are small local samples; the table reports observed counts without extrapolation.

## Build time

For the same dirty-Core `-graph` runs, median wall time improved from 31.5 seconds unfixed to 27.5 seconds fixed. Excluding each series' first run, medians were 30 and 27 seconds. The first fixed run took 82 seconds while populating the new staging trees.

## Validation

- `dotnet build GSharp.sln -c Release --no-restore -graph`: passed
- Strict DLL check: compiler plus `Compiler.Tests`, `Core.Tests`, and `Interpreter.Tests` copies were nonzero and shared MD5 `189f6849fc0e86d7df4591ae5a4ec6cb`
- Solution closure: `out/bin/Release/Gsharp.Extensions/` populated; all 123 `SampleConformanceTests` passed without `--no-build`
- SDK package payload: 105 entries (`tools/compiler`: 25, `tools/gsgen`: 62, `tools/extensions`: 3, `tools/task`: 1)

Closes #2974
