### PR TITLE
Fix interpreter generic CLR type reification

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundClrPropertyAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrPropertyAssignmentExpression.cs
@@ -27,7 +27,8 @@ public sealed class BoundClrPropertyAssignmentExpression : BoundExpression
         BoundExpression value,
         TypeSymbol resultType,
         TypeParameterSymbol constrainedReceiverTypeParameter = null,
-        TypeSymbol constrainedInterfaceType = null)
+        TypeSymbol constrainedInterfaceType = null,
+        TypeSymbol staticContainerType = null)
         : base(syntax)
     {
         Receiver = receiver;
@@ -36,6 +37,7 @@ public sealed class BoundClrPropertyAssignmentExpression : BoundExpression
         Type = resultType;
         ConstrainedReceiverTypeParameter = constrainedReceiverTypeParameter;
         ConstrainedInterfaceType = constrainedInterfaceType;
+        StaticContainerType = staticContainerType;
     }
 
     public BoundExpression Receiver { get; }
@@ -47,6 +49,8 @@ public sealed class BoundClrPropertyAssignmentExpression : BoundExpression
     public TypeParameterSymbol ConstrainedReceiverTypeParameter { get; }
 
     public TypeSymbol ConstrainedInterfaceType { get; }
+
+    public TypeSymbol StaticContainerType { get; }
 
     public bool IsConstrainedTypeParameterAccess => ConstrainedReceiverTypeParameter != null;
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -2341,7 +2341,13 @@ internal sealed partial class ExpressionBinder
             && TryGetWritableClrMember(staticMember, out _, out var staticTargetSymbol, out _))
         {
             var staticConverted = conversions.BindConversion(syntax.Value.Location, BindValue(staticTargetSymbol), staticTargetSymbol);
-            return new BoundClrPropertyAssignmentExpression(null, receiver: null, staticMember, staticConverted, staticTargetSymbol);
+            return new BoundClrPropertyAssignmentExpression(
+                null,
+                receiver: null,
+                staticMember,
+                staticConverted,
+                staticTargetSymbol,
+                staticContainerType: constructedImported.SymbolicReceiver);
         }
 
         Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);

--- a/src/Core/CodeAnalysis/ClosureValue.cs
+++ b/src/Core/CodeAnalysis/ClosureValue.cs
@@ -21,12 +21,19 @@ public sealed class ClosureValue
     /// <param name="body">The lambda body.</param>
     /// <param name="functionType">The function-type signature.</param>
     /// <param name="capturedLocals">Value-snapshot of captured locals at literal-evaluation time.</param>
-    public ClosureValue(FunctionSymbol function, BoundBlockStatement body, FunctionTypeSymbol functionType, Dictionary<VariableSymbol, object> capturedLocals)
+    /// <param name="capturedTypeArguments">Generic type-argument bindings visible at literal-evaluation time.</param>
+    public ClosureValue(
+        FunctionSymbol function,
+        BoundBlockStatement body,
+        FunctionTypeSymbol functionType,
+        Dictionary<VariableSymbol, object> capturedLocals,
+        Dictionary<TypeParameterSymbol, TypeSymbol> capturedTypeArguments)
     {
         Function = function;
         Body = body;
         FunctionType = functionType;
         CapturedLocals = capturedLocals;
+        CapturedTypeArguments = capturedTypeArguments;
     }
 
     /// <summary>Gets the synthetic function symbol.</summary>
@@ -40,4 +47,7 @@ public sealed class ClosureValue
 
     /// <summary>Gets the captured locals snapshot.</summary>
     public Dictionary<VariableSymbol, object> CapturedLocals { get; }
+
+    /// <summary>Gets the captured generic type-argument bindings.</summary>
+    public Dictionary<TypeParameterSymbol, TypeSymbol> CapturedTypeArguments { get; }
 }

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -28,6 +28,8 @@ namespace GSharp.Core.CodeAnalysis;
 public sealed partial class Evaluator
 #pragma warning restore CA1001
 {
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<ConcurrentDictionary<VariableSymbol, object>, Dictionary<TypeParameterSymbol, TypeSymbol>> RuntimeTypeArguments = new();
+
     private object EvaluateCallExpression(BoundCallExpression node)
     {
         // ADR-0047 §6 / issue #176: a [Conditional("SYMBOL")] call whose
@@ -79,6 +81,7 @@ public sealed partial class Evaluator
                 : localFunctionBodies[node.Function];
             var isIterator = IsIteratorFunction(node.Function, statement);
             object result;
+            RegisterRuntimeTypeArguments(locals, node.Function.TypeParameters, node.MethodTypeArguments);
             using (PushFrame(locals))
             {
                 if (isIterator)
@@ -365,6 +368,7 @@ public sealed partial class Evaluator
             frame[parameter] = value;
         }
 
+        RegisterRuntimeTypeArguments(frame, method.TypeParameters, node.MethodTypeArguments);
         using (PushFrame(frame))
         {
             var statement = program.Functions[method];
@@ -909,7 +913,8 @@ public sealed partial class Evaluator
             return emulatedResult;
         }
 
-        var result = node.Function.Method.Invoke(null, args);
+        var method = ResolveMemberForRuntimeType(node.Function.Method, ResolveRuntimeClrType(node.StaticContainerType));
+        var result = method.Invoke(null, args);
         WriteBackRefSlots(refSlots, args);
         return result;
     }
@@ -1009,7 +1014,7 @@ public sealed partial class Evaluator
         receiver = UnwrapClrReceiver(receiver);
         var args = new object[node.Arguments.Length];
         var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args, node.Method);
-        var method = ResolveMethodForReceiver(node.Method, receiver);
+        var method = ResolveMethodForReceiver(node.Method, receiver, ResolveRuntimeClrType(node.Receiver.Type));
 
         // concurrency: see TryGetInterpreterMapLock — routes `range m`'s
         // `GetEnumerator()`/`MoveNext()`, `m.ContainsKey(k)`, `m.Remove(k)`,
@@ -1047,13 +1052,14 @@ public sealed partial class Evaluator
     // The lookup also walks inherited interfaces (e.g. `MoveNext` lives on
     // the non-generic `IEnumerator` even when the receiver is reached via
     // `IEnumerator<T>`).
-    private static System.Reflection.MethodInfo ResolveMethodForReceiver(System.Reflection.MethodInfo method, object receiver)
+    private static System.Reflection.MethodInfo ResolveMethodForReceiver(System.Reflection.MethodInfo method, object receiver, Type symbolicReceiverType)
     {
         if (receiver == null || method == null)
         {
             return method;
         }
 
+        method = ResolveMemberForRuntimeType(method, symbolicReceiverType);
         var declaring = method.DeclaringType;
         if (declaring == null || declaring.IsAssignableFrom(receiver.GetType()))
         {
@@ -1112,6 +1118,92 @@ public sealed partial class Evaluator
             types: paramTypes,
             modifiers: null);
         return direct ?? method;
+    }
+
+    private void RegisterRuntimeTypeArguments(
+        ConcurrentDictionary<VariableSymbol, object> frame,
+        ImmutableArray<TypeParameterSymbol> parameters,
+        ImmutableArray<TypeSymbol> arguments)
+    {
+        if (parameters.IsDefaultOrEmpty || parameters.Length != arguments.Length)
+        {
+            return;
+        }
+
+        var substitutions = new Dictionary<TypeParameterSymbol, TypeSymbol>(parameters.Length);
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            substitutions.Add(parameters[i], ResolveRuntimeTypeSymbol(arguments[i]));
+        }
+
+        RuntimeTypeArguments.Add(frame, substitutions);
+    }
+
+    private Type ResolveRuntimeClrType(TypeSymbol type)
+    {
+        var resolved = ResolveRuntimeTypeSymbol(type);
+        return resolved is ImportedTypeSymbol imported
+            ? imported.ReifyClosedClrType()
+            : resolved?.ClrType;
+    }
+
+    private TypeSymbol ResolveRuntimeTypeSymbol(TypeSymbol type)
+    {
+        if (type is TypeParameterSymbol parameter)
+        {
+            foreach (var frame in Locals)
+            {
+                if (RuntimeTypeArguments.TryGetValue(frame, out var substitutions)
+                    && substitutions.TryGetValue(parameter, out var argument))
+                {
+                    return ReferenceEquals(argument, parameter) ? argument : ResolveRuntimeTypeSymbol(argument);
+                }
+            }
+
+            return type;
+        }
+
+        if (type is NullableTypeSymbol nullable)
+        {
+            var underlying = ResolveRuntimeTypeSymbol(nullable.UnderlyingType);
+            return ReferenceEquals(underlying, nullable.UnderlyingType)
+                ? type
+                : NullableTypeSymbol.Get(underlying);
+        }
+
+        if (type is not ImportedTypeSymbol imported
+            || imported.OpenDefinition == null
+            || imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            return type;
+        }
+
+        var arguments = ImmutableArray.CreateBuilder<TypeSymbol>(imported.TypeArguments.Length);
+        var changed = false;
+        foreach (var argument in imported.TypeArguments)
+        {
+            var resolved = ResolveRuntimeTypeSymbol(argument);
+            changed |= !ReferenceEquals(resolved, argument);
+            arguments.Add(resolved);
+        }
+
+        return changed
+            ? ImportedTypeSymbol.GetConstructed(imported.ClrType, imported.OpenDefinition, arguments.MoveToImmutable())
+            : type;
+    }
+
+    private static T ResolveMemberForRuntimeType<T>(T member, Type runtimeType)
+        where T : System.Reflection.MemberInfo
+    {
+        var declaring = member?.DeclaringType;
+        if (declaring?.IsGenericType != true
+            || runtimeType?.IsGenericType != true
+            || declaring.GetGenericTypeDefinition() != runtimeType.GetGenericTypeDefinition())
+        {
+            return member;
+        }
+
+        return runtimeType.GetMemberWithSameMetadataDefinitionAs(member) as T ?? member;
     }
 
     // Issue #517: `GetValueOrDefault()` and `GetValueOrDefault(T)` against the

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -28,7 +28,8 @@ namespace GSharp.Core.CodeAnalysis;
 public sealed partial class Evaluator
 #pragma warning restore CA1001
 {
-    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<ConcurrentDictionary<VariableSymbol, object>, Dictionary<TypeParameterSymbol, TypeSymbol>> RuntimeTypeArguments = new();
+    private readonly System.Runtime.CompilerServices.ConditionalWeakTable<ConcurrentDictionary<VariableSymbol, object>, Dictionary<TypeParameterSymbol, TypeSymbol>> runtimeTypeArguments = new();
+    private readonly ConcurrentDictionary<(System.Reflection.MemberInfo Member, Type RuntimeType), System.Reflection.MemberInfo> runtimeMembers = new();
 
     private object EvaluateCallExpression(BoundCallExpression node)
     {
@@ -369,6 +370,7 @@ public sealed partial class Evaluator
         }
 
         RegisterRuntimeTypeArguments(frame, method.TypeParameters, node.MethodTypeArguments);
+        RegisterRuntimeTypeArguments(frame, node.Receiver.Type);
         using (PushFrame(frame))
         {
             var statement = program.Functions[method];
@@ -1052,14 +1054,13 @@ public sealed partial class Evaluator
     // The lookup also walks inherited interfaces (e.g. `MoveNext` lives on
     // the non-generic `IEnumerator` even when the receiver is reached via
     // `IEnumerator<T>`).
-    private static System.Reflection.MethodInfo ResolveMethodForReceiver(System.Reflection.MethodInfo method, object receiver, Type symbolicReceiverType)
+    private static System.Reflection.MethodInfo ResolveMethodForReceiver(System.Reflection.MethodInfo method, object receiver)
     {
         if (receiver == null || method == null)
         {
             return method;
         }
 
-        method = ResolveMemberForRuntimeType(method, symbolicReceiverType);
         var declaring = method.DeclaringType;
         if (declaring == null || declaring.IsAssignableFrom(receiver.GetType()))
         {
@@ -1130,13 +1131,102 @@ public sealed partial class Evaluator
             return;
         }
 
-        var substitutions = new Dictionary<TypeParameterSymbol, TypeSymbol>(parameters.Length);
-        for (var i = 0; i < parameters.Length; i++)
+        var substitutions = runtimeTypeArguments.GetOrCreateValue(frame);
+        RegisterRuntimeTypeArguments(substitutions, parameters, arguments);
+    }
+
+    private void RegisterRuntimeTypeArguments(
+        IDictionary<TypeParameterSymbol, TypeSymbol> substitutions,
+        ImmutableArray<TypeParameterSymbol> parameters,
+        ImmutableArray<TypeSymbol> arguments)
+    {
+        if (parameters.IsDefaultOrEmpty || parameters.Length != arguments.Length)
         {
-            substitutions.Add(parameters[i], ResolveRuntimeTypeSymbol(arguments[i]));
+            return;
         }
 
-        RuntimeTypeArguments.Add(frame, substitutions);
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            substitutions[parameters[i]] = ResolveRuntimeTypeSymbol(arguments[i]);
+        }
+    }
+
+    private void RegisterRuntimeTypeArguments(
+        ConcurrentDictionary<VariableSymbol, object> frame,
+        IReadOnlyDictionary<TypeParameterSymbol, TypeSymbol> arguments)
+    {
+        if (arguments == null || arguments.Count == 0)
+        {
+            return;
+        }
+
+        var substitutions = runtimeTypeArguments.GetOrCreateValue(frame);
+        foreach (var pair in arguments)
+        {
+            substitutions[pair.Key] = ResolveRuntimeTypeSymbol(pair.Value);
+        }
+    }
+
+    private void RegisterRuntimeTypeArguments(
+        ConcurrentDictionary<VariableSymbol, object> frame,
+        TypeSymbol receiverType)
+    {
+        if (receiverType is StructSymbol constructed
+            && constructed.Definition != null
+            && !ReferenceEquals(constructed.Definition, constructed))
+        {
+            RegisterRuntimeTypeArguments(
+                runtimeTypeArguments.GetOrCreateValue(frame),
+                constructed.Definition.TypeParameters,
+                constructed.TypeArguments);
+        }
+        else if (receiverType is InterfaceSymbol constructedInterface
+            && constructedInterface.Definition != null
+            && !ReferenceEquals(constructedInterface.Definition, constructedInterface))
+        {
+            RegisterRuntimeTypeArguments(
+                runtimeTypeArguments.GetOrCreateValue(frame),
+                constructedInterface.Definition.TypeParameters,
+                constructedInterface.TypeArguments);
+        }
+    }
+
+    private Dictionary<TypeParameterSymbol, TypeSymbol> CaptureRuntimeTypeArguments(TypeSymbol receiverType = null)
+    {
+        var captured = new Dictionary<TypeParameterSymbol, TypeSymbol>();
+        foreach (var frame in Locals)
+        {
+            if (!runtimeTypeArguments.TryGetValue(frame, out var substitutions))
+            {
+                continue;
+            }
+
+            foreach (var pair in substitutions)
+            {
+                captured.TryAdd(pair.Key, pair.Value);
+            }
+        }
+
+        if (receiverType is StructSymbol constructed
+            && constructed.Definition != null
+            && !ReferenceEquals(constructed.Definition, constructed))
+        {
+            RegisterRuntimeTypeArguments(
+                captured,
+                constructed.Definition.TypeParameters,
+                constructed.TypeArguments);
+        }
+        else if (receiverType is InterfaceSymbol constructedInterface
+            && constructedInterface.Definition != null
+            && !ReferenceEquals(constructedInterface.Definition, constructedInterface))
+        {
+            RegisterRuntimeTypeArguments(
+                captured,
+                constructedInterface.Definition.TypeParameters,
+                constructedInterface.TypeArguments);
+        }
+
+        return captured;
     }
 
     private Type ResolveRuntimeClrType(TypeSymbol type)
@@ -1153,7 +1243,7 @@ public sealed partial class Evaluator
         {
             foreach (var frame in Locals)
             {
-                if (RuntimeTypeArguments.TryGetValue(frame, out var substitutions)
+                if (runtimeTypeArguments.TryGetValue(frame, out var substitutions)
                     && substitutions.TryGetValue(parameter, out var argument))
                 {
                     return ReferenceEquals(argument, parameter) ? argument : ResolveRuntimeTypeSymbol(argument);
@@ -1192,7 +1282,7 @@ public sealed partial class Evaluator
             : type;
     }
 
-    private static T ResolveMemberForRuntimeType<T>(T member, Type runtimeType)
+    private T ResolveMemberForRuntimeType<T>(T member, Type runtimeType)
         where T : System.Reflection.MemberInfo
     {
         var declaring = member?.DeclaringType;
@@ -1203,7 +1293,9 @@ public sealed partial class Evaluator
             return member;
         }
 
-        return runtimeType.GetMemberWithSameMetadataDefinitionAs(member) as T ?? member;
+        return (T)runtimeMembers.GetOrAdd(
+            (member, runtimeType),
+            static pair => pair.RuntimeType.GetMemberWithSameMetadataDefinitionAs(pair.Member));
     }
 
     // Issue #517: `GetValueOrDefault()` and `GetValueOrDefault(T)` against the

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -83,6 +83,7 @@ public sealed partial class Evaluator
             var isIterator = IsIteratorFunction(node.Function, statement);
             object result;
             RegisterRuntimeTypeArguments(locals, node.Function.TypeParameters, node.MethodTypeArguments);
+            RegisterRuntimeTypeArguments(locals, node.StaticGenericOwnerType);
             using (PushFrame(locals))
             {
                 if (isIterator)

--- a/src/Core/CodeAnalysis/Evaluator.Calls.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Calls.cs
@@ -1017,7 +1017,7 @@ public sealed partial class Evaluator
         receiver = UnwrapClrReceiver(receiver);
         var args = new object[node.Arguments.Length];
         var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args, node.Method);
-        var method = ResolveMethodForReceiver(node.Method, receiver, ResolveRuntimeClrType(node.Receiver.Type));
+        var method = ResolveMethodForReceiver(node.Method, receiver);
 
         // concurrency: see TryGetInterpreterMapLock — routes `range m`'s
         // `GetEnumerator()`/`MoveNext()`, `m.ContainsKey(k)`, `m.Remove(k)`,

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -785,12 +785,13 @@ public sealed partial class Evaluator
         }
 
         var body = node.LoweredBody ??= (BoundBlockStatement)Lowering.Lowerer.Lower(node.Body);
-        return MaterializeClosure(new ClosureValue(
-            node.Function,
-            body,
-            node.FunctionType,
-            captured,
-            CaptureRuntimeTypeArguments()),
+        return MaterializeClosure(
+            new ClosureValue(
+                node.Function,
+                body,
+                node.FunctionType,
+                captured,
+                CaptureRuntimeTypeArguments()),
             GetLambdaMethodName(node));
     }
 
@@ -810,12 +811,13 @@ public sealed partial class Evaluator
             captured[node.Function.ThisParameter] = EvaluateExpression(node.Receiver);
         }
 
-        return MaterializeClosure(new ClosureValue(
-            node.Function,
-            body,
-            node.FunctionType,
-            captured,
-            CaptureRuntimeTypeArguments(node.Receiver?.Type)),
+        return MaterializeClosure(
+            new ClosureValue(
+                node.Function,
+                body,
+                node.FunctionType,
+                captured,
+                CaptureRuntimeTypeArguments(node.Receiver?.Type)),
             node.Function.Name);
     }
 

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -1261,7 +1261,8 @@ public sealed partial class Evaluator
         var args = new object[node.Arguments.Length];
         var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args, node.Constructor);
 
-        var result = node.Constructor.Invoke(args);
+        var constructor = ResolveMemberForRuntimeType(node.Constructor, ResolveRuntimeClrType(node.Type));
+        var result = constructor.Invoke(args);
         WriteBackRefSlots(refSlots, args);
         return result;
     }
@@ -1310,7 +1311,8 @@ public sealed partial class Evaluator
         // from `int[].GetEnumerator()`) fails because the receiver doesn't
         // implement `IEnumerator<object>`. Route through the matching
         // closed-generic interface on the receiver's runtime type.
-        var member = ResolvePropertyOrFieldForReceiver(node.Member, receiver);
+        var runtimeType = ResolveRuntimeClrType(node.Receiver?.Type ?? node.StaticContainerType);
+        var member = ResolvePropertyOrFieldForReceiver(node.Member, receiver, runtimeType);
 
         // concurrency: see TryGetInterpreterMapLock — routes `m.Count`,
         // `m.Keys`, `m.Values`, etc. through the same per-map lock as
@@ -1339,13 +1341,14 @@ public sealed partial class Evaluator
         };
     }
 
-    private static System.Reflection.MemberInfo ResolvePropertyOrFieldForReceiver(System.Reflection.MemberInfo member, object receiver)
+    private static System.Reflection.MemberInfo ResolvePropertyOrFieldForReceiver(System.Reflection.MemberInfo member, object receiver, Type symbolicReceiverType)
     {
         if (receiver == null || member == null)
         {
-            return member;
+            return ResolveMemberForRuntimeType(member, symbolicReceiverType);
         }
 
+        member = ResolveMemberForRuntimeType(member, symbolicReceiverType);
         var declaring = member.DeclaringType;
         if (declaring == null || declaring.IsAssignableFrom(receiver.GetType()))
         {
@@ -1455,16 +1458,17 @@ public sealed partial class Evaluator
         var receiver = node.Receiver == null ? null : EvaluateExpression(node.Receiver);
         receiver = UnwrapClrReceiver(receiver);
         var value = EvaluateExpression(node.Value);
+        var member = ResolveMemberForRuntimeType(node.Member, ResolveRuntimeClrType(node.Receiver?.Type));
 
         // Issue #608: when the receiver is a StructValue (G# class instance)
         // and the member is from a CLR interface satisfied by a field, route the
         // write through the struct's field dictionary.
-        if (receiver is StructValue sv && TryWriteStructFieldForClrMember(sv, node.Member, value))
+        if (receiver is StructValue sv && TryWriteStructFieldForClrMember(sv, member, value))
         {
             return value;
         }
 
-        switch (node.Member)
+        switch (member)
         {
             case System.Reflection.PropertyInfo p:
                 p.SetValue(receiver, value);
@@ -1635,7 +1639,8 @@ public sealed partial class Evaluator
             args[i] = EvaluateExpression(node.Arguments[i]);
         }
 
-        return node.Indexer.GetValue(target, args);
+        var indexer = ResolveMemberForRuntimeType(node.Indexer, ResolveRuntimeClrType(node.Target.Type));
+        return indexer.GetValue(target, args);
     }
 
     private object EvaluateClrIndexAssignmentExpression(BoundClrIndexAssignmentExpression node)
@@ -1649,7 +1654,9 @@ public sealed partial class Evaluator
         }
 
         var value = EvaluateExpression(node.Value);
-        node.Indexer.SetValue(target, value, args);
+        var targetType = node.TargetExpression?.Type ?? node.Target?.Type;
+        var indexer = ResolveMemberForRuntimeType(node.Indexer, ResolveRuntimeClrType(targetType));
+        indexer.SetValue(target, value, args);
         return value;
     }
 

--- a/src/Core/CodeAnalysis/Evaluator.Expressions.cs
+++ b/src/Core/CodeAnalysis/Evaluator.Expressions.cs
@@ -785,8 +785,12 @@ public sealed partial class Evaluator
         }
 
         var body = node.LoweredBody ??= (BoundBlockStatement)Lowering.Lowerer.Lower(node.Body);
-        return MaterializeClosure(
-            new ClosureValue(node.Function, body, node.FunctionType, captured),
+        return MaterializeClosure(new ClosureValue(
+            node.Function,
+            body,
+            node.FunctionType,
+            captured,
+            CaptureRuntimeTypeArguments()),
             GetLambdaMethodName(node));
     }
 
@@ -806,8 +810,12 @@ public sealed partial class Evaluator
             captured[node.Function.ThisParameter] = EvaluateExpression(node.Receiver);
         }
 
-        return MaterializeClosure(
-            new ClosureValue(node.Function, body, node.FunctionType, captured),
+        return MaterializeClosure(new ClosureValue(
+            node.Function,
+            body,
+            node.FunctionType,
+            captured,
+            CaptureRuntimeTypeArguments(node.Receiver?.Type)),
             node.Function.Name);
     }
 
@@ -952,6 +960,7 @@ public sealed partial class Evaluator
             frame[closure.Function.Parameters[i]] = arguments[i];
         }
 
+        RegisterRuntimeTypeArguments(frame, closure.CapturedTypeArguments);
         using (PushFrame(frame))
         {
             return EvaluateUserMethodBody(closure.Function, closure.Body);
@@ -1341,7 +1350,7 @@ public sealed partial class Evaluator
         };
     }
 
-    private static System.Reflection.MemberInfo ResolvePropertyOrFieldForReceiver(System.Reflection.MemberInfo member, object receiver, Type symbolicReceiverType)
+    private System.Reflection.MemberInfo ResolvePropertyOrFieldForReceiver(System.Reflection.MemberInfo member, object receiver, Type symbolicReceiverType)
     {
         if (receiver == null || member == null)
         {
@@ -1458,7 +1467,9 @@ public sealed partial class Evaluator
         var receiver = node.Receiver == null ? null : EvaluateExpression(node.Receiver);
         receiver = UnwrapClrReceiver(receiver);
         var value = EvaluateExpression(node.Value);
-        var member = ResolveMemberForRuntimeType(node.Member, ResolveRuntimeClrType(node.Receiver?.Type));
+        var member = ResolveMemberForRuntimeType(
+            node.Member,
+            ResolveRuntimeClrType(node.Receiver?.Type ?? node.StaticContainerType));
 
         // Issue #608: when the receiver is a StructValue (G# class instance)
         // and the member is from a CLR interface satisfied by a field, route the

--- a/test/Interpreter.Tests/Issue2992SymbolicClrTypeInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2992SymbolicClrTypeInterpreterTests.cs
@@ -30,6 +30,22 @@ public class Issue2992SymbolicClrTypeInterpreterTests
     }
 
     [Fact]
+    public void StaticPropertyReadUsesClosedContainer()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            func ComparerName[T]() string {
+                return Comparer[T].Default.GetType().Name
+            }
+
+            Console.WriteLine(ComparerName[int32]())
+            """;
+
+        Assert.Equal("GenericComparer`1\n", RunSubmission(source));
+    }
+
+    [Fact]
     public void ConstructorUsesClosedClrType()
     {
         var source = """

--- a/test/Interpreter.Tests/Issue2992SymbolicClrTypeInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2992SymbolicClrTypeInterpreterTests.cs
@@ -142,6 +142,31 @@ public class Issue2992SymbolicClrTypeInterpreterTests
     }
 
     [Fact]
+    public void StaticClassTypeParameterUsesClosedContainer()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            class Holder[T any] {
+                shared {
+                    func CountOf(items List[T]) int32 {
+                        return items.Count
+                    }
+                }
+            }
+
+            var numbers = List[int32]()
+            numbers.Add(1)
+            numbers.Add(2)
+            numbers.Add(3)
+            numbers.Add(4)
+            Console.WriteLine(Holder[int32].CountOf(numbers))
+            """;
+
+        Assert.Equal("4\n", RunSubmission(source));
+    }
+
+    [Fact]
     public void DeferredClosureRetainsTypeArguments()
     {
         var source = """

--- a/test/Interpreter.Tests/Issue2992SymbolicClrTypeInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2992SymbolicClrTypeInterpreterTests.cs
@@ -14,25 +14,23 @@ namespace GSharp.Interpreter.Tests;
 public class Issue2992SymbolicClrTypeInterpreterTests
 {
     [Fact]
-    public void GenericParameterPositionUsesClosedClrType()
+    public void StaticClrCallUsesClosedContainer()
     {
         var source = """
-            import System.Collections.Generic
+            import GSharp.Interpreter.Tests.ProbeRef
 
-            func First[T](items List[T]) T {
-                return items[0]
+            func Marker[T]() int32 {
+                return GenericStaticSlot[T].GetMarker()
             }
 
-            var numbers = List[int32]()
-            numbers.Add(10)
-            Console.WriteLine(First[int32](numbers))
+            Console.WriteLine(Marker[int32]())
             """;
 
-        Assert.Equal("10\n", RunSubmission(source));
+        Assert.Equal("11\n", RunSubmission(source));
     }
 
     [Fact]
-    public void GenericConstructionAndReturnUseClosedClrType()
+    public void ConstructorUsesClosedClrType()
     {
         var source = """
             import System.Collections.Generic
@@ -42,11 +40,176 @@ public class Issue2992SymbolicClrTypeInterpreterTests
             }
 
             var numbers = Make[int32]()
-            numbers.Add(10)
+            numbers.Add(33)
             Console.WriteLine(numbers[0])
             """;
 
-        Assert.Equal("10\n", RunSubmission(source));
+        Assert.Equal("33\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void PropertyReadUsesClosedReceiver()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            func CapacityOf[T](items List[T]) int32 {
+                return items.Capacity
+            }
+
+            var numbers = List[int32](44)
+            Console.WriteLine(CapacityOf[int32](numbers))
+            """;
+
+        Assert.Equal("44\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void PropertyWriteUsesClosedReceiver()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            func SetCapacity[T](items List[T]) {
+                items.Capacity = 55
+            }
+
+            var numbers = List[int32]()
+            SetCapacity[int32](numbers)
+            Console.WriteLine(numbers.Capacity)
+            """;
+
+        Assert.Equal("55\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void IndexReadUsesClosedReceiver()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            func First[T](items List[T]) T {
+                return items[0]
+            }
+
+            var numbers = List[int32]()
+            numbers.Add(66)
+            Console.WriteLine(First[int32](numbers))
+            """;
+
+        Assert.Equal("66\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void IndexWriteUsesClosedReceiver()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            func SetFirst[T](items List[T], value T) {
+                items[0] = value
+            }
+
+            var numbers = List[int32]()
+            numbers.Add(1)
+            SetFirst[int32](numbers, 77)
+            Console.WriteLine(numbers[0])
+            """;
+
+        Assert.Equal("77\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void ClassTypeParameterUsesClosedReceiver()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            class Holder[T any] {
+                func CountOf(items List[T]) int32 {
+                    return items.Count
+                }
+            }
+
+            var holder = Holder[int32]()
+            var numbers = List[int32]()
+            numbers.Add(1)
+            numbers.Add(88)
+            Console.WriteLine(holder.CountOf(numbers))
+            """;
+
+        Assert.Equal("2\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void DeferredClosureRetainsTypeArguments()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            func MakeCounter[T]() (List[T]) -> int32 {
+                return func(items List[T]) int32 {
+                    return items.Count
+                }
+            }
+
+            var counter = MakeCounter[int32]()
+            var numbers = List[int32]()
+            numbers.Add(1)
+            numbers.Add(99)
+            Console.WriteLine(counter(numbers))
+            """;
+
+        Assert.Equal("2\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void DeferredMethodGroupRetainsClassTypeArguments()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            class Holder[T any] {
+                func Count(items List[T]) int32 {
+                    return items.Count
+                }
+            }
+
+            func GetCounter[T](holder Holder[T]) (List[T]) -> int32 {
+                return holder.Count
+            }
+
+            var holder = Holder[int32]()
+            var counter = GetCounter[int32](holder)
+            var numbers = List[int32]()
+            numbers.Add(1)
+            numbers.Add(2)
+            numbers.Add(3)
+            Console.WriteLine(counter(numbers))
+            """;
+
+        Assert.Equal("3\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void StaticPropertyWriteUsesClosedContainer()
+    {
+        var source = """
+            import GSharp.Interpreter.Tests.ProbeRef
+
+            func Marker() int32 {
+                return 111
+            }
+
+            func SetValue[T]() {
+                GenericStaticSlot[T].Value = Marker()
+            }
+
+            SetValue[int32]()
+            Console.WriteLine(GenericStaticSlot[int32].Value)
+            """;
+
+        Assert.Equal("111\n", RunSubmission(source));
     }
 
     private static string RunSubmission(string text)

--- a/test/Interpreter.Tests/Issue2992SymbolicClrTypeInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue2992SymbolicClrTypeInterpreterTests.cs
@@ -1,0 +1,69 @@
+// <copyright file="Issue2992SymbolicClrTypeInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Interpreter coverage for reifying imported generic types over function type parameters.
+/// </summary>
+public class Issue2992SymbolicClrTypeInterpreterTests
+{
+    [Fact]
+    public void GenericParameterPositionUsesClosedClrType()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            func First[T](items List[T]) T {
+                return items[0]
+            }
+
+            var numbers = List[int32]()
+            numbers.Add(10)
+            Console.WriteLine(First[int32](numbers))
+            """;
+
+        Assert.Equal("10\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void GenericConstructionAndReturnUseClosedClrType()
+    {
+        var source = """
+            import System.Collections.Generic
+
+            func Make[T]() List[T] {
+                return List[T]()
+            }
+
+            var numbers = Make[int32]()
+            numbers.Add(10)
+            Console.WriteLine(numbers[0])
+            """;
+
+        Assert.Equal("10\n", RunSubmission(source));
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}

--- a/test/Interpreter.Tests/ProbeRefTypes.cs
+++ b/test/Interpreter.Tests/ProbeRefTypes.cs
@@ -51,3 +51,12 @@ public interface IReadWrite
     /// <summary>Gets or sets the value.</summary>
     string Value { get; set; }
 }
+/// <summary>Generic CLR static property used by symbolic-container interpreter tests.</summary>
+public static class GenericStaticSlot<T>
+{
+    /// <summary>Gets or sets the per-construction value.</summary>
+    public static int Value { get; set; }
+
+    /// <summary>Returns a marker that identifies the closed generic construction.</summary>
+    public static int GetMarker() => typeof(T) == typeof(int) ? 11 : -11;
+}


### PR DESCRIPTION
## Summary

- track runtime generic arguments for function calls, constructed class/interface receivers, and static constructed class owners
- substitute those arguments into symbolic `ImportedTypeSymbol` instances, then call `ReifyClosedClrType()` before reflection
- remap seven retained reflection sites: static method calls, constructors, static property reads, instance property reads, property writes, index reads, and index writes
- preserve generic mappings in deferred closures and method groups
- carry symbolic container identity for static imported-generic property writes
- cache remapped reflection members per evaluator

Fixes #2992

## Baseline reproduction (`f70626452`)

`gsi samples/GenericTypeParameterAsTypeArgument.gs` failed with:

```
GS9999: Object type System.Collections.Generic.List`1[System.Object] does not match target type System.Collections.Generic.List`1[System.Int32].
```

The same source compiled and ran with `gsc`, printing:

```
10
20
42
```

Minimal probes also reproduced both reversed failure directions: erased `List<object>` against `List<int>`, and concrete `List<int>` against an erased `List<object>` target.

## Site-specific mutation evidence

Each retained reflection site has a distinct observable test. Hashes below are from the rebuilt `GSharp.Core.dll`, not the byte-identical `gsc` driver; the new static-property-read mutant used Release + `ContinuousIntegrationBuild=true`.

| Mutated site | Expected | Mutant result | Mutant Core MD5 |
| --- | --- | --- | --- |
| static method call | `11` | `-11` | `22ae24a658bfd3e03ef69462e1615599` |
| static property read | ``GenericComparer`1`` | ``ObjectComparer`1`` | `bc52c88cbb354366f452863bdca73960` |
| constructor | `33` | `GS9999` | `b78e775ff0ef179cd9e26704fd838436` |
| instance property read | `44` | `GS9999` | `53069e6ec9ab337f42277e1f333189dd` |
| property write | `55` | `GS9999` | `828e14254148bffda7793c2790beb2be` |
| index read | `66` | `GS9999` | `bfb620154ac8c2b79e798a5dd5bdfec9` |
| index write | `77` | `GS9999` | `d01d9ae8f04c1d79e4624de1801e7d1c` |

Supporting mapping mutations also died:

| Mutated mapping | Expected | Mutant result | Mutant Core MD5 |
| --- | --- | --- | --- |
| constructed class receiver | `2` | `GS9999` | `afc7dc9d6cfdc9b0d77643890a592e75` |
| static constructed class owner | `4` | `GS9999` | `f4e3a881a2de8cd640e5e6578dfed777` |
| deferred closure capture | `2` | `GS9999` | `4ada3cc3091fdbd0bc6bbacb382bf223` |
| deferred method-group capture | `3` | `GS9999` | `673711a933cf238d6f07c53b7b2f0e48` |
| static property runtime container | `111` | `0` | `3c0ea808ad69cd09de647c5890b74c68` |
| static property binder container | `111` | `0`; 1/1 test failed | `b19c28d647f9e9046457ed8488be0c30` |

Restoring the binder container made the full issue suite pass 11/11. A proposed imported instance-method remap was deleted: reverting it survived all 7 examined targeted/#794 tests, so the PR no longer carries that unobservable edit.

## Final validation

Rebased onto `origin/main` `46d3cc50fd874e9a03eefc9a8b28f94fe54e0adc`; head `c47416ac0e4b436eff057c56dd011832b5c26570`.

- issue + related #773/#794 interpreter tests: 25 passed, 0 failed, 25 total
- `gsi` sample: exit 0, values `10 / 20 / 42`
- `gsc` compile: exit 0; emitted assembly run: exit 0, values `10 / 20 / 42`
- three-dot diff check: clean

## Scope and structural check

The occurrence count did not survive contact with current tip: both current base and head contain 21 exact `.ClrType ?? typeof(object)` occurrences across 667 `src/**/*.cs` files, down from the earlier 27-site count. This PR rewrites none of them. Making the shared evaluator helper require a `siteId` produced exactly 7 unique `CS7036` errors, proving the reflection-site denominator. Current base has 0 `ReifyClosedClrType()` calls across 7 `Evaluator*.cs` files; head has 1 shared evaluator reification path.

`SignatureEncoder.cs` remains accurate because this change does not alter the interpreter channel-element fallback it describes. #2993/#2996 struct-literal allocation paths are untouched.





