### PR TITLE
Hoist select receive bindings in synchronous iterators

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
@@ -217,6 +217,7 @@ public static class IteratorRewriter
         {
             foreach (var arm in node.Cases)
             {
+                // As above, ByRef-like values cannot be state-machine fields.
                 if (arm.Variable != null
                     && !TypeSymbol.IsByRefLike(arm.Variable.Type)
                     && !Locals.Contains(arm.Variable))

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
@@ -213,6 +213,21 @@ public static class IteratorRewriter
             base.VisitVariableDeclaration(node);
         }
 
+        protected override void VisitSelectStatement(BoundSelectStatement node)
+        {
+            foreach (var arm in node.Cases)
+            {
+                if (arm.Variable != null
+                    && !TypeSymbol.IsByRefLike(arm.Variable.Type)
+                    && !Locals.Contains(arm.Variable))
+                {
+                    Locals.Add(arm.Variable);
+                }
+            }
+
+            base.VisitSelectStatement(node);
+        }
+
         protected override void VisitAddressOfExpression(BoundAddressOfExpression node)
         {
             if (node.Operand is BoundVariableExpression variable

--- a/test/Compiler.Tests/Emit/Issue2933AsyncSelectArmBindingTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2933AsyncSelectArmBindingTests.cs
@@ -291,6 +291,49 @@ public class Issue2933AsyncSelectArmBindingTests
         Assert.Equal(new[] { 10, 10, 10 }, values);
     }
 
+    [Fact]
+    public void SynchronousIteratorReceiveBindingRetainsSelectedArmValueAtRuntime()
+    {
+        const string Source = """
+            package Issue2975.SyncIterator
+            import System
+            import Gsharp.Extensions.Go
+
+            func Values() sequence[int32] {
+                let first = make(chan int32, 1)
+                let selected = make(chan int32, 1)
+                let third = make(chan int32, 1)
+                selected <- 7
+                select {
+                    case let value = <-first {
+                        yield -100
+                        yield value + 1000
+                    }
+                    case let value = <-selected {
+                        yield 200
+                        yield value
+                    }
+                    case let value = <-third {
+                        yield -300
+                        yield value + 3000
+                    }
+                }
+            }
+
+            for value in Values() {
+                if value != 200 {
+                    Console.WriteLine(value)
+                }
+            }
+            """;
+
+        Assert.Equal(
+            "7\n",
+            CompileLoadAndRun(
+                Source,
+                nameof(SynchronousIteratorReceiveBindingRetainsSelectedArmValueAtRuntime)));
+    }
+
     [Theory]
     [MemberData(nameof(SelectShapes))]
     public void RequestedSelectShapesLoadAndRun(string name, string expectedOutput, string source)

--- a/test/Compiler.Tests/Emit/Issue2933AsyncSelectArmBindingTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2933AsyncSelectArmBindingTests.cs
@@ -292,46 +292,107 @@ public class Issue2933AsyncSelectArmBindingTests
     }
 
     [Fact]
-    public void SynchronousIteratorReceiveBindingRetainsSelectedArmValueAtRuntime()
+    public void SynchronousIteratorReceiveBindingSurvivesYieldAtRuntime()
     {
         const string Source = """
-            package Issue2975.SyncIterator
+            package Issue2975.YieldThenRead
             import System
             import Gsharp.Extensions.Go
 
             func Values() sequence[int32] {
-                let first = make(chan int32, 1)
-                let selected = make(chan int32, 1)
-                let third = make(chan int32, 1)
-                selected <- 7
+                let ch = make(chan int32, 1)
+                ch <- 33
                 select {
-                    case let value = <-first {
-                        yield -100
-                        yield value + 1000
-                    }
-                    case let value = <-selected {
-                        yield 200
+                    case let value = <-ch {
+                        yield 11
                         yield value
-                    }
-                    case let value = <-third {
-                        yield -300
-                        yield value + 3000
+                        yield 22
                     }
                 }
             }
 
             for value in Values() {
-                if value != 200 {
-                    Console.WriteLine(value)
-                }
+                Console.WriteLine(value)
             }
             """;
 
         Assert.Equal(
-            "7\n",
+            "11\n33\n22\n",
             CompileLoadAndRun(
                 Source,
-                nameof(SynchronousIteratorReceiveBindingRetainsSelectedArmValueAtRuntime)));
+                nameof(SynchronousIteratorReceiveBindingSurvivesYieldAtRuntime)));
+    }
+
+    [Fact]
+    public void SynchronousIteratorReceiveBindingSurvivesLoopedYieldsAtRuntime()
+    {
+        const string Source = """
+            package Issue2975.LoopedYields
+            import System
+            import Gsharp.Extensions.Go
+
+            func Values() sequence[int32] {
+                let ch = make(chan int32, 1)
+                ch <- 44
+                select {
+                    case let value = <-ch {
+                        for i in 0 ... 2 {
+                            yield 100 + i
+                        }
+                        yield value
+                    }
+                }
+            }
+
+            for value in Values() {
+                Console.WriteLine(value)
+            }
+            """;
+
+        Assert.Equal(
+            "100\n101\n44\n",
+            CompileLoadAndRun(
+                Source,
+                nameof(SynchronousIteratorReceiveBindingSurvivesLoopedYieldsAtRuntime)));
+    }
+
+    [Fact]
+    public void NestedSynchronousIteratorReceiveBindingsSurviveYieldsAtRuntime()
+    {
+        const string Source = """
+            package Issue2975.NestedSelects
+            import System
+            import Gsharp.Extensions.Go
+
+            func Values() sequence[int32] {
+                let outer = make(chan int32, 1)
+                let inner = make(chan int32, 1)
+                outer <- 55
+                inner <- 66
+                select {
+                    case let outerValue = <-outer {
+                        yield 1
+                        select {
+                            case let innerValue = <-inner {
+                                yield 2
+                                yield innerValue
+                            }
+                        }
+                        yield outerValue
+                    }
+                }
+            }
+
+            for value in Values() {
+                Console.WriteLine(value)
+            }
+            """;
+
+        Assert.Equal(
+            "1\n2\n66\n55\n",
+            CompileLoadAndRun(
+                Source,
+                nameof(NestedSynchronousIteratorReceiveBindingsSurviveYieldsAtRuntime)));
     }
 
     [Theory]

--- a/test/Core.Tests/CodeAnalysis/Lowering/Iterators/IteratorRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Iterators/IteratorRewriterTests.cs
@@ -9,6 +9,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Lowering.Iterators;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Iterators;
@@ -101,6 +102,29 @@ public class IteratorRewriterTests
         // Assert: local should be in hoisted locals
         var plan = Assert.Single(result.Plans);
         Assert.Contains(plan.HoistedLocals, v => v.Name == "temp");
+    }
+
+    [Fact]
+    public void Rewrite_HoistsSelectReceiveBinding()
+    {
+        var seqType = SequenceTypeSymbol.Get(TypeSymbol.Int32);
+        var function = new FunctionSymbol("withSelect", ImmutableArray<ParameterSymbol>.Empty, seqType, package: Package);
+        var selectVariable = new LocalVariableSymbol("value", false, TypeSymbol.Int32);
+        var yield = new BoundYieldStatement(null, new BoundVariableExpression(null, selectVariable));
+        var select = new BoundSelectStatement(
+            null,
+            ImmutableArray.Create(new BoundSelectCase(
+                SelectCaseKind.ReceiveBind,
+                new BoundLiteralExpression(null, null),
+                value: null,
+                selectVariable,
+                Block(yield))));
+        var program = MakeProgram(function, Block(select));
+
+        var result = IteratorRewriter.Rewrite(program);
+
+        var plan = Assert.Single(result.Plans);
+        Assert.Contains(selectVariable, plan.HoistedLocals);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- collect `BoundSelectCase.Variable` bindings as synchronous iterator locals
- preserve the existing byref-like exclusion used for hoisted fields
- add structural and emitted-runtime regressions

## Root cause

`src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs:187` builds the synchronous iterator field map through `LocalCollector`, but that collector recorded variable declarations only. A receive-bind arm stores its binding as the bare `BoundSelectCase.Variable` symbol, not a `BoundVariableDeclaration`, so the variable never entered `HoistedLocals` or the resulting field map. The fix is the select visitor at `IteratorRewriter.cs:216`.

`HoistedFieldRewriter` already consumes this map correctly. `BoundSelectCase` is not a `BoundNode`, so there is no declaration or assignment node for that rewriter to redirect.

## Runtime dependency

This hoisting fix and #2967 are complementary halves of the mechanism. This PR creates the synchronous iterator field and redirects reads to it; #2967 copies the select receive out-slot into that field. #2967 merged as `a8ee8f22c` before this branch was rebased. This PR intentionally does not touch `MethodBodyEmitter.Statements.cs`.

The exact four-cell probe was rebuilt from source in every configuration and its printed value was read directly:

| Configuration | Printed value |
| --- | ---: |
| `47a400359` (neither fix) | 7 |
| `47a400359` + this hoisting patch | 0 |
| `a8ee8f22c` (#2967 only) | 7 |
| `a8ee8f22c` + this hoisting patch | 7 |

All four `gsc` and `dotnet exec` invocations exited 0. The `0` cell is the silent unwritten-field regression that occurs when hoisting lands without #2967.

## Tests and differential evidence

- `IteratorRewriterTests.Rewrite_HoistsSelectReceiveBinding` directly pins field-map construction.
- `Issue2933AsyncSelectArmBindingTests.SynchronousIteratorReceiveBindingRetainsSelectedArmValueAtRuntime` compiles, loads, and executes a synchronous iterator with three distinct receive-arm outcomes and asserts the selected binding prints `7` after suspension.
- Mutation round trip: head passed with `7`; deleting this PR's `VisitSelectStatement` made the runtime test fail with expected `7`, actual `0`; restoring the visitor passed with `7` again.

Current-head verification at `f26fc97e4087f6b21c46a6e88655ea6e38520d3e`:

- `dotnet build GSharp.sln -c Release -p:ContinuousIntegrationBuild=true`: exit 0, 0 warnings, 0 errors
- zero-byte check: 0 failures across 40 `GSharp.Core.dll` files
- propagation check: 0 mismatches across 5 ordinary outputs, MD5 `1c42c3c7e2d43ad20faa980f4f57c203`
- focused structural test: 1 passed
- focused emitted-runtime test: 1 passed
- direct emitted program output: `7`

Earlier full-suite counts were measured on the same `8acc2cc76` base before the emitted-runtime test was added:

| Suite | Base | Head |
| --- | ---: | ---: |
| Core | 7033 passed, 1 skipped | 7034 passed, 1 skipped |
| Compiler | 3988 passed | 3988 passed |
| Interpreter | 512 passed | 512 passed |
| Language Server | 452 passed | 452 passed |

No test used `--no-build`. Current validation uses the narrow selectors required by fleet throttle guidance.

Closes #2975.






## Required end-to-end coverage

The reviewer-requested synchronous iterator probes are now pinned by emitted-runtime tests:

- `SynchronousIteratorReceiveBindingSurvivesYieldAtRuntime`: `11 / 33 / 22`
- `SynchronousIteratorReceiveBindingSurvivesLoopedYieldsAtRuntime`: `100 / 101 / 44`
- `NestedSynchronousIteratorReceiveBindingsSurviveYieldsAtRuntime`: `1 / 2 / 66 / 55`

Each test compiles an executable, loads it with `Assembly.Load(File.ReadAllBytes(...))` plus `GetTypes()`, runs it in a bounded child process, and asserts printed values.

Production-hunk mutation, with tests retained:

- clean build rc 0, Core MD5 `1c42c3c7e2d43ad20faa980f4f57c203`: 3 passed
- removed `VisitSelectStatement`, build rc 0, Core MD5 `617c141f45a283100f9110392659f525`: all 3 failed (`33→0`, `44→0`, `66/55→0/0`)
- restored build rc 0, Core MD5 `1c42c3c7e2d43ad20faa980f4f57c203`: 3 passed

The `IsByRefLike` guard now documents that, like the declaration path above it, ByRef-like values cannot become state-machine fields.

