### PR TITLE
Fix IL verifier probe deadlocks and scoped suppressions

### DIFF
--- a/test/Compiler.Tests/Emit/Issue2900FixedPinReleaseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2900FixedPinReleaseEmitTests.cs
@@ -3,11 +3,9 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -32,12 +30,6 @@ public class Issue2900FixedPinReleaseEmitTests
         "StackUnexpectedArrayType",
         "ExpectedNumericType",
     };
-
-    private static readonly Dictionary<short, OpCode> OpCodesByValue = typeof(OpCodes)
-        .GetFields(BindingFlags.Public | BindingFlags.Static)
-        .Where(field => field.FieldType == typeof(OpCode))
-        .Select(field => (OpCode)field.GetValue(null)!)
-        .ToDictionary(opcode => opcode.Value);
 
     [Fact]
     public void BranchExits_UseLeaveThroughFinally_AndRun()
@@ -951,74 +943,14 @@ public class Issue2900FixedPinReleaseEmitTests
         var name = metadata.GetString(definition.Name);
         if (definition.RelativeVirtualAddress == 0)
         {
-            return new MethodIl(name, Array.Empty<Instruction>(), Array.Empty<ExceptionRegion>());
+            return new MethodIl(name, Array.Empty<IlInstruction>(), Array.Empty<ExceptionRegion>());
         }
 
         var body = pe.GetMethodBody(definition.RelativeVirtualAddress);
         return new MethodIl(
             name,
-            Decode(body.GetILBytes() ?? Array.Empty<byte>()),
+            IlInstructionReader.Read(body.GetILBytes() ?? Array.Empty<byte>()),
             body.ExceptionRegions.ToArray());
-    }
-
-    private static Instruction[] Decode(byte[] il)
-    {
-        var instructions = new List<Instruction>();
-        var offset = 0;
-        while (offset < il.Length)
-        {
-            var instructionOffset = offset;
-            short value = il[offset++] == 0xFE
-                ? unchecked((short)(0xFE00 | il[offset++]))
-                : unchecked((short)il[instructionOffset]);
-            var opcode = OpCodesByValue[value];
-            int? branchTarget = null;
-
-            switch (opcode.OperandType)
-            {
-                case OperandType.InlineNone:
-                    break;
-                case OperandType.ShortInlineBrTarget:
-                    branchTarget = offset + 1 + unchecked((sbyte)il[offset]);
-                    offset++;
-                    break;
-                case OperandType.InlineBrTarget:
-                    branchTarget = offset + 4 + BitConverter.ToInt32(il, offset);
-                    offset += 4;
-                    break;
-                case OperandType.InlineSwitch:
-                    var count = BitConverter.ToInt32(il, offset);
-                    offset += 4 + (count * 4);
-                    break;
-                case OperandType.ShortInlineI:
-                case OperandType.ShortInlineVar:
-                    offset++;
-                    break;
-                case OperandType.InlineVar:
-                    offset += 2;
-                    break;
-                case OperandType.InlineI:
-                case OperandType.ShortInlineR:
-                case OperandType.InlineField:
-                case OperandType.InlineMethod:
-                case OperandType.InlineSig:
-                case OperandType.InlineString:
-                case OperandType.InlineTok:
-                case OperandType.InlineType:
-                    offset += 4;
-                    break;
-                case OperandType.InlineI8:
-                case OperandType.InlineR:
-                    offset += 8;
-                    break;
-                default:
-                    throw new InvalidOperationException($"Unsupported IL operand type {opcode.OperandType}.");
-            }
-
-            instructions.Add(new Instruction(instructionOffset, opcode, branchTarget));
-        }
-
-        return instructions.ToArray();
     }
 
     private sealed class CompiledProgram : IDisposable
@@ -1093,11 +1025,6 @@ public class Issue2900FixedPinReleaseEmitTests
 
     private sealed record MethodIl(
         string Name,
-        Instruction[] Instructions,
+        IlInstruction[] Instructions,
         ExceptionRegion[] Regions);
-
-    private sealed record Instruction(
-        int Offset,
-        OpCode OpCode,
-        int? BranchTarget);
 }

--- a/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
@@ -311,7 +311,8 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
         var assembly = CompileVerifyLoadAndRun(
             "UnnamedFixed",
             Source,
-            ignoredVerificationErrors: new[] { "UnmanagedPointer", "StackByRef" });
+            ignoredVerificationErrors: new[] { "UnmanagedPointer", "StackByRef" },
+            ignoredVerificationScope: @"<Program>\.F$");
         // Known limitation (#2953): the fixed-return epilogue must be emitted first,
         // so fixed-containing non-void functions bypass the fall-through guard and
         // silently return the default slot instead of throwing.
@@ -324,7 +325,8 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
     private static Assembly CompileVerifyLoadAndRun(
         string name,
         string source,
-        IEnumerable<string> ignoredVerificationErrors = null)
+        IEnumerable<string> ignoredVerificationErrors = null,
+        string ignoredVerificationScope = null)
     {
         using var peStream = new MemoryStream();
         var result = new Compilation(SyntaxTree.Parse(SourceText.From(source))).Emit(peStream);
@@ -337,7 +339,10 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
         try
         {
             File.WriteAllBytes(assemblyPath, bytes);
-            IlVerifier.Verify(assemblyPath, ignoredErrorCodes: ignoredVerificationErrors);
+            IlVerifier.Verify(
+                assemblyPath,
+                ignoredErrorCodes: ignoredVerificationErrors,
+                ignoredErrorScope: ignoredVerificationScope);
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2922FixedSwitchIlTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2922FixedSwitchIlTests.cs
@@ -329,7 +329,8 @@ public class Issue2922FixedSwitchIlTests
         IlVerifier.Verify(
             program.AssemblyPath,
             additionalReferences: null,
-            ignoredErrorCodes: ignoredVerificationErrors);
+            ignoredErrorCodes: ignoredVerificationErrors,
+            ignoredErrorScope: ignoredVerificationErrors.Length == 0 ? null : @"<Program>\.F$");
         program.AssertLoadable();
         Assert.Equal(expectedOutput, program.Run());
     }
@@ -357,14 +358,38 @@ public class Issue2922FixedSwitchIlTests
         var method = assembly.GetTypes()
             .Single(type => type.Name == "<Program>")
             .GetMethod("F", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
-        var il = method.GetMethodBody()!.GetILAsByteArray()!;
-        var loadElementAddress = Array.IndexOf(il, unchecked((byte)OpCodes.Ldelema.Value));
+        var instructions = IlInstructionReader.Read(method.GetMethodBody()!.GetILAsByteArray()!);
+        var loadElementAddressIndex = Array.FindIndex(
+            instructions,
+            instruction => instruction.OpCode == OpCodes.Ldelema);
 
-        Assert.True(loadElementAddress >= 0);
-        var callOffset = loadElementAddress + 5;
-        Assert.Equal(unchecked((byte)OpCodes.Call.Value), il[callOffset]);
-        var calledMethod = method.Module.ResolveMethod(BitConverter.ToInt32(il, callOffset + 1));
+        Assert.True(loadElementAddressIndex >= 0);
+        Assert.True(loadElementAddressIndex + 1 < instructions.Length);
+        var call = instructions[loadElementAddressIndex + 1];
+        Assert.Equal(OpCodes.Call, call.OpCode);
+        Assert.True(call.MetadataToken.HasValue);
+        var calledMethod = method.Module.ResolveMethod(call.MetadataToken.Value);
         Assert.Equal("AsPointer", calledMethod!.Name);
+    }
+
+    [Fact]
+    public void InstructionReader_DoesNotTreatOperandByteAsOpcode()
+    {
+        var il = new byte[]
+        {
+            unchecked((byte)OpCodes.Ldc_I4.Value),
+            unchecked((byte)OpCodes.Ldelema.Value),
+            0,
+            0,
+            0,
+            unchecked((byte)OpCodes.Ret.Value),
+        };
+        Assert.Equal(1, Array.IndexOf(il, unchecked((byte)OpCodes.Ldelema.Value)));
+
+        var instructions = IlInstructionReader.Read(il);
+        Assert.Equal(
+            new[] { OpCodes.Ldc_I4, OpCodes.Ret },
+            instructions.Select(instruction => instruction.OpCode));
     }
 
     private static CompiledProgram Compile(string name, string source)

--- a/test/Compiler.Tests/IlInstructionReader.cs
+++ b/test/Compiler.Tests/IlInstructionReader.cs
@@ -1,0 +1,90 @@
+// <copyright file="IlInstructionReader.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace GSharp.Compiler.Tests;
+
+internal static class IlInstructionReader
+{
+    private static readonly Dictionary<short, OpCode> OpCodesByValue = typeof(OpCodes)
+        .GetFields(BindingFlags.Public | BindingFlags.Static)
+        .Where(field => field.FieldType == typeof(OpCode))
+        .Select(field => (OpCode)field.GetValue(null)!)
+        .ToDictionary(opcode => opcode.Value);
+
+    public static IlInstruction[] Read(byte[] il)
+    {
+        var instructions = new List<IlInstruction>();
+        var offset = 0;
+        while (offset < il.Length)
+        {
+            var instructionOffset = offset;
+            short value = il[offset++] == 0xFE
+                ? unchecked((short)(0xFE00 | il[offset++]))
+                : unchecked((short)il[instructionOffset]);
+            var opcode = OpCodesByValue[value];
+            int? branchTarget = null;
+            int? metadataToken = null;
+
+            switch (opcode.OperandType)
+            {
+                case OperandType.InlineNone:
+                    break;
+                case OperandType.ShortInlineBrTarget:
+                    branchTarget = offset + 1 + unchecked((sbyte)il[offset]);
+                    offset++;
+                    break;
+                case OperandType.InlineBrTarget:
+                    branchTarget = offset + 4 + BitConverter.ToInt32(il, offset);
+                    offset += 4;
+                    break;
+                case OperandType.InlineSwitch:
+                    var count = BitConverter.ToInt32(il, offset);
+                    offset += 4 + (count * 4);
+                    break;
+                case OperandType.ShortInlineI:
+                case OperandType.ShortInlineVar:
+                    offset++;
+                    break;
+                case OperandType.InlineVar:
+                    offset += 2;
+                    break;
+                case OperandType.InlineMethod:
+                    metadataToken = BitConverter.ToInt32(il, offset);
+                    offset += 4;
+                    break;
+                case OperandType.InlineI:
+                case OperandType.ShortInlineR:
+                case OperandType.InlineField:
+                case OperandType.InlineSig:
+                case OperandType.InlineString:
+                case OperandType.InlineTok:
+                case OperandType.InlineType:
+                    offset += 4;
+                    break;
+                case OperandType.InlineI8:
+                case OperandType.InlineR:
+                    offset += 8;
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unsupported IL operand type {opcode.OperandType}.");
+            }
+
+            instructions.Add(new IlInstruction(instructionOffset, opcode, branchTarget, metadataToken));
+        }
+
+        return instructions.ToArray();
+    }
+}
+
+internal sealed record IlInstruction(
+    int Offset,
+    OpCode OpCode,
+    int? BranchTarget,
+    int? MetadataToken);

--- a/test/Compiler.Tests/IlVerifier.cs
+++ b/test/Compiler.Tests/IlVerifier.cs
@@ -44,6 +44,7 @@ internal static class IlVerifier
 {
     private const string SkipEnvVar = "GSHARP_SKIP_ILVERIFY";
     private const int VerifyTimeoutMilliseconds = 30_000;
+    private const int ToolProbeTimeoutMilliseconds = 30_000;
     private const int KillGraceMilliseconds = 10_000;
     private const string UnavailableOutput = "<unavailable: output pipe held by a surviving descendant>";
 
@@ -71,10 +72,14 @@ internal static class IlVerifier
     /// already-tracked issues. Each entry should be the bracketed identifier
     /// from ilverify output (for example, <c>"CallVirtOnValueType"</c>); the
     /// helper translates it into the matching regex.</param>
+    /// <param name="ignoredErrorScope">Optional ilverify member-name regex
+    /// limiting <paramref name="ignoredErrorCodes"/> to matching methods. The
+    /// rest of the assembly is verified separately without suppressions.</param>
     public static void Verify(
         string assemblyPath,
         IEnumerable<string>? additionalReferences = null,
-        IEnumerable<string>? ignoredErrorCodes = null)
+        IEnumerable<string>? ignoredErrorCodes = null,
+        string? ignoredErrorScope = null)
     {
         if (Environment.GetEnvironmentVariable(SkipEnvVar) == "1")
         {
@@ -89,6 +94,46 @@ internal static class IlVerifier
         var (command, leadingArgs) = LocateTool();
         var references = BuildReferenceSet(assemblyPath, additionalReferences);
 
+        if (!string.IsNullOrWhiteSpace(ignoredErrorScope))
+        {
+            VerifyCore(
+                command,
+                leadingArgs,
+                assemblyPath,
+                references,
+                ignoredErrorCodes: null,
+                includedScope: null,
+                excludedScope: ignoredErrorScope);
+            VerifyCore(
+                command,
+                leadingArgs,
+                assemblyPath,
+                references,
+                ignoredErrorCodes,
+                includedScope: ignoredErrorScope,
+                excludedScope: null);
+            return;
+        }
+
+        VerifyCore(
+            command,
+            leadingArgs,
+            assemblyPath,
+            references,
+            ignoredErrorCodes,
+            includedScope: null,
+            excludedScope: null);
+    }
+
+    private static void VerifyCore(
+        string command,
+        IReadOnlyList<string> leadingArgs,
+        string assemblyPath,
+        IReadOnlyList<string> references,
+        IEnumerable<string>? ignoredErrorCodes,
+        string? includedScope,
+        string? excludedScope)
+    {
         var args = new List<string>(leadingArgs)
         {
             assemblyPath,
@@ -117,6 +162,18 @@ internal static class IlVerifier
                 args.Add("-g");
                 args.Add(code);
             }
+        }
+
+        if (includedScope is not null)
+        {
+            args.Add("-i");
+            args.Add(includedScope);
+        }
+
+        if (excludedScope is not null)
+        {
+            args.Add("-e");
+            args.Add(excludedScope);
         }
 
         var psi = new ProcessStartInfo(command)
@@ -378,27 +435,10 @@ internal static class IlVerifier
         psi.ArgumentList.Add("ilverify");
         psi.ArgumentList.Add("--version");
 
-        try
+        if (TryProbe(psi))
         {
-            using var proc = Process.Start(psi);
-            if (proc is null)
-            {
-                args = Array.Empty<string>();
-                return false;
-            }
-
-            proc.StandardOutput.ReadToEnd();
-            proc.StandardError.ReadToEnd();
-            proc.WaitForExit();
-            if (proc.ExitCode == 0)
-            {
-                args = new[] { "tool", "run", "ilverify" };
-                return true;
-            }
-        }
-        catch
-        {
-            // Fall through to the next probe.
+            args = new[] { "tool", "run", "ilverify" };
+            return true;
         }
 
         args = Array.Empty<string>();
@@ -416,18 +456,20 @@ internal static class IlVerifier
         };
         psi.ArgumentList.Add("--version");
 
+        return TryProbe(psi);
+    }
+
+    internal static bool TryProbe(
+        ProcessStartInfo startInfo,
+        int timeoutMilliseconds = ToolProbeTimeoutMilliseconds)
+    {
         try
         {
-            using var proc = Process.Start(psi);
-            if (proc is null)
-            {
-                return false;
-            }
-
-            proc.StandardOutput.ReadToEnd();
-            proc.StandardError.ReadToEnd();
-            proc.WaitForExit();
-            return proc.ExitCode == 0;
+            var (exitCode, _, _) = RunProcess(
+                startInfo,
+                "ilverify tool probe",
+                timeoutMilliseconds);
+            return exitCode == 0;
         }
         catch
         {

--- a/test/Compiler.Tests/IlVerifierTests.cs
+++ b/test/Compiler.Tests/IlVerifierTests.cs
@@ -220,7 +220,7 @@ public class IlVerifierTests
     [Fact]
     public void RunProcess_LargeStdoutAndStderr_DrainsBothPipes()
     {
-        // A regression that starts either drain after WaitForExit hangs this test.
+        // A regression that blocks in either drain before WaitForExit hangs this test.
         // xUnit's Fact timeout is unavailable because this assembly disables test
         // parallelization, and RunProcess's timeout cannot cover a deadlock placed
         // before its wait. Treat such a hang as the regression, not a flake.

--- a/test/Compiler.Tests/IlVerifierTests.cs
+++ b/test/Compiler.Tests/IlVerifierTests.cs
@@ -152,6 +152,51 @@ public class IlVerifierTests
     }
 
     [Fact]
+    public void Verify_MethodScopedIgnore_DoesNotHideSameErrorInAnotherMethod()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_ilv_scope_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "scope.gs");
+            var outPath = Path.Combine(tempDir, "scope.dll");
+            File.WriteAllText(
+                srcPath,
+                """
+                package P
+
+                unsafe func Ignored(p *int32) int32 { return *p }
+                unsafe func Visible(p *int32) int32 { return *p }
+                """);
+
+            var exit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+            Assert.Equal(0, exit);
+
+            var exception = Assert.Throws<XunitException>(
+                () => IlVerifier.Verify(
+                    outPath,
+                    ignoredErrorCodes: new[] { "UnmanagedPointer", "StackByRef" },
+                    ignoredErrorScope: @"<Program>\.Ignored$"));
+            Assert.Contains("::Visible(", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    [Fact]
     public void RunProcess_HungChild_TimesOutWithPartialOutput()
     {
         var assemblyPath = typeof(IlVerifierTests).Assembly.Location;
@@ -194,6 +239,19 @@ public class IlVerifierTests
     }
 
     [Fact]
+    public void TryProbe_LargeStdoutAndStderr_DrainsBothPipes()
+    {
+        const int OutputLength = 128 * 1024;
+        Assert.True(
+            IlVerifier.TryProbe(
+                CreateChildProcess(
+                    $"[Console]::Out.Write('o' * {OutputLength}); [Console]::Error.Write('e' * {OutputLength})",
+                    $"awk 'BEGIN {{ for (i = 0; i < {OutputLength}; i++) printf \"o\" }}'; " +
+                    $"awk 'BEGIN {{ for (i = 0; i < {OutputLength}; i++) printf \"e\" }}' >&2"),
+                timeoutMilliseconds: 10_000));
+    }
+
+    [Fact]
     public void RunProcess_EscapedDescendantHoldingPipe_TimeoutRemainsBounded()
     {
         if (OperatingSystem.IsWindows())
@@ -218,7 +276,7 @@ public class IlVerifierTests
                     timeoutMilliseconds: 2_000));
             stopwatch.Stop();
 
-            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(15), $"timeout took {stopwatch.Elapsed}");
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(20), $"timeout took {stopwatch.Elapsed}");
             Assert.Contains("process '/bin/sh' timed out after 2000 ms", exception.Message, StringComparison.Ordinal);
             Assert.Contains(
                 "<unavailable: output pipe held by a surviving descendant>",


### PR DESCRIPTION
## Summary

- Route both ilverify discovery probes through the existing bounded process runner, which starts concurrent async reads before its timeout/kill path.
- Add method-scoped ilverify suppressions by verifying the rest of the assembly without ignores, then the selected method with its documented ignores.
- Scope the fixed/pointer exemptions in the #2906 and #2922 tests to `<Program>.F`.
- Replace raw IL byte scanning with a shared opcode-aware instruction reader and add an operand-collision regression.
- Correct the stale #2966-era test comment: a drain that blocks before the bounded wait can hang; starting a drain after the wait instead reaches the timeout and fails boundedly.

## Evidence

- Post-rebase targeted validation, exit 0: 29 passed, 0 failed.
  - `IlVerifierTests`
  - `Issue2900FixedPinReleaseEmitTests`
  - `Issue2922FixedSwitchIlTests`
  - `Issue2906ExhaustiveSwitchReturnEmitTests.ExhaustiveEnum_UnnamedValueWithFixedReturn_UsesFixedEpilogueDefault`
  - Command used `-p:ContinuousIntegrationBuild=true` and did not use `--no-build`.
- #3007 perturbation: replaced `TryProbe` with sequential `ReadToEnd()` calls. A bounded runner timed out after 60 seconds and exited 124. Restoring the concurrent bounded path made the same test pass (1/1, exit 0, 162 ms).
- #3008 suppression perturbation: replaced the two-pass method scope with the old assembly-wide ignore. The regression failed with `Assert.Throws() Failure: No exception was thrown` (exit 1), proving the second method's genuine dereference fault was hidden. Restoring method scope passed (1/1, exit 0).
- Opcode regression uses IL where raw `Array.IndexOf` finds `0x8F` at index 1 inside an `ldc.i4` operand; the decoder correctly returns only `ldc.i4` and `ret` instructions.
- Pointer caller tests also load assemblies with `Assembly.Load(...)+GetTypes()` and execute through bounded child/task paths.
- `git log -S` traces the corrected sentence to `87ca66e85` (#2966), where the wait became bounded and made the inherited wording stale.

SDK/e2e tests were not run because this task explicitly prohibits touching the shared `gsharp.net.sdk` NuGet cache.

Fixes #3007
Fixes #3008
