### PR TITLE
gsi: honor explicit Main and integer exit codes

### DIFF
--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -290,7 +290,7 @@ public class Compilation
     /// <param name="variables">The symbol table with actual values.</param>
     /// <returns>An evaluation result.</returns>
     public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables) =>
-        Evaluate(variables, evaluateEntryPoint: true);
+        Evaluate(variables, evaluateEntryPoint: true, useEntryPointReturnType: false);
 
     /// <summary>
     /// Evaluates the current compilation provided a symbol table with actual values.
@@ -298,7 +298,20 @@ public class Compilation
     /// <param name="variables">The symbol table with actual values.</param>
     /// <param name="evaluateEntryPoint">Whether to invoke an explicit program entry point.</param>
     /// <returns>An evaluation result.</returns>
-    public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables, bool evaluateEntryPoint)
+    public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables, bool evaluateEntryPoint) =>
+        Evaluate(variables, evaluateEntryPoint, useEntryPointReturnType: evaluateEntryPoint);
+
+    /// <summary>
+    /// Evaluates the current compilation provided a symbol table with actual values.
+    /// </summary>
+    /// <param name="variables">The symbol table with actual values.</param>
+    /// <param name="evaluateEntryPoint">Whether to invoke an explicit program entry point.</param>
+    /// <param name="useEntryPointReturnType">Whether the declared entry-point return type controls the result.</param>
+    /// <returns>An evaluation result.</returns>
+    public EvaluationResult Evaluate(
+        Dictionary<VariableSymbol, object> variables,
+        bool evaluateEntryPoint,
+        bool useEntryPointReturnType)
     {
         var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics);
         var diagnostics = parseDiagnostics.Concat(GlobalScope.Diagnostics).ToImmutableArray();
@@ -342,7 +355,11 @@ public class Compilation
             program,
             (References ?? Symbols.ReferenceResolver.Default()).MapClrTypeToReferences);
 
-        var evaluator = new Evaluator(program, variables, evaluateEntryPoint);
+        var evaluator = new Evaluator(
+            program,
+            variables,
+            evaluateEntryPoint,
+            useEntryPointReturnType);
         try
         {
             var value = evaluator.Evaluate();

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -289,7 +289,16 @@ public class Compilation
     /// </summary>
     /// <param name="variables">The symbol table with actual values.</param>
     /// <returns>An evaluation result.</returns>
-    public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables)
+    public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables) =>
+        Evaluate(variables, evaluateEntryPoint: true);
+
+    /// <summary>
+    /// Evaluates the current compilation provided a symbol table with actual values.
+    /// </summary>
+    /// <param name="variables">The symbol table with actual values.</param>
+    /// <param name="evaluateEntryPoint">Whether to invoke an explicit program entry point.</param>
+    /// <returns>An evaluation result.</returns>
+    public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables, bool evaluateEntryPoint)
     {
         var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics);
         var diagnostics = parseDiagnostics.Concat(GlobalScope.Diagnostics).ToImmutableArray();
@@ -333,7 +342,7 @@ public class Compilation
             program,
             (References ?? Symbols.ReferenceResolver.Default()).MapClrTypeToReferences);
 
-        var evaluator = new Evaluator(program, variables);
+        var evaluator = new Evaluator(program, variables, evaluateEntryPoint);
         try
         {
             var value = evaluator.Evaluate();

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -154,6 +154,23 @@ public sealed partial class Evaluator
     /// <returns>The evaluation result.</returns>
     public object Evaluate()
     {
+        // The binder has already resolved top-level-statement versus explicit-Main precedence.
+        // A null declaration identifies the synthesized top-level entry point.
+        if (program.EntryPoint?.Declaration != null
+            && program.Functions.TryGetValue(program.EntryPoint, out var entryPointBody))
+        {
+            var locals = new ConcurrentDictionary<VariableSymbol, object>();
+            if (program.EntryPoint.Parameters.Length > 0)
+            {
+                locals[program.EntryPoint.Parameters[0]] = Array.Empty<string>();
+            }
+
+            using (PushFrame(locals))
+            {
+                return EvaluateFunctionBody(entryPointBody);
+            }
+        }
+
         return EvaluateFunctionBody(program.Statement);
     }
 

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -38,6 +38,7 @@ public sealed partial class Evaluator
     private readonly BoundProgram program;
     private readonly Dictionary<VariableSymbol, object> globals;
     private readonly bool evaluateEntryPoint;
+    private readonly bool useEntryPointReturnType;
 
     // Issue #1651: everything below this point used to be an ordinary
     // instance field. That is correct only because the interpreter was
@@ -101,21 +102,24 @@ public sealed partial class Evaluator
     /// <param name="program">The program.</param>
     /// <param name="variables">The variables.</param>
     public Evaluator(BoundProgram program, Dictionary<VariableSymbol, object> variables)
-        : this(program, variables, evaluateEntryPoint: true)
+        : this(
+            program,
+            variables,
+            evaluateEntryPoint: true,
+            useEntryPointReturnType: false)
     {
     }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Evaluator"/> class.
-    /// </summary>
-    /// <param name="program">The program.</param>
-    /// <param name="variables">The variables.</param>
-    /// <param name="evaluateEntryPoint">Whether to invoke an explicit program entry point.</param>
-    public Evaluator(BoundProgram program, Dictionary<VariableSymbol, object> variables, bool evaluateEntryPoint)
+    internal Evaluator(
+        BoundProgram program,
+        Dictionary<VariableSymbol, object> variables,
+        bool evaluateEntryPoint,
+        bool useEntryPointReturnType)
     {
         this.program = program;
         globals = variables;
         this.evaluateEntryPoint = evaluateEntryPoint;
+        this.useEntryPointReturnType = useEntryPointReturnType;
         Locals.Push(new ConcurrentDictionary<VariableSymbol, object>());
     }
 
@@ -197,6 +201,11 @@ public sealed partial class Evaluator
 
     private object EvaluateEntryPointBody(FunctionSymbol entryPoint, BoundBlockStatement body)
     {
+        if (!useEntryPointReturnType)
+        {
+            return EvaluateFunctionBody(body);
+        }
+
         if (entryPoint.Type != TypeSymbol.Void
             && entryPoint.Type != TypeSymbol.Int32
             && entryPoint.Type != TypeSymbol.UInt32)

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -37,6 +37,7 @@ public sealed partial class Evaluator
 {
     private readonly BoundProgram program;
     private readonly Dictionary<VariableSymbol, object> globals;
+    private readonly bool evaluateEntryPoint;
 
     // Issue #1651: everything below this point used to be an ordinary
     // instance field. That is correct only because the interpreter was
@@ -100,9 +101,21 @@ public sealed partial class Evaluator
     /// <param name="program">The program.</param>
     /// <param name="variables">The variables.</param>
     public Evaluator(BoundProgram program, Dictionary<VariableSymbol, object> variables)
+        : this(program, variables, evaluateEntryPoint: true)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Evaluator"/> class.
+    /// </summary>
+    /// <param name="program">The program.</param>
+    /// <param name="variables">The variables.</param>
+    /// <param name="evaluateEntryPoint">Whether to invoke an explicit program entry point.</param>
+    public Evaluator(BoundProgram program, Dictionary<VariableSymbol, object> variables, bool evaluateEntryPoint)
     {
         this.program = program;
         globals = variables;
+        this.evaluateEntryPoint = evaluateEntryPoint;
         Locals.Push(new ConcurrentDictionary<VariableSymbol, object>());
     }
 
@@ -156,11 +169,14 @@ public sealed partial class Evaluator
     {
         // The binder has already resolved top-level-statement versus explicit-Main precedence.
         // A null declaration identifies the synthesized top-level entry point.
-        if (program.EntryPoint?.Declaration != null
-            && program.Functions.TryGetValue(program.EntryPoint, out var entryPointBody))
+        if (evaluateEntryPoint && program.EntryPoint?.Declaration != null)
         {
+            // Every resolved explicit entry point must have a bound body; fail loudly if that
+            // invariant is broken rather than silently evaluating an empty top-level block.
+            var entryPointBody = program.Functions[program.EntryPoint];
             var locals = new ConcurrentDictionary<VariableSymbol, object>();
-            if (program.EntryPoint.Parameters.Length > 0)
+            if (program.EntryPoint.Parameters.Length == 1
+                && program.EntryPoint.Parameters[0].Type == SliceTypeSymbol.Get(TypeSymbol.String))
             {
                 locals[program.EntryPoint.Parameters[0]] = Array.Empty<string>();
             }

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -169,25 +169,43 @@ public sealed partial class Evaluator
     {
         // The binder has already resolved top-level-statement versus explicit-Main precedence.
         // A null declaration identifies the synthesized top-level entry point.
-        if (evaluateEntryPoint && program.EntryPoint?.Declaration != null)
+        if (evaluateEntryPoint && program.EntryPoint is { } entryPoint)
         {
-            // Every resolved explicit entry point must have a bound body; fail loudly if that
-            // invariant is broken rather than silently evaluating an empty top-level block.
-            var entryPointBody = program.Functions[program.EntryPoint];
-            var locals = new ConcurrentDictionary<VariableSymbol, object>();
-            if (program.EntryPoint.Parameters.Length == 1
-                && program.EntryPoint.Parameters[0].Type == SliceTypeSymbol.Get(TypeSymbol.String))
+            if (entryPoint.Declaration != null)
             {
-                locals[program.EntryPoint.Parameters[0]] = Array.Empty<string>();
+                // Every resolved explicit entry point must have a bound body; fail loudly if that
+                // invariant is broken rather than silently evaluating an empty top-level block.
+                var entryPointBody = program.Functions[entryPoint];
+                var locals = new ConcurrentDictionary<VariableSymbol, object>();
+                if (entryPoint.Parameters.Length == 1
+                    && entryPoint.Parameters[0].Type == SliceTypeSymbol.Get(TypeSymbol.String))
+                {
+                    locals[entryPoint.Parameters[0]] = Array.Empty<string>();
+                }
+
+                using (PushFrame(locals))
+                {
+                    return EvaluateEntryPointBody(entryPoint, entryPointBody);
+                }
             }
 
-            using (PushFrame(locals))
-            {
-                return EvaluateFunctionBody(entryPointBody);
-            }
+            return EvaluateEntryPointBody(entryPoint, program.Statement);
         }
 
         return EvaluateFunctionBody(program.Statement);
+    }
+
+    private object EvaluateEntryPointBody(FunctionSymbol entryPoint, BoundBlockStatement body)
+    {
+        if (entryPoint.Type != TypeSymbol.Void
+            && entryPoint.Type != TypeSymbol.Int32
+            && entryPoint.Type != TypeSymbol.UInt32)
+        {
+            throw new InvalidOperationException("Entry point must have a return type of void, int32, or uint32.");
+        }
+
+        var value = EvaluateFunctionBody(body);
+        return entryPoint.Type == TypeSymbol.Void ? null : value;
     }
 
     // Issue #1651: goroutines run with their own locals/control-transfer

--- a/src/Repl/Engine/SessionEngine.cs
+++ b/src/Repl/Engine/SessionEngine.cs
@@ -157,6 +157,12 @@ public sealed class SessionEngine
     public bool CaptureConsole { get; set; }
 
     /// <summary>
+    /// When <see langword="true"/>, invokes an explicit program entry point. Script mode enables
+    /// this; interactive submissions leave it disabled so declaring <c>Main</c> has no side effect.
+    /// </summary>
+    public bool RunEntryPoint { get; set; }
+
+    /// <summary>
     /// Optional provider that supplies a line of standard input when evaluated code reads from
     /// <see cref="Console.In"/> (e.g. <c>Console.ReadLine()</c>). Returning <see langword="null"/>
     /// signals end-of-input. When unset, <see cref="Console.In"/> is left untouched.
@@ -211,7 +217,7 @@ public sealed class SessionEngine
             {
                 var tree = SyntaxTree.Parse(SourceText.From(text, fileName));
                 var compilation = previous == null ? new Compilation(tree) : previous.ContinueWith(tree);
-                var result = compilation.Evaluate(variables);
+                var result = compilation.Evaluate(variables, evaluateEntryPoint: RunEntryPoint);
 
                 var hasError = result.Diagnostics.Any(d => d.IsError);
 

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -54,7 +54,7 @@ public static class Program
             return 1;
         }
 
-        var engine = new SessionEngine();
+        var engine = new SessionEngine { RunEntryPoint = true };
         var cell = engine.Evaluate(File.ReadAllText(arg), arg);
         if (cell.Diagnostics.Length > 0)
         {

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -61,11 +61,21 @@ public static class Program
             Console.Error.WriteDiagnostics(cell.Diagnostics);
         }
 
-        if (!cell.HasError && cell.Value is not null)
+        if (cell.HasError)
+        {
+            return 1;
+        }
+
+        if (cell.Value is int exitCode)
+        {
+            return exitCode;
+        }
+
+        if (cell.Value is not null)
         {
             Console.WriteLine(cell.Value);
         }
 
-        return cell.HasError ? 1 : 0;
+        return 0;
     }
 }

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -71,9 +71,9 @@ public static class Program
             return exitCode;
         }
 
-        if (cell.Value is not null)
+        if (cell.Value is uint unsignedExitCode)
         {
-            Console.WriteLine(cell.Value);
+            return unchecked((int)unsignedExitCode);
         }
 
         return 0;

--- a/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
@@ -37,6 +37,37 @@ public class Issue2984MainEntryPointInterpreterTests
     }
 
     [Fact]
+    public void EvaluatorDefaultRunsEntryPoint()
+    {
+        const string Source = """
+            import System
+
+            func Main() {
+                Console.WriteLine("evaluator-main")
+            }
+            """;
+
+        using var output = new StringWriter();
+        var previousOutput = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            var compilation = new Compilation(SyntaxTree.Parse(Source));
+            var evaluator = new Evaluator(
+                compilation.BoundProgram,
+                new Dictionary<VariableSymbol, object>());
+
+            evaluator.Evaluate();
+
+            Assert.Equal("evaluator-main\n", output.ToString().Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            Console.SetOut(previousOutput);
+        }
+    }
+
+    [Fact]
     public void ClassScopedSharedMainRuns()
     {
         const string Source = """

--- a/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
@@ -1,0 +1,128 @@
+// <copyright file="Issue2984MainEntryPointInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2984: the interpreter invokes the entry point selected by the binder.
+/// </summary>
+[Collection("ConsoleIo")]
+public class Issue2984MainEntryPointInterpreterTests
+{
+    [Fact]
+    public void PackageScopeMainRuns()
+    {
+        const string Source = """
+            import System
+
+            func Main() {
+                Console.WriteLine("package-main")
+            }
+            """;
+
+        var (result, output) = Evaluate(Source);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.Equal("package-main\n", output);
+    }
+
+    [Fact]
+    public void ClassScopedSharedMainRuns()
+    {
+        const string Source = """
+            import System
+
+            class Launcher {
+                shared {
+                    func Main() {
+                        Console.WriteLine("class-main")
+                    }
+                }
+            }
+            """;
+
+        var (result, output) = Evaluate(Source);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.Equal("class-main\n", output);
+    }
+
+    [Fact]
+    public void TopLevelStatementsStillRun()
+    {
+        const string Source = """
+            import System
+
+            Console.WriteLine("top-level")
+            """;
+
+        var (result, output) = Evaluate(Source);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("top-level\n", output);
+    }
+
+    [Fact]
+    public void TopLevelStatementsWinOverExplicitMain()
+    {
+        const string Source = """
+            import System
+
+            Console.WriteLine("top-level")
+
+            func Main() {
+                Console.WriteLine("explicit-main")
+            }
+            """;
+
+        var (result, output) = Evaluate(Source);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Id == "GS0166");
+        Assert.Equal("top-level\n", output);
+    }
+
+    [Fact]
+    public void MainArgsReceivesEmptyArray()
+    {
+        const string Source = """
+            import System
+
+            func Main(args []string) {
+                Console.WriteLine(args.Length)
+            }
+            """;
+
+        var (result, output) = Evaluate(Source);
+
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.Equal("0\n", output);
+    }
+
+    private static (EvaluationResult Result, string Output) Evaluate(string source)
+    {
+        using var output = new StringWriter();
+        var previousOutput = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            var result = new Compilation(SyntaxTree.Parse(source))
+                .Evaluate(new Dictionary<VariableSymbol, object>());
+            return (result, output.ToString().Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            Console.SetOut(previousOutput);
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
@@ -109,6 +109,28 @@ public class Issue2984MainEntryPointInterpreterTests
         Assert.Equal("0\n", output);
     }
 
+    [Fact]
+    public void NonArgsMainParameterIsNotSeededWithStringArray()
+    {
+        const string Source = """
+            import System
+
+            func Main(x int32) {
+                Console.WriteLine(x)
+            }
+            """;
+
+        var (result, output) = Evaluate(Source);
+
+        Assert.Contains(
+            result.Diagnostics,
+            diagnostic => diagnostic.IsError && diagnostic.Message.Contains("x int32"));
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            diagnostic => diagnostic.Message.Contains("System.String[]"));
+        Assert.Equal(string.Empty, output);
+    }
+
     private static (EvaluationResult Result, string Output) Evaluate(string source)
     {
         using var output = new StringWriter();

--- a/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2984MainEntryPointInterpreterTests.cs
@@ -68,6 +68,27 @@ public class Issue2984MainEntryPointInterpreterTests
     }
 
     [Fact]
+    public void CompilationEvaluationPreservesTopLevelExpressionValue()
+    {
+        var result = new Compilation(SyntaxTree.Parse("40 + 2"))
+            .Evaluate(new Dictionary<VariableSymbol, object>());
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void EvaluatorDefaultPreservesTopLevelExpressionValue()
+    {
+        var compilation = new Compilation(SyntaxTree.Parse("40 + 2"));
+        var evaluator = new Evaluator(
+            compilation.BoundProgram,
+            new Dictionary<VariableSymbol, object>());
+
+        Assert.Equal(42, evaluator.Evaluate());
+    }
+
+    [Fact]
     public void ClassScopedSharedMainRuns()
     {
         const string Source = """

--- a/test/Interpreter.Tests/Issue2984ReplEntryPointTests.cs
+++ b/test/Interpreter.Tests/Issue2984ReplEntryPointTests.cs
@@ -1,0 +1,37 @@
+// <copyright file="Issue2984ReplEntryPointTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Repl.Engine;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2984: interactive declarations do not execute a script entry point.
+/// </summary>
+[Collection("ConsoleIo")]
+public class Issue2984ReplEntryPointTests
+{
+    [Fact]
+    public void DeclarationOnlySubmissionsDoNotRunMain()
+    {
+        var engine = new SessionEngine { CaptureConsole = true };
+
+        var mainDeclaration = engine.Evaluate(
+            """
+            import System
+
+            func Main() {
+                Console.WriteLine("main")
+            }
+            """);
+        var nextDeclaration = engine.Evaluate("func Helper() { }");
+
+        Assert.False(mainDeclaration.HasError);
+        Assert.False(nextDeclaration.HasError);
+        Assert.Equal(
+            (string.Empty, string.Empty),
+            (mainDeclaration.Output, nextDeclaration.Output));
+    }
+}

--- a/test/Interpreter.Tests/Issue2984ReplEntryPointTests.cs
+++ b/test/Interpreter.Tests/Issue2984ReplEntryPointTests.cs
@@ -34,4 +34,33 @@ public class Issue2984ReplEntryPointTests
             (string.Empty, string.Empty),
             (mainDeclaration.Output, nextDeclaration.Output));
     }
+
+    [Fact]
+    public void ScriptEntryPointRunsOnlyOnDeclaringSubmission()
+    {
+        var engine = new SessionEngine { CaptureConsole = true, RunEntryPoint = true };
+
+        var mainDeclaration = engine.Evaluate(
+            """
+            import System
+
+            func Main() int32 {
+                Console.WriteLine("main-once")
+                return 7
+            }
+            """);
+        var nextDeclaration = engine.Evaluate("func Helper() { }");
+        var nextExpression = engine.Evaluate("40 + 2");
+
+        Assert.False(mainDeclaration.HasError);
+        Assert.False(nextDeclaration.HasError);
+        Assert.False(nextExpression.HasError);
+        Assert.Equal(7, mainDeclaration.Value);
+        Assert.Null(nextDeclaration.Value);
+        Assert.Null(nextExpression.Value);
+        Assert.Equal("main-once\n", mainDeclaration.Output);
+        Assert.Equal(
+            (string.Empty, string.Empty),
+            (nextDeclaration.Output, nextExpression.Output));
+    }
 }

--- a/test/Interpreter.Tests/Issue3010EntryPointDriverMatrixTests.cs
+++ b/test/Interpreter.Tests/Issue3010EntryPointDriverMatrixTests.cs
@@ -1,0 +1,241 @@
+// <copyright file="Issue3010EntryPointDriverMatrixTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issues #2984 and #3010: entry-point result behavior agrees across compiler
+/// evaluation, emitted execution, and interpretation.
+/// </summary>
+[Collection("ConsoleIo")]
+public class Issue3010EntryPointDriverMatrixTests
+{
+    public enum Driver
+    {
+        CompilerEvaluation,
+        CompilerEmission,
+        Interpreter,
+    }
+
+    public static IEnumerable<object[]> DriverCases()
+    {
+        var cases = new[]
+        {
+            (
+                "explicit-int-3",
+                """
+                import System
+
+                func Main() int32 {
+                    Console.WriteLine("main-int")
+                    return 3
+                }
+                """,
+                3,
+                "main-int\n"),
+            (
+                "explicit-int-0",
+                """
+                import System
+
+                func Main() int32 {
+                    Console.WriteLine("main-zero")
+                    return 0
+                }
+                """,
+                0,
+                "main-zero\n"),
+            (
+                "explicit-void-bare-int",
+                """
+                import System
+
+                func Main() {
+                    Console.WriteLine("void-bare-int")
+                    5 + 6
+                }
+                """,
+                0,
+                "void-bare-int\n"),
+            (
+                "explicit-void-ignored-int-call",
+                """
+                import System
+
+                func Compute() int32 {
+                    return 22
+                }
+
+                func Main() {
+                    Console.WriteLine("void-call")
+                    Compute()
+                }
+                """,
+                0,
+                "void-call\n"),
+            (
+                "explicit-void-bare-string",
+                """
+                import System
+
+                func Main() {
+                    Console.WriteLine("void-string")
+                    "leaked"
+                }
+                """,
+                0,
+                "void-string\n"),
+            (
+                "explicit-void-print",
+                """
+                import System
+
+                func Main() {
+                    Console.WriteLine("void-print")
+                }
+                """,
+                0,
+                "void-print\n"),
+            (
+                "top-level-bare-int",
+                """
+                import System
+
+                Console.WriteLine("top-bare")
+                16 + 17
+                """,
+                0,
+                "top-bare\n"),
+            (
+                "top-level-return-3",
+                """
+                import System
+
+                Console.WriteLine("top-return")
+                return 3
+                """,
+                3,
+                "top-return\n"),
+        };
+
+        foreach (var (name, source, processExitCode, output) in cases)
+        {
+            foreach (var driver in Enum.GetValues<Driver>())
+            {
+                var exitCode = driver == Driver.CompilerEvaluation ? 0 : processExitCode;
+                var standardOutput = driver == Driver.CompilerEvaluation
+                    ? output + "Success.\n"
+                    : output;
+                yield return new object[] { name, source, driver, exitCode, standardOutput };
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(DriverCases))]
+    public void EntryPointResultMatrixMatchesDriverContract(
+        string name,
+        string source,
+        Driver driver,
+        int expectedExitCode,
+        string expectedOutput)
+    {
+        var result = Run(name, source, driver);
+
+        Assert.Equal(expectedExitCode, result.ExitCode);
+        Assert.Equal(expectedOutput, result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) Run(
+        string name,
+        string source,
+        Driver driver)
+    {
+        var root = Path.Combine(Environment.CurrentDirectory, $".issue3010-matrix-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        var sourcePath = Path.Combine(root, name + ".gs");
+        File.WriteAllText(sourcePath, source);
+
+        try
+        {
+            return driver switch
+            {
+                Driver.CompilerEvaluation => CaptureConsole(
+                    () => GSharp.Compiler.Program.Main(new[] { sourcePath })),
+                Driver.CompilerEmission => CompileAndRun(root, name, sourcePath),
+                Driver.Interpreter => CaptureConsole(
+                    () => GSharp.Repl.Program.Main(new[] { sourcePath })),
+                _ => throw new InvalidOperationException($"Unexpected driver {driver}."),
+            };
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) CompileAndRun(
+        string root,
+        string name,
+        string sourcePath)
+    {
+        var outputDirectory = Path.Combine(root, "emit");
+        Directory.CreateDirectory(outputDirectory);
+        var assemblyPath = Path.Combine(outputDirectory, name + ".dll");
+        var compile = CaptureConsole(
+            () => GSharp.Compiler.Program.Main(new[] { sourcePath, "/out:" + assemblyPath }));
+
+        Assert.Equal(0, compile.ExitCode);
+        Assert.True(File.Exists(assemblyPath), compile.StandardOutput + compile.StandardError);
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        var standardOutput = process.StandardOutput.ReadToEnd();
+        var standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        return (
+            process.ExitCode,
+            standardOutput.Replace("\r\n", "\n"),
+            standardError.Replace("\r\n", "\n"));
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) CaptureConsole(
+        Func<int> action)
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+        var previousOutput = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(output);
+        Console.SetError(error);
+        try
+        {
+            return (
+                action(),
+                output.ToString().Replace("\r\n", "\n"),
+                error.ToString().Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            Console.SetOut(previousOutput);
+            Console.SetError(previousError);
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
+++ b/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
@@ -103,7 +103,9 @@ public class Issue3010EntryPointExitCodeTests
 
         Assert.Equal(1, result.ExitCode);
         Assert.Equal(string.Empty, result.StandardOutput);
-        Assert.Equal("GS0100: Not all code paths return a value.\n", result.StandardError);
+        Assert.Contains(
+            "error GS0100: Not all code paths return a value.",
+            result.StandardError);
     }
 
     [Fact]
@@ -210,8 +212,8 @@ public class Issue3010EntryPointExitCodeTests
 
         Assert.Equal(1, result.ExitCode);
         Assert.Equal(string.Empty, result.StandardOutput);
-        Assert.Equal(
-            "GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.\n",
+        Assert.Contains(
+            "error GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.",
             result.StandardError);
     }
 
@@ -235,8 +237,8 @@ public class Issue3010EntryPointExitCodeTests
 
         Assert.Equal(1, result.ExitCode);
         Assert.Equal(string.Empty, result.StandardOutput);
-        Assert.Equal(
-            "GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.\n",
+        Assert.Contains(
+            "error GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.",
             result.StandardError);
     }
 

--- a/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
+++ b/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
@@ -1,0 +1,99 @@
+// <copyright file="Issue3010EntryPointExitCodeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3010: integer script results are process exit codes, not displayed values.
+/// </summary>
+[Collection("ConsoleIo")]
+public class Issue3010EntryPointExitCodeTests
+{
+    [Fact]
+    public void ExplicitMainIntegerResultBecomesExitCode()
+    {
+        const string Source = """
+            import System
+
+            func Main() int32 {
+                Console.WriteLine("main")
+                return 3
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(3, result.ExitCode);
+        Assert.Equal("main\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void TopLevelIntegerResultBecomesExitCode()
+    {
+        const string Source = """
+            import System
+
+            Console.WriteLine("tls")
+            return 3
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(3, result.ExitCode);
+        Assert.Equal("tls\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void NonIntegerResultIsStillPrinted()
+    {
+        var result = RunScript("\"text-result\"");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("text-result\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void NoResultStillReturnsZeroWithoutOutput()
+    {
+        var result = RunScript("func Helper() { }");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) RunScript(string source)
+    {
+        var path = Path.Combine(Environment.CurrentDirectory, $".issue3010-{Guid.NewGuid():N}.gs");
+        File.WriteAllText(path, source);
+
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+        var previousOutput = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(output);
+        Console.SetError(error);
+        try
+        {
+            var exitCode = GSharp.Repl.Program.Main(new[] { path });
+            return (
+                exitCode,
+                output.ToString().Replace("\r\n", "\n"),
+                error.ToString().Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            Console.SetOut(previousOutput);
+            Console.SetError(previousError);
+            File.Delete(path);
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
+++ b/test/Interpreter.Tests/Issue3010EntryPointExitCodeTests.cs
@@ -22,13 +22,13 @@ public class Issue3010EntryPointExitCodeTests
 
             func Main() int32 {
                 Console.WriteLine("main")
-                return 3
+                return 7
             }
             """;
 
         var result = RunScript(Source);
 
-        Assert.Equal(3, result.ExitCode);
+        Assert.Equal(7, result.ExitCode);
         Assert.Equal("main\n", result.StandardOutput);
         Assert.Equal(string.Empty, result.StandardError);
     }
@@ -40,28 +40,279 @@ public class Issue3010EntryPointExitCodeTests
             import System
 
             Console.WriteLine("tls")
-            return 3
+            return 7
             """;
 
         var result = RunScript(Source);
 
-        Assert.Equal(3, result.ExitCode);
+        Assert.Equal(7, result.ExitCode);
         Assert.Equal("tls\n", result.StandardOutput);
         Assert.Equal(string.Empty, result.StandardError);
     }
 
     [Fact]
-    public void NonIntegerResultIsStillPrinted()
+    public void ExplicitMainIntegerZeroReturnsZero()
     {
-        var result = RunScript("\"text-result\"");
+        const string Source = """
+            import System
+
+            func Main() int32 {
+                Console.WriteLine("zero")
+                return 0
+            }
+            """;
+
+        var result = RunScript(Source);
 
         Assert.Equal(0, result.ExitCode);
-        Assert.Equal("text-result\n", result.StandardOutput);
+        Assert.Equal("zero\n", result.StandardOutput);
         Assert.Equal(string.Empty, result.StandardError);
     }
 
     [Fact]
-    public void NoResultStillReturnsZeroWithoutOutput()
+    public void ExplicitMainUnsignedIntegerResultBecomesExitCode()
+    {
+        const string Source = """
+            import System
+
+            func Main() uint32 {
+                Console.WriteLine("unsigned")
+                return 7
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(7, result.ExitCode);
+        Assert.Equal("unsigned\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void ExplicitMainIntegerFalloffIsRejected()
+    {
+        const string Source = """
+            import System
+
+            func Main() int32 {
+                Console.WriteLine("must-not-run")
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardOutput);
+        Assert.Equal("GS0100: Not all code paths return a value.\n", result.StandardError);
+    }
+
+    [Fact]
+    public void ExplicitVoidMainDiscardsBareIntegerExpression()
+    {
+        const string Source = """
+            import System
+
+            func Main() {
+                Console.WriteLine("void-int")
+                40 + 2
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("void-int\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void ExplicitVoidMainDiscardsBareStringExpression()
+    {
+        const string Source = """
+            import System
+
+            func Main() {
+                Console.WriteLine("void-string")
+                "leaked"
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("void-string\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void ExplicitVoidMainDiscardsIgnoredIntegerCall()
+    {
+        const string Source = """
+            import System
+
+            func Compute() int32 {
+                return 11
+            }
+
+            func Main() {
+                Console.WriteLine("void-call-int")
+                Compute()
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("void-call-int\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void ExplicitVoidMainDiscardsIgnoredGSharpValueCall()
+    {
+        const string Source = """
+            import System
+
+            struct Marker {
+                var N int32
+            }
+
+            func Make() Marker {
+                return Marker{N: 33}
+            }
+
+            func Main() {
+                Console.WriteLine("void-call-type")
+                Make()
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("void-call-type\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void ExplicitStringMainIsRejectedBeforeExecution()
+    {
+        const string Source = """
+            import System
+
+            func Main() string {
+                Console.WriteLine("must-not-run")
+                return "invalid"
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardOutput);
+        Assert.Equal(
+            "GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.\n",
+            result.StandardError);
+    }
+
+    [Fact]
+    public void ExplicitGSharpValueMainIsRejectedBeforeExecution()
+    {
+        const string Source = """
+            import System
+
+            struct Marker {
+                var N int32
+            }
+
+            func Main() Marker {
+                Console.WriteLine("must-not-run")
+                return Marker{N: 33}
+            }
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardOutput);
+        Assert.Equal(
+            "GSI001: Evaluation error: Entry point must have a return type of void, int32, or uint32.\n",
+            result.StandardError);
+    }
+
+    [Fact]
+    public void TopLevelVoidEntryPointDiscardsBareIntegerExpression()
+    {
+        const string Source = """
+            import System
+
+            Console.WriteLine("top-int")
+            40 + 2
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("top-int\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void TopLevelVoidEntryPointDiscardsBareStringExpression()
+    {
+        const string Source = """
+            import System
+
+            Console.WriteLine("top-string")
+            "leaked"
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("top-string\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void TopLevelVoidEntryPointDiscardsIgnoredIntegerCall()
+    {
+        const string Source = """
+            import System
+
+            func Compute() int32 {
+                return 22
+            }
+
+            Console.WriteLine("top-call-int")
+            Compute()
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("top-call-int\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void TopLevelNoResultReturnsZero()
+    {
+        const string Source = """
+            import System
+
+            Console.WriteLine("top-no-result")
+            """;
+
+        var result = RunScript(Source);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("top-no-result\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public void DeclarationOnlyScriptReturnsZeroWithoutOutput()
     {
         var result = RunScript("func Helper() { }");
 


### PR DESCRIPTION
## Compiled rule

Measured with direct Release `gsc` and `gsi` binaries:

- With no top-level statements, the binder-selected explicit `Main` is the entry point. `gsc` runs it.
- With top-level statements and explicit `Main`, the synthesized top-level entry point wins. `gsc` reports warning GS0166 and does not run explicit `Main`.
- Declared return type controls program results: `void` discards the final evaluated value; `int32` and `uint32` become process exit codes; a top-level `return <int>` likewise becomes the synthesized entry point's exit code. Trailing top-level expressions do not become results.

## Fix

- `src/Core/CodeAnalysis/Evaluator.cs:172-217` invokes the binder-selected entry point, seeds only `Main(args []string)`, and normalizes the result from `FunctionSymbol.Type`, the same declared-return signal used by emit.
- `src/Core/CodeAnalysis/Compilation/Compilation.cs:292-362` separates entry-point execution from declared-return normalization. Existing direct `Compilation`/`Evaluator` APIs still expose expression values; file-mode execution applies program exit semantics.
- `src/Repl/Engine/SessionEngine.cs:159-163,220` adds an explicit script-mode switch. Interactive REPL submissions remain declarative; declaring `Main` does not run it. Script sessions run it only on the declaring submission, not again on a later `ContinueWith` submission.
- `src/Repl/Program.cs:57-79` enables script mode, returns `int32`/`uint32` results as exit codes, returns 1 on diagnostics, and never prints discarded expression values.

## Three-driver entry-point matrix

Each cell is covered by `Issue3010EntryPointDriverMatrixTests`: `{top-level, explicit Main} × {gsc evaluation, gsc /out emission, gsi}`. Compiler evaluation owns its `Success.` status line and always returns 0 after successful evaluation; emitted and interpreted programs expose the language process exit code.

| Shape | bare `gsc` evaluation | `gsc /out:` + `dotnet` | `gsi` |
|---|---|---|---|
| `Main() int32` returns 3 | rc 0, `main-int\nSuccess.\n` | rc 3, `main-int\n` | rc 3, `main-int\n` |
| `Main() int32` returns 0 | rc 0, `main-zero\nSuccess.\n` | rc 0, `main-zero\n` | rc 0, `main-zero\n` |
| void `Main()` + bare int | rc 0, `void-bare-int\nSuccess.\n` | rc 0, `void-bare-int\n` | rc 0, `void-bare-int\n` |
| void `Main()` + ignored int call | rc 0, `void-call\nSuccess.\n` | rc 0, `void-call\n` | rc 0, `void-call\n` |
| void `Main()` + bare string | rc 0, `void-string\nSuccess.\n` | rc 0, `void-string\n` | rc 0, `void-string\n` |
| void `Main()` + explicit print | rc 0, `void-print\nSuccess.\n` | rc 0, `void-print\n` | rc 0, `void-print\n` |
| top-level trailing int expression | rc 0, `top-bare\nSuccess.\n` | rc 0, `top-bare\n` | rc 0, `top-bare\n` |
| top-level `return 3` | rc 0, `top-return\nSuccess.\n` | rc 3, `top-return\n` | rc 3, `top-return\n` |

Trailing expressions are discarded because the binder declares those entry points `void`; explicit/top-level `return <int>` declares an integer entry point and therefore supplies the emitted/interpreted process exit code.

## Bidirectional evidence

Same base `6ec381c5ddc15b573dc6a8701edcb17ae4413a99`, head `94b65165edea279b8e862f7fcdc7349461412ac3`:

| Probe | Base `gsi` | Head `gsi` |
|---|---|---|
| `Main()` prints `hello-2984` | rc 0, `∅` | rc 0, `hello-2984\n` |
| `Main() int32` prints and returns 42 | rc 0, `∅` | rc 42, `main-int\n` |
| void `Main()` ends in `40+2` | rc 0, `∅` | rc 0, `void-trailing\n` |

## Product mutation

Twenty-two condition/value inversions covered every production behavior in the eight production diff hunks. Every mutant built successfully, changed the owning `GSharp.Core.dll` or `gsi.dll`, passed the 34-file zero-byte and six-copy propagation gates, and was killed.

| Production area | Mutants | Killing tests |
|---|---:|---|
| `Compilation.cs` defaults and evaluator forwarding | 4/4 | `PackageScopeMainRuns`; `ExplicitVoidMainDiscardsBareIntegerExpression` |
| `Evaluator.cs` state, dispatch, args, declared return validation/result | 11/11 | `EvaluatorDefaultRunsEntryPoint`; `CompilationEvaluationPreservesTopLevelExpressionValue`; `MainArgsReceivesEmptyArray`; explicit void/int/uint result tests |
| `SessionEngine.cs` mode default and forwarding | 2/2 | `DeclarationOnlySubmissionsDoNotRunMain` |
| `Program.cs` script enablement, error/int/uint/zero exits | 5/5 | explicit void/int/uint result tests |

## Validation

Current main/base is `6ec381c5ddc15b573dc6a8701edcb17ae4413a99`; head is `94b65165edea279b8e862f7fcdc7349461412ac3`.

- Release solution build, serialized with CI mode: 0 warnings, 0 errors.
- Targeted #2984/#3010 tests: 51/51, including 24 three-driver matrix cells.
- Same-base Interpreter population: 637 passed on base → 688 passed on head, 51 new executed cases.
- Final CI TRX suites: Interpreter 688/688; Core 7088 passed + 1 skipped; Compiler 4146/4146.
- `cs2gs`: 1874/1874.
- Artifact gate after clean rebuild: 34 `GSharp.Core.dll` files examined, 0 zero-byte; six consumer copies had one md5 and identical mtimes.
- `git merge-tree --write-tree origin/main HEAD`: clean; merged tree `41e72e54e2fbd9d463e062fd502e5495f42c258f` equals `HEAD^{tree}`.
- CI at pushed head: 29 successful checks, 2 expected publish checks skipped; PR reports `MERGEABLE` / `CLEAN`.

Fixes #2984
Fixes #3010



