### PR TITLE
Preserve delegate identity through erased lambda slots

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -815,12 +815,14 @@ internal sealed partial class ExpressionBinder
         return true;
     }
 
+    private static TypeSymbol UnwrapExpressionTreeDelegate(TypeSymbol type) =>
+        MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(type, out var delegateType)
+            ? delegateType
+            : type;
+
     private static bool IsCanonicalFunctionDelegate(TypeSymbol type)
     {
-        if (MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(type, out var delegateType))
-        {
-            type = delegateType;
-        }
+        type = UnwrapExpressionTreeDelegate(type);
 
         if (type is ImportedTypeSymbol imported)
         {
@@ -854,10 +856,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        if (MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(type, out var delegateType))
-        {
-            type = delegateType;
-        }
+        type = UnwrapExpressionTreeDelegate(type);
 
         return !TypeSymbol.ContainsTypeParameter(type)
             && type?.ClrType?.ContainsGenericParameters != true;
@@ -865,6 +864,9 @@ internal sealed partial class ExpressionBinder
 
     private static bool SameDelegateIdentity(TypeSymbol left, TypeSymbol right)
     {
+        left = UnwrapExpressionTreeDelegate(left);
+        right = UnwrapExpressionTreeDelegate(right);
+
         if (ReferenceEquals(left, right))
         {
             return true;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -814,25 +814,6 @@ internal sealed partial class ExpressionBinder
         return true;
     }
 
-    private static bool IsCanonicalFunctionDelegate(TypeSymbol type)
-    {
-        if (MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(type, out var delegateType))
-        {
-            type = delegateType;
-        }
-
-        if (type is not ImportedTypeSymbol imported)
-        {
-            return true;
-        }
-
-        var openDefinition = imported.OpenDefinition ?? imported.ClrType;
-        var fullName = openDefinition?.FullName;
-        return fullName == "System.Action"
-            || fullName?.StartsWith("System.Action`", StringComparison.Ordinal) == true
-            || fullName?.StartsWith("System.Func`", StringComparison.Ordinal) == true;
-    }
-
     /// <summary>
     /// Issue #1512 / #2365: builds a symbolic <see cref="FunctionTypeSymbol"/> for
     /// a lambda argument bound to a CLR/imported method whose delegate (or
@@ -1048,7 +1029,14 @@ internal sealed partial class ExpressionBinder
                         // void-discard / ordinary target-typed return-type
                         // inference applies instead of inferring the return
                         // type purely from the lambda body.
-                        boundArgs[idx] = lambdas.BindLambdaExpression(lambdaSyntax, target, inferReturnTypeFromBody: !exactReturnIndices.Contains(idx));
+                        var literal = lambdas.BindLambdaExpression(
+                            lambdaSyntax,
+                            target.FunctionType,
+                            inferReturnTypeFromBody: !exactReturnIndices.Contains(idx));
+                        boundArgs[idx] = conversions.BindConversion(
+                            ce.Arguments[idx].Location,
+                            literal,
+                            target.DelegateType);
                     }
                 }
 
@@ -1339,11 +1327,11 @@ internal sealed partial class ExpressionBinder
     /// each deferred lambda's delegate <em>parameter</em> types through those
     /// inferred symbolic arguments (reusing
     /// <see cref="MemberLookup.MapOpenClrTypeToSymbolic(Type, Type, ImmutableArray{TypeSymbol}, MethodInfo, ImmutableArray{TypeSymbol})"/>).
-    /// A per-slot <see cref="FunctionTypeSymbol"/> carrying those parameter
-    /// types is produced. Non-generic methods on constructed generic receivers
-    /// are recovered from the open declaring type too, including delegates
-    /// whose only symbolic slot is their return type. Candidates must agree on
-    /// the recovered shape.
+    /// A per-slot target carrying both the exact mapped delegate identity and
+    /// its <see cref="FunctionTypeSymbol"/> shape is produced. Non-generic
+    /// methods on constructed generic receivers are recovered from the open
+    /// declaring type too, including delegates whose only symbolic slot is
+    /// their return type. Candidates must agree on both identity and shape.
     ///
     /// Issue #2345: also recovers the delegate's <em>return</em> shape when it
     /// is fully closed by the same unification (including the common case of a
@@ -1367,7 +1355,7 @@ internal sealed partial class ExpressionBinder
         List<int> deferredIndices,
         BoundExpression[] boundArgs,
         HashSet<int> deferred,
-        out Dictionary<int, FunctionTypeSymbol> targets,
+        out Dictionary<int, (TypeSymbol DelegateType, FunctionTypeSymbol FunctionType)> targets,
         out HashSet<int> exactReturnIndices)
     {
         exactReturnIndices = new HashSet<int>();
@@ -1422,7 +1410,7 @@ internal sealed partial class ExpressionBinder
             arityByIndex[idx] = lambda.Parameters.Count;
         }
 
-        Dictionary<int, ImmutableArray<TypeSymbol>> agreed = null;
+        Dictionary<int, (TypeSymbol DelegateType, ImmutableArray<TypeSymbol> ParameterTypes)> agreed = null;
         Dictionary<int, TypeSymbol> agreedReturnTypes = null;
         var anySymbolicType = false;
 
@@ -1473,7 +1461,7 @@ internal sealed partial class ExpressionBinder
                     : MemberLookup.InferSymbolicMethodTypeArguments(openMethod, symbolicArgVector);
             var methodTypeArgs = ImmutableArray.Create(inferred);
 
-            var slotTargets = new Dictionary<int, ImmutableArray<TypeSymbol>>();
+            var slotTargets = new Dictionary<int, (TypeSymbol DelegateType, ImmutableArray<TypeSymbol> ParameterTypes)>();
             var slotReturnTypes = new Dictionary<int, TypeSymbol>();
             var candidateUsable = true;
             var candidateHasSymbolicType = false;
@@ -1488,6 +1476,7 @@ internal sealed partial class ExpressionBinder
                 }
 
                 var openParameterType = openParameters[paramIndex].ParameterType;
+                TypeSymbol mappedDelegate;
                 FunctionTypeSymbol functionType;
                 if (openParameterType.IsGenericParameter)
                 {
@@ -1495,14 +1484,8 @@ internal sealed partial class ExpressionBinder
                             openParameterType,
                             receiverOpenDefinition,
                             receiverTypeArguments,
-                            out var mappedDelegate,
+                            out mappedDelegate,
                             out functionType))
-                    {
-                        candidateUsable = false;
-                        break;
-                    }
-
-                    if (!IsCanonicalFunctionDelegate(mappedDelegate))
                     {
                         candidateUsable = false;
                         break;
@@ -1587,6 +1570,18 @@ internal sealed partial class ExpressionBinder
                         break;
                     }
 
+                    mappedDelegate = MemberLookup.MapOpenClrTypeToSymbolic(
+                        openParameterType,
+                        receiverOpenDefinition,
+                        receiverTypeArguments,
+                        openMethod,
+                        methodTypeArgs);
+                    if (mappedDelegate == null || mappedDelegate == TypeSymbol.Error)
+                    {
+                        candidateUsable = false;
+                        break;
+                    }
+
                     var returnClrType = invoke.ReturnType;
                     var mappedReturnType = returnClrType != null && returnClrType.IsSameAs(typeof(void))
                         ? TypeSymbol.Void
@@ -1607,7 +1602,7 @@ internal sealed partial class ExpressionBinder
                     }
                 }
 
-                slotTargets[idx] = functionType.ParameterTypes;
+                slotTargets[idx] = (mappedDelegate, functionType.ParameterTypes);
 
                 // Issue #2345: recover the delegate's return shape too, when it
                 // is fully closed by this unification (most commonly `void`,
@@ -1637,7 +1632,7 @@ internal sealed partial class ExpressionBinder
                 agreed = slotTargets;
                 agreedReturnTypes = slotReturnTypes;
             }
-            else if (!SymbolicLambdaParameterTypesAgree(agreed, slotTargets))
+            else if (!SymbolicLambdaTargetsAgree(agreed, slotTargets))
             {
                 return false;
             }
@@ -1668,7 +1663,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var built = new Dictionary<int, FunctionTypeSymbol>();
+        var built = new Dictionary<int, (TypeSymbol DelegateType, FunctionTypeSymbol FunctionType)>();
         foreach (var kv in agreed)
         {
             if (agreedReturnTypes != null && agreedReturnTypes.TryGetValue(kv.Key, out var exactReturn))
@@ -1679,14 +1674,18 @@ internal sealed partial class ExpressionBinder
                 // inferReturnTypeFromBody, letting InferLambdaReturnType's
                 // void-discard rule (issue #889) and ordinary target-typed
                 // inference apply.
-                built[kv.Key] = FunctionTypeSymbol.Get(kv.Value, exactReturn);
+                built[kv.Key] = (
+                    kv.Value.DelegateType,
+                    FunctionTypeSymbol.Get(kv.Value.ParameterTypes, exactReturn));
                 exactReturnIndices.Add(kv.Key);
             }
             else
             {
                 // The return slot is a placeholder; callers bind with
                 // inferReturnTypeFromBody so the lambda infers its own return type.
-                built[kv.Key] = FunctionTypeSymbol.Get(kv.Value, TypeSymbol.Object);
+                built[kv.Key] = (
+                    kv.Value.DelegateType,
+                    FunctionTypeSymbol.Get(kv.Value.ParameterTypes, TypeSymbol.Object));
             }
         }
 
@@ -1694,7 +1693,9 @@ internal sealed partial class ExpressionBinder
         return true;
     }
 
-    private static bool SymbolicLambdaParameterTypesAgree(Dictionary<int, ImmutableArray<TypeSymbol>> a, Dictionary<int, ImmutableArray<TypeSymbol>> b)
+    private static bool SymbolicLambdaTargetsAgree(
+        Dictionary<int, (TypeSymbol DelegateType, ImmutableArray<TypeSymbol> ParameterTypes)> a,
+        Dictionary<int, (TypeSymbol DelegateType, ImmutableArray<TypeSymbol> ParameterTypes)> b)
     {
         if (a.Count != b.Count)
         {
@@ -1703,14 +1704,16 @@ internal sealed partial class ExpressionBinder
 
         foreach (var kv in a)
         {
-            if (!b.TryGetValue(kv.Key, out var other) || other.Length != kv.Value.Length)
+            if (!b.TryGetValue(kv.Key, out var other)
+                || !Equals(kv.Value.DelegateType, other.DelegateType)
+                || other.ParameterTypes.Length != kv.Value.ParameterTypes.Length)
             {
                 return false;
             }
 
-            for (var i = 0; i < kv.Value.Length; i++)
+            for (var i = 0; i < kv.Value.ParameterTypes.Length; i++)
             {
-                if (!Equals(kv.Value[i], other[i]))
+                if (!Equals(kv.Value.ParameterTypes[i], other.ParameterTypes[i]))
                 {
                     return false;
                 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -14,6 +14,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using GSharp.Core.CodeAnalysis.Emit;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Lowering.Async;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -814,6 +815,93 @@ internal sealed partial class ExpressionBinder
         return true;
     }
 
+    private static bool IsCanonicalFunctionDelegate(TypeSymbol type)
+    {
+        if (MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(type, out var delegateType))
+        {
+            type = delegateType;
+        }
+
+        if (type is ImportedTypeSymbol imported)
+        {
+            var definition = imported.OpenDefinition ?? imported.ClrType;
+            if (definition != null
+                && AssemblyName.ReferenceMatchesDefinition(
+                    definition.Assembly.GetName(),
+                    typeof(Action).Assembly.GetName()))
+            {
+                var coreLibrary = definition.Assembly;
+                var arity = definition.IsGenericTypeDefinition
+                    ? definition.GetGenericArguments().Length
+                    : 0;
+                if (definition == coreLibrary.GetType("System.Action")
+                    || (arity > 0
+                        && (definition == coreLibrary.GetType($"System.Action`{arity}")
+                            || definition == coreLibrary.GetType($"System.Func`{arity}"))))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ShouldConvertToNominalDelegate(TypeSymbol type)
+    {
+        if (IsCanonicalFunctionDelegate(type))
+        {
+            return false;
+        }
+
+        if (MemberLookup.TryGetExpressionTreeDelegateTypeFromSymbol(type, out var delegateType))
+        {
+            type = delegateType;
+        }
+
+        return !TypeSymbol.ContainsTypeParameter(type)
+            && type?.ClrType?.ContainsGenericParameters != true;
+    }
+
+    private static bool SameDelegateIdentity(TypeSymbol left, TypeSymbol right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is not ImportedTypeSymbol leftImported
+            || right is not ImportedTypeSymbol rightImported)
+        {
+            return Equals(left, right);
+        }
+
+        var leftDefinition = leftImported.OpenDefinition ?? leftImported.ClrType;
+        var rightDefinition = rightImported.OpenDefinition ?? rightImported.ClrType;
+        if (!TypeIdentityComparer.Instance.Equals(leftDefinition, rightDefinition)
+            || leftImported.TypeArguments.Length != rightImported.TypeArguments.Length)
+        {
+            return false;
+        }
+
+        if (IsCanonicalFunctionDelegate(left) && IsCanonicalFunctionDelegate(right))
+        {
+            return true;
+        }
+
+        for (var i = 0; i < leftImported.TypeArguments.Length; i++)
+        {
+            if (!SameDelegateIdentity(
+                    leftImported.TypeArguments[i],
+                    rightImported.TypeArguments[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     /// <summary>
     /// Issue #1512 / #2365: builds a symbolic <see cref="FunctionTypeSymbol"/> for
     /// a lambda argument bound to a CLR/imported method whose delegate (or
@@ -1033,10 +1121,12 @@ internal sealed partial class ExpressionBinder
                             lambdaSyntax,
                             target.FunctionType,
                             inferReturnTypeFromBody: !exactReturnIndices.Contains(idx));
-                        boundArgs[idx] = conversions.BindConversion(
-                            ce.Arguments[idx].Location,
-                            literal,
-                            target.DelegateType);
+                        boundArgs[idx] = ShouldConvertToNominalDelegate(target.DelegateType)
+                            ? conversions.BindConversion(
+                                ce.Arguments[idx].Location,
+                                literal,
+                                target.DelegateType)
+                            : literal;
                     }
                 }
 
@@ -1705,7 +1795,7 @@ internal sealed partial class ExpressionBinder
         foreach (var kv in a)
         {
             if (!b.TryGetValue(kv.Key, out var other)
-                || !Equals(kv.Value.DelegateType, other.DelegateType)
+                || !SameDelegateIdentity(kv.Value.DelegateType, other.DelegateType)
                 || other.ParameterTypes.Length != kv.Value.ParameterTypes.Length)
             {
                 return false;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -827,19 +827,27 @@ internal sealed partial class ExpressionBinder
         if (type is ImportedTypeSymbol imported)
         {
             var definition = imported.OpenDefinition ?? imported.ClrType;
-            if (definition != null
-                && AssemblyName.ReferenceMatchesDefinition(
-                    definition.Assembly.GetName(),
-                    typeof(Action).Assembly.GetName()))
+            if (definition?.IsGenericType == true && !definition.IsGenericTypeDefinition)
             {
-                var coreLibrary = definition.Assembly;
+                definition = definition.GetGenericTypeDefinition();
+            }
+
+            var coreLibrary = definition?.BaseType?.Assembly;
+            if (string.Equals(
+                    definition?.BaseType?.FullName,
+                    "System.MulticastDelegate",
+                    StringComparison.Ordinal)
+                && coreLibrary != null)
+            {
                 var arity = definition.IsGenericTypeDefinition
                     ? definition.GetGenericArguments().Length
                     : 0;
-                if (definition == coreLibrary.GetType("System.Action")
-                    || (arity > 0
-                        && (definition == coreLibrary.GetType($"System.Action`{arity}")
-                            || definition == coreLibrary.GetType($"System.Func`{arity}"))))
+                var fullName = definition.FullName;
+                if ((string.Equals(fullName, "System.Action", StringComparison.Ordinal)
+                        || (arity > 0
+                            && (string.Equals(fullName, $"System.Action`{arity}", StringComparison.Ordinal)
+                                || string.Equals(fullName, $"System.Func`{arity}", StringComparison.Ordinal))))
+                    && TypeIdentityComparer.Instance.Equals(definition, coreLibrary.GetType(fullName)))
                 {
                     return true;
                 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1070,7 +1070,13 @@ internal sealed partial class ExpressionBinder
                 && TryResolveSymbolicDelegateTargetForCtor(
                     openGenericDefinition, symbolicTypeArgs, sourceArgIndex: i, argName: argName, out var symbolicTarget))
             {
-                boundArguments.Add(lambdas.BindLambdaExpression(ctorLambdaSyntax, symbolicTarget));
+                var literal = lambdas.BindLambdaExpression(
+                    ctorLambdaSyntax,
+                    symbolicTarget.FunctionType);
+                boundArguments.Add(conversions.BindConversion(
+                    syntax.Arguments[i].Location,
+                    literal,
+                    symbolicTarget.DelegateType));
                 symbolicCtorDelegateArgs.Add(i);
                 continue;
             }
@@ -1444,11 +1450,12 @@ internal sealed partial class ExpressionBinder
     /// <paramref name="argName"/>) of a constructed-generic CLR constructor whose
     /// type arguments include a same-compilation user-defined type. The closed
     /// CLR ctor parameter is type-erased (e.g. <c>Func&lt;object&gt;</c>); this
-    /// recovers the real shape (e.g. <c>() -&gt; Foo</c>) by substituting the
+    /// recovers the exact mapped delegate identity and its real shape (e.g.
+    /// <c>Func&lt;Foo&gt;</c> and <c>() -&gt; Foo</c>) by substituting the
     /// receiver's symbolic type arguments through the OPEN constructor's
     /// parameter type. Returns <see langword="false"/> (deferring to the ordinary
     /// erased path) when there is no symbolic substitution in effect, when the
-    /// candidate ctors disagree on the delegate shape, or when no open ctor
+    /// candidate ctors disagree on identity or shape, or when no open ctor
     /// exposes a delegate parameter at that position.
     /// </summary>
     private static bool TryResolveSymbolicDelegateTargetForCtor(
@@ -1456,9 +1463,9 @@ internal sealed partial class ExpressionBinder
         ImmutableArray<TypeSymbol> symbolicTypeArgs,
         int sourceArgIndex,
         string argName,
-        out FunctionTypeSymbol target)
+        out (TypeSymbol DelegateType, FunctionTypeSymbol FunctionType) target)
     {
-        target = null;
+        target = (null, null);
         if (openGenericDefinition == null || symbolicTypeArgs.IsDefaultOrEmpty)
         {
             return false;
@@ -1510,25 +1517,25 @@ internal sealed partial class ExpressionBinder
                     symbolicTypeArgs,
                     out var mappedDelegate,
                     out var candidate)
-                || (parameters[paramIndex].ParameterType.IsGenericParameter
-                    && !IsCanonicalFunctionDelegate(mappedDelegate))
                 || candidate == null)
             {
                 continue;
             }
 
-            if (target == null)
+            if (target.FunctionType == null)
             {
-                target = candidate;
+                target = (mappedDelegate, candidate);
             }
-            else if (!ReferenceEquals(target, candidate) && !target.Equals(candidate))
+            else if (!Equals(target.DelegateType, mappedDelegate)
+                || (!ReferenceEquals(target.FunctionType, candidate)
+                    && !target.FunctionType.Equals(candidate)))
             {
-                target = null;
+                target = (null, null);
                 return false;
             }
         }
 
-        return target != null;
+        return target.FunctionType != null;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1073,10 +1073,12 @@ internal sealed partial class ExpressionBinder
                 var literal = lambdas.BindLambdaExpression(
                     ctorLambdaSyntax,
                     symbolicTarget.FunctionType);
-                boundArguments.Add(conversions.BindConversion(
-                    syntax.Arguments[i].Location,
-                    literal,
-                    symbolicTarget.DelegateType));
+                boundArguments.Add(ShouldConvertToNominalDelegate(symbolicTarget.DelegateType)
+                    ? conversions.BindConversion(
+                        syntax.Arguments[i].Location,
+                        literal,
+                        symbolicTarget.DelegateType)
+                    : literal);
                 symbolicCtorDelegateArgs.Add(i);
                 continue;
             }
@@ -1526,7 +1528,7 @@ internal sealed partial class ExpressionBinder
             {
                 target = (mappedDelegate, candidate);
             }
-            else if (!Equals(target.DelegateType, mappedDelegate)
+            else if (!SameDelegateIdentity(target.DelegateType, mappedDelegate)
                 || (!ReferenceEquals(target.FunctionType, candidate)
                     && !target.FunctionType.Equals(candidate)))
             {

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -529,6 +529,54 @@ public class Issue2918InlineLambdaErasedReceiverTests
                 "Issue2948CorpusJoinChain.Owner"));
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CanonicalLinqSelectorsOverErasedUserTypes_VerifyLoadAndRun(bool topLevel)
+    {
+        const string declarations = """
+            package Issue2948CanonicalLinqSelectors
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            interface IEntry {
+                prop Size int64 {
+                    get;
+                }
+            }
+
+            class Entry : IEntry {
+                prop Size int64 {
+                    get;
+                    init;
+                }
+
+                init(size int64) { Size = size }
+            }
+
+            func Total(entries List[IEntry]) int64 ->
+                int64(8) + entries.Sum(
+                    (entry IEntry) -> entry.Size)
+            """;
+
+        const string statements = """
+            let entries = List[IEntry]{
+                Entry(11),
+                Entry(22),
+                Entry(33)
+            }
+            Console.WriteLine(Total(entries))
+            """;
+
+        Assert.Equal(
+            "74\n",
+            CompileVerifyLoadAndRun(
+                WithExecutionScope(declarations, statements, topLevel),
+                "Issue2948CanonicalLinqSelectors.IEntry",
+                useRefPackReferences: true));
+    }
+
     [Fact]
     public void ImportedNamedDelegatesThroughErasedListSlots_VerifyLoadAndRun()
     {
@@ -937,7 +985,8 @@ public class Issue2918InlineLambdaErasedReceiverTests
         bool verifyIl = true,
         string contractsSource = Contracts,
         string contractsAssemblyName = "Issue2918Contracts",
-        bool allowDirectObjectParameter = false)
+        bool allowDirectObjectParameter = false,
+        bool useRefPackReferences = false)
     {
         var directory = CreateDirectory("Issue2918_");
         try
@@ -949,15 +998,21 @@ public class Issue2918InlineLambdaErasedReceiverTests
             var sourcePath = Path.Combine(directory, "test.gs");
             var assemblyPath = Path.Combine(directory, "test.dll");
             File.WriteAllText(sourcePath, source);
-            Compile(
-            [
+            var args = new List<string>
+            {
                 "/out:" + assemblyPath,
                 "/target:exe",
                 "/targetframework:net10.0",
                 "/nowarn:GS9100",
-                "/r:" + contractsPath,
-                sourcePath,
-            ]);
+            };
+            if (useRefPackReferences)
+            {
+                args.AddRange(RefPackReferences().Select(reference => "/r:" + reference));
+            }
+
+            args.Add("/r:" + contractsPath);
+            args.Add(sourcePath);
+            Compile(args.ToArray());
 
             if (verifyIl)
             {
@@ -1212,6 +1267,30 @@ public class Issue2918InlineLambdaErasedReceiverTests
             prefix + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
         return directory;
+    }
+
+    private static IEnumerable<string> RefPackReferences()
+    {
+        var runtimeDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        var dotnetRoot = Directory.GetParent(runtimeDirectory)?.Parent?.Parent?.FullName;
+        var tfm = $"net{Environment.Version.Major}.0";
+        var packsRoot = Path.Combine(dotnetRoot!, "packs", "Microsoft.NETCore.App.Ref");
+        var version = Environment.Version.ToString(3);
+        var referenceDirectory = Path.Combine(packsRoot, version, "ref", tfm);
+        if (!Directory.Exists(referenceDirectory))
+        {
+            referenceDirectory = Directory.EnumerateDirectories(
+                    packsRoot,
+                    Environment.Version.Major + ".*")
+                .OrderByDescending(directory => directory, StringComparer.Ordinal)
+                .Select(directory => Path.Combine(directory, "ref", tfm))
+                .FirstOrDefault(Directory.Exists);
+        }
+
+        Assert.False(
+            string.IsNullOrEmpty(referenceDirectory),
+            $"No {tfm} reference pack found under '{packsRoot}'.");
+        return Directory.EnumerateFiles(referenceDirectory!, "*.dll");
     }
 
     private static void DeleteDirectory(string directory)

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -69,6 +69,8 @@ public class Issue2918InlineLambdaErasedReceiverTests
             public string Kind { get; }
         }
 
+        public delegate bool CustomPredicate<T>(T value);
+
         public sealed class PredHolder<T>
         {
             public PredHolder(Predicate<T> callback) => Kind = "pred";
@@ -84,6 +86,35 @@ public class Issue2918InlineLambdaErasedReceiverTests
 
             public string RuntimeTypeName =>
                 Value!.GetType().GetGenericTypeDefinition().FullName!;
+        }
+        """;
+
+    private const string AssemblyCollisionContracts = """
+        using System.Collections.Generic;
+
+        namespace System
+        {
+            public delegate TResult Func<T, TResult>(T left, T right);
+        }
+
+        namespace Issue2948Collision
+        {
+            public static class Factory
+            {
+                public static List<global::System.Func<T, int>> Create<T>() =>
+                    new();
+
+                public static string DelegateAssemblyName<T>(
+                    List<global::System.Func<T, int>> values) =>
+                    values[0].GetType()
+                        .Assembly.GetName().Name!;
+
+                public static int InvokeFirst<T>(
+                    List<global::System.Func<T, int>> values,
+                    T left,
+                    T right) =>
+                    values[0](left, right);
+            }
         }
         """;
 
@@ -318,58 +349,60 @@ public class Issue2918InlineLambdaErasedReceiverTests
     }
 
     [Fact]
-    public void ImportedPredicateThroughErasedListSlot_IsRejected()
+    public void ImportedNamedDelegatesThroughErasedListSlots_VerifyLoadAndRun()
     {
         const string source = """
-            package Issue2918PredicateSlot
+            package Issue2948NamedDelegateLists
             import System
             import System.Collections.Generic
+            import Issue2918Contracts
 
             class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            class Args : EventArgs {
                 let N int32
                 init(n int32) { N = n }
             }
 
             func Main() {
                 let predicates = List[Predicate[Src]]()
-                predicates.Add((item Src) -> item.N > 2)
-            }
-            """;
+                predicates.Add((item) -> item.N > 2)
+                Console.WriteLine(predicates[0](Src(3)))
 
-        var diagnostics = CompileExpectingFailure(source);
-        Assert.Contains("GS0159", diagnostics, StringComparison.Ordinal);
-        Assert.Contains("GS0155", diagnostics, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void ImportedComparisonThroughErasedListSlot_IsRejected()
-    {
-        const string source = """
-            package Issue2918ComparisonSlot
-            import System
-            import System.Collections.Generic
-
-            class Src {
-                let N int32
-                init(n int32) { N = n }
-            }
-
-            func Main() {
                 let comparisons = List[Comparison[Src]]()
                 comparisons.Add((left Src, right Src) -> left.N - right.N)
+                Console.WriteLine(comparisons[0](Src(5), Src(2)))
+
+                let converters = List[Converter[Src, int32]]()
+                converters.Add((item Src) -> item.N + 10)
+                Console.WriteLine(converters[0](Src(4)))
+
+                let events = List[EventHandler[Args]]()
+                events.Add((sender object?, args Args) -> Console.WriteLine(args.N))
+                events[0](nil, Args(4))
+
+                let custom = List[CustomPredicate[Src]]()
+                custom.Add((item Src) -> item.N == 6)
+                Console.WriteLine(custom[0](Src(6)))
             }
             """;
 
-        var diagnostics = CompileExpectingFailure(source);
-        Assert.Contains("GS0159", diagnostics, StringComparison.Ordinal);
-        Assert.Contains("GS0155", diagnostics, StringComparison.Ordinal);
+        Assert.Equal(
+            "True\n3\n14\n4\nTrue\n",
+            CompileVerifyLoadAndRun(
+                source,
+                "Issue2948NamedDelegateLists.Src",
+                allowDirectObjectParameter: true));
     }
 
     [Fact]
-    public void ImportedPredicateThroughErasedConstructorSlot_IsRejected()
+    public void ImportedNamedDelegatesThroughErasedConstructorSlots_VerifyLoadAndRun()
     {
         const string source = """
-            package Issue2918PredicateConstructor
+            package Issue2948NamedDelegateConstructors
             import System
             import Issue2918Contracts
 
@@ -379,16 +412,98 @@ public class Issue2918InlineLambdaErasedReceiverTests
             }
 
             func Main() {
-                let box = DelegateBox[Predicate[Src]](
-                    (item Src) -> item.N > 2)
-                Console.WriteLine(box.RuntimeTypeName)
-                Console.WriteLine(box.Value(Src(3)))
+                let predicate = DelegateBox[Predicate[Src]](
+                    (item) -> item.N > 2)
+                Console.WriteLine(predicate.RuntimeTypeName)
+                Console.WriteLine(predicate.Value!!(Src(3)))
+
+                let comparison = DelegateBox[Comparison[Src]](
+                    (left Src, right Src) -> left.N - right.N)
+                Console.WriteLine(comparison.RuntimeTypeName)
+                Console.WriteLine(comparison.Value!!(Src(5), Src(2)))
+
+                let converter = DelegateBox[Converter[Src, int32]](
+                    (item Src) -> item.N + 10)
+                Console.WriteLine(converter.RuntimeTypeName)
+                Console.WriteLine(converter.Value!!(Src(4)))
+
+                let custom = DelegateBox[CustomPredicate[Src]](
+                    (item Src) -> item.N == 6)
+                Console.WriteLine(custom.RuntimeTypeName)
+                Console.WriteLine(custom.Value!!(Src(6)))
+            }
+            """;
+
+        Assert.Equal(
+            """
+            System.Predicate`1
+            True
+            System.Comparison`1
+            3
+            System.Converter`2
+            14
+            Issue2918Contracts.CustomPredicate`1
+            True
+
+            """.Replace("\r\n", "\n", StringComparison.Ordinal),
+            CompileVerifyLoadAndRun(source, "Issue2948NamedDelegateConstructors.Src"));
+    }
+
+    [Fact]
+    public void MismatchedLambdaArityThroughErasedDelegateSlot_IsRejected()
+    {
+        const string source = """
+            package Issue2937LambdaArity
+            import System
+            import System.Collections.Generic
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let callbacks = List[System.Action[Src]]()
+                callbacks.Add(
+                    (left Src, right Src) ->
+                        Console.WriteLine(left.N + right.N))
             }
             """;
 
         var diagnostics = CompileExpectingFailure(source);
         Assert.Contains("GS0159", diagnostics, StringComparison.Ordinal);
         Assert.Contains("GS0155", diagnostics, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SameFullNameDelegateFromUserAssembly_RetainsAssemblyIdentity()
+    {
+        const string source = """
+            package Issue2948AssemblyIdentity
+            import System
+            import Issue2948Collision
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let callbacks = Factory.Create[Src]()
+                callbacks.Add((left Src, right Src) -> left.N + right.N)
+                Console.WriteLine(Factory.DelegateAssemblyName(callbacks))
+                Console.WriteLine(
+                    Factory.InvokeFirst(callbacks, Src(20), Src(22)))
+            }
+            """;
+
+        Assert.Equal(
+            "Issue2948CollisionContracts\n42\n",
+            CompileVerifyLoadAndRun(
+                source,
+                "Issue2948AssemblyIdentity.Src",
+                contractsSource: AssemblyCollisionContracts,
+                contractsAssemblyName: "Issue2948CollisionContracts"));
     }
 
     [Fact]
@@ -656,13 +771,16 @@ public class Issue2918InlineLambdaErasedReceiverTests
     private static string CompileVerifyLoadAndRun(
         string source,
         string expectedSourceTypeName,
-        bool verifyIl = true)
+        bool verifyIl = true,
+        string contractsSource = Contracts,
+        string contractsAssemblyName = "Issue2918Contracts",
+        bool allowDirectObjectParameter = false)
     {
         var directory = CreateDirectory("Issue2918_");
         try
         {
-            var contractsPath = Path.Combine(directory, "Issue2918Contracts.dll");
-            CompileCSharp(Contracts, contractsPath, "Issue2918Contracts");
+            var contractsPath = Path.Combine(directory, contractsAssemblyName + ".dll");
+            CompileCSharp(contractsSource, contractsPath, contractsAssemblyName);
             IlVerifier.Verify(contractsPath);
 
             var sourcePath = Path.Combine(directory, "test.gs");
@@ -686,7 +804,8 @@ public class Issue2918InlineLambdaErasedReceiverTests
             AssertLoadsWithReifiedLambdaSignatures(
                 assemblyPath,
                 contractsPath,
-                expectedSourceTypeName);
+                expectedSourceTypeName,
+                allowDirectObjectParameter);
             return Run(assemblyPath, directory);
         }
         finally
@@ -698,8 +817,12 @@ public class Issue2918InlineLambdaErasedReceiverTests
     private static void AssertLoadsWithReifiedLambdaSignatures(
         string assemblyPath,
         string contractsPath,
-        string expectedSourceTypeName)
+        string expectedSourceTypeName,
+        bool allowDirectObjectParameter = false)
     {
+        Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(contractsPath)).GetTypes());
+        Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+
         var loadContext = new AssemblyLoadContext(
             "Issue2918_" + Guid.NewGuid().ToString("N"),
             isCollectible: true);
@@ -737,7 +860,9 @@ public class Issue2918InlineLambdaErasedReceiverTests
                 method =>
                     ContainsObjectGenericArgument(method.ReturnType)
                     || method.GetParameters().Any(parameter =>
-                        ContainsObjectGenericArgument(parameter.ParameterType)));
+                        ContainsObjectGenericArgument(parameter.ParameterType)
+                        && !(allowDirectObjectParameter
+                            && parameter.ParameterType == typeof(object))));
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -520,32 +520,6 @@ public class Issue2918InlineLambdaErasedReceiverTests
     }
 
     [Fact]
-    public void MismatchedLambdaArityThroughErasedDelegateSlot_IsRejected()
-    {
-        const string source = """
-            package Issue2937LambdaArity
-            import System
-            import System.Collections.Generic
-
-            class Src {
-                let N int32
-                init(n int32) { N = n }
-            }
-
-            func Main() {
-                let callbacks = List[System.Action[Src]]()
-                callbacks.Add(
-                    (left Src, right Src) ->
-                        Console.WriteLine(left.N + right.N))
-            }
-            """;
-
-        var diagnostics = CompileExpectingFailure(source);
-        Assert.Contains("GS0159", diagnostics, StringComparison.Ordinal);
-        Assert.Contains("GS0155", diagnostics, StringComparison.Ordinal);
-    }
-
-    [Fact]
     public void SameFullNameDelegateFromUserAssembly_RetainsAssemblyIdentity()
     {
         const string source = """

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -78,6 +78,26 @@ public class Issue2918InlineLambdaErasedReceiverTests
             public string Kind { get; }
         }
 
+        public sealed class MethodDelegateOverloads<T>
+        {
+            public string Add(Predicate<T> callback) =>
+                "pred";
+
+            public string Add(Func<T, bool> callback) =>
+                "func";
+        }
+
+        public sealed class ConstructorDelegateOverloads<T>
+        {
+            public ConstructorDelegateOverloads(Predicate<T> callback) =>
+                Kind = "pred";
+
+            public ConstructorDelegateOverloads(Func<T, bool> callback) =>
+                Kind = "func";
+
+            public string Kind { get; }
+        }
+
         public sealed class DelegateBox<T>
         {
             public DelegateBox(T value) => Value = value;
@@ -346,6 +366,56 @@ public class Issue2918InlineLambdaErasedReceiverTests
         Assert.Equal(
             "symbolic\nclosed\n",
             CompileVerifyLoadAndRun(source, "Issue2918ConstructorOverloads.Src"));
+    }
+
+    [Fact]
+    public void NominalDelegateDisagreement_KeepsMethodOverloadAmbiguous()
+    {
+        const string source = """
+            package Issue2948MethodNominalDisagreement
+            import System
+            import Issue2918Contracts
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let methods = MethodDelegateOverloads[Src]()
+                Console.WriteLine(methods.Add((item) -> true))
+            }
+            """;
+
+        _ = CompileExpectingFailureOrReportingRuntimeOutput(source);
+    }
+
+    [Fact]
+    public void NominalDelegateDisagreement_PreservesConstructorOverloadResolution()
+    {
+        const string source = """
+            package Issue2948ConstructorNominalDisagreement
+            import System
+            import Issue2918Contracts
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+
+            func Main() {
+                let constructed = ConstructorDelegateOverloads[Src](
+                    (item) -> true)
+                Console.WriteLine(constructed.Kind)
+            }
+            """;
+
+        Assert.Equal(
+            "func\n",
+            CompileVerifyLoadAndRun(
+                source,
+                expectedSourceTypeName: null,
+                allowDirectObjectParameter: true));
     }
 
     [Fact]
@@ -854,7 +924,10 @@ public class Issue2918InlineLambdaErasedReceiverTests
                     method.ReturnType + "("
                     + string.Join(",", method.GetParameters().Select(parameter => parameter.ParameterType))
                     + ")"));
-            Assert.Contains(expectedSourceTypeName, signatures, StringComparison.Ordinal);
+            if (!string.IsNullOrEmpty(expectedSourceTypeName))
+            {
+                Assert.Contains(expectedSourceTypeName, signatures, StringComparison.Ordinal);
+            }
             Assert.DoesNotContain(
                 lambdas,
                 method =>
@@ -945,6 +1018,46 @@ public class Issue2918InlineLambdaErasedReceiverTests
             ]);
 
             Assert.NotEqual(0, exitCode);
+            return output;
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    private static string CompileExpectingFailureOrReportingRuntimeOutput(string source)
+    {
+        var directory = CreateDirectory("Issue2948_Ambiguous_");
+        try
+        {
+            var contractsPath = Path.Combine(directory, "Issue2918Contracts.dll");
+            CompileCSharp(Contracts, contractsPath, "Issue2918Contracts");
+
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var assemblyPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+            var (exitCode, output) = RunCompiler(
+            [
+                "/out:" + assemblyPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                "/r:" + contractsPath,
+                sourcePath,
+            ]);
+
+            if (exitCode == 0)
+            {
+                IlVerifier.Verify(assemblyPath, additionalReferences: new[] { contractsPath });
+                Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(contractsPath)).GetTypes());
+                Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+                var runtimeOutput = Run(assemblyPath, directory);
+                throw new XunitException(
+                    "Expected ambiguous delegate overloads to be rejected, "
+                    + $"but the program ran with output:\n{runtimeOutput}");
+            }
+
             return output;
         }
         finally

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -368,10 +368,12 @@ public class Issue2918InlineLambdaErasedReceiverTests
             CompileVerifyLoadAndRun(source, "Issue2918ConstructorOverloads.Src"));
     }
 
-    [Fact]
-    public void NominalDelegateDisagreement_KeepsMethodOverloadAmbiguous()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NominalDelegateDisagreement_KeepsMethodOverloadAmbiguous(bool topLevel)
     {
-        const string source = """
+        const string declarations = """
             package Issue2948MethodNominalDisagreement
             import System
             import Issue2918Contracts
@@ -380,20 +382,23 @@ public class Issue2918InlineLambdaErasedReceiverTests
                 let N int32
                 init(n int32) { N = n }
             }
-
-            func Main() {
-                let methods = MethodDelegateOverloads[Src]()
-                Console.WriteLine(methods.Add((item) -> true))
-            }
             """;
 
-        _ = CompileExpectingFailureOrReportingRuntimeOutput(source);
+        const string statements = """
+            let methods = MethodDelegateOverloads[Src]()
+            Console.WriteLine(methods.Add((item) -> true))
+            """;
+
+        _ = CompileExpectingFailureOrReportingRuntimeOutput(
+            WithExecutionScope(declarations, statements, topLevel));
     }
 
-    [Fact]
-    public void NominalDelegateDisagreement_PreservesConstructorOverloadResolution()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NominalDelegateDisagreement_PreservesConstructorOverloadResolution(bool topLevel)
     {
-        const string source = """
+        const string declarations = """
             package Issue2948ConstructorNominalDisagreement
             import System
             import Issue2918Contracts
@@ -402,20 +407,126 @@ public class Issue2918InlineLambdaErasedReceiverTests
                 let N int32
                 init(n int32) { N = n }
             }
+            """;
 
-            func Main() {
-                let constructed = ConstructorDelegateOverloads[Src](
-                    (item) -> true)
-                Console.WriteLine(constructed.Kind)
-            }
+        const string statements = """
+            let constructed = ConstructorDelegateOverloads[Src](
+                (item) -> true)
+            Console.WriteLine(constructed.Kind)
             """;
 
         Assert.Equal(
             "func\n",
             CompileVerifyLoadAndRun(
-                source,
+                WithExecutionScope(declarations, statements, topLevel),
                 expectedSourceTypeName: null,
                 allowDirectObjectParameter: true));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CorpusJoinLetConstruct_ResolvesDelegateAndExpressionTargets(bool topLevel)
+    {
+        const string declarations = """
+            package Issue2948CorpusJoinLet
+            import System
+            import System.Linq
+
+            data class Owner(Id int32, Name string) {
+            }
+
+            data class Pet(Name string, OwnerId int32) {
+            }
+            """;
+
+        const string statements = """
+            let owners []Owner = []Owner{Owner(1, "ada"), Owner(2, "bea")}
+            let pets []Pet = []Pet{Pet("rex", 2), Pet("tom", 1)}
+            let matched = owners.Join(
+                pets,
+                (o Owner) -> o.Id,
+                (p Pet) -> p.OwnerId,
+                (o Owner, p Pet) -> { return (o, p) })
+            Console.WriteLine(matched.Count())
+            """;
+
+        Assert.Equal(
+            "2\n",
+            CompileVerifyLoadAndRun(
+                WithExecutionScope(declarations, statements, topLevel),
+                "Issue2948CorpusJoinLet.Owner"));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CorpusJoinResultSelectorLetConstruct_VerifyLoadAndRun(bool topLevel)
+    {
+        const string declarations = """
+            package Issue2948CorpusJoinResult
+            import System
+            import System.Linq
+
+            data class Owner(Id int32, Name string) {
+            }
+
+            data class Pet(Name string, OwnerId int32) {
+            }
+            """;
+
+        const string statements = """
+            let owners []Owner = []Owner{Owner(1, "ada"), Owner(2, "bea")}
+            let pets []Pet = []Pet{Pet("rex", 2), Pet("tom", 1)}
+            let matched = owners.Join(
+                pets,
+                (o Owner) -> o.Id,
+                (p Pet) -> p.OwnerId,
+                (o Owner, p Pet) -> o.Name + "+" + p.Name)
+            Console.WriteLine(String.Join(",", matched!!))
+            """;
+
+        Assert.Equal(
+            "ada+tom,bea+rex\n",
+            CompileVerifyLoadAndRun(
+                WithExecutionScope(declarations, statements, topLevel),
+                "Issue2948CorpusJoinResult.Owner"));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CorpusJoinChainedSelectAndWriteLine_VerifyLoadAndRun(bool topLevel)
+    {
+        const string declarations = """
+            package Issue2948CorpusJoinChain
+            import System
+            import System.Linq
+
+            data class Owner(Id int32, Name string) {
+            }
+
+            data class Pet(Name string, OwnerId int32) {
+            }
+            """;
+
+        const string statements = """
+            let owners []Owner = []Owner{Owner(1, "ada"), Owner(2, "bea"), Owner(3, "cid")}
+            let pets []Pet = []Pet{Pet("rex", 2), Pet("tom", 1), Pet("ziggy", 2)}
+            let matched = owners.Join(pets, (o Owner) -> o.Id, (p Pet) -> p.OwnerId, (o Owner, p Pet) -> {
+                return (o, p)
+            }).Select((pair (Owner, Pet)) -> {
+                let (o, p) = pair
+                return "${o.Name}+${p.Name}"
+            })
+            Console.WriteLine("JoinClause: matched=${String.Join(",", matched!!)}")
+            """;
+
+        Assert.Equal(
+            "JoinClause: matched=ada+tom,bea+rex,bea+ziggy\n",
+            CompileVerifyLoadAndRun(
+                WithExecutionScope(declarations, statements, topLevel),
+                "Issue2948CorpusJoinChain.Owner"));
     }
 
     [Fact]
@@ -811,6 +922,14 @@ public class Issue2918InlineLambdaErasedReceiverTests
             DeleteDirectory(directory);
         }
     }
+
+    private static string WithExecutionScope(
+        string declarations,
+        string statements,
+        bool topLevel) =>
+        topLevel
+            ? declarations + "\n" + statements
+            : declarations + "\nfunc Main() {\n" + statements + "\n}";
 
     private static string CompileVerifyLoadAndRun(
         string source,

--- a/test/Interpreter.Tests/Issue2918InlineLambdaErasedReceiverInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2918InlineLambdaErasedReceiverInterpreterTests.cs
@@ -217,6 +217,51 @@ public class Issue2918InlineLambdaErasedReceiverInterpreterTests
             Evaluate(WithExecutionScope(declarations, statements, topLevel)));
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CanonicalLinqSelectorsOverErasedUserTypes_Evaluate(bool topLevel)
+    {
+        const string declarations = """
+            package Issue2948CanonicalLinqSelectorsInterpreter
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            interface IEntry {
+                prop Size int64 {
+                    get;
+                }
+            }
+
+            class Entry : IEntry {
+                prop Size int64 {
+                    get;
+                    init;
+                }
+
+                init(size int64) { Size = size }
+            }
+
+            func Total(entries List[IEntry]) int64 ->
+                int64(8) + entries.Sum(
+                    (entry IEntry) -> entry.Size)
+            """;
+
+        const string statements = """
+            let entries = List[IEntry]{
+                Entry(11),
+                Entry(22),
+                Entry(33)
+            }
+            Console.WriteLine(Total(entries))
+            """;
+
+        Assert.Equal(
+            "74\n",
+            Evaluate(WithExecutionScope(declarations, statements, topLevel)));
+    }
+
     private static string WithExecutionScope(
         string declarations,
         string statements,

--- a/test/Interpreter.Tests/Issue2918InlineLambdaErasedReceiverInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2918InlineLambdaErasedReceiverInterpreterTests.cs
@@ -2,12 +2,34 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using Xunit;
 
 namespace GSharp.Interpreter.Tests;
+
+public sealed class Issue2948MethodDelegateOverloads<T>
+{
+    public string Add(Predicate<T> callback) => "pred";
+
+    public string Add(Func<T, bool> callback) => "func";
+}
+
+public sealed class Issue2948ConstructorDelegateOverloads<T>
+{
+    public Issue2948ConstructorDelegateOverloads(Predicate<T> callback) =>
+        Kind = "pred";
+
+    public Issue2948ConstructorDelegateOverloads(Func<T, bool> callback) =>
+        Kind = "func";
+
+    public string Kind { get; }
+}
 
 /// <summary>
 /// Issue #2918: evaluate-mode binding preserves inline lambda targets through
@@ -42,5 +64,206 @@ public class Issue2918InlineLambdaErasedReceiverInterpreterTests
             .Concat(compilation.BoundProgram.Diagnostics);
 
         Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NominalDelegateDisagreement_KeepsMethodOverloadAmbiguous(bool topLevel)
+    {
+        const string declarations = """
+            package Issue2948MethodNominalDisagreementInterpreter
+            import System
+            import GSharp.Interpreter.Tests
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+            """;
+
+        const string statements = """
+            let methods = Issue2948MethodDelegateOverloads[Src]()
+            Console.WriteLine(methods.Add((item) -> true))
+            """;
+
+        var output = RunSubmission(
+            WithExecutionScope(declarations, statements, topLevel));
+        Assert.Contains("error GS0159: Cannot find function Add.", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("pred", output, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NominalDelegateDisagreement_PreservesConstructorOverloadResolution(bool topLevel)
+    {
+        const string declarations = """
+            package Issue2948ConstructorNominalDisagreementInterpreter
+            import System
+            import GSharp.Interpreter.Tests
+
+            class Src {
+                let N int32
+                init(n int32) { N = n }
+            }
+            """;
+
+        const string statements = """
+            let constructed = Issue2948ConstructorDelegateOverloads[Src](
+                (item) -> true)
+            Console.WriteLine(constructed.Kind)
+            """;
+
+        Assert.Equal(
+            "func\n",
+            Evaluate(WithExecutionScope(declarations, statements, topLevel)));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CorpusJoinLetConstruct_Evaluates(bool topLevel)
+    {
+        const string declarations = """
+            package Issue2948CorpusJoinLetInterpreter
+            import System
+            import System.Linq
+
+            data class Owner(Id int32, Name string) {
+            }
+
+            data class Pet(Name string, OwnerId int32) {
+            }
+            """;
+
+        const string statements = """
+            let owners []Owner = []Owner{Owner(1, "ada"), Owner(2, "bea")}
+            let pets []Pet = []Pet{Pet("rex", 2), Pet("tom", 1)}
+            let matched = owners.Join(
+                pets,
+                (o Owner) -> o.Id,
+                (p Pet) -> p.OwnerId,
+                (o Owner, p Pet) -> { return o.Name + "+" + p.Name })
+            Console.WriteLine(matched.Count())
+            """;
+
+        Assert.Equal(
+            "2\n",
+            Evaluate(WithExecutionScope(declarations, statements, topLevel)));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CorpusJoinResultSelectorLetConstruct_Evaluates(bool topLevel)
+    {
+        const string declarations = """
+            package Issue2948CorpusJoinResultInterpreter
+            import System
+            import System.Linq
+
+            data class Owner(Id int32, Name string) {
+            }
+
+            data class Pet(Name string, OwnerId int32) {
+            }
+            """;
+
+        const string statements = """
+            let owners []Owner = []Owner{Owner(1, "ada"), Owner(2, "bea")}
+            let pets []Pet = []Pet{Pet("rex", 2), Pet("tom", 1)}
+            let matched = owners.Join(
+                pets,
+                (o Owner) -> o.Id,
+                (p Pet) -> p.OwnerId,
+                (o Owner, p Pet) -> o.Name + "+" + p.Name)
+            Console.WriteLine(String.Join(",", matched!!))
+            """;
+
+        Assert.Equal(
+            "ada+tom,bea+rex\n",
+            Evaluate(WithExecutionScope(declarations, statements, topLevel)));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CorpusJoinChainedSelectAndWriteLine_Evaluates(bool topLevel)
+    {
+        const string declarations = """
+            package Issue2948CorpusJoinChainInterpreter
+            import System
+            import System.Linq
+
+            data class Owner(Id int32, Name string) {
+            }
+
+            data class Pet(Name string, OwnerId int32) {
+            }
+            """;
+
+        const string statements = """
+            let owners []Owner = []Owner{Owner(1, "ada"), Owner(2, "bea"), Owner(3, "cid")}
+            let pets []Pet = []Pet{Pet("rex", 2), Pet("tom", 1), Pet("ziggy", 2)}
+            let matched = owners.Join(pets, (o Owner) -> o.Id, (p Pet) -> p.OwnerId, (o Owner, p Pet) -> {
+                return o.Name + "+" + p.Name
+            }).Select((name string) -> name)
+            Console.WriteLine("JoinClause: matched=${String.Join(",", matched!!)}")
+            """;
+
+        Assert.Equal(
+            "JoinClause: matched=ada+tom,bea+rex,bea+ziggy\n",
+            Evaluate(WithExecutionScope(declarations, statements, topLevel)));
+    }
+
+    private static string WithExecutionScope(
+        string declarations,
+        string statements,
+        bool topLevel) =>
+        topLevel
+            ? declarations + "\n" + statements
+            : declarations + "\nfunc Run() {\n" + statements + "\n}\nRun()";
+
+    private static string Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(source);
+        var compilation = new Compilation(tree);
+
+        using var output = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            var variables = new Dictionary<VariableSymbol, object>();
+            var result = compilation.Evaluate(variables);
+            var errors = result.Diagnostics.Where(diagnostic => diagnostic.IsError).ToList();
+            Assert.True(
+                errors.Count == 0,
+                "evaluation failed:\n" + string.Join("\n", errors.Select(diagnostic => diagnostic.ToString())));
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+
+    private static string RunSubmission(string source)
+    {
+        using var output = new StringWriter();
+        var previousOut = Console.Out;
+        Console.SetOut(output);
+        try
+        {
+            new GSharpRepl().EvaluateSubmission(source);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+
+        return output.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## Summary
- carry exact mapped delegate identity through deferred method and constructor lambda targeting
- normalize `Expression<TDelegate>` to `TDelegate` before candidate identity comparison, preserving valid LINQ `Enumerable.Func` / `Queryable.Expression<Func>` agreement
- convert to nominal delegates only when the mapped target is fully closed
- recognize BCL `Action`/`Func` by exact type identity from the delegate's actual `System.MulticastDelegate` assembly, not a `FullName` prefix or the host runtime assembly
- keep user-assembly `System.Func` and nominally distinct `Predicate<T>` / `Func<T,bool>` delegates distinct

## Regressions
The G11 failure was candidate identity, not a transparent-identifier special case. These translated constructs now compile:

| Construct | Kind | `f5e9d8925` base | pre-fix PR head | final |
|---|---|---:|---:|---:|
| `CorpusJoinLetConstruct` | `LetConstruct` | 0 errors | 1 of 3 corpus errors | 0 errors |
| `CorpusJoinResultSelectorLetConstruct` | `LetConstruct` | 0 errors | 1 of 3 corpus errors | 0 errors |
| `CorpusJoinChainedSelectAndWriteLine` | `GSharpConstruct` | 0 errors | 1 of 3 corpus errors | 0 errors |

A fresh solution-built driver also rebuilds translated `Oahu.Decrypt` with 0 warnings / 0 errors; the old host-assembly gate produced 25 GS0155/GS0156/GS0159 errors.

## Scope matrix
The new G11, Oahu-shaped LINQ, and nominal identity tests cover `{top-level, in-function}` × `{gsc, gsi}`. Interpreter in-function cases define `Run()` and invoke it from top level; the sources are not all wrapped in an uncalled `func Main()`.

## Mutations
All product mutants were rebuilt and killed after the final completed rebase:

| Product mutation | Compiler | Interpreter |
|---|---:|---:|
| remove expression-tree unwrapping | 4/6 failed | 3/6 failed |
| invert method identity agreement | 2/2 failed | 2/2 failed |
| invert constructor identity agreement | 2/2 failed | 2/2 failed |
| invert symbolic closed-target conjunct | 2/2 failed | n/a |
| invert CLR closed-target conjunct | 2/2 failed | n/a |
| restore host-assembly BCL identity gate | 2/2 failed | n/a |

Every restore rebuilt successfully and returned to source blob `91734065...` and Core DLL MD5 `d9808715a4562ca3418d6bd8f88fa180`.

## Verification
Measurements are true of merged-tree anchor `402b85615` plus head `7b1802199`:

- `Compiler.Tests`: **4163 passed / 0 failed / 4163 total**
- `Interpreter.Tests`: **726 passed / 0 failed / 726 total**
- targeted regression matrix: compiler **14/14**, interpreter **12/12**
- bidirectional diagnostics/docs gate: **4/4**
- Release solution build: **0 warnings / 0 errors**
- fresh `Core/` and driver `Compiler/` DLLs: identical mtime and MD5 `d9808715a4562ca3418d6bd8f88fa180`
- G11 positive control (`MissingLength`): build fails; exact restore: **0 errors**
- Oahu positive control (`MissingRenderSize`): build fails; exact restore: **0 errors**

`main` advanced to `4469e3237` via #3120 while the 1h17m full suite was running. `git merge-tree` against that tip is conflict-free, with no overlap in this PR's four changed files; the test shelf SHA is stated above rather than mislabelled as the newer tree.

Fixes #2948
Fixes #2937


## CI
GitHub Actions run [30776786449](https://github.com/DavidObando/gsharp/actions/runs/30776786449) is fully green against PR base `4469e3237`: build, e2e, both cs2gs corpus gates (including Oahu), all test shards, and extensions.
