### PR TITLE
Fix delegate property invocation through interfaces

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -3383,7 +3383,7 @@ internal sealed partial class ExpressionBinder
         }
 
         if (structSym != null
-            && TryBindUserStructDelegateMemberInvocation(
+            && TryBindUserDelegateMemberInvocation(
                 receiver: null,
                 structSym,
                 methodName,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -419,9 +419,9 @@ internal sealed partial class ExpressionBinder
         return null;
     }
 
-    private bool TryBindUserStructDelegateMemberInvocation(
+    private bool TryBindUserDelegateMemberInvocation(
         BoundExpression receiver,
-        StructSymbol receiverStruct,
+        TypeSymbol receiverType,
         string methodName,
         ImmutableArray<BoundExpression> arguments,
         CallExpressionSyntax ce,
@@ -430,9 +430,10 @@ internal sealed partial class ExpressionBinder
     {
         result = null;
 
+        var receiverStruct = receiverType as StructSymbol;
         FieldSymbol matchedField = null;
         StructSymbol declaringType = null;
-        if (isStatic)
+        if (isStatic && receiverStruct != null)
         {
             TypeMemberModel.TryGetStaticFieldIncludingInherited(
                 receiverStruct,
@@ -440,7 +441,7 @@ internal sealed partial class ExpressionBinder
                 out matchedField,
                 out declaringType);
         }
-        else
+        else if (receiverStruct != null)
         {
             // Walk the base chain so an inherited delegate field on a base class
             // is invokable on a derived instance.
@@ -465,7 +466,7 @@ internal sealed partial class ExpressionBinder
                     out var property,
                     out var propertyDeclaringType)
                 : TypeMemberModel.TryGetProperty(
-                    receiverStruct,
+                    receiverType,
                     methodName,
                     out property,
                     out propertyDeclaringType);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2384,16 +2384,15 @@ internal sealed partial class ExpressionBinder
                 {
                     return overloads.BindUserInstanceCall(receiver, defaultIfaceMethod, arguments, ce, argumentNames);
                 }
+            }
 
-                // Issue #527: fall back to a delegate/function-typed member on
-                // the user struct/class. This is the same delegate-as-callable
-                // dispatch used for the imported-CLR path below; here the
-                // receiver's ClrType is null (the user type has not yet been
-                // emitted) so we have to handle the symbol-only shape too.
-                if (TryBindUserStructDelegateMemberInvocation(receiver, userClass, methodName, arguments, ce, isStatic: false, out var userDelegateFieldCall))
-                {
-                    return userDelegateFieldCall;
-                }
+            // Issues #527 and #2925: source struct/class and interface
+            // delegate members are callable before their CLR types exist.
+            if (receiver != null
+                && receiver.Type is StructSymbol or InterfaceSymbol
+                && TryBindUserDelegateMemberInvocation(receiver, receiver.Type, methodName, arguments, ce, isStatic: false, out var userDelegateFieldCall))
+            {
+                return userDelegateFieldCall;
             }
 
             // Phase 3.B.6 / ADR-0019: extension function fallback for
@@ -2527,15 +2526,14 @@ internal sealed partial class ExpressionBinder
             {
                 return overloads.BindUserInstanceCall(receiver, defaultIfaceMethodPriority, arguments, ce, argumentNames);
             }
+        }
 
-            // Issue #527: a G#-defined struct/class field or property whose type is a
-            // function (or named delegate) is invokable through the same
-            // call syntax as a bare function-typed variable. Lower to a load
-            // of the member value followed by an indirect call.
-            if (TryBindUserStructDelegateMemberInvocation(receiver, userClassPriority, methodName, arguments, ce, isStatic: false, out var userDelegateCall))
-            {
-                return userDelegateCall;
-            }
+        // Issues #527 and #2925: a G#-defined struct/class or interface
+        // delegate member is invokable through bare call syntax.
+        if (receiver.Type is StructSymbol or InterfaceSymbol
+            && TryBindUserDelegateMemberInvocation(receiver, receiver.Type, methodName, arguments, ce, isStatic: false, out var userDelegateCall))
+        {
+            return userDelegateCall;
         }
 
         // Issue #517: a value-type `T?` lowers to `System.Nullable<T>` at the

--- a/test/Compiler.Tests/Emit/Issue2925InterfaceDelegatePropertyInvocationTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2925InterfaceDelegatePropertyInvocationTests.cs
@@ -1,0 +1,144 @@
+// <copyright file="Issue2925InterfaceDelegatePropertyInvocationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2925: delegate properties are callable through source-interface
+/// receivers for class and struct implementors.
+/// </summary>
+public class Issue2925InterfaceDelegatePropertyInvocationTests
+{
+    [Fact]
+    public void InterfaceDelegateProperties_ClassAndStruct_GetOnlyAndGetSet_Invoke()
+    {
+        const string Source = """
+            package Issue2925
+            import System
+
+            interface IActionBox {
+                prop P System.Action[int32] { get }
+            }
+
+            class ClassActionBox : IActionBox {
+                let Handler System.Action[int32]
+                init(handler System.Action[int32]) { Handler = handler }
+                prop P System.Action[int32] -> Handler
+            }
+
+            struct StructActionBox : IActionBox {
+                prop P System.Action[int32] { get; set }
+            }
+
+            interface IMapper {
+                prop P System.Func[int32, int32] { get; set }
+            }
+
+            class ClassMapper : IMapper {
+                prop P System.Func[int32, int32] { get; set }
+            }
+
+            struct StructMapper : IMapper {
+                prop P System.Func[int32, int32] { get; set }
+            }
+
+            func Main() {
+                let classAction IActionBox = ClassActionBox((value int32) -> Console.WriteLine(value))
+                classAction.P(1)
+
+                var structActionValue = StructActionBox{}
+                structActionValue.P = (value int32) -> Console.WriteLine(value)
+                let structAction IActionBox = structActionValue
+                structAction.P(2)
+
+                let classConcrete = ClassMapper()
+                classConcrete.P = (value int32) -> value + 1
+                let classMapper IMapper = classConcrete
+                Console.WriteLine(classMapper.P(41))
+
+                var structConcrete = StructMapper{}
+                structConcrete.P = (value int32) -> value + 2
+                let structMapper IMapper = structConcrete
+                Console.WriteLine(structMapper.P(40))
+            }
+            """;
+
+        Assert.Equal("1\n2\n42\n42\n", CompileAndRun(Source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var outputDirectory = Path.Combine(AppContext.BaseDirectory, "issue2925", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+        try
+        {
+            var sourcePath = Path.Combine(outputDirectory, "Program.gs");
+            var outputPath = Path.Combine(outputDirectory, "Issue2925.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var standardOut = new StringWriter();
+            using var standardError = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(standardOut);
+            Console.SetError(standardError);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(
+                exitCode == 0,
+                $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
+            IlVerifier.Verify(outputPath);
+            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            _ = assembly.GetTypes();
+            var entryPoint = assembly.EntryPoint
+                ?? throw new InvalidOperationException("Emitted assembly has no entry point.");
+
+            previousOut = Console.Out;
+            using var output = new StringWriter();
+            Console.SetOut(output);
+            try
+            {
+                entryPoint.Invoke(
+                    null,
+                    entryPoint.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+            }
+
+            return output.ToString().Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Interpreter.Tests/Issue2925InterfaceDelegatePropertyInvocationTests.cs
+++ b/test/Interpreter.Tests/Issue2925InterfaceDelegatePropertyInvocationTests.cs
@@ -1,0 +1,85 @@
+// <copyright file="Issue2925InterfaceDelegatePropertyInvocationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Interpreter parity for issue #2925's source-interface delegate property
+/// invocation.
+/// </summary>
+public class Issue2925InterfaceDelegatePropertyInvocationTests
+{
+    [Fact]
+    public void InterfaceDelegateProperties_ClassAndStruct_GetOnlyAndGetSet_Invoke()
+    {
+        var output = RunSubmission("""
+            interface IActionBox {
+                prop P System.Action[int32] { get }
+            }
+
+            class ClassActionBox : IActionBox {
+                let Handler System.Action[int32]
+                init(handler System.Action[int32]) { Handler = handler }
+                prop P System.Action[int32] -> Handler
+            }
+
+            struct StructActionBox : IActionBox {
+                prop P System.Action[int32] { get; set }
+            }
+
+            interface IMapper {
+                prop P System.Func[int32, int32] { get; set }
+            }
+
+            class ClassMapper : IMapper {
+                prop P System.Func[int32, int32] { get; set }
+            }
+
+            struct StructMapper : IMapper {
+                prop P System.Func[int32, int32] { get; set }
+            }
+
+            let classAction IActionBox = ClassActionBox((value int32) -> Console.WriteLine(value))
+            classAction.P(1)
+
+            var structActionValue = StructActionBox{}
+            structActionValue.P = (value int32) -> Console.WriteLine(value)
+            let structAction IActionBox = structActionValue
+            structAction.P(2)
+
+            let classConcrete = ClassMapper()
+            classConcrete.P = (value int32) -> value + 1
+            let classMapper IMapper = classConcrete
+            Console.WriteLine(classMapper.P(41))
+
+            var structConcrete = StructMapper{}
+            structConcrete.P = (value int32) -> value + 2
+            let structMapper IMapper = structConcrete
+            Console.WriteLine(structMapper.P(40))
+            """);
+
+        Assert.Equal("1\n2\n42\n42\n", output);
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var output = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            new GSharpRepl().EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return output.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
## Summary
- generalize the existing source delegate-member invocation helper to accept both struct/class and interface receiver symbols
- route both invocation fallback sites through the generalized helper
- cover class and struct implementors, get-only and get/set properties, and `System.Action` / generic `System.Func` delegates in compiler and interpreter tests

## Root cause
`src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs:2391-2393` and `:2533-2534` only reached the delegate-member fallback for `StructSymbol` receivers. The shared helper in `ExpressionBinder.Calls.Arguments.cs:422-469` also accepted only `StructSymbol`, even though `TypeMemberModel.TryGetProperty` already supports `InterfaceSymbol`. Interface delegate-property calls therefore skipped the property load + indirect invocation path and fell through to GS0159.

## Base to head evidence
Base `a6b1561f2`:
- `gsc` repro: `GS0159: Cannot find function P.`
- `gsi` repro: `GS0159: Cannot find function P.`

Head `81e44da88`:
- direct `out/bin/Release/Compiler/gsc` compile + execution: `1`
- direct `out/bin/Release/Repl/gsi` execution: `1`
- serial Release solution build passed; `GSharp.Core.dll` was non-empty and MD5-identical across Compiler, Core.Tests, Compiler.Tests, and Interpreter.Tests outputs

## Tests
Same base (`a6b1561f2`) for both measurements:

| Suite | Base | Head |
| --- | ---: | ---: |
| Core | 7028 passed, 1 skipped | 7028 passed, 1 skipped |
| Compiler | 3906 passed | 3907 passed |
| Interpreter | 491 passed | 492 passed |
| Language Server | 452 passed | 452 passed |

Closes #2925