### PR TITLE
Document gsi compiled-only storage boundary

### DIFF
--- a/docs/adr/0125-fixed-pinned-statement.md
+++ b/docs/adr/0125-fixed-pinned-statement.md
@@ -3,7 +3,7 @@
 - **Status**: Accepted
 - **Date**: 2026-06-27
 - **Phase**: Phase 9 — low-level / interop depth
-- **Related**: ADR-0039 (managed by-ref pointers / address-of / dereference), ADR-0056 (ref-returning members / `modreq(InAttribute)` ref-returns), ADR-0122 (unsafe context and unmanaged raw pointers `*T`, issue [#1014](https://github.com/DavidObando/gsharp/issues/1014)), ADR-0124 (`stackalloc`/`localloc`, issue [#1024](https://github.com/DavidObando/gsharp/issues/1024)), ADR-0152 (interpreter compiled-only storage boundary), issue [#1026](https://github.com/DavidObando/gsharp/issues/1026), issue [#1043](https://github.com/DavidObando/gsharp/issues/1043), issue [#2900](https://github.com/DavidObando/gsharp/issues/2900)
+- **Related**: ADR-0039 (managed by-ref pointers / address-of / dereference), ADR-0056 (ref-returning members / `modreq(InAttribute)` ref-returns), ADR-0122 (unsafe context and unmanaged raw pointers `*T`, issue [#1014](https://github.com/DavidObando/gsharp/issues/1014)), ADR-0124 (`stackalloc`/`localloc`, issue [#1024](https://github.com/DavidObando/gsharp/issues/1024)), ADR-0153 (interpreter compiled-only storage boundary), issue [#1026](https://github.com/DavidObando/gsharp/issues/1026), issue [#1043](https://github.com/DavidObando/gsharp/issues/1043), issue [#2900](https://github.com/DavidObando/gsharp/issues/2900)
 
 ## Context
 
@@ -194,7 +194,7 @@ kind: it gets a real `case` in `MethodBodyEmitter.EmitStatement` and in
   a nested lambda remains legal because that lambda has its own function body;
   normal fixed-pointer escape rules still prevent capturing the pointer.
 - `fixed` is compiled-only under
-  [ADR-0152](0152-interpreter-compiled-only-storage-boundary.md). `gsi` reports
+  [ADR-0153](0153-interpreter-compiled-only-storage-boundary.md). `gsi` reports
   that pinning requires the CIL pinned-local emit path; it does not attempt to
   emulate pinning without a storage and address model.
 - Deferred: fixed-size buffers.

--- a/docs/adr/0125-fixed-pinned-statement.md
+++ b/docs/adr/0125-fixed-pinned-statement.md
@@ -3,7 +3,7 @@
 - **Status**: Accepted
 - **Date**: 2026-06-27
 - **Phase**: Phase 9 — low-level / interop depth
-- **Related**: ADR-0039 (managed by-ref pointers / address-of / dereference), ADR-0056 (ref-returning members / `modreq(InAttribute)` ref-returns), ADR-0122 (unsafe context and unmanaged raw pointers `*T`, issue [#1014](https://github.com/DavidObando/gsharp/issues/1014)), ADR-0124 (`stackalloc`/`localloc`, issue [#1024](https://github.com/DavidObando/gsharp/issues/1024)), issue [#1026](https://github.com/DavidObando/gsharp/issues/1026), issue [#1043](https://github.com/DavidObando/gsharp/issues/1043), issue [#2900](https://github.com/DavidObando/gsharp/issues/2900)
+- **Related**: ADR-0039 (managed by-ref pointers / address-of / dereference), ADR-0056 (ref-returning members / `modreq(InAttribute)` ref-returns), ADR-0122 (unsafe context and unmanaged raw pointers `*T`, issue [#1014](https://github.com/DavidObando/gsharp/issues/1014)), ADR-0124 (`stackalloc`/`localloc`, issue [#1024](https://github.com/DavidObando/gsharp/issues/1024)), ADR-0152 (interpreter compiled-only storage boundary), issue [#1026](https://github.com/DavidObando/gsharp/issues/1026), issue [#1043](https://github.com/DavidObando/gsharp/issues/1043), issue [#2900](https://github.com/DavidObando/gsharp/issues/2900)
 
 ## Context
 
@@ -193,6 +193,10 @@ kind: it gets a real `case` in `MethodBodyEmitter.EmitStatement` and in
   A state-machine suspension cannot preserve a pinned local. Suspension inside
   a nested lambda remains legal because that lambda has its own function body;
   normal fixed-pointer escape rules still prevent capturing the pointer.
+- `fixed` is compiled-only under
+  [ADR-0152](0152-interpreter-compiled-only-storage-boundary.md). `gsi` reports
+  that pinning requires the CIL pinned-local emit path; it does not attempt to
+  emulate pinning without a storage and address model.
 - Deferred: fixed-size buffers.
 
 ## Diagnostics

--- a/docs/adr/0152-interpreter-compiled-only-storage-boundary.md
+++ b/docs/adr/0152-interpreter-compiled-only-storage-boundary.md
@@ -1,0 +1,98 @@
+# ADR-0152: Interpreter compiled-only storage boundary
+
+- **Status**: Accepted
+- **Date**: 2026-08-01
+- **Phase**: Phase 9 — low-level / interop depth
+- **Related**: ADR-0039 (managed by-ref pointers), ADR-0122 (unsafe context and unmanaged pointers), ADR-0124 (`stackalloc`), ADR-0125 (`fixed`), issues [#2956](https://github.com/DavidObando/gsharp/issues/2956), [#3004](https://github.com/DavidObando/gsharp/issues/3004), and [#2939](https://github.com/DavidObando/gsharp/issues/2939)
+
+## Context
+
+The compiled backend has a CLR storage model. It can emit managed byrefs,
+unmanaged pointers, pinned locals, `localloc`, `sizeof`, `ldftn`, and `calli`.
+The tree-walking interpreter models values, not storage locations. Its local
+frames contain values, and it has no address space, alias identity, pointer
+lifetime, or GC-pinning mechanism.
+
+ADR-0039's interpreter support for `ref` and `out` does not provide a general
+pointer model. `&x` and `*p` are evaluated as identity operations. Ref/out calls
+work only because the call-site machinery recognizes an address-of argument,
+records its source slot, and writes the result back after the call. Outside
+that position, an address is reduced to a value copy. Issue #3004 demonstrates
+the consequence: after `var p *int32 = &x`, a later write to `x` is invisible
+through `*p`, so `gsi` returns a plausible stale value with exit code 0.
+
+`fixed` is the cleanest existing boundary. The evaluator already rejects it
+with a self-contained message explaining that pinning requires the CIL
+pinned-local emit path. `stackalloc`, `sizeof` over unmanaged storage, method
+function pointers, and function-pointer invocation use the same pattern.
+
+Script-mode `gsi` prints only a diagnostic ID and message. It does not render a
+source location or caret. Boundary messages therefore must name the construct,
+state that the interpreter does not support it, and explain which compiled
+runtime facility it requires. They cannot rely on surrounding diagnostic
+rendering for meaning.
+
+## Decision
+
+Constructs that require real address identity, unmanaged pointer operations,
+pinning, stack allocation, or function-pointer execution are **compiled-only**.
+`gsi` must report a self-contained boundary diagnostic instead of attempting a
+value-only approximation. Users who need these constructs must compile with
+`gsc`.
+
+The `unsafe` context itself remains supported. It is a permission boundary, not
+a storage operation; an `unsafe` block containing only otherwise-supported
+value operations continues to evaluate normally.
+
+The current implementation status is:
+
+| Construct | Current `gsi` behavior | Contract status |
+|---|---|---|
+| `unsafe { ... }` without a storage-only construct | Evaluates normally | Supported |
+| `fixed` over array/slice, string, or a pinnable-reference source | Self-contained boundary diagnostic | Meets contract |
+| `stackalloc` | Self-contained boundary diagnostic | Meets contract |
+| `sizeof` requiring the CIL unmanaged-storage path | Self-contained boundary diagnostic | Meets contract |
+| `&Method` function pointer | Self-contained boundary diagnostic | Meets contract |
+| Function-pointer invocation | Self-contained boundary diagnostic | Meets contract |
+| `*p = value` | Generic “Unexpected node” evaluator failure | Must become a boundary |
+| `*(p + 1)` | Raw reflection/conversion failure | Must become a boundary |
+| Free-standing `&x` followed by `*p` | Silently returns a copied, stale value | Must become a boundary; tracked by #3004 |
+| Pointer arithmetic or comparison over copied values | May return coincidentally plausible results | Must become a boundary |
+
+Until the evaluator has a dedicated boundary diagnostic code, the clean
+boundary sites surface through `GS9999` with exact, construct-specific messages.
+This is an interim classification limitation, not permission to treat every
+`GS9999` as intentional. The conformance work in #2939 must classify only the
+known boundary messages as `IntentionalBoundary` and must assert that each
+listed boundary fires; any other `GS9999` remains a failure.
+
+## Consequences
+
+- `gsi` does not promise compiled/interpreted parity for storage-dependent
+  unsafe constructs.
+- Existing ref/out call-site write-back remains supported because it does not
+  expose a reusable pointer value.
+- Boundary tests pin complete script-mode output and non-zero exit status, so a
+  message remains useful without a rendered source location.
+- Issue #3004 owns the highest-severity contract violation: free-standing
+  address-of and dereference currently return a wrong answer instead of failing.
+- A future dedicated diagnostic code can replace the interim `GS9999`
+  classification without changing the boundary itself.
+
+## Alternatives considered
+
+### Emulate `fixed` and unmanaged pointers in the interpreter
+
+Rejected. Faithful behavior requires a storage-location abstraction,
+alias-preserving cells, address identity, pointer arithmetic, lifetime rules,
+stack allocation, and pinning semantics across arrays, strings, spans, locals,
+and calls. This is a memory-model subsystem, not a localized implementation of
+one statement. A partial model would preserve the current, more dangerous
+failure mode: plausible wrong answers.
+
+### Reject only `fixed`
+
+Rejected. `fixed` is one user of the missing storage model and is already the
+best-behaved member of the family. Drawing the line at one keyword would leave
+`&`, `*`, pointer arithmetic, `stackalloc`, `sizeof`, and function pointers with
+inconsistent or silently incorrect behavior.

--- a/docs/adr/0153-interpreter-compiled-only-storage-boundary.md
+++ b/docs/adr/0153-interpreter-compiled-only-storage-boundary.md
@@ -1,9 +1,9 @@
-# ADR-0152: Interpreter compiled-only storage boundary
+# ADR-0153: Interpreter compiled-only storage boundary
 
 - **Status**: Accepted
 - **Date**: 2026-08-01
 - **Phase**: Phase 9 — low-level / interop depth
-- **Related**: ADR-0039 (managed by-ref pointers), ADR-0122 (unsafe context and unmanaged pointers), ADR-0124 (`stackalloc`), ADR-0125 (`fixed`), issues [#2956](https://github.com/DavidObando/gsharp/issues/2956), [#3004](https://github.com/DavidObando/gsharp/issues/3004), and [#2939](https://github.com/DavidObando/gsharp/issues/2939)
+- **Related**: ADR-0039 (managed by-ref pointers), ADR-0122 (unsafe context and unmanaged pointers), ADR-0124 (`stackalloc`), ADR-0125 (`fixed`), issues [#2956](https://github.com/DavidObando/gsharp/issues/2956), [#3004](https://github.com/DavidObando/gsharp/issues/3004), [#3022](https://github.com/DavidObando/gsharp/issues/3022), and [#2939](https://github.com/DavidObando/gsharp/issues/2939)
 
 ## Context
 
@@ -26,19 +26,22 @@ with a self-contained message explaining that pinning requires the CIL
 pinned-local emit path. `stackalloc`, `sizeof` over unmanaged storage, method
 function pointers, and function-pointer invocation use the same pattern.
 
-Script-mode `gsi` prints only a diagnostic ID and message. It does not render a
-source location or caret. Boundary messages therefore must name the construct,
-state that the interpreter does not support it, and explain which compiled
-runtime facility it requires. They cannot rely on surrounding diagnostic
-rendering for meaning.
+Script-mode diagnostic rendering is not part of this boundary contract and may
+include a source location and caret. Boundary messages must still name the
+construct, state that the interpreter does not support it, and explain which
+compiled runtime facility it requires. They cannot rely on surrounding
+diagnostic rendering for meaning.
 
 ## Decision
 
-Constructs that require real address identity, unmanaged pointer operations,
-pinning, stack allocation, or function-pointer execution are **compiled-only**.
-`gsi` must report a self-contained boundary diagnostic instead of attempting a
-value-only approximation. Users who need these constructs must compile with
-`gsc`.
+Constructs whose interpreter behavior requires real address identity —
+including pinning, stack allocation, unmanaged-pointer storage or dereference,
+and function-pointer execution — are **compiled-only**. `gsi` must report a
+self-contained boundary diagnostic instead of attempting a value-only
+approximation. Users who need these constructs must compile with `gsc`.
+
+This ADR governs only the evaluator's storage-model boundary. It does not
+redefine unsafe/native language validity or CIL emission.
 
 The `unsafe` context itself remains supported. It is a permission boundary, not
 a storage operation; an `unsafe` block containing only otherwise-supported
@@ -54,9 +57,10 @@ The current implementation status is:
 | `sizeof` requiring the CIL unmanaged-storage path | Self-contained boundary diagnostic | Meets contract |
 | `&Method` function pointer | Self-contained boundary diagnostic | Meets contract |
 | Function-pointer invocation | Self-contained boundary diagnostic | Meets contract |
-| `*p = value` | Generic “Unexpected node” evaluator failure | Must become a boundary |
-| `*(p + 1)` | Raw reflection/conversion failure | Must become a boundary |
-| Free-standing `&x` followed by `*p` | Silently returns a copied, stale value | Must become a boundary; tracked by #3004 |
+| Ref local alias (`let ref r = arr[i]`) | Re-evaluates the initializer at read time; silently wrong | Must become a boundary; tracked by #3022 |
+| `*p = value` | Boundary enforcement is owned by #3028; without it, falls through to a generic “Unexpected node” failure | Must be a boundary |
+| `*(p + 1)` | Boundary enforcement is owned by #3028; without it, leaks a raw reflection/conversion failure | Must be a boundary |
+| Free-standing `&x` followed by `*p` | Boundary enforcement is owned by #3028; without it, silently returns a copied, stale value | Must be a boundary; underlying aliasing tracked by #3004 |
 | Pointer arithmetic or comparison over copied values | May return coincidentally plausible results | Must become a boundary |
 
 Until the evaluator has a dedicated boundary diagnostic code, the clean
@@ -70,10 +74,11 @@ listed boundary fires; any other `GS9999` remains a failure.
 
 - `gsi` does not promise compiled/interpreted parity for storage-dependent
   unsafe constructs.
-- Existing ref/out call-site write-back remains supported because it does not
-  expose a reusable pointer value.
-- Boundary tests pin complete script-mode output and non-zero exit status, so a
-  message remains useful without a rendered source location.
+- Existing ref/out argument write-back at call sites remains supported; this
+  does not provide stable ref-local aliasing.
+- Boundary tests pin non-zero exit status, empty standard output, and the
+  self-contained diagnostic message while tolerating surrounding renderer
+  context.
 - Issue #3004 owns the highest-severity contract violation: free-standing
   address-of and dereference currently return a wrong answer instead of failing.
 - A future dedicated diagnostic code can replace the interim `GS9999`

--- a/docs/adr/0153-interpreter-compiled-only-storage-boundary.md
+++ b/docs/adr/0153-interpreter-compiled-only-storage-boundary.md
@@ -3,7 +3,7 @@
 - **Status**: Accepted
 - **Date**: 2026-08-01
 - **Phase**: Phase 9 — low-level / interop depth
-- **Related**: ADR-0039 (managed by-ref pointers), ADR-0122 (unsafe context and unmanaged pointers), ADR-0124 (`stackalloc`), ADR-0125 (`fixed`), issues [#2956](https://github.com/DavidObando/gsharp/issues/2956), [#3004](https://github.com/DavidObando/gsharp/issues/3004), [#3022](https://github.com/DavidObando/gsharp/issues/3022), and [#2939](https://github.com/DavidObando/gsharp/issues/2939)
+- **Related**: ADR-0039 (managed by-ref pointers), ADR-0122 (unsafe context and unmanaged pointers), ADR-0124 (`stackalloc`), ADR-0125 (`fixed`), issues [#2956](https://github.com/DavidObando/gsharp/issues/2956), [#3004](https://github.com/DavidObando/gsharp/issues/3004), [#3022](https://github.com/DavidObando/gsharp/issues/3022), [#3028](https://github.com/DavidObando/gsharp/pull/3028), [#3032](https://github.com/DavidObando/gsharp/pull/3032), and [#2939](https://github.com/DavidObando/gsharp/issues/2939)
 
 ## Context
 
@@ -17,9 +17,9 @@ ADR-0039's interpreter support for `ref` and `out` does not provide a general
 pointer model. `&x` and `*p` are evaluated as identity operations. Ref/out calls
 work only because the call-site machinery recognizes an address-of argument,
 records its source slot, and writes the result back after the call. Outside
-that position, an address is reduced to a value copy. Issue #3004 demonstrates
-the consequence: after `var p *int32 = &x`, a later write to `x` is invisible
-through `*p`, so `gsi` returns a plausible stale value with exit code 0.
+that position, an address was previously reduced to a value copy. Issue #3004
+demonstrated the consequence; #3028 now rejects free-standing unmanaged pointer
+operations with `GS0513` and exit code 1.
 
 `fixed` is the cleanest existing boundary. The evaluator already rejects it
 with a self-contained message explaining that pinning requires the CIL
@@ -57,18 +57,16 @@ The current implementation status is:
 | `sizeof` requiring the CIL unmanaged-storage path | Self-contained boundary diagnostic | Meets contract |
 | `&Method` function pointer | Self-contained boundary diagnostic | Meets contract |
 | Function-pointer invocation | Self-contained boundary diagnostic | Meets contract |
-| Ref local alias (`let ref r = arr[i]`) | Re-evaluates the initializer at read time; silently wrong | Must become a boundary; tracked by #3022 |
-| `*p = value` | Boundary enforcement is owned by #3028; without it, falls through to a generic “Unexpected node” failure | Must be a boundary |
-| `*(p + 1)` | Boundary enforcement is owned by #3028; without it, leaks a raw reflection/conversion failure | Must be a boundary |
-| Free-standing `&x` followed by `*p` | Boundary enforcement is owned by #3028; without it, silently returns a copied, stale value | Must be a boundary; underlying aliasing tracked by #3004 |
+| Ref local alias (`let ref r = arr[i]`) | Re-evaluates the initializer at read time; silently wrong | Must alias a captured storage location; fixed by #3032 |
+| `*p = value` | `GS0513` compiled-only boundary | Meets contract |
+| `*(p + 1)` | `GS0513` fires before pointer arithmetic is evaluated | Meets contract |
+| Free-standing `&x` followed by `*p` | `GS0513` compiled-only boundary | Meets contract |
 | Pointer arithmetic or comparison over copied values | May return coincidentally plausible results | Must become a boundary |
 
-Until the evaluator has a dedicated boundary diagnostic code, the clean
-boundary sites surface through `GS9999` with exact, construct-specific messages.
-This is an interim classification limitation, not permission to treat every
-`GS9999` as intentional. The conformance work in #2939 must classify only the
-known boundary messages as `IntentionalBoundary` and must assert that each
-listed boundary fires; any other `GS9999` remains a failure.
+The evaluator reports compiled-only storage boundaries through `GS0513` with
+exact, construct-specific messages. The conformance work in #2939 must classify
+that code as `IntentionalBoundary` and assert that each listed boundary fires;
+`GS9999` remains a failure.
 
 ## Consequences
 
@@ -79,10 +77,8 @@ listed boundary fires; any other `GS9999` remains a failure.
 - Boundary tests pin non-zero exit status, empty standard output, and the
   self-contained diagnostic message while tolerating surrounding renderer
   context.
-- Issue #3004 owns the highest-severity contract violation: free-standing
-  address-of and dereference currently return a wrong answer instead of failing.
-- A future dedicated diagnostic code can replace the interim `GS9999`
-  classification without changing the boundary itself.
+- Issue #3004's free-standing address-of and dereference case is now rejected
+  by `GS0513`.
 
 ## Alternatives considered
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -307,6 +307,16 @@ These diagnostics indicate an internal compiler problem. If you encounter them, 
 | GS9998 | Error | An unexpected `NotSupportedException` or `InvalidOperationException` was raised during IL emission. The message text contains the original exception message. |
 | GS9999 | Error | An unexpected exception was caught by the evaluator. The message text contains the original exception message. |
 
+#### Interpreter compiled-only boundaries
+
+[ADR-0152](adr/0152-interpreter-compiled-only-storage-boundary.md) defines
+storage-dependent unsafe constructs as compiled-only. The clean boundary sites
+for `fixed`, `stackalloc`, unmanaged `sizeof`, and function pointers currently
+surface through `GS9999` with a self-contained message naming the construct and
+the required CIL emit path. This is an interim diagnostic classification: only
+those exact boundary messages are intentional; any other evaluator `GS9999`
+still indicates a defect.
+
 ## Documentation diagnostics (GS0227–GS0231)
 
 | Code | Severity | Message |

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -312,10 +312,9 @@ These diagnostics indicate an internal compiler problem. If you encounter them, 
 [ADR-0153](adr/0153-interpreter-compiled-only-storage-boundary.md) defines
 storage-dependent unsafe constructs as compiled-only. The clean boundary sites
 for `fixed`, `stackalloc`, unmanaged `sizeof`, and function pointers currently
-surface through `GS9999` with a self-contained message naming the construct and
-the required CIL emit path. This is an interim diagnostic classification: only
-those exact boundary messages are intentional; any other evaluator `GS9999`
-still indicates a defect.
+surface through `GS0513` with a self-contained message naming the construct and
+the required CIL emit path. Evaluator `GS9999` diagnostics still indicate a
+defect.
 
 ## Documentation diagnostics (GS0227–GS0231)
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -309,7 +309,7 @@ These diagnostics indicate an internal compiler problem. If you encounter them, 
 
 #### Interpreter compiled-only boundaries
 
-[ADR-0152](adr/0152-interpreter-compiled-only-storage-boundary.md) defines
+[ADR-0153](adr/0153-interpreter-compiled-only-storage-boundary.md) defines
 storage-dependent unsafe constructs as compiled-only. The clean boundary sites
 for `fixed`, `stackalloc`, unmanaged `sizeof`, and function pointers currently
 surface through `GS9999` with a self-contained message naming the construct and

--- a/test/Interpreter.Tests/Issue2956InterpreterBoundaryTests.cs
+++ b/test/Interpreter.Tests/Issue2956InterpreterBoundaryTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace GSharp.Interpreter.Tests;
 
 /// <summary>
-/// Issue #2956 / ADR-0152: script-mode <c>gsi</c> reports self-contained
+/// Issue #2956 / ADR-0153: script-mode <c>gsi</c> reports self-contained
 /// diagnostics for constructs that require the compiled storage model.
 /// </summary>
 [Collection("ConsoleIo")]
@@ -156,7 +156,7 @@ public class Issue2956InterpreterBoundaryTests
 
         Assert.Equal(1, result.ExitCode);
         Assert.Equal(string.Empty, result.StandardOutput);
-        Assert.Equal($"GS9999: {message}\n", result.StandardError);
+        Assert.Contains($"GS9999: {message}", result.StandardError);
     }
 
     private static (int ExitCode, string StandardOutput, string StandardError) RunGsi(

--- a/test/Interpreter.Tests/Issue2956InterpreterBoundaryTests.cs
+++ b/test/Interpreter.Tests/Issue2956InterpreterBoundaryTests.cs
@@ -1,0 +1,196 @@
+// <copyright file="Issue2956InterpreterBoundaryTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #2956 / ADR-0152: script-mode <c>gsi</c> reports self-contained
+/// diagnostics for constructs that require the compiled storage model.
+/// </summary>
+[Collection("ConsoleIo")]
+public class Issue2956InterpreterBoundaryTests
+{
+    [Fact]
+    public void FixedArrayReportsCompiledOnlyBoundary()
+    {
+        AssertBoundary(
+            nameof(FixedArrayReportsCompiledOnlyBoundary),
+            """
+            import System
+
+            unsafe {
+                let values = []int32{1, 2}
+                fixed p *int32 = values {
+                    Console.WriteLine(values.Length)
+                }
+            }
+            """,
+            "'fixed' (pinning) statements are not supported in the interpreter; they require the CIL pinned-local emit path.");
+    }
+
+    [Fact]
+    public void FixedStringReportsCompiledOnlyBoundary()
+    {
+        AssertBoundary(
+            nameof(FixedStringReportsCompiledOnlyBoundary),
+            """
+            import System
+
+            unsafe {
+                fixed p *uint16 = "A" {
+                    Console.WriteLine(*p)
+                }
+            }
+            """,
+            "'fixed' (pinning) statements are not supported in the interpreter; they require the CIL pinned-local emit path.");
+    }
+
+    [Fact]
+    public void FixedPinnableSpanReportsCompiledOnlyBoundary()
+    {
+        AssertBoundary(
+            nameof(FixedPinnableSpanReportsCompiledOnlyBoundary),
+            """
+            import System
+
+            unsafe {
+                fixed p *int32 = Span[int32].Empty {
+                    Console.WriteLine(*p)
+                }
+            }
+            """,
+            "'fixed' (pinning) statements are not supported in the interpreter; they require the CIL pinned-local emit path.");
+    }
+
+    [Fact]
+    public void StackAllocReportsCompiledOnlyBoundary()
+    {
+        AssertBoundary(
+            nameof(StackAllocReportsCompiledOnlyBoundary),
+            """
+            func run() int32 {
+                let values = stackalloc [2]int32
+                return values.Length
+            }
+
+            run()
+            """,
+            "stackalloc is not supported in the interpreter; it requires the CIL localloc emit path.");
+    }
+
+    [Fact]
+    public void SizeOfUserStructReportsCompiledOnlyBoundary()
+    {
+        AssertBoundary(
+            nameof(SizeOfUserStructReportsCompiledOnlyBoundary),
+            """
+            struct Pair {
+                var Left int32
+                var Right int32
+            }
+
+            unsafe {
+                sizeof(Pair)
+            }
+            """,
+            "sizeof on an unmanaged-pointer struct pointee is not supported in the interpreter; it requires the CIL sizeof emit path.");
+    }
+
+    [Fact]
+    public void FunctionPointerAddressReportsCompiledOnlyBoundary()
+    {
+        AssertBoundary(
+            nameof(FunctionPointerAddressReportsCompiledOnlyBoundary),
+            """
+            unsafe func identity(value int32) int32 {
+                return value
+            }
+
+            unsafe {
+                let pointer *func(int32) int32 = &identity
+            }
+            """,
+            "'&Method' function pointers are not supported in the interpreter; they require the CIL ldftn/calli emit path (ADR-0122 §9).");
+    }
+
+    [Fact]
+    public void FunctionPointerInvocationReportsCompiledOnlyBoundary()
+    {
+        AssertBoundary(
+            nameof(FunctionPointerInvocationReportsCompiledOnlyBoundary),
+            """
+            unsafe {
+                let pointer *func(int32) int32 = nil
+                pointer(1)
+            }
+            """,
+            "function-pointer invocation ('fp(args)') is not supported in the interpreter; it requires the CIL calli emit path (ADR-0122 §9).");
+    }
+
+    [Fact]
+    public void UnsafeBlockWithoutStorageOnlyConstructEvaluatesNormally()
+    {
+        var result = RunGsi(
+            nameof(UnsafeBlockWithoutStorageOnlyConstructEvaluatesNormally),
+            """
+            import System
+
+            unsafe {
+                Console.WriteLine(42)
+            }
+            """);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("42\n", result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    private static void AssertBoundary(string name, string source, string message)
+    {
+        var result = RunGsi(name, source);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardOutput);
+        Assert.Equal($"GS9999: {message}\n", result.StandardError);
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) RunGsi(
+        string name,
+        string source)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue2956InterpreterBoundaryTests),
+            name);
+        Directory.CreateDirectory(directory);
+        var sourcePath = Path.Combine(directory, "test.gs");
+        File.WriteAllText(sourcePath, source);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        int exitCode;
+        try
+        {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            exitCode = GSharp.Repl.Program.Main(new[] { sourcePath });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        return (
+            exitCode,
+            stdout.ToString().Replace("\r\n", "\n", StringComparison.Ordinal),
+            stderr.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+    }
+}

--- a/test/Interpreter.Tests/Issue2956InterpreterBoundaryTests.cs
+++ b/test/Interpreter.Tests/Issue2956InterpreterBoundaryTests.cs
@@ -156,7 +156,7 @@ public class Issue2956InterpreterBoundaryTests
 
         Assert.Equal(1, result.ExitCode);
         Assert.Equal(string.Empty, result.StandardOutput);
-        Assert.Contains($"GS9999: {message}", result.StandardError);
+        Assert.Contains(message, result.StandardError);
     }
 
     private static (int ExitCode, string StandardOutput, string StandardError) RunGsi(

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -303,10 +303,9 @@ These diagnostics indicate an internal compiler problem. If you encounter them, 
 
 Storage-dependent unsafe constructs are compiled-only. The clean boundary
 sites for `fixed`, `stackalloc`, unmanaged `sizeof`, and function pointers
-currently surface through `GS9999` with a self-contained message naming the
-construct and the required CIL emit path. This is an interim diagnostic
-classification: only those exact boundary messages are intentional; any other
-evaluator `GS9999` still indicates a defect.
+currently surface through `GS0513` with a self-contained message naming the
+construct and the required CIL emit path. Evaluator `GS9999` diagnostics still
+indicate a defect.
 
 ## Documentation diagnostics (GS0227–GS0231)
 

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -299,6 +299,15 @@ These diagnostics indicate an internal compiler problem. If you encounter them, 
 | GS9998 | Error | An unexpected `NotSupportedException` or `InvalidOperationException` was raised during IL emission. The message text contains the original exception message. |
 | GS9999 | Error | An unexpected exception was caught by the evaluator. The message text contains the original exception message. |
 
+#### Interpreter compiled-only boundaries
+
+Storage-dependent unsafe constructs are compiled-only. The clean boundary
+sites for `fixed`, `stackalloc`, unmanaged `sizeof`, and function pointers
+currently surface through `GS9999` with a self-contained message naming the
+construct and the required CIL emit path. This is an interim diagnostic
+classification: only those exact boundary messages are intentional; any other
+evaluator `GS9999` still indicates a defect.
+
 ## Documentation diagnostics (GS0227–GS0231)
 
 | Code | Severity | Message |


### PR DESCRIPTION
## Summary

- accept option B in ADR-0153: the interpreter models values, not storage, so storage-dependent pinning, allocation, pointer, and function-pointer operations are compiled-only
- link the existing `fixed` design to that boundary and document the `GS0513` compiled-only classification in both diagnostics references
- add script-mode `gsi` coverage for array, string, pinnable-span, `stackalloc`, `sizeof`, function-pointer address/invocation, and the supported plain-`unsafe` guard

Fixes #2956

## Scope

The evaluator already contains the intended `fixed` boundary and self-contained message. This PR changes no production code; it records the accepted storage-model contract and pins existing behavior. Unsafe/native language validity and CIL emission remain outside ADR-0153.

No diagnostic ID or `| GSxxxx |` row is added. Clean boundary sites use the existing `GS0513` diagnostic with exact construct-specific messages.

## Review fixes

- renumber ADR-0152 to ADR-0153 to avoid #3024
- tolerate source-location/caret renderer context while preserving exit-code, stdout, and message assertions
- document that managed ref locals must alias captured storage, with the queued fix in #3032
- record #3028's `GS0513` boundary for free-standing unmanaged pointer operations

## Verification

- Release solution build with `ContinuousIntegrationBuild=true`: 0 warnings, 0 errors
- `Issue2956InterpreterBoundaryTests`: 8 examined, 8 passed
- 40 `GSharp.Core.dll` copies examined, 0 zero-byte files
- five ordinary `GSharp.Core.dll` copies shared md5 `bafd05ea00792b7beaca480319e43e65`
- boundary tests assert exit code 1, empty stdout, and the self-contained diagnostic message; diagnostic ID and renderer context may change

No full suites or e2e tests were run; fleet throttle requires the narrowest selector, and this PR contains documentation plus targeted interpreter tests only.
