### PR TITLE
gsi: construct class literals before applying initializers

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -651,21 +651,41 @@ public sealed partial class Evaluator
 
     private object EvaluateStructLiteralExpression(BoundStructLiteralExpression node)
     {
-        var sv = new StructValue(node.StructType);
+        var constructor = node.StructType.EffectiveExplicitConstructors
+            .FirstOrDefault(c => c.Function.Parameters.IsDefaultOrEmpty);
+        var invokesConstructor = node.StructType.IsClass
+            && node.StructType.PrimaryConstructorParameters.IsDefaultOrEmpty
+            && (constructor != null || node.StructType.EffectiveExplicitConstructors.IsDefaultOrEmpty);
+        var sv = invokesConstructor
+            ? (StructValue)EvaluateConstructorCallExpression(
+                new BoundConstructorCallExpression(
+                    node.Syntax,
+                    node.StructType,
+                    ImmutableArray<BoundExpression>.Empty,
+                    constructor))
+            : new StructValue(node.StructType);
 
-        // Default-initialize all fields (walking inheritance), then apply explicit initializers.
-        for (var t = node.StructType; t != null; t = t.BaseClass)
+        // Primary-constructor literals use default construction before applying
+        // named initializers, matching the emitter's newobj/stfld sequence.
+        if (!invokesConstructor)
         {
-            foreach (var f in t.Fields)
+            for (var t = node.StructType; t != null; t = t.BaseClass)
             {
-                if (!sv.Fields.ContainsKey(f.Name))
+                foreach (var f in t.Fields)
                 {
-                    sv.Fields[f.Name] = ClrDefaultValue(f.Type);
+                    if (!sv.Fields.ContainsKey(f.Name))
+                    {
+                        sv.Fields[f.Name] = ClrDefaultValue(f.Type);
+                    }
                 }
             }
-        }
 
-        ApplyClassFieldInitializers(sv, node.StructType);
+            ApplyClassFieldInitializers(sv, node.StructType);
+            if (node.StructType.IsClass)
+            {
+                AllocateClrBacking(sv, node.StructType, activeInit: null);
+            }
+        }
 
         foreach (var init in node.Initializers)
         {

--- a/test/Interpreter.Tests/Issue2993StructLiteralConstructionTests.cs
+++ b/test/Interpreter.Tests/Issue2993StructLiteralConstructionTests.cs
@@ -1,0 +1,111 @@
+// <copyright file="Issue2993StructLiteralConstructionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issues #2993 and #2996: class literals must run construction before applying
+/// their explicit member initializers.
+/// </summary>
+public class Issue2993StructLiteralConstructionTests
+{
+    [Fact]
+    public void ClassLiteral_RunsConstructorBeforeExplicitInitializers()
+    {
+        const string Source = """
+            import System
+
+            class Counter {
+                prop N int32 { get; init; }
+                prop M int32 { get; set; }
+
+                init() {
+                    Console.WriteLine("ctor-ran")
+                    N = 7
+                    M = 9
+                }
+            }
+
+            var c = Counter{ M: 1 }
+            Console.WriteLine(c.N)
+            Console.WriteLine(c.M)
+            """;
+
+        Assert.Equal("ctor-ran\n7\n1\n", Evaluate(Source));
+    }
+
+    [Fact]
+    public void ClassLiteral_PreservesConstructorInitializedCollection()
+    {
+        const string Source = """
+            import System
+            import System.Collections.Generic
+
+            class Bag {
+                prop Items IList[int32] { get; init; }
+
+                init() {
+                    Items = List[int32]()
+                }
+            }
+
+            var b = Bag{ Items: {} }
+            Console.WriteLine(b.Items.Count)
+            """;
+
+        Assert.Equal("0\n", Evaluate(Source));
+    }
+
+    [Fact]
+    public void ClassLiteral_AllocatesImportedBaseBacking()
+    {
+        const string Source = """
+            import System
+            import System.IO
+
+            class Buffer : MemoryStream {
+                func Describe(label string) string {
+                    return label
+                }
+            }
+
+            var b = Buffer{}
+            Console.WriteLine(b.CanRead)
+            """;
+
+        Assert.Equal("True\n", Evaluate(Source));
+    }
+
+    private static string Evaluate(string source)
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(source));
+
+        using var outWriter = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+            var errors = result.Diagnostics.Where(d => d.IsError).ToArray();
+            Assert.True(
+                errors.Length == 0,
+                "evaluation failed:\n" + string.Join("\n", errors.Select(d => d.ToString())));
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}

--- a/test/Interpreter.Tests/Issue2993StructLiteralConstructionTests.cs
+++ b/test/Interpreter.Tests/Issue2993StructLiteralConstructionTests.cs
@@ -86,6 +86,23 @@ public class Issue2993StructLiteralConstructionTests
         Assert.Equal("True\n", Evaluate(Source));
     }
 
+    [Fact]
+    public void ClassLiteral_WithPrimaryConstructor_AllocatesImportedBaseBacking()
+    {
+        const string Source = """
+            import System
+            import System.IO
+
+            class Buffer(Label string) : MemoryStream {
+            }
+
+            var b = Buffer{ Label: "primary" }
+            Console.WriteLine(b.CanRead)
+            """;
+
+        Assert.Equal("True\n", Evaluate(Source));
+    }
+
     private static string Evaluate(string source)
     {
         var compilation = new Compilation(SyntaxTree.Parse(source));


### PR DESCRIPTION
## Summary

Make interpreted class literals perform construction before applying named member initializers.

`EvaluateStructLiteralExpression` previously allocated a bare `StructValue`, initialized its field dictionary, and applied literal entries. It never invoked a declared `init()` and never called `AllocateClrBacking`. This caused both reported failures:

- constructor-established state was absent, including silent wrong scalar values (#2993)
- classes derived from imported CLR bases had no reflection receiver (#2996)

The evaluator now reuses `EvaluateConstructorCallExpression` for class literals with a default/parameterless construction path, then applies literal entries so explicit values win over constructor defaults. Primary-constructor literals retain their existing default-construction semantics and receive CLR backing without invoking the primary constructor with nonexistent positional arguments.

## Design correction found during validation

Unconditionally delegating every class literal to `EvaluateConstructorCallExpression`, as proposed in the issue design, is not safe. Existing `Circle{Radius: 3}` primary-constructor literals then pass zero arguments to the synthesized primary constructor and fail with `Index was outside the bounds of the array.` Two `Issue1636TypeTestNarrowingSubtypeGateTests` caught this. The final guard preserves the emitter's default-construction-plus-member-write behavior for that shape; all seven tests in that class pass.

The production footprint remains confined to `EvaluateStructLiteralExpression`.

## Differentials

| Probe | Before | After |
|---|---|---|
| `Counter{M:1}` | `0 / 1` | `ctor-ran / 7 / 1` |
| `Bag{Items:{}}` | `GS9999: Non-static method requires a target.` | `0` |
| `Buffer{}.CanRead` | `GS9999: ... target type ... StructValue` | `True` |

The scalar regression test also assigns `M = 9` in the constructor and requires the literal's `M: 1` to win, pinning construction order rather than only constructor execution.

Removing the production diff made all three focused tests fail; restoring it made all three pass. The round trip rebuilt the changed assembly:

```text
source md5:   10d892b56039ffb89d3c641a3d82375b -> 59841d0f06b5b723cd61f8715c2e0a25 -> 10d892b56039ffb89d3c641a3d82375b
Core DLL md5: 7188a264417e23ba994bde1826dd701c -> 83176327f32690549e5dfb08a119f9c1 -> 7188a264417e23ba994bde1826dd701c
```

Ordinary construction remained byte-identical before and after (`Buffer()`, `Bag()`, and concrete `List[int32]`): output `True / 0 / 4`, md5 `620ffd19148725aa0b51170546af07ce` in both states.

## Validation

Executed baseline at `e80132516`:

| Suite | Passed | Skipped |
|---|---:|---:|
| Core | 7028 | 1 |
| Compiler | 3931 | 0 |
| Interpreter | 493 | 0 |
| LanguageServer | 452 | 0 |

Final checks:

- Core: 7028 passed, 1 skipped
- Interpreter: 496 passed
- focused regressions: 3 passed
- `dotnet build GSharp.sln -c Release -graph`: passed
- all 40 `GSharp.Core.dll` files were nonzero
- five ordinary output copies agreed at md5 `7188a264417e23ba994bde1826dd701c`
- no `MSB302[67]` or `MSB3883`

## Follow-up discovered

The imported-base sample now executes all inherited property/method operations correctly. Its final inherited virtual `ToString()` still prints `System.EventArgs` instead of the emitted G# derived type name. Ordinary `Args()` construction has the same mismatch, proving it is separate from class-literal construction. Filed #3015 with the `Oahu` label rather than expanding this fix beyond the assigned evaluator footprint.

Fixes #2993
Fixes #2996
