### PR TITLE
Fix interpreter lambda body lowering

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundFunctionLiteralExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFunctionLiteralExpression.cs
@@ -44,4 +44,6 @@ public sealed class BoundFunctionLiteralExpression : BoundExpression
     public override TypeSymbol Type => FunctionType;
 
     public override BoundNodeKind Kind => BoundNodeKind.FunctionLiteralExpression;
+
+    internal BoundBlockStatement LoweredBody { get; set; }
 }

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -759,7 +759,8 @@ public sealed partial class Evaluator
             captured[v] = LookupVariable(v);
         }
 
-        return MaterializeClosure(new ClosureValue(node.Function, node.Body, node.FunctionType, captured));
+        var body = node.LoweredBody ??= (BoundBlockStatement)Lowering.Lowerer.Lower(node.Body);
+        return MaterializeClosure(new ClosureValue(node.Function, body, node.FunctionType, captured));
     }
 
     private object EvaluateMethodGroupExpression(BoundMethodGroupExpression node)

--- a/test/Interpreter.Tests/Issue3003LambdaBodyLoweringTests.cs
+++ b/test/Interpreter.Tests/Issue3003LambdaBodyLoweringTests.cs
@@ -1,0 +1,127 @@
+// <copyright file="Issue3003LambdaBodyLoweringTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #3003: function-literal bodies must be lowered before evaluation.
+/// </summary>
+public class Issue3003LambdaBodyLoweringTests
+{
+    [Fact]
+    public void LambdaBody_LowersIfAndAllForForms()
+    {
+        const string Source = """
+            let choose = func(n int32) string {
+                if n > 0 {
+                    return "positive"
+                }
+                return "zero"
+            }
+
+            let sumRange = func() int32 {
+                var sum = 0
+                for value in []int32{1, 2, 3} {
+                    sum += value
+                }
+                return sum
+            }
+
+            let countEllipsis = func() int32 {
+                var count = 0
+                for _ in 0 ... 3 {
+                    count++
+                }
+                return count
+            }
+
+            let countInfinite = func() int32 {
+                var count = 0
+                for {
+                    count++
+                    if count == 3 {
+                        break
+                    }
+                }
+                return count
+            }
+
+            Console.WriteLine(choose(1))
+            Console.WriteLine(sumRange())
+            Console.WriteLine(countEllipsis())
+            Console.WriteLine(countInfinite())
+            """;
+
+        Assert.Equal("positive\n6\n3\n3\n", Evaluate(Source));
+    }
+
+    [Fact]
+    public void LambdaBody_PreservesConditionForSwitchAndMethodGroupDelegate()
+    {
+        const string Source = """
+            func sign(n int32) string {
+                if n > 0 {
+                    return "positive"
+                }
+                return "zero"
+            }
+
+            let countTo = func(n int32) int32 {
+                var count = 0
+                for count < n {
+                    count++
+                }
+                return count
+            }
+
+            let classify = func(n int32) string {
+                switch n {
+                    case 1 {
+                        return "one"
+                    }
+                    default {
+                        return "other"
+                    }
+                }
+            }
+
+            let signDelegate (int32) -> string = sign
+
+            Console.WriteLine(countTo(3))
+            Console.WriteLine(classify(1))
+            Console.WriteLine(signDelegate(1))
+            Console.WriteLine(signDelegate(0))
+            """;
+
+        Assert.Equal("3\none\npositive\nzero\n", Evaluate(Source));
+    }
+
+    private static string Evaluate(string source)
+    {
+        using var outWriter = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var result = new Compilation(SyntaxTree.Parse(source))
+                .Evaluate(new Dictionary<VariableSymbol, object>());
+
+            Assert.Empty(result.Diagnostics);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}

--- a/test/Interpreter.Tests/Issue750ConstraintOverloadInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue750ConstraintOverloadInterpreterTests.cs
@@ -99,6 +99,27 @@ public class Issue750ConstraintOverloadInterpreterTests
         Assert.Equal("beta\n33\n42\n", Evaluate(source));
     }
 
+    [Fact]
+    public void FlatMap_NullableReturningLambdaWithIf_RunsInInterpreter()
+    {
+        var source = """
+            import System
+            import Gsharp.Extensions.Optional
+
+            let name string? = "ada"
+            let first = name.FlatMap(func(s string) string? {
+                if s.Length > 0 {
+                    return s.Substring(0, 1)
+                }
+                return nil
+            })
+
+            Console.WriteLine(first ?? "<none>")
+            """;
+
+        Assert.Equal("a\n", Evaluate(source));
+    }
+
     private static string Evaluate(string source)
     {
         // The Compilation.Default reference resolver enumerates


### PR DESCRIPTION
## Summary
- lower and cache function-literal bodies when the interpreter materializes closures
- cover all four lowered statement forms plus condition-for, switch, and method-group controls
- cover the nullable-returning `Optional.FlatMap` reproduction in the referenced in-process interpreter harness

## Verification
- base -> head: `IfStatement`, `ForRangeStatement`, `ForEllipsisStatement`, and `ForInfiniteStatement` each changed from `GS9999` to expected output
- base -> head: isolated `Optional.FlatMap` changed from `TargetInvocationException` to `a`
- targeted interpreter regressions: 3 passed

## Full #2995 sample
Direct `gsi samples/GsharpExtensionsOptional.gs` does not reach `FlatMap`: it exits 1 with 19 `GS0159` diagnostics because the CLI cannot resolve `Gsharp.Extensions`. The compiled expected line is therefore not reproduced end-to-end. #2995 remains open; the exact line-by-line measurement is recorded on that issue.

Fixes #3003
Related: #2995